### PR TITLE
chore: remove duplicate VSCode extension recommendation for Tailwind CSS

### DIFF
--- a/web-app/.vscode/extensions.json
+++ b/web-app/.vscode/extensions.json
@@ -5,7 +5,6 @@
     "dbaeumer.vscode-eslint",
     "streetsidesoftware.code-spell-checker",
     "prisma.prisma",
-    "lokalise.i18n-ally",
-    "bradlc.vscode-tailwindcss"
+    "lokalise.i18n-ally"
   ]
 }


### PR DESCRIPTION
### Summary
This PR removes the duplicate recommendation for the `bradlc.vscode-tailwindcss` extension from the `.vscode/extensions.json` file in the `web-app` directory.

### Details
- The `bradlc.vscode-tailwindcss` extension was listed twice in the recommendations. This PR removes the duplicate, ensuring only unique extension recommendations are present.

### Motivation
- Keeps the VSCode extension recommendations clean and avoids confusion for contributors.

### Checklist
- [x] Duplicate extension recommendation removed
- [x] File formatting preserved

---
This PR follows the [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) specification.