### PR TITLE
feat(job-detail): display input fields with descriptive labels and schema support

### DIFF
--- a/web-app/prisma/migrations/20250616093348_add_input_schema_to_job/migration.sql
+++ b/web-app/prisma/migrations/20250616093348_add_input_schema_to_job/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Job" ADD COLUMN     "inputSchema" JSONB;

--- a/web-app/prisma/migrations/20250616093348_add_input_schema_to_job/migration.sql
+++ b/web-app/prisma/migrations/20250616093348_add_input_schema_to_job/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "Job" ADD COLUMN     "inputSchema" JSONB;
+ALTER TABLE "Job" ADD COLUMN "inputSchema" JSONB DEFAULT '{}';

--- a/web-app/prisma/migrations/20250616100850_remove_input_schema_default/migration.sql
+++ b/web-app/prisma/migrations/20250616100850_remove_input_schema_default/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `inputSchema` on table `Job` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Job" ALTER COLUMN "inputSchema" SET NOT NULL,
+ALTER COLUMN "inputSchema" DROP DEFAULT;

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -400,6 +400,7 @@ model Job {
   agentJobStatus AgentJobStatus?
 
   paymentId         String
+  inputSchema       Json?
   input             String
   inputHash         String? // On-Chain hash of the input data
   output            String?

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -400,7 +400,7 @@ model Job {
   agentJobStatus AgentJobStatus?
 
   paymentId         String
-  inputSchema       Json?
+  inputSchema       Json
   input             String
   inputHash         String? // On-Chain hash of the input data
   output            String?

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx
@@ -1,22 +1,47 @@
 import { useTranslations } from "next-intl";
+import { z } from "zod";
 
 import DefaultErrorBoundary from "@/components/default-error-boundary";
+import { jobInputSchema } from "@/lib/job-input";
+import { JsonValue } from "@/prisma/generated/client/runtime/library";
 
 interface JobDetailsInputsProps {
   rawInput: string | null;
+  inputSchema: JsonValue | null;
 }
 
-export default function JobDetailsInputs({ rawInput }: JobDetailsInputsProps) {
+export default function JobDetailsInputs({
+  rawInput,
+  inputSchema,
+}: JobDetailsInputsProps) {
   return (
     <DefaultErrorBoundary fallback={<JobDetailsInputsError />}>
-      <JobDetailsInputsInner rawInput={rawInput} />
+      <JobDetailsInputsInner rawInput={rawInput} inputSchema={inputSchema} />
     </DefaultErrorBoundary>
   );
 }
 
-function JobDetailsInputsInner({ rawInput }: JobDetailsInputsProps) {
+function JobDetailsInputsInner({
+  rawInput,
+  inputSchema,
+}: JobDetailsInputsProps) {
   const t = useTranslations("App.Agents.Jobs.JobDetails.Input");
   const input = rawInput ? JSON.parse(rawInput) : {};
+
+  let idNameMap: Record<string, string> = {};
+  if (typeof inputSchema === "string") {
+    const inputSchemaObject = JSON.parse(inputSchema);
+    idNameMap = z
+      .array(jobInputSchema())
+      .parse(inputSchemaObject)
+      .reduce(
+        (acc, item) => {
+          acc[item.id] = item.name;
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+  }
 
   return (
     <div className="flex flex-col gap-2">
@@ -27,7 +52,7 @@ function JobDetailsInputsInner({ rawInput }: JobDetailsInputsProps) {
               className="flex flex-row items-start gap-4 text-base"
               key={key}
             >
-              <span className="font-bold">{key}</span>
+              <span className="font-bold">{idNameMap[key] || key}</span>
               <span className="break-words">
                 {typeof value === "object"
                   ? JSON.stringify(value)

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx
@@ -29,11 +29,10 @@ function JobDetailsInputsInner({
   const input = rawInput ? JSON.parse(rawInput) : {};
 
   let idNameMap: Record<string, string> = {};
-  if (typeof inputSchema === "string") {
-    const inputSchemaObject = JSON.parse(inputSchema);
+  if (Array.isArray(inputSchema)) {
     idNameMap = z
       .array(jobInputSchema())
-      .parse(inputSchemaObject)
+      .parse(inputSchema)
       .reduce(
         (acc, item) => {
           acc[item.id] = item.name;

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/job-details.tsx
@@ -38,7 +38,10 @@ export default function JobDetails({ job, className }: JobDetailsProps) {
         >
           <JobDetailsHeader createdAt={job.createdAt} status={job.status} />
           <AccordionItemWrapper value="input" title={t("Input.title")}>
-            <JobDetailsInputs rawInput={job.input} />
+            <JobDetailsInputs
+              rawInput={job.input}
+              inputSchema={job.inputSchema}
+            />
           </AccordionItemWrapper>
           <AccordionItemWrapper value="output" title={t("Output.title")}>
             <JobDetailsOutputs job={job} />

--- a/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
@@ -69,13 +69,13 @@ export default function JobInputsFormClient({
   ) => {
     try {
       setLoading(true);
-
       // Transform input data to match expected type
       // Filter out null values and ensure arrays are of correct type
       const transformedInputData = filterOutNullValues(values);
       const result = await startJobWithInputData({
         agentId: agentId,
         maxAcceptedCents: agentCreditsPrice.cents,
+        inputSchema: JSON.stringify(input_data),
         inputData: transformedInputData,
       });
 

--- a/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
@@ -75,7 +75,7 @@ export default function JobInputsFormClient({
       const result = await startJobWithInputData({
         agentId: agentId,
         maxAcceptedCents: agentCreditsPrice.cents,
-        inputSchema: JSON.stringify(input_data),
+        inputSchema: input_data,
         inputData: transformedInputData,
       });
 

--- a/web-app/src/lib/db/job/repo.ts
+++ b/web-app/src/lib/db/job/repo.ts
@@ -108,6 +108,7 @@ interface CreateJobData {
   agentJobId: string;
   agentId: string;
   userId: string;
+  inputSchema: string;
   input: string;
   paymentId: string;
   creditsPrice: CreditsPrice;
@@ -143,6 +144,7 @@ export async function createJob(
         },
       },
       paymentId: data.paymentId,
+      inputSchema: data.inputSchema,
       input: data.input,
       identifierFromPurchaser: data.identifierFromPurchaser,
       externalDisputeUnlockTime: data.externalDisputeUnlockTime,

--- a/web-app/src/lib/db/job/repo.ts
+++ b/web-app/src/lib/db/job/repo.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { CreditsPrice, getCreditTransactionByJobId, prisma } from "@/lib/db";
+import { JobInputSchemaType } from "@/lib/job-input";
 import {
   AgentJobStatus,
   Job,
@@ -108,7 +109,7 @@ interface CreateJobData {
   agentJobId: string;
   agentId: string;
   userId: string;
-  inputSchema: string;
+  inputSchema: JobInputSchemaType[];
   input: string;
   paymentId: string;
   creditsPrice: CreditsPrice;

--- a/web-app/src/lib/services/job/schemas.ts
+++ b/web-app/src/lib/services/job/schemas.ts
@@ -6,7 +6,7 @@ export const startJobInputSchema = z.object({
   userId: z.string(),
   agentId: z.string(),
   maxAcceptedCents: z.bigint(),
-  inputSchema: z.string(),
+  inputSchema: z.array(jobInputSchema()),
   inputData: z.map(
     z.string(),
     z.union([z.number(), z.string(), z.boolean(), z.array(z.number())]),

--- a/web-app/src/lib/services/job/schemas.ts
+++ b/web-app/src/lib/services/job/schemas.ts
@@ -6,6 +6,7 @@ export const startJobInputSchema = z.object({
   userId: z.string(),
   agentId: z.string(),
   maxAcceptedCents: z.bigint(),
+  inputSchema: z.string(),
   inputData: z.map(
     z.string(),
     z.union([z.number(), z.string(), z.boolean(), z.array(z.number())]),

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -41,7 +41,8 @@ export async function getMyJobsByAgentId(
 export async function startJob(input: StartJobInputSchemaType): Promise<Job> {
   return await prisma.$transaction(
     async (tx) => {
-      const { userId, agentId, maxAcceptedCents, inputData } = input;
+      const { userId, agentId, maxAcceptedCents, inputData, inputSchema } =
+        input;
 
       const agent = await getAgentById(agentId, tx);
       if (!agent) {
@@ -98,6 +99,7 @@ export async function startJob(input: StartJobInputSchemaType): Promise<Job> {
           agentId,
           userId,
           input: JSON.stringify(Object.fromEntries(inputData)),
+          inputSchema: inputSchema,
           paymentId: purchaseResponse.data.id,
           creditsPrice,
           identifierFromPurchaser,


### PR DESCRIPTION
## ✨ What’s new?

This PR enhances the Job Detail page by introducing support for displaying job input fields with descriptive labels, leveraging the new `inputSchema` property on the `Job` model. This improves clarity and user experience by mapping input field IDs to human-readable names.

### Key changes:
- **Database:**
  - Added a required `inputSchema` JSONB column to the `Job` table (with migration).
- **Backend:**
  - Passes and persists the input schema when creating jobs.
  - Updates service and validation logic to handle the new schema.
- **Frontend:**
  - The Job Details UI now displays input fields using descriptive names from the schema, not just raw keys.
  - Improved type safety and error handling for input parsing.
  - All UI changes follow Shadcn UI, Radix, and Tailwind best practices, with full i18n support via next-intl.

### 🧪 How to test
- Create a job with a custom input schema and verify the Job Detail page shows the correct field names and values.