### PR TITLE
chore(ci): add database migration step to deployment workflows

### DIFF
--- a/.github/workflows/deploy-main-webapp.yml
+++ b/.github/workflows/deploy-main-webapp.yml
@@ -20,6 +20,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the app
+        run: pnpm prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
       - name: Deploy the app
         uses: digitalocean/app_action/deploy@v2
         env:

--- a/.github/workflows/deploy-release-web-app.yml
+++ b/.github/workflows/deploy-release-web-app.yml
@@ -19,6 +19,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the app
+        run: pnpm prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
       - name: Deploy the app
         uses: digitalocean/app_action/deploy@v2
         env:


### PR DESCRIPTION
This PR updates the GitHub Actions workflows for both main and release deployments of the web application to include a database migration step before deploying. Specifically:

- Adds a step to install pnpm and project dependencies.
- Runs pnpm prisma migrate deploy to apply any pending Prisma migrations to the production database, using the DATABASE_URL secret.
- Ensures the database schema is up-to-date before the deployment step to DigitalOcean.

This change helps prevent schema drift and ensures the application is always deployed with the latest database structure. No application code was modified.
