### PR TITLE
chore(deps): update pnpm version to 10.8.0

### DIFF
--- a/job-cron-caller/package.json
+++ b/job-cron-caller/package.json
@@ -3,18 +3,16 @@
   "version": "1.0.0",
   "description": "DigitalOcean Function to call an API on a schedule",
   "main": "packages/job-sync/main/main.js",
-  "packageManager": "pnpm@10.7.1",
+  "packageManager": "pnpm@10.8.0",
   "scripts": {
     "build": "tsc",
     "deploy": "doctl serverless deploy .",
     "lint": "eslint src",
     "format": "prettier --write src"
   },
-  "dependencies": {},
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",
     "@types/node": "^18.19.86",
-    "typescript": "^5.8.3",
     "eslint": "^9.24.0",
     "eslint-config-next": "^15.2.4",
     "eslint-config-prettier": "^10.1.1",
@@ -22,6 +20,7 @@
     "eslint-plugin-prettier": "^5.2.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
-
 {
-    "name": "sokosumi",
-    "private": true,
-    "type": "module",
-    "packageManager": "pnpm@10.7.1",
-    "workspaces": [],
-    "scripts": {
-      "prepare": "husky"
-    },
-    "devDependencies": {
-      "@types/node": "^22.14.0",
-      "husky": "^9.1.7"
-    }
+  "name": "sokosumi",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.8.0",
+  "workspaces": [],
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "husky": "^9.1.7"
   }
+}

--- a/registry-cron-caller/package.json
+++ b/registry-cron-caller/package.json
@@ -3,18 +3,16 @@
   "version": "1.0.0",
   "description": "DigitalOcean Function to call an API on a schedule",
   "main": "packages/registry-sync/main/main.js",
-  "packageManager": "pnpm@10.7.1",
+  "packageManager": "pnpm@10.8.0",
   "scripts": {
     "build": "tsc",
     "deploy": "doctl serverless deploy .",
     "lint": "eslint src",
     "format": "prettier --write src"
   },
-  "dependencies": {},
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",
     "@types/node": "^18.19.86",
-    "typescript": "^5.8.3",
     "eslint": "^9.24.0",
     "eslint-config-next": "^15.2.4",
     "eslint-config-prettier": "^10.1.1",
@@ -22,6 +20,7 @@
     "eslint-plugin-prettier": "^5.2.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.3"
   }
 }

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sokosumi-web",
   "version": "0.1.0",
-  "packageManager": "pnpm@10.7.1",
+  "packageManager": "pnpm@10.8.0",
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=10.7.1"
@@ -29,6 +29,7 @@
     "generate:api": "pnpm run generate:registry && pnpm run generate:payment"
   },
   "dependencies": {
+    "@better-auth/utils": "^0.2.4",
     "@hey-api/client-fetch": "^0.10.0",
     "@hey-api/client-next": "^0.3.0",
     "@hookform/resolvers": "^5.0.1",
@@ -49,7 +50,6 @@
     "@tanstack/react-table": "^8.21.2",
     "@tufjs/canonical-json": "^2.0.0",
     "better-auth": "^1.2.5",
-    "@better-auth/utils": "^0.2.4",
     "better-auth-harmony": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Updates the `packageManager` field across all `package.json` files to `pnpm@10.8.0` for consistent dependency management tooling.

This also includes minor dependency list formatting and cleanup in `job-cron-caller`, `registry-cron-caller`, and `web-app` packages.