### PR TITLE
feat(landing): add i18n support for Featured Agents section on landing page 🌍✨

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -280,6 +280,10 @@
         "caption": "The most powerful way to find and hire agents. Prompt, run, edit and deploy your agents.",
         "title": "A marketplace for agent-to-agent interactions"
       },
+      "FeaturedAgents": {
+        "title": "Featured Agents",
+        "button": "Explore all"
+      },
       "NumberTalks": {
         "title": "Number Talks",
         "Numbers": {

--- a/web-app/src/app/(landing)/components/featured-agents.tsx
+++ b/web-app/src/app/(landing)/components/featured-agents.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 
 import { AgentCard } from "@/components/agents";
 import { Button } from "@/components/ui/button";
@@ -6,6 +7,7 @@ import { getAgents } from "@/lib/db/services/agent.service";
 import { getAgentCreditsPrice } from "@/lib/db/services/credit.service";
 
 export default async function FeaturedAgents() {
+  const t = await getTranslations("Landing.Page.FeaturedAgents");
   const agents = await getAgents();
   const firstFourAgents = agents.slice(0, 4);
 
@@ -18,9 +20,9 @@ export default async function FeaturedAgents() {
   return (
     <div className="flex w-full flex-col gap-16">
       <div className="flex items-center justify-between">
-        <h2 className="text-4xl font-light">{"Featured Agents"}</h2>
+        <h2 className="text-4xl font-light">{t("title")}</h2>
         <Button className="bg-quarterny text-foreground hover:bg-quarterny/90 text-sm">
-          <Link href="/agents">{"Explore all"}</Link>
+          <Link href="/agents">{t("button")}</Link>
         </Button>
       </div>
 


### PR DESCRIPTION
#### 📝 Summary
This PR introduces internationalization (i18n) for the "Featured Agents" section on the landing page. The section title and button label are now translated using `next-intl`, ensuring a localized experience for users.

#### 🛠️ Changes
- Added `Landing.Page.FeaturedAgents` translations to `messages/en.json`.
- Updated `featured-agents.tsx` to use `getTranslations` from `next-intl/server` for the section title and button.
- Replaced hardcoded strings with translation keys.

#### 🌐 Why
- Improves accessibility and user experience for non-English speakers.
- Aligns with our commitment to full internationalization across the app.

#### 📚 References
- [next-intl documentation](https://next-intl-docs.vercel.app/docs/getting-started/app-router)

---

Relates to #324 
