### PR TITLE
fix(api): return 409 Conflict for sync lock and reduce lock timeout to 2 minutes

### DIFF
--- a/web-app/src/app/api/sync/agents/route.ts
+++ b/web-app/src/app/api/sync/agents/route.ts
@@ -35,7 +35,7 @@ async function agentSync() {
     if (error instanceof Error && error.message === "LOCK_IS_LOCKED") {
       return NextResponse.json(
         { message: "Syncing already in progress" },
-        { status: 429 },
+        { status: 409 },
       );
     }
     return NextResponse.json(

--- a/web-app/src/app/api/sync/jobs/route.ts
+++ b/web-app/src/app/api/sync/jobs/route.ts
@@ -39,7 +39,7 @@ async function jobSync(): Promise<Response> {
     if (error instanceof Error && error.message === "LOCK_IS_LOCKED") {
       return NextResponse.json(
         { message: "Syncing already in progress" },
-        { status: 429 },
+        { status: 409 },
       );
     }
     return NextResponse.json(

--- a/web-app/src/config/env.secrets.ts
+++ b/web-app/src/config/env.secrets.ts
@@ -91,7 +91,7 @@ const envSecretsSchema = z.object({
   LOCK_TIMEOUT: z
     .number({ coerce: true })
     .min(1 * 60 * 1000)
-    .default(10 * 60 * 1000), // 10 minutes
+    .default(2 * 60 * 1000), // 2 minutes
   LOCK_TIMEOUT_BUFFER: z
     .number({ coerce: true })
     .min(1000)


### PR DESCRIPTION
### Changes  
- Updated the sync endpoints (`/api/sync/agents` and `/api/sync/jobs`) to return HTTP status **409 Conflict** instead of **429 Too Many Requests** when a sync lock is already in place. This provides a more semantically correct response for resource locking scenarios.
- Reduced the default `LOCK_TIMEOUT` in `env.secrets.ts` from **10 minutes** to **2 minutes** to allow faster recovery from stale locks and improve system responsiveness.

### Rationale  
- **409 Conflict** is the appropriate status code for resource contention, indicating that the request could not be completed due to a conflict with the current state of the resource (i.e., a sync is already in progress).
- Shortening the lock timeout minimizes the risk of long lockouts due to unexpected failures or crashes, improving the user and developer experience.

### Impact  
- API consumers will now receive a 409 status when a sync is already running, which should be handled accordingly in clients.
- The system will automatically release locks after 2 minutes if not cleared, reducing the chance of prolonged lock contention.

---

**Checklist:**
- [x] Uses conventional commit format
- [x] Updates are backward compatible for API consumers (status code change is documented)
- [x] No breaking changes to sync logic, only improved error signaling and timeout configuration