### PR TITLE
refactor(db): remove unique constraint and relation for on-chain transaction hash in Job

### DIFF
--- a/web-app/prisma/migrations/20250520193606_transaction_hash_not_unique/migration.sql
+++ b/web-app/prisma/migrations/20250520193606_transaction_hash_not_unique/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `onChainTransactionId` on the `Job` table. All the data in the column will be lost.
+  - You are about to drop the `OnChainTransaction` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Job" DROP CONSTRAINT "Job_onChainTransactionId_fkey";
+
+-- DropIndex
+DROP INDEX "Job_onChainTransactionId_key";
+
+-- AlterTable
+ALTER TABLE "Job" DROP COLUMN "onChainTransactionId",
+ADD COLUMN     "onChainTransactionHash" TEXT,
+ADD COLUMN     "onChainTransactionStatus" "OnChainTransactionStatus";
+
+-- DropTable
+DROP TABLE "OnChainTransaction";

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -364,24 +364,13 @@ model Job {
 
   onChainStatus OnChainJobStatus?
 
-  onChainTransaction   OnChainTransaction? @relation(fields: [onChainTransactionId], references: [id])
-  onChainTransactionId String?             @unique
+  onChainTransactionHash   String?
+  onChainTransactionStatus OnChainTransactionStatus?
 
   creditTransaction           CreditTransaction  @relation("CreditTransactionJob", fields: [creditTransactionId], references: [id])
   creditTransactionId         String             @unique
   refundedCreditTransaction   CreditTransaction? @relation("RefundedCreditTransactionJob", fields: [refundedCreditTransactionId], references: [id])
   refundedCreditTransactionId String?            @unique
-}
-
-model OnChainTransaction {
-  id        String   @id @default(cuid())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  hash   String                   @unique
-  status OnChainTransactionStatus
-
-  job Job?
 }
 
 enum OnChainTransactionStatus {

--- a/web-app/src/lib/db/job/repo.ts
+++ b/web-app/src/lib/db/job/repo.ts
@@ -235,22 +235,10 @@ export async function updateJobWithPurchase(
   if (transaction) {
     data = {
       ...data,
-      onChainTransaction: {
-        upsert: {
-          create: {
-            hash: transaction.txHash,
-            status: transactionStatusToOnChainTransactionStatus(
-              transaction.status,
-            ),
-          },
-          update: {
-            hash: transaction.txHash,
-            status: transactionStatusToOnChainTransactionStatus(
-              transaction.status,
-            ),
-          },
-        },
-      },
+      onChainTransactionHash: transaction.txHash,
+      onChainTransactionStatus: transactionStatusToOnChainTransactionStatus(
+        transaction.status,
+      ),
     };
   }
 

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -172,6 +172,7 @@ async function syncRegistryStatus(
   try {
     return await updateJobWithPurchase(job.id, purchase, tx);
   } catch {
+    console.log("Error syncing registry status: ", job.id);
     return job;
   }
 }
@@ -184,6 +185,7 @@ async function syncAgentJobStatus(
   try {
     return await updateJobWithAgentJobStatus(job.id, jobStatusResponse, tx);
   } catch {
+    console.log("Error syncing agent job status: ", job.id);
     return job;
   }
 }


### PR DESCRIPTION
### Overview  
This PR removes the unique constraint and relation for the on-chain transaction hash from the `Job` model. The previous implementation assumed that each job would have a unique on-chain transaction, but in practice, the transaction hash is not guaranteed to be unique across jobs.

### Key Changes  
- **Prisma Schema:**  
  - Removed the `OnChainTransaction` model and its relation from the `Job` model.
  - Replaced the `onChainTransactionId` field with two new fields on `Job`:  
    - `onChainTransactionHash: String?`  
    - `onChainTransactionStatus: OnChainTransactionStatus?`
  - Dropped the unique constraint on the transaction hash.
- **Migration:**  
  - Dropped the `OnChainTransaction` table and the `onChainTransactionId` column from `Job`.
  - Added the new fields to `Job`.
- **Backend Logic:**  
  - Updated all usages to write the transaction hash and status directly to the `Job` record, rather than through a related `OnChainTransaction`.
  - Removed upsert logic for the now-removed relation.
- **Error Logging:**  
  - Added error logs for failed job status syncs for easier debugging.

### Motivation  
- The transaction hash is not unique across jobs, so enforcing uniqueness caused issues with data integrity and prevented valid use cases.
- Simplifies the data model and related code by removing unnecessary indirection.

### Impact  
- **Database:**  
  - Existing data in the `OnChainTransaction` table and the `onChainTransactionId` column will be lost after migration.
- **Code:**  
  - All code now interacts with the transaction hash and status directly on the `Job` model.
- **No API changes** for consumers, but downstream systems should be aware of the schema change.
