### PR TITLE
fix(auth): refresh router after navigation in SignInForm

### DIFF
--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -27,6 +28,7 @@ export default function SignInForm({
   const t = useTranslations("Auth.Pages.SignIn.Form");
 
   const router = useRouter();
+  const [hasNavigated, setHasNavigated] = useState(false);
 
   const form = useForm<SignInFormSchemaType>({
     resolver: zodResolver(
@@ -74,11 +76,17 @@ export default function SignInForm({
             }
           }
           router.push(redirectUrl);
-          router.refresh();
+          setHasNavigated(true);
         },
       },
     );
   };
+
+  useEffect(() => {
+    if (hasNavigated) {
+      router.refresh();
+    }
+  }, [hasNavigated, router]);
 
   return (
     <AuthForm


### PR DESCRIPTION
## Summary

This PR updates the SignInForm component to ensure the router is refreshed after navigation, addressing potential issues with stale session or UI state after login.

### Changes
- Adds a `hasNavigated` state to track navigation after login.
- Uses a `useEffect` to call `router.refresh()` only after navigation, preventing premature refreshes.

### Motivation
This change ensures that the session and UI are properly updated after a successful login, improving reliability and user experience.

---
- Follows Conventional Commits 1.0.0
- Uses best practices for Next.js 15, React 19, and TypeScript.
- Styling and components remain consistent with Shadcn UI, Radix, and Tailwind CSS.

Closes: n/a