### PR TITLE
feat(job): add smartContractAddress to jobs

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -27,6 +27,7 @@
     "data-migration:add-organization": "tsx ./prisma/migrations/20250520120625_add_organization/data-migration.ts",
     "data-migration:add-cents-to-fiat-transaction": "tsx ./prisma/migrations/20250528171822_add_cents_to_fiat_transaction/data-migration.ts",
     "data-migration:set-member-role-to-member": "tsx ./prisma/migrations/20250610084837_set_member_role_to_member/data-migration.ts",
+    "data-migration:add-smart-contract-address-to-job": "tsx ./prisma/migrations/20250620064250_add_smart_contract_address_to_job/data-migration.ts",
     "format": "prettier --log-level silent --write src/**/*.ts",
     "generate:payment": "openapi-ts -f openapi-ts.payment.config.ts",
     "generate:registry": "openapi-ts -f openapi-ts.registry.config.ts",

--- a/web-app/prisma/migrations/20250620064250_add_smart_contract_address_to_job/data-migration.ts
+++ b/web-app/prisma/migrations/20250620064250_add_smart_contract_address_to_job/data-migration.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-restricted-properties */
+import { PrismaClient } from "@/prisma/generated/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const smartContractAddress =
+    process.env.PAYMENT_SMART_CONTRACT_ADDRESS ??
+    "addr1w8sr3luhqv0ftxjc6yrafw0tfesvtecrpck0s83arm0ttfqmk20n5";
+  // Set a smart contract address for jobs where it is still null
+  const result = await prisma.$executeRaw`
+    UPDATE "Job"
+    SET "smartContractAddress" = ${smartContractAddress}
+    WHERE "smartContractAddress" IS NULL;
+  `;
+
+  console.log(`Updated ${result} jobs with fallback smart contract address`);
+}
+
+main()
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => await prisma.$disconnect());

--- a/web-app/prisma/migrations/20250620064250_add_smart_contract_address_to_job/migration.sql
+++ b/web-app/prisma/migrations/20250620064250_add_smart_contract_address_to_job/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Job" ADD COLUMN     "smartContractAddress" TEXT;

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -401,15 +401,16 @@ model Job {
   agentJobId     String
   agentJobStatus AgentJobStatus?
 
-  paymentId         String
-  inputSchema       Json
-  input             String
-  inputHash         String? // On-Chain hash of the input data
-  output            String?
-  outputHash        String? // On-Chain hash of the output data
-  startedAt         DateTime  @default(now())
-  completedAt       DateTime? // when the job was completed on the agent side
-  resultSubmittedAt DateTime? // when the job on-chain status was `RESULT_SUBMITTED`
+  paymentId            String
+  inputSchema          Json
+  input                String
+  inputHash            String? // On-Chain hash of the input data
+  output               String?
+  outputHash           String? // On-Chain hash of the output data
+  startedAt            DateTime  @default(now())
+  completedAt          DateTime? // when the job was completed on the agent side
+  resultSubmittedAt    DateTime? // when the job on-chain status was `RESULT_SUBMITTED`
+  smartContractAddress String?
 
   nextAction          NextJobAction           @default(NONE)
   nextActionErrorType NextJobActionErrorType?

--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -133,7 +133,7 @@ export default function RequestRefundButton({
     setError(null);
 
     try {
-      job = await requestRefundJob(job.blockchainIdentifier);
+      job = await requestRefundJob(job);
       setIsRefundRequested(
         job.nextAction === NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
       );

--- a/web-app/src/config/env.config.ts
+++ b/web-app/src/config/env.config.ts
@@ -51,6 +51,7 @@ const envSecretsSchema = z.object({
     .string()
     .url()
     .default("https://payment.masumi.network/api/v1"),
+  PAYMENT_SMART_CONTRACT_ADDRESS: z.string().optional(),
 
   // BetterAuth Settings
   BETTER_AUTH_URL: z.string().url().default("http://localhost:3000"),

--- a/web-app/src/lib/db/job/repo.ts
+++ b/web-app/src/lib/db/job/repo.ts
@@ -118,6 +118,7 @@ interface CreateJobData {
   inputSchema: JobInputSchemaType[];
   input: string;
   paymentId: string;
+  smartContractAddress: string;
   creditsPrice: CreditsPrice;
   identifierFromPurchaser: string;
   externalDisputeUnlockTime: Date;
@@ -151,6 +152,7 @@ export async function createJob(
         },
       },
       paymentId: data.paymentId,
+      smartContractAddress: data.smartContractAddress,
       inputSchema: data.inputSchema,
       input: data.input,
       identifierFromPurchaser: data.identifierFromPurchaser,

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -123,11 +123,14 @@ export async function startJob(input: StartJobInputSchemaType): Promise<Job> {
           input: JSON.stringify(Object.fromEntries(inputData)),
           inputSchema: inputSchema,
           paymentId: purchaseResponse.data.id,
+          smartContractAddress:
+            purchaseResponse.data.PaymentSource.smartContractAddress,
           creditsPrice,
           identifierFromPurchaser,
           externalDisputeUnlockTime: new Date(
             startJobResponse.externalDisputeUnlockTime,
           ),
+
           submitResultTime: new Date(startJobResponse.submitResultTime),
           unlockTime: new Date(startJobResponse.unlockTime),
           blockchainIdentifier: startJobResponse.blockchainIdentifier,

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -182,9 +182,7 @@ async function requestRefundIfNeeded(job: Job) {
 
   // Only make one refund request if either condition is met
   if (shouldRequestRefund) {
-    const refundResult = await postPaymentClientRequestRefund(
-      job.blockchainIdentifier,
-    );
+    const refundResult = await postPaymentClientRequestRefund(job);
     if (!refundResult.ok) {
       console.error(
         `Failed to request refund for job ${job.id}:`,
@@ -197,7 +195,7 @@ async function requestRefundIfNeeded(job: Job) {
 export async function syncJob(job: Job) {
   const [agentJobStatus, onChainPurchase] = await Promise.all([
     getAgentJobStatus(job),
-    getOnChainPurchase(job.paymentId),
+    getOnChainPurchase(job),
   ]);
 
   await prisma.$transaction(
@@ -254,10 +252,8 @@ async function syncAgentJobStatus(
   }
 }
 
-async function getOnChainPurchase(
-  jobPaymentId: string,
-): Promise<Purchase | null> {
-  const purchaseResult = await getPaymentClientPurchase(jobPaymentId);
+async function getOnChainPurchase(job: Job): Promise<Purchase | null> {
+  const purchaseResult = await getPaymentClientPurchase(job);
   if (!purchaseResult.ok) {
     return null;
   }
@@ -279,20 +275,16 @@ export async function getAgentJobStatus(
   return jobStatusResult.data;
 }
 
-export async function requestRefundJob(
-  jobBlockchainIdentifier: string,
-): Promise<JobWithStatus> {
-  const refundResult = await postPaymentClientRequestRefund(
-    jobBlockchainIdentifier,
-  );
+export async function requestRefundJob(job: Job): Promise<JobWithStatus> {
+  const refundResult = await postPaymentClientRequestRefund(job);
   if (!refundResult.ok) {
     throw new Error(refundResult.error);
   }
-  const job = await setNextActionToJob(
-    jobBlockchainIdentifier,
+  const jobWithStatus = await setNextActionToJob(
+    job.blockchainIdentifier,
     NextJobAction.SET_REFUND_REQUESTED_REQUESTED,
   );
-  return job;
+  return jobWithStatus;
 }
 
 export async function getNotFinalizedLatestJobsByAgentIds(

--- a/web-app/src/lib/services/job/third-party.ts
+++ b/web-app/src/lib/services/job/third-party.ts
@@ -2,7 +2,7 @@
 
 import { Err, Ok, Result } from "ts-res";
 
-import { getEnvPublicConfig } from "@/config/env.config";
+import { getEnvPublicConfig, getEnvSecrets } from "@/config/env.config";
 import {
   getPurchase,
   postPurchase,
@@ -165,6 +165,7 @@ export async function createPurchase(
           startJobResponse.externalDisputeUnlockTime.toString(),
         submitResultTime: startJobResponse.submitResultTime.toString(),
         unlockTime: startJobResponse.unlockTime.toString(),
+        smartContractAddress: getEnvSecrets().PAYMENT_SMART_CONTRACT_ADDRESS,
         metadata: JSON.stringify({
           inputData: Object.fromEntries(inputData),
           jobId: startJobResponse.job_id,
@@ -175,7 +176,6 @@ export async function createPurchase(
     if (postPurchaseResponse.error || !postPurchaseResponse.data) {
       return Err("Failed to create purchase request");
     }
-
     return Ok(postPurchaseResponse.data);
   } catch (err) {
     return Err(String(err));

--- a/web-app/src/lib/services/job/third-party.ts
+++ b/web-app/src/lib/services/job/third-party.ts
@@ -12,6 +12,7 @@ import {
 import { getPaymentClient } from "@/lib/api/payment-service.client";
 import { AgentWithRelations, getAgentApiBaseUrl } from "@/lib/db";
 import { JobInputData } from "@/lib/job-input";
+import { Job } from "@/prisma/generated/client";
 
 import {
   jobStatusResponseSchema,
@@ -86,15 +87,16 @@ export async function startAgentJob(
 }
 
 export async function postPaymentClientRequestRefund(
-  jobBlockchainIdentifier: string,
+  job: Job,
 ): Promise<Result<void, string>> {
   try {
     const paymentClient = getPaymentClient();
     const refundResponse = await postPurchaseRequestRefund({
       client: paymentClient,
       body: {
-        blockchainIdentifier: jobBlockchainIdentifier,
+        blockchainIdentifier: job.blockchainIdentifier,
         network: getEnvPublicConfig().NEXT_PUBLIC_NETWORK,
+        smartContractAddress: job.smartContractAddress ?? undefined,
       },
     });
 
@@ -109,16 +111,17 @@ export async function postPaymentClientRequestRefund(
 }
 
 export async function getPaymentClientPurchase(
-  paymentId: string,
+  job: Job,
 ): Promise<Result<Purchase, string>> {
   try {
     const paymentClient = getPaymentClient();
     const purchaseResponse = await getPurchase({
       client: paymentClient,
       query: {
-        cursorId: paymentId,
+        cursorId: job.paymentId,
         network: getEnvPublicConfig().NEXT_PUBLIC_NETWORK,
         limit: 1,
+        smartContractAddress: job.smartContractAddress ?? undefined,
       },
     });
 


### PR DESCRIPTION
This pull request introduces the 'smartContractAddress' field to the 'Job' model and integrates it throughout the job lifecycle.

Key changes:

- **Prisma Schema:** Added an optional 'smartContractAddress' field to the 'Job' model.
- **Job Creation:** The 'smartContractAddress' is now provided when a job is created. It is sourced from the payment service upon purchase.
- **Payment Service Integration:** The 'smartContractAddress' is now passed to the payment service for operations like 'getPurchase' and 'requestRefund' to interact with the correct smart contract instance.
- **Data Migration:** A migration script has been added to backfill the 'smartContractAddress' for existing jobs using a fallback address defined in the environment variables.
- **Configuration:** Added 'PAYMENT_SMART_CONTRACT_ADDRESS' to the environment configuration to specify the default smart contract address.