### PR TITLE
feat(api): add test Vercel cron function at /api/sync

### DIFF
--- a/web-app/src/app/api/sync/route.ts
+++ b/web-app/src/app/api/sync/route.ts
@@ -1,0 +1,8 @@
+import { authenticateApiRequest } from "@/lib/auth/utils";
+
+export function GET(request: Request) {
+  const authResult = authenticateApiRequest(request);
+  if (!authResult.ok) return authResult.response;
+
+  return new Response("Hello from Vercel!");
+}

--- a/web-app/vercel.json
+++ b/web-app/vercel.json
@@ -2,11 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
-      "path": "/api/sync/agents",
-      "schedule": "5 * * * *"
-    },
-    {
-      "path": "/api/sync/jobs",
+      "path": "/api/sync",
       "schedule": "* * * * *"
     }
   ]


### PR DESCRIPTION

This PR introduces a test API route at `/api/sync` to validate Vercel cron job integration. The new route is protected by `authenticateApiRequest` and returns a simple response ("Hello from Vercel!") when accessed with valid authentication.

**Changes:**
- Added `GET` handler in `web-app/src/app/api/sync/route.ts` that authenticates requests and returns a test message.
- Updated `vercel.json` to schedule the `/api/sync` endpoint to run every minute via Vercel's cron feature.

**Purpose:**  
This is a temporary/test implementation to verify that Vercel cron jobs are working as expected with authenticated API routes.

**Notes:**  
- No production logic is included; this is for testing only.
- Existing cron paths for `/api/sync/agents` and `/api/sync/jobs` have been replaced by `/api/sync` for this test.  
- Please do not merge to main until cron job behavior is confirmed.