### PR TITLE
fix(web-app): update plain.js report URL

### DIFF
--- a/web-app/public/js/plain.js
+++ b/web-app/public/js/plain.js
@@ -27,7 +27,7 @@
         {
           icon: "error",
           text: "Report an Agentic Service",
-          url: "https://forms.gle/fKSjmnySXQFB9X749",
+          url: "https://tally.so/r/mJbVEY",
         },
       ],
     });


### PR DESCRIPTION
This pull request updates the URL for reporting an agentic service in the Plain JS plugin from a Google Form to a Tally.so form.