### PR TITLE
fix(i18n): clarify job status by renaming "Payment Pending" to "Payment Processing"

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -578,7 +578,7 @@
           "JobStatusBadge": {
             "completed": "Completed",
             "failed": "Failed",
-            "paymentPending": "Payment Pending",
+            "paymentProcessing": "Payment Processing",
             "paymentFailed": "Payment Failed",
             "processing": "Processing",
             "agentConnectionFailed": "Agent Connection Failed",

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/job-status-badge.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/job-status-badge.tsx
@@ -42,7 +42,7 @@ export default function JobStatusBadge({
           variant="default"
           className={cn("bg-yellow-100 text-yellow-800", className)}
         >
-          {t("paymentPending")}
+          {t("paymentProcessing")}
         </Badge>
       );
     case JobStatus.PROCESSING:


### PR DESCRIPTION
### Summary
This PR updates the job status label from "Payment Pending" to "Payment Processing" throughout the application. The goal is to provide users with a clearer understanding of the current state of their job payments, reducing confusion around whether a payment is awaiting action or actively being processed.

### Changes
- Updated the English translation key in `messages/en.json`:
  - Changed `"paymentPending": "Payment Pending"` to `"paymentProcessing": "Payment Processing"`
- Updated the `JobStatusBadge` component to use the new `paymentProcessing` label.

### Rationale
- "Payment Pending" could be interpreted as requiring user action or waiting for an external event.
- "Payment Processing" more accurately reflects that the system is actively handling the payment, improving user clarity and reducing support inquiries.

### Testing
- Verified that jobs in the payment processing state now display the updated label in the UI.
- Confirmed that no references to the old label remain in the affected components.
