### PR TITLE
refactor(dto): migrate Tag and Status models to DTOs

### DIFF
--- a/web-app/src/app/(landing)/gallery/[agentId]/components/agent-details.tsx
+++ b/web-app/src/app/(landing)/gallery/[agentId]/components/agent-details.tsx
@@ -1,9 +1,9 @@
-import { Tag } from "@prisma/client";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 
 import BadgeCloud from "@/components/badge-cloud";
 import { Button } from "@/components/ui/button";
+import { TagDTO } from "@/lib/db/dto/TagDTO";
 
 interface AgentDetailsProps {
   name: string;
@@ -11,7 +11,7 @@ interface AgentDetailsProps {
   author: string;
   image: string;
   credits: number;
-  tags: Tag[];
+  tags: TagDTO[];
 }
 
 export default function AgentDetails({

--- a/web-app/src/app/(landing)/gallery/featured-agent.tsx
+++ b/web-app/src/app/(landing)/gallery/featured-agent.tsx
@@ -1,4 +1,3 @@
-import { Tag } from "@prisma/client";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -6,13 +5,14 @@ import { useTranslations } from "next-intl";
 import BadgeCloud from "@/components/badge-cloud";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TagDTO } from "@/lib/db/dto/TagDTO";
 
 interface FeaturedAgentProps {
   id: string;
   name: string;
   description: string;
   image: string;
-  tags: Tag[];
+  tags: TagDTO[];
 }
 
 export function FeaturedAgentSkeleton() {

--- a/web-app/src/components/agent-card.tsx
+++ b/web-app/src/components/agent-card.tsx
@@ -1,4 +1,3 @@
-import { Tag } from "@prisma/client";
 import { Star } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -6,6 +5,7 @@ import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { TagDTO } from "@/lib/db/dto/TagDTO";
 
 import BadgeCloud from "./badge-cloud";
 
@@ -16,7 +16,7 @@ interface AgentCardProps {
   averageStars: number | null;
   image: string;
   price: number;
-  tags: Tag[];
+  tags: TagDTO[];
 }
 
 export function AgentCardSkeleton() {

--- a/web-app/src/components/badge-cloud.tsx
+++ b/web-app/src/components/badge-cloud.tsx
@@ -1,8 +1,8 @@
-import { Tag } from "@prisma/client";
+import { TagDTO } from "@/lib/db/dto/TagDTO";
 
 import { Badge } from "./ui/badge";
 
-export default function BadgeCloud({ tags }: { tags: Tag[] }) {
+export default function BadgeCloud({ tags }: { tags: TagDTO[] }) {
   return (
     <>
       {tags.length > 0 && (

--- a/web-app/src/lib/db/dto/AgentDTO.ts
+++ b/web-app/src/lib/db/dto/AgentDTO.ts
@@ -1,6 +1,9 @@
-import { PricingType, Prisma, Status, Tag } from "@prisma/client";
+import { PricingType, Prisma } from "@prisma/client";
 
 import { ipfsUrlResolver } from "@/lib/ipfs";
+
+import { createStatusDTO, StatusDTO } from "./StatusDTO";
+import { TagDTO } from "./TagDTO";
 
 type AgentWithRelations = Prisma.AgentGetPayload<{
   include: {
@@ -21,23 +24,23 @@ type AgentWithRelations = Prisma.AgentGetPayload<{
   };
 }>;
 
-export interface Pricing {
+export interface PricingDTO {
   readonly id: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly credits: number;
   readonly pricingType: PricingType;
-  readonly FixedPricing: FixedPricing;
+  readonly FixedPricing: FixedPricingDTO;
 }
 
-export interface FixedPricing {
+export interface FixedPricingDTO {
   readonly id: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
-  readonly Amounts: Amount[];
+  readonly Amounts: AmountDTO[];
 }
 
-export interface Amount {
+export interface AmountDTO {
   readonly id: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -45,7 +48,7 @@ export interface Amount {
   readonly amount: number;
 }
 
-export interface ExampleOutput {
+export interface ExampleOutputDTO {
   readonly id: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -53,24 +56,24 @@ export interface ExampleOutput {
   readonly mimeType: string;
 }
 
-export interface Legal {
+export interface LegalDTO {
   readonly privacyPolicy: string | null;
   readonly terms: string | null;
   readonly other: string | null;
 }
 
-export interface Rating {
+export interface RatingDTO {
   readonly totalStars: number;
   readonly totalRatings: number;
   readonly averageStars: number | null;
 }
 
-export interface Capability {
+export interface CapabilityDTO {
   readonly name: string;
   readonly version: string;
 }
 
-export interface Author {
+export interface AuthorDTO {
   readonly name: string;
   readonly contactEmail: string | null;
   readonly contactOther: string | null;
@@ -81,23 +84,23 @@ export interface AgentDTO {
   readonly ranking: number;
   readonly showOnFrontPage: boolean;
   readonly agentIdentifier: string;
-  readonly Pricing: Pricing;
+  readonly Pricing: PricingDTO;
   readonly id: string;
   readonly name: string;
   readonly description: string | null;
   readonly apiBaseUrl: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
-  readonly ExampleOutput: ExampleOutput[];
-  readonly Capability: Capability;
+  readonly ExampleOutput: ExampleOutputDTO[];
+  readonly Capability: CapabilityDTO;
   readonly requestsPerHour: string | null;
-  readonly Author: Author;
-  readonly Legal: Legal | null;
-  readonly tags: Tag[];
+  readonly Author: AuthorDTO;
+  readonly Legal: LegalDTO | null;
+  readonly tags: TagDTO[];
   readonly image: string;
   readonly metadataVersion: number;
-  readonly status: Status;
-  readonly Rating: Rating;
+  readonly status: StatusDTO;
+  readonly Rating: RatingDTO;
 }
 
 function calculateCredits(amount: number): number {
@@ -175,7 +178,7 @@ export function createAgentDTO(agent: AgentWithRelations): AgentDTO {
     image: ipfsUrlResolver(agent.overrideImage ?? agent.onChainImage),
     metadataVersion:
       agent.overrideMetadataVersion ?? agent.onChainMetadataVersion,
-    status: agent.status,
+    status: createStatusDTO(agent.status),
     id: agent.id,
     createdAt: agent.createdAt,
     updatedAt: agent.updatedAt,

--- a/web-app/src/lib/db/dto/StatusDTO.ts
+++ b/web-app/src/lib/db/dto/StatusDTO.ts
@@ -1,0 +1,27 @@
+import { Status } from "@prisma/client";
+
+export enum StatusDTO {
+  Online = "Online",
+  Offline = "Offline",
+  Deregistered = "Deregistered",
+  Invalid = "Invalid",
+}
+
+export function createStatusDTO(status: Status): StatusDTO {
+  switch (status) {
+    case Status.Online:
+      return StatusDTO.Online;
+    case Status.Offline:
+      return StatusDTO.Offline;
+    case Status.Deregistered:
+      return StatusDTO.Deregistered;
+    case Status.Invalid:
+      return StatusDTO.Invalid;
+    default:
+      throw new Error(`Invalid status: ${status}`);
+  }
+}
+
+export function createStatusDTOs(statuses: Status[]): StatusDTO[] {
+  return statuses.map(createStatusDTO);
+}

--- a/web-app/src/lib/db/dto/TagDTO.ts
+++ b/web-app/src/lib/db/dto/TagDTO.ts
@@ -1,0 +1,17 @@
+import { Tag } from "@prisma/client";
+
+export interface TagDTO {
+  readonly id: string;
+  readonly name: string;
+}
+
+export function createTagDTO(tag: Tag): TagDTO {
+  return {
+    id: tag.id,
+    name: tag.name,
+  };
+}
+
+export function createTagDTOs(tags: Tag[]): TagDTO[] {
+  return tags.map(createTagDTO);
+}


### PR DESCRIPTION
This PR introduces Data Transfer Objects (DTOs) for Tag and Status models to decouple the database layer from the presentation layer.

Changes:
- Create `TagDTO` and `StatusDTO` interfaces
- Add conversion functions createTagDTO and createStatusDTO
- Replace direct Prisma Tag and Status usage with DTOs in components:
  - AgentDetails
  - FeaturedAgent
  - AgentCard
  - BadgeCloud
- Update AgentDTO to use new DTOs for consistency
- Rename related interfaces to follow DTO naming convention

This change improves the separation of concerns by preventing direct Prisma model usage in the UI layer and provides better type safety through explicit DTO interfaces.