### PR TITLE
chore: remove deprecated inputHash null filter from job sync

### DIFF
--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -102,11 +102,6 @@ async function syncAllJobs() {
             gt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
           },
         },
-        // Get jobs that are missing input hash
-        // Remove in July 2025
-        {
-          inputHash: null,
-        },
       ],
     },
   });


### PR DESCRIPTION
## Summary
Removes the deprecated filter condition for jobs with `inputHash: null` from the job synchronization endpoint.

## Changes
- Removed the OR condition that was filtering for jobs with `inputHash: null` in the sync jobs query
- This was temporary code that was scheduled for removal in July 2025 according to the inline comment

## Rationale
This filter was added as a temporary measure to handle jobs missing input hashes during a migration period. Since the migration period has passed and all jobs should now have input hashes, this condition is no longer needed and can be safely removed.

## Testing
- Verified that job synchronization continues to work correctly without this filter
- Confirmed that all existing jobs have valid input hashes