### PR TITLE
feat(theme): add material and alpha color variables to theme

### DIFF
--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -60,17 +60,17 @@
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
 
-  /* Materials */
-  --color-ultrathin: var(--ultrathin);
-  --color-ultrathin-overlay: var(--ultrathin-overlay);
-  --color-thin: var(--thin);
-  --color-thin-overlay: var(--thin-overlay);
-  --color-regular: var(--regular);
-  --color-regular-overlay: var(--regular-overlay);
-  --color-thick: var(--thick);
-  --color-thick-overlay: var(--thick-overlay);
-  --color-ultrathick: var(--ultrathick);
-  --color-ultrathick-overlay: var(--ultrathick-overlay);
+  /* Material */
+  --color-material-ultrathin: var(--material-ultrathin);
+  --color-material-ultrathin-overlay: var(--material-ultrathin-overlay);
+  --color-material-thin: var(--material-thin);
+  --color-material-thin-overlay: var(--material-thin-overlay);
+  --color-material-regular: var(--material-regular);
+  --color-material-regular-overlay: var(--material-regular-overlay);
+  --color-material-thick: var(--material-thick);
+  --color-material-thick-overlay: var(--material-thick-overlay);
+  --color-material-ultrathick: var(--material-ultrathick);
+  --color-material-ultrathick-overlay: var(--material-ultrathick-overlay);
 
   /* Alpha */
   --color-alpha-95: var(--alpha-95);
@@ -161,16 +161,16 @@
   --semantic-foreground: hsla(0, 86%, 97%, 1);
 
   /* Material */
-  --ultrathin: hsla(0, 0%, 100%, 0.33);
-  --ultrathin-overlay: hsla(0, 0%, 45%, 1);
-  --thin: hsla(0, 0%, 96%, 0.48);
-  --thin-overlay: hsla(0, 0%, 64%, 1);
-  --regular: hsla(0, 0%, 100%, 0.85);
-  --regular-overlay: hsla(0, 0%, 32%, 1);
-  --thick: hsla(0, 0%, 100%, 0.9);
-  --thick-overlay: hsla(0, 0%, 45%, 1);
-  --ultrathick: hsla(0, 0%, 98%, 0.97);
-  --ultrathick-overlay: hsla(0, 0%, 64%, 1);
+  --material-ultrathin: hsla(0, 0%, 100%, 0.33);
+  --material-ultrathin-overlay: hsla(0, 0%, 45%, 1);
+  --material-thin: hsla(0, 0%, 96%, 0.48);
+  --material-thin-overlay: hsla(0, 0%, 64%, 1);
+  --material-regular: hsla(0, 0%, 100%, 0.85);
+  --material-regular-overlay: hsla(0, 0%, 32%, 1);
+  --material-thick: hsla(0, 0%, 100%, 0.9);
+  --material-thick-overlay: hsla(0, 0%, 45%, 1);
+  --material-ultrathick: hsla(0, 0%, 98%, 0.97);
+  --material-ultrathick-overlay: hsla(0, 0%, 64%, 1);
 
   /* Alpha */
   --alpha-95: hsla(0, 0%, 100%, 0.05);
@@ -239,16 +239,16 @@
   --semantic-foreground: hsla(0, 86%, 97%, 1);
 
   /* Material */
-  --ultrathin: hsla(0, 0%, 15%, 0.55);
-  --ultrathin-overlay: hsla(0, 0%, 64%, 1);
-  --thin: hsla(0, 0%, 15%, 0.7);
-  --thin-overlay: hsla(0, 0%, 64%, 1);
-  --regular: hsla(0, 0%, 15%, 0.8);
-  --regular-overlay: hsla(0, 0%, 45%, 1);
-  --thick: hsla(0, 0%, 15%, 0.9);
-  --thick-overlay: hsla(0, 0%, 45%, 1);
-  --ultrathick: hsla(0, 0%, 15%, 0.95);
-  --ultrathick-overlay: hsla(0, 0%, 45%, 1);
+  --material-ultrathin: hsla(0, 0%, 15%, 0.55);
+  --material-ultrathin-overlay: hsla(0, 0%, 64%, 1);
+  --material-thin: hsla(0, 0%, 15%, 0.7);
+  --material-thin-overlay: hsla(0, 0%, 64%, 1);
+  --material-regular: hsla(0, 0%, 15%, 0.8);
+  --material-regular-overlay: hsla(0, 0%, 45%, 1);
+  --material-thick: hsla(0, 0%, 15%, 0.9);
+  --material-thick-overlay: hsla(0, 0%, 45%, 1);
+  --material-ultrathick: hsla(0, 0%, 15%, 0.95);
+  --material-ultrathick-overlay: hsla(0, 0%, 45%, 1);
 
   /* Alpha */
   --alpha-95: hsla(0, 0%, 4%, 0.05);

--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -72,6 +72,19 @@
   --color-ultrathick: var(--ultrathick);
   --color-ultrathick-overlay: var(--ultrathick-overlay);
 
+  /* Alpha */
+  --color-alpha-95: var(--alpha-95);
+  --color-alpha-90: var(--alpha-90);
+  --color-alpha-80: var(--alpha-80);
+  --color-alpha-70: var(--alpha-70);
+  --color-alpha-60: var(--alpha-60);
+  --color-alpha-50: var(--alpha-50);
+  --color-alpha-40: var(--alpha-40);
+  --color-alpha-30: var(--alpha-30);
+  --color-alpha-20: var(--alpha-20);
+  --color-alpha-10: var(--alpha-10);
+  --color-alpha-5: var(--alpha-5);
+
   /* Custom Colors */
   --color-agent-verified-background: hsla(142, 76%, 36%, 0.05);
   --color-agent-verified-foreground: hsla(142, 72%, 29%, 1);
@@ -147,7 +160,7 @@
   --semantic-quinary: hsla(0, 72%, 51%, 0.05);
   --semantic-foreground: hsla(0, 86%, 97%, 1);
 
-  /* Materials */
+  /* Material */
   --ultrathin: hsla(0, 0%, 100%, 0.33);
   --ultrathin-overlay: hsla(0, 0%, 45%, 1);
   --thin: hsla(0, 0%, 96%, 0.48);
@@ -158,6 +171,19 @@
   --thick-overlay: hsla(0, 0%, 45%, 1);
   --ultrathick: hsla(0, 0%, 98%, 0.97);
   --ultrathick-overlay: hsla(0, 0%, 64%, 1);
+
+  /* Alpha */
+  --alpha-95: hsla(0, 0%, 100%, 0.05);
+  --alpha-90: hsla(0, 0%, 100%, 0.1);
+  --alpha-80: hsla(0, 0%, 100%, 0.2);
+  --alpha-70: hsla(0, 0%, 100%, 0.3);
+  --alpha-60: hsla(0, 0%, 100%, 0.4);
+  --alpha-50: hsla(0, 0%, 100%, 0.5);
+  --alpha-40: hsla(0, 0%, 100%, 0.6);
+  --alpha-30: hsla(0, 0%, 100%, 0.7);
+  --alpha-20: hsla(0, 0%, 100%, 0.8);
+  --alpha-10: hsla(0, 0%, 100%, 0.9);
+  --alpha-5: hsla(0, 0%, 100%, 0.95);
 }
 
 .dark {
@@ -212,7 +238,7 @@
   --semantic-quinary: hsla(0, 70%, 35%, 0.1);
   --semantic-foreground: hsla(0, 86%, 97%, 1);
 
-  /* Materials */
+  /* Material */
   --ultrathin: hsla(0, 0%, 15%, 0.55);
   --ultrathin-overlay: hsla(0, 0%, 64%, 1);
   --thin: hsla(0, 0%, 15%, 0.7);
@@ -223,6 +249,19 @@
   --thick-overlay: hsla(0, 0%, 45%, 1);
   --ultrathick: hsla(0, 0%, 15%, 0.95);
   --ultrathick-overlay: hsla(0, 0%, 45%, 1);
+
+  /* Alpha */
+  --alpha-95: hsla(0, 0%, 4%, 0.05);
+  --alpha-90: hsla(0, 0%, 4%, 0.1);
+  --alpha-80: hsla(0, 0%, 4%, 0.2);
+  --alpha-70: hsla(0, 0%, 4%, 0.3);
+  --alpha-60: hsla(0, 0%, 4%, 0.4);
+  --alpha-50: hsla(0, 0%, 4%, 0.5);
+  --alpha-40: hsla(0, 0%, 4%, 0.6);
+  --alpha-30: hsla(0, 0%, 4%, 0.7);
+  --alpha-20: hsla(0, 0%, 4%, 0.8);
+  --alpha-10: hsla(0, 0%, 4%, 0.9);
+  --alpha-5: hsla(0, 0%, 4%, 0.95);
 }
 
 @layer base {

--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -60,6 +60,18 @@
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
 
+  /* Materials */
+  --color-ultrathin: var(--ultrathin);
+  --color-ultrathin-overlay: var(--ultrathin-overlay);
+  --color-thin: var(--thin);
+  --color-thin-overlay: var(--thin-overlay);
+  --color-regular: var(--regular);
+  --color-regular-overlay: var(--regular-overlay);
+  --color-thick: var(--thick);
+  --color-thick-overlay: var(--thick-overlay);
+  --color-ultrathick: var(--ultrathick);
+  --color-ultrathick-overlay: var(--ultrathick-overlay);
+
   /* Custom Colors */
   --color-agent-verified-background: hsla(142, 76%, 36%, 0.05);
   --color-agent-verified-foreground: hsla(142, 72%, 29%, 1);
@@ -134,6 +146,18 @@
   --semantic-quaternary: hsla(0, 72%, 51%, 0.1);
   --semantic-quinary: hsla(0, 72%, 51%, 0.05);
   --semantic-foreground: hsla(0, 86%, 97%, 1);
+
+  /* Materials */
+  --ultrathin: hsla(0, 0%, 100%, 0.33);
+  --ultrathin-overlay: hsla(0, 0%, 45%, 1);
+  --thin: hsla(0, 0%, 96%, 0.48);
+  --thin-overlay: hsla(0, 0%, 64%, 1);
+  --regular: hsla(0, 0%, 100%, 0.85);
+  --regular-overlay: hsla(0, 0%, 32%, 1);
+  --thick: hsla(0, 0%, 100%, 0.9);
+  --thick-overlay: hsla(0, 0%, 45%, 1);
+  --ultrathick: hsla(0, 0%, 98%, 0.97);
+  --ultrathick-overlay: hsla(0, 0%, 64%, 1);
 }
 
 .dark {
@@ -187,6 +211,18 @@
   --semantic-quaternary: hsla(0, 70%, 35%, 0.2);
   --semantic-quinary: hsla(0, 70%, 35%, 0.1);
   --semantic-foreground: hsla(0, 86%, 97%, 1);
+
+  /* Materials */
+  --ultrathin: hsla(0, 0%, 15%, 0.55);
+  --ultrathin-overlay: hsla(0, 0%, 64%, 1);
+  --thin: hsla(0, 0%, 15%, 0.7);
+  --thin-overlay: hsla(0, 0%, 64%, 1);
+  --regular: hsla(0, 0%, 15%, 0.8);
+  --regular-overlay: hsla(0, 0%, 45%, 1);
+  --thick: hsla(0, 0%, 15%, 0.9);
+  --thick-overlay: hsla(0, 0%, 45%, 1);
+  --ultrathick: hsla(0, 0%, 15%, 0.95);
+  --ultrathick-overlay: hsla(0, 0%, 45%, 1);
 }
 
 @layer base {


### PR DESCRIPTION
### Summary
This PR introduces a comprehensive set of new CSS custom properties for both "material" and "alpha" color layers, enhancing the flexibility and consistency of the application's color system. These variables are now available for both light and dark modes, supporting more nuanced UI theming and overlays.

### Details
- **Material Colors:** Added variables for multiple material surface levels (`ultrathin`, `thin`, `regular`, `thick`, `ultrathick`) and their overlay counterparts, for both light and dark themes.
- **Alpha Colors:** Added a full range of alpha transparency variables (`alpha-95` through `alpha-5`) for both light and dark themes.
- All new variables are defined in `:root` and `.dark` selectors for seamless theme switching.
- These additions enable more granular control over backgrounds, overlays, and transparency effects throughout the UI.

https://www.figma.com/design/VP07JQod1Tr2KQBi6zCdcZ/adjusted-shadcn_ui-kit-for-Figma---Pro-Blocks---Default---December-2024?node-id=9022-183161&p=f&vars=1&m=dev