### PR TITLE
fix(ui): align agent cards to start instead of space-between

### DIFF
--- a/web-app/src/components/agents/agents.tsx
+++ b/web-app/src/components/agents/agents.tsx
@@ -64,10 +64,7 @@ function Agents({
 }: AgentsProps) {
   return (
     <div
-      className={cn(
-        "flex flex-wrap justify-between gap-3 space-y-4",
-        className,
-      )}
+      className={cn("flex flex-wrap justify-start gap-3 space-y-4", className)}
     >
       {agents.map((agent, index) => (
         <AgentCard


### PR DESCRIPTION
## Summary
This PR updates the alignment of agent cards in the `Agents` component. The flex container's `justify-content` property is changed from `justify-between` to `justify-start`, ensuring that agent cards are aligned to the start of the row rather than being spaced out across the container.

## Details
- Updated the `className` in `src/components/agents/agents.tsx`:
  - Changed `justify-between` to `justify-start` in the flex container.
- This change improves the visual consistency of agent card alignment, especially when the number of cards does not fill the entire row.

## Rationale
- Aligning cards to the start provides a more predictable and visually appealing layout, particularly for responsive designs and varying card counts.
- Follows UI/UX best practices for card grid layouts.

## Testing
- Verified that agent cards now align to the left (start) of the container.
- Confirmed that the layout remains responsive and visually consistent in both light and dark modes.

Closes: #MAS-100
