### PR TITLE
fix: update option input values as index number

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -576,7 +576,8 @@
             "value": {
               "required": "Option is required"
             },
-            "min": "Must have at least 1 option"
+            "min": "Must have at least 1 option",
+            "unique": "Option values must be unique"
           }
         },
         "Validations": {

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -617,9 +617,11 @@
         },
         "Option": {
           "required": "{name} is required",
-          "invalid": "{name} must be one of {options}",
           "min": "{name} must have at least {value, plural, =1 {1 option} other {# options}}",
-          "max": "{name} must have at most {value, plural, =1 {1 option} other {# options}}"
+          "max": "{name} must have at most {value, plural, =1 {1 option} other {# options}}",
+          "integer": "{name} option value must be an index",
+          "nonnegative": "{name} option value must be non negative index",
+          "invalid": "{name} option value must be index from 0 to {maxValue}"
         }
       },
       "Error": {

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-input.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-input.tsx
@@ -103,8 +103,8 @@ function InputField({ field, jobInputSchema }: InputFieldProps) {
     if (isSingle) {
       return (
         <Select
-          value={Array.isArray(field.value) ? field.value[0] : ""}
-          onValueChange={(value) => field.onChange([value])}
+          value={Array.isArray(field.value) ? values[field.value[0]] : ""}
+          onValueChange={(value) => field.onChange([values.indexOf(value)])}
         >
           <SelectTrigger className="w-full">
             <SelectValue />
@@ -125,8 +125,18 @@ function InputField({ field, jobInputSchema }: InputFieldProps) {
       return (
         <MultipleSelect
           name={name}
-          value={Array.isArray(field.value) ? field.value : []}
-          onChange={field.onChange}
+          value={
+            Array.isArray(field.value)
+              ? field.value.map((index) => values[index])
+              : []
+          }
+          onChange={(optionValues) =>
+            field.onChange(
+              optionValues
+                .map((optionValue) => values.indexOf(optionValue))
+                .sort(),
+            )
+          }
           options={values}
           className="w-full"
         />

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-inputs-form.client.tsx
@@ -28,33 +28,12 @@ interface JobInputsFormClientProps {
   className?: string | undefined;
 }
 
-function transformFormData(values: JobInputsFormSchemaType) {
-  return Object.entries(values).reduce(
-    (acc, [key, value]) => {
-      if (value === null) return acc;
-
-      if (
-        Array.isArray(value) &&
-        value.every((item) => typeof item === "string")
-      ) {
-        const numArray = value.map((v) => Number(v)).filter((n) => !isNaN(n));
-        if (numArray.length === value.length) {
-          acc[key] = numArray;
-          return acc;
-        }
-      }
-
-      if (
-        typeof value === "string" ||
-        typeof value === "number" ||
-        typeof value === "boolean"
-      ) {
-        acc[key] = value;
-      }
-
-      return acc;
-    },
-    {} as Record<string, string | number | boolean | number[]>,
+function filterOutNullValues(values: JobInputsFormSchemaType) {
+  return Object.fromEntries(
+    Object.entries(values).filter(([_, value]) => value !== null) as [
+      string,
+      string | number | boolean | number[],
+    ][],
   );
 }
 
@@ -80,7 +59,7 @@ export default function JobInputsFormClient({
     try {
       // Transform input data to match expected type
       // Filter out null values and ensure arrays are of correct type
-      const transformedInputData = transformFormData(values);
+      const transformedInputData = filterOutNullValues(values);
       const result = await startJobWithInputData({
         agentId: agentId,
         maxAcceptedCreditCost: agentPricing,

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-inputs-form.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-inputs-form.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 
 import DefaultErrorBoundary from "@/components/default-error-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getAgentInputSchema } from "@/lib/db/services/agent.service";
+import { inputSchemaMock } from "@/lib/db/mocks/input-schema";
 
 import JobInputsFormClient from "./job-inputs-form.client";
 
@@ -36,7 +36,8 @@ async function JobInputsFormInner({
   agentPricing,
   className,
 }: JobInputsFormProps) {
-  const inputSchema = await getAgentInputSchema(agentId);
+  // const inputSchema = await getAgentInputSchema(agentId);
+  const inputSchema = inputSchemaMock;
 
   return (
     <JobInputsFormClient

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-inputs-form.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-input/job-inputs-form.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 
 import DefaultErrorBoundary from "@/components/default-error-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
-import { inputSchemaMock } from "@/lib/db/mocks/input-schema";
+import { getAgentInputSchema } from "@/lib/db/services/agent.service";
 
 import JobInputsFormClient from "./job-inputs-form.client";
 
@@ -36,8 +36,7 @@ async function JobInputsFormInner({
   agentPricing,
   className,
 }: JobInputsFormProps) {
-  // const inputSchema = await getAgentInputSchema(agentId);
-  const inputSchema = inputSchemaMock;
+  const inputSchema = await getAgentInputSchema(agentId);
 
   return (
     <JobInputsFormClient

--- a/web-app/src/lib/job-input/form-schema.ts
+++ b/web-app/src/lib/job-input/form-schema.ts
@@ -147,9 +147,17 @@ const makeZodSchemaFromJobInputOptionSchema = (
     validations,
   } = jobInputOptionSchema;
   const defaultSchema = z.array(
-    z.string().refine((val) => values.includes(val), {
-      message: t?.("Option.invalid", { name, options: values.join(", ") }),
-    }),
+    z
+      .number()
+      .int({
+        message: t?.("Option.integer", { name }),
+      })
+      .nonnegative({
+        message: t?.("Option.nonnegative", { name }),
+      })
+      .max(values.length - 1, {
+        message: t?.("Option.invalid", { name, maxValue: values.length - 1 }),
+      }),
     { message: t?.("Option.required", { name }) },
   );
   if (!validations) return defaultSchema;

--- a/web-app/src/lib/job-input/job-input.ts
+++ b/web-app/src/lib/job-input/job-input.ts
@@ -153,7 +153,10 @@ export const jobInputOptionSchema = (
             message: t?.("Data.Values.value.required"),
           }),
         )
-        .min(1, { message: t?.("Data.Values.min") }),
+        .min(1, { message: t?.("Data.Values.min") })
+        .refine((items) => new Set(items).size === items.length, {
+          message: t?.("Data.Values.unique"),
+        }),
       placeholder: z.string().optional(),
       description: z.string().optional(),
     }),


### PR DESCRIPTION
## Changes

* Use index (number) for option values instead of option values
* Remove `transformFormData` function and just add `filterOutNullValues` to filter out `null` value
* Check option data `values` are unique or not

## Note

The select (both single and multi) will not work correctly if there is duplicate value in data `values` from schema
Because index is depend on `Array.indexOf` which only takes first index