### PR TITLE
fix(agent-card): increase agent name line-height to prevent text cutoff

### DIFF
--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -92,7 +92,7 @@ const agentCardContentVariants = cva("flex flex-col", {
       xs: "flex-1 gap-1 min-w-0 [&_h3]:font-medium [&_h3]:text-xs [&_p]:text-xs",
       sm: "flex-1 gap-2 min-w-0 [&_h3]:font-medium [&_h3]:text-sm [&_p]:text-sm",
       md: "flex-1 gap-2 p-1 [&_h3]:font-medium [&_h3]:text-base [&_p]:text-base",
-      lg: "flex-1 p-12 gap-12 [&>div]:gap-2 [&_h3]:font-light [&_h3]:text-3xl [&_p]:text-base",
+      lg: "flex-1 p-12 max-w-1/2 gap-12 [&>div]:gap-2 [&_h3]:font-light [&_h3]:text-3xl [&_p]:text-base",
     },
   },
   defaultVariants: {
@@ -237,7 +237,7 @@ function AgentCard({
         <div className={cn(agentCardContentVariants({ size }))}>
           <div className="flex flex-col">
             <div className="flex items-center gap-2">
-              <h3 className="text-foreground truncate text-base leading-6 font-medium">
+              <h3 className="text-foreground truncate text-base leading-9 font-medium">
                 {getAgentName(agent)}
               </h3>
               <AgentVerifiedBadge />


### PR DESCRIPTION
This PR addresses an issue where the agent name in the `AgentCard` component was being cut off due to an insufficient line-height. The line-height for the agent name (`h3`) has been increased from `leading-6` to `leading-9`, ensuring the full name is visible and not truncated.  
Additionally, a minor adjustment was made to the `lg` size variant to include `max-w-1/2` for improved layout consistency.

**Changes:**
- Increased line-height for agent name to prevent text cutoff.
- Updated `lg` size variant with `max-w-1/2` for better layout control.

**Reasoning:**  
The previous line-height setting caused longer or larger agent names to be visually truncated, impacting readability and user experience. This fix ensures agent names are fully displayed across all supported sizes.