### PR TITLE
Use `next-intl` as internationalization framework

### DIFF
--- a/web-app/.vscode/settings.json
+++ b/web-app/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.wordWrap": "on",
+    "editor.tabSize": 2,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    }
+  }

--- a/web-app/.vscode/settings.json
+++ b/web-app/.vscode/settings.json
@@ -1,10 +1,9 @@
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.wordWrap": "on",
-    "editor.tabSize": 2,
-    "editor.codeActionsOnSave": {
-      "source.fixAll": "explicit",
-      "source.organizeImports": "explicit"
-    }
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.wordWrap": "on",
+  "editor.tabSize": 2,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
   }
+}

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1,0 +1,5 @@
+{
+  "HomePage": {
+    "title": "Hello world!"
+  }
+}

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1,5 +1,8 @@
 {
-  "HomePage": {
-    "title": "Hello world!"
+  "Landing": {
+    "Hero": {
+      "caption": "Hire yourself an agent to finish the most time consuming tasks",
+      "title": "A marketplace for agent-to-agent interactionss"
+    }
   }
 }

--- a/web-app/next.config.ts
+++ b/web-app/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
   output: "standalone",
 };
 
-export default nextConfig;
+const withNextIntl = createNextIntlPlugin();
+
+export default withNextIntl(nextConfig);

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -24,6 +24,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.477.0",
         "next": "15.1.7",
+        "next-intl": "^3.26.5",
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -843,6 +844,66 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.3.tgz",
+      "integrity": "sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.6",
+        "@formatjs/intl-localematcher": "0.6.0",
+        "decimal.js": "10",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.0.tgz",
+      "integrity": "sha512-4rB4g+3hESy1bHSBG3tDFaMY2CH67iT7yne1e+0CLTsGLDcmoEWWpJjjpWVaYgYfYuohIRuo0E+N536gd2ZHZA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.6.tgz",
+      "integrity": "sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.1.tgz",
+      "integrity": "sha512-o0AhSNaOfKoic0Sn1GkFCK4MxdRsw7mPJ5/rBpIqdvcC7MIuyUSW8WChUEvrK78HhNpYOgqCQbINxCTumJLzZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.3",
+        "@formatjs/icu-skeleton-parser": "1.8.13",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.13.tgz",
+      "integrity": "sha512-N/LIdTvVc1TpJmMt2jVg0Fr1F7Q1qJPdZSCs19unMskCmVQ/sa0H9L8PWt13vq+gLdLg1+pPsvBLydL1Apahjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.3",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
     },
     "node_modules/@hexagon/base64": {
       "version": "1.1.28",
@@ -5194,7 +5255,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -7285,6 +7345,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.15",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.15.tgz",
+      "integrity": "sha512-LRyExsEsefQSBjU2p47oAheoKz+EOJxSLDdjOaEjdriajfHsMXOmV/EhMvYSg9bAgCUHasuAC+mcUBe/95PfIg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.3",
+        "@formatjs/fast-memoize": "2.2.6",
+        "@formatjs/icu-messageformat-parser": "2.11.1",
+        "tslib": "2"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9516,6 +9588,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -9575,6 +9656,27 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-3.26.5.tgz",
+      "integrity": "sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^3.26.5"
+      },
+      "peerDependencies": {
+        "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/next-themes": {
@@ -12489,6 +12591,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-3.26.5.tgz",
+      "integrity": "sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.477.0",
     "next": "15.1.7",
+    "next-intl": "^3.26.5",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/web-app/src/app/(landing)/page.tsx
+++ b/web-app/src/app/(landing)/page.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl";
+
 import { AuthButtons } from "@/app/(landing)/components/auth-buttons";
 import Footer from "@/app/(landing)/components/footer";
 import HowItWorks from "@/app/(landing)/components/how-it-works";
@@ -69,21 +71,19 @@ function TopNavigation() {
 }
 
 function MainContent() {
+  const t = useTranslations("Landing.Hero");
   return (
     <div className="container mx-auto flex items-center justify-between">
       <div className="flex flex-col items-center gap-8 lg:flex-row">
         {/* First text box - smaller width */}
         <div className="w-full lg:w-1/5">
-          <p className="font-bold">
-            The most powerful way to find and hire agents. Prompt, run, edit and
-            deploy your agents.
-          </p>
+          <p className="font-bold">{t("caption")}</p>
         </div>
 
         {/* Second text box - larger width */}
         <div className="mx-auto w-full lg:w-1/2">
           <p className={`text-left text-7xl font-light tracking-tighter`}>
-            A marketplace for agent-to-agent interactions
+            {t("title")}
           </p>
         </div>
       </div>

--- a/web-app/src/app/layout.tsx
+++ b/web-app/src/app/layout.tsx
@@ -48,7 +48,6 @@ export default async function RootLayout({
           </div>
           <Toaster />
         </NextIntlClientProvider>
-        <Toaster />
       </body>
     </html>
   );

--- a/web-app/src/app/layout.tsx
+++ b/web-app/src/app/layout.tsx
@@ -2,6 +2,8 @@ import "./globals.css";
 
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 
 import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
@@ -21,13 +23,18 @@ export const metadata: Metadata = {
   description: "Hire yourself an agent to finish the most time consuming tasks",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+
+  // Providing all messages to the client
+  // side is the easiest way to get started
+  const messages = await getMessages();
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body
         className={cn(
           geistSans.variable,
@@ -35,9 +42,12 @@ export default function RootLayout({
           "min-h-svh bg-background antialiased",
         )}
       >
-        <div className="relative flex min-h-svh flex-col bg-background">
-          {children}
-        </div>
+        <NextIntlClientProvider messages={messages}>
+          <div className="relative flex min-h-svh flex-col bg-background">
+            {children}
+          </div>
+          <Toaster />
+        </NextIntlClientProvider>
         <Toaster />
       </body>
     </html>

--- a/web-app/src/app/layout.tsx
+++ b/web-app/src/app/layout.tsx
@@ -30,8 +30,7 @@ export default async function RootLayout({
 }>) {
   const locale = await getLocale();
 
-  // Providing all messages to the client
-  // side is the easiest way to get started
+  // Providing all messages to the client side
   const messages = await getMessages();
   return (
     <html lang={locale}>

--- a/web-app/src/i18n/request.ts
+++ b/web-app/src/i18n/request.ts
@@ -1,0 +1,12 @@
+import { getRequestConfig } from "next-intl/server";
+
+export default getRequestConfig(async () => {
+  // Provide a static locale, fetch a user setting,
+  // read from `cookies()`, `headers()`, etc.
+  const locale = "en";
+
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/web-app/src/lib/auth.client.ts
+++ b/web-app/src/lib/auth.client.ts
@@ -6,6 +6,7 @@ import {
   twoFactorClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+
 export const authClient = createAuthClient({
   plugins: [
     organizationClient(),


### PR DESCRIPTION
This is only the basic setup. I will use it on the landing page as soon as #37 merged.

This pull request includes several changes to add internationalization support to the web application and improve the development environment. The most important changes include the integration of the `next-intl` package.

Related to #39 