### PR TITLE
fix(stripe): Conditionally set customer or customer_email in checkout session

### DIFF
--- a/web-app/src/lib/actions/stripe.actions.ts
+++ b/web-app/src/lib/actions/stripe.actions.ts
@@ -68,8 +68,9 @@ export async function createCheckoutSession(
       },
     ],
     client_reference_id: fiatTransactionId,
-    customer: user.stripeCustomerId ?? undefined,
-    customer_email: user.email,
+    ...(user.stripeCustomerId
+      ? { customer: user.stripeCustomerId }
+      : { customer_email: user.email }),
     billing_address_collection: "required",
     success_url: `${origin}/app/billing/success?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${origin}/app/billing/cancel`,


### PR DESCRIPTION
**Description:**

This pull request modifies the `createCheckoutSession` action in `src/lib/actions/stripe.actions.ts`.

Previously, both `customer` (if available) and `customer_email` were potentially being sent to the Stripe Checkout Session creation endpoint. According to Stripe's API documentation, only one of these parameters should be provided. Providing both can lead to errors or unexpected behavior.

This change introduces conditional logic to ensure that:
- If `user.stripeCustomerId` exists, the `customer` parameter is set with this ID.
- If `user.stripeCustomerId` does not exist, the `customer_email` parameter is set with `user.email`.

This ensures compliance with Stripe's API requirements and prevents potential issues during the checkout process.