### PR TITLE
refactor(agent-card): remove secondary CTA and clarify "Show Details" action

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -45,7 +45,7 @@
       "agentsNotFound": "No Agents found",
       "hire": "Hire Agent",
       "AgentCard": {
-        "view": "View Agent",
+        "view": "Show Details",
         "pricing": "{price, plural, =0 {For Free} =1 {1 credit} other {# credits}}",
         "addedToBookmarks": "Agent added to pinned agents",
         "removedFromBookmarks": "Agent removed from pinned agents",

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -223,9 +223,7 @@ function AgentCard({
                   />
                 </ClickBlocker>
               )}
-              <ClickBlocker>
-                <AgentHireButton agentId={agent.id} />
-              </ClickBlocker>
+              <Button variant="primary">{t("view")}</Button>
             </div>
           </div>
 


### PR DESCRIPTION
### Summary  
This PR updates the Agent Card component to streamline its call-to-action (CTA) and improve clarity for users:

- **Removes the secondary "Hire Agent" CTA** from the Agent Card, reducing visual clutter and potential confusion.
- **Renames the primary CTA** from "View Agent" to "Show Details" for improved clarity, reflecting that the button only displays agent details and does not initiate a hiring flow.

### Details  
- Updated the English translation key from `"View Agent"` to `"Show Details"` in `messages/en.json`.
- Replaced the `AgentHireButton` with a single primary button labeled "Show Details" in the Agent Card component.
- Ensured the UI now presents a single, clear action for users to view agent details, aligning with UX best practices.

### Motivation  
This change simplifies the Agent Card interface, making it clear to users that the only available action is to view more information about the agent. The previous dual-CTA design could mislead users into thinking they could hire directly from the card, which is not the intended flow.

### Checklist  
- [x] Only one CTA is present on the Agent Card.
- [x] Button label is clear and matches the intended action.
- [x] All related translation keys are updated.
- [x] No references to the removed CTA remain.
