### PR TITLE
fix: job detail long content issue

### DIFF
--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
@@ -18,8 +18,13 @@ interface JobDetailsProps {
 export default function JobDetails({ job, className }: JobDetailsProps) {
   const t = useTranslations("App.Agents.Jobs.JobDetails");
   return (
-    <div className={cn("flex h-full min-h-[300px] flex-1 flex-col", className)}>
-      <ScrollArea className="h-full">
+    <div
+      className={cn(
+        "job-details-width flex h-full min-h-[300px] flex-1 flex-col",
+        className,
+      )}
+    >
+      <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:block!">
         <Accordion
           type="multiple"
           defaultValue={["input", "output"]}

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
@@ -1,9 +1,12 @@
+import {
+  Root as ScrollAreaRoot,
+  ScrollAreaViewport,
+} from "@radix-ui/react-scroll-area";
 import { useFormatter, useTranslations } from "next-intl";
 
 import AccordionItemWrapper from "@/app/agents/[agentId]/jobs/components/accordion-wrapper";
 import JobStatusBadge from "@/app/agents/[agentId]/jobs/components/job-status-badge";
 import { Accordion } from "@/components/ui/accordion";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { JobStatus, JobWithStatus } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
@@ -24,21 +27,23 @@ export default function JobDetails({ job, className }: JobDetailsProps) {
         className,
       )}
     >
-      <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:block!">
-        <Accordion
-          type="multiple"
-          defaultValue={["input", "output"]}
-          className="w-full space-y-1.5"
-        >
-          <JobDetailsHeader createdAt={job.createdAt} status={job.status} />
-          <AccordionItemWrapper value="input" title={t("Input.title")}>
-            <JobDetailsInputs rawInput={job.input} />
-          </AccordionItemWrapper>
-          <AccordionItemWrapper value="output" title={t("Output.title")}>
-            <JobDetailsOutputs rawOutput={job.output} />
-          </AccordionItemWrapper>
-        </Accordion>
-      </ScrollArea>
+      <ScrollAreaRoot className="overflow-hidden">
+        <ScrollAreaViewport className="h-full w-full [&>div]:!block">
+          <Accordion
+            type="multiple"
+            defaultValue={["input", "output"]}
+            className="w-full space-y-1.5"
+          >
+            <JobDetailsHeader createdAt={job.createdAt} status={job.status} />
+            <AccordionItemWrapper value="input" title={t("Input.title")}>
+              <JobDetailsInputs rawInput={job.input} />
+            </AccordionItemWrapper>
+            <AccordionItemWrapper value="output" title={t("Output.title")}>
+              <JobDetailsOutputs rawOutput={job.output} />
+            </AccordionItemWrapper>
+          </Accordion>
+        </ScrollAreaViewport>
+      </ScrollAreaRoot>
     </div>
   );
 }

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
@@ -1,12 +1,9 @@
-import {
-  Root as ScrollAreaRoot,
-  ScrollAreaViewport,
-} from "@radix-ui/react-scroll-area";
 import { useFormatter, useTranslations } from "next-intl";
 
 import AccordionItemWrapper from "@/app/agents/[agentId]/jobs/components/accordion-wrapper";
 import JobStatusBadge from "@/app/agents/[agentId]/jobs/components/job-status-badge";
 import { Accordion } from "@/components/ui/accordion";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { JobStatus, JobWithStatus } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
@@ -27,23 +24,21 @@ export default function JobDetails({ job, className }: JobDetailsProps) {
         className,
       )}
     >
-      <ScrollAreaRoot className="overflow-hidden">
-        <ScrollAreaViewport className="h-full w-full [&>div]:!block">
-          <Accordion
-            type="multiple"
-            defaultValue={["input", "output"]}
-            className="w-full space-y-1.5"
-          >
-            <JobDetailsHeader createdAt={job.createdAt} status={job.status} />
-            <AccordionItemWrapper value="input" title={t("Input.title")}>
-              <JobDetailsInputs rawInput={job.input} />
-            </AccordionItemWrapper>
-            <AccordionItemWrapper value="output" title={t("Output.title")}>
-              <JobDetailsOutputs rawOutput={job.output} />
-            </AccordionItemWrapper>
-          </Accordion>
-        </ScrollAreaViewport>
-      </ScrollAreaRoot>
+      <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:block!">
+        <Accordion
+          type="multiple"
+          defaultValue={["input", "output"]}
+          className="w-full space-y-1.5"
+        >
+          <JobDetailsHeader createdAt={job.createdAt} status={job.status} />
+          <AccordionItemWrapper value="input" title={t("Input.title")}>
+            <JobDetailsInputs rawInput={job.input} />
+          </AccordionItemWrapper>
+          <AccordionItemWrapper value="output" title={t("Output.title")}>
+            <JobDetailsOutputs rawOutput={job.output} />
+          </AccordionItemWrapper>
+        </Accordion>
+      </ScrollArea>
     </div>
   );
 }

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/jobs-table.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/jobs-table.tsx
@@ -45,9 +45,7 @@ export default function JobsTable({ jobs }: JobsTableProps) {
             params.jobId !== row.id,
         });
       }}
-      containerClassName={cn(
-        "w-full lg:w-[max(480px,32%)] rounded-xl bg-muted/50",
-      )}
+      containerClassName={cn("job-table-width rounded-xl bg-muted/50")}
       defaultSort={[
         {
           id: "startedAt",

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/jobs-table.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/jobs-table.tsx
@@ -45,7 +45,9 @@ export default function JobsTable({ jobs }: JobsTableProps) {
             params.jobId !== row.id,
         });
       }}
-      containerClassName={cn("job-table-width rounded-xl bg-muted/50")}
+      containerClassName={cn(
+        "job-table-width min-h-[300px] rounded-xl bg-muted/50",
+      )}
       defaultSort={[
         {
           id: "startedAt",

--- a/web-app/src/app/app/layout.tsx
+++ b/web-app/src/app/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function AppLayout({ children }: AppLayoutProps) {
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
       <Sidebar />
-      <div className="flex flex-1 flex-col">
+      <div className="flex w-full flex-1 flex-col">
         <Header className="h-[64px]" />
         <main className="min-h-[calc(100svh-64px)]">{children}</main>
         <FooterSections className="p-4 lg:p-6 xl:p-8" />

--- a/web-app/src/app/app/layout.tsx
+++ b/web-app/src/app/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function AppLayout({ children }: AppLayoutProps) {
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
       <Sidebar />
-      <div className="flex w-full flex-1 flex-col">
+      <div className="flex flex-1 flex-col overflow-hidden">
         <Header className="h-[64px]" />
         <main className="min-h-[calc(100svh-64px)]">{children}</main>
         <FooterSections className="p-4 lg:p-6 xl:p-8" />

--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -329,3 +329,11 @@
     padding: var(--spacing-6, 24px);
   }
 }
+
+@utility job-table-width {
+  @apply w-full lg:w-[max(480px,32%)];
+}
+
+@utility job-details-width {
+  @apply w-full lg:w-[calc(100%-max(480px,32%))];
+}

--- a/web-app/src/app/layout.tsx
+++ b/web-app/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
         className={cn(
           geistSans.variable,
           geistMono.variable,
-          "bg-background min-h-svh antialiased",
+          "bg-background min-h-svh max-w-dvw antialiased",
         )}
       >
         <Script src="/js/plain.js" strategy="afterInteractive" />


### PR DESCRIPTION
## Changes

* Add `max-w-dvw` to `body` tag in app layout so we have width limitation
* Add constant width class name to `JobDetails` component just like `JobTable` because they are both in inline.
* Add job details and job table's width class name to global.css
* Refactor job detail' scroll area (`display: block!`) so it have width limitaion

## Reference
https://github.com/shadcn-ui/ui/issues/3833