### PR TITLE
fix(web-app): fix app layout so scroll is visible

### DIFF
--- a/web-app/src/app/app/layout.tsx
+++ b/web-app/src/app/app/layout.tsx
@@ -34,8 +34,8 @@ export default async function AppLayout({ children }: AppLayoutProps) {
       <div className="flex h-svh flex-1 flex-col">
         <Header className="h-[64px]" />
         <main className="flex min-h-[calc(100svh-64px)] flex-1 flex-col">
-          <BreadcrumbNavigation className="px-4 py-4 sm:px-8" />
-          <div className="flex flex-1 flex-col lg:overflow-hidden">
+          <BreadcrumbNavigation className="flex h-[48px] items-center px-4 sm:px-8" />
+          <div className="flex min-h-[calc(100%-48px)] flex-1 flex-col">
             {children}
           </div>
         </main>


### PR DESCRIPTION
Fix app layout.

What was wrong?

App layout doesn't show overflow scroll.
This is related to #163 

How to fix it?

Give static height to both app layout's header and breadcrumb, and set main content as min-h-100svh-header-breadcrumb
