### PR TITLE
refactor: remove dependabot reviewers option and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# They are default owners
+
+*       @mrgrauel @golddydev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
-    reviewers:
-      - "mrgrauel"
-      - "golddydev"
     commit-message:
       prefix: "chore(deps)"
 
@@ -22,12 +19,9 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
-    reviewers:
-      - "mrgrauel"
-      - "golddydev"
     commit-message:
       prefix: "chore(deps)"
-  
+
   # Enable version updates for npm in the job-cron-caller directory
   - package-ecosystem: "npm"
     directory: "/job-cron-caller"
@@ -39,12 +33,9 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
-    reviewers:
-      - "mrgrauel"
-      - "golddydev"
     commit-message:
       prefix: "chore(deps)"
-  
+
   # Enable version updates for npm in the registry-cron-caller directory
   - package-ecosystem: "npm"
     directory: "/registry-cron-caller"
@@ -56,8 +47,5 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
-    reviewers:
-      - "mrgrauel"
-      - "golddydev"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Changes

* Remove dependabot's `reviewers` option and add `CODEOWNERS`

## Reference

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/