### PR TITLE
fix(button): change "Open App" Button variant from secondary to primary

### DIFF
--- a/web-app/src/app/(landing)/components/app-connection.tsx
+++ b/web-app/src/app/(landing)/components/app-connection.tsx
@@ -36,7 +36,7 @@ async function AppConnectionContent() {
   }
 
   return (
-    <Button variant="secondary" asChild>
+    <Button variant="primary" asChild>
       <Link href="/app">
         <UserRoundIcon className="size-4" />
         {t("app")}


### PR DESCRIPTION
PR Description:
## Summary
- Changed the `AppConnection` button variant from `secondary` to `primary` in the landing page component.

## Details
- Updated the `<Button>` in `web-app/src/app/(landing)/components/app-connection.tsx` to use `variant="primary"` for improved visual prominence and consistency with primary actions.

## Motivation
- Ensures the "Go to App" action stands out as the main call-to-action on the landing page, aligning with UI/UX best practices.

## Notes
- No breaking changes.
- No impact on functionality; purely a UI/UX improvement.
