### PR TITLE
fix(db): organizations filters do not update

### DIFF
--- a/web-app/src/app/(auth)/register/page.tsx
+++ b/web-app/src/app/(auth)/register/page.tsx
@@ -6,6 +6,8 @@ import { getAllOrganizations } from "@/lib/db";
 import SignUpForm from "./components/form";
 import SignUpHeader from "./components/header";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("Auth.Pages.SignUp.Metadata");
 


### PR DESCRIPTION
## What
- Add `export const dynamic = "force-dynamic"` to the register page

## Why
- Ensures the register page is rendered dynamically on each request
- Prevents static generation/caching issues with organization data fetching
- Guarantees fresh organization list is loaded for each user registration

## Impact
- Register page will now fetch fresh data on every request
- Improved data consistency for organization selection during registration
- Slight performance trade-off for better data accuracy