### PR TITLE
feat(billing): implement coupon redemption for fixed-amount credits

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -720,6 +720,8 @@
       "couponLabel": "Coupon Code",
       "couponPlaceholder": "Enter coupon code",
       "couponOrCreditsError": "Please enter either a credit amount or a coupon code",
+      "couponCleared": "Coupon cleared - purchasing credits instead",
+      "creditsCleared": "Credits cleared - using coupon instead",
       "Error": {
         "title": "Something Went Wrong",
         "message": "We encountered an error loading the billing information.",

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -719,6 +719,7 @@
       "topUpButton": "Top Up",
       "couponLabel": "Coupon Code",
       "couponPlaceholder": "Enter coupon code",
+      "couponOrCreditsError": "Please enter either a credit amount or a coupon code",
       "Error": {
         "title": "Something Went Wrong",
         "message": "We encountered an error loading the billing information.",

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -744,6 +744,9 @@
       },
       "invalidCredits": "Invalid credit amount",
       "invalidCoupon": "Invalid or inactive coupon code",
+      "couponNotFound": "Coupon code not found",
+      "couponTypeError": "This coupon type is not supported",
+      "couponCurrencyError": "Coupon currency is not supported",
       "checkoutFailed": "Failed to create checkout"
     },
     "Account": {

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -199,11 +199,15 @@ export default function BillingForm({
                       disabled={form.formState.isSubmitting}
                       {...field}
                       onChange={(e) => {
-                        const value = e.target.value;
-                        // Prevent negative values and validate range
-                        const numValue =
-                          value === "" ? undefined : Math.max(1, Number(value));
-                        handleFieldChange("credits", numValue);
+                        const { value } = e.target;
+                        if (value === "") {
+                          handleFieldChange("credits", undefined);
+                        } else {
+                          const numValue = Number(value);
+                          if (Number.isFinite(numValue) && numValue >= 0) {
+                            handleFieldChange("credits", numValue);
+                          }
+                        }
                       }}
                       value={field.value ?? ""}
                     />

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -85,13 +85,13 @@ export default function BillingForm({
   const coupon = watch("coupon");
 
   const handleFieldChange = useCallback(
-    (field: "credits" | "coupon", value: number | string) => {
+    (field: "credits" | "coupon", value: number | string | undefined) => {
       if (field === "credits") {
-        const numValue = typeof value === "string" ? Number(value) : value;
+        const numValue = value as number | undefined;
         setValue("credits", numValue);
 
         // Only clear coupon if we have a valid credit amount and coupon exists
-        if (numValue > 0) {
+        if (numValue && numValue > 0) {
           const currentCoupon = form.getValues("coupon");
           if (currentCoupon) {
             setValue("coupon", "");
@@ -99,7 +99,7 @@ export default function BillingForm({
           }
         }
       } else if (field === "coupon") {
-        const strValue = String(value);
+        const strValue = String(value ?? "");
         setValue("coupon", strValue);
 
         // Only clear credits if we have a valid coupon and credits exist
@@ -203,7 +203,7 @@ export default function BillingForm({
                         // Prevent negative values and validate range
                         const numValue =
                           value === "" ? undefined : Math.max(1, Number(value));
-                        handleFieldChange("credits", numValue ?? 0);
+                        handleFieldChange("credits", numValue);
                       }}
                       value={field.value ?? ""}
                     />

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -25,12 +25,26 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { purchaseCredits } from "@/lib/actions";
+import { getFreeCreditsWithCoupon, purchaseCredits } from "@/lib/actions";
 
-const billingFormSchema = z.object({
-  credits: z.number().min(1, "Amount must be at least 1 credit"),
-  coupon: z.string().optional(),
-});
+const billingFormSchema = z
+  .object({
+    credits: z.number().optional(),
+    coupon: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      // Either credits must be provided and > 0, OR coupon must be provided and not empty
+      const hasValidCredits = data.credits != null && data.credits > 0;
+      const hasValidCoupon =
+        data.coupon != null && data.coupon.trim().length > 0;
+      return hasValidCredits || hasValidCoupon;
+    },
+    {
+      message: "Please enter either a credit amount or a coupon code",
+      path: ["credits"], // This will show the error on the credits field
+    },
+  );
 
 type BillingFormData = z.infer<typeof billingFormSchema>;
 
@@ -51,17 +65,30 @@ export default function BillingForm({
   const form = useForm<BillingFormData>({
     resolver: zodResolver(billingFormSchema),
     defaultValues: {
-      credits: 0,
+      credits: undefined,
       coupon: "",
     },
   });
 
   const { watch, setValue } = form;
   const credits = watch("credits");
+  const coupon = watch("coupon");
 
   const onSubmit = async (data: BillingFormData) => {
     try {
-      const result = await purchaseCredits(priceId, data.credits, data.coupon);
+      let result;
+
+      // If coupon is provided, use coupon redemption flow
+      if (data.coupon && data.coupon.trim().length > 0) {
+        result = await getFreeCreditsWithCoupon(priceId, data.coupon.trim());
+      }
+      // Otherwise, use credit purchase flow
+      else if (data.credits && data.credits > 0) {
+        result = await purchaseCredits(priceId, data.credits);
+      } else {
+        toast.error(t("couponOrCreditsError"));
+        return;
+      }
 
       if (result.success && result.url) {
         window.location.href = result.url;
@@ -70,12 +97,19 @@ export default function BillingForm({
       }
     } catch (error) {
       console.error("Failed to create checkout session:", error);
-      toast.error("An unexpected error occurred");
+      toast.error(t("Error.title"));
     }
   };
 
   const handleQuickAmount = (amount: number) => {
     setValue("credits", amount);
+    setValue("coupon", ""); // Clear coupon when selecting credits
+  };
+
+  const handleCouponChange = (value: string) => {
+    if (value.trim().length > 0) {
+      setValue("credits", undefined); // Clear credits when entering coupon
+    }
   };
 
   return (
@@ -113,8 +147,14 @@ export default function BillingForm({
                       min="1"
                       disabled={form.formState.isSubmitting}
                       {...field}
-                      onChange={(e) => field.onChange(Number(e.target.value))}
-                      value={field.value || ""}
+                      onChange={(e) => {
+                        const value = Number(e.target.value);
+                        field.onChange(value);
+                        if (value > 0) {
+                          setValue("coupon", ""); // Clear coupon when entering credits
+                        }
+                      }}
+                      value={field.value ?? ""}
                     />
                   </FormControl>
                   <FormMessage />
@@ -134,6 +174,10 @@ export default function BillingForm({
                       disabled={form.formState.isSubmitting}
                       autoComplete="off"
                       {...field}
+                      onChange={(e) => {
+                        field.onChange(e.target.value);
+                        handleCouponChange(e.target.value);
+                      }}
                     />
                   </FormControl>
                   <FormMessage />
@@ -144,7 +188,11 @@ export default function BillingForm({
           <CardFooter className="flex items-center justify-between pt-6">
             <Button
               type="submit"
-              disabled={!credits || credits <= 0 || form.formState.isSubmitting}
+              disabled={
+                form.formState.isSubmitting ||
+                ((!credits || credits <= 0) &&
+                  (!coupon || coupon.trim().length === 0))
+              }
             >
               {form.formState.isSubmitting && (
                 <Loader2 className="mr-2 size-4 animate-spin" />

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -61,6 +62,9 @@ export default function BillingForm({
 }: BillingFormProps) {
   const t = useTranslations("App.Billing");
   const formatter = useFormatter();
+  const [clearedField, setClearedField] = useState<"credits" | "coupon" | null>(
+    null,
+  );
 
   const form = useForm<BillingFormData>({
     resolver: zodResolver(billingFormSchema),
@@ -73,6 +77,29 @@ export default function BillingForm({
   const { watch, setValue } = form;
   const credits = watch("credits");
   const coupon = watch("coupon");
+
+  const handleFieldChange = useCallback(
+    (field: "credits" | "coupon", value: number | string) => {
+      if (field === "credits") {
+        const numValue = typeof value === "string" ? Number(value) : value;
+        setValue("credits", numValue);
+        if (numValue > 0 && coupon) {
+          setValue("coupon", "");
+          setClearedField("coupon");
+          setTimeout(() => setClearedField(null), 2000);
+        }
+      } else if (field === "coupon") {
+        const strValue = String(value);
+        setValue("coupon", strValue);
+        if (strValue.length > 0 && (credits ?? 0) > 0) {
+          setValue("credits", undefined);
+          setClearedField("credits");
+          setTimeout(() => setClearedField(null), 2000);
+        }
+      }
+    },
+    [setValue, coupon, credits],
+  );
 
   const onSubmit = async (data: BillingFormData) => {
     try {
@@ -101,16 +128,25 @@ export default function BillingForm({
     }
   };
 
-  const handleQuickAmount = (amount: number) => {
-    setValue("credits", amount);
-    setValue("coupon", ""); // Clear coupon when selecting credits
-  };
+  const handleQuickAmount = useCallback(
+    (amount: number) => {
+      handleFieldChange("credits", amount);
+    },
+    [handleFieldChange],
+  );
 
-  const handleCouponChange = (value: string) => {
-    if (value.trim().length > 0) {
-      setValue("credits", undefined); // Clear credits when entering coupon
-    }
-  };
+  const FieldClearedIndicator = ({
+    show,
+    message,
+  }: {
+    show: boolean;
+    message: string;
+  }) =>
+    show ? (
+      <div className="text-muted-foreground mt-1 text-xs transition-opacity duration-200">
+        {message}
+      </div>
+    ) : null;
 
   return (
     <Card>
@@ -148,15 +184,18 @@ export default function BillingForm({
                       disabled={form.formState.isSubmitting}
                       {...field}
                       onChange={(e) => {
-                        const value = Number(e.target.value);
-                        field.onChange(value);
-                        if (value > 0) {
-                          setValue("coupon", ""); // Clear coupon when entering credits
-                        }
+                        const value = e.target.value;
+                        const numValue =
+                          value === "" ? undefined : Number(value);
+                        handleFieldChange("credits", numValue ?? 0);
                       }}
                       value={field.value ?? ""}
                     />
                   </FormControl>
+                  <FieldClearedIndicator
+                    show={clearedField === "credits"}
+                    message={t("creditsCleared")}
+                  />
                   <FormMessage />
                 </FormItem>
               )}
@@ -175,11 +214,15 @@ export default function BillingForm({
                       autoComplete="off"
                       {...field}
                       onChange={(e) => {
-                        field.onChange(e.target.value);
-                        handleCouponChange(e.target.value);
+                        const value = e.target.value;
+                        handleFieldChange("coupon", value);
                       }}
                     />
                   </FormControl>
+                  <FieldClearedIndicator
+                    show={clearedField === "coupon"}
+                    message={t("couponCleared")}
+                  />
                   <FormMessage />
                 </FormItem>
               )}

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -35,15 +35,21 @@ const billingFormSchema = z
   })
   .refine(
     (data) => {
-      // Either credits must be provided and > 0, OR coupon must be provided and not empty
       const hasValidCredits = data.credits != null && data.credits > 0;
       const hasValidCoupon =
         data.coupon != null && data.coupon.trim().length > 0;
       return hasValidCredits || hasValidCoupon;
     },
-    {
-      message: "Please enter either a credit amount or a coupon code",
-      path: ["credits"], // This will show the error on the credits field
+    (data) => {
+      // Show error on the field that makes more sense contextually
+      const hasCreditsAttempt = data.credits != null;
+      const hasCouponAttempt =
+        data.coupon != null && data.coupon.trim().length > 0;
+
+      return {
+        message: "Please enter either a credit amount or a coupon code",
+        path: hasCreditsAttempt && !hasCouponAttempt ? ["credits"] : ["coupon"],
+      };
     },
   );
 
@@ -83,22 +89,30 @@ export default function BillingForm({
       if (field === "credits") {
         const numValue = typeof value === "string" ? Number(value) : value;
         setValue("credits", numValue);
-        if (numValue > 0 && coupon) {
-          setValue("coupon", "");
-          setClearedField("coupon");
-          setTimeout(() => setClearedField(null), 2000);
+
+        // Only clear coupon if we have a valid credit amount and coupon exists
+        if (numValue > 0) {
+          const currentCoupon = form.getValues("coupon");
+          if (currentCoupon) {
+            setValue("coupon", "");
+            setClearedField("coupon");
+          }
         }
       } else if (field === "coupon") {
         const strValue = String(value);
         setValue("coupon", strValue);
-        if (strValue.length > 0 && (credits ?? 0) > 0) {
-          setValue("credits", undefined);
-          setClearedField("credits");
-          setTimeout(() => setClearedField(null), 2000);
+
+        // Only clear credits if we have a valid coupon and credits exist
+        if (strValue.length > 0) {
+          const currentCredits = form.getValues("credits");
+          if (currentCredits && currentCredits > 0) {
+            setValue("credits", undefined);
+            setClearedField("credits");
+          }
         }
       }
     },
-    [setValue, coupon, credits],
+    [setValue, form],
   );
 
   const onSubmit = async (data: BillingFormData) => {
@@ -181,12 +195,14 @@ export default function BillingForm({
                       type="number"
                       placeholder={t("creditsPlaceholder")}
                       min="1"
+                      max="10000"
                       disabled={form.formState.isSubmitting}
                       {...field}
                       onChange={(e) => {
                         const value = e.target.value;
+                        // Prevent negative values and validate range
                         const numValue =
-                          value === "" ? undefined : Number(value);
+                          value === "" ? undefined : Math.max(1, Number(value));
                         handleFieldChange("credits", numValue ?? 0);
                       }}
                       value={field.value ?? ""}

--- a/web-app/src/components/billing/billing-form.tsx
+++ b/web-app/src/components/billing/billing-form.tsx
@@ -76,7 +76,7 @@ export default function BillingForm({
     resolver: zodResolver(billingFormSchema),
     defaultValues: {
       credits: undefined,
-      coupon: "",
+      coupon: undefined,
     },
   });
 

--- a/web-app/src/lib/actions/billing/action.ts
+++ b/web-app/src/lib/actions/billing/action.ts
@@ -81,12 +81,25 @@ export async function getFreeCreditsWithCoupon(
     // Handle specific coupon errors
     if (error instanceof CouponError) {
       const t = await getTranslations("App.Billing");
+      let errorMessage = t("invalidCoupon"); // Default message
+
+      switch (error.code) {
+        case "COUPON_NOT_FOUND":
+          errorMessage = t("couponNotFound");
+          break;
+        case "COUPON_TYPE_ERROR":
+          errorMessage = t("couponTypeError");
+          break;
+        case "COUPON_CURRENCY_ERROR":
+          errorMessage = t("couponCurrencyError");
+          break;
+        default:
+          break;
+      }
+
       return {
         success: false,
-        error:
-          error.code === "COUPON_NOT_FOUND"
-            ? t("couponNotFound")
-            : t("invalidCoupon"),
+        error: errorMessage,
       };
     }
 

--- a/web-app/src/lib/actions/billing/action.ts
+++ b/web-app/src/lib/actions/billing/action.ts
@@ -6,6 +6,7 @@ import { getEnvSecrets } from "@/config/env.config";
 import { getSessionOrThrow } from "@/lib/auth/utils";
 import {
   createStripeCheckoutSession,
+  getCreditsForCoupon,
   getPromotionCode,
   getWelcomePromotionCode,
 } from "@/lib/services";
@@ -46,10 +47,44 @@ export async function claimFreeCredits(): Promise<{
   }
 }
 
+export async function getFreeCreditsWithCoupon(
+  priceId: string,
+  couponId: string,
+) {
+  try {
+    const session = await getSessionOrThrow();
+
+    const credits = await getCreditsForCoupon(couponId);
+    // Validate and get the promotion code for this user and couponId
+    const promo = await getPromotionCode(session.user.id, couponId, 1);
+    if (!promo || !promo.active) {
+      const t = await getTranslations("App.Billing");
+      return {
+        success: false,
+        error: t("invalidCoupon"),
+      };
+    }
+    const { url } = await createStripeCheckoutSession(
+      session.user.id,
+      credits,
+      priceId,
+      promo.id,
+    );
+    return {
+      success: true,
+      url,
+    };
+  } catch (error) {
+    console.error("Failed to create checkout session:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
 export async function purchaseCredits(
   priceId: string,
   credits: number,
-  couponId?: string,
 ): Promise<{
   success: boolean;
   url?: string;
@@ -67,25 +102,11 @@ export async function purchaseCredits(
 
     const session = await getSessionOrThrow();
 
-    let promotionCodeId: string | null = null;
-    if (couponId) {
-      // Validate and get the promotion code for this user and couponId
-      const promo = await getPromotionCode(session.user.id, couponId, 1);
-      if (!promo || !promo.active) {
-        return {
-          success: false,
-          error: t("invalidCoupon"),
-        };
-      }
-      promotionCodeId = promo.id;
-    }
-
     // Create the checkout session
     const { url } = await createStripeCheckoutSession(
       session.user.id,
       credits,
       priceId,
-      promotionCodeId,
     );
 
     return {

--- a/web-app/src/lib/actions/billing/action.ts
+++ b/web-app/src/lib/actions/billing/action.ts
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 
 import { getEnvSecrets } from "@/config/env.config";
 import { getSessionOrThrow } from "@/lib/auth/utils";
+import { CouponError } from "@/lib/errors/coupon-errors";
 import {
   createStripeCheckoutSession,
   getCreditsForCoupon,
@@ -76,6 +77,19 @@ export async function getFreeCreditsWithCoupon(
     };
   } catch (error) {
     console.error("Failed to create checkout session:", error);
+
+    // Handle specific coupon errors
+    if (error instanceof CouponError) {
+      const t = await getTranslations("App.Billing");
+      return {
+        success: false,
+        error:
+          error.code === "COUPON_NOT_FOUND"
+            ? t("couponNotFound")
+            : t("invalidCoupon"),
+      };
+    }
+
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",

--- a/web-app/src/lib/actions/billing/action.ts
+++ b/web-app/src/lib/actions/billing/action.ts
@@ -55,7 +55,7 @@ export async function getFreeCreditsWithCoupon(
   try {
     const session = await getSessionOrThrow();
 
-    const credits = await getCreditsForCoupon(couponId);
+    const credits = await getCreditsForCoupon(couponId, priceId);
     // Validate and get the promotion code for this user and couponId
     const promo = await getPromotionCode(session.user.id, couponId, 1);
     if (!promo || !promo.active) {

--- a/web-app/src/lib/actions/billing/index.ts
+++ b/web-app/src/lib/actions/billing/index.ts
@@ -1,1 +1,5 @@
-export { claimFreeCredits, purchaseCredits } from "./action";
+export {
+  claimFreeCredits,
+  getFreeCreditsWithCoupon,
+  purchaseCredits,
+} from "./action";

--- a/web-app/src/lib/errors/coupon-errors.ts
+++ b/web-app/src/lib/errors/coupon-errors.ts
@@ -21,10 +21,10 @@ export class CouponTypeError extends CouponError {
 }
 
 export class CouponCurrencyError extends CouponError {
-  constructor(currency: string) {
-    super(
-      `Coupon currency ${currency} is not supported`,
-      "COUPON_CURRENCY_ERROR",
-    );
+  constructor(currency: string, expectedCurrency?: string) {
+    const message = expectedCurrency
+      ? `Coupon currency ${currency} does not match expected currency ${expectedCurrency}`
+      : `Coupon currency ${currency} is not supported`;
+    super(message, "COUPON_CURRENCY_ERROR");
   }
 }

--- a/web-app/src/lib/errors/coupon-errors.ts
+++ b/web-app/src/lib/errors/coupon-errors.ts
@@ -1,0 +1,30 @@
+export class CouponError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+  ) {
+    super(message);
+    this.name = "CouponError";
+  }
+}
+
+export class CouponNotFoundError extends CouponError {
+  constructor(couponId: string) {
+    super(`Coupon ${couponId} not found`, "COUPON_NOT_FOUND");
+  }
+}
+
+export class CouponTypeError extends CouponError {
+  constructor(message: string) {
+    super(message, "COUPON_TYPE_ERROR");
+  }
+}
+
+export class CouponCurrencyError extends CouponError {
+  constructor(currency: string) {
+    super(
+      `Coupon currency ${currency} is not supported`,
+      "COUPON_CURRENCY_ERROR",
+    );
+  }
+}

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -125,5 +125,5 @@ export async function getCreditsForCoupon(
   if (!coupon.amount_off) {
     throw new CouponTypeError("Coupon must have a fixed amount");
   }
-  return coupon.amount_off / conversionFactors.amountPerCredit;
+  return Math.floor(coupon.amount_off / conversionFactors.amountPerCredit);
 }

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -11,6 +11,11 @@ import {
   prisma,
   updateFiatTransactionServicePaymentId,
 } from "@/lib/db";
+import {
+  CouponCurrencyError,
+  CouponNotFoundError,
+  CouponTypeError,
+} from "@/lib/errors/coupon-errors";
 
 import {
   createCheckoutSession,
@@ -97,16 +102,16 @@ export async function getPromotionCode(
 export async function getCreditsForCoupon(couponId: string): Promise<number> {
   const coupon = await getCouponById(couponId);
   if (!coupon) {
-    throw new Error("Coupon not found");
+    throw new CouponNotFoundError(couponId);
   }
   if (coupon.percent_off) {
-    throw new Error("Coupon is a percentage off");
+    throw new CouponTypeError("Only fixed-amount coupons are supported");
   }
   if (coupon.currency !== "usd") {
-    throw new Error("Coupon currency is not USD");
+    throw new CouponCurrencyError(coupon.currency ?? "null");
   }
   if (!coupon.amount_off) {
-    throw new Error("Coupon amount off is not set");
+    throw new CouponTypeError("Coupon must have a fixed amount");
   }
   return coupon.amount_off / 100;
 }

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -16,6 +16,7 @@ import {
   createCheckoutSession,
   createCustomer,
   getConversionFactors,
+  getCouponById,
   getOrCreatePromotionCode,
 } from "./third-party";
 
@@ -91,4 +92,21 @@ export async function getPromotionCode(
     maxRedemptions,
     metadata,
   );
+}
+
+export async function getCreditsForCoupon(couponId: string): Promise<number> {
+  const coupon = await getCouponById(couponId);
+  if (!coupon) {
+    throw new Error("Coupon not found");
+  }
+  if (coupon.percent_off) {
+    throw new Error("Coupon is a percentage off");
+  }
+  if (coupon.currency !== "usd") {
+    throw new Error("Coupon currency is not USD");
+  }
+  if (!coupon.amount_off) {
+    throw new Error("Coupon amount off is not set");
+  }
+  return coupon.amount_off / 100;
 }

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -110,6 +110,9 @@ export async function getCreditsForCoupon(
   if (coupon.percent_off) {
     throw new CouponTypeError("Only fixed-amount coupons are supported");
   }
+  if (!coupon.amount_off) {
+    throw new CouponTypeError("Coupon must have a fixed amount");
+  }
 
   const conversionFactors = await getConversionFactors(priceId);
 
@@ -122,8 +125,5 @@ export async function getCreditsForCoupon(
     );
   }
 
-  if (!coupon.amount_off) {
-    throw new CouponTypeError("Coupon must have a fixed amount");
-  }
-  return Math.floor(coupon.amount_off / conversionFactors.amountPerCredit);
+  return Math.ceil(coupon.amount_off / conversionFactors.amountPerCredit);
 }

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -99,7 +99,10 @@ export async function getPromotionCode(
   );
 }
 
-export async function getCreditsForCoupon(couponId: string): Promise<number> {
+export async function getCreditsForCoupon(
+  couponId: string,
+  priceId: string,
+): Promise<number> {
   const coupon = await getCouponById(couponId);
   if (!coupon) {
     throw new CouponNotFoundError(couponId);
@@ -107,11 +110,20 @@ export async function getCreditsForCoupon(couponId: string): Promise<number> {
   if (coupon.percent_off) {
     throw new CouponTypeError("Only fixed-amount coupons are supported");
   }
-  if (coupon.currency !== "usd") {
-    throw new CouponCurrencyError(coupon.currency ?? "null");
+
+  const conversionFactors = await getConversionFactors(priceId);
+
+  if (
+    coupon.currency?.toLowerCase() !== conversionFactors.currency.toLowerCase()
+  ) {
+    throw new CouponCurrencyError(
+      coupon.currency ?? "unknown",
+      conversionFactors.currency,
+    );
   }
+
   if (!coupon.amount_off) {
     throw new CouponTypeError("Coupon must have a fixed amount");
   }
-  return coupon.amount_off / 100;
+  return coupon.amount_off / conversionFactors.amountPerCredit;
 }

--- a/web-app/src/lib/services/stripe/third-party.ts
+++ b/web-app/src/lib/services/stripe/third-party.ts
@@ -135,5 +135,9 @@ export async function getOrCreatePromotionCode(
 export async function getCouponById(
   couponId: string,
 ): Promise<Stripe.Coupon | null> {
-  return await stripe.coupons.retrieve(couponId);
+  try {
+    return await stripe.coupons.retrieve(couponId);
+  } catch {
+    return null;
+  }
 }

--- a/web-app/src/lib/services/stripe/third-party.ts
+++ b/web-app/src/lib/services/stripe/third-party.ts
@@ -131,3 +131,9 @@ export async function getOrCreatePromotionCode(
     return null;
   }
 }
+
+export async function getCouponById(
+  couponId: string,
+): Promise<Stripe.Coupon | null> {
+  return await stripe.coupons.retrieve(couponId);
+}


### PR DESCRIPTION
This pull request introduces functionality for users to redeem Stripe coupons for a fixed amount of free credits. The billing form has been updated to support either purchasing credits directly or applying a coupon code, but not both simultaneously.

#### Key Changes:

*   **`web-app/src/components/billing/billing-form.tsx`**:
    *   The form now exclusively accepts either a credit purchase amount or a coupon code.
    *   Inputting a value in one field (credits or coupon) automatically clears the other, ensuring a clear user flow.
    *   Form validation (`zod`) has been updated to enforce that one of the two fields must be filled.
    *   Submitting a coupon triggers the new `getFreeCreditsWithCoupon` action.

*   **`web-app/src/lib/actions/billing/action.ts`**:
    *   Introduced `getFreeCreditsWithCoupon`, a new server action that:
        *   Retrieves the credit value from a given coupon ID.
        *   Validates the promotion code for the user.
        *   Creates a Stripe Checkout session for the user to claim their free credits.
    *   The `purchaseCredits` action has been streamlined by removing the now-obsolete coupon handling logic.

*   **`web-app/src/lib/services/stripe/service.ts`**:
    *   Added `getCreditsForCoupon` to fetch coupon details from Stripe.
    *   It validates that the coupon is for a fixed amount (`amount_off`) in USD and converts this amount into a corresponding number of credits.

*   **`web-app/src/lib/services/stripe/third-party.ts`**:
    *   Added `getCouponById` to retrieve a coupon object from the Stripe API.

*   **`web-app/messages/en.json`**:
    *   Added a new translation for the error message when a user tries to submit the form without providing either a credit amount or a coupon.