### PR TITLE
feat: add example outputs playlist modal

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -64,7 +64,8 @@
           "title2": "At a Glance"
         },
         "Section4": {
-          "title": "Example Outputs"
+          "title": "Example Outputs",
+          "download": "Download"
         },
         "Section5": {
           "title": "From the developer",

--- a/web-app/src/components/agents/agent-detail/agent-detail.tsx
+++ b/web-app/src/components/agents/agent-detail/agent-detail.tsx
@@ -61,7 +61,10 @@ export function AgentDetail({
       </CardSection>
       {exampleOutputs.length > 0 && (
         <CardSection className={cardClassName}>
-          <AgentDetailSection4 exampleOutputs={exampleOutputs} />
+          <AgentDetailSection4
+            exampleOutputs={exampleOutputs}
+            agentId={agent.id}
+          />
         </CardSection>
       )}
       {legal && (

--- a/web-app/src/components/agents/agent-detail/section-4/example-detail-thumbnail.tsx
+++ b/web-app/src/components/agents/agent-detail/section-4/example-detail-thumbnail.tsx
@@ -1,0 +1,48 @@
+import { Maximize2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ExampleOutput } from "@/prisma/generated/client";
+
+interface ExampleDetailThumbnailProps {
+  exampleOutput: ExampleOutput;
+  onClick?: (() => void) | undefined;
+  showMaximizeButton?: boolean | undefined;
+  className?: string | undefined;
+}
+
+export default function ExampleDetailThumbnail({
+  exampleOutput,
+  onClick,
+  className,
+  showMaximizeButton = true,
+}: ExampleDetailThumbnailProps) {
+  const { name, mimeType } = exampleOutput;
+
+  return (
+    <div
+      className={cn(
+        "border-quinary bg-accent relative flex h-60 w-60 flex-col items-center justify-center gap-2 rounded-lg border shadow-sm",
+        {
+          group: showMaximizeButton,
+        },
+        className,
+      )}
+      onClick={onClick}
+    >
+      <div className="m-4">
+        <h3 className="line-clamp-2 w-full text-center text-sm font-medium">
+          {name}
+        </h3>
+        <p className="text-muted-foreground w-full truncate text-center text-xs">
+          {mimeType}
+        </p>
+        <div className="absolute top-2 right-2 hidden group-hover:block">
+          <Button variant="outline" size="icon">
+            <Maximize2 />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/agents/agent-detail/section-4/index.ts
+++ b/web-app/src/components/agents/agent-detail/section-4/index.ts
@@ -1,0 +1,1 @@
+export * from "./section-4";

--- a/web-app/src/components/agents/agent-detail/section-4/playlist-modal.tsx
+++ b/web-app/src/components/agents/agent-detail/section-4/playlist-modal.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Download, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { AgentHireButton } from "@/components/agents/agent-hire-button";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import { ExampleOutput } from "@/prisma/generated/client";
+
+import ExampleDetailThumbnail from "./example-detail-thumbnail";
+
+interface PlaylistModalProps {
+  open: boolean;
+  onClose: () => void;
+  exampleOutputs: ExampleOutput[];
+  agentId: string;
+  initialIndex?: number | undefined;
+}
+
+export default function PlaylistModal({
+  open,
+  onClose,
+  exampleOutputs,
+  agentId,
+  initialIndex,
+}: PlaylistModalProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex ?? 0);
+
+  useEffect(() => {
+    if (initialIndex) {
+      setCurrentIndex(initialIndex);
+    }
+  }, [initialIndex]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
+
+  const handlePlaylistClick = (index: number) => {
+    setCurrentIndex(index);
+  };
+
+  const selectedExampleOutput = exampleOutputs[currentIndex];
+
+  if (exampleOutputs.length === 0 || !selectedExampleOutput) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay className="backdrop-blur-lg" />
+        <DialogContent className="w-[80vw] max-w-full! min-w-3xl! border-none bg-transparent p-0 focus:ring-0 focus:outline-none [&>button]:hidden">
+          <DialogTitle className="hidden" />
+          <DialogDescription className="hidden" />
+          <div className="flex h-[90svh] w-full">
+            <PlaylistSidebar
+              exampleOutputs={exampleOutputs}
+              currentIndex={currentIndex}
+              onClick={handlePlaylistClick}
+            />
+            <PlaylistMainSection
+              selectedExampleOutput={selectedExampleOutput}
+              agentId={agentId}
+              onClose={onClose}
+            />
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+}
+
+function PlaylistSidebar({
+  exampleOutputs,
+  currentIndex,
+  onClick,
+}: {
+  exampleOutputs: ExampleOutput[];
+  currentIndex: number;
+  onClick: (index: number) => void;
+}) {
+  return (
+    <ScrollArea className="bg-muted h-full rounded-l-xl">
+      <div className="flex w-full flex-col gap-1.5 p-3 pr-6">
+        {exampleOutputs.map((exampleOutput, index) => (
+          <ExampleDetailThumbnail
+            key={exampleOutput.id}
+            exampleOutput={exampleOutput}
+            className={cn("h-24 w-24 cursor-pointer p-2", {
+              "border-primary border-2": currentIndex === index,
+            })}
+            showMaximizeButton={false}
+            onClick={() => onClick(index)}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function PlaylistMainSection({
+  selectedExampleOutput,
+  agentId,
+  onClose,
+}: {
+  selectedExampleOutput: ExampleOutput;
+  agentId: string;
+  onClose: () => void;
+}) {
+  const t = useTranslations("Components.Agents.AgentDetail.Section4");
+
+  return (
+    <div className="bg-background flex-1 rounded-r-xl">
+      <div className="flex items-center justify-between px-6 py-3">
+        <p className="text-foreground text-lg font-medium">
+          {selectedExampleOutput.name}
+        </p>
+        <div className="flex items-center gap-1">
+          <AgentHireButton agentId={agentId} />
+          <Button variant="ghost" size="icon" onClick={onClose}>
+            <X />
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-col items-center justify-center gap-6 p-6">
+        <ExampleDetailThumbnail
+          exampleOutput={selectedExampleOutput}
+          showMaximizeButton={false}
+        />
+        <Button variant="primary" asChild>
+          <a
+            href={selectedExampleOutput.url}
+            download
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Download />
+            {t("download")}
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/agents/agent-detail/section-4/section-4.tsx
+++ b/web-app/src/components/agents/agent-detail/section-4/section-4.tsx
@@ -1,38 +1,54 @@
-import Image from "next/image";
+"use client";
+
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ExampleOutput } from "@/prisma/generated/client";
 
+import ExampleDetailThumbnail from "./example-detail-thumbnail";
+import PlaylistModal from "./playlist-modal";
+
 function AgentDetailSection4({
   exampleOutputs,
+  agentId,
 }: {
   exampleOutputs: ExampleOutput[];
+  agentId: string;
 }) {
   const t = useTranslations("Components.Agents.AgentDetail.Section4");
+  const [open, setOpen] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleThumbnailClick = (index: number) => {
+    setOpen(true);
+    setCurrentIndex(index);
+  };
 
   return (
     <div className="w-full">
       <p className="mb-2 text-xs uppercase">{t("title")}</p>
-      <ScrollArea className="h-64 w-full">
+      <ScrollArea className="h-60 w-full">
         <div className="flex h-full gap-2">
-          {exampleOutputs.map((exampleOutput) => (
+          {exampleOutputs.map((exampleOutput, index) => (
             <div key={exampleOutput.id} className="h-full w-full">
-              <div className="relative h-64 w-64">
-                <Image
-                  src={exampleOutput.url}
-                  alt={exampleOutput.name}
-                  fill
-                  className="object-cover"
-                  sizes="33vw"
-                />
-              </div>
+              <ExampleDetailThumbnail
+                exampleOutput={exampleOutput}
+                onClick={() => handleThumbnailClick(index)}
+              />
             </div>
           ))}
         </div>
         <ScrollBar orientation="horizontal" />
       </ScrollArea>
+      <PlaylistModal
+        open={open}
+        onClose={() => setOpen(false)}
+        exampleOutputs={exampleOutputs}
+        agentId={agentId}
+        initialIndex={currentIndex}
+      />
     </div>
   );
 }
@@ -41,10 +57,10 @@ function AgentDetailSection4Skeleton() {
   return (
     <div className="w-full">
       <Skeleton className="mb-2 h-4 w-12" />
-      <ScrollArea className="h-64 w-full">
+      <ScrollArea className="h-60 w-full">
         <div className="flex h-full gap-2">
           {[1, 2, 3, 4].map((i) => (
-            <Skeleton key={i} className="h-64 w-64" />
+            <Skeleton key={i} className="h-60 w-60" />
           ))}
         </div>
         <ScrollBar orientation="horizontal" />

--- a/web-app/src/components/agents/agent-hire-button.tsx
+++ b/web-app/src/components/agents/agent-hire-button.tsx
@@ -3,15 +3,17 @@
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { ComponentProps } from "react";
 
 import { Button } from "@/components/ui/button";
 import useWithAuthentication from "@/hooks/use-with-authentication";
 
 interface AgentHireButtonProps {
   agentId: string;
+  size?: ComponentProps<typeof Button>["size"] | undefined;
 }
 
-function AgentHireButton({ agentId }: AgentHireButtonProps) {
+function AgentHireButton({ agentId, size = "lg" }: AgentHireButtonProps) {
   const t = useTranslations("Components.Agents");
   const router = useRouter();
   const { isPending, ModalComponent, withAuthentication } =
@@ -25,7 +27,7 @@ function AgentHireButton({ agentId }: AgentHireButtonProps) {
     <>
       {ModalComponent}
       <Button
-        size="lg"
+        size={size}
         variant="primary"
         onClick={withAuthentication(handleHire)}
         disabled={isPending}


### PR DESCRIPTION
## Changes

* Add Agents' Example Outputs Playlist modal
* Make Example Output Thumbnail components (for now it is dummy)
* Update AgentHireButton to accept size as prop