### PR TITLE
chore(deps): update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "daily"
       time: "06:00"
       timezone: "Europe/Berlin"
-          
+
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
@@ -49,23 +49,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  # Enable version updates for npm in the job-cron-caller directory
+  # Enable version updates for npm in the sync-function directory
   - package-ecosystem: "npm"
-    directory: "/job-cron-caller"
-    ignore:
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-    schedule:
-      interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore(deps)"
-
-  # Enable version updates for npm in the registry-cron-caller directory
-  - package-ecosystem: "npm"
-    directory: "/registry-cron-caller"
+    directory: "/sync-function"
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Changes

* Remove dependabot configuration for deprecated directories - `job-cron-caller` and `registry-cron-caller`
* Add dependabot configuration for new `sync-function` directory