### PR TITLE
feat(user-avatar): integrate gravatar and add support menu item

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -68,7 +68,8 @@
     "UserAvatar": {
       "account": "Account",
       "logout": "Log out",
-      "billing": "Billing"
+      "billing": "Billing",
+      "support": "Support"
     },
     "DataTable": {
       "Data": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -72,6 +72,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
+    "gravatar-url": "^4.0.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.503.0",
     "markdown-to-jsx": "^7.7.6",

--- a/web-app/pnpm-lock.yaml
+++ b/web-app/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
+      gravatar-url:
+        specifier: ^4.0.1
+        version: 4.0.1
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2494,6 +2497,9 @@ packages:
   better-call@1.0.8:
     resolution: {integrity: sha512-/PV8JLqDRUN7JyBPbklVsS/8E4SO3pnf8hbpa8B7xrBrr+BBYpeOAxoqtnsyk/pRs35vNB4MZx8cn9dBuNlLDA==}
 
+  blueimp-md5@2.19.0:
+    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -3287,6 +3293,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  gravatar-url@4.0.1:
+    resolution: {integrity: sha512-AiU83cghGg2D8vAUwrMXCByejkkm4RtLwMNGmPU7VhqBYhsxcBCV0SAzRpYNbUCpTci5v46J/KFKPmDYaG2oyA==}
+    engines: {node: '>=12'}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -3902,6 +3912,10 @@ packages:
     resolution: {integrity: sha512-OvAXqwq57uOk+WZqFFNCMZz8yDp8BD3WazW1wAKHUrPbbdr89K9DWS6JXY09vd9xNdPNeurI8DU/X4flcfaD8A==}
     peerDependencies:
       react: ^18.0 || ^19.0
+
+  md5-hex@4.0.0:
+    resolution: {integrity: sha512-di38zHPn4Tz8LCb5Lz8SpLb/20Hv23aPXpF4Bq1mR5r9JuCZQ/JpcDUxFfZF9Ur5GiUvqS5NQOkR+fm5cYZ0IQ==}
+    engines: {node: '>=12'}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -4818,6 +4832,10 @@ packages:
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
 
   typed-array-buffer@1.0.3:
@@ -7324,6 +7342,8 @@ snapshots:
       set-cookie-parser: 2.7.1
       uncrypto: 0.1.3
 
+  blueimp-md5@2.19.0: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -8274,6 +8294,11 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  gravatar-url@4.0.1:
+    dependencies:
+      md5-hex: 4.0.0
+      type-fest: 1.4.0
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -9080,6 +9105,10 @@ snapshots:
     dependencies:
       marked: 7.0.4
       react: 19.1.0
+
+  md5-hex@4.0.0:
+    dependencies:
+      blueimp-md5: 2.19.0
 
   memoize-one@5.2.1: {}
 
@@ -9973,6 +10002,8 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@1.4.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
+++ b/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
@@ -11,7 +11,6 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -61,15 +60,6 @@ export default function UserAvatarClient({ user }: UserAvatarClientProps) {
         </TooltipProvider>
 
         <DropdownMenuContent className="w-56" align="end" forceMount>
-          <DropdownMenuLabel className="font-normal">
-            <div className="flex flex-col space-y-1">
-              <p className="text-sm leading-none font-medium">{user.name}</p>
-              <p className="text-muted-foreground text-xs leading-none">
-                {user.email}
-              </p>
-            </div>
-          </DropdownMenuLabel>
-          <DropdownMenuSeparator />
           <DropdownMenuGroup>
             <DropdownMenuItem className="cursor-pointer" asChild>
               <Link href="/app/account" className="flex items-center gap-2">

--- a/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
+++ b/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import gravatarUrl from "gravatar-url";
 import { CreditCardIcon, LogOut, User as UserIcon } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -49,7 +50,10 @@ export default function UserAvatarClient({ user }: UserAvatarClientProps) {
                   aria-label={`User profile for ${user.name ?? "current user"}`}
                 >
                   <UserAvatarContent
-                    imageUrl={user.image ?? ""}
+                    imageUrl={gravatarUrl(user.email, {
+                      size: 80,
+                      default: "404",
+                    })}
                     imageAlt={user.name ?? "User avatar"}
                   />
                 </Button>

--- a/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
+++ b/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import gravatarUrl from "gravatar-url";
-import { CreditCardIcon, LogOut, User as UserIcon } from "lucide-react";
+import {
+  CircleHelp,
+  CreditCardIcon,
+  LogOut,
+  User as UserIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 
@@ -35,6 +40,10 @@ export default function UserAvatarClient({ user }: UserAvatarClientProps) {
   const { Component, showModal } = useModal(({ open, onOpenChange }) => (
     <LogoutModal open={open} onOpenChange={onOpenChange} email={user.email} />
   ));
+
+  const handleSupport = () => {
+    window.open("https://www.masumi.network/contact", "_blank");
+  };
 
   return (
     <>
@@ -78,6 +87,14 @@ export default function UserAvatarClient({ user }: UserAvatarClientProps) {
               </Link>
             </DropdownMenuItem>
           </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="flex cursor-pointer items-center gap-2"
+            onClick={handleSupport}
+          >
+            <CircleHelp className="text-muted-foreground" />
+            {t("support")}
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="flex cursor-pointer items-center gap-2"

--- a/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
+++ b/web-app/src/app/app/components/user-avatar/user-avatar.client.tsx
@@ -68,7 +68,7 @@ export default function UserAvatarClient({ user }: UserAvatarClientProps) {
                 </Button>
               </DropdownMenuTrigger>
             </TooltipTrigger>
-            <TooltipContent side="bottom">{user.name}</TooltipContent>
+            <TooltipContent side="bottom">{user.email}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 


### PR DESCRIPTION
# Changes
- Integrate Gravatar for user avatars using user's email
- Add support menu item that links to `masumi.network/contact`
- Remove redundant user info label from dropdown menu
- Add `gravatar-url` dependency and related packages
- Add translation for support menu item

# Technical Details
- Use `gravatar-url` package to generate avatar URLs with fallback
- Support menu opens in new tab
- Avatar size set to 80px
- Gravatar fallback set to "404"