### PR TITLE
fix: correct dispute unlock time condition in job sync query

### DIFF
--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -95,7 +95,7 @@ async function syncAllJobs() {
         onChainStatus: OnChainJobStatus.RESULT_SUBMITTED,
         agentJobStatus: AgentJobStatus.COMPLETED,
         externalDisputeUnlockTime: {
-          gt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
+          lt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
         },
       },
     },


### PR DESCRIPTION
## Summary
Fixes the dispute unlock time condition in the job synchronization query to properly identify jobs that are past their dispute period.

## Changes
- Changed `externalDisputeUnlockTime` condition from `gt` (greater than) to `lt` (less than) in the job sync query
- This ensures we only process jobs where the 10-minute grace period has actually elapsed

## Problem
The previous condition (`gt`) was incorrectly selecting jobs where the dispute unlock time was in the future (greater than 10 minutes ago), which would include jobs still within their dispute period.

## Solution
The corrected condition (`lt`) now properly selects jobs where the dispute unlock time is in the past (less than 10 minutes ago), meaning the dispute period has ended and the job can be processed.

## Impact
- Jobs will now be correctly identified for processing after their dispute period expires
- Prevents premature processing of jobs still within the dispute window
- Ensures proper adherence to the 10-minute grace period logic