### PR TITLE
chore: override markdown max-width and use article tag

### DIFF
--- a/web-app/src/components/markdown.tsx
+++ b/web-app/src/components/markdown.tsx
@@ -9,7 +9,7 @@ interface MarkdownProps {
 const defaultOptions: MarkdownToJSX.Options = {
   disableParsingRawHTML: true,
   wrapper: ({ children }) => (
-    <div className="prose dark:prose-invert">{children}</div>
+    <article className="prose dark:prose-invert max-w-none">{children}</article>
   ),
   forceWrapper: true,
 };


### PR DESCRIPTION
## Changes

* Override `markdown` wrapper's max-width (for better visual look)
* Use semantic `article` tag for better practise