### PR TITLE
refactor(agents-showcase): replace agent description with short author name

### DIFF
--- a/web-app/src/app/(landing)/components/agents-showcase/agents-showcase.client.tsx
+++ b/web-app/src/app/(landing)/components/agents-showcase/agents-showcase.client.tsx
@@ -5,9 +5,9 @@ import { useMemo, useState } from "react";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   AgentWithRelations,
-  getAgentDescription,
   getAgentName,
   getAgentResolvedImage,
+  getShortAgentAuthorName,
 } from "@/lib/db";
 
 import AgentShowcaseCard from "./agent-showcase-card";
@@ -28,7 +28,7 @@ export default function AgentsShowcaseClient({
     <AgentShowcaseCard
       agentId={firstAgent.id}
       name={getAgentName(firstAgent)}
-      description={getAgentDescription(firstAgent)}
+      description={getShortAgentAuthorName(firstAgent)}
       image={getAgentResolvedImage(firstAgent)}
       isExpanded={!focused}
     />
@@ -40,7 +40,7 @@ export default function AgentsShowcaseClient({
         key={agent.id}
         agentId={agent.id}
         name={getAgentName(agent)}
-        description={getAgentDescription(agent)}
+        description={getShortAgentAuthorName(agent)}
         image={getAgentResolvedImage(agent)}
       />
     ));


### PR DESCRIPTION
### Summary  
This PR updates the Agents Showcase component to display the short author name instead of the agent description. Specifically, it replaces the usage of `getAgentDescription` with `getShortAgentAuthorName` for the `description` prop in both the main and mapped `AgentShowcaseCard` components.

### Details  
- Updated imports to use `getShortAgentAuthorName` from `@/lib/db`.
- Replaced all instances of `getAgentDescription(agent)` with `getShortAgentAuthorName(agent)` in `agents-showcase.client.tsx`.
- The UI now shows the short author name beneath each agent's name, providing a more concise and relevant context for users.

### Motivation  
This change improves the clarity and relevance of the information shown in the Agents Showcase, making it easier for users to quickly identify the author of each agent.

### Notes  
- No changes were made to the underlying data model or other components.
- This update is UI-focused and does not affect backend logic.