### PR TITLE
chore: fix duplicate key issue due to same href

### DIFF
--- a/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
@@ -189,7 +189,7 @@ function AcceptTermsOfService({
     <div className="text-muted-foreground text-right text-xs">
       <span>{t("acceptByClickingSubmit")}</span>
       {legalLinks.map((legalLink, index) => (
-        <React.Fragment key={legalLink.href}>
+        <React.Fragment key={index}>
           <Link href={legalLink.href} className="text-foreground">
             <span>{legalLink.label}</span>
           </Link>


### PR DESCRIPTION
## Changes

* Fix duplicated key issues on job input form client's legal links
(Because some of legal links have same href)