### PR TITLE
feat: add refund request functionality to job details

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -628,14 +628,20 @@
             "none": "No result data",
             "download": "Download",
             "requestRefund": "Request Refund",
-            "Tooltip": {
-              "available": {
-                "title": "Refund available",
-                "description": "You can request a refund until {unlockAt}."
-              },
-              "unavailable": {
-                "title": "Refund no longer available",
-                "description": "You could have requested a refund until {unlockAt}."
+            "refundRequested": "Refund Requested",
+            "Refund": {
+              "error": "Failed to request refund",
+              "request": "Request Refund",
+              "requested": "Refund Requested",
+              "Tooltip": {
+                "available": {
+                  "title": "Refund available",
+                  "description": "You can request a refund until {unlockAt}."
+                },
+                "unavailable": {
+                  "title": "Refund no longer available",
+                  "description": "You could have requested a refund until {unlockAt}."
+                }
               }
             }
           }

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -627,7 +627,8 @@
             "title": "Output",
             "failedToParseOutput": "Failed to parse output",
             "none": "No result data",
-            "download": "Download as Markdown"
+            "download": "Download",
+            "requestRefund": "Request Refund"
           }
         }
       }

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -627,7 +627,17 @@
             "failedToParseOutput": "Failed to parse output",
             "none": "No result data",
             "download": "Download",
-            "requestRefund": "Request Refund"
+            "requestRefund": "Request Refund",
+            "Tooltip": {
+              "available": {
+                "title": "Refund available",
+                "description": "You can request a refund until {unlockAt}."
+              },
+              "unavailable": {
+                "title": "Refund no longer available",
+                "description": "You could have requested a refund until {unlockAt}."
+              }
+            }
           }
         }
       }

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -627,12 +627,11 @@
             "failedToParseOutput": "Failed to parse output",
             "none": "No result data",
             "download": "Download",
-            "requestRefund": "Request Refund",
-            "refundRequested": "Refund Requested",
             "Refund": {
               "error": "Failed to request refund",
               "request": "Request Refund",
               "requested": "Refund Requested",
+              "refunded": "Refunded",
               "Tooltip": {
                 "available": {
                   "title": "Refund available",

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/download-markdown.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/download-markdown.tsx
@@ -29,18 +29,16 @@ export default function DownloadMarkdown({
   const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
 
   return (
-    <div className="flex justify-end">
-      <Button
-        variant="ghost"
-        onClick={downloadFile}
-        className={cn(
-          "text-muted-foreground flex items-center justify-end gap-2 text-sm",
-          className,
-        )}
-      >
-        <Download className="h-4 w-4" />
-        {t("download")}
-      </Button>
-    </div>
+    <Button
+      variant="ghost"
+      onClick={downloadFile}
+      className={cn(
+        "text-muted-foreground flex items-center justify-end gap-2 text-sm",
+        className,
+      )}
+    >
+      <Download className="h-4 w-4" />
+      {t("download")}
+    </Button>
   );
 }

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
@@ -35,7 +35,7 @@ export default function JobDetails({ job, className }: JobDetailsProps) {
             <JobDetailsInputs rawInput={job.input} />
           </AccordionItemWrapper>
           <AccordionItemWrapper value="output" title={t("Output.title")}>
-            <JobDetailsOutputs rawOutput={job.output} />
+            <JobDetailsOutputs job={job} />
           </AccordionItemWrapper>
         </Accordion>
       </ScrollArea>

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/services/job/schemas";
 
 import DownloadMarkdown from "./download-markdown";
+import RequestRefundButton from "./refund-request";
 
 interface JobDetailsOutputsProps {
   rawOutput: string | null;
@@ -56,7 +57,10 @@ function JobDetailsOutputsInner({ rawOutput }: JobDetailsOutputsProps) {
       {output.result ? (
         <>
           <Markdown>{output.result}</Markdown>
-          <DownloadMarkdown markdown={output.result} />
+          <div className="flex justify-between gap-2">
+            <DownloadMarkdown markdown={output.result} />
+            <RequestRefundButton />
+          </div>
         </>
       ) : (
         <p className="text-base">{t("none")}</p>

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from "next-intl";
 
 import DefaultErrorBoundary from "@/components/default-error-boundary";
 import Markdown from "@/components/markdown";
+import { JobWithStatus } from "@/lib/db";
 import {
   jobStatusResponseSchema,
   JobStatusResponseSchemaType,
@@ -12,7 +13,7 @@ import DownloadMarkdown from "./download-markdown";
 import RequestRefundButton from "./refund-request";
 
 interface JobDetailsOutputsProps {
-  rawOutput: string | null;
+  job: JobWithStatus;
 }
 
 interface JobDetailsOutputsLayoutProps {
@@ -23,20 +24,18 @@ function JobDetailsOutputsLayout({ children }: JobDetailsOutputsLayoutProps) {
   return <div className="flex flex-col gap-2">{children}</div>;
 }
 
-export default function JobDetailsOutputs({
-  rawOutput,
-}: JobDetailsOutputsProps) {
+export default function JobDetailsOutputs({ job }: JobDetailsOutputsProps) {
   return (
     <DefaultErrorBoundary fallback={<JobDetailsOutputsError />}>
-      <JobDetailsOutputsInner rawOutput={rawOutput} />
+      <JobDetailsOutputsInner job={job} />
     </DefaultErrorBoundary>
   );
 }
 
-function JobDetailsOutputsInner({ rawOutput }: JobDetailsOutputsProps) {
+function JobDetailsOutputsInner({ job }: JobDetailsOutputsProps) {
   const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
 
-  if (!rawOutput) {
+  if (!job.output) {
     return (
       <JobDetailsOutputsLayout>
         <p className="text-base">{t("none")}</p>
@@ -46,7 +45,7 @@ function JobDetailsOutputsInner({ rawOutput }: JobDetailsOutputsProps) {
 
   let output: JobStatusResponseSchemaType;
   try {
-    const parsedOutput = JSON.parse(rawOutput);
+    const parsedOutput = JSON.parse(job.output);
     output = jobStatusResponseSchema.parse(parsedOutput);
   } catch {
     return <JobDetailsOutputsError />;
@@ -59,7 +58,9 @@ function JobDetailsOutputsInner({ rawOutput }: JobDetailsOutputsProps) {
           <Markdown>{output.result}</Markdown>
           <div className="flex justify-between gap-2">
             <DownloadMarkdown markdown={output.result} />
-            <RequestRefundButton />
+            {job.unlockTime.getTime() > Date.now() && (
+              <RequestRefundButton job={job} />
+            )}
           </div>
         </>
       ) : (

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
@@ -58,9 +58,7 @@ function JobDetailsOutputsInner({ job }: JobDetailsOutputsProps) {
           <Markdown>{output.result}</Markdown>
           <div className="flex justify-between gap-2">
             <DownloadMarkdown markdown={output.result} />
-            {job.unlockTime.getTime() > Date.now() && (
-              <RequestRefundButton job={job} />
-            )}
+            <RequestRefundButton job={job} />
           </div>
         </>
       ) : (

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -1,10 +1,18 @@
 "use client";
 
 import { TicketX } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useFormatter, useTranslations } from "next-intl";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { JobWithStatus } from "@/lib/db";
+import { requestRefundJob } from "@/lib/services/job/service";
 import { cn } from "@/lib/utils";
 
 interface RequestRefundButtonProps {
@@ -17,11 +25,51 @@ export default function RequestRefundButton({
   className,
 }: RequestRefundButtonProps) {
   const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const format = useFormatter();
 
-  return (
+  const isRefundDisabled = job.unlockTime.getTime() < Date.now();
+  const { title, description } = isRefundDisabled
+    ? {
+        title: t("Tooltip.unavailable.title"),
+        description: t("Tooltip.unavailable.description", {
+          unlockAt: format.dateTime(job.unlockTime, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          }),
+        }),
+      }
+    : {
+        title: t("Tooltip.available.title"),
+        description: t("Tooltip.available.description", {
+          unlockAt: format.dateTime(job.unlockTime, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          }),
+        }),
+      };
+
+  const handleClick = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await requestRefundJob(job.blockchainIdentifier);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const buttonElement = (
     <Button
       variant="ghost"
-      onClick={() => console.log("foobar")}
+      onClick={handleClick}
+      disabled={isLoading || isRefundDisabled}
       className={cn(
         "text-muted-foreground flex items-center justify-end gap-2 text-sm",
         className,
@@ -30,5 +78,21 @@ export default function RequestRefundButton({
       <TicketX className="h-4 w-4" />
       {t("requestRefund")}
     </Button>
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0}>{buttonElement}</span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium">{title}</h4>
+            <p className="text-muted-foreground text-xs">{description}</p>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -102,8 +102,6 @@ export default function RequestRefundButton({
       };
 
   const handleClick = async () => {
-    if (isLoading) return;
-
     setIsLoading(true);
     setError(null);
 

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -121,8 +121,10 @@ export default function RequestRefundButton({
     setError(null);
 
     try {
-      await requestRefundJob(job.blockchainIdentifier);
-      setIsRefundRequested(true);
+      job = await requestRefundJob(job.blockchainIdentifier);
+      setIsRefundRequested(
+        job.nextAction === NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -4,13 +4,16 @@ import { TicketX } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
+import { JobWithStatus } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
 interface RequestRefundButtonProps {
+  job: JobWithStatus;
   className?: string;
 }
 
 export default function RequestRefundButton({
+  job,
   className,
 }: RequestRefundButtonProps) {
   const t = useTranslations("App.Agents.Jobs.JobDetails.Output");

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -14,7 +14,7 @@ import {
 import { JobWithStatus } from "@/lib/db";
 import { requestRefundJob } from "@/lib/services/job/service";
 import { cn } from "@/lib/utils";
-import { OnChainJobStatus } from "@/prisma/generated/client";
+import { NextJobAction, OnChainJobStatus } from "@/prisma/generated/client";
 
 interface RequestRefundButtonProps {
   job: JobWithStatus;
@@ -28,11 +28,13 @@ export default function RequestRefundButton({
   const t = useTranslations("App.Agents.Jobs.JobDetails.Output.Refund");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const format = useFormatter();
-
-  let isRefundRequested =
+  const [isRefundRequested, setIsRefundRequested] = useState(
     job.onChainStatus === OnChainJobStatus.REFUND_REQUESTED ||
-    job.onChainStatus === OnChainJobStatus.REFUND_WITHDRAWN;
+      job.onChainStatus === OnChainJobStatus.REFUND_WITHDRAWN ||
+      job.nextAction === NextJobAction.SET_REFUND_REQUESTED_INITIATED ||
+      job.nextAction === NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
+  );
+  const format = useFormatter();
 
   const isRefundDisabled = job.unlockTime.getTime() < Date.now();
   const { title, description } = isRefundDisabled
@@ -63,14 +65,14 @@ export default function RequestRefundButton({
 
     try {
       await requestRefundJob(job.blockchainIdentifier);
-      isRefundRequested = true;
+      setIsRefundRequested(true);
     } catch (err) {
+      console.log(err);
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
       setIsLoading(false);
     }
   };
-
   const buttonElement = (
     <div>
       <Button

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { TicketX } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface RequestRefundButtonProps {
+  className?: string;
+}
+
+export default function RequestRefundButton({
+  className,
+}: RequestRefundButtonProps) {
+  const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
+
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => console.log("foobar")}
+      className={cn(
+        "text-muted-foreground flex items-center justify-end gap-2 text-sm",
+        className,
+      )}
+    >
+      <TicketX className="h-4 w-4" />
+      {t("requestRefund")}
+    </Button>
+  );
+}

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -47,6 +47,34 @@ function ButtonBase({
   );
 }
 
+function makeTitleAndDescription(
+  isRefundDisabled: boolean,
+  unlockTime: Date,
+  t: IntlTranslation<"App.Agents.Jobs.JobDetails.Output.Refund">,
+  formatter: IntlDateFormatter,
+) {
+  const unlockTimeFormatted = formatter.dateTime(unlockTime, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+  const { title, description } = isRefundDisabled
+    ? {
+        title: t("Tooltip.unavailable.title"),
+        description: t("Tooltip.unavailable.description", {
+          unlockAt: unlockTimeFormatted,
+        }),
+      }
+    : {
+        title: t("Tooltip.available.title"),
+        description: t("Tooltip.available.description", {
+          unlockAt: unlockTimeFormatted,
+        }),
+      };
+
+  return { title, description };
+}
+
 export default function RequestRefundButton({
   job,
   className,
@@ -59,7 +87,7 @@ export default function RequestRefundButton({
       job.nextAction === NextJobAction.SET_REFUND_REQUESTED_INITIATED ||
       job.nextAction === NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
   );
-  const format = useFormatter();
+  const formatter = useFormatter();
 
   const isRefunded = job.onChainStatus === OnChainJobStatus.REFUND_WITHDRAWN;
   if (isRefunded) {
@@ -81,25 +109,12 @@ export default function RequestRefundButton({
   }
 
   const isRefundDisabled = job.unlockTime.getTime() < Date.now();
-  const { title, description } = isRefundDisabled
-    ? {
-        title: t("Tooltip.unavailable.title"),
-        description: t("Tooltip.unavailable.description", {
-          unlockAt: format.dateTime(job.unlockTime, {
-            dateStyle: "medium",
-            timeStyle: "short",
-          }),
-        }),
-      }
-    : {
-        title: t("Tooltip.available.title"),
-        description: t("Tooltip.available.description", {
-          unlockAt: format.dateTime(job.unlockTime, {
-            dateStyle: "medium",
-            timeStyle: "short",
-          }),
-        }),
-      };
+  const { title, description } = makeTitleAndDescription(
+    isRefundDisabled,
+    job.unlockTime,
+    t,
+    formatter,
+  );
 
   const handleClick = async () => {
     setIsLoading(true);

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -21,6 +21,32 @@ interface RequestRefundButtonProps {
   className?: string;
 }
 
+function ButtonBase({
+  disabled,
+  onClick,
+  children,
+  className,
+}: {
+  disabled: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "text-muted-foreground flex items-center justify-end gap-2 text-sm",
+        className,
+      )}
+    >
+      {children}
+    </Button>
+  );
+}
+
 export default function RequestRefundButton({
   job,
   className,
@@ -30,11 +56,29 @@ export default function RequestRefundButton({
   const [error, setError] = useState<string | null>(null);
   const [isRefundRequested, setIsRefundRequested] = useState(
     job.onChainStatus === OnChainJobStatus.REFUND_REQUESTED ||
-      job.onChainStatus === OnChainJobStatus.REFUND_WITHDRAWN ||
       job.nextAction === NextJobAction.SET_REFUND_REQUESTED_INITIATED ||
       job.nextAction === NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
   );
   const format = useFormatter();
+
+  const isRefunded = job.onChainStatus === OnChainJobStatus.REFUND_WITHDRAWN;
+  if (isRefunded) {
+    return (
+      <ButtonBase disabled={true} className={className}>
+        <HandCoins className="h-4 w-4" />
+        {t("refunded")}
+      </ButtonBase>
+    );
+  }
+
+  if (isRefundRequested) {
+    return (
+      <ButtonBase disabled={true} className={className}>
+        <LoaderCircle className="h-4 w-4 animate-spin" />
+        {t("requested")}
+      </ButtonBase>
+    );
+  }
 
   const isRefundDisabled = job.unlockTime.getTime() < Date.now();
   const { title, description } = isRefundDisabled
@@ -67,7 +111,6 @@ export default function RequestRefundButton({
       await requestRefundJob(job.blockchainIdentifier);
       setIsRefundRequested(true);
     } catch (err) {
-      console.log(err);
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
       setIsLoading(false);
@@ -75,14 +118,10 @@ export default function RequestRefundButton({
   };
   const buttonElement = (
     <div>
-      <Button
-        variant="ghost"
+      <ButtonBase
         onClick={handleClick}
         disabled={isLoading || isRefundDisabled || isRefundRequested}
-        className={cn(
-          "text-muted-foreground flex items-center justify-end gap-2 text-sm",
-          className,
-        )}
+        className={className}
       >
         {isLoading ? (
           <LoaderCircle className="h-4 w-4 animate-spin" />
@@ -90,26 +129,10 @@ export default function RequestRefundButton({
           <HandCoins className="h-4 w-4" />
         )}
         {t("request")}
-      </Button>
+      </ButtonBase>
       {error && <p className="text-xs text-red-500">{t("error")}</p>}
     </div>
   );
-
-  if (isRefundRequested) {
-    return (
-      <Button
-        variant="ghost"
-        disabled={true}
-        className={cn(
-          "text-muted-foreground flex items-center justify-end gap-2 text-sm",
-          className,
-        )}
-      >
-        <LoaderCircle className="h-4 w-4 animate-spin" />
-        {t("requested")}
-      </Button>
-    );
-  }
 
   return (
     <TooltipProvider>

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TicketX } from "lucide-react";
+import { HandCoins, LoaderCircle } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -14,6 +14,7 @@ import {
 import { JobWithStatus } from "@/lib/db";
 import { requestRefundJob } from "@/lib/services/job/service";
 import { cn } from "@/lib/utils";
+import { OnChainJobStatus } from "@/prisma/generated/client";
 
 interface RequestRefundButtonProps {
   job: JobWithStatus;
@@ -24,10 +25,14 @@ export default function RequestRefundButton({
   job,
   className,
 }: RequestRefundButtonProps) {
-  const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
+  const t = useTranslations("App.Agents.Jobs.JobDetails.Output.Refund");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const format = useFormatter();
+
+  let isRefundRequested =
+    job.onChainStatus === OnChainJobStatus.REFUND_REQUESTED ||
+    job.onChainStatus === OnChainJobStatus.REFUND_WITHDRAWN;
 
   const isRefundDisabled = job.unlockTime.getTime() < Date.now();
   const { title, description } = isRefundDisabled
@@ -58,6 +63,7 @@ export default function RequestRefundButton({
 
     try {
       await requestRefundJob(job.blockchainIdentifier);
+      isRefundRequested = true;
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
@@ -66,19 +72,42 @@ export default function RequestRefundButton({
   };
 
   const buttonElement = (
-    <Button
-      variant="ghost"
-      onClick={handleClick}
-      disabled={isLoading || isRefundDisabled}
-      className={cn(
-        "text-muted-foreground flex items-center justify-end gap-2 text-sm",
-        className,
-      )}
-    >
-      <TicketX className="h-4 w-4" />
-      {t("requestRefund")}
-    </Button>
+    <div>
+      <Button
+        variant="ghost"
+        onClick={handleClick}
+        disabled={isLoading || isRefundDisabled || isRefundRequested}
+        className={cn(
+          "text-muted-foreground flex items-center justify-end gap-2 text-sm",
+          className,
+        )}
+      >
+        {isLoading ? (
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+        ) : (
+          <HandCoins className="h-4 w-4" />
+        )}
+        {t("request")}
+      </Button>
+      {error && <p className="text-xs text-red-500">{t("error")}</p>}
+    </div>
   );
+
+  if (isRefundRequested) {
+    return (
+      <Button
+        variant="ghost"
+        disabled={true}
+        className={cn(
+          "text-muted-foreground flex items-center justify-end gap-2 text-sm",
+          className,
+        )}
+      >
+        <LoaderCircle className="h-4 w-4 animate-spin" />
+        {t("requested")}
+      </Button>
+    );
+  }
 
   return (
     <TooltipProvider>

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -32,7 +32,7 @@ export default function BillingForm({
   currency,
 }: BillingFormProps) {
   const t = useTranslations("App.Billing");
-  const format = useFormatter();
+  const formatter = useFormatter();
   const [customAmount, setCustomAmount] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -100,7 +100,7 @@ export default function BillingForm({
         </Button>
         <p className="text-muted-foreground text-sm">
           {t("costPerCredit", {
-            cost: format.number(amountPerCredit / 100, {
+            cost: formatter.number(amountPerCredit / 100, {
               style: "currency",
               currency,
             }),

--- a/web-app/src/lib/api/generated/payment/types.gen.ts
+++ b/web-app/src/lib/api/generated/payment/types.gen.ts
@@ -436,9 +436,14 @@ export type GetPaymentResponses = {
                     txHash: string | null;
                 }> | null;
                 RequestedFunds: Array<{
-                    id: string;
-                    createdAt: string;
-                    updatedAt: string;
+                    amount: string;
+                    unit: string;
+                }>;
+                WithdrawnForSeller: Array<{
+                    amount: string;
+                    unit: string;
+                }>;
+                WithdrawnForBuyer: Array<{
                     amount: string;
                     unit: string;
                 }>;
@@ -557,9 +562,14 @@ export type PostPaymentResponses = {
                 errorNote: string | null;
             };
             RequestedFunds: Array<{
-                id: string;
-                createdAt: string;
-                updatedAt: string;
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForSeller: Array<{
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForBuyer: Array<{
                 amount: string;
                 unit: string;
             }>;
@@ -650,9 +660,14 @@ export type PostPaymentSubmitResultResponses = {
                 resultHash: string | null;
             };
             RequestedFunds: Array<{
-                id: string;
-                createdAt: string;
-                updatedAt: string;
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForSeller: Array<{
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForBuyer: Array<{
                 amount: string;
                 unit: string;
             }>;
@@ -739,9 +754,14 @@ export type PostPaymentAuthorizeRefundResponses = {
                 resultHash: string | null;
             };
             RequestedFunds: Array<{
-                id: string;
-                createdAt: string;
-                updatedAt: string;
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForSeller: Array<{
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForBuyer: Array<{
                 amount: string;
                 unit: string;
             }>;
@@ -854,9 +874,14 @@ export type GetPurchaseResponses = {
                     status: 'Pending' | 'Confirmed' | 'FailedViaTimeout';
                 }>;
                 PaidFunds: Array<{
-                    id: string;
-                    createdAt: string;
-                    updatedAt: string;
+                    amount: string;
+                    unit: string;
+                }>;
+                WithdrawnForSeller: Array<{
+                    amount: string;
+                    unit: string;
+                }>;
+                WithdrawnForBuyer: Array<{
                     amount: string;
                     unit: string;
                 }>;
@@ -989,9 +1014,14 @@ export type PostPurchaseResponses = {
                 status: 'Pending' | 'Confirmed' | 'FailedViaTimeout';
             } | null;
             PaidFunds: Array<{
-                id: string;
-                createdAt: string;
-                updatedAt: string;
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForSeller: Array<{
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForBuyer: Array<{
                 amount: string;
                 unit: string;
             }>;
@@ -1083,9 +1113,14 @@ export type PostPurchaseRequestRefundResponses = {
                 status: 'Pending' | 'Confirmed' | 'FailedViaTimeout';
             } | null;
             PaidFunds: Array<{
-                id: string;
-                createdAt: string;
-                updatedAt: string;
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForSeller: Array<{
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForBuyer: Array<{
                 amount: string;
                 unit: string;
             }>;
@@ -1177,9 +1212,14 @@ export type PostPurchaseCancelRefundRequestResponses = {
                 status: 'Pending' | 'Confirmed' | 'FailedViaTimeout';
             } | null;
             PaidFunds: Array<{
-                id: string;
-                createdAt: string;
-                updatedAt: string;
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForSeller: Array<{
+                amount: string;
+                unit: string;
+            }>;
+            WithdrawnForBuyer: Array<{
                 amount: string;
                 unit: string;
             }>;

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -7,8 +7,10 @@ import {
   createJob,
   getAgentById,
   JobStatus,
+  JobWithStatus,
   prisma,
   refundJob,
+  setNextActionToJob,
   updateJobWithAgentJobStatus,
   updateJobWithPurchase,
 } from "@/lib/db";
@@ -16,6 +18,7 @@ import { calculateInputHash } from "@/lib/utils";
 import {
   AgentJobStatus,
   Job,
+  NextJobAction,
   OnChainJobStatus,
   Prisma,
 } from "@/prisma/generated/client";
@@ -183,7 +186,7 @@ async function syncAgentJobStatus(
   tx: Prisma.TransactionClient,
 ): Promise<Job> {
   try {
-    return await updateJobWithAgentJobStatus(job.id, jobStatusResponse, tx);
+    return await updateJobWithAgentJobStatus(job, jobStatusResponse, tx);
   } catch {
     console.log("Error syncing agent job status: ", job.id);
     return job;
@@ -215,11 +218,18 @@ export async function getAgentJobStatus(
   return jobStatusResult.data;
 }
 
-export async function requestRefundJob(jobBlockchainIdentifier: string) {
+export async function requestRefundJob(
+  jobBlockchainIdentifier: string,
+): Promise<JobWithStatus> {
   const refundResult = await postPaymentClientRequestRefund(
     jobBlockchainIdentifier,
   );
   if (!refundResult.ok) {
     throw new Error(refundResult.error);
   }
+  const job = await setNextActionToJob(
+    jobBlockchainIdentifier,
+    NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
+  );
+  return job;
 }

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -144,12 +144,12 @@ export async function syncJob(job: Job) {
           if (job.agentJobStatus !== AgentJobStatus.COMPLETED) {
             const resultSubmittedAt = job.resultSubmittedAt;
             if (!resultSubmittedAt) {
-              await postPaymentClientRequestRefund(job);
+              await postPaymentClientRequestRefund(job.blockchainIdentifier);
             } else if (
               new Date().getTime() - resultSubmittedAt.getTime() >
               10 * 60 * 1000 // 10 minutes
             ) {
-              await postPaymentClientRequestRefund(job);
+              await postPaymentClientRequestRefund(job.blockchainIdentifier);
             }
           }
           break;
@@ -213,4 +213,13 @@ export async function getAgentJobStatus(
     return null;
   }
   return jobStatusResult.data;
+}
+
+export async function requestRefundJob(jobBlockchainIdentifier: string) {
+  const refundResult = await postPaymentClientRequestRefund(
+    jobBlockchainIdentifier,
+  );
+  if (!refundResult.ok) {
+    throw new Error(refundResult.error);
+  }
 }

--- a/web-app/src/lib/services/job/third-party.ts
+++ b/web-app/src/lib/services/job/third-party.ts
@@ -12,7 +12,6 @@ import {
 import { getPaymentClient } from "@/lib/api/payment-service.client";
 import { AgentWithRelations, getAgentApiBaseUrl } from "@/lib/db";
 import { JobInputData } from "@/lib/job-input";
-import { Job } from "@/prisma/generated/client";
 
 import {
   jobStatusResponseSchema,
@@ -87,14 +86,14 @@ export async function startAgentJob(
 }
 
 export async function postPaymentClientRequestRefund(
-  job: Job,
+  jobBlockchainIdentifier: string,
 ): Promise<Result<void, string>> {
   try {
     const paymentClient = getPaymentClient();
     const refundResponse = await postPurchaseRequestRefund({
       client: paymentClient,
       body: {
-        blockchainIdentifier: job.blockchainIdentifier,
+        blockchainIdentifier: jobBlockchainIdentifier,
         network: getEnvPublicConfig().NEXT_PUBLIC_NETWORK,
       },
     });


### PR DESCRIPTION
## 📋 Summary
Add refund request functionality to the job details page, allowing users to request refunds for jobs within the allowed timeframe.

## ✨ Features
- **Refund Request Button**: New button in job details output section to request refunds
- **Smart State Management**: Button shows different states (available, requested, completed)
- **Tooltip Information**: Helpful tooltips explaining refund availability and deadlines
- **Time-based Availability**: Refunds only available until the job's unlock time
- **Error Handling**: Proper error states and loading indicators

## 🔧 Changes
- Add new `RequestRefundButton` component with comprehensive state management
- Update job details output layout to include refund functionality alongside download
- Refactor `postPaymentClientRequestRefund` to accept blockchain identifier directly
- Add new `requestRefundJob` service function for UI interactions
- Add complete internationalization support for refund-related text

## 🎨 UI/UX Improvements
- Consistent button styling matching existing download button
- Responsive layout with proper spacing between action buttons
- Accessible tooltips with clear messaging about refund availability
- Loading states and error feedback for better user experience

## 🔄 Technical Details
- Pass full job object to output components for access to refund-related data
- Maintain existing functionality while adding new refund capabilities
- Follow established patterns for API error handling and state management

## 🐛 Known Issues
- The refund fails on Preprod because the payment service cannot find a collateral UTXO
   `Requesting refund failed: No collateral UTXO found`
- A re-request following the initial failure also fails on the payment service