### PR TITLE
refactor: cta hire agent opens the new job view

### DIFF
--- a/web-app/src/app/(landing)/agents/[agentId]/page.tsx
+++ b/web-app/src/app/(landing)/agents/[agentId]/page.tsx
@@ -1,8 +1,12 @@
 import { notFound } from "next/navigation";
 
 import { AgentDetail } from "@/components/agents";
+import {
+  CreateJobModal,
+  CreateJobModalContextProvider,
+} from "@/components/create-job-modal";
 import { getAgentById, getJobsByAgentId } from "@/lib/db";
-import { getAgentCreditsPrice } from "@/lib/services";
+import { getAgentCreditsPrice, getAgentInputSchema } from "@/lib/services";
 
 export default async function AgentDetailPage({
   params,
@@ -23,11 +27,21 @@ export default async function AgentDetailPage({
 
   const jobs = await getJobsByAgentId(agentId);
 
+  const agentInputSchemaPromise = getAgentInputSchema(agentId);
+
   return (
-    <AgentDetail
-      agent={agent}
-      agentCreditsPrice={agentCreditsPrice}
-      jobs={jobs}
-    />
+    <CreateJobModalContextProvider>
+      <AgentDetail
+        agent={agent}
+        agentCreditsPrice={agentCreditsPrice}
+        jobs={jobs}
+      />
+      {/* Create Job Modal */}
+      <CreateJobModal
+        agent={agent}
+        agentCreditsPrice={agentCreditsPrice}
+        inputSchemaPromise={agentInputSchemaPromise}
+      />
+    </CreateJobModalContextProvider>
   );
 }

--- a/web-app/src/app/(landing)/agents/page.tsx
+++ b/web-app/src/app/(landing)/agents/page.tsx
@@ -2,7 +2,14 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { AgentCard, Agents, AgentsNotAvailable } from "@/components/agents";
-import { getOnlineAgentsWithCreditsPrice } from "@/lib/services";
+import {
+  CreateJobModal,
+  CreateJobModalContextProvider,
+} from "@/components/create-job-modal";
+import {
+  getAgentInputSchema,
+  getOnlineAgentsWithCreditsPrice,
+} from "@/lib/services";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("Landing.Agents.Metadata");
@@ -20,16 +27,29 @@ export default async function GalleryPage() {
     return <AgentsNotAvailable />;
   }
 
+  const featuredAgentWithPrice = agentsWithPrice[0];
+  const featuredAgentInputSchemaPromise = getAgentInputSchema(
+    featuredAgentWithPrice.agent.id,
+  );
+
   return (
     <div className="container mx-auto px-12 pt-4 pb-8">
       <div className="space-y-24">
-        {/* Featured Agent Section */}
-        <AgentCard
-          agent={agentsWithPrice[0].agent}
-          agentCreditsPrice={agentsWithPrice[0].creditsPrice}
-          className="w-full"
-          size="lg"
-        />
+        <CreateJobModalContextProvider>
+          {/* Featured Agent Section */}
+          <AgentCard
+            agent={featuredAgentWithPrice.agent}
+            agentCreditsPrice={featuredAgentWithPrice.creditsPrice}
+            className="w-full"
+            size="lg"
+          />
+          {/* Create Job Modal */}
+          <CreateJobModal
+            agent={featuredAgentWithPrice.agent}
+            agentCreditsPrice={featuredAgentWithPrice.creditsPrice}
+            inputSchemaPromise={featuredAgentInputSchemaPromise}
+          />
+        </CreateJobModalContextProvider>
 
         {/* Agent Cards Grid */}
         <Agents

--- a/web-app/src/app/app/agents/[agentId]/page.tsx
+++ b/web-app/src/app/app/agents/[agentId]/page.tsx
@@ -1,10 +1,15 @@
 import { notFound } from "next/navigation";
 
 import { AgentDetail } from "@/components/agents";
+import {
+  CreateJobModal,
+  CreateJobModalContextProvider,
+} from "@/components/create-job-modal";
 import { requireAuthentication } from "@/lib/auth/utils";
 import { getAgentById, getJobsByAgentId } from "@/lib/db";
 import {
   getAgentCreditsPrice,
+  getAgentInputSchema,
   getOrCreateFavoriteAgentList,
 } from "@/lib/services";
 
@@ -29,14 +34,24 @@ export default async function AgentDetailPage({
   const agentList = await getOrCreateFavoriteAgentList(session.user.id);
   const jobs = await getJobsByAgentId(agentId);
 
+  const agentInputSchemaPromise = getAgentInputSchema(agentId);
+
   return (
-    <div className="mx-auto flex justify-center px-4 py-8">
-      <AgentDetail
+    <CreateJobModalContextProvider>
+      <div className="mx-auto flex justify-center px-4 py-8">
+        <AgentDetail
+          agent={agent}
+          agentCreditsPrice={agentCreditsPrice}
+          agentList={agentList}
+          jobs={jobs}
+        />
+      </div>
+      {/* Create Job Modal */}
+      <CreateJobModal
         agent={agent}
         agentCreditsPrice={agentCreditsPrice}
-        agentList={agentList}
-        jobs={jobs}
+        inputSchemaPromise={agentInputSchemaPromise}
       />
-    </div>
+    </CreateJobModalContextProvider>
   );
 }

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -121,7 +121,7 @@ const agentCardPricingAndButtonsContentVariants = cva(
       size: {
         xs: "hidden",
         sm: "hidden",
-        md: "[&>div:nth-child(2)]:hidden [&>div>p]:font-medium [&>div>p]:text-sm",
+        md: "[&>div>p]:font-medium [&>div>p]:text-sm",
         lg: "[&>div>p]:font-medium [&>div>p]:text-base",
       },
     },
@@ -173,7 +173,7 @@ function AgentCardSkeleton({
           </div>
           <div className="flex items-center gap-1.5">
             <Skeleton className="h-6 w-18" />
-            <Skeleton className="h-6 w-18" />
+            {size === "lg" && <Skeleton className="h-6 w-18" />}
           </div>
         </div>
       </div>
@@ -275,7 +275,7 @@ function AgentCard({
                   </AgentDetailLink>
                 </Button>
               )}
-              <AgentHireButton agentId={agent.id} />
+              {size === "lg" && <AgentHireButton />}
             </div>
           </div>
         </div>

--- a/web-app/src/components/agents/agent-detail/section-1.tsx
+++ b/web-app/src/components/agents/agent-detail/section-1.tsx
@@ -87,7 +87,7 @@ function AgentDetailSection1({
                 })}
               </span>
             </div>
-            <AgentHireButton agentId={agent.id} />
+            <AgentHireButton />
           </div>
         </div>
       </div>

--- a/web-app/src/components/agents/agent-detail/section-4/playlist-modal.tsx
+++ b/web-app/src/components/agents/agent-detail/section-4/playlist-modal.tsx
@@ -24,7 +24,6 @@ interface PlaylistModalProps {
   open: boolean;
   onClose: () => void;
   exampleOutputs: ExampleOutput[];
-  agentId: string;
   initialIndex?: number | undefined;
 }
 
@@ -32,7 +31,6 @@ export default function PlaylistModal({
   open,
   onClose,
   exampleOutputs,
-  agentId,
   initialIndex,
 }: PlaylistModalProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex ?? 0);
@@ -74,7 +72,6 @@ export default function PlaylistModal({
             />
             <PlaylistMainSection
               selectedExampleOutput={selectedExampleOutput}
-              agentId={agentId}
               onClose={onClose}
             />
           </div>
@@ -113,11 +110,9 @@ function PlaylistSidebar({
 
 function PlaylistMainSection({
   selectedExampleOutput,
-  agentId,
   onClose,
 }: {
   selectedExampleOutput: ExampleOutput;
-  agentId: string;
   onClose: () => void;
 }) {
   const t = useTranslations("Components.Agents.AgentDetail.Section4");
@@ -129,7 +124,7 @@ function PlaylistMainSection({
           {selectedExampleOutput.name}
         </p>
         <div className="flex items-center gap-1">
-          <AgentHireButton agentId={agentId} size="default" />
+          <AgentHireButton />
           <Button variant="ghost" size="icon" onClick={onClose}>
             <X />
           </Button>

--- a/web-app/src/components/agents/agent-hire-button.tsx
+++ b/web-app/src/components/agents/agent-hire-button.tsx
@@ -1,26 +1,26 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ComponentProps } from "react";
 
+import { useCreateJobModalContext } from "@/components/create-job-modal";
 import { Button } from "@/components/ui/button";
 import useWithAuthentication from "@/hooks/use-with-authentication";
 
 interface AgentHireButtonProps {
-  agentId: string;
   size?: ComponentProps<typeof Button>["size"] | undefined;
 }
 
-function AgentHireButton({ agentId, size = "lg" }: AgentHireButtonProps) {
+function AgentHireButton({ size = "lg" }: AgentHireButtonProps) {
   const t = useTranslations("Components.Agents");
-  const router = useRouter();
   const { isPending, ModalComponent, withAuthentication } =
     useWithAuthentication();
 
+  const { setOpen } = useCreateJobModalContext();
+
   const handleHire = () => {
-    router.push(`/app/agents/${agentId}/jobs`);
+    setOpen(true);
   };
 
   return (

--- a/web-app/src/components/create-job-modal/create-job-section.tsx
+++ b/web-app/src/components/create-job-modal/create-job-section.tsx
@@ -31,7 +31,8 @@ export default function CreateJobSection({
   agentCreditsPrice,
   inputSchemaPromise,
 }: CreateJobSectionProps) {
-  const { accordionValue, setAccordionValue } = useCreateJobModalContext();
+  const { accordionValue, setAccordionValue, loading } =
+    useCreateJobModalContext();
 
   const handleAccordionValueChange = (value: string[]) => {
     setAccordionValue(value);
@@ -46,25 +47,36 @@ export default function CreateJobSection({
         className="w-full space-y-1.5"
         onValueChange={handleAccordionValueChange}
       >
-        <InformationAccordionItem agent={agent} />
+        <InformationAccordionItem agent={agent} disabled={loading} />
         <InputAccordionItem
           agent={agent}
           agentCreditsPrice={agentCreditsPrice}
           inputSchemaPromise={inputSchemaPromise}
+          disabled={loading}
         />
       </Accordion>
     </div>
   );
 }
 
-function InformationAccordionItem({ agent }: { agent: AgentWithRelations }) {
+function InformationAccordionItem({
+  agent,
+  disabled,
+}: {
+  agent: AgentWithRelations;
+  disabled?: boolean | undefined;
+}) {
   const t = useTranslations("App.Agents.Jobs.CreateJob.Information");
   const name = getAgentName(agent);
   const description = getAgentDescription(agent);
   const image = getAgentResolvedImage(agent);
 
   return (
-    <AccordionItemWrapper value="information" title={t("title")}>
+    <AccordionItemWrapper
+      value="information"
+      title={t("title")}
+      disabled={disabled}
+    >
       <div className="flex flex-wrap gap-6">
         <div className="h-24 w-24">
           <Image
@@ -88,15 +100,17 @@ function InputAccordionItem({
   agent,
   agentCreditsPrice,
   inputSchemaPromise,
+  disabled,
 }: {
   agent: AgentWithRelations;
   agentCreditsPrice: CreditsPrice;
   inputSchemaPromise: Promise<JobInputsDataSchemaType>;
+  disabled?: boolean | undefined;
 }) {
   const t = useTranslations("App.Agents.Jobs.CreateJob.Input");
 
   return (
-    <AccordionItemWrapper value="input" title={t("title")}>
+    <AccordionItemWrapper value="input" title={t("title")} disabled={disabled}>
       <div className="flex flex-col gap-6">
         <p className="text-sm">{t("description")}</p>
         <JobInputsForm


### PR DESCRIPTION
## Changes

* Update `AgentHireButton` to open create job modal
* Wrap agent detail page (landing, app) with create-job-modal-context-provider, and show modal on CTA "Hire Agent"
* Wrap landing gallery page's Featured Agent with create-job-modal-context-provider to show modal on CTA "Hire Agent"
* Refactor `AgentCard` component not to render `AgentHireButton` when size is not `lg`
* Disable Create Job Modal accordion item while job is submitting