### PR TITLE
feat(landing): add BVG logo to logos section on landing page

### DIFF
--- a/web-app/src/app/(landing)/components/endorsements.tsx
+++ b/web-app/src/app/(landing)/components/endorsements.tsx
@@ -39,6 +39,14 @@ export default function Endorsements() {
       width: 220,
       height: 40,
     },
+    {
+      key: "bvg",
+      srcLight: "/endorsement/bvg-black.svg",
+      srcDark: "/endorsement/bvg-white.svg",
+      alt: "BVG",
+      width: 75,
+      height: 67,
+    },
   ];
 
   return (


### PR DESCRIPTION
This PR adds the BVG (Berliner Verkehrsbetriebe) logo to the logos section on the sokosumi landing page.

**Details:**
- Integrates the BVG logo alongside existing partner logos.
- Ensures correct placement and visual consistency with other logos.
- Uses responsive design principles for optimal display on all devices.
- Follows Shadcn UI, Radix, and Tailwind CSS conventions for styling.
- Maintains accessibility and supports both dark and light modes.

This update enhances the landing page by representing BVG as a key partner, improving brand visibility and trust.