### PR TITLE
chore: bump pnpm from 10.11.0 to 10.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokosumi",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.11.1",
   "workspaces": [],
   "scripts": {
     "prepare": "husky"


### PR DESCRIPTION
## Summary
Updates the package manager version from pnpm 10.11.0 to 10.11.1.

## Changes
- Updated `packageManager` field in `package.json` from `pnpm@10.11.0` to `pnpm@10.11.1`

This is a minor version bump for the package manager and should not affect functionality.