### PR TITLE
fix(agents): prevent crash when agent CreditCost is unavailable

### DIFF
--- a/web-app/src/app/(landing)/agents/page.tsx
+++ b/web-app/src/app/(landing)/agents/page.tsx
@@ -22,27 +22,48 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function GalleryPage() {
   const agents: AgentWithRelations[] = await getOnlineAgents();
 
-  if (!agents.length) {
-    return <AgentsNotAvailable />;
+  // Combine agent and price, omitting agents where getAgentCreditsPrice throws
+  const agentPriceResults = await Promise.allSettled(
+    agents.map(async (agent) => {
+      const agentCreditsPrice = await getAgentCreditsPrice(agent);
+      return { agent, agentCreditsPrice };
+    }),
+  );
+
+  interface AgentWithPrice {
+    agent: AgentWithRelations;
+    agentCreditsPrice: Awaited<ReturnType<typeof getAgentCreditsPrice>>;
   }
 
-  const agentCreditsPriceList = await Promise.all(
-    agents.map((agent) => getAgentCreditsPrice(agent)),
-  );
+  const agentsWithPrice: AgentWithPrice[] = agentPriceResults
+    .filter(
+      (result): result is PromiseFulfilledResult<AgentWithPrice> =>
+        result.status === "fulfilled",
+    )
+    .map((result) => result.value);
+
+  if (!agentsWithPrice.length) {
+    return <AgentsNotAvailable />;
+  }
 
   return (
     <div className="container mx-auto px-12 pt-4 pb-8">
       <div className="space-y-24">
         {/* Featured Agent Section */}
         <AgentCard
-          agent={agents[0]}
-          agentCreditsPrice={agentCreditsPriceList[0]}
+          agent={agentsWithPrice[0].agent}
+          agentCreditsPrice={agentsWithPrice[0].agentCreditsPrice}
           className="w-full"
           size="lg"
         />
 
         {/* Agent Cards Grid */}
-        <Agents agents={agents} agentCreditsPriceList={agentCreditsPriceList} />
+        <Agents
+          agents={agentsWithPrice.map((item) => item.agent)}
+          agentCreditsPriceList={agentsWithPrice.map(
+            (item) => item.agentCreditsPrice,
+          )}
+        />
 
         {/* Agent Modal Wrapper */}
         <AgentModal />


### PR DESCRIPTION
### Summary  
This PR addresses an issue where the `/agents` landing page would crash if an agent's `CreditCost` could not be determined (e.g., when `getAgentCreditsPrice` throws). The solution ensures that only agents with a successfully resolved `CreditCost` are rendered, and gracefully handles cases where no agents are available.

### Details  
- Uses `Promise.allSettled` to fetch agent credit prices, filtering out agents where `getAgentCreditsPrice` fails.
- Only agents with a valid `CreditCost` are passed to the UI components.
- If no agents with a valid `CreditCost` are available, the `AgentsNotAvailable` component is rendered.
- Prevents runtime errors and improves user experience by handling missing or failing price data.

### Testing  
- Verified that the page no longer crashes when some agents have missing or failing `CreditCost` data.
- Confirmed that agents with valid prices are displayed as expected.
- Confirmed that the "not available" state is shown if all agents fail to provide a price.