### PR TITLE
refactor(db/job): remove onChainTransaction from jobInclude

### DIFF
--- a/web-app/src/lib/db/job/types.ts
+++ b/web-app/src/lib/db/job/types.ts
@@ -7,7 +7,6 @@ import {
 export const jobInclude = {
   agent: true,
   user: true,
-  onChainTransaction: true,
 } as const;
 
 export const jobOrderBy = {


### PR DESCRIPTION
### Summary
This PR removes the `onChainTransaction` property from the `jobInclude` object in `src/lib/db/job/types.ts`.

### Details
- **Removed:** `onChainTransaction: true` from the `jobInclude` object.
- This change likely reflects a shift in how job-related data is queried or a simplification of the job include structure.

### Rationale
- The `onChainTransaction` relation is no longer required in the default job include set, possibly due to changes in data requirements or to optimize query performance.
- This helps keep the data layer lean and focused on currently relevant relations.

### Impact
- Any queries or services relying on `jobInclude` will no longer automatically include `onChainTransaction` data.
- If this relation is still needed in specific cases, it should be explicitly included where necessary.
