### PR TITLE
fix(job-details): overflow text issue on job detail inputs

### DIFF
--- a/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx
@@ -48,11 +48,13 @@ function JobDetailsInputsInner({
         <div>
           {Object.entries(input).map(([key, value]) => (
             <div
-              className="flex flex-row items-start gap-4 text-base"
+              className="grid grid-cols-3 items-start gap-4 text-base"
               key={key}
             >
-              <span className="font-bold">{idNameMap[key] || key}</span>
-              <span className="break-words">
+              <span className="col-span-1 font-bold break-all">
+                {idNameMap[key] || key}
+              </span>
+              <span className="col-span-2 break-all">
                 {typeof value === "object"
                   ? JSON.stringify(value)
                   : String(value)}


### PR DESCRIPTION
### Summary
This PR addresses text overflow issues in the job details inputs display by adding proper text wrapping classes to prevent content from breaking the layout.

### Changes Made
- Added `break-all` CSS class to both the key (field name) and value spans in the job inputs display
- This ensures long text content wraps properly within the grid layout instead of overflowing

### Technical Details
- **File Modified**: `web-app/src/app/app/agents/[agentId]/jobs/@right/components/job-details/inputs.tsx`
- **Lines 47-49**: Added `break-all` class to the field name span
- **Lines 50-54**: Added `break-all` class to the field value span

### Testing
- Verify that long field names and values display correctly without overflow
- Confirm the grid layout remains intact with various input lengths
- Test with both short and very long text content
