### PR TITLE
fix(create-job-modal): image container

### DIFF
--- a/web-app/src/components/create-job-modal/create-job-section.tsx
+++ b/web-app/src/components/create-job-modal/create-job-section.tsx
@@ -74,12 +74,12 @@ function InformationAccordionItem({
       disabled={disabled}
     >
       <div className="flex flex-wrap gap-6">
-        <div className="h-16 w-16 md:h-24 md:w-24">
+        <div className="relative aspect-square w-16 md:w-24">
           <Image
             src={image}
             alt={name}
-            width={96}
-            height={96}
+            fill
+            sizes="(max-width: 768px) 50vw, 33vw"
             className="rounded-md object-cover"
           />
         </div>


### PR DESCRIPTION
### Summary
This PR fixes an issue where the agent image in the create job modal section was not maintaining its square aspect ratio, causing visual inconsistencies in the UI.

### Changes Made
- **Modified `create-job-section.tsx`**: Updated the image container styling from `w-16 md:w-24` to `w-16 md:w-24` with `aspect-square` class to ensure the image maintains a perfect square aspect ratio across all screen sizes.

### Technical Details
- The image container now uses `aspect-square` class which ensures the width and height are always equal
- Uses next/image fill property to fill up image container which is always square
- The fix maintains responsive behavior while ensuring consistent visual presentation

### Testing
- [x] Verified the agent image displays as a perfect square on mobile devices
- [x] Verified the agent image displays as a perfect square on desktop screens
- [x] Confirmed the image maintains proper aspect ratio when the modal is resized
