### PR TITLE
refactor(job-inputs-form): use useAsyncRouter for navigation and await router.push

### DIFF
--- a/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
@@ -3,7 +3,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Command, CornerDownLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import React from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -12,6 +11,7 @@ import { toast } from "sonner";
 import { useCreateJobModalContext } from "@/components/create-job-modal";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
+import { useAsyncRouter } from "@/hooks/use-async-router";
 import usePreventEnterSubmit from "@/hooks/use-prevent-enter-submit";
 import {
   CommonErrorCode,
@@ -61,7 +61,7 @@ export default function JobInputsFormClient({
     defaultValues: defaultValues(input_data),
     mode: "onChange",
   });
-  const router = useRouter();
+  const router = useAsyncRouter();
 
   const { os, isMobile } = getOSFromUserAgent();
 
@@ -84,14 +84,14 @@ export default function JobInputsFormClient({
     });
 
     if (result.ok) {
-      router.push(`/app/agents/${agentId}/jobs/${result.data.jobId}`);
+      await router.push(`/app/agents/${agentId}/jobs/${result.data.jobId}`);
     } else {
       switch (result.error.code) {
         case CommonErrorCode.UNAUTHENTICATED:
           toast.error(t("Error.unauthenticated"), {
             action: {
               label: t("Error.unauthenticatedAction"),
-              onClick: () => router.push(`/login`),
+              onClick: async () => await router.push(`/login`),
             },
           });
           break;
@@ -102,7 +102,7 @@ export default function JobInputsFormClient({
           toast.error(t("Error.insufficientBalance"), {
             action: {
               label: t("Error.insufficientBalanceAction"),
-              onClick: () => router.push(`/app/billing`),
+              onClick: async () => await router.push(`/app/billing`),
             },
           });
           break;


### PR DESCRIPTION
This PR refactors the JobInputsFormClient component to improve navigation handling by replacing the useRouter hook from next/navigation with a custom useAsyncRouter hook. All router.push calls are now awaited to ensure proper navigation flow, especially in async contexts such as toast action handlers.

**Key changes:**
- Replaced useRouter with useAsyncRouter for navigation.
- Updated all router.push calls to be awaited, including those in toast action handlers.
- Ensured navigation actions are handled asynchronously for better reliability and user experience.

This change improves navigation consistency and prevents potential issues with unawaited navigation in async event handlers. No user-facing changes are expected.