### PR TITLE
chore: disable next.js middleware instrument to reduce bundle size

### DIFF
--- a/web-app/next.config.ts
+++ b/web-app/next.config.ts
@@ -46,5 +46,10 @@ export default withSentryConfig(
 
     // Automatically tree-shake Sentry logger statements to reduce bundle size
     disableLogger: true,
+
+    // Automatically instrument Next.js middleware with error and performance monitoring.
+    // disable it on `dev mode` to reduce large middleware bundle size
+    // eslint-disable-next-line no-restricted-properties
+    autoInstrumentMiddleware: process.env.NODE_ENV === "production",
   },
 );


### PR DESCRIPTION
## Warning

```bash
<w> [webpack.cache.PackFileCacheStrategy] Serializing big strings (318kiB) impacts deserialization performance (consider using Buffer instead and decode when needed)
```
We get this warning because of big middleware bundle size.


## Changes

* Disable next.js middleware instrument to reduce bundle size


## Reference

https://github.com/getsentry/sentry-javascript/issues/15100#issuecomment-2732790153
