### PR TITLE
fix(api): correct prisma query syntax in job sync filter

### DIFF
--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -90,6 +90,8 @@ async function syncAllJobs() {
             gt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
           },
         },
+      ],
+      AND: [
         // Filter out jobs that are already completed and the external dispute unlock time has passed
         {
           onChainStatus: {


### PR DESCRIPTION
### What changed
Fixed a syntax error in the Prisma query within the job sync API endpoint where the OR and AND conditions were not properly structured.

### Technical details
- Added missing closing bracket `],` for the OR condition array
- Added proper `AND: [` syntax to structure the query conditions correctly
- This ensures the Prisma query properly filters jobs using both OR and AND conditions

### Impact
- Resolves potential runtime errors in the job synchronization process
- Ensures proper filtering of jobs based on on-chain status, payment status, and dispute unlock times
- Maintains the intended logic of excluding finalized jobs while including jobs with recent activity