### PR TITLE
feat(ui): add agent image to job creation information panel

### DIFF
--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
@@ -51,7 +51,7 @@ function InformationAccordionItem({ agent }: { agent: AgentWithRelations }) {
   return (
     <AccordionItemWrapper value="information" title={t("title")}>
       <div className="flex flex-wrap gap-2">
-        <div className="h-24 w-24 flex-shrink-0">
+        <div className="h-24 w-24">
           <Image
             src={image}
             alt={name}
@@ -60,7 +60,7 @@ function InformationAccordionItem({ agent }: { agent: AgentWithRelations }) {
             className="rounded-md object-cover"
           />
         </div>
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex flex-1 flex-col gap-0.5">
           <h3 className="text-lg font-bold">{name}</h3>
           {description && <p className="text-sm">{description}</p>}
         </div>

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 
 import { Accordion } from "@/components/ui/accordion";
@@ -7,6 +8,7 @@ import {
   CreditsPrice,
   getAgentDescription,
   getAgentName,
+  getAgentResolvedImage,
 } from "@/lib/db";
 
 import AccordionItemWrapper from "./accordion-wrapper";
@@ -44,12 +46,24 @@ function InformationAccordionItem({ agent }: { agent: AgentWithRelations }) {
   const t = useTranslations("App.Agents.Jobs.CreateJob.Information");
   const name = getAgentName(agent);
   const description = getAgentDescription(agent);
+  const image = getAgentResolvedImage(agent);
 
   return (
     <AccordionItemWrapper value="information" title={t("title")}>
-      <div className="flex flex-1 flex-col gap-0.5">
-        <h3 className="text-lg font-bold">{name}</h3>
-        {description && <p className="text-sm">{description}</p>}
+      <div className="flex flex-wrap gap-2">
+        <div className="h-24 w-24 flex-shrink-0">
+          <Image
+            src={image}
+            alt={name}
+            width={96}
+            height={96}
+            className="rounded-md object-cover"
+          />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <h3 className="text-lg font-bold">{name}</h3>
+          {description && <p className="text-sm">{description}</p>}
+        </div>
       </div>
     </AccordionItemWrapper>
   );

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/create-job-section.tsx
@@ -60,7 +60,7 @@ function InformationAccordionItem({ agent }: { agent: AgentWithRelations }) {
             className="rounded-md object-cover"
           />
         </div>
-        <div className="flex flex-1 flex-col gap-0.5">
+        <div className="flex flex-1 flex-col justify-center gap-0.5">
           <h3 className="text-lg font-bold">{name}</h3>
           {description && <p className="text-sm">{description}</p>}
         </div>

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/job-columns.tsx
@@ -2,6 +2,7 @@ import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useFormatter, useTranslations } from "next-intl";
 
 import { DataTableColumnHeader } from "@/components/data-table";
+import { MiddleTruncate } from "@/components/middle-truncate";
 import { JobWithRelations } from "@/lib/db";
 
 import JobStatusBadge from "./job-status-badge";
@@ -55,8 +56,11 @@ export function getJobColumns(
         <DataTableColumnHeader column={column} title={t("Header.id")} />
       ),
       cell: ({ row }) => (
-        <div className="p-2 whitespace-nowrap">
-          <div className="font-mono text-xs">{row.original.id}</div>
+        <div className="p-2">
+          <MiddleTruncate
+            text={row.original.id}
+            className="font-mono text-xs"
+          />
         </div>
       ),
       enableSorting: true,

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/job-columns.tsx
@@ -21,7 +21,7 @@ export function getJobColumns(
         <DataTableColumnHeader column={column} title={t("Header.started")} />
       ),
       cell: ({ row }) => (
-        <div className="p-2 whitespace-nowrap">
+        <div className="py-2 whitespace-nowrap">
           {dateFormatter.dateTime(new Date(row.original.startedAt), {
             year: "numeric",
             month: "short",
@@ -40,7 +40,7 @@ export function getJobColumns(
         <DataTableColumnHeader column={column} title={t("Header.status")} />
       ),
       cell: ({ row }) => (
-        <div className="p-2">
+        <div>
           <JobStatusBadge status={row.original.status} />
         </div>
       ),
@@ -56,7 +56,7 @@ export function getJobColumns(
         <DataTableColumnHeader column={column} title={t("Header.id")} />
       ),
       cell: ({ row }) => (
-        <div className="p-2">
+        <div>
           <MiddleTruncate
             text={row.original.id}
             className="font-mono text-xs"

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/job-columns.tsx
@@ -16,12 +16,12 @@ export function getJobColumns(
   return {
     startedAtColumn: columnHelper.accessor("startedAt", {
       id: "startedAt",
-      minSize: 100,
+      minSize: 80,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title={t("Header.started")} />
       ),
       cell: ({ row }) => (
-        <div className="py-2 whitespace-nowrap">
+        <div className="p-2 whitespace-nowrap">
           {dateFormatter.dateTime(new Date(row.original.startedAt), {
             year: "numeric",
             month: "short",
@@ -50,8 +50,7 @@ export function getJobColumns(
 
     idColumn: columnHelper.accessor("id", {
       id: "id",
-      minSize: 200,
-      enableResizing: true,
+      minSize: 100,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title={t("Header.id")} />
       ),

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/jobs-table.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/jobs-table.tsx
@@ -44,7 +44,7 @@ export default function JobsTable({ jobs }: JobsTableProps) {
         return "active:bg-muted hover:bg-muted";
       }}
       containerClassName={cn(
-        "w-full lg:w-[max(500px,42%)] rounded-xl bg-muted/50",
+        "w-full lg:w-[max(465px,32%)] rounded-xl bg-muted/50",
       )}
       defaultSort={[
         {

--- a/web-app/src/components/middle-truncate.tsx
+++ b/web-app/src/components/middle-truncate.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+interface MiddleTruncateProps {
+  text: string;
+  className?: string;
+  ellipsis?: string;
+  startChars?: number;
+  endChars?: number;
+}
+
+export function MiddleTruncate({
+  text,
+  className,
+  ellipsis = "...",
+  startChars = 6,
+  endChars = 6,
+}: MiddleTruncateProps) {
+  if (text.length <= startChars + endChars) {
+    return <span className={className}>{text}</span>;
+  }
+
+  const start = text.slice(0, startChars);
+  const end = text.slice(-endChars);
+
+  return (
+    <span className={cn("inline-flex", className)} title={text}>
+      <span>{start}</span>
+      <span>{ellipsis}</span>
+      <span>{end}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
### Overview
Enhances the job creation interface by adding the agent's image to the information accordion panel, providing better visual context for users when creating jobs.

### Changes
- Add agent image display using Next.js Image component for optimal performance
- Implement responsive layout with flex-wrap for better mobile support
- Configure image with proper dimensions (96x96) and rounded corners
- Maintain text content layout with proper spacing and overflow handling

### Visual Changes
- Adds a 96x96px agent image with rounded corners
- Maintains existing text layout with proper spacing