### PR TITLE
feat(analytics): integrate Plausible analytics into the application

### DIFF
--- a/web-app/next.config.ts
+++ b/web-app/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import { withPlausibleProxy } from "next-plausible";
 
 const nextConfig: NextConfig = {
   images: {
@@ -14,4 +15,4 @@ const nextConfig: NextConfig = {
 
 const withNextIntl = createNextIntlPlugin();
 
-export default withNextIntl(nextConfig);
+export default withNextIntl(withPlausibleProxy()(nextConfig));

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -77,6 +77,7 @@
     "markdown-to-jsx": "7.7.6",
     "next": "15.3.2",
     "next-intl": "4.1.0",
+    "next-plausible": "^3.12.4",
     "next-themes": "0.4.6",
     "nuqs": "2.4.3",
     "p-timeout": "6.1.4",

--- a/web-app/pnpm-lock.yaml
+++ b/web-app/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       next-intl:
         specifier: 4.1.0
         version: 4.1.0(next@15.3.2(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
+      next-plausible:
+        specifier: ^3.12.4
+        version: 3.12.4(next@15.3.2(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4166,6 +4169,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  next-plausible@3.12.4:
+    resolution: {integrity: sha512-cD3+ixJxf8yBYvsideTxqli3fvrB7R4BXcvsNJz8Sm2X1QN039WfiXjCyNWkub4h5++rRs6fHhchUMnOuJokcg==}
+    peerDependencies:
+      next: '^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 '
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -9602,6 +9612,12 @@ snapshots:
       use-intl: 4.1.0(react@19.1.0)
     optionalDependencies:
       typescript: 5.8.3
+
+  next-plausible@3.12.4(next@15.3.2(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      next: 15.3.2(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/web-app/src/app/layout.tsx
+++ b/web-app/src/app/layout.tsx
@@ -4,10 +4,12 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
+import PlausibleProvider from "next-plausible";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { AgentModal } from "@/components/agents";
 import { Toaster } from "@/components/ui/sonner";
+import { getEnvSecrets } from "@/config/env.config";
 import { ThemeProvider } from "@/lib/context/theme-context";
 import { cn } from "@/lib/utils";
 
@@ -36,6 +38,12 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        <PlausibleProvider
+          domain={getEnvSecrets().PLAUSIBLE_DOMAIN}
+          trackOutboundLinks={true}
+        />
+      </head>
       <body
         className={cn(
           geistSans.variable,

--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -22,6 +22,9 @@ const envSecretsSchema = z.object({
     .default("false")
     .transform((val) => val === "true"),
 
+  // Plausible
+  PLAUSIBLE_DOMAIN: z.string().default("sokosumi.com"),
+
   // Stripe
   STRIPE_PUBLISHABLE_KEY: z.string().min(1),
   STRIPE_SECRET_KEY: z.string().min(1),


### PR DESCRIPTION
### Summary

This PR introduces Plausible Analytics integration into the Next.js application using the `next-plausible` package. The analytics script is now loaded via a proxy for improved privacy and performance, and the domain is configurable via environment variables.

### Details

- **Dependency Added:**  
  - `next-plausible@^3.12.4` added to `package.json` and `pnpm-lock.yaml`.
- **Next.js Config:**  
  - Wrapped the Next.js config with `withPlausibleProxy` to enable proxying of Plausible scripts.
- **Root Layout:**  
  - Added `PlausibleProvider` to the `<head>` of the app, using the domain from environment variables and enabling outbound link tracking.
- **Environment Config:**  
  - Added `PLAUSIBLE_DOMAIN` to the environment config with a default value of `sokosumi.com`.

### How it works

- The Plausible script is loaded and configured via the provider in the app's root layout.
- The domain for analytics is managed through environment variables, allowing for easy changes per environment.
- Outbound link tracking is enabled by default.

### Testing

- Ensure the `PLAUSIBLE_DOMAIN` environment variable is set correctly for your deployment.
- Deploy the app and verify that analytics events are sent to your Plausible dashboard.

---

Related: #620 
