### PR TITLE
refactor(breadcrumb): use next/link

### DIFF
--- a/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
+++ b/web-app/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import React from "react";
@@ -53,8 +54,8 @@ export default function BreadcrumbNavigationClient({
               {segment.isCurrent ? (
                 <BreadcrumbPage>{segment.label}</BreadcrumbPage>
               ) : (
-                <BreadcrumbLink href={segment.href}>
-                  {segment.label}
+                <BreadcrumbLink asChild>
+                  <Link href={segment.href}>{segment.label}</Link>
                 </BreadcrumbLink>
               )}
             </BreadcrumbItem>


### PR DESCRIPTION
## Changes

* Use next/link instead of <a> link in breadcrumb for better user experience.

## Benefits

* There is no entire reloading when user clicks breadcrumb link.