### PR TITLE
feat(job-details): add "Download as Markdown" button for job output

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -623,7 +623,8 @@
           "Output": {
             "title": "Output",
             "failedToParseOutput": "Failed to parse output",
-            "none": "No result data"
+            "none": "No result data",
+            "download": "Download as Markdown"
           }
         }
       }

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/download-markdown.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/download-markdown.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DownloadMarkdownProps {
+  markdown: string;
+  className?: string;
+}
+
+export default function DownloadMarkdown({
+  markdown,
+  className,
+}: DownloadMarkdownProps) {
+  const downloadFile = () => {
+    const url = URL.createObjectURL(
+      new Blob([markdown], { type: "text/markdown" }),
+    );
+    Object.assign(document.createElement("a"), {
+      href: url,
+      download: "output.md",
+    }).click();
+    URL.revokeObjectURL(url);
+  };
+
+  const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
+
+  return (
+    <div className="flex justify-end">
+      <Button
+        variant="ghost"
+        onClick={downloadFile}
+        className={cn(
+          "text-muted-foreground flex items-center justify-end gap-2 text-sm",
+          className,
+        )}
+      >
+        <Download className="h-4 w-4" />
+        {t("download")}
+      </Button>
+    </div>
+  );
+}

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useTranslations } from "next-intl";
 
 import DefaultErrorBoundary from "@/components/default-error-boundary";
@@ -6,6 +7,8 @@ import {
   jobStatusResponseSchema,
   JobStatusResponseSchemaType,
 } from "@/lib/services/job/schemas";
+
+import DownloadMarkdown from "./download-markdown";
 
 interface JobDetailsOutputsProps {
   rawOutput: string | null;
@@ -51,7 +54,10 @@ function JobDetailsOutputsInner({ rawOutput }: JobDetailsOutputsProps) {
   return (
     <JobDetailsOutputsLayout>
       {output.result ? (
-        <Markdown>{output.result}</Markdown>
+        <>
+          <Markdown>{output.result}</Markdown>
+          <DownloadMarkdown markdown={output.result} />
+        </>
       ) : (
         <p className="text-base">{t("none")}</p>
       )}
@@ -68,3 +74,27 @@ function JobDetailsOutputsError() {
     </div>
   );
 }
+
+// function Download({ markdown }: { markdown: string }) {
+//   const downloadFile = () => {
+//     const url = URL.createObjectURL(
+//       new Blob([markdown], { type: "text/markdown" }),
+//     );
+//     Object.assign(document.createElement("a"), {
+//       href: url,
+//       download: "output.md",
+//     }).click();
+//     URL.revokeObjectURL(url);
+//   };
+
+//   const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
+
+//   return (
+//     <button
+//       onClick={() => downloadFile()}
+//       className="text-muted-foreground text-sm"
+//     >
+//       {t("download")}
+//     </button>
+//   );
+// }


### PR DESCRIPTION
### Summary
This PR introduces a "Download as Markdown" button to the job output section in the Job Details view. Users can now easily download the result output as a Markdown file for further use or sharing.

### Details
- Added a new `DownloadMarkdown` component that provides a button to download the output as a Markdown file (`output.md`).
- Integrated the download button into the job output section, displayed when there is result data.
- Updated English translations (`en.json`) to include the "Download as Markdown" label.
- Ensured the button uses Shadcn UI, is styled with Tailwind, and supports i18n via `next-intl`.
- The download button is only shown when output data is present.

### Motivation
This feature improves user experience by allowing users to export and save job results in a convenient, portable format.

### Notes
- The button is hidden if there is no output data.
- The implementation follows the codebase’s conventions for modularity, styling, and internationalization.
