### PR TITLE
feat: add copy button to job output

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -631,6 +631,9 @@
             "failedToParseOutput": "Failed to parse output",
             "none": "No result data",
             "download": "Download",
+            "copy": "Copy",
+            "copySuccess": "Output copied to clipboard",
+            "copyError": "Failed to copy output",
             "Refund": {
               "error": "Failed to request refund",
               "request": "Request Refund",

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/copy-markdown.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/copy-markdown.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Copy } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface CopyMarkdownProps {
+  markdown: string;
+  className?: string;
+}
+
+export default function CopyMarkdown({
+  markdown,
+  className,
+}: CopyMarkdownProps) {
+  const t = useTranslations("App.Agents.Jobs.JobDetails.Output");
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      toast.success(t("copySuccess"));
+    } catch {
+      toast.error(t("copyError"));
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={copyToClipboard}
+      className={cn("text-muted-foreground", className)}
+      title={t("copy")}
+    >
+      <Copy className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/download-markdown.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/download-markdown.tsx
@@ -31,14 +31,12 @@ export default function DownloadMarkdown({
   return (
     <Button
       variant="ghost"
+      size="icon"
       onClick={downloadFile}
-      className={cn(
-        "text-muted-foreground flex items-center justify-end gap-2 text-sm",
-        className,
-      )}
+      className={cn("text-muted-foreground", className)}
+      title={t("download")}
     >
       <Download className="h-4 w-4" />
-      {t("download")}
     </Button>
   );
 }

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/outputs.tsx
@@ -9,6 +9,7 @@ import {
   JobStatusResponseSchemaType,
 } from "@/lib/services/job/schemas";
 
+import CopyMarkdown from "./copy-markdown";
 import DownloadMarkdown from "./download-markdown";
 import RequestRefundButton from "./refund-request";
 
@@ -57,7 +58,10 @@ function JobDetailsOutputsInner({ job }: JobDetailsOutputsProps) {
         <>
           <Markdown>{output.result}</Markdown>
           <div className="flex justify-between gap-2">
-            <DownloadMarkdown markdown={output.result} />
+            <div className="flex gap-1">
+              <DownloadMarkdown markdown={output.result} />
+              <CopyMarkdown markdown={output.result} />
+            </div>
             <RequestRefundButton job={job} />
           </div>
         </>


### PR DESCRIPTION
This PR implements the copy button functionality for job outputs as specified in MAS-125.

## Changes
- **New CopyMarkdown component**: Implements clipboard functionality using `navigator.clipboard.writeText()`
- **Updated DownloadMarkdown component**: Changed to icon-only button for consistency
- **Improved layout**: Copy button positioned directly next to download button on the left side
- **Enhanced UX**: Toast notifications for copy success/error states
- **Internationalization**: Added translation keys for copy functionality

## Technical Details
- Uses the existing toast system (sonner) for user feedback
- Follows the same patterns as the existing ShareButton component
- Maintains accessibility with proper title attributes
- Icon-only buttons for cleaner UI (Download and Copy icons from lucide-react)
- Responsive layout that keeps refund button on the right side

## Testing
- ✅ Code passes all linting checks
- ✅ Follows existing code patterns and conventions
- ✅ Proper error handling for clipboard API failures

Resolves: MAS-125

---
*This is a Droid-assisted PR*