### PR TITLE
fix: add sentry dsn as public env so we can set that only on production

### DIFF
--- a/web-app/.env.example
+++ b/web-app/.env.example
@@ -12,6 +12,10 @@ STRIPE_SECRET_KEY=<replace-with-your-secret-key>
 STRIPE_PRICE_ID=<replace-with-your-price-id>
 STRIPE_WEBHOOK_SECRET=<replace-with-your-webhook-secret>
 
+# Sentry
+# only set this on production mode
+SENTRY_DSN=<your-sentry-dsn>
+
 # Registry
 REGISTRY_API_KEY=<registry-api-key>
 

--- a/web-app/sentry.edge.config.ts
+++ b/web-app/sentry.edge.config.ts
@@ -5,8 +5,10 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+import { getEnvPublicConfig } from "@/config/env.config";
+
 Sentry.init({
-  dsn: "https://0f7db95968a52973b5927eb69ea181fa@o4509292861325312.ingest.de.sentry.io/4509292868010064",
+  dsn: getEnvPublicConfig().NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/web-app/sentry.server.config.ts
+++ b/web-app/sentry.server.config.ts
@@ -4,8 +4,10 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+import { getEnvPublicConfig } from "@/config/env.config";
+
 Sentry.init({
-  dsn: "https://0f7db95968a52973b5927eb69ea181fa@o4509292861325312.ingest.de.sentry.io/4509292868010064",
+  dsn: getEnvPublicConfig().NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -121,6 +121,8 @@ const envPublicConfigSchema = z.object({
     .max(256)
     .default(256),
 
+  NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
+
   NEXT_PUBLIC_MASUMI_URL: z.string().url().default("https://masumi.network"),
   NEXT_PUBLIC_KODOSUMI_URL: z.string().url().default("https://kodosumi.com"),
   NEXT_PUBLIC_SOKOSUMI_URL: z.string().url().default("https://sokosumi.com"),

--- a/web-app/src/instrumentation-client.ts
+++ b/web-app/src/instrumentation-client.ts
@@ -4,8 +4,10 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+import { getEnvPublicConfig } from "@/config/env.config";
+
 Sentry.init({
-  dsn: "https://0f7db95968a52973b5927eb69ea181fa@o4509292861325312.ingest.de.sentry.io/4509292868010064",
+  dsn: getEnvPublicConfig().NEXT_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [Sentry.replayIntegration()],


### PR DESCRIPTION
## Changes

* Add sentry dsn as public env variable so we can set that only on production

## Benefit

* Do not receive notification on development (which is annoying)

## Reference

https://github.com/getsentry/sentry-javascript/discussions/8546#discussioncomment-6556295