### PR TITLE
feat(stripe): enable promotion codes in checkout session creation

### DIFF
--- a/web-app/src/lib/actions/stripe/action.ts
+++ b/web-app/src/lib/actions/stripe/action.ts
@@ -77,6 +77,7 @@ export async function createCheckoutSession(
         quantity: quantity,
       },
     ],
+    allow_promotion_codes: true,
     client_reference_id: fiatTransactionId,
     ...(user.stripeCustomerId
       ? { customer: user.stripeCustomerId }


### PR DESCRIPTION
### Summary  
This PR updates the Stripe checkout session creation logic to allow the use of promotion codes by setting `allow_promotion_codes: true` in the session configuration.

### Details  
- **File changed:** `src/lib/actions/stripe/action.ts`
- **Change:**  
  - Added the `allow_promotion_codes: true` property to the `createCheckoutSession` function's Stripe session payload.
- **Effect:**  
  - Users can now enter and apply valid promotion codes during the Stripe checkout process.

### Motivation  
Enabling promotion codes improves the flexibility of the checkout experience, allowing users to benefit from discounts and marketing campaigns.
