### PR TITLE
chore: replace Node.js crypto UUID usage with `uuid` package

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -72,6 +72,7 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "^10.0.4",
+    "uuid": "^11.1.0",
     "vaul": "^1.1.2",
     "zod": "^3.24.2"
   },

--- a/web-app/pnpm-lock.yaml
+++ b/web-app/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       use-debounce:
         specifier: ^10.0.4
         version: 10.0.4(react@19.1.0)
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4303,9 +4306,6 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
 
-  tailwindcss@4.1.3:
-    resolution: {integrity: sha512-2Q+rw9vy1WFXu5cIxlvsabCwhU2qUwodGq03ODhLJ0jW4ek5BUtoCsnLB0qG+m8AHgEsSJcJGDSDe06FXlP74g==}
-
   tailwindcss@4.1.4:
     resolution: {integrity: sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A==}
 
@@ -4460,6 +4460,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -9044,8 +9048,6 @@ snapshots:
     dependencies:
       tailwindcss: 4.1.4
 
-  tailwindcss@4.1.3: {}
-
   tailwindcss@4.1.4: {}
 
   tapable@2.2.1: {}
@@ -9228,6 +9230,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.2
+
+  uuid@11.1.0: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:

--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import { v4 as uuidv4 } from "uuid";
 
 import { getEnvSecrets } from "@/config/env.config";
 import { convertCreditsToBaseUnits } from "@/lib/db/utils/credit.utils";
@@ -37,10 +37,10 @@ const seedUser = async (): Promise<string> => {
 
   const account = await prisma.account.create({
     data: {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       userId: user.id,
       providerId: "credential",
-      accountId: crypto.randomUUID(),
+      accountId: uuidv4(),
       password: password,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-properties */
+import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
 /**
@@ -77,7 +78,7 @@ const envSecretsSchema = z.object({
     .number({ coerce: true })
     .min(3 * 60 * 1000)
     .default(10 * 60 * 1000), // 10 minutes
-  INSTANCE_ID: z.string().min(1).default(crypto.randomUUID()),
+  INSTANCE_ID: z.string().min(1).default(uuidv4()),
   REGISTRY_API_URL: z
     .string()
     .url()

--- a/web-app/src/lib/db/services/job.service.ts
+++ b/web-app/src/lib/db/services/job.service.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
 import { getEnvPublicConfig } from "@/config/env.config";
@@ -56,8 +57,7 @@ export async function startJob(
       }
       const baseUrl = getApiBaseUrl(agent);
       const startJobUrl = new URL(`/start_job`, baseUrl);
-      const identifierFromPurchaser = crypto
-        .randomUUID()
+      const identifierFromPurchaser = uuidv4()
         .replace(/-/g, "")
         .substring(0, 25);
 


### PR DESCRIPTION
## Description

This PR refactors all usages of Node.js `crypto.randomUUID()` (where relevant to UUID generation) to use the `uuid` package (`v4`), which is now added as a dependency. This change ensures consistent UUID generation across environments and aligns with best practices for cross-platform compatibility.

### Changes

- Added `uuid@^11.1.0` to dependencies in `package.json` and `pnpm-lock.yaml`.
- Replaced all instances of `crypto.randomUUID()` with `uuidv4()`:
  - `prisma/seed.ts`: For `account.id` and `account.accountId`.
  - `src/config/env.config.ts`: For default `INSTANCE_ID`.
  - `src/lib/db/services/job.service.ts`: For `identifierFromPurchaser`.
- Imported `uuidv4` from the `uuid` package in affected files.

### Rationale

- The `uuid` package is widely adopted, well-maintained, and provides a consistent API for UUID generation.
- Using a dedicated package avoids potential issues with Node.js version compatibility and future-proofs the codebase for environments where the Node.js `crypto` module may not be available or consistent (e.g., edge runtimes, browser environments).

### Notes

- No functional changes to UUID generation logic—only the implementation source has changed.
- All usages of UUIDs are now standardized to use the same method.

### Reference
Relates to #374: It extracts the `uuid` change
