### PR TITLE
feat: add OUTPUT_PENDING job status with auto-refund logic

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -618,7 +618,7 @@
           "disputeResolved": "Dispute Resolved",
           "refundRequested": "Refund Requested",
           "refundResolved": "Refunded",
-          "outputPending": "Output Pending",
+          "outputPending": "Output Missing",
           "unknown": "Unknown"
         },
         "JobDetails": {

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -603,22 +603,23 @@
             "started": "Started",
             "status": "Status",
             "id": "ID"
-          },
-          "JobStatusBadge": {
-            "completed": "Completed",
-            "failed": "Failed",
-            "paymentProcessing": "Payment Processing",
-            "paymentFailed": "Payment Failed",
-            "processing": "Processing",
-            "agentConnectionFailed": "Agent Connection Failed",
-            "paymentNodeConnectionFailed": "Node Connection Failed",
-            "inputRequired": "Input Required",
-            "disputeRequested": "Dispute Requested",
-            "disputeResolved": "Dispute Resolved",
-            "refundRequested": "Refund Requested",
-            "refundResolved": "Refunded",
-            "unknown": "Unknown"
           }
+        },
+        "StatusBadge": {
+          "completed": "Completed",
+          "failed": "Failed",
+          "paymentProcessing": "Payment Processing",
+          "paymentFailed": "Payment Failed",
+          "processing": "Processing",
+          "agentConnectionFailed": "Agent Connection Failed",
+          "paymentNodeConnectionFailed": "Node Connection Failed",
+          "inputRequired": "Input Required",
+          "disputeRequested": "Dispute Requested",
+          "disputeResolved": "Dispute Resolved",
+          "refundRequested": "Refund Requested",
+          "refundResolved": "Refunded",
+          "outputPending": "Output Pending",
+          "unknown": "Unknown"
         },
         "JobDetails": {
           "Input": {

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/job-status-badge.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/job-status-badge.tsx
@@ -15,7 +15,7 @@ export default function JobStatusBadge({
   status,
   className,
 }: JobStatusBadgeProps) {
-  const t = useTranslations("App.Agents.Jobs.JobsTable.JobStatusBadge");
+  const t = useTranslations("App.Agents.Jobs.StatusBadge");
   switch (status) {
     case JobStatus.COMPLETED:
       return (
@@ -57,7 +57,7 @@ export default function JobStatusBadge({
       return (
         <Badge
           variant="default"
-          className={cn("bg-blue-100 text-blue-800", className)}
+          className={cn("bg-sky-100 text-sky-800", className)}
         >
           {t("processing")}
         </Badge>
@@ -84,7 +84,7 @@ export default function JobStatusBadge({
       return (
         <Badge
           variant="default"
-          className={cn("bg-green-100 text-green-800", className)}
+          className={cn("bg-purple-100 text-purple-800", className)}
         >
           {t("refundResolved")}
         </Badge>
@@ -102,9 +102,18 @@ export default function JobStatusBadge({
       return (
         <Badge
           variant="default"
-          className={cn("bg-green-100 text-green-800", className)}
+          className={cn("bg-purple-100 text-purple-800", className)}
         >
           {t("disputeResolved")}
+        </Badge>
+      );
+    case JobStatus.OUTPUT_PENDING:
+      return (
+        <Badge
+          variant="default"
+          className={cn("bg-red-100 text-red-800", className)}
+        >
+          {t("outputPending")}
         </Badge>
       );
     default:

--- a/web-app/src/lib/db/job/types.ts
+++ b/web-app/src/lib/db/job/types.ts
@@ -24,13 +24,17 @@ export enum JobErrorNoteKeys {
 
 export enum JobStatus {
   COMPLETED = "completed",
-  FAILED = "failed",
-  PAYMENT_PENDING = "payment_pending",
-  PAYMENT_FAILED = "payment_failed",
   PROCESSING = "processing",
   INPUT_REQUIRED = "input_required",
+  OUTPUT_PENDING = "output_pending", // Result is submitted on-chain, but not available by the agent
+  FAILED = "failed",
+
+  PAYMENT_PENDING = "payment_pending",
+  PAYMENT_FAILED = "payment_failed",
+
   REFUND_PENDING = "refund_pending",
   REFUND_RESOLVED = "refund_resolved",
+
   DISPUTE_PENDING = "dispute_pending",
   DISPUTE_RESOLVED = "dispute_resolved",
 }

--- a/web-app/src/lib/db/job/utils.ts
+++ b/web-app/src/lib/db/job/utils.ts
@@ -55,8 +55,6 @@ export function computeJobStatus(job: Job): JobStatus {
       return JobStatus.DISPUTE_PENDING;
     case OnChainJobStatus.DISPUTED_WITHDRAWN:
       return JobStatus.DISPUTE_RESOLVED;
-    default:
-      return JobStatus.PROCESSING;
   }
 }
 

--- a/web-app/src/lib/db/job/utils.ts
+++ b/web-app/src/lib/db/job/utils.ts
@@ -36,7 +36,7 @@ export function computeJobStatus(job: Job): JobStatus {
         case AgentJobStatus.COMPLETED:
           return JobStatus.COMPLETED;
         default:
-          return JobStatus.PROCESSING;
+          return JobStatus.OUTPUT_PENDING;
       }
     case OnChainJobStatus.FUNDS_WITHDRAWN:
       switch (agentJobStatus) {

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -17,13 +17,7 @@ import {
   updateJobWithPurchase,
 } from "@/lib/db";
 import { calculateInputHash } from "@/lib/utils";
-import {
-  AgentJobStatus,
-  Job,
-  NextJobAction,
-  OnChainJobStatus,
-  Prisma,
-} from "@/prisma/generated/client";
+import { Job, NextJobAction, Prisma } from "@/prisma/generated/client";
 import { getAgentPricing } from "@/services/agent";
 import { getCreditsPrice, validateCreditsBalance } from "@/services/credit";
 
@@ -126,6 +120,34 @@ export async function startJob(input: StartJobInputSchemaType): Promise<Job> {
   );
 }
 
+/**
+ * Requests a refund for a job if certain conditions are met:
+ * 1. If the current time is within 1 hour before the unlock time
+ * 2. If the job result was submitted more than 10 minutes ago
+ *
+ * This function helps ensure timely refunds for jobs that are either
+ * approaching their unlock deadline or have had results submitted
+ * but may not be processing correctly.
+ *
+ * @param job - The job to potentially request a refund for
+ */
+async function requestRefundIfNeeded(job: Job) {
+  const currentTime = new Date();
+  const oneHourBeforeUnlock = new Date(
+    job.unlockTime.getTime() - 60 * 60 * 1000, // 1 hour before unlock
+  );
+  if (currentTime >= oneHourBeforeUnlock) {
+    await postPaymentClientRequestRefund(job.blockchainIdentifier);
+  }
+  const resultSubmittedAt = job.resultSubmittedAt;
+  if (
+    resultSubmittedAt &&
+    currentTime.getTime() - resultSubmittedAt.getTime() > 10 * 60 * 1000 // 10 minutes
+  ) {
+    await postPaymentClientRequestRefund(job.blockchainIdentifier);
+  }
+}
+
 export async function syncJob(job: Job) {
   const [agentJobStatus, onChainPurchase] = await Promise.all([
     getAgentJobStatus(job),
@@ -140,7 +162,6 @@ export async function syncJob(job: Job) {
       if (agentJobStatus) {
         job = await syncAgentJobStatus(job, agentJobStatus, tx);
       }
-      // Refund if the job failed
       const jobStatus = computeJobStatus(job);
       switch (jobStatus) {
         case JobStatus.PAYMENT_FAILED:
@@ -148,32 +169,7 @@ export async function syncJob(job: Job) {
           await refundJob(job.id, tx);
           break;
         case JobStatus.OUTPUT_PENDING:
-          const currentTime = new Date();
-          const oneHourBeforeUnlock = new Date(
-            job.unlockTime.getTime() - 60 * 60 * 1000, // 1 hour before unlock
-          );
-          if (currentTime >= oneHourBeforeUnlock) {
-            await refundJob(job.id, tx);
-          }
-          break;
-        default:
-          break;
-      }
-
-      // Request a refund if the job is not completed after 10 minutes
-      switch (job.onChainStatus) {
-        case OnChainJobStatus.RESULT_SUBMITTED:
-          if (job.agentJobStatus !== AgentJobStatus.COMPLETED) {
-            const resultSubmittedAt = job.resultSubmittedAt;
-            if (!resultSubmittedAt) {
-              await postPaymentClientRequestRefund(job.blockchainIdentifier);
-            } else if (
-              new Date().getTime() - resultSubmittedAt.getTime() >
-              10 * 60 * 1000 // 10 minutes
-            ) {
-              await postPaymentClientRequestRefund(job.blockchainIdentifier);
-            }
-          }
+          await requestRefundIfNeeded(job);
           break;
         default:
           break;

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -132,19 +132,38 @@ export async function startJob(input: StartJobInputSchemaType): Promise<Job> {
  * @param job - The job to potentially request a refund for
  */
 async function requestRefundIfNeeded(job: Job) {
+  let shouldRequestRefund = false;
   const currentTime = new Date();
+
+  // Check if we're within 1 hour of unlock time
   const oneHourBeforeUnlock = new Date(
     job.unlockTime.getTime() - 60 * 60 * 1000, // 1 hour before unlock
   );
+
   if (currentTime >= oneHourBeforeUnlock) {
-    await postPaymentClientRequestRefund(job.blockchainIdentifier);
+    shouldRequestRefund = true;
   }
+
+  // Check if result was submitted more than 10 minutes ago
   const resultSubmittedAt = job.resultSubmittedAt;
   if (
     resultSubmittedAt &&
     currentTime.getTime() - resultSubmittedAt.getTime() > 10 * 60 * 1000 // 10 minutes
   ) {
-    await postPaymentClientRequestRefund(job.blockchainIdentifier);
+    shouldRequestRefund = true;
+  }
+
+  // Only make one refund request if either condition is met
+  if (shouldRequestRefund) {
+    const refundResult = await postPaymentClientRequestRefund(
+      job.blockchainIdentifier,
+    );
+    if (!refundResult.ok) {
+      console.error(
+        `Failed to request refund for job ${job.id}:`,
+        refundResult.error,
+      );
+    }
   }
 }
 

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -147,6 +147,15 @@ export async function syncJob(job: Job) {
         case JobStatus.REFUND_RESOLVED:
           await refundJob(job.id, tx);
           break;
+        case JobStatus.OUTPUT_PENDING:
+          const currentTime = new Date();
+          const oneHourBeforeUnlock = new Date(
+            job.unlockTime.getTime() - 60 * 60 * 1000, // 1 hour before unlock
+          );
+          if (currentTime >= oneHourBeforeUnlock) {
+            await refundJob(job.id, tx);
+          }
+          break;
         default:
           break;
       }


### PR DESCRIPTION
## Summary
Adds a new `OUTPUT_PENDING` job status to better handle cases where results are submitted on-chain but not yet available from the agent, with automatic refund logic when approaching unlock time.

## Changes
### New Job Status
- **Added `OUTPUT_PENDING` status**: Represents jobs where results are submitted on-chain but not available by the agent
- **Updated status enum ordering**: Reorganized `JobStatus` enum for better logical grouping (processing states, payment states, refund/dispute states)

### Status Badge Updates
- **Renamed translation key**: `JobStatusBadge` → `StatusBadge` for consistency
- **Updated badge colors**: 
  - Processing: blue → sky for better accessibility
  - Refund/Dispute resolved: green → purple to distinguish from completed status
- **Added OUTPUT_PENDING badge**: Red styling to indicate attention needed

### Logic Improvements
- **Updated job status computation**: Jobs with submitted results but incomplete agent processing now show `OUTPUT_PENDING` instead of `PROCESSING`
- **Added auto-refund logic**: Jobs in `OUTPUT_PENDING` status automatically trigger refund 1 hour before unlock time
- **Removed default fallback**: Simplified status computation by removing unnecessary default case

### Translation Updates
- Added `outputPending` translation key
- Fixed JSON structure in messages file

## Why These Changes?
1. **Better user clarity**: `OUTPUT_PENDING` provides clearer communication about job state
2. **Improved UX**: Users understand when results are submitted but not yet processed
3. **Automatic protection**: Auto-refund prevents users from losing funds when agents fail to deliver
4. **Visual consistency**: Updated badge colors create better status hierarchy