### PR TITLE
refactor(pages): remove static generation from agent detail pages

### DIFF
--- a/web-app/src/app/(landing)/agents/[agentId]/page.tsx
+++ b/web-app/src/app/(landing)/agents/[agentId]/page.tsx
@@ -1,26 +1,10 @@
 import { notFound } from "next/navigation";
 
 import { AgentDetails } from "@/components/agents";
-import { getAgentById, getAgents } from "@/lib/db/services/agent.service";
+import { getAgentById } from "@/lib/db/services/agent.service";
 import { calculateAgentHumandReadableCreditCost } from "@/lib/db/services/credit.service";
 
 import BackToGallery from "./components/back-to-gallery";
-
-// Next.js will invalidate the cache when a
-// request comes in, at most once every 1 hour (3600 seconds).
-export const revalidate = 3600;
-
-// We'll prerender only the params from `generateStaticParams` at build time.
-// If a request comes in for a path that hasn't been generated,
-// Next.js will server-render the page on-demand.
-export const dynamicParams = true; // or false, to 404 on unknown paths
-
-export async function generateStaticParams() {
-  const agents = await getAgents();
-  return agents.map((agent) => ({
-    agentId: String(agent.id),
-  }));
-}
 
 export default async function Page({
   params,

--- a/web-app/src/app/app/agents/[agentId]/page.tsx
+++ b/web-app/src/app/app/agents/[agentId]/page.tsx
@@ -2,27 +2,11 @@ import { notFound } from "next/navigation";
 
 import { AgentDetails } from "@/components/agents";
 import { requireAuthentication } from "@/lib/auth/utils";
-import { getAgentById, getAgents } from "@/lib/db/services/agent.service";
+import { getAgentById } from "@/lib/db/services/agent.service";
 import { getOrCreateFavoriteAgentList } from "@/lib/db/services/agentList.service";
 import { calculateAgentHumandReadableCreditCost } from "@/lib/db/services/credit.service";
 
 import BackToGallery from "./components/back-to-gallery";
-
-// Next.js will invalidate the cache when a
-// request comes in, at most once every 1 hour (3600 seconds).
-export const revalidate = 3600;
-
-// We'll prerender only the params from `generateStaticParams` at build time.
-// If a request comes in for a path that hasn't been generated,
-// Next.js will server-render the page on-demand.
-export const dynamicParams = true; // or false, to 404 on unknown paths
-
-export async function generateStaticParams() {
-  const agents = await getAgents();
-  return agents.map((agent) => ({
-    agentId: String(agent.id),
-  }));
-}
 
 export default async function Page({
   params,


### PR DESCRIPTION
# Description

This PR removes static generation configuration from agent detail pages in both the landing and app routes, switching to a fully dynamic rendering approach.

## Changes
- Remove `generateStaticParams` function that was pre-generating paths for agent detail pages
- Remove `revalidate` configuration that was set to 3600 seconds
- Remove `dynamicParams` configuration
- Simplify imports by removing unused `getAgents` function

## Motivation
- Moving to dynamic rendering ensures we always serve fresh agent data without relying on revalidation periods, which is more suitable for frequently updated agent content.
- Newly synced agents on the server causing an `500` error. `DYNAMIC_SERVER_USAGE`

## Impact
- More consistent and up-to-date agent details
- Reduced build time as we no longer pre-generate agent pages
- Slightly increased response time for first page load (trade-off for freshness)