### PR TITLE
fix: prevent overwriting job completedAt timestamp when already set

### DIFF
--- a/web-app/src/lib/db/job/repo.ts
+++ b/web-app/src/lib/db/job/repo.ts
@@ -201,7 +201,10 @@ export async function updateJobWithAgentJobStatus(
   const output = JSON.stringify(jobStatusResponse);
   const agentJobStatus = jobStatusToAgentJobStatus(jobStatusResponse.status);
   const data: Prisma.JobUpdateInput = { agentJobStatus, output };
-  if (agentJobStatus === AgentJobStatus.COMPLETED) {
+  if (
+    agentJobStatus === AgentJobStatus.COMPLETED &&
+    data.completedAt === null
+  ) {
     data.completedAt = new Date();
   }
   const job = await tx.job.update({


### PR DESCRIPTION
## What
Adds a null check for `completedAt` before setting the completion timestamp when updating a job to COMPLETED status.

## Why
Previously, the `completedAt` timestamp would be overwritten every time a job status was updated to COMPLETED, even if the job was already completed. This could result in inaccurate completion times and loss of the original completion timestamp.

## Changes
- Added condition `data.completedAt === null` to only set `completedAt` when it hasn't been set before
- Ensures completion timestamp is preserved once initially set

## Impact
- Fixes data integrity issue with job completion timestamps
- Maintains accurate completion time tracking for jobs