### PR TITLE
feat(landing): add imprint, privacy policy, and terms dummy pages; update footer navigation

### DIFF
--- a/web-app/.cursor/rules/interface.mdc
+++ b/web-app/.cursor/rules/interface.mdc
@@ -5,4 +5,6 @@ alwaysApply: true
 ---
 - Use Shadcn UI, Radix, and Tailwind for components and styling.
 - Implement responsive design with Tailwind CSS.
+- Never use hardcoded colors such as hex values.
+- Ensure compatibility with both dark and light modes.
 - Use `next-intl` for Internationalization for Next.js

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1,4 +1,13 @@
 {
+  "Footer": {
+    "Navigation": {
+      "PrivacyPolicy": "Privacy Policy",
+      "TermsAndConditions": "Terms & Conditions",
+      "Imprint": "Imprint",
+      "Contact": "Contact"
+    },
+    "copyright": "© {year} Masumi"
+  },
   "Job": {
     "CreationFailed": "Failed to create job",
     "RefundFailed": "Failed to refund job",
@@ -99,15 +108,6 @@
       "Connection": {
         "dashboard": "Dashboard"
       }
-    },
-    "Footer": {
-      "Navigation": {
-        "PrivacyPolicy": "Privacy Policy",
-        "TermsAndConditions": "Terms & Conditions",
-        "CookiePolicy": "Cookie Policy",
-        "Contact": "Contact"
-      },
-      "copyright": "© {year} Masumi"
     },
     "Auth": {
       "Schema": {

--- a/web-app/src/app/(landing)/imprint/page.tsx
+++ b/web-app/src/app/(landing)/imprint/page.tsx
@@ -1,0 +1,14 @@
+export default function ImprintPage() {
+  return (
+    <>
+      <section className="bg-background mx-auto mt-8 max-w-2xl rounded-lg p-6 shadow">
+        <h1 className="text-foreground mb-4 text-2xl font-bold">{"Imprint"}</h1>
+        <p className="text-muted-foreground">
+          {
+            "This is a dummy imprint component. Replace this text with your actual imprint content."
+          }
+        </p>
+      </section>
+    </>
+  );
+}

--- a/web-app/src/app/(landing)/layout.tsx
+++ b/web-app/src/app/(landing)/layout.tsx
@@ -2,8 +2,8 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { BreadcrumbNavigation } from "@/components/breadcrumb-navigation";
+import Footer from "@/components/footer";
 
-import Footer from "./components/footer";
 import Header from "./components/header";
 
 interface LandingLayoutProps {

--- a/web-app/src/app/(landing)/privacy-policy/page.tsx
+++ b/web-app/src/app/(landing)/privacy-policy/page.tsx
@@ -1,0 +1,16 @@
+export default function PrivacyPage() {
+  return (
+    <>
+      <section className="bg-background mx-auto mt-8 max-w-2xl rounded-lg p-6 shadow">
+        <h1 className="text-foreground mb-4 text-2xl font-bold">
+          {"Privacy Policy"}
+        </h1>
+        <p className="text-muted-foreground">
+          {
+            "This is a dummy privacy policy component. Replace this text with your actual privacy policy content."
+          }
+        </p>
+      </section>
+    </>
+  );
+}

--- a/web-app/src/app/(landing)/terms-of-service/page.tsx
+++ b/web-app/src/app/(landing)/terms-of-service/page.tsx
@@ -1,0 +1,16 @@
+export default function TermsPage() {
+  return (
+    <>
+      <section className="bg-background mx-auto mt-8 max-w-2xl rounded-lg p-6 shadow">
+        <h1 className="text-foreground mb-4 text-2xl font-bold">
+          {"Terms & Conditions"}
+        </h1>
+        <p className="text-muted-foreground">
+          {
+            "This is a dummy terms & conditions component. Replace this text with your actual terms & conditions content."
+          }
+        </p>
+      </section>
+    </>
+  );
+}

--- a/web-app/src/components/footer.tsx
+++ b/web-app/src/components/footer.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { SokosumiLogo } from "@/components/masumi-logos";
 
 export default function Footer() {
-  const t = useTranslations("Landing.Footer");
+  const t = useTranslations("Footer");
   return (
     <footer
       id="footer"
@@ -43,15 +43,16 @@ export default function Footer() {
               </li>
               <li>
                 <Link
-                  href="/cookie-policy"
+                  href="/imprint"
                   className="text-muted-foreground hover:text-landing-footer-foreground flex items-center gap-1 text-sm"
                 >
-                  {t("Navigation.CookiePolicy")}
+                  {t("Navigation.Imprint")}
                 </Link>
               </li>
               <li>
                 <Link
-                  href="/contact"
+                  href="https://www.masumi.network/contact"
+                  target="_blank"
                   className="text-muted-foreground hover:text-landing-footer-foreground flex items-center gap-1 text-sm"
                 >
                   {t("Navigation.Contact")}


### PR DESCRIPTION
## Summary

This PR introduces new legal pages and updates the footer navigation for the landing section.

## Changes

- **New Pages:**
  - `/imprint`: Imprint page with placeholder content.
  - `/privacy-policy`: Privacy Policy page with placeholder content.
  - `/terms-of-service`: Terms & Conditions page with placeholder content.

- **Footer Navigation:**
  - Links to the new Imprint page.
  - Contact link now opens the external Masumi contact page in a new tab.
  - Removed Cookie Policy link.
  - Uses the new `Footer` translation namespace.

- **Internationalization:**
  - Footer navigation translations moved to the new `Footer` namespace in `messages/en.json`.
  - Removed old `Landing.Footer` keys.

### References:
* Relates to #390 
* Relates to #391 
* Relates to #395