### PR TITLE
fix(sync-function): correct SOKOSUMI_URL usage and API endpoint construction

### DIFF
--- a/.github/workflows/deploy-main-sync-function.yml
+++ b/.github/workflows/deploy-main-sync-function.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: ./sync-function
     env:
-      SOKOSUMI_API_URL: ${{ vars.SOKOSUMI_API_URL }}
+      SOKOSUMI_URL: ${{ vars.SOKOSUMI_URL }}
       ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
       SOKOSUMI_FUNCTION_NAMESPACE: ${{ vars.SOKOSUMI_FUNCTION_NAMESPACE }}
     steps:

--- a/.github/workflows/deploy-release-sync-function.yml
+++ b/.github/workflows/deploy-release-sync-function.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: ./sync-function
     env:
-      SOKOSUMI_API_URL: ${{ vars.SOKOSUMI_API_URL }}
+      SOKOSUMI_URL: ${{ vars.SOKOSUMI_URL }}
       ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
       SOKOSUMI_FUNCTION_NAMESPACE: ${{ vars.SOKOSUMI_FUNCTION_NAMESPACE }}
     steps:

--- a/sync-function/project.yml
+++ b/sync-function/project.yml
@@ -14,7 +14,7 @@ packages:
         parameters: {}
         environment:
           ADMIN_KEY: ${ADMIN_KEY}
-          SOKOSUMI_API_URL: ${SOKOSUMI_API_URL}
+          SOKOSUMI_URL: ${SOKOSUMI_URL}
         annotations: {}
         limits: {}
         triggers:

--- a/sync-function/src/main.ts
+++ b/sync-function/src/main.ts
@@ -12,7 +12,6 @@ interface FunctionResponse {
 // Generic function for API calls
 async function callApi(apiUrlString: string, endpoint: string) {
   const url = new URL(endpoint, apiUrlString);
-  console.log("URL:", url);
   const adminKey = process.env.ADMIN_KEY;
   if (!adminKey) {
     throw new Error("ADMIN_KEY environment variable not set");
@@ -33,8 +32,6 @@ export async function main(_args: unknown): Promise<FunctionResponse> {
   try {
     // Get API endpoint from environment variable
     const apiUrlString = process.env.SOKOSUMI_URL;
-    console.log("SOKOSUMI URL:", apiUrlString);
-
     if (!apiUrlString) {
       return {
         statusCode: 400,

--- a/sync-function/src/main.ts
+++ b/sync-function/src/main.ts
@@ -12,6 +12,7 @@ interface FunctionResponse {
 // Generic function for API calls
 async function callApi(apiUrlString: string, endpoint: string) {
   const url = new URL(endpoint, apiUrlString);
+  console.log("URL:", url);
   const adminKey = process.env.ADMIN_KEY;
   if (!adminKey) {
     throw new Error("ADMIN_KEY environment variable not set");
@@ -31,12 +32,13 @@ async function callApi(apiUrlString: string, endpoint: string) {
 export async function main(_args: unknown): Promise<FunctionResponse> {
   try {
     // Get API endpoint from environment variable
-    const apiUrlString = process.env.SOKOSUMI_API_URL;
+    const apiUrlString = process.env.SOKOSUMI_URL;
+    console.log("SOKOSUMI URL:", apiUrlString);
 
     if (!apiUrlString) {
       return {
         statusCode: 400,
-        body: { error: "SOKOSUMI_API_URL environment variable not set" },
+        body: { error: "SOKOSUMI_URL environment variable not set" },
       };
     }
 
@@ -44,8 +46,8 @@ export async function main(_args: unknown): Promise<FunctionResponse> {
     let agentsData, jobsData;
     try {
       [agentsData, jobsData] = await Promise.all([
-        callApi(apiUrlString, "/sync/agents"),
-        callApi(apiUrlString, "/sync/jobs"),
+        callApi(apiUrlString, "api/sync/agents"),
+        callApi(apiUrlString, "api/sync/jobs"),
       ]);
     } catch (err) {
       return {

--- a/sync-function/src/main.ts
+++ b/sync-function/src/main.ts
@@ -10,8 +10,8 @@ interface FunctionResponse {
 }
 
 // Generic function for API calls
-async function callApi(apiUrlString: string, endpoint: string) {
-  const url = new URL(endpoint, apiUrlString);
+async function callApi(baseUrl: string, endpoint: string) {
+  const url = new URL(endpoint, baseUrl);
   const adminKey = process.env.ADMIN_KEY;
   if (!adminKey) {
     throw new Error("ADMIN_KEY environment variable not set");
@@ -31,8 +31,8 @@ async function callApi(apiUrlString: string, endpoint: string) {
 export async function main(_args: unknown): Promise<FunctionResponse> {
   try {
     // Get API endpoint from environment variable
-    const apiUrlString = process.env.SOKOSUMI_URL;
-    if (!apiUrlString) {
+    const baseUrl = process.env.SOKOSUMI_URL;
+    if (!baseUrl) {
       return {
         statusCode: 400,
         body: { error: "SOKOSUMI_URL environment variable not set" },
@@ -43,8 +43,8 @@ export async function main(_args: unknown): Promise<FunctionResponse> {
     let agentsData, jobsData;
     try {
       [agentsData, jobsData] = await Promise.all([
-        callApi(apiUrlString, "api/sync/agents"),
-        callApi(apiUrlString, "api/sync/jobs"),
+        callApi(baseUrl, "api/sync/agents"),
+        callApi(baseUrl, "api/sync/jobs"),
       ]);
     } catch (err) {
       return {


### PR DESCRIPTION

This PR addresses an issue where the API URL was incorrectly constructed in the sync-function deployment and source code. The following changes have been made:

- Replaced all instances of the `SOKOSUMI_API_URL` environment variable with `SOKOSUMI_URL` in workflow files, deployment configuration, and code.
- Updated the API call logic in `sync-function/src/main.ts` to use the correct base URL and endpoint paths, ensuring the URL is constructed properly (e.g., `SOKOSUMI_URL + /api/sync/agents`).
- Updated error messages and environment variable checks to reference `SOKOSUMI_URL`.
- Ensured consistency across GitHub Actions workflows and the `project.yml` configuration.

**Why:**  
The previous implementation incorrectly constructed the API URL, leading to failed requests. This fix ensures the correct base URL and endpoint paths are used, allowing the sync-function to communicate with the backend as intended.

**Impact:**  
- Fixes deployment and runtime issues related to API calls in the sync-function.
- No breaking changes to other parts of the system.
