### PR TITLE
fix: include jobs with none null nextActionErrorType in sync process

### DIFF
--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -81,7 +81,6 @@ async function syncAllJobs() {
           onChainStatus: {
             notIn: finalizedOnChainJobStatuses,
           },
-          nextActionErrorType: null,
         },
         {
           onChainStatus: null,


### PR DESCRIPTION
## What Changed
Removed the `nextActionErrorType: null` filter condition from the job sync query in the `syncAllJobs()` function.

## Why
Previously, jobs only with `nextActionErrorType: null` were being included in the synchronization process. This filter was likely preventing valid jobs from being synced properly.

## Impact
- Jobs with any `nextActionErrorType` value will now be included in the sync process
- This should improve job synchronization coverage and ensure all eligible jobs are processed