### PR TITLE
feat(auth): add home navigation via logo in auth layout

### DIFF
--- a/web-app/src/app/(auth)/layout.tsx
+++ b/web-app/src/app/(auth)/layout.tsx
@@ -27,7 +27,9 @@ export default function AuthLayout({
   return (
     <div className="flex h-svh gap-6 p-6">
       <div className="flex h-full flex-1 flex-col gap-6">
-        <ThemedLogo LogoComponent={SokosumiLogo} priority />
+        <Link href="/">
+          <ThemedLogo LogoComponent={SokosumiLogo} priority />
+        </Link>
         <div className="mx-auto flex w-full max-w-md flex-1 items-center justify-center">
           {children}
         </div>


### PR DESCRIPTION
### Changes
* Wraps the ThemedLogo component with a Link component in the authentication layout
* Enables navigation to the home page (/) when clicking the logo
* Maintains existing logo styling and priority loading

### Why
* This change improves the user experience by:
   * Adding a standard navigation pattern where logos link to the home page
   * Providing an easy way for users to exit the authentication flow
   * Following web conventions for logo behavior