### PR TITLE
fix(navigation): remove app home route from breadcrumb navigation

### DIFF
--- a/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
+++ b/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
@@ -23,10 +23,6 @@ interface BreadcrumbSegment {
 
 interface BreadcrumbNavigationClientProps {
   /**
-   * Optional segments to override the default path-based segments
-   */
-  segments?: BreadcrumbSegment[];
-  /**
    * Optional map of path segments to their display labels
    */
   segmentLabels?: Record<string, string>;
@@ -38,7 +34,6 @@ interface BreadcrumbNavigationClientProps {
 }
 
 export default function BreadcrumbNavigationClient({
-  segments: customSegments,
   segmentLabels = {},
   agents,
   className,
@@ -46,9 +41,9 @@ export default function BreadcrumbNavigationClient({
   const pathname = usePathname();
   const t = useTranslations("Navigation");
 
-  const segments = (
-    customSegments ?? generateSegments(pathname, segmentLabels, agents, t)
-  ).filter((segment) => segment.href !== AppRoute.Home);
+  const segments = generateSegments(pathname, segmentLabels, agents, t).filter(
+    (segment) => segment.href !== AppRoute.Home,
+  );
 
   // Only show breadcrumb if there are 2 or more segments
   if (segments.length < 2) {

--- a/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
+++ b/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
@@ -45,8 +45,9 @@ export default function BreadcrumbNavigationClient({
   const pathname = usePathname();
   const t = useTranslations("Navigation");
 
-  const segments =
-    customSegments ?? generateSegments(pathname, segmentLabels, agents, t);
+  const segments = (
+    customSegments ?? generateSegments(pathname, segmentLabels, agents, t)
+  ).filter((segment) => segment.href !== "/app");
 
   // Only show breadcrumb if there are 2 or more segments
   if (segments.length < 2) {

--- a/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
+++ b/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
@@ -13,6 +13,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { AgentDTO } from "@/lib/db/dto/AgentDTO";
+import { AppRoute } from "@/types/routes";
 
 interface BreadcrumbSegment {
   label: string;
@@ -47,7 +48,7 @@ export default function BreadcrumbNavigationClient({
 
   const segments = (
     customSegments ?? generateSegments(pathname, segmentLabels, agents, t)
-  ).filter((segment) => segment.href !== "/app");
+  ).filter((segment) => segment.href !== AppRoute.Home);
 
   // Only show breadcrumb if there are 2 or more segments
   if (segments.length < 2) {


### PR DESCRIPTION
This PR removes the app home route from the breadcrumb navigation to improve UI clarity and reduce redundancy.

Changes:
- Filter out AppRoute.Home from breadcrumb segments
- Maintain existing breadcrumb functionality for all other routes
- Keep minimum segment requirement (2+) for breadcrumb visibility