### PR TITLE
feat(agent): display author organization in place of author name

### DIFF
--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -11,10 +11,10 @@ import {
   AgentWithRelations,
   convertCentsToCredits,
   CreditsPrice,
-  getAgentAuthorName,
   getAgentName,
   getAgentResolvedImage,
   getAgentTags,
+  getShortAgentAuthorName,
 } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
@@ -243,7 +243,7 @@ function AgentCard({
               <AgentVerifiedBadge />
             </div>
             <p className="text-muted-foreground truncate text-sm">
-              {getAgentAuthorName(agent)}
+              {getShortAgentAuthorName(agent)}
             </p>
           </div>
           {/* View Button */}

--- a/web-app/src/components/agents/agent-detail/section-1.tsx
+++ b/web-app/src/components/agents/agent-detail/section-1.tsx
@@ -13,9 +13,9 @@ import {
   AgentWithRelations,
   convertCentsToCredits,
   CreditsPrice,
-  getAgentAuthorName,
   getAgentName,
   getAgentResolvedImage,
+  getFullAgentAuthorName,
 } from "@/lib/db";
 
 interface AgentDetailSection1Props {
@@ -75,7 +75,7 @@ function AgentDetailSection1({
                 />
               </div>
               <p className="text-muted-foreground">
-                {getAgentAuthorName(agent)}
+                {getFullAgentAuthorName(agent)}
               </p>
             </div>
           </div>

--- a/web-app/src/lib/db/agent/types.ts
+++ b/web-app/src/lib/db/agent/types.ts
@@ -61,9 +61,3 @@ export interface AgentLegal {
   readonly terms: string | null;
   readonly other: string | null;
 }
-
-export interface AgentAuthor {
-  readonly name: string;
-  readonly email: string | null;
-  readonly other: string | null;
-}

--- a/web-app/src/lib/db/agent/utils.ts
+++ b/web-app/src/lib/db/agent/utils.ts
@@ -3,7 +3,6 @@ import { ipfsUrlResolver } from "@/lib/ipfs";
 import { Agent, ExampleOutput } from "@/prisma/generated/client";
 
 import {
-  AgentAuthor,
   AgentLegal,
   AgentWithExampleOutput,
   AgentWithRating,
@@ -90,16 +89,30 @@ export function getAgentLegalOther(agent: Agent): string | null {
   return agent.overrideLegalOther ?? agent.legalOther;
 }
 
-export function getAgentAuthor(agent: Agent): AgentAuthor {
-  return {
-    name: agent.overrideAuthorName ?? agent.authorName,
-    email: agent.overrideAuthorContactEmail ?? agent.authorContactEmail,
-    other: agent.overrideAuthorContactOther ?? agent.authorContactOther,
-  };
+export function getAgentAuthorOrganization(agent: Agent): string | null {
+  return agent.overrideAuthorOrganization ?? agent.authorOrganization;
 }
 
-export function getAgentAuthorName(agent: Agent): string {
+export function getShortAgentAuthorName(agent: Agent): string {
+  // Prioritize organization over name
+  const organization = getAgentAuthorOrganization(agent);
+  if (organization) {
+    return organization;
+  }
   return agent.overrideAuthorName ?? agent.authorName;
+}
+
+export function getFullAgentAuthorName(agent: Agent): string {
+  // For detail pages, show both organization and name
+  const organization = getAgentAuthorOrganization(agent);
+  const name = agent.overrideAuthorName ?? agent.authorName;
+
+  if (organization && name) {
+    return `${organization} (${name})`;
+  } else if (organization) {
+    return organization;
+  }
+  return name;
 }
 
 export function getAgentAuthorEmail(agent: Agent): string | null {


### PR DESCRIPTION
## Summary

- Show `authorOrganization` with higher priority than `authorName` throughout the interface.
- On the detail page, show both: `authorOrganization (authorName)` if both are present.
- Refactored agent author utility functions for clarity and future extensibility.

### Acceptance Criteria
- Show the `authorOrganization` if given with a higher priority as the `authorName`.
- On the detail page show both: `authorOrganization (authorName)`.
