### PR TITLE
fix(sentry): use NEXT_PUBLIC_SENTRY_DSN from process.env for Sentry config

### DIFF
--- a/web-app/.env.example
+++ b/web-app/.env.example
@@ -14,7 +14,7 @@ STRIPE_WEBHOOK_SECRET=<replace-with-your-webhook-secret>
 
 # Sentry
 # only set this on production mode
-SENTRY_DSN=<your-sentry-dsn>
+NEXT_PUBLIC_SENTRY_DSN=<your-sentry-dsn>
 
 # Registry
 REGISTRY_API_KEY=<registry-api-key>

--- a/web-app/sentry.edge.config.ts
+++ b/web-app/sentry.edge.config.ts
@@ -5,10 +5,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-import { getEnvPublicConfig } from "@/config/env.config";
-
 Sentry.init({
-  dsn: getEnvPublicConfig().NEXT_PUBLIC_SENTRY_DSN,
+  // eslint-disable-next-line no-restricted-properties
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/web-app/sentry.server.config.ts
+++ b/web-app/sentry.server.config.ts
@@ -4,10 +4,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-import { getEnvPublicConfig } from "@/config/env.config";
-
 Sentry.init({
-  dsn: getEnvPublicConfig().NEXT_PUBLIC_SENTRY_DSN,
+  // eslint-disable-next-line no-restricted-properties
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,


### PR DESCRIPTION
### Summary

This PR updates the Sentry configuration to use the `NEXT_PUBLIC_SENTRY_DSN` environment variable directly from `process.env` instead of relying on the `getEnvPublicConfig` helper. The `.env.example` file is also updated to reflect this change, ensuring consistency and clarity for environment variable usage.

### Changes

- Updated `.env.example`:
  - Changed `SENTRY_DSN` to `NEXT_PUBLIC_SENTRY_DSN` for clarity and alignment with Next.js conventions.
- Updated `sentry.edge.config.ts` and `sentry.server.config.ts`:
  - Replaced usage of `getEnvPublicConfig().NEXT_PUBLIC_SENTRY_DSN` with `process.env.NEXT_PUBLIC_SENTRY_DSN`.
  - Removed unnecessary import of `getEnvPublicConfig`.
  - Added an ESLint disable comment for restricted property access on `process.env`.

### Rationale

- Aligns Sentry DSN environment variable naming with Next.js best practices (`NEXT_PUBLIC_` prefix for variables exposed to the client).
- Simplifies configuration by reading directly from `process.env`.
- Reduces indirection and potential confusion for developers setting up Sentry.

### Impact

- No breaking changes expected.
- Developers should update their `.env` files to use `NEXT_PUBLIC_SENTRY_DSN` instead of `SENTRY_DSN`.
