### PR TITLE
feat(auth/register): add marketing opt-in checkbox to registration form

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -366,6 +366,9 @@
             "Name": {
               "placeholder": "Name"
             },
+            "MarketingOptIn": {
+              "label": "I would like to receive updates and news from Sokosumi"
+            },
             "Organization": {
               "placeholder": "Select an organization",
               "search": "Search organizations",

--- a/web-app/prisma/migrations/20250522120506_add_marketing_opt_in/migration.sql
+++ b/web-app/prisma/migrations/20250522120506_add_marketing_opt_in/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "marketingOptIn" BOOLEAN NOT NULL DEFAULT false;

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -36,6 +36,8 @@ model User {
   members     Member[]
   invitations Invitation[]
 
+  marketingOptIn Boolean @default(false)
+
   @@unique([email])
   @@map("user")
 }

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -14,6 +14,7 @@ import {
   SignUpFormSchemaType,
 } from "@/auth/register/data";
 import { createOrganizationMember } from "@/lib/actions";
+import { updateUserMarketingOptIn } from "@/lib/actions/user/action";
 import { authClient } from "@/lib/auth/auth.client";
 import { OrganizationWithMembersCount } from "@/lib/db";
 
@@ -35,10 +36,12 @@ export default function SignUpForm({ organizations }: SignUpFormProps) {
       password: "",
       confirmPassword: "",
       organizationId: "",
+      marketingOptIn: false,
     },
   });
 
   const onSubmit = async (values: SignUpFormSchemaType) => {
+    console.log("values", values);
     const userResult = await authClient.signUp.email(
       {
         email: values.email,
@@ -68,6 +71,21 @@ export default function SignUpForm({ organizations }: SignUpFormProps) {
     );
     if (!userResult.data?.user) {
       return;
+    }
+
+    // Update marketing opt-in status
+    if (values.marketingOptIn !== undefined) {
+      const marketingOptInResult = await updateUserMarketingOptIn(
+        userResult.data.user.id,
+        values.marketingOptIn,
+      );
+      console.log("marketingOptInResult", marketingOptInResult);
+      if (!marketingOptInResult.success) {
+        console.error(
+          "Failed to update marketing opt-in:",
+          marketingOptInResult.error,
+        );
+      }
     }
 
     // create member using organization

--- a/web-app/src/app/(auth)/register/data.ts
+++ b/web-app/src/app/(auth)/register/data.ts
@@ -17,6 +17,7 @@ const signUpFormSchema = (t?: IntlTranslation<"Library.Auth.Schema">) =>
       password: passwordSchema(t),
       confirmPassword: confirmPasswordSchema(t),
       organizationId: organizationIdSchema(t),
+      marketingOptIn: z.boolean().optional(),
     })
     .refine(({ password, confirmPassword }) => password === confirmPassword, {
       path: ["confirmPassword"],
@@ -47,6 +48,11 @@ const signUpFormData: FormData<SignUpFormSchemaType, "Auth.Pages.SignUp.Form"> =
       name: "confirmPassword",
       placeholderKey: "Fields.ConfirmPassword.placeholder",
       type: "password",
+    },
+    {
+      name: "marketingOptIn",
+      type: "checkbox",
+      labelKey: "Fields.MarketingOptIn.label",
     },
   ];
 

--- a/web-app/src/lib/actions/user/action.ts
+++ b/web-app/src/lib/actions/user/action.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { setUserMarketingOptIn } from "@/lib/db/user/repo";
+
+export interface UpdateUserMarketingOptInResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function updateUserMarketingOptIn(
+  userId: string,
+  marketingOptIn: boolean,
+): Promise<UpdateUserMarketingOptInResult> {
+  try {
+    await setUserMarketingOptIn(userId, marketingOptIn);
+    return { success: true };
+  } catch (error) {
+    console.error("Error updating marketing opt-in status:", error);
+    return { success: false, error: "Failed to update marketing preference" };
+  }
+}

--- a/web-app/src/lib/actions/user/index.ts
+++ b/web-app/src/lib/actions/user/index.ts
@@ -1,0 +1,1 @@
+export * from "./action";

--- a/web-app/src/lib/db/user/repo.ts
+++ b/web-app/src/lib/db/user/repo.ts
@@ -20,3 +20,14 @@ export async function getUserById(
     where: { id },
   });
 }
+
+export async function setUserMarketingOptIn(
+  userId: string,
+  marketingOptIn: boolean,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<User> {
+  return await tx.user.update({
+    where: { id: userId },
+    data: { marketingOptIn },
+  });
+}


### PR DESCRIPTION
This PR introduces a marketing opt-in checkbox to the user registration flow, allowing new users to choose whether they wish to receive updates and news from Sokosumi.

**Key Changes:**
- Added a new boolean field marketingOptIn to the User model in Prisma, with a default value of false.
- Created a new migration to add the marketingOptIn column to the user table.
- Updated the registration form UI to include a checkbox for marketing opt-in, with internationalized label text.
- Extended the registration form schema and data to support the new checkbox field.
- Implemented backend logic to persist the user's marketing preference during registration via a new updateUserMarketingOptIn server action and supporting repo function.
- Ensured the marketingOptIn value is saved immediately after user creation in the registration flow.

**Notes:**
- The checkbox is optional and defaults to unchecked (false).
- All UI changes follow Shadcn UI, Radix, and Tailwind conventions, and are fully internationalized.
- No breaking changes for existing users; the new field is non-intrusive and backward compatible.
