### PR TITLE
fix: correct path to add-cents-to-fiat-transaction data migration script

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -25,7 +25,7 @@
     "prisma:studio": "prisma studio",
     "data-migration:job-sync": "tsx ./prisma/migrations/20250519112751_job_sync/data-migration.ts",
     "data-migration:add-organization": "tsx ./prisma/migrations/20250520120625_add_organization/data-migration.ts",
-    "data-migration:add-cents-to-fiat-transaction": "tsx ./prisma/migrations/20250602120625_add_cents_to_fiat_transaction/data-migration.ts",
+    "data-migration:add-cents-to-fiat-transaction": "tsx ./prisma/migrations/20250528171822_add_cents_to_fiat_transaction/data-migration.ts",
     "format": "prettier --log-level silent --write src/**/*.ts",
     "generate:payment": "openapi-ts -f openapi-ts.payment.config.ts",
     "generate:registry": "openapi-ts -f openapi-ts.registry.config.ts",


### PR DESCRIPTION
## Summary
Fixes incorrect path reference in package.json for the `data-migration:add-cents-to-fiat-transaction` script.

## Changes
- Updated script path from `20250602120625_add_cents_to_fiat_transaction` to `20250528171822_add_cents_to_fiat_transaction`
- Corrects the migration timestamp to match the actual migration file that exists in the filesystem

## Impact
- Resolves script execution error when running `pnpm run data-migration:add-cents-to-fiat-transaction`
- Ensures the migration script points to the correct migration directory

## Testing
- Verified the correct migration directory exists at `prisma/migrations/20250528171822_add_cents_to_fiat_transaction/`
- Script path now correctly references the existing migration