### PR TITLE
refactor(ui): add glow effect on agent card

### DIFF
--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -303,7 +303,7 @@
 }
 
 @utility agent-card-image-shadow {
-  box-shadow: 0px 0px 16px 8px
+  box-shadow: 0px 0px 16px 6px
     color-mix(in oklab, var(--foreground) 30%, transparent);
 }
 

--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -302,6 +302,11 @@
   }
 }
 
+@utility agent-card-image-shadow {
+  box-shadow: 0px 0px 16px 8px
+    color-mix(in oklab, var(--foreground) 30%, transparent);
+}
+
 @utility agent-detail-card {
   background: var(--material-thin, rgba(245, 245, 245, 0.48));
   border-radius: var(--border-radius-xl, 12px);

--- a/web-app/src/app/globals.css
+++ b/web-app/src/app/globals.css
@@ -303,8 +303,8 @@
 }
 
 @utility agent-card-image-shadow {
-  box-shadow: 0px 0px 16px 6px
-    color-mix(in oklab, var(--foreground) 30%, transparent);
+  box-shadow: 0px 0px 12px 4px
+    color-mix(in oklab, var(--muted-foreground) 30%, transparent);
 }
 
 @utility agent-detail-card {

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -39,13 +39,13 @@ const agentCardVariants = cva("flex rounded-lg border-none p-1 shadow-none", {
 });
 
 const agentCardImageContainerVariants = cva(
-  "relative group overflow-hidden rounded-lg shrink-0 shadow-foreground/10 shadow-lg",
+  "relative group overflow-hidden rounded-lg shrink-0",
   {
     variants: {
       size: {
-        xs: "w-16 h-16 aspect-square",
-        sm: "w-24 h-24 aspect-square",
-        md: "w-full aspect-[1.6]",
+        xs: "w-16 h-16 aspect-square agent-card-image-shadow",
+        sm: "w-24 h-24 aspect-square agent-card-image-shadow",
+        md: "w-full aspect-[1.6] agent-card-image-shadow",
         lg: "w-xl aspect-[1.6]",
       },
     },


### PR DESCRIPTION
## Changes

* Make utility class name `agent-card-image-shadow` for glow effect
* Add glow effect for `xs`, `sm`, `md` variants of `AgentCard`

## NOTE

* For now glow effect use `muted-foreground` color