### PR TITLE
refactor(validation): replace nonempty() with min(1) in Zod schemas

### DIFF
--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -14,27 +14,27 @@ const envSchemaSecrets = z.object({
     .transform((val) => val === "true"),
 
   // Authentication
-  BETTER_AUTH_SECRET: z.string().nonempty(),
+  BETTER_AUTH_SECRET: z.string().min(1),
 
   // Resend
-  RESEND_API_KEY: z.string().nonempty(),
+  RESEND_API_KEY: z.string().min(1),
   RESEND_FROM_EMAIL: z.string().email(),
 
   // Social Providers
-  GOOGLE_CLIENT_ID: z.string().nonempty(),
-  GOOGLE_CLIENT_SECRET: z.string().nonempty(),
+  GOOGLE_CLIENT_ID: z.string().min(1),
+  GOOGLE_CLIENT_SECRET: z.string().min(1),
 
-  MICROSOFT_CLIENT_ID: z.string().nonempty(),
-  MICROSOFT_CLIENT_SECRET: z.string().nonempty(),
+  MICROSOFT_CLIENT_ID: z.string().min(1),
+  MICROSOFT_CLIENT_SECRET: z.string().min(1),
 
   // Admin
-  ADMIN_KEY: z.string().min(8).nonempty(),
+  ADMIN_KEY: z.string().min(8),
 
-  APPLE_CLIENT_ID: z.string().nonempty(),
-  APPLE_CLIENT_SECRET: z.string().nonempty(),
+  APPLE_CLIENT_ID: z.string().min(1),
+  APPLE_CLIENT_SECRET: z.string().min(1),
 
-  LINKEDIN_CLIENT_ID: z.string().nonempty(),
-  LINKEDIN_CLIENT_SECRET: z.string().nonempty(),
+  LINKEDIN_CLIENT_ID: z.string().min(1),
+  LINKEDIN_CLIENT_SECRET: z.string().min(1),
 
   // BetterAuth Settings
   BETTER_AUTH_SESSION_EXPIRES_IN: z

--- a/web-app/src/lib/auth/data.ts
+++ b/web-app/src/lib/auth/data.ts
@@ -5,7 +5,7 @@ import { getEnvPublicConfig } from "@/config/env.config";
 export const nameSchema = (t?: IntlTranslation<"Library.Auth.Schema">) =>
   z
     .string({ message: t?.("Name.invalid") })
-    .nonempty({ message: t?.("Name.required") })
+    .min(1, { message: t?.("Name.required") })
     .min(2, { message: t?.("Name.min") })
     .max(128, {
       message: t?.("Name.max"),
@@ -14,13 +14,13 @@ export const nameSchema = (t?: IntlTranslation<"Library.Auth.Schema">) =>
 export const emailSchema = (t?: IntlTranslation<"Library.Auth.Schema">) =>
   z
     .string({ message: t?.("Email.invalid") })
-    .nonempty({ message: t?.("Email.required") })
+    .min(1, { message: t?.("Email.required") })
     .email({ message: t?.("Email.invalid") });
 
 export const passwordSchema = (t?: IntlTranslation<"Library.Auth.Schema">) =>
   z
     .string({ message: t?.("Password.invalid") })
-    .nonempty({ message: t?.("Password.required") })
+    .min(1, { message: t?.("Password.required") })
     .min(getEnvPublicConfig().NEXT_PUBLIC_PASSWORD_MIN_LENGTH, {
       message: t?.("Password.min"),
     })
@@ -42,18 +42,18 @@ export const confirmPasswordSchema = (
 ) =>
   z
     .string({ message: t?.("ConfirmPassword.invalid") })
-    .nonempty({ message: t?.("ConfirmPassword.required") });
+    .min(1, { message: t?.("ConfirmPassword.required") });
 
 export const currentPasswordSchema = (
   t?: IntlTranslation<"Library.Auth.Schema">,
 ) =>
   z
     .string({ message: t?.("CurrentPassword.invalid") })
-    .nonempty({ message: t?.("CurrentPassword.required") });
+    .min(1, { message: t?.("CurrentPassword.required") });
 
 export const inputPasswordSchema = (
   t?: IntlTranslation<"Library.Auth.Schema">,
 ) =>
   z
     .string({ message: t?.("InputPassword.invalid") })
-    .nonempty({ message: t?.("InputPassword.required") });
+    .min(1, { message: t?.("InputPassword.required") });


### PR DESCRIPTION
Replace usage of nonempty() with min(1) in Zod string validations to follow recommended practices.

- [nonempty()](https://zod.dev/?id=nonempty) is designed specifically for array validation in [Zod](https://zod.dev)
- min(1) is the recommended approach for ensuring non-empty strings
- Updated validation schemas in env.config.ts and auth/data.ts
- No functional changes, only following best practices

This change improves code clarity by using the more appropriate validation method for string fields while maintaining the same validation behavior.