### PR TITLE
fix: url path adding when agent urls contained path segments

### DIFF
--- a/web-app/src/lib/db/agent/utils.ts
+++ b/web-app/src/lib/db/agent/utils.ts
@@ -38,7 +38,10 @@ export function getAgentApiBaseUrl(agent: Agent): URL {
   if (apiBaseUrl.hash !== "") {
     throw new Error("Agent API base URL must not have a hash");
   }
-  return new URL(agent.overrideApiBaseUrl ?? agent.apiBaseUrl);
+
+  const usedUrl = agent.overrideApiBaseUrl ?? agent.apiBaseUrl;
+  const cleanedUrl = usedUrl.endsWith("/") ? usedUrl.slice(0, -1) : usedUrl;
+  return new URL(cleanedUrl);
 }
 
 export function getAgentAverageStars(agent: AgentWithRating): number | null {

--- a/web-app/src/lib/services/agent/third-party.ts
+++ b/web-app/src/lib/services/agent/third-party.ts
@@ -13,7 +13,7 @@ export async function fetchAgentInputSchema(
 ): Promise<Result<JobInputsDataSchemaType, string>> {
   try {
     const baseUrl = getAgentApiBaseUrl(agent);
-    const inputSchemaUrl = new URL(`/input_schema`, baseUrl);
+    const inputSchemaUrl = new URL(`${baseUrl.href}/input_schema`);
     console.log("fetching input schema for", inputSchemaUrl.href);
     const response = await fetch(inputSchemaUrl);
 

--- a/web-app/src/lib/services/job/third-party.ts
+++ b/web-app/src/lib/services/job/third-party.ts
@@ -26,7 +26,7 @@ export async function fetchAgentJobStatus(
 ): Promise<Result<JobStatusResponseSchemaType, string>> {
   try {
     const baseUrl = getAgentApiBaseUrl(agent);
-    const jobStatusUrl = new URL(`/status`, baseUrl);
+    const jobStatusUrl = new URL(`${baseUrl.href}/status`);
     jobStatusUrl.searchParams.set("job_id", jobId);
     const jobStatusResponse = await fetch(jobStatusUrl, {
       method: "GET",
@@ -55,7 +55,7 @@ export async function startAgentJob(
 ): Promise<Result<StartJobResponseSchemaType, string>> {
   try {
     const baseUrl = getAgentApiBaseUrl(agent);
-    const startJobUrl = new URL(`/start_job`, baseUrl);
+    const startJobUrl = new URL(`${baseUrl.href}/start_job`);
 
     const startJobResponse = await fetch(startJobUrl, {
       method: "POST",


### PR DESCRIPTION
Fixes the `new Url("/example",baseUrl)`if the baseURL of the agent already contained path segments like `/api/v1/`