### PR TITLE
fix(auth): update redirect paths from '/signin' to '/login'

### DIFF
--- a/web-app/src/app/(landing)/(auth)/forgot-password/components/form.tsx
+++ b/web-app/src/app/(landing)/(auth)/forgot-password/components/form.tsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordForm({
         },
         onSuccess: () => {
           toast.success(t("success"));
-          router.push("/signin");
+          router.push("/login");
         },
       },
     );

--- a/web-app/src/app/(landing)/(auth)/reset-password/components/form.tsx
+++ b/web-app/src/app/(landing)/(auth)/reset-password/components/form.tsx
@@ -45,7 +45,7 @@ export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
         },
         onSuccess: () => {
           toast.success(t("success"));
-          router.push("/signin");
+          router.push("/login");
         },
       },
     );

--- a/web-app/src/app/(landing)/(auth)/reset-password/page.tsx
+++ b/web-app/src/app/(landing)/(auth)/reset-password/page.tsx
@@ -24,7 +24,7 @@ export default async function ResetPasswordPage({
   const { token } = await searchParams;
 
   if (!token) {
-    redirect("/signin");
+    redirect("/login");
   }
 
   return (

--- a/web-app/src/app/(landing)/components/auth-buttons.tsx
+++ b/web-app/src/app/(landing)/components/auth-buttons.tsx
@@ -15,9 +15,9 @@ interface AuthButtonsProps {
 export default function AuthButtons({ containerClassName }: AuthButtonsProps) {
   const pathname = usePathname();
 
-  if (pathname.startsWith("/signin")) return <SignUpButton />;
+  if (pathname.startsWith("/login")) return <SignUpButton />;
 
-  if (pathname.startsWith("/signup")) return <SignInButton />;
+  if (pathname.startsWith("/register")) return <SignInButton />;
 
   return (
     <div className={cn("flex items-center gap-4", containerClassName)}>

--- a/web-app/src/lib/auth/utils.ts
+++ b/web-app/src/lib/auth/utils.ts
@@ -13,7 +13,7 @@ export async function requireAuthentication(): Promise<{
   });
 
   if (!session) {
-    redirect("/signin");
+    redirect("/login");
   }
 
   return { session };

--- a/web-app/src/middleware/authorization.ts
+++ b/web-app/src/middleware/authorization.ts
@@ -12,7 +12,7 @@ export async function authorizationMiddleware(
     // Check if the session cookie is present
     if (!sessionCookie) {
       // Redirect to login page if not authenticated
-      return NextResponse.redirect(new URL("/signin", req.url));
+      return NextResponse.redirect(new URL("/login", req.url));
     }
   }
   // Allow the request to proceed if authenticated


### PR DESCRIPTION
Change all instances of redirecting to '/signin' to '/login' for consistency across authentication flows.