### PR TITLE
refactor(layout): move kanji logo to landing layout

### DIFF
--- a/web-app/src/app/(landing)/components/hero.tsx
+++ b/web-app/src/app/(landing)/components/hero.tsx
@@ -1,17 +1,12 @@
 import { useTranslations } from "next-intl";
 
-import { KanjiLogo, ThemedLogo } from "@/components/masumi-logos";
-
 import AgentsShowcase from "./agents-showcase";
 
 export default function Hero() {
   const t = useTranslations("Landing.Page.Hero");
   return (
     <>
-      <div className="landing-hero-bg blur-in absolute inset-0 z-0 h-full w-full" />
-      <div className="absolute right-0 z-0 flex h-full w-full items-center justify-end p-12">
-        <ThemedLogo LogoComponent={KanjiLogo} />
-      </div>
+      <div className="landing-hero-bg absolute h-full w-full" />
       <div className="z-10 container flex flex-col items-center gap-6 px-12 text-center md:px-6">
         <h1 className="w-full text-center text-7xl font-bold whitespace-pre-line">
           {t("title")}

--- a/web-app/src/app/(landing)/layout.tsx
+++ b/web-app/src/app/(landing)/layout.tsx
@@ -35,7 +35,7 @@ export default function LandingLayout({ children }: LandingLayoutProps) {
 
 function Kanji() {
   return (
-    <div className="absolute right-0 z-0 flex h-full w-full items-center justify-end p-12">
+    <div className="fixed right-0 z-0 flex h-full w-full items-center justify-end p-12">
       <ThemedLogo LogoComponent={KanjiLogo} />
     </div>
   );

--- a/web-app/src/app/(landing)/layout.tsx
+++ b/web-app/src/app/(landing)/layout.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
+import { KanjiLogo, ThemedLogo } from "@/components/masumi-logos";
+
 import Footer from "./components/footer";
 import Header from "./components/header";
 
@@ -25,7 +27,16 @@ export default function LandingLayout({ children }: LandingLayoutProps) {
     <div className="flex min-h-svh flex-col">
       <Header />
       <main className="flex-1 pt-24">{children}</main>
+      <Kanji />
       <Footer />
+    </div>
+  );
+}
+
+function Kanji() {
+  return (
+    <div className="absolute right-0 z-0 flex h-full w-full items-center justify-end p-12">
+      <ThemedLogo LogoComponent={KanjiLogo} />
     </div>
   );
 }

--- a/web-app/src/app/(landing)/layout.tsx
+++ b/web-app/src/app/(landing)/layout.tsx
@@ -35,7 +35,7 @@ export default function LandingLayout({ children }: LandingLayoutProps) {
 
 function Kanji() {
   return (
-    <div className="fixed right-0 z-0 flex h-full w-full items-center justify-end p-12">
+    <div className="pointer-events-none fixed right-0 z-0 flex h-full w-full items-center justify-end p-12">
       <ThemedLogo LogoComponent={KanjiLogo} />
     </div>
   );

--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -167,20 +167,3 @@
     background-repeat: no-repeat;
   }
 }
-
-@utility blur-in {
-  filter: blur(10px);
-  opacity: 0.5;
-  animation: blur-in 3s ease forwards;
-}
-
-@keyframes blur-in {
-  0% {
-    filter: blur(10px);
-    opacity: 0.5;
-  }
-  100% {
-    filter: blur(0px);
-    opacity: 1;
-  }
-}


### PR DESCRIPTION
This PR reorganizes the landing page structure by moving the Kanji logo from the hero component to the landing layout level.

Changes:
- Extracted Kanji logo into a separate component in landing layout
- Removed logo-related code from hero component
- Simplified hero background styling
- Logo is now visible across all landing pages

This change improves component organization by:
- Making the hero component more focused on its core content
- Ensuring consistent logo placement across landing pages
- Following better separation of concerns