### PR TITLE
fix(api/sync): support GET for Vercel cron triggers and split agent/job sync endpoints

### DIFF
--- a/web-app/src/app/api/sync/route.ts
+++ b/web-app/src/app/api/sync/route.ts
@@ -1,8 +1,0 @@
-import { authenticateApiRequest } from "@/lib/auth/utils";
-
-export function GET(request: Request) {
-  const authResult = authenticateApiRequest(request);
-  if (!authResult.ok) return authResult.response;
-
-  return new Response("Hello from Vercel!");
-}

--- a/web-app/src/lib/auth/utils.ts
+++ b/web-app/src/lib/auth/utils.ts
@@ -114,26 +114,3 @@ export function authenticateCronSecret(
   }
   return { ok: true };
 }
-
-/**
- * Authenticates an API route request using either the admin-api-key header or a Bearer token (CRON_SECRET).
- * Returns an object indicating the authentication result and type.
- * Usage: Call at the top of your route handler and handle the result accordingly.
- */
-export function authenticateApiRequest(
-  request: Request,
-): { ok: true; type: "admin" | "cron" } | { ok: false; response: Response } {
-  const adminResult = authenticateAdminApiKey(request);
-  if (adminResult.ok) return { ok: true, type: "admin" };
-  const cronResult = authenticateCronSecret(request);
-  if (cronResult.ok) return { ok: true, type: "cron" };
-
-  // Determine which authentication method was attempted
-  const hasAdminKey = !!request.headers.get("admin-api-key");
-  const hasAuthHeader = !!request.headers.get("authorization");
-
-  if (hasAdminKey) return adminResult;
-  if (hasAuthHeader) return cronResult;
-  // If neither header is present, default to admin error for backward compatibility
-  return adminResult;
-}

--- a/web-app/vercel.json
+++ b/web-app/vercel.json
@@ -2,7 +2,11 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
-      "path": "/api/sync",
+      "path": "/api/sync/agents",
+      "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/sync/jobs",
       "schedule": "* * * * *"
     }
   ]


### PR DESCRIPTION
### Problem  
Vercel's cron jobs always trigger endpoints using the GET method, but our `/api/sync/agents` and `/api/sync/jobs` endpoints previously only supported POST for authenticated sync operations. This caused scheduled syncs to fail, as GET requests were not handled for these endpoints.

### Solution  
- Added GET handlers to `/api/sync/agents` and `/api/sync/jobs` that authenticate using the cron secret and trigger the sync logic.
- Refactored authentication:  
  - GET requests now require the cron secret (for Vercel cron compatibility).
  - POST requests require the admin API key (for manual/admin-triggered syncs).
  - Removed the now-unused `authenticateApiRequest` helper.
- Updated Vercel cron configuration to point directly to `/api/sync/agents` and `/api/sync/jobs` with appropriate schedules.

### Impact  
- Vercel cron jobs will now successfully trigger agent and job syncs via GET requests.
- Manual/admin syncs remain possible via POST with the admin API key.
- Endpoints are now more explicit and secure in their authentication requirements.

---

**Note:**  
This change is required for Vercel cron compatibility, as Vercel only issues GET requests for scheduled jobs.  
No breaking changes to existing admin workflows.