### PR TITLE
feat: add terms of use acceptance checkbox to registration flow

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -618,7 +618,8 @@
             "organization": "Organization not found",
             "emailDomainNotAllowedByOrganization": "Email domain not allowed to join organization",
             "userExists": "User already exists",
-            "emailDomainNotAllowed": "Email must end with {allowedEmailDomains}"
+            "emailDomainNotAllowed": "Email must end with {allowedEmailDomains}",
+            "termsNotAccepted": "You must accept the terms and conditions to register"
           },
           "Login": {
             "message": "Already have an account?",

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -578,6 +578,14 @@
             "Name": {
               "placeholder": "Name"
             },
+            "TermsAccepted": {
+              "Label": {
+                "iAgreeTo": "I agree to the",
+                "termsOfService": "Terms of Service",
+                "and": "and",
+                "privacyPolicy": "Privacy Policy"
+              }
+            },
             "MarketingOptIn": {
               "label": "I would like to receive updates and news from Sōkosumi"
             },

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -27,6 +27,7 @@
     "data-migration:add-organization": "tsx ./prisma/migrations/20250520120625_add_organization/data-migration.ts",
     "data-migration:add-cents-to-fiat-transaction": "tsx ./prisma/migrations/20250528171822_add_cents_to_fiat_transaction/data-migration.ts",
     "data-migration:set-member-role-to-member": "tsx ./prisma/migrations/20250610084837_set_member_role_to_member/data-migration.ts",
+    "data-migration:set-terms-accepted-to-true": "tsx ./prisma/migrations/20250620094653_add_terms_fields_to_user/data-migration.ts",
     "format": "prettier --log-level silent --write src/**/*.ts",
     "generate:payment": "openapi-ts -f openapi-ts.payment.config.ts",
     "generate:registry": "openapi-ts -f openapi-ts.registry.config.ts",

--- a/web-app/prisma/migrations/20250620094653_add_terms_fields_to_user/data-migration.ts
+++ b/web-app/prisma/migrations/20250620094653_add_terms_fields_to_user/data-migration.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from "@/prisma/generated/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // Use raw SQL to set termsAccepted to true for all users
+  const result = await prisma.$executeRaw`
+    UPDATE "user" 
+    SET "termsAccepted" = true, "termsAcceptedAt" = "createdAt", "termsVersion" = '1.0'
+  `;
+
+  console.log(`Updated ${result} users with termsAccepted set to true`);
+}
+
+main()
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => await prisma.$disconnect());

--- a/web-app/prisma/migrations/20250620094653_add_terms_fields_to_user/migration.sql
+++ b/web-app/prisma/migrations/20250620094653_add_terms_fields_to_user/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "termsAccepted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "termsAcceptedAt" TIMESTAMP(3),
+ADD COLUMN     "termsVersion" TEXT DEFAULT '1.0';

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -38,6 +38,11 @@ model User {
 
   marketingOptIn Boolean @default(false)
 
+  // terms
+  termsAccepted   Boolean   @default(false)
+  termsAcceptedAt DateTime?
+  termsVersion    String?   @default("1.0")
+
   @@unique([email])
   @@map("user")
 }

--- a/web-app/src/app/(auth)/components/form/form-fields.tsx
+++ b/web-app/src/app/(auth)/components/form/form-fields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import {
   ControllerRenderProps,
@@ -99,6 +100,19 @@ function FormInput<T extends FieldValues>({
     name === "organizationId" && !!prefilledOrganizationId;
 
   if (type === "checkbox") {
+    const TermsAcceptedLabel = t.has("Fields.TermsAccepted.Label") ? (
+      <Label htmlFor={labelKey?.toString() ?? name.toString()}>
+        {t("Fields.TermsAccepted.Label.iAgreeTo")}
+        <Link target="_blank" href="/terms-of-service" className="underline">
+          {t("Fields.TermsAccepted.Label.termsOfService")}
+        </Link>
+        {t("Fields.TermsAccepted.Label.and")}
+        <Link target="_blank" href="/privacy-policy" className="underline">
+          {t("Fields.TermsAccepted.Label.privacyPolicy")}
+        </Link>
+      </Label>
+    ) : null;
+
     return (
       <div className="flex items-center gap-2">
         <Checkbox
@@ -106,9 +120,13 @@ function FormInput<T extends FieldValues>({
           checked={field.value}
           onCheckedChange={field.onChange}
         />
-        <Label htmlFor={labelKey?.toString() ?? name.toString()}>
-          {labelKey && t(labelKey)}
-        </Label>
+        {name === "termsAccepted" ? (
+          TermsAcceptedLabel
+        ) : (
+          <Label htmlFor={labelKey?.toString() ?? name.toString()}>
+            {labelKey && t(labelKey)}
+          </Label>
+        )}
       </div>
     );
   }

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -50,6 +50,7 @@ export default function SignUpForm({
       password: "",
       confirmPassword: "",
       organizationId: prefilledOrganizationId ?? "",
+      termsAccepted: false,
       marketingOptIn: false,
     },
   });
@@ -144,6 +145,8 @@ export default function SignUpForm({
     router.push("/login");
   };
 
+  const termsAccepted = form.watch("termsAccepted");
+
   return (
     <AuthForm
       form={form}
@@ -155,7 +158,12 @@ export default function SignUpForm({
       organizations={organizations}
     >
       <div className="flex flex-col gap-4">
-        <SubmitButton form={form} label={t("submit")} className="w-full" />
+        <SubmitButton
+          form={form}
+          label={t("submit")}
+          className="w-full"
+          disabled={!termsAccepted}
+        />
         <div className="flex flex-col items-center gap-2 sm:flex-row">
           <span className="text-muted-foreground text-sm">
             {t("Login.message")}

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -97,6 +97,9 @@ export default function SignUpForm({
                 }),
               );
               break;
+            case "TERMS_NOT_ACCEPTED":
+              toast.error(t("Errors.termsNotAccepted"));
+              break;
             default:
               toast.error(t("error"));
               break;

--- a/web-app/src/app/(auth)/register/data.ts
+++ b/web-app/src/app/(auth)/register/data.ts
@@ -17,6 +17,7 @@ const signUpFormSchema = (t?: IntlTranslation<"Library.Auth.Schema">) =>
       password: passwordSchema(t),
       confirmPassword: confirmPasswordSchema(t),
       organizationId: organizationIdSchema(t),
+      termsAccepted: z.boolean(),
       marketingOptIn: z.boolean().optional(),
     })
     .refine(({ password, confirmPassword }) => password === confirmPassword, {
@@ -48,6 +49,10 @@ const signUpFormData: FormData<SignUpFormSchemaType, "Auth.Pages.SignUp.Form"> =
       name: "confirmPassword",
       placeholderKey: "Fields.ConfirmPassword.placeholder",
       type: "password",
+    },
+    {
+      name: "termsAccepted",
+      type: "checkbox",
     },
     {
       name: "marketingOptIn",

--- a/web-app/src/lib/auth/auth.ts
+++ b/web-app/src/lib/auth/auth.ts
@@ -45,6 +45,13 @@ export const auth = betterAuth({
               message: allowedEmailDomains.join(", "),
             });
           }
+
+          if (!ctx.body?.termsAccepted) {
+            throw new APIError("BAD_REQUEST", {
+              code: "TERMS_NOT_ACCEPTED",
+            });
+          }
+
           break;
         }
       }
@@ -106,6 +113,12 @@ export const auth = betterAuth({
     },
     deleteUser: {
       enabled: true,
+    },
+    additionalFields: {
+      termsAccepted: {
+        type: "boolean",
+        required: true,
+      },
     },
   },
   rateLimit: {


### PR DESCRIPTION
### 🎯 Summary
This PR implements mandatory terms of service and privacy policy acceptance during user registration, ensuring compliance with legal requirements and improving user consent tracking.

### ✨ Features Added
- **Terms Acceptance Tracking**: Added three new fields to the User model:
  - `termsAccepted`: Boolean flag indicating user acceptance
  - `termsAcceptedAt`: Timestamp of when terms were accepted
  - `termsVersion`: Version of terms accepted (defaults to '1.0')
- **Registration Form Enhancement**: Added terms acceptance checkbox with links to Terms of Service and Privacy Policy
- **Form Validation**: Registration is disabled until terms are accepted
- **Backend Validation**: Server-side validation ensures terms acceptance before user creation
- **Data Migration**: Existing users are automatically marked as having accepted terms

### 🔧 Technical Changes

#### Database Schema
- Added `termsAccepted`, `termsAcceptedAt`, and `termsVersion` columns to User table
- Created migration with data migration script for existing users

#### Frontend Components
- Enhanced `FormInput` component to handle terms acceptance checkbox with proper labeling
- Updated registration form to include terms acceptance field
- Added form validation to disable submit button until terms are accepted

#### Backend Logic
- Added terms acceptance validation in auth configuration
- Enhanced error handling with specific `TERMS_NOT_ACCEPTED` error code
- Updated form schema to include terms acceptance validation

### 🚀 Migration Strategy
- **Backward Compatible**: Existing users are automatically migrated with `termsAccepted: true`
- **Data Migration Script**: `pnpm run data-migration:set-terms-accepted-to-true` handles existing user data
- **Default Values**: New users start with `termsAccepted: false` and must explicitly accept

### 🧪 Testing Considerations
- Verify registration flow requires terms acceptance
- Confirm existing users can still access the system