### PR TITLE
fix(landing): agent show case image size

### DIFF
--- a/web-app/src/app/(landing)/components/agents-showcase.tsx
+++ b/web-app/src/app/(landing)/components/agents-showcase.tsx
@@ -37,7 +37,7 @@ const AgentShowcaseCard = ({
           alt={name}
           className="object-cover"
           fill
-          sizes="(max-width: 768px) 90px, 90px"
+          sizes="90px"
         />
       </div>
       <div className="w-[210px] px-3 opacity-100 transition-opacity duration-300 group-hover:opacity-100">


### PR DESCRIPTION
## Changes

* This PR fixes agent show case image size when original image's aspect ratio is not 1:1. We use Image's `fill` property with `object-cover`.