### PR TITLE
revert(ui): restore agent card alignment to space-between

### DIFF
--- a/web-app/src/components/agents/agents.tsx
+++ b/web-app/src/components/agents/agents.tsx
@@ -64,7 +64,10 @@ function Agents({
 }: AgentsProps) {
   return (
     <div
-      className={cn("flex flex-wrap justify-start gap-3 space-y-4", className)}
+      className={cn(
+        "flex flex-wrap justify-between gap-3 space-y-4",
+        className,
+      )}
     >
       {agents.map((agent, index) => (
         <AgentCard


### PR DESCRIPTION
This PR reverts the alignment change introduced in #658, restoring the original layout of the agent cards in the Agents component. The flex container now uses justify-between instead of justify-start, ensuring agent cards are spaced evenly across the row as before.

- Reverts: fix(ui): align agent cards to start instead of space-between (#658)
- Affected file: src/components/agents/agents.tsx
- Restores previous flex alignment for improved visual distribution of agent cards

No other changes were made.
