### PR TITLE
refactor(jobs): migrate from dummy data to dynamic agent input schema

### DIFF
--- a/web-app/src/app/app/jobs/[agentId]/components/create-job-section.tsx
+++ b/web-app/src/app/app/jobs/[agentId]/components/create-job-section.tsx
@@ -4,15 +4,19 @@ import { useTranslations } from "next-intl";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { getCredits, getDescription } from "@/lib/db/extension/agent";
 import { AgentWithRelations } from "@/lib/db/services/agent.service";
+import { JobInputsDataSchemaType } from "@/lib/job-input";
 
 import { JobInputsForm } from "./job-input";
-import { dummyInputData } from "./job-input/data";
 
 interface CreateJobSectionProps {
   agent: AgentWithRelations;
+  inputSchema: JobInputsDataSchemaType;
 }
 
-export default function CreateJobSection({ agent }: CreateJobSectionProps) {
+export default function CreateJobSection({
+  agent,
+  inputSchema,
+}: CreateJobSectionProps) {
   const t = useTranslations("App.Jobs.CreateJob");
 
   const description = getDescription(agent);
@@ -42,10 +46,7 @@ export default function CreateJobSection({ agent }: CreateJobSectionProps) {
             <h1 className="text-xl font-bold">{t("Input.title")}</h1>
             <p className="text-base">{t("Input.description")}</p>
           </div>
-          <JobInputsForm
-            credits={credits}
-            jobInputsDataSchema={dummyInputData}
-          />
+          <JobInputsForm credits={credits} jobInputsDataSchema={inputSchema} />
         </div>
       </ScrollArea>
     </div>

--- a/web-app/src/app/app/jobs/[agentId]/components/right-section.tsx
+++ b/web-app/src/app/app/jobs/[agentId]/components/right-section.tsx
@@ -3,15 +3,20 @@
 import { useSearchParams } from "next/navigation";
 
 import { AgentWithRelations } from "@/lib/db/services/agent.service";
+import { JobInputsDataSchemaType } from "@/lib/job-input";
 
 import CreateJobSection from "./create-job-section";
 import JobDetailSection from "./job-detail-section";
 
 interface RightSectionProps {
   agent: AgentWithRelations;
+  inputSchema: JobInputsDataSchemaType;
 }
 
-export default function RightSection({ agent }: RightSectionProps) {
+export default function RightSection({
+  agent,
+  inputSchema,
+}: RightSectionProps) {
   const searchParams = useSearchParams();
   const jobId = searchParams.get("jobId") ?? "";
 
@@ -19,5 +24,5 @@ export default function RightSection({ agent }: RightSectionProps) {
     return <JobDetailSection agent={agent} />;
   }
 
-  return <CreateJobSection agent={agent} />;
+  return <CreateJobSection agent={agent} inputSchema={inputSchema} />;
 }

--- a/web-app/src/app/app/jobs/[agentId]/page.tsx
+++ b/web-app/src/app/app/jobs/[agentId]/page.tsx
@@ -5,7 +5,11 @@ import { notFound } from "next/navigation";
 
 import { requireAuthentication } from "@/lib/auth/utils";
 import { getDescription, getLegal, getName } from "@/lib/db/extension/agent";
-import { getAgentById, getAgents } from "@/lib/db/services/agent.service";
+import {
+  getAgentById,
+  getAgentInputSchema,
+  getAgents,
+} from "@/lib/db/services/agent.service";
 import { getJobsByAgentId } from "@/lib/db/services/job.service";
 
 import Footer from "./components/footer";
@@ -65,12 +69,14 @@ export default async function JobPage({
   const { session } = await requireAuthentication();
   const jobs = await getJobsByAgentId(agentId, session.user.id);
 
+  const inputSchema = await getAgentInputSchema(agentId);
+
   return (
     <div className="flex h-full flex-1 flex-col p-4 lg:p-6 xl:p-8">
       <Header agent={agent} />
       <div className="mt-6 flex flex-1 flex-col justify-center gap-4 lg:flex-row lg:overflow-hidden">
         <JobsTable jobs={jobs} />
-        <RightSection agent={agent} />
+        <RightSection agent={agent} inputSchema={inputSchema} />
       </div>
       <Footer legal={getLegal(agent)} />
     </div>

--- a/web-app/src/lib/db/mocks/input-schema.ts
+++ b/web-app/src/lib/db/mocks/input-schema.ts
@@ -5,7 +5,7 @@ import {
   ValidJobInputValidationTypes,
 } from "@/lib/job-input";
 
-export const dummyInputData: JobInputsDataSchemaType = {
+export const inputSchemaMock: JobInputsDataSchemaType = {
   input_data: [
     {
       id: "text",

--- a/web-app/src/lib/db/services/agent.service.ts
+++ b/web-app/src/lib/db/services/agent.service.ts
@@ -4,7 +4,7 @@ import { getPaymentInformation } from "@/lib/api/generated/registry";
 import { getRegistryClient } from "@/lib/api/registry-service.client";
 import { getApiBaseUrl } from "@/lib/db/extension/agent";
 import prisma from "@/lib/db/prisma";
-import { jobInputSchema } from "@/lib/job-input";
+import { jobInputsDataSchema } from "@/lib/job-input";
 
 import { getOrCreateFavoriteAgentList } from "./agentList.service";
 
@@ -95,7 +95,8 @@ export async function getAgentInputSchema(agentId: string) {
 
   const response = await fetch(inputSchemaUrl);
   const schema = await response.json();
-  const inputSchema = jobInputSchema(undefined).parse(schema);
+
+  const inputSchema = jobInputsDataSchema(undefined).parse(schema);
 
   return inputSchema;
 }

--- a/web-app/src/lib/db/services/agent.service.ts
+++ b/web-app/src/lib/db/services/agent.service.ts
@@ -3,8 +3,9 @@ import { Prisma } from "@prisma/client";
 import { getPaymentInformation } from "@/lib/api/generated/registry";
 import { getRegistryClient } from "@/lib/api/registry-service.client";
 import { getApiBaseUrl } from "@/lib/db/extension/agent";
+import { inputSchemaMock } from "@/lib/db/mocks/input-schema";
 import prisma from "@/lib/db/prisma";
-import { jobInputsDataSchema } from "@/lib/job-input";
+import { jobInputsDataSchema, JobInputsDataSchemaType } from "@/lib/job-input";
 
 import { getOrCreateFavoriteAgentList } from "./agentList.service";
 
@@ -83,7 +84,9 @@ export async function getHiredAgentsOrderedByLatestJob(userId: string) {
   });
 }
 
-export async function getAgentInputSchema(agentId: string) {
+export async function getAgentInputSchema(
+  agentId: string,
+): Promise<JobInputsDataSchemaType> {
   const agent = await getAgentById(agentId);
 
   if (!agent) {
@@ -93,12 +96,17 @@ export async function getAgentInputSchema(agentId: string) {
   const baseUrl = getApiBaseUrl(agent);
   const inputSchemaUrl = new URL(`/input_schema`, baseUrl);
 
-  const response = await fetch(inputSchemaUrl);
-  const schema = await response.json();
+  try {
+    const response = await fetch(inputSchemaUrl);
+    const schema = await response.json();
 
-  const inputSchema = jobInputsDataSchema(undefined).parse(schema);
+    const inputSchema = jobInputsDataSchema(undefined).parse(schema);
 
-  return inputSchema;
+    return inputSchema;
+  } catch (error) {
+    console.error("Error fetching agent input schema", error);
+    return inputSchemaMock;
+  }
 }
 
 export async function getAgentPricing(agentId: string) {


### PR DESCRIPTION
🔨 Implements dynamic job input schema fetching from agent API endpoints, replacing hardcoded dummy data.

Changes:
- ✨ Add `getAgentInputSchema` implementation to fetch schema from agent API
- 🔄 Update components to use dynamic schema instead of dummy data
- 🥅 Add error handling with fallback to mock schema
- ♻️ Refactor component props to properly type and pass input schema

This change improves the job creation flow by using real agent input schemas instead of static test data, making the system more dynamic and production-ready.

Missing:
- :fire: Error handling occurs if the `input_schema` cannot be loaded. For now, it is filled with a mock.