### PR TITLE
feat(db): add getOnlineAgents and getAgentsWithStatus for agent filtering

### DIFF
--- a/web-app/src/app/(landing)/agents/page.tsx
+++ b/web-app/src/app/(landing)/agents/page.tsx
@@ -7,7 +7,7 @@ import {
   Agents,
   AgentsNotAvailable,
 } from "@/components/agents";
-import { AgentWithRelations, getAgents } from "@/lib/db";
+import { AgentWithRelations, getOnlineAgents } from "@/lib/db";
 import { getAgentCreditsPrice } from "@/lib/services";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function GalleryPage() {
-  const agents: AgentWithRelations[] = await getAgents();
+  const agents: AgentWithRelations[] = await getOnlineAgents();
 
   if (!agents.length) {
     return <AgentsNotAvailable />;

--- a/web-app/src/app/(landing)/components/agents-showcase.tsx
+++ b/web-app/src/app/(landing)/components/agents-showcase.tsx
@@ -5,7 +5,7 @@ import React, { Suspense } from "react";
 import { AgentModal, AgentModalTrigger } from "@/components/agents";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getAgentResolvedImage, getAgents } from "@/lib/db";
+import { getAgentResolvedImage, getOnlineAgents } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
 interface AgentCardProps {
@@ -58,7 +58,7 @@ const AgentCardSkeleton = () => {
 };
 
 async function AgentsShowcaseList() {
-  const agents = await getAgents();
+  const agents = await getOnlineAgents();
   const firstFiveAgents = agents.slice(0, 5);
 
   return (

--- a/web-app/src/app/(landing)/components/featured-agents.tsx
+++ b/web-app/src/app/(landing)/components/featured-agents.tsx
@@ -3,13 +3,13 @@ import { getTranslations } from "next-intl/server";
 
 import { AgentCard } from "@/components/agents";
 import { Button } from "@/components/ui/button";
-import { getAgents } from "@/lib/db";
+import { getOnlineAgents } from "@/lib/db";
 import { getAgentCreditsPrice } from "@/lib/services";
 import { cn } from "@/lib/utils";
 
 export default async function FeaturedAgents() {
   const t = await getTranslations("Landing.Page.FeaturedAgents");
-  const agents = await getAgents();
+  const agents = await getOnlineAgents();
   const firstFourAgents = agents.slice(0, 4);
 
   const agentPriceList = await Promise.all(

--- a/web-app/src/app/app/agents/page.tsx
+++ b/web-app/src/app/app/agents/page.tsx
@@ -3,7 +3,7 @@ import { getTranslations } from "next-intl/server";
 
 import { AgentModal } from "@/components/agents";
 import { requireAuthentication } from "@/lib/auth/utils";
-import { AgentWithRelations, getAgents, getTags } from "@/lib/db";
+import { AgentWithRelations, getOnlineAgents, getTags } from "@/lib/db";
 import {
   getAgentCreditsPrice,
   getOrCreateFavoriteAgentList,
@@ -23,7 +23,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function GalleryPage() {
-  const agents: AgentWithRelations[] = await getAgents();
+  const agents: AgentWithRelations[] = await getOnlineAgents();
   const tags: Tag[] = await getTags();
   const tagNames = tags.map((tag) => tag.name);
 

--- a/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.tsx
+++ b/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 
-import { getAgents } from "@/lib/db";
+import { getOnlineAgents } from "@/lib/db";
 
 import BreadcrumbNavigationClient from "./breadcrumb-navigation.client";
 import BreadcrumbNavigationSkeleton from "./breadcrumb-navigation.skeleton";
@@ -34,7 +34,7 @@ async function BreadcrumbNavigationInner({
   className?: string | undefined;
   segmentLabels?: Record<string, string>;
 }) {
-  const agents = await getAgents();
+  const agents = await getOnlineAgents();
 
   return (
     <BreadcrumbNavigationClient

--- a/web-app/src/lib/db/agent/repo.ts
+++ b/web-app/src/lib/db/agent/repo.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/db";
-import { Prisma } from "@/prisma/generated/client";
+import { AgentStatus, Prisma } from "@/prisma/generated/client";
 
 import {
   agentInclude,
@@ -10,6 +10,24 @@ import {
   AgentWithJobs,
   AgentWithRelations,
 } from "./types";
+
+export async function getOnlineAgents(
+  tx: Prisma.TransactionClient = prisma,
+): Promise<AgentWithRelations[]> {
+  return await getAgentsWithStatus(AgentStatus.ONLINE, tx);
+}
+
+export async function getAgentsWithStatus(
+  status: AgentStatus,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<AgentWithRelations[]> {
+  return await tx.agent.findMany({
+    include: agentInclude,
+    where: {
+      status,
+    },
+  });
+}
 
 export async function getAgents(
   tx: Prisma.TransactionClient = prisma,


### PR DESCRIPTION
### Summary

This PR introduces two new database utility functions, `getOnlineAgents` and `getAgentsWithStatus`, to enable filtering agents by their status (e.g., online). All relevant usages of the previous `getAgents` function in the landing and app pages, as well as supporting components, have been updated to use `getOnlineAgents` for improved accuracy and performance.

### Details

- Added `getOnlineAgents` and `getAgentsWithStatus` to `web-app/src/lib/db/agent/repo.ts` for status-based agent retrieval.
- Updated imports and usages of `getAgents` to `getOnlineAgents` in:
  - Landing page (`web-app/src/app/(landing)/agents/page.tsx`)
  - Agents showcase component (`web-app/src/app/(landing)/components/agents-showcase.tsx`)
  - Featured agents component (`web-app/src/app/(landing)/components/featured-agents.tsx`)
  - App agents page (`web-app/src/app/app/agents/page.tsx`)
  - Breadcrumb navigation (`web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.tsx`)
- Ensured all affected components now only display agents with an online status.

### Motivation

- Improves user experience by only showing agents that are currently online.
- Lays the groundwork for more flexible agent filtering in the future.

### Notes

- No breaking changes; `getAgents` remains available for backward compatibility.
- All changes follow project conventions for modularity, naming, and best practices.

---

Closes #<issue-number-if-applicable>
