### PR TITLE
ci: add concurrency groups to deployment workflows

### DIFF
--- a/.github/workflows/deploy-main-sync-function.yml
+++ b/.github/workflows/deploy-main-sync-function.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: staging-deployment
+  cancel-in-progress: false
+
 jobs:
   deploy-functions:
     name: Deploy Function
@@ -28,7 +32,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -47,7 +51,5 @@ jobs:
         env:
           namespace: ${{ vars.SOKOSUMI_FUNCTION_NAMESPACE }}
 
-      - name: Deploy 
+      - name: Deploy
         run: pnpm masumi-sync:doctl:deploy
-
-  

--- a/.github/workflows/deploy-main-webapp.yml
+++ b/.github/workflows/deploy-main-webapp.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: staging-deployment
+  cancel-in-progress: false
+
 jobs:
   deploy-app:
     name: Deploy App
@@ -19,7 +23,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/deploy-release-sync-function.yml
+++ b/.github/workflows/deploy-release-sync-function.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: production-deployment
+  cancel-in-progress: false
+
 jobs:
   deploy-function:
     name: Deploy Function
@@ -28,7 +32,7 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/deploy-release-web-app.yml
+++ b/.github/workflows/deploy-release-web-app.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: production-deployment
+  cancel-in-progress: false
+
 jobs:
   deploy-app:
     name: Deploy App


### PR DESCRIPTION
### Summary

This PR adds concurrency groups to the deployment workflows for both staging and production environments. This ensures that only one deployment runs at a time for each environment, preventing overlapping deployments and potential conflicts.

#### Changes
- Added `concurrency` groups to the following workflows:
  - `.github/workflows/deploy-main-sync-function.yml` (staging)
  - `.github/workflows/deploy-main-webapp.yml` (staging)
  - `.github/workflows/deploy-release-sync-function.yml` (production)
  - `.github/workflows/deploy-release-web-app.yml` (production)
- Set `cancel-in-progress: false` to allow all started jobs to finish.

#### Motivation
Concurrency control improves deployment reliability and prevents race conditions or resource contention during automated deployments.

---

- Follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standards for PR title and commits.