### PR TITLE
feat(auth): restrict signup to allowed email domains for non-production environments

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -386,7 +386,8 @@
           },
           "Errors": {
             "Submit": {
-              "userExists": "User already exists"
+              "userExists": "User already exists",
+              "emailDomainNotAllowed": "Email must end with {allowedEmailDomains}"
             }
           },
           "Login": {

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -40,10 +40,20 @@ export default function SignUpForm() {
         callbackURL: "/app",
       },
       {
+        onRequest: (ctx) => {
+          console.log("ctx onRequest", ctx);
+        },
         onError: (ctx) => {
           switch (ctx.error.code) {
             case "USER_ALREADY_EXISTS":
               toast.error(t("Errors.Submit.userExists"));
+              break;
+            case "EMAIL_DOMAIN_NOT_ALLOWED":
+              toast.error(
+                t("Errors.Submit.emailDomainNotAllowed", {
+                  allowedEmailDomains: ctx.error.message,
+                }),
+              );
               break;
             default:
               toast.error(t("error"));

--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -11,6 +11,11 @@ const envSecretsSchema = z.object({
   DATABASE_URL: z.string().url(),
   MIN_FEE_CREDITS: z.number({ coerce: true }).min(0).default(1),
   FREE_CREDITS_ON_SIGNUP: z.number({ coerce: true }).min(0).default(0),
+  ALLOWED_EMAIL_DOMAINS: z
+    .string()
+    .default("")
+    .transform((val) => (val.trim() === "" ? [] : val.split(",")))
+    .pipe(z.array(z.string())),
 
   SHOW_AGENTS_BY_DEFAULT: z
     .string()


### PR DESCRIPTION
## Description

This PR introduces a signup restriction to protect development, staging, and pre-release environments from misuse. Users can now only register with email addresses belonging to explicitly allowed domains, as specified in the `ALLOWED_EMAIL_DOMAINS` environment variable.

### Key Changes

- **Environment Variable:**  
  Added `ALLOWED_EMAIL_DOMAINS` to the environment config. This variable accepts a comma-separated list of allowed email domains (e.g., `example.com,company.org`). If left empty, no domain restriction is enforced.
- **Auth Middleware:**  
  Implemented a `before` hook in the authentication flow to check the domain of the email during signup. If the domain is not allowed, the signup is blocked and a clear error message is shown.
- **Internationalization:**  
  Added a new error message for disallowed email domains to the English translation file.
- **UI Feedback:**  
  The registration form now displays a user-friendly error if the email domain is not permitted.

### Motivation

This restriction helps prevent unauthorized signups and potential abuse in non-production environments, ensuring only users with approved email domains can create accounts.

### How to Use

1. Set the `ALLOWED_EMAIL_DOMAINS` environment variable in your `.env` file:
   ```
   ALLOWED_EMAIL_DOMAINS=example.com,company.org
   ```
2. Only users with emails ending in these domains will be able to register.

### Notes

- In production, you can leave `ALLOWED_EMAIL_DOMAINS` empty to allow all domains.
- The restriction is enforced server-side and provides localized error feedback to users.
- For dev.sokosumi.com and beta.sokosumi.com, the restriction will automatically activate once this change is deployed. The environment variables are already set to `mkr.io` and `house-of-communication.com`.
- 
---

Closes #617 
