### PR TITLE
fix: correct GitHub Actions step names for database migration

### DIFF
--- a/.github/workflows/deploy-main-webapp.yml
+++ b/.github/workflows/deploy-main-webapp.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build the app
+      - name: Migrate database
         run: pnpm prisma migrate deploy
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/deploy-release-web-app.yml
+++ b/.github/workflows/deploy-release-web-app.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build the app
+      - name: Migrate database
         run: pnpm prisma migrate deploy
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## Description
This PR fixes misleading step names in GitHub Actions workflows for deployment.

## Changes
- Updated step name from "Build the app" to "Migrate database" in `deploy-main-webapp.yml`
- Updated step name from "Build the app" to "Migrate database" in `deploy-release-web-app.yml`

## Problem
The workflow steps were labeled as "Build the app" but were actually running `pnpm prisma migrate deploy`, which performs database migrations. This created confusion about what each step was actually doing.

## Solution
Renamed the step labels to accurately reflect their purpose: migrating the database schema.