### PR TITLE
chore: add sizes props to image for optimization

### DIFF
--- a/web-app/src/app/(landing)/(auth)/components/heroes.tsx
+++ b/web-app/src/app/(landing)/(auth)/components/heroes.tsx
@@ -9,6 +9,7 @@ export default function Heroes() {
             src="/placeholder.svg"
             alt="Hero"
             fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             className="object-cover"
           />
         </div>

--- a/web-app/src/app/(landing)/agents/components/featured-agent.tsx
+++ b/web-app/src/app/(landing)/agents/components/featured-agent.tsx
@@ -71,6 +71,7 @@ export function FeaturedAgent({ agent }: FeaturedAgentProps) {
           src={getResolvedImage(agent)}
           alt={`${getName(agent)} image`}
           fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           className="rounded-lg object-cover"
           priority
         />

--- a/web-app/src/app/(landing)/components/how-it-works.tsx
+++ b/web-app/src/app/(landing)/components/how-it-works.tsx
@@ -26,6 +26,7 @@ export default function HowItWorks() {
                   src="/placeholder.svg"
                   alt={`${t(`Steps.${key}.title`)} illustration`}
                   fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                   className="object-cover"
                 />
               </div>

--- a/web-app/src/app/(landing)/components/join-our-community.tsx
+++ b/web-app/src/app/(landing)/components/join-our-community.tsx
@@ -15,6 +15,7 @@ export function JoinOurCommunity() {
               src="/placeholder.svg"
               alt="Community Placeholder"
               fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
               className="rounded-lg object-cover"
               priority
             />

--- a/web-app/src/app/(landing)/components/monetize-your-agent.tsx
+++ b/web-app/src/app/(landing)/components/monetize-your-agent.tsx
@@ -48,6 +48,7 @@ export function MonetizeYourAgent() {
               src="/placeholder.svg"
               alt="Community Placeholder"
               fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
               className="rounded-lg object-cover"
               priority
             />

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -95,6 +95,7 @@ function AgentCard({
           src={getResolvedImage(agent)}
           alt={`${getName(agent)} image`}
           fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           className="object-cover"
         />
       </div>

--- a/web-app/src/components/agents/agent-detail.tsx
+++ b/web-app/src/components/agents/agent-detail.tsx
@@ -111,6 +111,7 @@ function AgentDetails({
             src={getResolvedImage(agent)}
             alt={getName(agent)}
             fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             className="rounded-md object-cover"
             priority
           />


### PR DESCRIPTION
Added sizes to next.js Image tag for optimization.

When image uses `fill` property, without `sizes` next.js will assume the image width is 100vw and load unnecessarily big image

## Reference
https://nextjs.org/docs/pages/api-reference/components/image#sizes