### PR TITLE
fix: prisma migration seed script

### DIFF
--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-restricted-properties */
-import { getEnvPublicConfig } from "@/config/env.public";
 import { usdmUnit } from "@/lib/utils";
 import { PrismaClient } from "@/prisma/generated/client";
+
+type Network = "Mainnet" | "Preprod" | "Preview";
 
 const prisma = new PrismaClient();
 
@@ -9,7 +10,7 @@ const seedDatabase = process.env.SEED_DATABASE === "true";
 
 const seedUSDMCreditCost = async () => {
   console.log("Seeding USDM credit cost...");
-  const unit = usdmUnit(getEnvPublicConfig().NEXT_PUBLIC_NETWORK);
+  const unit = usdmUnit(process.env.NEXT_PUBLIC_NETWORK as Network);
   await prisma.creditCost.upsert({
     where: {
       unit,

--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -1,11 +1,11 @@
+/* eslint-disable no-restricted-properties */
 import { getEnvPublicConfig } from "@/config/env.public";
-import { getEnvSecrets } from "@/config/env.secrets";
 import { usdmUnit } from "@/lib/utils";
 import { PrismaClient } from "@/prisma/generated/client";
 
 const prisma = new PrismaClient();
 
-const seedDatabase = getEnvSecrets().SEED_DATABASE;
+const seedDatabase = process.env.SEED_DATABASE;
 
 const seedUSDMCreditCost = async () => {
   console.log("Seeding USDM credit cost...");

--- a/web-app/prisma/seed.ts
+++ b/web-app/prisma/seed.ts
@@ -5,7 +5,7 @@ import { PrismaClient } from "@/prisma/generated/client";
 
 const prisma = new PrismaClient();
 
-const seedDatabase = process.env.SEED_DATABASE;
+const seedDatabase = process.env.SEED_DATABASE === "true";
 
 const seedUSDMCreditCost = async () => {
   console.log("Seeding USDM credit cost...");

--- a/web-app/src/lib/services/stripe/third-party.ts
+++ b/web-app/src/lib/services/stripe/third-party.ts
@@ -14,8 +14,7 @@ const stripe = new Stripe(getEnvSecrets().STRIPE_SECRET_KEY);
  *
  * @param priceId - The Stripe price ID to fetch (defaults to STRIPE_PRICE_ID from environment).
  * @returns An object containing:
- *   - centsPerUnitAmount: The price per credit in cents, adjusted for the app's credit base.
- *   - unitAmountPerCredit: The Stripe unit amount per credit (in the currency's smallest unit).
+ *   - amountPerCredit: The Stripe unit amount per credit (in the currency's smallest unit).
  *   - currency: The currency code (e.g., 'usd').
  * @throws If the Stripe price cannot be retrieved, is missing unit_amount, or is not in USD.
  */


### PR DESCRIPTION
### Summary

This PR removes usage of `server-only` function in seed script and use `process.env` directly.

Because `server-only` can only be used from Next.js Server Component not regular node.js environment.
