### PR TITLE
fix(form): make optional job inputs truly optional in form schema

### DIFF
--- a/web-app/src/lib/job-input/form-schema.ts
+++ b/web-app/src/lib/job-input/form-schema.ts
@@ -72,7 +72,7 @@ const makeZodSchemaFromJobInputTextareaSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.nullable() : schema;
+  return canBeOptional ? schema.optional() : schema;
 };
 
 const makeZodSchemaFromJobInputStringSchema = (
@@ -120,7 +120,7 @@ const makeZodSchemaFromJobInputStringSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.nullable() : schema;
+  return canBeOptional ? schema.optional() : schema;
 };
 
 const makeZodSchemaFromJobInputNumberSchema = (
@@ -163,7 +163,7 @@ const makeZodSchemaFromJobInputNumberSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.nullable() : schema;
+  return canBeOptional ? schema.optional() : schema;
 };
 
 // For Boolean Schema we can ignore validations
@@ -223,5 +223,5 @@ const makeZodSchemaFromJobInputOptionSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.nullable() : schema;
+  return canBeOptional ? schema.optional() : schema;
 };


### PR DESCRIPTION
### Summary
This PR updates the Zod schema generation logic for job input forms to ensure that fields marked as optional are actually treated as optional in the form validation. Previously, optional fields were incorrectly set as `nullable()`, which did not align with expected form behavior. This change replaces `.nullable()` with `.optional()` for all relevant job input types (string, textarea, number, option).

### Details
- Updated the schema builders in `form-schema.ts` for string, textarea, number, and option input types.
- Now, when a job input is marked as optional, the generated Zod schema uses `.optional()` instead of `.nullable()`.
- This ensures that optional fields are not required by the form and can be omitted entirely, matching user expectations and improving UX.

### Impact
- Users can now submit forms without filling out optional job input fields.
- Validation errors for missing optional fields are no longer shown.
- No impact on required fields or other validation logic.

### Testing
- Verified that forms with optional fields can be submitted without those fields filled.
- Confirmed that required fields still enforce validation as expected.