### PR TITLE
feat(auth): implement authentication middleware for dashboard routes

### DIFF
--- a/web-app/src/middleware.ts
+++ b/web-app/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authorizationMiddleware } from "./middleware/authorization";
+
+export async function middleware(req: NextRequest) {
+  // Apply authorization middleware
+  const authResponse = await authorizationMiddleware(req);
+  if (authResponse) return authResponse;
+
+  // If all middlewares pass, proceed with the request
+  return NextResponse.next();
+}
+
+// Specify the paths where the middleware should run
+export const config = {
+  matcher: ["/dashboard/:path*"],
+};

--- a/web-app/src/middleware/authorization.ts
+++ b/web-app/src/middleware/authorization.ts
@@ -1,0 +1,20 @@
+import { getSessionCookie } from "better-auth/cookies";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export async function authorizationMiddleware(req: NextRequest) {
+  const sessionCookie = getSessionCookie(req);
+
+  // Define the path you want to restrict
+  const restrictedPath = "/dashboard";
+
+  if (req.nextUrl.pathname.startsWith(restrictedPath)) {
+    // Check if the session cookie is present
+    if (!sessionCookie) {
+      // Redirect to login page if not authenticated
+      return NextResponse.redirect(new URL("/signin", req.url));
+    }
+  }
+  // Allow the request to proceed if authenticated
+  return NextResponse.next();
+}


### PR DESCRIPTION
# Description
Adds middleware functionality to protect `dashboard/:path*` routes with session-based authentication.

## Changes
- Creates main middleware configuration that runs on `/dashboard/*` routes
- Implements authorization middleware to check for valid session cookies
- Redirects unauthenticated users to the signin page
- Uses better-auth package for cookie management

## Technical Details
- Middleware is configured to run only on dashboard routes for performance
- Authorization check is performed before any other middleware
- Follows Next.js 13+ middleware patterns
- Type-safe implementation using NextRequest/NextResponse

## Testing
Please verify:
- Accessing dashboard routes without authentication redirects to signin
- Valid session cookies allow access to dashboard routes
- Non-dashboard routes remain accessible without authentication