### PR TITLE
refactor(agent): remove unused getAgentPricing and update job pricing validation

### DIFF
--- a/web-app/src/lib/services/agent/service.ts
+++ b/web-app/src/lib/services/agent/service.ts
@@ -8,7 +8,6 @@ import {
 } from "@/lib/db";
 import {
   prisma,
-  retrieveAgentWithFixedPricingById,
   retrieveAgentWithRelationsById,
   retrieveAllCreditCosts,
   retrieveHiredAgentsWithJobsByUserIdAndOrganization,
@@ -19,10 +18,7 @@ import { JobInputsDataSchemaType } from "@/lib/job-input";
 import { getAgentCreditsPrice } from "@/lib/services/";
 import { AgentStatus, Prisma } from "@/prisma/generated/client";
 
-import {
-  fetchAgentInputSchema,
-  getAgentPaymentInformation,
-} from "./third-party";
+import { fetchAgentInputSchema } from "./third-party";
 
 /**
  * Check if a user has access to a specific agent based on organization membership
@@ -187,40 +183,6 @@ export async function getAgentInputSchema(
     throw new Error(inputSchemaResult.error);
   }
   return inputSchemaResult.data;
-}
-
-/**
- * Retrieve pricing information for a specific agent
- *
- * This function fetches an agent by ID and retrieves its pricing information,
- * including fixed pricing details and payment structure. The pricing data is
- * used to calculate costs for jobs and display pricing information to users.
- *
- * @param id - The unique identifier of the agent whose pricing to retrieve
- * @param tx - (Optional) Prisma transaction client for DB operations. Defaults to the main Prisma client.
- * @returns A Promise that resolves to the agent's pricing information
- * @throws Error if the agent is not found or if the pricing cannot be fetched
- *
- * @example
- * ```typescript
- * const pricing = await getAgentPricing("agent123");
- * // Returns the pricing information for the agent
- * ```
- */
-export async function getAgentPricing(
-  id: string,
-  tx: Prisma.TransactionClient = prisma,
-) {
-  const agent = await retrieveAgentWithFixedPricingById(id, tx);
-
-  if (!agent) {
-    throw new Error("Agent not found");
-  }
-  const agentPricingResult = await getAgentPaymentInformation(agent);
-  if (!agentPricingResult.ok) {
-    throw new Error(agentPricingResult.error);
-  }
-  return agentPricingResult.data;
 }
 
 /**


### PR DESCRIPTION
This PR refactors the agent and job service logic to streamline agent pricing retrieval and validation:

- Removes the unused getAgentPricing function and its related imports from agent/service.ts, as pricing is now accessed directly from agent relations.
- Updates startJob in job/service.ts to:
  - Retrieve agent pricing amounts directly from agent.pricing.fixedPricing.
  - Validate that the job's pricing schema matches the agent's pricing schema using the new tryValidatePricing helper.
  - Throw clear errors if pricing is missing or mismatched.
- Adds the tryValidatePricing function to ensure job and agent pricing schemas are identical before proceeding.
- Cleans up related imports and improves error handling for pricing mismatches.

This refactor improves code clarity, reduces indirection, and ensures robust validation of job pricing against agent configuration. No changes to external API or user-facing behavior.