### PR TITLE
ci: remove explicit pnpm version from GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary

Removes the explicit `version: latest` configuration from the pnpm installation step in the Claude Code GitHub Actions workflow.

## Changes

- Remove `version: latest` from `pnpm/action-setup@v4` step in `.github/workflows/claude.yml`

## Rationale

The `pnpm/action-setup@v4` action automatically detects and uses the pnpm version specified in the `packageManager` field of `package.json` (`pnpm@10.11.1`). Explicitly setting `version: latest` overrides this behavior and could lead to version inconsistencies between local development and CI environments.

By removing this explicit version, we ensure that:
- CI uses the same pnpm version as specified in the project configuration
- Version consistency is maintained across all environments
- The workflow respects the project's package manager version lock