### PR TITLE
fix(stripe): adjust webhook response status codes for failed transactions

### DIFF
--- a/web-app/src/app/api/stripe/webhook/route.ts
+++ b/web-app/src/app/api/stripe/webhook/route.ts
@@ -159,7 +159,7 @@ const updateFiatTransactionStatus = async (
     if (!fiatTransaction) {
       return NextResponse.json(
         { message: `Fiat transaction for session ${session.id} not found` },
-        { status: 500 },
+        { status: status === "FAILED" ? 200 : 500 },
       );
     }
 
@@ -168,7 +168,7 @@ const updateFiatTransactionStatus = async (
         {
           message: `Session client reference id ${session.client_reference_id} does not match fiat transaction id ${fiatTransaction.id}`,
         },
-        { status: 500 },
+        { status: status === "FAILED" ? 200 : 500 },
       );
     }
 


### PR DESCRIPTION
## Description
Updates the Stripe webhook handler to return 200 status code for failed transactions instead of 500, while maintaining 500 status for other error scenarios. This change aligns with Stripe's webhook best practices where any non-2xx response will trigger webhook retries.

### Changes
- Modified error response status codes in `updateFiatTransactionStatus` function to return 200 for failed transactions
- Maintains 500 status code for other error scenarios

### Why
- Prevents unnecessary webhook retries from Stripe when a transaction legitimately fails
- Improves webhook reliability and reduces server load from retries
- Follows Stripe's webhook best practices for handling failed transactions

### Testing
- Verify webhook handles failed transactions correctly
- Confirm successful transactions maintain existing behavior
- Test webhook retries only occur for non-failed transaction errors