### PR TITLE
fix(pnpm): hoist eslint and prettier modules, allow prisma script

### DIFF
--- a/job-cron-caller/pnpm-workspace.yaml
+++ b/job-cron-caller/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+publicHoistPattern:
+  - "*eslint*"
+  - "*prettier*"

--- a/registry-cron-caller/pnpm-workspace.yaml
+++ b/registry-cron-caller/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+publicHoistPattern:
+  - "*eslint*"
+  - "*prettier*"

--- a/web-app/pnpm-workspace.yaml
+++ b/web-app/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+publicHoistPattern:
+  - "*eslint*"
+  - "*prettier*"
+
+ignoredBuiltDependencies:
+  - "@prisma/engines"
+  - "@swc/core"
+  - esbuild
+  - prisma
+  - sharp
+
+onlyBuiltDependencies:
+  - "@prisma/client"


### PR DESCRIPTION
## What does this PR do?

This PR hoists `prettier` and `eslint` modules to root module directory, so it is possible to import them (even they are hidden modules)

Allow `@prisma/client`'s post install script to run using `onlyBuiltDependencies`

## Why this is needed

Since pnpm uses strict module resolution (each package is isolated, they don't see each other)
That is why some modules couldn't load `eslint` and `prettier` related packages (they are hidden, not defined in package.json)

## Reference

https://pnpm.io/settings#publichoistpattern

https://pnpm.io/settings#onlybuiltdependencies