### PR TITLE
chore: use link instead of button's onclick

### DIFF
--- a/web-app/src/app/app/agents/[agentId]/jobs/components/header.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/header.tsx
@@ -1,6 +1,5 @@
-"use client";
 import { Bookmark, Plus } from "lucide-react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import { AgentBookmarkButton } from "@/components/agents/agent-bookmark-button";
@@ -64,7 +63,7 @@ export default function Header({
   favoriteAgentList,
 }: HeaderProps) {
   const t = useTranslations("App.Agents.Jobs.Header");
-  const router = useRouter();
+
   return (
     <div className="flex flex-col items-center gap-4 lg:flex-row lg:gap-6 xl:gap-8">
       <div className="flex flex-row items-center gap-4">
@@ -80,16 +79,12 @@ export default function Header({
         <div className="w-full text-end text-base">
           {t("price", { price: agentPricing })}
         </div>
-        <Button
-          className="gap-2"
-          onClick={() => {
-            router.push(`/app/agents/${agent.id}/jobs`);
-            router.refresh();
-          }}
-        >
-          <Plus />
-          {t("createNewJob")}
-        </Button>
+        <Link href={`/app/agents/${agent.id}/jobs`}>
+          <Button className="gap-2">
+            <Plus />
+            {t("createNewJob")}
+          </Button>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Changes

Update job layout's header's `create new job` button.
Use link's href instead of button's onclick (not using "use client")

## Benefits

* Improve SEO