### PR TITLE
feat(auth): implement social authentication providers

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -15,7 +15,9 @@
     },
     "SocialButtons": {
       "continueWith": "Continue with {provider}",
-      "divider": "Or Continue With"
+      "divider": "or continue with",
+      "success": "Sign In successful",
+      "error": "Sign In failed"
     },
     "Words": {
       "signIn": "Sign In",
@@ -116,6 +118,7 @@
         },
         "Form": {
           "success": "We've sent you an email to reset your password",
+          "error": "Failed to reset password",
           "reset_password": "Reset Password",
           "Fields": {
             "Email": {

--- a/web-app/src/app/(landing)/(auth)/actions.ts
+++ b/web-app/src/app/(landing)/(auth)/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+import { auth } from "@/lib/auth";
+
+export async function signInSocial(provider: "google") {
+  try {
+    await auth.api.signInSocial({
+      body: {
+        provider: provider,
+      },
+    });
+    return { success: true };
+  } catch {
+    return { error: "Failed to create account" };
+  }
+}

--- a/web-app/src/app/(landing)/(auth)/actions.ts
+++ b/web-app/src/app/(landing)/(auth)/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 import { auth } from "@/lib/auth";
 
-export async function signInSocial(provider: "google") {
+export async function signInSocial(
+  provider: "google" | "microsoft" | "apple" | "linkedin",
+) {
   try {
     await auth.api.signInSocial({
       body: {

--- a/web-app/src/app/(landing)/(auth)/components/social-buttons.tsx
+++ b/web-app/src/app/(landing)/(auth)/components/social-buttons.tsx
@@ -3,13 +3,18 @@
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ComponentProps } from "react";
-import { GoogleLoginButton } from "react-social-login-buttons";
+import {
+  AppleLoginButton,
+  GoogleLoginButton,
+  LinkedInLoginButton,
+  MicrosoftLoginButton,
+} from "react-social-login-buttons";
 import { toast } from "sonner";
 
 import { signInSocial } from "../actions";
 import Divider from "./divider";
 
-type SocialKey = "google";
+type SocialKey = "google" | "microsoft" | "apple" | "linkedin";
 const socialButtons: Array<{
   key: SocialKey;
   button: React.FC<ComponentProps<typeof GoogleLoginButton>>;
@@ -17,6 +22,18 @@ const socialButtons: Array<{
   {
     key: "google",
     button: GoogleLoginButton,
+  },
+  {
+    key: "microsoft",
+    button: MicrosoftLoginButton,
+  },
+  {
+    key: "apple",
+    button: AppleLoginButton,
+  },
+  {
+    key: "linkedin",
+    button: LinkedInLoginButton,
   },
 ];
 

--- a/web-app/src/app/(landing)/(auth)/components/social-buttons.tsx
+++ b/web-app/src/app/(landing)/(auth)/components/social-buttons.tsx
@@ -47,7 +47,7 @@ export default function SocialButtons() {
       toast.success(t("success"));
       router.push("/dashboard");
     } else {
-      toast.error(result.error || t("error"));
+      toast.error(t("error"));
     }
   };
 

--- a/web-app/src/app/(landing)/(auth)/components/social-buttons.tsx
+++ b/web-app/src/app/(landing)/(auth)/components/social-buttons.tsx
@@ -1,53 +1,42 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ComponentProps } from "react";
-import {
-  AppleLoginButton,
-  GoogleLoginButton,
-  LinkedInLoginButton,
-  MicrosoftLoginButton,
-} from "react-social-login-buttons";
+import { GoogleLoginButton } from "react-social-login-buttons";
+import { toast } from "sonner";
 
+import { signInSocial } from "../actions";
 import Divider from "./divider";
 
-type SocialKey = "Google" | "Microsoft" | "Apple" | "LinkedIn";
+type SocialKey = "google";
 const socialButtons: Array<{
   key: SocialKey;
   button: React.FC<ComponentProps<typeof GoogleLoginButton>>;
 }> = [
   {
-    key: "Google",
+    key: "google",
     button: GoogleLoginButton,
-  },
-  {
-    key: "Microsoft",
-    button: MicrosoftLoginButton,
-  },
-  {
-    key: "Apple",
-    button: AppleLoginButton,
-  },
-  {
-    key: "LinkedIn",
-    button: LinkedInLoginButton,
   },
 ];
 
-interface SocialButtonsProps {
-  variant: "signin" | "signup";
-}
-
-export default function SocialButtons({ variant }: SocialButtonsProps) {
+export default function SocialButtons() {
   const t = useTranslations("Auth.SocialButtons");
+  const router = useRouter();
 
-  const handleClick = (key: SocialKey) => {
-    console.log({ variant, key });
+  const handleClick = async (key: SocialKey) => {
+    const result = await signInSocial(key);
+    if (result.success) {
+      toast.success(t("success"));
+      router.push("/dashboard");
+    } else {
+      toast.error(result.error || t("error"));
+    }
   };
 
   return (
     <>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
+      <div className="grid grid-cols-1 gap-4 lg:gap-6">
         {socialButtons.map((socialButton) => (
           <socialButton.button
             onClick={() => handleClick(socialButton.key)}

--- a/web-app/src/app/(landing)/(auth)/forgot-password/components/form.tsx
+++ b/web-app/src/app/(landing)/(auth)/forgot-password/components/form.tsx
@@ -49,7 +49,7 @@ export default function ForgotPasswordForm() {
     setLoading(false);
 
     if (result.error) {
-      toast.error(result.error);
+      toast.error(t("error"));
       return;
     }
 

--- a/web-app/src/app/(landing)/(auth)/signin/components/form.tsx
+++ b/web-app/src/app/(landing)/(auth)/signin/components/form.tsx
@@ -49,7 +49,7 @@ export default function SignInForm() {
     setLoading(false);
 
     if (result.error) {
-      toast.error(result.error);
+      toast.error(t("error"));
       return;
     }
 

--- a/web-app/src/app/(landing)/(auth)/signin/page.tsx
+++ b/web-app/src/app/(landing)/(auth)/signin/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
+import SocialButtons from "../components/social-buttons";
 import SignInForm from "./components/form";
 import SignInHeader from "./components/header";
 
@@ -18,7 +19,7 @@ export default function SignIn() {
     <div className="flex flex-1 flex-col">
       <SignInHeader />
       <div className="flex flex-1 flex-col gap-6 p-6 pt-0">
-        {/* <SocialButtons variant="signin" /> */}
+        <SocialButtons />
         <SignInForm />
       </div>
     </div>

--- a/web-app/src/app/(landing)/(auth)/signin/page.tsx
+++ b/web-app/src/app/(landing)/(auth)/signin/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
-import SocialButtons from "../components/social-buttons";
 import SignInForm from "./components/form";
 import SignInHeader from "./components/header";
 
@@ -19,7 +18,7 @@ export default function SignIn() {
     <div className="flex flex-1 flex-col">
       <SignInHeader />
       <div className="flex flex-1 flex-col gap-6 p-6 pt-0">
-        <SocialButtons />
+        {/* <SocialButtons /> */}
         <SignInForm />
       </div>
     </div>

--- a/web-app/src/app/(landing)/(auth)/signup/components/form.tsx
+++ b/web-app/src/app/(landing)/(auth)/signup/components/form.tsx
@@ -65,7 +65,7 @@ export default function SignUpForm() {
       toast.success(t("success"));
       router.push("/signin");
     } else {
-      toast.error(result.error || t("error"));
+      toast.error(t("error"));
     }
   };
 

--- a/web-app/src/app/(landing)/(auth)/signup/page.tsx
+++ b/web-app/src/app/(landing)/(auth)/signup/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
+import SocialButtons from "../components/social-buttons";
 import SignUpForm from "./components/form";
 import SignUpHeader from "./components/header";
 
@@ -18,7 +19,7 @@ export default function SignUp() {
     <div className="flex flex-1 flex-col">
       <SignUpHeader />
       <div className="flex flex-1 flex-col gap-6 p-6 pt-0">
-        {/* <SocialButtons variant="signup" /> */}
+        <SocialButtons />
         <SignUpForm />
       </div>
     </div>

--- a/web-app/src/app/(landing)/(auth)/signup/page.tsx
+++ b/web-app/src/app/(landing)/(auth)/signup/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
-import SocialButtons from "../components/social-buttons";
 import SignUpForm from "./components/form";
 import SignUpHeader from "./components/header";
 
@@ -19,7 +18,7 @@ export default function SignUp() {
     <div className="flex flex-1 flex-col">
       <SignUpHeader />
       <div className="flex flex-1 flex-col gap-6 p-6 pt-0">
-        <SocialButtons />
+        {/* <SocialButtons /> */}
         <SignUpForm />
       </div>
     </div>

--- a/web-app/src/lib/auth.ts
+++ b/web-app/src/lib/auth.ts
@@ -62,6 +62,18 @@ export const auth = betterAuth({
       clientId: process.env.GOOGLE_CLIENT_ID || "",
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
     },
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID || "",
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET || "",
+    },
+    apple: {
+      clientId: process.env.APPLE_CLIENT_ID || "",
+      clientSecret: process.env.APPLE_CLIENT_SECRET || "",
+    },
+    linkedin: {
+      clientId: process.env.LINKEDIN_CLIENT_ID || "",
+      clientSecret: process.env.LINKEDIN_CLIENT_SECRET || "",
+    },
   },
   plugins: [
     organization(),

--- a/web-app/src/lib/auth.ts
+++ b/web-app/src/lib/auth.ts
@@ -41,7 +41,6 @@ export const auth = betterAuth({
     enabled: true,
     requireEmailVerification: true,
     sendResetPassword: async ({ user, url }) => {
-      console.log("sendResetPassword", user, url);
       const t = await getTranslations("Auth.Email.ResetPassword");
 
       await resend.emails.send({
@@ -59,25 +58,10 @@ export const auth = betterAuth({
     storage: "database",
   },
   socialProviders: {
-    // google: {
-    //   clientId: process.env.GOOGLE_CLIENT_ID || "<google-client-id>",
-    //   clientSecret:
-    //     process.env.GOOGLE_CLIENT_SECRET || "<google-client-secret>",
-    // },
-    // microsoft: {
-    //   clientId: process.env.MICROSOFT_CLIENT_ID || "<microsoft-client-id>",
-    //   clientSecret:
-    //     process.env.MICROSOFT_CLIENT_SECRET || "<microsoft-client-secret>",
-    // },
-    // apple: {
-    //   clientId: process.env.APPLE_CLIENT_ID || "<apple-client-id>",
-    //   clientSecret: process.env.APPLE_CLIENT_SECRET || "<apple-client-secret>",
-    // },
-    // linkedin: {
-    //   clientId: process.env.LINKEDIN_CLIENT_ID || "<linkedin-client-id>",
-    //   clientSecret:
-    //     process.env.LINKEDIN_CLIENT_SECRET || "<linkedin-client-secret>",
-    // },
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID || "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+    },
   },
   plugins: [
     organization(),


### PR DESCRIPTION
This PR adds social authentication functionality to the application, allowing users to sign in with Google, Microsoft, Apple, and LinkedIn accounts.

### Changes:
- Add server action for handling social authentication
- Configure social provider credentials in auth configuration
- Update SocialButtons component to handle authentication flow
- Improve error handling and success messages for authentication
- Standardize error message handling across auth forms
- Update translations for social authentication messages

### Note: Social provider credentials need to be configured in environment variables:
- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
- `MICROSOFT_CLIENT_ID` and `MICROSOFT_CLIENT_SECRET`
- `APPLE_CLIENT_ID` and `APPLE_CLIENT_SECRET`
- `LINKEDIN_CLIENT_ID` and `LINKEDIN_CLIENT_SECRET`

No need for a `NEXT_PUBLIC` prefix; it's all server-side.

### How to use
* Re-add the SocialButton component  
* Configure the environment variables for the Social Provider