### PR TITLE
refactor(job-input): change required to optional in validations

### DIFF
--- a/web-app/src/lib/job-input/__tests__/job-input.test.ts
+++ b/web-app/src/lib/job-input/__tests__/job-input.test.ts
@@ -9,7 +9,7 @@ describe("jobInputSchema", () => {
   describe("String input type", () => {
     const validStringInput = {
       id: "test-id",
-      type: ValidJobInputTypes.String,
+      type: ValidJobInputTypes.STRING,
       name: "Test String Input",
       data: {
         placeholder: "Enter text",
@@ -80,7 +80,7 @@ describe("jobInputSchema", () => {
   describe("Number input type", () => {
     const validNumberInput = {
       id: "number-id",
-      type: ValidJobInputTypes.Number,
+      type: ValidJobInputTypes.NUMBER,
       name: "Test Number Input",
       data: {
         placeholder: "Enter number",
@@ -126,7 +126,7 @@ describe("jobInputSchema", () => {
   describe("Boolean input type", () => {
     const validBooleanInput = {
       id: "boolean-id",
-      type: ValidJobInputTypes.Boolean,
+      type: ValidJobInputTypes.BOOLEAN,
       name: "Test Boolean Input",
       data: {
         description: "Test boolean description",
@@ -146,10 +146,10 @@ describe("jobInputSchema", () => {
       expect(result.success).toBe(true);
     });
 
-    it("should accept boolean input with required validation", () => {
+    it("should accept boolean input with optional validation", () => {
       const result = jobInputSchema(mockT).safeParse({
         ...validBooleanInput,
-        validations: [{ validation: "required" }],
+        validations: [{ validation: "optional" }],
       });
       expect(result.success).toBe(true);
     });
@@ -166,7 +166,7 @@ describe("jobInputSchema", () => {
   describe("Option input type", () => {
     const validOptionInput = {
       id: "option-id",
-      type: ValidJobInputTypes.Option,
+      type: ValidJobInputTypes.OPTION,
       name: "Test Option Input",
       data: {
         values: ["option1", "option2", "option3"],
@@ -213,7 +213,7 @@ describe("jobInputSchema", () => {
       const result = jobInputSchema(mockT).safeParse({
         ...validOptionInput,
         validations: [
-          { validation: "required", value: "false" },
+          { validation: "optional", value: "true" },
           { validation: "min", value: "2" },
           { validation: "max", value: "4" },
         ],
@@ -233,7 +233,7 @@ describe("jobInputSchema", () => {
   describe("None input type", () => {
     const validNoneInput = {
       id: "none-id",
-      type: ValidJobInputTypes.None,
+      type: ValidJobInputTypes.NONE,
       name: "Test None Input",
       data: {
         description: "Test none description",

--- a/web-app/src/lib/job-input/job-input.ts
+++ b/web-app/src/lib/job-input/job-input.ts
@@ -27,7 +27,7 @@ export const jobInputStringSchema = (
     id: z.string().min(1, {
       message: t?.("Id.required"),
     }),
-    type: z.enum([ValidJobInputTypes.String], {
+    type: z.enum([ValidJobInputTypes.STRING], {
       message: t?.("Type.enum", {
         options: Object.values(ValidJobInputTypes).join(", "),
       }),
@@ -60,7 +60,7 @@ export const jobInputNumberSchema = (
     id: z.string().min(1, {
       message: t?.("Id.required"),
     }),
-    type: z.enum([ValidJobInputTypes.Number], {
+    type: z.enum([ValidJobInputTypes.NUMBER], {
       message: t?.("Type.enum", {
         options: Object.values(ValidJobInputTypes).join(", "),
       }),
@@ -92,7 +92,7 @@ export const jobInputBooleanSchema = (
     id: z.string().min(1, {
       message: t?.("Id.required"),
     }),
-    type: z.enum([ValidJobInputTypes.Boolean], {
+    type: z.enum([ValidJobInputTypes.BOOLEAN], {
       message: t?.("Type.enum", {
         options: Object.values(ValidJobInputTypes).join(", "),
       }),
@@ -116,7 +116,7 @@ export const jobInputOptionSchema = (
     id: z.string().min(1, {
       message: t?.("Id.required"),
     }),
-    type: z.enum([ValidJobInputTypes.Option], {
+    type: z.enum([ValidJobInputTypes.OPTION], {
       message: t?.("Type.enum", {
         options: Object.values(ValidJobInputTypes).join(", "),
       }),
@@ -151,7 +151,7 @@ export const jobInputNoneSchema = (
     id: z.string().min(1, {
       message: t?.("Id.required"),
     }),
-    type: z.enum([ValidJobInputTypes.None], {
+    type: z.enum([ValidJobInputTypes.NONE], {
       message: t?.("Type.enum", {
         options: Object.values(ValidJobInputTypes).join(", "),
       }),

--- a/web-app/src/lib/job-input/type.ts
+++ b/web-app/src/lib/job-input/type.ts
@@ -1,22 +1,22 @@
 export enum ValidJobInputTypes {
-  String = "string",
-  Number = "number",
-  Boolean = "boolean",
-  Option = "option",
-  None = "none",
+  STRING = "string",
+  NUMBER = "number",
+  BOOLEAN = "boolean",
+  OPTION = "option",
+  NONE = "none",
 }
 export enum ValidJobInputValidationTypes {
-  Min = "min",
-  Max = "max",
-  Format = "format",
-  Required = "required",
+  MIN = "min",
+  MAX = "max",
+  FORMAT = "format",
+  OPTIONAL = "optional",
 }
 
 export enum ValidJobInputFormatValues {
-  Url = "url",
-  Email = "email",
-  Integer = "integer",
-  Nonempty = "nonempty",
+  URL = "url",
+  EMAIL = "email",
+  INTEGER = "integer",
+  NONEMPTY = "nonempty",
 }
 
 type JobInputType = ValidJobInputTypes;

--- a/web-app/src/lib/job-input/validation.ts
+++ b/web-app/src/lib/job-input/validation.ts
@@ -9,7 +9,7 @@ import {
 const formatNonEmptyValidationValueSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
-  z.enum([ValidJobInputFormatValues.Nonempty], {
+  z.enum([ValidJobInputFormatValues.NONEMPTY], {
     message: t?.("Validations.Value.enum", {
       options: Object.values(ValidJobInputFormatValues).join(", "),
       validation: "format",
@@ -19,7 +19,7 @@ const formatNonEmptyValidationValueSchema = (
 const formatUrlValidationValueSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
-  z.enum([ValidJobInputFormatValues.Url], {
+  z.enum([ValidJobInputFormatValues.URL], {
     message: t?.("Validations.Value.enum", {
       options: Object.values(ValidJobInputFormatValues).join(", "),
       validation: "format",
@@ -29,7 +29,7 @@ const formatUrlValidationValueSchema = (
 const formatEmailValidationValueSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
-  z.enum([ValidJobInputFormatValues.Email], {
+  z.enum([ValidJobInputFormatValues.EMAIL], {
     message: t?.("Validations.Value.enum", {
       options: Object.values(ValidJobInputFormatValues).join(", "),
       validation: "format",
@@ -39,7 +39,7 @@ const formatEmailValidationValueSchema = (
 const formatIntegerValidationValueSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
-  z.enum([ValidJobInputFormatValues.Integer], {
+  z.enum([ValidJobInputFormatValues.INTEGER], {
     message: t?.("Validations.Value.enum", {
       options: Object.values(ValidJobInputFormatValues).join(", "),
       validation: "format",
@@ -62,7 +62,7 @@ export const requiredValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Required], {
+    validation: z.enum([ValidJobInputValidationTypes.OPTIONAL], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),
@@ -74,7 +74,7 @@ export const minValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Min], {
+    validation: z.enum([ValidJobInputValidationTypes.MIN], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),
@@ -86,7 +86,7 @@ export const maxValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Max], {
+    validation: z.enum([ValidJobInputValidationTypes.MAX], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),
@@ -98,7 +98,7 @@ export const formatUrlValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Format], {
+    validation: z.enum([ValidJobInputValidationTypes.FORMAT], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),
@@ -110,7 +110,7 @@ export const formatEmailValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Format], {
+    validation: z.enum([ValidJobInputValidationTypes.FORMAT], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),
@@ -122,7 +122,7 @@ export const formatIntegerValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Format], {
+    validation: z.enum([ValidJobInputValidationTypes.FORMAT], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),
@@ -134,7 +134,7 @@ export const formatNonEmptyValidationSchema = (
   t?: IntlTranslation<JobInputSchemaIntlPath>,
 ) =>
   z.object({
-    validation: z.enum([ValidJobInputValidationTypes.Format], {
+    validation: z.enum([ValidJobInputValidationTypes.FORMAT], {
       message: t?.("Validations.Validation.enum", {
         options: Object.values(ValidJobInputValidationTypes).join(", "),
       }),


### PR DESCRIPTION
## Changes
- Standardized all enum values to use uppercase naming convention:
  - `ValidJobInputTypes` (e.g., `String` → `STRING`)
  - `ValidJobInputValidationTypes` (e.g., `Min` → `MIN`)
  - `ValidJobInputFormatValues` (e.g., `Url` → `URL`)
- Changed validation type from "required" to "optional" for better semantic clarity
- Updated corresponding test cases to reflect the validation type change

## Impact
This is a breaking change that standardizes our enum naming conventions and improves validation semantics. All enum values now follow uppercase naming convention for better consistency with TypeScript best practices.

## Testing
- All existing tests have been updated and pass
- Test cases properly validate the new enum values and validation types