### PR TITLE
refactor(app-layout-restrictor): fix blinking restrictor

### DIFF
--- a/web-app/src/components/app-layout-restrictor.tsx
+++ b/web-app/src/components/app-layout-restrictor.tsx
@@ -5,12 +5,14 @@ import { useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
 import useWindowSize from "@/hooks/use-window-size";
+import { cn } from "@/lib/utils";
 
 export default function AppLayoutRestrictor() {
   const t = useTranslations("Components.AppLayoutRestrictor");
 
-  const { innerWidth } = useWindowSize();
-  const showRestrictor = innerWidth < 1024;
+  const windowSize = useWindowSize();
+  const notOnClient = !windowSize;
+  const showRestrictor = !!windowSize && windowSize.innerWidth < 1024;
 
   useEffect(() => {
     document.body.style.overflow = showRestrictor ? "hidden" : "auto";
@@ -20,21 +22,31 @@ export default function AppLayoutRestrictor() {
     };
   }, [showRestrictor]);
 
-  if (!showRestrictor) {
+  if (!notOnClient && !showRestrictor) {
     return null;
   }
 
   return (
-    <div className="bg-background fixed top-0 left-0 z-[999999] flex h-svh w-svw items-center justify-center rounded-none p-4">
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col items-center justify-center gap-2 text-center">
-          <h1 className="text-xl font-bold">{t("title")}</h1>
-          <p className="text-muted-foreground text-sm">{t("description")}</p>
+    <div
+      className={cn(
+        "fixed top-0 left-0 z-[999999] flex h-svh w-svw items-center justify-center rounded-none p-4",
+        {
+          "bg-background/70 backdrop-blur-3xl": notOnClient,
+          "bg-background": showRestrictor,
+        },
+      )}
+    >
+      {showRestrictor && (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col items-center justify-center gap-2 text-center">
+            <h1 className="text-xl font-bold">{t("title")}</h1>
+            <p className="text-muted-foreground text-sm">{t("description")}</p>
+          </div>
+          <Button onClick={() => window.location.reload()} size="sm">
+            {t("reload")}
+          </Button>
         </div>
-        <Button onClick={() => window.location.reload()} size="sm">
-          {t("reload")}
-        </Button>
-      </div>
+      )}
     </div>
   );
 }

--- a/web-app/src/hooks/use-window-size.ts
+++ b/web-app/src/hooks/use-window-size.ts
@@ -22,15 +22,10 @@ const readWindowSize = () => {
   };
 };
 
-const initialValue: WindowSize = {
-  innerWidth: 0,
-  outerWidth: 0,
-  innerHeight: 0,
-  outerHeight: 0,
-};
-
-export default function useWindowSize(): WindowSize {
-  const [windowSize, setWindowSize] = useState<WindowSize>(initialValue);
+export default function useWindowSize(): WindowSize | undefined {
+  const [windowSize, setWindowSize] = useState<WindowSize | undefined>(
+    undefined,
+  );
 
   const handleSize = useCallback(() => {
     const newWindowSize = readWindowSize();
@@ -45,7 +40,6 @@ export default function useWindowSize(): WindowSize {
     handleSize();
 
     return () => {
-      console.log("unmounting");
       window.removeEventListener("resize", handleSize);
     };
   }, [handleSize]);


### PR DESCRIPTION
## Changes

* Fix blinking app-layout-restrictor; show blur with no text first and then show text if on mobile device

## Benefit

* Users won't see `Mobile not supported`, even when they are on desktop (only on the first load)