### PR TITLE
fix: revalidate router cache after user log in

### DIFF
--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -74,6 +74,7 @@ export default function SignInForm({
             }
           }
           router.push(redirectUrl);
+          router.refresh();
         },
       },
     );


### PR DESCRIPTION
## Changes

* Revalidate router cache after user logs in to show updated session information in user avatar component

## Why this happens

* Because we have UserAvatar component in `/app` layout.tsx, which is stored in router cache and data is not re-fetched on client-side navigation.
