### PR TITLE
refactor(job-inputs-form): replace useAsyncRouter with useRouter and improve loading state handling

### DIFF
--- a/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
@@ -129,7 +129,7 @@ export default function JobInputsFormClient({
         className="plausible-event-name=Hire"
       >
         <fieldset
-          disabled={loading}
+          disabled={loading || form.formState.isSubmitting}
           className={cn("flex flex-1 flex-col gap-6", className)}
         >
           {input_data.map((jobInputSchema) => (
@@ -153,11 +153,17 @@ export default function JobInputsFormClient({
                 </div>
                 <Button
                   type="submit"
-                  disabled={loading}
+                  disabled={
+                    loading ||
+                    form.formState.isSubmitting ||
+                    !form.formState.isValid
+                  }
                   className="items-center justify-between gap-2"
                 >
                   <div className="flex items-center gap-1">
-                    {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+                    {(loading || form.formState.isSubmitting) && (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
                     {t("submit")}
                   </div>
                   {!isMobile && (


### PR DESCRIPTION
This PR refactors the `JobInputsFormClient` component to use Next.js's built-in `useRouter` from `next/navigation` instead of the custom `useAsyncRouter` hook. The following improvements and changes are included:

- Replaces all usages of `useAsyncRouter` with `useRouter` for navigation.
- Updates navigation callbacks in toast actions to use the new router.
- Refactors loading state handling to use the `loading` value from the modal context, ensuring consistent UI feedback during async operations.
- Disables the form and submit button based on the unified `loading` and `formState.isSubmitting` states.
- Ensures the loading spinner is shown whenever the form is submitting or the modal is in a loading state.
- Minor cleanup and improved code clarity.

These changes improve that the navigation to the job list directly occurs without a intermediate transaction to close the modal window.