### PR TITLE
chore(vercel): update /api/sync/jobs cron schedule to every 2 minutes

### DIFF
--- a/web-app/vercel.json
+++ b/web-app/vercel.json
@@ -7,7 +7,7 @@
     },
     {
       "path": "/api/sync/jobs",
-      "schedule": "* * * * *"
+      "schedule": "*/2 * * * *"
     }
   ]
 }


### PR DESCRIPTION
This PR updates the Vercel serverless function schedule for the `/api/sync/jobs` endpoint.  
- **Change:** The cron schedule is modified from running every minute (`* * * * *`) to every 2 minutes (`*/2 * * * *`).
- **Reason:** This adjustment reduces the frequency of job sync executions, which can help optimize resource usage and prevent unnecessary load.

No other changes are included in this PR.  
Please review and merge if the new schedule aligns with operational requirements.