### PR TITLE
fix(job): improve payment pending/failed logic and UI for jobs without purchase

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -947,6 +947,7 @@
         "StatusBadge": {
           "completed": "Completed",
           "failed": "Failed",
+          "paymentPending": "Payment Processing",
           "paymentFailed": "Payment Failed",
           "processing": "Processing",
           "agentConnectionFailed": "Agent Connection Failed",

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -723,11 +723,18 @@
           "hiredType": "hired",
           "Statuses": {
             "completed": "Completed",
-            "refunded": "Refunded",
-            "disputeResolved": "Dispute Resolved",
             "failed": "Failed",
+            "paymentPending": "Payment Processing",
+            "paymentFailed": "Payment Failed",
+            "processing": "Processing",
+            "agentConnectionFailed": "Agent Connection Failed",
+            "paymentNodeConnectionFailed": "Node Connection Failed",
             "inputRequired": "Input Required",
-            "processing": "Processing"
+            "disputeRequested": "Dispute Requested",
+            "disputeResolved": "Dispute Resolved",
+            "refundRequested": "Refund Requested",
+            "refundResolved": "Refunded",
+            "outputPending": "Output Missing"
           }
         }
       },

--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -98,7 +98,7 @@ async function syncAllJobs() {
         {
           purchaseId: null,
           createdAt: {
-            lt: new Date(Date.now() - 1000 * 60 * 5), // 5min grace period
+            gt: new Date(Date.now() - 1000 * 60 * 5), // 5min grace period
           },
         },
       ],

--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -87,13 +87,21 @@ async function syncAllJobs() {
           },
         },
       ],
-      NOT: {
-        onChainStatus: OnChainJobStatus.RESULT_SUBMITTED,
-        agentJobStatus: AgentJobStatus.COMPLETED,
-        externalDisputeUnlockTime: {
-          lt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
+      NOT: [
+        {
+          onChainStatus: OnChainJobStatus.RESULT_SUBMITTED,
+          agentJobStatus: AgentJobStatus.COMPLETED,
+          externalDisputeUnlockTime: {
+            lt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
+          },
         },
-      },
+        {
+          purchaseId: null,
+          createdAt: {
+            lt: new Date(Date.now() - 1000 * 60 * 5), // 5min grace period
+          },
+        },
+      ],
     },
   });
 

--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -95,12 +95,6 @@ async function syncAllJobs() {
             lt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
           },
         },
-        {
-          purchaseId: null,
-          createdAt: {
-            gt: new Date(Date.now() - 1000 * 60 * 5), // 5min grace period
-          },
-        },
       ],
     },
   });

--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -95,6 +95,11 @@ async function syncAllJobs() {
             lt: new Date(Date.now() - 1000 * 60 * 10), // 10min grace period
           },
         },
+        {
+          refundedCreditTransactionId: {
+            not: null,
+          },
+        },
       ],
     },
   });

--- a/web-app/src/app/app/agents/[agentId]/jobs/components/job-status-badge.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/components/job-status-badge.tsx
@@ -45,6 +45,14 @@ export default function JobStatusBadge({
         </Badge>
       );
     case JobStatus.PAYMENT_PENDING:
+      return (
+        <Badge
+          variant="default"
+          className={cn("bg-sky-100 text-sky-800", className)}
+        >
+          {t("paymentPending")}
+        </Badge>
+      );
     case JobStatus.PROCESSING:
       return (
         <Badge

--- a/web-app/src/app/app/components/sidebar/components/agent-job-status-indicator.tsx
+++ b/web-app/src/app/app/components/sidebar/components/agent-job-status-indicator.tsx
@@ -65,20 +65,25 @@ function AgentJobStatusIndicatorContent({ status }: { status: JobStatus }) {
   switch (status) {
     case JobStatus.COMPLETED:
       return <p>{t("completed")}</p>;
-    case JobStatus.REFUND_RESOLVED:
-      return <p>{t("refunded")}</p>;
-    case JobStatus.DISPUTE_RESOLVED:
-      return <p>{t("disputeResolved")}</p>;
     case JobStatus.FAILED:
-    case JobStatus.PAYMENT_FAILED:
       return <p>{t("failed")}</p>;
+    case JobStatus.PAYMENT_FAILED:
+      return <p>{t("paymentFailed")}</p>;
+    case JobStatus.PAYMENT_PENDING:
+      return <p>{t("paymentPending")}</p>;
+    case JobStatus.PROCESSING:
+      return <p>{t("processing")}</p>;
     case JobStatus.INPUT_REQUIRED:
       return <p>{t("inputRequired")}</p>;
-    case JobStatus.PAYMENT_PENDING:
-    case JobStatus.PROCESSING:
-    case JobStatus.OUTPUT_PENDING:
     case JobStatus.REFUND_PENDING:
+      return <p>{t("refundRequested")}</p>;
+    case JobStatus.REFUND_RESOLVED:
+      return <p>{t("refundResolved")}</p>;
     case JobStatus.DISPUTE_PENDING:
-      return <p>{t("processing")}</p>;
+      return <p>{t("disputeRequested")}</p>;
+    case JobStatus.DISPUTE_RESOLVED:
+      return <p>{t("disputeResolved")}</p>;
+    case JobStatus.OUTPUT_PENDING:
+      return <p>{t("outputPending")}</p>;
   }
 }

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -19,17 +19,19 @@ function isPaymentFailed(job: Job): boolean {
  */
 export function computeJobStatus(job: Job): JobStatus {
   const { onChainStatus, agentJobStatus, nextActionErrorType } = job;
+  // If the job has already been refunded, return the refund resolved status
+  if (job.refundedCreditTransactionId) {
+    return JobStatus.REFUND_RESOLVED;
+  }
+  // If the job has no purchase, it means the job is not yet started
   if (job.purchaseId === null) {
     if (isPaymentFailed(job)) {
-      if (job.refundedCreditTransactionId) {
-        return JobStatus.REFUND_RESOLVED;
-      } else {
-        return JobStatus.PAYMENT_FAILED;
-      }
+      return JobStatus.PAYMENT_FAILED;
     } else {
       return JobStatus.PAYMENT_PENDING;
     }
   }
+  // If the job has a purchase, it means the job is started
   switch (onChainStatus) {
     case null:
       if (nextActionErrorType === null) {

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -1,4 +1,5 @@
 import { JobStatus } from "@/lib/db/types";
+import { PAYMENT_FAILED_GRACE_PERIOD } from "@/lib/services";
 import {
   AgentJobStatus,
   Job,
@@ -13,12 +14,14 @@ import {
  */
 export function computeJobStatus(job: Job): JobStatus {
   const { onChainStatus, agentJobStatus, nextActionErrorType } = job;
-
+  if (job.purchaseId === null) {
+    if (job.createdAt < new Date(Date.now() - PAYMENT_FAILED_GRACE_PERIOD)) {
+      return JobStatus.PAYMENT_FAILED;
+    }
+    return JobStatus.PAYMENT_PENDING;
+  }
   switch (onChainStatus) {
     case null:
-      if (job.purchaseId === null) {
-        return JobStatus.PAYMENT_FAILED;
-      }
       if (nextActionErrorType === null) {
         return JobStatus.PAYMENT_PENDING;
       }

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -1,5 +1,4 @@
 import { JobStatus } from "@/lib/db/types";
-import { PAYMENT_FAILED_GRACE_PERIOD } from "@/lib/services";
 import {
   AgentJobStatus,
   Job,
@@ -9,16 +8,23 @@ import {
   OnChainTransactionStatus,
 } from "@/prisma/generated/client";
 
+const PAYMENT_FAILED_GRACE_PERIOD = 1000 * 60 * 5; // 5min
+
+function isPaymentFailed(job: Job): boolean {
+  return job.createdAt < new Date(Date.now() - PAYMENT_FAILED_GRACE_PERIOD);
+}
+
 /**
  * Compute the overall job status by combining the on-chain and agent statuses.
  */
 export function computeJobStatus(job: Job): JobStatus {
   const { onChainStatus, agentJobStatus, nextActionErrorType } = job;
   if (job.purchaseId === null) {
-    if (job.createdAt < new Date(Date.now() - PAYMENT_FAILED_GRACE_PERIOD)) {
+    if (isPaymentFailed(job)) {
       return JobStatus.PAYMENT_FAILED;
+    } else {
+      return JobStatus.PAYMENT_PENDING;
     }
-    return JobStatus.PAYMENT_PENDING;
   }
   switch (onChainStatus) {
     case null:

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -16,11 +16,13 @@ export function computeJobStatus(job: Job): JobStatus {
 
   switch (onChainStatus) {
     case null:
-      if (nextActionErrorType === null) {
-        return JobStatus.PAYMENT_PENDING;
-      } else {
+      if (job.purchaseId === null) {
         return JobStatus.PAYMENT_FAILED;
       }
+      if (nextActionErrorType === null) {
+        return JobStatus.PAYMENT_PENDING;
+      }
+      return JobStatus.PAYMENT_FAILED;
     case OnChainJobStatus.FUNDS_LOCKED:
       switch (agentJobStatus) {
         case AgentJobStatus.AWAITING_INPUT:

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -23,6 +23,7 @@ export function computeJobStatus(job: Job): JobStatus {
   if (job.refundedCreditTransactionId) {
     return JobStatus.REFUND_RESOLVED;
   }
+
   // If the job has no purchase, it means the job is not yet started
   if (job.purchaseId === null) {
     if (isPaymentFailed(job)) {
@@ -31,6 +32,7 @@ export function computeJobStatus(job: Job): JobStatus {
       return JobStatus.PAYMENT_PENDING;
     }
   }
+
   // If the job has a purchase, it means the job is started
   switch (onChainStatus) {
     case null:

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -21,7 +21,11 @@ export function computeJobStatus(job: Job): JobStatus {
   const { onChainStatus, agentJobStatus, nextActionErrorType } = job;
   if (job.purchaseId === null) {
     if (isPaymentFailed(job)) {
-      return JobStatus.PAYMENT_FAILED;
+      if (job.refundedCreditTransactionId) {
+        return JobStatus.REFUND_RESOLVED;
+      } else {
+        return JobStatus.PAYMENT_FAILED;
+      }
     } else {
       return JobStatus.PAYMENT_PENDING;
     }

--- a/web-app/src/lib/db/repositories/job.ts
+++ b/web-app/src/lib/db/repositories/job.ts
@@ -259,6 +259,7 @@ export async function refundJob(
     where: { id: jobId },
     select: { refundedCreditTransaction: true },
   });
+
   // If the job has already been refunded, do nothing
   if (job?.refundedCreditTransaction) {
     return;
@@ -358,9 +359,7 @@ export async function updateJobWithPurchase(
 
   const job = await tx.job.update({
     where: { id: jobId },
-    data: {
-      ...data,
-    },
+    data,
     include: jobInclude,
   });
   return mapJobWithStatus(job);

--- a/web-app/src/lib/db/repositories/job.ts
+++ b/web-app/src/lib/db/repositories/job.ts
@@ -357,7 +357,9 @@ export async function updateJobWithPurchase(
 
   const job = await tx.job.update({
     where: { id: jobId },
-    data,
+    data: {
+      ...data,
+    },
     include: jobInclude,
   });
   return mapJobWithStatus(job);

--- a/web-app/src/lib/db/repositories/job.ts
+++ b/web-app/src/lib/db/repositories/job.ts
@@ -259,6 +259,7 @@ export async function refundJob(
     where: { id: jobId },
     select: { refundedCreditTransaction: true },
   });
+  // If the job has already been refunded, do nothing
   if (job?.refundedCreditTransaction) {
     return;
   }

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -36,8 +36,6 @@ import {
   startAgentJob,
 } from "./third-party";
 
-export const PAYMENT_FAILED_GRACE_PERIOD = 1000 * 60 * 5; // 5min
-
 function getMatchedInputHash(
   inputData: JobInputData,
   identifierFromPurchaser: string,

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -229,17 +229,9 @@ async function requestRefundIfNeeded(job: Job) {
 }
 
 export async function syncJob(job: Job) {
-  if (!job.purchaseId) {
-    if (job.createdAt < new Date(Date.now() - 1000 * 60 * 1)) {
-      // 1min grace period for jobs that don't have a purchase id
-      await refundJob(job.id);
-    }
-    return;
-  }
-
   const [agentJobStatus, onChainPurchase] = await Promise.all([
     getAgentJobStatus(job),
-    getOnChainPurchase(job.purchaseId),
+    job.purchaseId ? getOnChainPurchase(job.purchaseId) : null,
   ]);
 
   await prisma.$transaction(

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -36,6 +36,8 @@ import {
   startAgentJob,
 } from "./third-party";
 
+export const PAYMENT_FAILED_GRACE_PERIOD = 1000 * 60 * 5; // 5min
+
 function getMatchedInputHash(
   inputData: JobInputData,
   identifierFromPurchaser: string,

--- a/web-app/src/lib/services/job/service.ts
+++ b/web-app/src/lib/services/job/service.ts
@@ -20,7 +20,13 @@ import { generateJobName } from "@/lib/generateJobName";
 import { JobInputData } from "@/lib/job-input";
 import { StartJobInputSchemaType } from "@/lib/schemas";
 import { getInputHash, getInputHashDeprecated } from "@/lib/utils";
-import { Job, NextJobAction, Prisma } from "@/prisma/generated/client";
+import {
+  AgentJobStatus,
+  Job,
+  NextJobAction,
+  OnChainJobStatus,
+  Prisma,
+} from "@/prisma/generated/client";
 import { getAgentPricing } from "@/services/agent";
 import {
   getCreditsPrice,
@@ -228,10 +234,27 @@ async function requestRefundIfNeeded(job: Job) {
   }
 }
 
+function shouldSyncAgentStatus(job: Job): boolean {
+  if (job.refundedCreditTransactionId) {
+    return false;
+  }
+  if (
+    job.onChainStatus === OnChainJobStatus.RESULT_SUBMITTED &&
+    job.agentJobStatus === AgentJobStatus.COMPLETED
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function shouldSyncMasumiStatus(job: Job): boolean {
+  return job.refundedCreditTransactionId === null;
+}
+
 export async function syncJob(job: Job) {
   const [agentJobStatus, onChainPurchase] = await Promise.all([
-    getAgentJobStatus(job),
-    job.purchaseId ? getOnChainPurchase(job.purchaseId) : null,
+    shouldSyncAgentStatus(job) ? getAgentJobStatus(job) : null,
+    shouldSyncMasumiStatus(job) ? getOnChainPurchase(job.purchaseId) : null,
   ]);
 
   await prisma.$transaction(
@@ -289,8 +312,11 @@ async function syncAgentJobStatus(
 }
 
 async function getOnChainPurchase(
-  jobPurchaseId: string,
+  jobPurchaseId: string | null,
 ): Promise<Purchase | null> {
+  if (jobPurchaseId === null) {
+    return null;
+  }
   const purchaseResult = await getPaymentClientPurchase(jobPurchaseId);
   if (!purchaseResult.ok) {
     return null;


### PR DESCRIPTION
## Summary

This PR refines the logic for handling jobs stuck in "payment pending" or "payment failed" states, and improves the UI badge display for these statuses.

### Key Changes

- **Job Status Logic:**
  - Introduces a 5-minute grace period for jobs without a purchase before marking them as `PAYMENT_FAILED`.
  - Returns `PAYMENT_PENDING` for jobs without a purchase within the grace period.
  - Ensures jobs already refunded are marked as `REFUND_RESOLVED`.
  - Refactors `computeJobStatus` for clarity and correctness.
- **UI Updates:**
  - Adds a new "Payment Processing" badge for the `PAYMENT_PENDING` state in the job status badge component.
  - Updates i18n messages to include the new `paymentPending` label.
- **Repository/Service:**
  - Ensures idempotency in the refund logic (no double refunds).
  - Cleans up job sync logic to avoid unnecessary refund attempts and handle jobs without purchases more gracefully.

### Motivation

Previously, jobs could remain indefinitely in a "payment pending" state if a purchase was never created, leading to poor UX and potential confusion. This update ensures jobs are automatically marked as failed after a reasonable period, and the UI reflects this state clearly.

### Testing

- Verified that jobs without purchases show "Payment Processing" for 5 minutes, then "Payment Failed".
- Confirmed that refunded jobs are always marked as "Refund Resolved".
- Checked that the new badge and i18n label render correctly in the UI.