### PR TITLE
refactor(auth): rename username to name and standardize password constraints

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -100,9 +100,9 @@
               "label": "Email",
               "placeholder": "me@example.com"
             },
-            "Username": {
-              "label": "Username",
-              "placeholder": "JohnDoe"
+            "Name": {
+              "label": "Name",
+              "placeholder": "John Doe"
             },
             "Password": {
               "label": "Password",
@@ -117,13 +117,14 @@
             "Email": {
               "invalid": "Please enter a valid email address."
             },
-            "Username": {
-              "min": "Username must be at least 2 characters.",
-              "max": "Username must be maximum 50 characters.",
-              "regex": "Username must contain only letters, numbers, and underscores."
+            "Name": {
+              "min": "Name must be at least 2 characters.",
+              "max": "Name must be maximum 128 characters.",
+              "regex": "Name must contain only letters, numbers, and underscores."
             },
             "Password": {
               "min": "Password must be at least 8 characters.",
+              "max": "Password must be maximum 128 characters.",
               "regex": "Password must contain at least one uppercase letter, one lowercase letter, and one number."
             },
             "ConfirmPassword": {
@@ -182,6 +183,7 @@
           "Errors": {
             "Password": {
               "min": "Password must be at least 8 characters",
+              "max": "Password must be maximum 128 characters",
               "regex": "Password must contain at least one uppercase letter, one lowercase letter, and one number."
             },
             "ConfirmPassword": {
@@ -195,7 +197,7 @@
       "ResetPassword": {
         "subject": "Sokosumi - Reset your password",
         "title": "Reset your password",
-        "greeting": "Hello {username}",
+        "greeting": "Hello {name}",
         "message": "We received a request to reset your password for your account. If you didn't make this request, you can safely ignore this email.",
         "button": "Reset Password",
         "linkInstructions": "Or copy and paste this URL into your browser:",
@@ -204,7 +206,7 @@
       "Verification": {
         "subject": "Sokosumi - Verify your email address",
         "title": "Verify your email address",
-        "greeting": "Hello {username}",
+        "greeting": "Hello {name}",
         "message": "Thank you for signing up! Please verify your email address by clicking the button below. This helps us ensure the security of your account.",
         "button": "Verify Email",
         "linkInstructions": "Or copy and paste this URL into your browser:",

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -119,8 +119,7 @@
             },
             "Name": {
               "min": "Name must be at least 2 characters.",
-              "max": "Name must be maximum 128 characters.",
-              "regex": "Name must contain only letters, numbers, and underscores."
+              "max": "Name must be maximum 128 characters."
             },
             "Password": {
               "min": "Password must be at least 8 characters.",

--- a/web-app/src/app/(landing)/(auth)/data.ts
+++ b/web-app/src/app/(landing)/(auth)/data.ts
@@ -1,13 +1,18 @@
 import { z } from "zod";
 
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "@/constants";
+
 export const passwordSchema = ({
   minError,
+  maxError,
   regexError,
 }: {
   minError?: string;
+  maxError?: string;
   regexError?: string;
 }) =>
   z
     .string()
-    .min(8, minError)
+    .min(PASSWORD_MIN_LENGTH, minError)
+    .max(PASSWORD_MAX_LENGTH, maxError)
     .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, regexError);

--- a/web-app/src/app/(landing)/(auth)/reset-password/data.ts
+++ b/web-app/src/app/(landing)/(auth)/reset-password/data.ts
@@ -13,6 +13,7 @@ export const resetPasswordFormSchema = (
     .object({
       password: passwordSchema({
         minError: t?.("Errors.Password.min"),
+        maxError: t?.("Errors.Password.max"),
         regexError: t?.("Errors.Password.regex"),
       }),
       confirmPassword: z.string(),

--- a/web-app/src/app/(landing)/(auth)/signin/actions.ts
+++ b/web-app/src/app/(landing)/(auth)/signin/actions.ts
@@ -22,7 +22,6 @@ export async function signin(formData: SignInFormSchemaType) {
     });
     return { success: true };
   } catch (error) {
-    console.log(error);
     if (error && typeof error === "object" && "statusCode" in error) {
       if (error.statusCode === 403) {
         return { error: "Please verify your email address" };

--- a/web-app/src/app/(landing)/(auth)/signup/actions.ts
+++ b/web-app/src/app/(landing)/(auth)/signup/actions.ts
@@ -11,12 +11,12 @@ export async function signup(formData: SignUpFormSchemaType) {
     return { error: "Invalid form data" };
   }
 
-  const { email, username, password } = validatedFields.data;
+  const { email, name, password } = validatedFields.data;
 
   try {
     await auth.api.signUpEmail({
       body: {
-        name: username,
+        name,
         email,
         password,
       },

--- a/web-app/src/app/(landing)/(auth)/signup/components/form.tsx
+++ b/web-app/src/app/(landing)/(auth)/signup/components/form.tsx
@@ -22,7 +22,7 @@ export default function SignUpForm() {
     resolver: zodResolver(signUpFormSchema(t)),
     defaultValues: {
       email: "",
-      username: "",
+      name: "",
       password: "",
       confirmPassword: "",
     },

--- a/web-app/src/app/(landing)/(auth)/signup/data.ts
+++ b/web-app/src/app/(landing)/(auth)/signup/data.ts
@@ -12,8 +12,7 @@ const signUpFormSchema = (
       name: z
         .string()
         .min(2, t?.("Errors.Name.min"))
-        .max(128, t?.("Errors.Name.max"))
-        .regex(/^\S*$/, t?.("Errors.Name.regex")),
+        .max(128, t?.("Errors.Name.max")),
       email: z.string().email(t?.("Errors.Email.invalid")),
       password: passwordSchema({
         minError: t?.("Errors.Password.min"),

--- a/web-app/src/app/(landing)/(auth)/signup/data.ts
+++ b/web-app/src/app/(landing)/(auth)/signup/data.ts
@@ -9,14 +9,15 @@ const signUpFormSchema = (
 ) =>
   z
     .object({
-      username: z
+      name: z
         .string()
-        .min(2, t?.("Errors.Username.min"))
-        .max(50, t?.("Errors.Username.max"))
-        .regex(/^\S*$/, t?.("Errors.Username.regex")),
+        .min(2, t?.("Errors.Name.min"))
+        .max(128, t?.("Errors.Name.max"))
+        .regex(/^\S*$/, t?.("Errors.Name.regex")),
       email: z.string().email(t?.("Errors.Email.invalid")),
       password: passwordSchema({
         minError: t?.("Errors.Password.min"),
+        maxError: t?.("Errors.Password.max"),
         regexError: t?.("Errors.Password.regex"),
       }),
       confirmPassword: z.string(),
@@ -36,9 +37,9 @@ const signUpFormData: FormData<SignUpFormSchemaType, "Auth.Pages.SignUp.Form"> =
       placeholderKey: "Fields.Email.placeholder",
     },
     {
-      name: "username",
-      labelKey: "Fields.Username.label",
-      placeholderKey: "Fields.Username.placeholder",
+      name: "name",
+      labelKey: "Fields.Name.label",
+      placeholderKey: "Fields.Name.placeholder",
     },
     {
       name: "password",

--- a/web-app/src/constants/index.ts
+++ b/web-app/src/constants/index.ts
@@ -2,3 +2,7 @@ export const KEYBOARD_INPUT_DEBOUNCE_TIME = 300; // milliseconds
 
 export const MASUMI_URL = "https://masumi.network";
 export const KODOSUMI_URL = "https://kodosumi.com";
+export const SOKOSUMI_URL = "https://sokosumi.com";
+
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MAX_LENGTH = 128;

--- a/web-app/src/lib/better-auth/auth.ts
+++ b/web-app/src/lib/better-auth/auth.ts
@@ -41,7 +41,7 @@ export const auth = betterAuth({
         to: user.email,
         subject: t("subject"),
         react: reactVerificationEmail({
-          username: user.email,
+          name: user.name,
           verificationLink: url,
         }),
       });
@@ -61,7 +61,7 @@ export const auth = betterAuth({
         to: user.email,
         subject: t("subject"),
         react: reactResetPasswordEmail({
-          username: user.email,
+          name: user.name,
           resetLink: url,
         }),
       });

--- a/web-app/src/lib/better-auth/auth.ts
+++ b/web-app/src/lib/better-auth/auth.ts
@@ -10,6 +10,8 @@ import {
 import { passkey } from "better-auth/plugins/passkey";
 import { getTranslations } from "next-intl/server";
 
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "@/constants";
+
 import prisma from "../db/prisma";
 import { resend } from "../email/resend";
 import { reactResetPasswordEmail } from "../email/reset-password";
@@ -48,6 +50,8 @@ export const auth = betterAuth({
   },
   emailAndPassword: {
     enabled: true,
+    maxPasswordLength: PASSWORD_MAX_LENGTH,
+    minPasswordLength: PASSWORD_MIN_LENGTH,
     requireEmailVerification: true,
     sendResetPassword: async ({ user, url }) => {
       const t = await getTranslations("Auth.Email.ResetPassword");

--- a/web-app/src/lib/email/reset-password.tsx
+++ b/web-app/src/lib/email/reset-password.tsx
@@ -15,12 +15,12 @@ import {
 import { getTranslations } from "next-intl/server";
 
 interface BetterAuthResetPasswordEmailProps {
-  username: string;
+  name: string;
   resetLink: string;
 }
 
 export const ResetPasswordEmail = async ({
-  username,
+  name,
   resetLink,
 }: BetterAuthResetPasswordEmailProps) => {
   const t = await getTranslations("Auth.Email.ResetPassword");
@@ -36,7 +36,7 @@ export const ResetPasswordEmail = async ({
               {t("title")}
             </Heading>
             <Text className="text-[14px] leading-[24px] text-black">
-              {t("greeting", { username })}
+              {t("greeting", { name })}
             </Text>
             <Text className="text-[14px] leading-[24px] text-black">
               {t("message")}

--- a/web-app/src/lib/email/verification.tsx
+++ b/web-app/src/lib/email/verification.tsx
@@ -15,12 +15,12 @@ import {
 import { getTranslations } from "next-intl/server";
 
 interface BetterAuthVerificationEmailProps {
-  username: string;
+  name: string;
   verificationLink: string;
 }
 
 export const VerificationEmail = async ({
-  username,
+  name,
   verificationLink,
 }: BetterAuthVerificationEmailProps) => {
   const t = await getTranslations("Auth.Email.Verification");
@@ -36,7 +36,7 @@ export const VerificationEmail = async ({
               {t("title")}
             </Heading>
             <Text className="text-[14px] leading-[24px] text-black">
-              {t("greeting", { username })}
+              {t("greeting", { name })}
             </Text>
             <Text className="text-[14px] leading-[24px] text-black">
               {t("message")}


### PR DESCRIPTION
This PR improves the authentication system by standardizing field names and password constraints across the application.

Key Changes:
- Renamed "Username" field to "Name" throughout the application for better clarity
- Added PASSWORD_MAX_LENGTH constant (128 characters)
- Implemented consistent password length validation across all auth forms
- Configured better-auth to use the same password length constraints
- Removed debug console.log from signin action
- Added SOKOSUMI_URL constant to constants file
- Updated email templates to use "name" instead of "username"

### Technical Details
- Password constraints are now centralized in constants (min: 8, max: 128)
- Removed regex validation for name field (previously restricted to letters, numbers, and underscores)
- Updated translations to reflect the field name changes
- Applied consistent password validation across signup and reset password forms

### Testing
Please verify:
- Sign up flow with the new "Name" field
- Password validation on both signup and reset password forms
- Email templates render correctly with the user's name