### PR TITLE
chore(deps): update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - "mrgrauel"
       - "golddydev"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "chore(deps)"
 
   # Enable version updates for npm in the web-app directory
   - package-ecosystem: "npm"
@@ -26,7 +26,7 @@ updates:
       - "mrgrauel"
       - "golddydev"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "chore(deps)"
   
   # Enable version updates for npm in the job-cron-caller directory
   - package-ecosystem: "npm"
@@ -43,7 +43,7 @@ updates:
       - "mrgrauel"
       - "golddydev"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "chore(deps)"
   
   # Enable version updates for npm in the registry-cron-caller directory
   - package-ecosystem: "npm"
@@ -60,4 +60,4 @@ updates:
       - "mrgrauel"
       - "golddydev"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "mrgrauel"
-      - "bytegen-dev"
       - "golddydev"
     commit-message:
       prefix: "build(deps)"
@@ -25,7 +24,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "mrgrauel"
-      - "bytegen-dev"
       - "golddydev"
     commit-message:
       prefix: "build(deps)"
@@ -43,7 +41,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "mrgrauel"
-      - "bytegen-dev"
       - "golddydev"
     commit-message:
       prefix: "build(deps)"
@@ -61,7 +58,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "mrgrauel"
-      - "bytegen-dev"
       - "golddydev"
     commit-message:
       prefix: "build(deps)"


### PR DESCRIPTION
This PR updates the dependabot configuration with the following changes:

- Change commit message prefix from `build(deps)` to `chore(deps)` across all package ecosystems
- Remove `bytegen-dev` from the reviewers list for all dependency updates

This change better aligns with conventional commit standards where dependency updates are typically categorized under `chore` rather than `build`.

Affected package ecosystems:
- npm (root)
- npm (web-app)
- npm (job-cron-caller)
- npm (registry-cron-caller)