### PR TITLE
refactor(endorsements): remove Lufthansa and BVG from endorsements list

### DIFF
--- a/web-app/src/app/(landing)/components/endorsements.tsx
+++ b/web-app/src/app/(landing)/components/endorsements.tsx
@@ -24,22 +24,6 @@ export default function Endorsements() {
       height: 40,
     },
     {
-      key: "lufthansa",
-      srcLight: "/endorsement/lufthansa-black.svg",
-      srcDark: "/endorsement/lufthansa-white.svg",
-      alt: "Lufthansa",
-      width: 64,
-      height: 64,
-    },
-    {
-      key: "bvg",
-      srcLight: "/endorsement/bvg-black.svg",
-      srcDark: "/endorsement/bvg-white.svg",
-      alt: "BVG",
-      width: 72,
-      height: 64,
-    },
-    {
       key: "cardano-foundation",
       srcLight: "/endorsement/cardano-black.svg",
       srcDark: "/endorsement/cardano-white.svg",


### PR DESCRIPTION
### Summary  
This pull request removes Lufthansa and BVG from the endorsements list displayed on the landing page.

### Details  
- Deleted the Lufthansa and BVG entries from the `endorsements` array in `src/app/(landing)/components/endorsements.tsx`.
- No other logic or UI changes were made.

### Rationale  
- The removal was requested to update the list of organizations shown as endorsers.
- Ensures the endorsements section accurately reflects current partnerships.

### Impact  
- Lufthansa and BVG logos will no longer appear in the endorsements section on the landing page.
- No breaking changes or side effects expected.
