### PR TITLE
feat: add with-authentication hooks and apply to hire agent button

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -93,6 +93,14 @@
       "jobs": "Jobs",
       "agents": "Gallery",
       "account": "Account"
+    },
+    "Modals": {
+      "AuthenticationModal": {
+        "title": "Welcome back",
+        "description": "Log in or register to hire agents and start the jobs",
+        "login": "Login",
+        "register": "Register"
+      }
     }
   },
   "Landing": {

--- a/web-app/src/app/(landing)/agents/components/featured-agent-hire-button.tsx
+++ b/web-app/src/app/(landing)/agents/components/featured-agent-hire-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import useWithAuthentication from "@/hooks/use-with-authentication";
+
+interface FeaturedAgentHireButtonProps {
+  agentId: string;
+}
+
+export default function FeaturedAgentHireButton({
+  agentId,
+}: FeaturedAgentHireButtonProps) {
+  const t = useTranslations("Landing.Agents.FeaturedAgent");
+  const router = useRouter();
+  const { isPending, ModalComponent, withAuthentication } =
+    useWithAuthentication();
+
+  const handleHire = () => {
+    router.push(`/app/agents/${agentId}/jobs`);
+  };
+
+  return (
+    <>
+      {ModalComponent}
+      <Button
+        size="lg"
+        onClick={withAuthentication(handleHire)}
+        disabled={isPending}
+      >
+        {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        {t("hire")}
+      </Button>
+    </>
+  );
+}

--- a/web-app/src/app/(landing)/agents/components/featured-agent.tsx
+++ b/web-app/src/app/(landing)/agents/components/featured-agent.tsx
@@ -16,6 +16,8 @@ import {
   getAgentTags,
 } from "@/lib/db";
 
+import FeaturedAgentHireButton from "./featured-agent-hire-button";
+
 export function FeaturedAgentSkeleton() {
   return (
     <div className="flex flex-col items-center gap-8 md:flex-row">
@@ -96,9 +98,7 @@ export function FeaturedAgent({ agent, creditsPrice }: FeaturedAgentProps) {
                 {t("view")}
               </Button>
             </Link>
-            <Link href={`/app/agents/${agent.id}/jobs`}>
-              <Button size="lg">{t("hire")}</Button>
-            </Link>
+            <FeaturedAgentHireButton agentId={agent.id} />
           </div>
         </div>
       </div>

--- a/web-app/src/components/modals/authentication-modal.tsx
+++ b/web-app/src/components/modals/authentication-modal.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface AuthenticationModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function AuthenticationModal({
+  open,
+  onOpenChange,
+}: AuthenticationModalProps) {
+  const t = useTranslations("Components.Modals.AuthenticationModal");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-center text-lg font-medium">
+            {t("title")}
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground text-center text-base">
+            {t("description")}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="block space-y-1.5">
+          <Link href="/login" className="block">
+            <Button className="w-full">{t("login")}</Button>
+          </Link>
+          <Link href="/register" className="block">
+            <Button variant="secondary" className="w-full">
+              {t("register")}
+            </Button>
+          </Link>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web-app/src/hooks/use-authentication-modal.tsx
+++ b/web-app/src/hooks/use-authentication-modal.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useState } from "react";
+
+import AuthenticationModal from "@/components/modals/authentication-modal";
+
+export default function useAuthenticationModal() {
+  const [open, setOpen] = useState(false);
+
+  const showModal = () => setOpen(true);
+
+  return {
+    Component: <AuthenticationModal open={open} onOpenChange={setOpen} />,
+    showModal,
+  };
+}

--- a/web-app/src/hooks/use-with-authentication.ts
+++ b/web-app/src/hooks/use-with-authentication.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { useSession } from "@/lib/auth/auth.client";
+
+import useAuthenticationModal from "./use-authentication-modal";
+
+type Callback =
+  | ((...args: unknown[]) => void)
+  | ((...args: unknown[]) => Promise<void>);
+
+export default function useWithAuthentication() {
+  const { data: session, isPending } = useSession();
+  const { Component, showModal } = useAuthenticationModal();
+
+  const withAuthentication = useCallback(
+    (callback: Callback) => {
+      if (isPending) {
+        return () => {};
+      }
+
+      if (!session) {
+        return showModal;
+      }
+
+      return callback;
+    },
+    [isPending, session, showModal],
+  );
+
+  return {
+    isPending,
+    withAuthentication,
+    ModalComponent: Component,
+  };
+}


### PR DESCRIPTION
## Changes

* Added `AuthenticationModal`  component
* Added `use-with-authentication` and `use-authentication-modal` hooks
* Apply use-with-authentication to `Hire Agent` button

## Benefit

* Re-usability of `use-with-authentication` hook