### PR TITLE
feat(sidebar): add hired agents section and refactor agents list

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -351,8 +351,10 @@
       "Content": {
         "AgentsList": {
           "pinnedTitle": "Your Pinned Agents",
+          "hiredTitle": "Your Hired Agents",
           "noAgents": "No {type} agents yet",
-          "pinnedType": "pinned"
+          "pinnedType": "pinned",
+          "hiredType": "hired"
         }
       },
       "Footer": {

--- a/web-app/src/app/app/components/sidebar/components/agents-list.tsx
+++ b/web-app/src/app/app/components/sidebar/components/agents-list.tsx
@@ -1,4 +1,3 @@
-import { AgentListType } from "@prisma/client";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
@@ -14,8 +13,10 @@ import {
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { requireAuthentication } from "@/lib/auth/utils";
-import { getHiredAgentsWithJobs } from "@/lib/db/services/agent.service";
-import { getOrCreateFavoriteAgentList } from "@/lib/db/services/agentList.service";
+import {
+  getFavoriteAgents,
+  getHiredAgentsWithJobs,
+} from "@/lib/db/services/agent.service";
 import { AppRoute } from "@/types/routes";
 
 function AgentsListSkeleton() {
@@ -48,29 +49,19 @@ async function AgentsListContent() {
   const t = await getTranslations("App.Sidebar.Content.AgentsList");
   const { session } = await requireAuthentication();
 
-  const list = await getOrCreateFavoriteAgentList(session.user.id);
-
-  const agentListTitleTranslations: Record<AgentListType, string> = {
-    [AgentListType.FAVORITE]: t("pinnedTitle"),
-  };
-
-  const agentListTypeTranslations: Record<AgentListType, string> = {
-    [AgentListType.FAVORITE]: t("pinnedType"),
-  };
-
+  const favoriteAgents = await getFavoriteAgents(session.user.id);
   const hiredAgents = await getHiredAgentsWithJobs(session.user.id);
-  console.log(hiredAgents);
 
   return (
     <ScrollArea className="h-full">
-      <SidebarGroup key={list.id}>
+      <SidebarGroup key="favorite-agents">
         <SidebarGroupLabel className="text-base">
-          {agentListTitleTranslations[list.type]}
+          {t("pinnedTitle")}
         </SidebarGroupLabel>
         <SidebarGroupContent className="mt-2">
-          {list.agents.length > 0 ? (
+          {favoriteAgents.length > 0 ? (
             <SidebarMenu>
-              {list.agents.map((agent) => (
+              {favoriteAgents.map((agent) => (
                 <SidebarMenuItem key={agent.id}>
                   <SidebarMenuButton asChild>
                     <Link href={`${AppRoute.Jobs}/${agent.id}`}>
@@ -82,11 +73,37 @@ async function AgentsListContent() {
             </SidebarMenu>
           ) : (
             <p className="text-muted-foreground px-3 text-sm">
-              {t("noAgents", { type: agentListTypeTranslations[list.type] })}
+              {t("noAgents", { type: t("pinnedType") })}
             </p>
           )}
         </SidebarGroupContent>
       </SidebarGroup>
+
+      <SidebarGroup key="hired-agents">
+        <SidebarGroupLabel className="text-base">
+          {t("hiredTitle")}
+        </SidebarGroupLabel>
+        <SidebarGroupContent className="mt-2">
+          {hiredAgents.length > 0 ? (
+            <SidebarMenu>
+              {hiredAgents.map((agent) => (
+                <SidebarMenuItem key={agent.id}>
+                  <SidebarMenuButton asChild>
+                    <Link href={`${AppRoute.Jobs}/${agent.id}`}>
+                      <span className="whitespace-nowrap">{agent.name}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          ) : (
+            <p className="text-muted-foreground px-3 text-sm">
+              {t("noAgents", { type: t("hiredType") })}
+            </p>
+          )}
+        </SidebarGroupContent>
+      </SidebarGroup>
+
       <ScrollBar orientation="horizontal" />
     </ScrollArea>
   );

--- a/web-app/src/app/app/components/sidebar/components/agents-list.tsx
+++ b/web-app/src/app/app/components/sidebar/components/agents-list.tsx
@@ -54,55 +54,21 @@ async function AgentsListContent() {
 
   return (
     <ScrollArea className="h-full">
-      <SidebarGroup key="favorite-agents">
-        <SidebarGroupLabel className="text-base">
-          {t("pinnedTitle")}
-        </SidebarGroupLabel>
-        <SidebarGroupContent className="mt-2">
-          {favoriteAgents.length > 0 ? (
-            <SidebarMenu>
-              {favoriteAgents.map((agent) => (
-                <SidebarMenuItem key={agent.id}>
-                  <SidebarMenuButton asChild>
-                    <Link href={`${AppRoute.Jobs}/${agent.id}`}>
-                      <span className="whitespace-nowrap">{agent.name}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          ) : (
-            <p className="text-muted-foreground px-3 text-sm">
-              {t("noAgents", { type: t("pinnedType") })}
-            </p>
-          )}
-        </SidebarGroupContent>
-      </SidebarGroup>
+      <AgentSection
+        groupKey="favorite-agents"
+        title={t("pinnedTitle")}
+        agents={favoriteAgents}
+        noAgentsType={t("pinnedType")}
+        t={t}
+      />
 
-      <SidebarGroup key="hired-agents">
-        <SidebarGroupLabel className="text-base">
-          {t("hiredTitle")}
-        </SidebarGroupLabel>
-        <SidebarGroupContent className="mt-2">
-          {hiredAgents.length > 0 ? (
-            <SidebarMenu>
-              {hiredAgents.map((agent) => (
-                <SidebarMenuItem key={agent.id}>
-                  <SidebarMenuButton asChild>
-                    <Link href={`${AppRoute.Jobs}/${agent.id}`}>
-                      <span className="whitespace-nowrap">{agent.name}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          ) : (
-            <p className="text-muted-foreground px-3 text-sm">
-              {t("noAgents", { type: t("hiredType") })}
-            </p>
-          )}
-        </SidebarGroupContent>
-      </SidebarGroup>
+      <AgentSection
+        groupKey="hired-agents"
+        title={t("hiredTitle")}
+        agents={hiredAgents}
+        noAgentsType={t("hiredType")}
+        t={t}
+      />
 
       <ScrollBar orientation="horizontal" />
     </ScrollArea>
@@ -114,5 +80,52 @@ export default function AgentsList() {
     <Suspense fallback={<AgentsListSkeleton />}>
       <AgentsListContent />
     </Suspense>
+  );
+}
+
+// Minimal agent interface that includes only the properties we need
+interface AgentDisplay {
+  id: string;
+  name: string;
+}
+
+interface AgentSectionProps {
+  groupKey: string;
+  title: string;
+  agents: AgentDisplay[];
+  noAgentsType: string;
+  t: Awaited<ReturnType<typeof getTranslations>>;
+}
+
+function AgentSection({
+  groupKey,
+  title,
+  agents,
+  noAgentsType,
+  t,
+}: AgentSectionProps) {
+  return (
+    <SidebarGroup key={groupKey}>
+      <SidebarGroupLabel className="text-base">{title}</SidebarGroupLabel>
+      <SidebarGroupContent className="mt-2">
+        {agents.length > 0 ? (
+          <SidebarMenu>
+            {agents.map((agent) => (
+              <SidebarMenuItem key={agent.id}>
+                <SidebarMenuButton asChild>
+                  <Link href={`${AppRoute.Jobs}/${agent.id}`}>
+                    <span className="whitespace-nowrap">{agent.name}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        ) : (
+          <p className="text-muted-foreground px-3 text-sm">
+            {t("noAgents", { type: noAgentsType })}
+          </p>
+        )}
+      </SidebarGroupContent>
+    </SidebarGroup>
   );
 }

--- a/web-app/src/app/app/components/sidebar/components/agents-list.tsx
+++ b/web-app/src/app/app/components/sidebar/components/agents-list.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { requireAuthentication } from "@/lib/auth/utils";
+import { getHiredAgentsWithJobs } from "@/lib/db/services/agent.service";
 import { getOrCreateFavoriteAgentList } from "@/lib/db/services/agentList.service";
 import { AppRoute } from "@/types/routes";
 
@@ -56,6 +57,9 @@ async function AgentsListContent() {
   const agentListTypeTranslations: Record<AgentListType, string> = {
     [AgentListType.FAVORITE]: t("pinnedType"),
   };
+
+  const hiredAgents = await getHiredAgentsWithJobs(session.user.id);
+  console.log(hiredAgents);
 
   return (
     <ScrollArea className="h-full">

--- a/web-app/src/lib/db/services/agent.service.ts
+++ b/web-app/src/lib/db/services/agent.service.ts
@@ -37,3 +37,25 @@ export async function getAgentById(id: string): Promise<AgentDTO> {
 
   return await createAgentDTO(agent);
 }
+
+export async function getHiredAgentsWithJobs(userId: string) {
+  return prisma.agent.findMany({
+    where: {
+      jobs: {
+        some: {
+          userId: userId,
+        },
+      },
+    },
+    include: {
+      jobs: {
+        where: {
+          userId: userId,
+        },
+        orderBy: {
+          startedAt: "desc",
+        },
+      },
+    },
+  });
+}

--- a/web-app/src/lib/db/services/agent.service.ts
+++ b/web-app/src/lib/db/services/agent.service.ts
@@ -1,6 +1,8 @@
 import { AgentDTO, createAgentDTO } from "@/lib/db/dto/AgentDTO";
 import prisma from "@/lib/db/prisma";
 
+import { getOrCreateFavoriteAgentList } from "./agentList.service";
+
 const agentInclude = {
   pricing: {
     include: { fixedPricing: { include: { amounts: true } } },
@@ -38,8 +40,13 @@ export async function getAgentById(id: string): Promise<AgentDTO> {
   return await createAgentDTO(agent);
 }
 
+export async function getFavoriteAgents(userId: string) {
+  const list = await getOrCreateFavoriteAgentList(userId);
+  return list.agents;
+}
+
 export async function getHiredAgentsWithJobs(userId: string) {
-  return prisma.agent.findMany({
+  const agentsWithJobs = await prisma.agent.findMany({
     where: {
       jobs: {
         some: {
@@ -55,7 +62,20 @@ export async function getHiredAgentsWithJobs(userId: string) {
         orderBy: {
           startedAt: "desc",
         },
+        take: 1,
       },
     },
+  });
+  // Then sort them manually by the startedAt of the most recent job
+  return agentsWithJobs.sort((a, b) => {
+    const aLatestJob = a.jobs[0];
+    const bLatestJob = b.jobs[0];
+
+    // If either agent has no jobs, put them at the end
+    if (!aLatestJob) return 1;
+    if (!bLatestJob) return -1;
+
+    // Sort by startedAt descending (newest first)
+    return bLatestJob.startedAt.getTime() - aLatestJob.startedAt.getTime();
   });
 }


### PR DESCRIPTION
# What does this PR do?
- Adds a new "Hired Agents" section to the sidebar alongside pinned agents
- Refactors the AgentsList component to handle multiple agent sections
- Introduces new database service functions for fetching favorite and hired agents
- Adds new translation strings for hired agents section

# Technical Details
- Created a reusable `AgentSection` component to reduce code duplication
- Added `getFavoriteAgents` and `getHiredAgentsWithJobs` service functions
- Hired agents are sorted by their most recent job's start date
- Updated English translations to support the new hired agents section

# Testing
Please verify:
- Both pinned and hired agents sections appear correctly in the sidebar
- Agents are properly sorted in the hired section by most recent job
- Empty state messages display correctly for both sections
- Navigation to agent job pages works as expected