### PR TITLE
feat(credits): enhance credit display with low balance CTA

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -430,8 +430,9 @@
     },
     "Header": {
       "Credit": {
-        "balance": "Credits Balance: {credits}",
-        "unavailable": "Credits Balance: unknown"
+        "unavailable": "Credits unavailable",
+        "balance": "{credits, plural, =0 {No credits} =1 {1 credit} other {# credits}}",
+        "buy": "Buy Credits"
       }
     },
     "Billing": {

--- a/web-app/src/app/app/components/user-credits.tsx
+++ b/web-app/src/app/app/components/user-credits.tsx
@@ -1,6 +1,8 @@
 import { headers } from "next/headers";
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
+import { Button } from "@/components/ui/button";
 import { auth } from "@/lib/auth/auth";
 import { getUserById } from "@/lib/db";
 import { getCredits } from "@/lib/services";
@@ -26,10 +28,17 @@ export default async function UserCredits() {
     );
   }
   return (
-    <div className="flex flex-col items-end gap-0.5">
-      <div className="text-sm font-semibold">{user.name}</div>
-      <div className="text-muted-foreground text-xs">
-        {t("balance", { credits: credits })}
+    <div className="flex items-center gap-4">
+      {credits <= 50.0 && (
+        <Button variant="default" size="sm" asChild>
+          <Link href="/app/billing">{t("buy")}</Link>
+        </Button>
+      )}
+      <div className="flex flex-col items-end gap-0.5">
+        <div className="text-sm font-semibold">{user.name}</div>
+        <div className="text-muted-foreground text-xs">
+          {t("balance", { credits: credits })}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
# Changes
- Implement low balance detection (≤50 credits)
- Add "Buy Credits" CTA button that appears when balance smaller or equal to `50.0`
- Improve layout with flex container and consistent spacing

# Implementation Details
- Uses `next-intl` pluralization rules for better i18n support
- Links to billing page for credit purchase
- Maintains consistent UI with Shadcn Button component
- Preserves dark/light mode compatibility