### PR TITLE
fix: landing layout

### DIFF
--- a/web-app/src/app/(landing)/layout.tsx
+++ b/web-app/src/app/(landing)/layout.tsx
@@ -27,7 +27,7 @@ export default async function LandingLayout({ children }: LandingLayoutProps) {
     <UTMProvider>
       <div className="flex flex-col">
         <Header className="h-30" />
-        <main className="min-h-svh flex-1 pt-16 lg:pt-20">{children}</main>
+        <main className="min-h-svh flex-1 pt-30">{children}</main>
         <Footer />
       </div>
     </UTMProvider>

--- a/web-app/src/app/(landing)/layout.tsx
+++ b/web-app/src/app/(landing)/layout.tsx
@@ -27,7 +27,9 @@ export default async function LandingLayout({ children }: LandingLayoutProps) {
     <UTMProvider>
       <div className="flex flex-col">
         <Header className="h-30" />
-        <main className="min-h-svh flex-1 pt-30">{children}</main>
+        <main className="min-h-[calc(100svh-120px)] flex-1 pt-30">
+          {children}
+        </main>
         <Footer />
       </div>
     </UTMProvider>

--- a/web-app/src/app/(landing)/page.tsx
+++ b/web-app/src/app/(landing)/page.tsx
@@ -11,7 +11,7 @@ export default function LandingPage() {
   return (
     <>
       {/* Hero Section */}
-      <section className="relative -mt-16 flex max-h-[900px] min-h-svh flex-col items-center justify-center overflow-hidden py-20 lg:-mt-20">
+      <section className="relative -mt-30 flex max-h-[900px] min-h-svh flex-col items-center justify-center overflow-hidden py-20">
         <Hero />
       </section>
 


### PR DESCRIPTION
## Summary

This PR fixes landing page's layout to match with updated header. (we now add banner to header)

## Changes

* Fix landing page's main content's padding to `pt-30` because landing header's height is `h-30`.
* Fix landing page's hero section's margin to `-mt-30`.
* Fix landing page's main content's min width to `min-w-[calc(100svh-120px)]`.