### PR TITLE
refactor(db): centralize types and standardize credit handling

### DIFF
--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -6,7 +6,7 @@ import {
 import crypto from "crypto";
 
 import { getEnvSecrets } from "@/config/env.config";
-import { convertCreditsToBaseUnits } from "@/lib/db/services/credit.service";
+import { convertCreditsToBaseUnits } from "@/lib/db/utils/credit.utils";
 
 import { hashPassword } from "./util/password";
 
@@ -54,7 +54,7 @@ const seedUser = async (): Promise<string> => {
 
   const creditTransaction = await prisma.creditTransaction.create({
     data: {
-      amount: await convertCreditsToBaseUnits(1000.5123),
+      amount: convertCreditsToBaseUnits(1000.5123),
       type: CreditTransactionType.TOP_UP,
       userId: user.id,
       includedFee: 0,

--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -54,7 +54,7 @@ const seedUser = async (): Promise<string> => {
 
   const creditTransaction = await prisma.creditTransaction.create({
     data: {
-      amount: convertCreditsToBaseUnits(1000.5123),
+      amount: await convertCreditsToBaseUnits(1000.5123),
       type: CreditTransactionType.TOP_UP,
       userId: user.id,
       includedFee: 0,

--- a/web-app/src/app/(landing)/agents/components/featured-agent.tsx
+++ b/web-app/src/app/(landing)/agents/components/featured-agent.tsx
@@ -11,7 +11,7 @@ import {
   getResolvedImage,
   getTags,
 } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 export function FeaturedAgentSkeleton() {
   return (

--- a/web-app/src/app/(landing)/agents/page.tsx
+++ b/web-app/src/app/(landing)/agents/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { Agents, AgentsNotAvailable } from "@/components/agents";
-import { AgentWithRelations, getAgents } from "@/lib/db/services/agent.service";
+import { getAgents } from "@/lib/db/services/agent.service";
 import { calculateAgentHumandReadableCreditCost } from "@/lib/db/services/credit.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 import { FeaturedAgent } from "./components/featured-agent";
 

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { getDescription } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 import { JobInputsDataSchemaType } from "@/lib/job-input";
 
 import { JobInputsForm } from "./job-input";

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/header.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/header.tsx
@@ -7,8 +7,8 @@ import { AgentBookmarkButton } from "@/components/agents/agent-bookmark-button";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getName } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
 import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 interface HeaderProps {
   agent: AgentWithRelations;

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/header.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/header.tsx
@@ -7,8 +7,8 @@ import { AgentBookmarkButton } from "@/components/agents/agent-bookmark-button";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getName } from "@/lib/db/extension/agent";
-import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
 import { AgentWithRelations } from "@/lib/db/types/agent.types";
+import { AgentListWithAgent } from "@/lib/db/types/agentList.types";
 
 interface HeaderProps {
   agent: AgentWithRelations;

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-columns.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-columns.tsx
@@ -2,7 +2,7 @@ import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useFormatter, useTranslations } from "next-intl";
 
 import { DataTableColumnHeader } from "@/components/data-table";
-import { JobWithRelations } from "@/lib/db/services/job.service";
+import { JobWithRelations } from "@/lib/db/types/job.types";
 
 import JobStatusBadge from "./job-status-badge";
 

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-detail-section.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-detail-section.tsx
@@ -1,5 +1,5 @@
 import { getDescription } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 interface JobDetailSectionProps {
   agent: AgentWithRelations;

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details.tsx
@@ -3,7 +3,7 @@ import { useFormatter, useTranslations } from "next-intl";
 import Markdown from "react-markdown";
 
 import JobStatusBadge from "@/app/agents/[agentId]/jobs/@right/components/job-status-badge";
-import { JobWithRelations } from "@/lib/db/services/job.service";
+import { JobWithRelations } from "@/lib/db/types/job.types";
 import { cn } from "@/lib/utils";
 
 interface JobDetailsProps {

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/jobs-table.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/jobs-table.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
 
 import { DataTable } from "@/components/data-table";
-import { JobWithRelations } from "@/lib/db/services/job.service";
+import { JobWithRelations } from "@/lib/db/types/job.types";
 import { cn } from "@/lib/utils";
 
 import { getJobColumns } from "./job-columns";

--- a/web-app/src/app/app/agents/components/filtered-agents.tsx
+++ b/web-app/src/app/app/agents/components/filtered-agents.tsx
@@ -9,8 +9,8 @@ import {
   AgentsNotFound,
 } from "@/components/agents";
 import { getTags } from "@/lib/db/extension/agent";
-import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
 import { AgentWithRelations } from "@/lib/db/types/agent.types";
+import { AgentListWithAgent } from "@/lib/db/types/agentList.types";
 
 import { FilterState } from "./use-gallery-filter";
 

--- a/web-app/src/app/app/agents/components/filtered-agents.tsx
+++ b/web-app/src/app/app/agents/components/filtered-agents.tsx
@@ -9,8 +9,8 @@ import {
   AgentsNotFound,
 } from "@/components/agents";
 import { getTags } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
 import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 import { FilterState } from "./use-gallery-filter";
 

--- a/web-app/src/app/app/agents/page.tsx
+++ b/web-app/src/app/app/agents/page.tsx
@@ -6,7 +6,7 @@ import { requireAuthentication } from "@/lib/auth/utils";
 import { getAgents } from "@/lib/db/services/agent.service";
 import { getOrCreateFavoriteAgentList } from "@/lib/db/services/agentList.service";
 import { calculateAgentHumandReadableCreditCost } from "@/lib/db/services/credit.service";
-import { getCachedTags } from "@/lib/db/services/tag.service";
+import { getTags } from "@/lib/db/services/tag.service";
 import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 import FilterSection from "./components/filter-section";
@@ -23,7 +23,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function GalleryPage() {
   const agents: AgentWithRelations[] = await getAgents();
-  const tags: Tag[] = await getCachedTags();
+  const tags: Tag[] = await getTags();
   const tagNames = tags.map((tag) => tag.name);
 
   const { session } = await requireAuthentication();

--- a/web-app/src/app/app/agents/page.tsx
+++ b/web-app/src/app/app/agents/page.tsx
@@ -3,10 +3,11 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { requireAuthentication } from "@/lib/auth/utils";
-import { AgentWithRelations, getAgents } from "@/lib/db/services/agent.service";
+import { getAgents } from "@/lib/db/services/agent.service";
 import { getOrCreateFavoriteAgentList } from "@/lib/db/services/agentList.service";
 import { calculateAgentHumandReadableCreditCost } from "@/lib/db/services/credit.service";
 import { getCachedTags } from "@/lib/db/services/tag.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 import FilterSection from "./components/filter-section";
 import FilteredAgents from "./components/filtered-agents";

--- a/web-app/src/app/app/components/user-credits.tsx
+++ b/web-app/src/app/app/components/user-credits.tsx
@@ -2,7 +2,8 @@ import { headers } from "next/headers";
 import { getTranslations } from "next-intl/server";
 
 import { auth } from "@/lib/auth/auth";
-import { getUserById, getUserCredits } from "@/lib/db/services/user.service";
+import { getHumandReadableCreditBalance } from "@/lib/db/services/credit.service";
+import { getUserById } from "@/lib/db/services/user.service";
 import { cn } from "@/lib/utils";
 
 export default async function UserCredits({
@@ -20,7 +21,7 @@ export default async function UserCredits({
   }
 
   const user = await getUserById(session.user.id);
-  const credits = await getUserCredits(session.user.id);
+  const credits = await getHumandReadableCreditBalance(session.user.id);
 
   if (!user) {
     return <div className={cn(className)}>{t("unavailable")}</div>;

--- a/web-app/src/components/agents/agent-bookmark-button.tsx
+++ b/web-app/src/components/agents/agent-bookmark-button.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { toggleAgentInList } from "@/lib/actions/agent.actions";
-import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
+import { AgentListWithAgent } from "@/lib/db/types/agentList.types";
 import { cn } from "@/lib/utils";
 
 interface AgentBookmarkButtonProps {

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -10,8 +10,8 @@ import {
   getResolvedImage,
   getTags,
 } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
 import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 import { cn } from "@/lib/utils";
 
 import { AgentBookmarkButton } from "./agent-bookmark-button";

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -10,8 +10,8 @@ import {
   getResolvedImage,
   getTags,
 } from "@/lib/db/extension/agent";
-import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
 import { AgentWithRelations } from "@/lib/db/types/agent.types";
+import { AgentListWithAgent } from "@/lib/db/types/agentList.types";
 import { cn } from "@/lib/utils";
 
 import { AgentBookmarkButton } from "./agent-bookmark-button";

--- a/web-app/src/components/agents/agent-detail.tsx
+++ b/web-app/src/components/agents/agent-detail.tsx
@@ -14,8 +14,8 @@ import {
   getResolvedImage,
   getTags,
 } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
 import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 import { cn } from "@/lib/utils";
 
 import { AgentBookmarkButton } from "./agent-bookmark-button";

--- a/web-app/src/components/agents/agent-detail.tsx
+++ b/web-app/src/components/agents/agent-detail.tsx
@@ -14,8 +14,8 @@ import {
   getResolvedImage,
   getTags,
 } from "@/lib/db/extension/agent";
-import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
 import { AgentWithRelations } from "@/lib/db/types/agent.types";
+import { AgentListWithAgent } from "@/lib/db/types/agentList.types";
 import { cn } from "@/lib/utils";
 
 import { AgentBookmarkButton } from "./agent-bookmark-button";

--- a/web-app/src/components/agents/agents.tsx
+++ b/web-app/src/components/agents/agents.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
 import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 import { cn } from "@/lib/utils";
 
 import { AgentCard, AgentCardSkeleton } from "./agent-card";

--- a/web-app/src/components/agents/agents.tsx
+++ b/web-app/src/components/agents/agents.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 
-import { AgentListWithAgent } from "@/lib/db/services/agentList.service";
 import { AgentWithRelations } from "@/lib/db/types/agent.types";
+import { AgentListWithAgent } from "@/lib/db/types/agentList.types";
 import { cn } from "@/lib/utils";
 
 import { AgentCard, AgentCardSkeleton } from "./agent-card";

--- a/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
+++ b/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
@@ -13,7 +13,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { getName } from "@/lib/db/extension/agent";
-import { AgentWithRelations } from "@/lib/db/services/agent.service";
+import { AgentWithRelations } from "@/lib/db/types/agent.types";
 
 interface BreadcrumbSegment {
   label: string;

--- a/web-app/src/lib/actions/job.actions.ts
+++ b/web-app/src/lib/actions/job.actions.ts
@@ -50,7 +50,7 @@ export async function startJobWithInputData(input: StartJobInput): Promise<{
   const job = await startJob(
     session.user.id,
     data.agentId,
-    BigInt(convertCreditsToBaseUnits(data.maxAcceptedCreditCost)),
+    await convertCreditsToBaseUnits(data.maxAcceptedCreditCost),
     inputMap,
   );
 

--- a/web-app/src/lib/actions/job.actions.ts
+++ b/web-app/src/lib/actions/job.actions.ts
@@ -4,8 +4,8 @@ import { headers } from "next/headers";
 import { z } from "zod";
 
 import { auth } from "@/lib/auth/auth";
-import { convertCreditsToBaseUnits } from "@/lib/db/services/credit.service";
 import { startJob } from "@/lib/db/services/job.service";
+import { convertCreditsToBaseUnits } from "@/lib/db/utils/credit.utils";
 
 const startJobInputSchema = z.object({
   agentId: z.string(),
@@ -50,7 +50,7 @@ export async function startJobWithInputData(input: StartJobInput): Promise<{
   const job = await startJob(
     session.user.id,
     data.agentId,
-    await convertCreditsToBaseUnits(data.maxAcceptedCreditCost),
+    convertCreditsToBaseUnits(data.maxAcceptedCreditCost),
     inputMap,
   );
 

--- a/web-app/src/lib/db/services/agent.service.ts
+++ b/web-app/src/lib/db/services/agent.service.ts
@@ -1,33 +1,13 @@
-import { Prisma } from "@prisma/client";
-
+"use server";
 import { getPaymentInformation } from "@/lib/api/generated/registry";
 import { getRegistryClient } from "@/lib/api/registry-service.client";
 import { getApiBaseUrl } from "@/lib/db/extension/agent";
 import { inputSchemaMock } from "@/lib/db/mocks/input-schema";
 import prisma from "@/lib/db/prisma";
+import { agentInclude, AgentWithRelations } from "@/lib/db/types/agent.types";
 import { jobInputsDataSchema, JobInputsDataSchemaType } from "@/lib/job-input";
 
 import { getOrCreateFavoriteAgentList } from "./agentList.service";
-
-const agentPricingInclude = {
-  pricing: {
-    include: { fixedPricing: { include: { amounts: true } } },
-  },
-} as const;
-
-export const agentInclude = {
-  ...agentPricingInclude,
-  exampleOutput: true,
-  overrideExampleOutput: true,
-  tags: true,
-  overrideTags: true,
-  rating: true,
-  userAgentRating: true,
-} as const;
-
-export type AgentWithRelations = Prisma.AgentGetPayload<{
-  include: typeof agentInclude;
-}>;
 
 export async function getAgents(): Promise<AgentWithRelations[]> {
   return await prisma.agent.findMany({

--- a/web-app/src/lib/db/services/agentList.service.ts
+++ b/web-app/src/lib/db/services/agentList.service.ts
@@ -1,14 +1,11 @@
-import { AgentList, AgentListType, Prisma } from "@prisma/client";
+"use server";
+import { AgentList, AgentListType } from "@prisma/client";
 
 import prisma from "@/lib/db/prisma";
-
-const agentListInclude = {
-  agents: true,
-} as const;
-
-export type AgentListWithAgent = Prisma.AgentListGetPayload<{
-  include: typeof agentListInclude;
-}>;
+import {
+  agentListInclude,
+  AgentListWithAgent,
+} from "@/lib/db/types/agentList.types";
 
 export async function getAgentLists(
   userId: string,

--- a/web-app/src/lib/db/services/credit.service.ts
+++ b/web-app/src/lib/db/services/credit.service.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { getEnvPublicConfig } from "@/config/env.config";
 import { AgentWithFixedPricing } from "@/lib/db/extension/agent";
 import prisma from "@/lib/db/prisma";
+import { convertBaseUnitsToCredits } from "@/lib/db/utils/credit.utils";
 
 export async function getHumandReadableCreditBalance(
   userId: string,
@@ -131,16 +132,4 @@ export async function calculateCreditCost(
     totalCreditCost += BigInt(Math.ceil(totalCost));
   }
   return totalCreditCost;
-}
-
-export async function convertBaseUnitsToCredits(
-  credits: bigint,
-): Promise<number> {
-  return Number(credits) / 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE;
-}
-
-export async function convertCreditsToBaseUnits(
-  credits: number,
-): Promise<bigint> {
-  return BigInt(credits * 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE);
 }

--- a/web-app/src/lib/db/services/credit.service.ts
+++ b/web-app/src/lib/db/services/credit.service.ts
@@ -1,3 +1,4 @@
+"use server";
 import { CreditTransactionStatus, CreditTransactionType } from "@prisma/client";
 import { z } from "zod";
 
@@ -127,10 +128,14 @@ export async function calculateCreditCost(
   return totalCreditCost;
 }
 
-export function formatCreditsForDisplay(credits: bigint): number {
+export async function formatCreditsForDisplay(
+  credits: bigint,
+): Promise<number> {
   return Number(credits) / 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE;
 }
 
-export function convertCreditsToBaseUnits(credits: number): bigint {
+export async function convertCreditsToBaseUnits(
+  credits: number,
+): Promise<bigint> {
   return BigInt(credits * 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE);
 }

--- a/web-app/src/lib/db/services/credit.service.ts
+++ b/web-app/src/lib/db/services/credit.service.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { CreditTransactionStatus, CreditTransactionType } from "@prisma/client";
 import { z } from "zod";
 
@@ -6,7 +7,9 @@ import { getEnvPublicConfig } from "@/config/env.config";
 import { AgentWithFixedPricing } from "@/lib/db/extension/agent";
 import prisma from "@/lib/db/prisma";
 
-export async function getCreditBalance(userId: string): Promise<number> {
+export async function getHumandReadableCreditBalance(
+  userId: string,
+): Promise<number> {
   const creditBalance = await prisma.creditTransaction.aggregate({
     where: { userId },
     _sum: {
@@ -14,7 +17,9 @@ export async function getCreditBalance(userId: string): Promise<number> {
     },
   });
 
-  return Number(creditBalance._sum.amount ?? 0);
+  return await convertBaseUnitsToCredits(
+    creditBalance._sum.amount ?? BigInt(0),
+  );
 }
 
 export async function creditTransactionSpend(
@@ -88,13 +93,13 @@ export async function calculateAgentHumandReadableCreditCost(
     return 0.0;
   }
   const creditCost = await calculateCreditCost(amounts);
-  return formatCreditsForDisplay(creditCost);
+  return convertBaseUnitsToCredits(creditCost);
 }
 
 /**
  * Calculate the credit cost for a job
  * @param amounts - The amounts to calculate the credit cost for
- * @returns The credit cost for the job
+ * @returns The credit cost for the job in base units
  * @throws Error if credit cost for a unit is not found or if fee percentage is negative
  */
 export async function calculateCreditCost(
@@ -128,7 +133,7 @@ export async function calculateCreditCost(
   return totalCreditCost;
 }
 
-export async function formatCreditsForDisplay(
+export async function convertBaseUnitsToCredits(
   credits: bigint,
 ): Promise<number> {
   return Number(credits) / 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE;

--- a/web-app/src/lib/db/services/job.service.ts
+++ b/web-app/src/lib/db/services/job.service.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { CreditTransactionType, Job } from "@prisma/client";
 import { z } from "zod";
 

--- a/web-app/src/lib/db/services/job.service.ts
+++ b/web-app/src/lib/db/services/job.service.ts
@@ -1,4 +1,4 @@
-import { CreditTransactionType, Job, Prisma } from "@prisma/client";
+import { CreditTransactionType, Job } from "@prisma/client";
 import { z } from "zod";
 
 import { getEnvPublicConfig } from "@/config/env.config";
@@ -6,6 +6,11 @@ import { getPurchase, postPurchase } from "@/lib/api/generated/payment";
 import { getPaymentClient } from "@/lib/api/payment-service.client";
 import { getApiBaseUrl } from "@/lib/db/extension/agent";
 import prisma from "@/lib/db/prisma";
+import {
+  jobInclude,
+  jobOrderBy,
+  JobWithRelations,
+} from "@/lib/db/types/job.types";
 import { calculatedInputHash } from "@/lib/utils";
 
 import { getAgentById, getAgentPricing } from "./agent.service";
@@ -183,19 +188,6 @@ export async function startJob(
     throw new Error("Failed to create job", { cause: error });
   }
 }
-
-const jobInclude = {
-  agent: true,
-  user: true,
-} as const;
-
-const jobOrderBy = {
-  createdAt: "desc",
-} as const;
-
-export type JobWithRelations = Prisma.JobGetPayload<{
-  include: typeof jobInclude;
-}>;
 
 /**
  * Retrieves all jobs associated with a specific agent and user

--- a/web-app/src/lib/db/services/tag.service.ts
+++ b/web-app/src/lib/db/services/tag.service.ts
@@ -1,18 +1,7 @@
+"use server";
 import { Tag } from "@prisma/client";
-import { unstable_cache } from "next/cache";
 
 import prisma from "@/lib/db/prisma";
-
-export const getCachedTags = unstable_cache(
-  async (): Promise<Tag[]> => {
-    return await getTags();
-  },
-  ["tags"],
-  {
-    revalidate: 3600,
-    tags: ["tags"],
-  },
-);
 
 export async function getTags(): Promise<Tag[]> {
   const tags = await prisma.tag.findMany({

--- a/web-app/src/lib/db/services/user.service.ts
+++ b/web-app/src/lib/db/services/user.service.ts
@@ -1,8 +1,8 @@
+"use server";
+
 import { User } from "@prisma/client";
 
 import prisma from "@/lib/db/prisma";
-
-import { formatCreditsForDisplay } from "./credit.service";
 
 export async function getUserByEmail(email: string): Promise<User | null> {
   return await prisma.user.findUnique({
@@ -14,16 +14,4 @@ export async function getUserById(id: string): Promise<User | null> {
   return await prisma.user.findUnique({
     where: { id },
   });
-}
-
-export async function getUserCredits(id: string): Promise<number> {
-  const result = await prisma.creditTransaction.aggregate({
-    where: {
-      userId: id,
-    },
-    _sum: {
-      amount: true,
-    },
-  });
-  return formatCreditsForDisplay(result._sum.amount ?? BigInt(0));
 }

--- a/web-app/src/lib/db/types/agent.types.ts
+++ b/web-app/src/lib/db/types/agent.types.ts
@@ -1,0 +1,21 @@
+import { Prisma } from "@prisma/client";
+
+export const agentPricingInclude = {
+  pricing: {
+    include: { fixedPricing: { include: { amounts: true } } },
+  },
+} as const;
+
+export const agentInclude = {
+  ...agentPricingInclude,
+  exampleOutput: true,
+  overrideExampleOutput: true,
+  tags: true,
+  overrideTags: true,
+  rating: true,
+  userAgentRating: true,
+} as const;
+
+export type AgentWithRelations = Prisma.AgentGetPayload<{
+  include: typeof agentInclude;
+}>;

--- a/web-app/src/lib/db/types/agentList.types.ts
+++ b/web-app/src/lib/db/types/agentList.types.ts
@@ -1,0 +1,9 @@
+import { Prisma } from "@prisma/client";
+
+export const agentListInclude = {
+  agents: true,
+} as const;
+
+export type AgentListWithAgent = Prisma.AgentListGetPayload<{
+  include: typeof agentListInclude;
+}>;

--- a/web-app/src/lib/db/types/job.types.ts
+++ b/web-app/src/lib/db/types/job.types.ts
@@ -1,0 +1,14 @@
+import { Prisma } from "@prisma/client";
+
+export const jobInclude = {
+  agent: true,
+  user: true,
+} as const;
+
+export const jobOrderBy = {
+  createdAt: "desc",
+} as const;
+
+export type JobWithRelations = Prisma.JobGetPayload<{
+  include: typeof jobInclude;
+}>;

--- a/web-app/src/lib/db/utils/credit.utils.ts
+++ b/web-app/src/lib/db/utils/credit.utils.ts
@@ -1,0 +1,9 @@
+import { getEnvPublicConfig } from "@/config/env.config";
+
+export function convertBaseUnitsToCredits(credits: bigint): number {
+  return Number(credits) / 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE;
+}
+
+export function convertCreditsToBaseUnits(credits: number): bigint {
+  return BigInt(credits * 10 ** getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BASE);
+}


### PR DESCRIPTION
This pull request refactors database services and related type definitions for improved organization and consistency.

**Key Changes:**

1.  **Centralized Prisma Types:**
    *   Moved Prisma `include` objects and generated types (e.g., `AgentWithRelations`, `JobWithRelations`, `AgentListWithAgent`) from service files (`*.service.ts`) into dedicated files under `src/lib/db/types/`.
    *   Updated imports across the codebase to use the new type locations.

2.  **Standardized Credit Handling:**
    *   Renamed `getCreditBalance` to `getHumandReadableCreditBalance` for better clarity.
    *   Modified credit-related functions in `credit.service.ts` to consistently work with and return human-readable credit amounts (numbers) instead of base units (bigint).
    *   Made credit conversion functions (`convertBaseUnitsToCredits`, `convertCreditsToBaseUnits`) asynchronous and updated call sites (`seed.ts`, `job.actions.ts`) to use `await`.
    *   Removed the `getUserCredits` function from `user.service.ts` as its functionality is covered by `getHumandReadableCreditBalance`.

3.  **Server Actions:**
    *   Added the `"use server";` directive to all database service files (`src/lib/db/services/**/*.ts`) to explicitly mark them as Server Actions.

4.  **Tag Caching:**
    *   Removed the `unstable_cache` implementation (`getCachedTags`) from `tag.service.ts`, simplifying tag fetching.

**Benefits:**

*   Improves code structure and maintainability by colocating related database types.
*   Enhances clarity by standardizing the representation of credit values.
*   Explicitly declares service modules intended for server-side execution.
*   Simplifies data fetching logic for tags.

**References:**
I noticed that while working on #304. I moved the changes out of the other pull request, because it's unrelated.