### PR TITLE
fix(db): add default role field to seed user

### DIFF
--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -27,6 +27,7 @@ const seedUser = async (): Promise<string> => {
       email: getEnvSecrets().SEED_USER_EMAIL,
       name: "Sokosumi Developer",
       emailVerified: true,
+      role: "user",
       createdAt: new Date(),
       updatedAt: new Date(),
     },


### PR DESCRIPTION
# Description
Adds the 'role' field with a default value of "user" to the seed user creation in the database seeding script.

## Changes
- Added role field initialization in prisma/seed.ts for the seed user
- Default role is set to "user"