### PR TITLE
fix(ui): adjust padding for header, main, and agents gallery for consistent layout

### DIFF
--- a/web-app/src/app/app/agents/[agentId]/jobs/layout.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/layout.tsx
@@ -72,7 +72,7 @@ async function JobLayoutInner({ right, params, children }: JobLayoutProps) {
     <CreateJobModalContextProvider
       agentsWithPrice={[{ agent, creditsPrice: agentCreditsPrice }]}
     >
-      <div className="flex h-full flex-col p-4 lg:h-[calc(100svh-64px)] lg:p-6 xl:p-8">
+      <div className="flex h-full flex-col lg:h-[calc(100svh-64px)]">
         <Header
           agent={agent}
           agentCreditsPrice={agentCreditsPrice}

--- a/web-app/src/app/app/agents/[agentId]/jobs/loading.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function JobPageLoading() {
   return (
-    <div className="flex w-full flex-col gap-4 rounded-md border p-4 lg:w-[max(400px,36%)]">
+    <div className="flex w-full flex-col gap-4 rounded-md border p-2 lg:w-[max(400px,36%)]">
       {Array.from({ length: 5 }).map((_, index) => (
         <div key={index} className="flex items-center justify-around">
           <Skeleton className="h-8 w-24" />

--- a/web-app/src/app/app/agents/[agentId]/jobs/loading.tsx
+++ b/web-app/src/app/app/agents/[agentId]/jobs/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function JobPageLoading() {
   return (
-    <div className="flex w-full flex-col gap-4 rounded-md border p-2 lg:w-[max(400px,36%)]">
+    <div className="job-table-width flex flex-col gap-4 rounded-xl border p-2">
       {Array.from({ length: 5 }).map((_, index) => (
         <div key={index} className="flex items-center justify-around">
           <Skeleton className="h-8 w-24" />

--- a/web-app/src/app/app/agents/loading.tsx
+++ b/web-app/src/app/app/agents/loading.tsx
@@ -2,7 +2,7 @@ import { AgentsSkeleton } from "@/components/agents";
 
 export default function GalleryLoading() {
   return (
-    <div className="w-full p-8 xl:px-16">
+    <div className="w-full">
       <div className="space-y-12">
         {/* Agent Cards Grid Skeleton */}
         <AgentsSkeleton />

--- a/web-app/src/app/app/agents/page.tsx
+++ b/web-app/src/app/app/agents/page.tsx
@@ -34,7 +34,7 @@ export default async function GalleryPage() {
   const favoriteAgents = await getFavoriteAgents();
 
   return (
-    <div className="w-full px-4 py-4 sm:px-8 xl:px-16">
+    <div className="w-full">
       <div className="space-y-12">
         <FilterSection tags={tagNames} />
         {/* Agent Cards Grid */}

--- a/web-app/src/app/app/components/header.tsx
+++ b/web-app/src/app/app/components/header.tsx
@@ -13,12 +13,12 @@ export default function Header({ className }: HeaderProps) {
   return (
     <header
       className={cn(
-        "border-grid bg-background/95 sticky top-0 z-50 flex w-full items-center gap-2 border-b px-4 py-3",
+        "border-grid bg-background/95 sticky top-0 z-50 flex w-full items-center gap-2 border-b py-3",
         className,
       )}
     >
       <CustomTrigger when="invisible" />
-      <BreadcrumbNavigation className="flex flex-1 px-2 sm:px-4" />
+      <BreadcrumbNavigation className="flex flex-1" />
       <UserCredits />
       <UserAvatar />
     </header>

--- a/web-app/src/app/app/components/header.tsx
+++ b/web-app/src/app/app/components/header.tsx
@@ -13,7 +13,7 @@ export default function Header({ className }: HeaderProps) {
   return (
     <header
       className={cn(
-        "border-grid bg-background/95 sticky top-0 z-50 flex w-full items-center gap-2 border-b py-3",
+        "border-grid bg-background/95 sticky top-0 z-50 flex w-full items-center gap-2 border-b",
         className,
       )}
     >

--- a/web-app/src/app/app/layout.tsx
+++ b/web-app/src/app/app/layout.tsx
@@ -35,9 +35,9 @@ export default async function AppLayout({ children }: AppLayoutProps) {
       <SidebarProvider defaultOpen={defaultOpen}>
         <Sidebar />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <Header className="h-[64px]" />
-          <main className="min-h-[calc(100svh-64px)]">{children}</main>
-          <FooterSections className="p-4 lg:p-6 xl:p-8" />
+          <Header className="h-[64px] p-4" />
+          <main className="min-h-[calc(100svh-64px)] p-4">{children}</main>
+          <FooterSections className="p-4" />
         </div>
       </SidebarProvider>
     </>


### PR DESCRIPTION
### Summary
This PR refines the layout and spacing of key UI sections for improved consistency and alignment across the app:

- **Header**: Moves padding from internal elements to the header container, ensuring consistent spacing and removing redundant `px-4` from child components.
- **Main Content**: Adds `p-4` padding to the main content area for better content alignment and visual balance.
- **Footer**: Standardizes footer padding to `p-4` for uniformity across breakpoints.
- **Agents Gallery**: Removes extra horizontal padding from the agents gallery page to align with the new layout structure.

### Motivation
These changes address inconsistencies in padding and spacing between the header, main content, and footer, resulting in a cleaner and more cohesive user interface. This also simplifies responsive design and makes future layout adjustments easier.

### Details
- Updated `Header` to use `p-4` on the container and removed `px-4` from `BreadcrumbNavigation`.
- Updated `main` to include `p-4` for consistent content padding.
- Standardized `FooterSections` to use `p-4` padding.
- Removed redundant `px-4`/`sm:px-8`/`xl:px-16` from the agents gallery page container.

### Testing
- Verified layout on mobile, tablet, and desktop breakpoints.
- Confirmed header, main, and footer spacing is visually consistent.
- Checked that the agents gallery grid aligns with the new layout.