### PR TITLE
fix(auth): update translation namespace for forgot password header

### DIFF
--- a/web-app/src/app/(landing)/(auth)/forgot-password/components/header.tsx
+++ b/web-app/src/app/(landing)/(auth)/forgot-password/components/header.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 
 export default function ForgotPasswordHeader() {
-  const t = useTranslations("LandingAuth.Pages.ForgotPassword.Header");
+  const t = useTranslations("Landing.Auth.Pages.ForgotPassword.Header");
 
   return (
     <div className="space-y-2 p-6">


### PR DESCRIPTION
### Changes
- Updates the translation namespace from "LandingAuth.Pages.ForgotPassword.Header" to "Landing.Auth.Pages.ForgotPassword.Header" in the forgot password header component

### Testing
- Verify that forgot password page translations are working correctly
- Ensure no translation keys are missing or showing placeholder text