### PR TITLE
feat(credits): enforce minimum fee of 1 credit in cents for credit purchases

### DIFF
--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 const envSecretsSchema = z.object({
   // Database
   DATABASE_URL: z.string().url(),
+  MIN_FEE_CREDITS: z.number({ coerce: true }).min(0).default(1),
 
   SHOW_AGENTS_BY_DEFAULT: z
     .string()

--- a/web-app/src/lib/services/credit/service.ts
+++ b/web-app/src/lib/services/credit/service.ts
@@ -4,6 +4,7 @@ import { getEnvPublicConfig } from "@/config/env.config";
 import {
   AgentWithFixedPricing,
   convertCentsToCredits,
+  convertCreditsToCents,
   CreditsPrice,
   getCentsByUserId,
   getCreditCostByUnit,
@@ -105,11 +106,11 @@ export async function getCreditsPrice(
     throw new Error("Added fee percentage must be equal to or greater than 0");
   }
   const feeMultiplier = feePercentagePoints / 100;
-
   const amountsParsed = pricingAmountsSchema.parse(amounts);
 
   let totalCents = BigInt(0);
   let totalFee = BigInt(0);
+  const minFeeCents = convertCreditsToCents(1); // 1 credit in cents
   for (const amount of amountsParsed) {
     const creditCost = await getCreditCostByUnit(amount.unit, tx);
     if (!creditCost) {
@@ -121,6 +122,9 @@ export async function getCreditsPrice(
     // round up to the nearest integer
     totalCents += BigInt(Math.ceil(cents));
     totalFee += BigInt(Math.ceil(fee));
+  }
+  if (totalFee < minFeeCents) {
+    totalFee = minFeeCents;
   }
   return { cents: totalCents + totalFee, includedFee: totalFee };
 }

--- a/web-app/src/lib/services/credit/service.ts
+++ b/web-app/src/lib/services/credit/service.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getEnvPublicConfig } from "@/config/env.config";
+import { getEnvPublicConfig, getEnvSecrets } from "@/config/env.config";
 import {
   AgentWithFixedPricing,
   convertCentsToCredits,
@@ -110,7 +110,7 @@ export async function getCreditsPrice(
 
   let totalCents = BigInt(0);
   let totalFee = BigInt(0);
-  const minFeeCents = convertCreditsToCents(1); // 1 credit in cents
+  const minFeeCents = convertCreditsToCents(getEnvSecrets().MIN_FEE_CREDITS);
   for (const amount of amountsParsed) {
     const creditCost = await getCreditCostByUnit(amount.unit, tx);
     if (!creditCost) {


### PR DESCRIPTION
#### Summary
This PR updates the credit pricing logic to ensure that the included fee for credit purchases is never less than the value of 1 credit (in cents). This change guarantees a minimum fee is always applied, regardless of the calculated percentage-based fee.

#### Details
- Introduced a minimum fee (`minFeeCents`) equal to the value of 1 credit (in cents), using the `convertCreditsToCents` utility.
- After calculating the total fee, the logic now checks if the fee is less than `minFeeCents`. If so, it sets the fee to `minFeeCents`.
- This ensures that very small purchases or low fee percentages still result in a non-zero, meaningful fee.

#### Rationale
- Prevents scenarios where the fee could be zero or negligible due to rounding or low purchase amounts.
- Ensures consistent revenue and covers transaction costs for all credit purchases.

#### Impact
- Affects the `getCreditsPrice` function in `web-app/src/lib/services/credit/service.ts`.
- No changes to the public API, but the returned fee and total price may be slightly higher for small transactions.

#### Testing
- Please verify that credit purchases with small amounts or low fee percentages now always include a minimum fee equal to 1 credit (in cents).
- Existing tests for credit pricing should be updated or extended to cover this edge case.

---

Closes #517 