### PR TITLE
fix: disable sendDefaultPii until sentry fixes their issue

### DIFF
--- a/web-app/sentry.edge.config.ts
+++ b/web-app/sentry.edge.config.ts
@@ -11,7 +11,9 @@ Sentry.init({
 
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // sendDefaultPii: true,
+  // TODO: Uncomment this when Sentry team fixed open issue
+  // https://github.com/getsentry/sentry-javascript/issues/16542
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/web-app/sentry.server.config.ts
+++ b/web-app/sentry.server.config.ts
@@ -10,7 +10,9 @@ Sentry.init({
 
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // sendDefaultPii: true,
+  // TODO: Uncomment this when Sentry team fixed open issue
+  // https://github.com/getsentry/sentry-javascript/issues/16542
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/web-app/src/instrumentation-client.ts
+++ b/web-app/src/instrumentation-client.ts
@@ -6,7 +6,10 @@ Sentry.init({
 
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // sendDefaultPii: true,
+  // TODO: Uncomment this when Sentry team fixed open issue
+  // https://github.com/getsentry/sentry-javascript/issues/16542
+
   integrations: [Sentry.replayIntegration({})],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.


### PR DESCRIPTION
## Summary

This PR disables `sendDefaultPii` option from Sentry configuration, because this causes next.js application warning.

## Reference

https://github.com/getsentry/sentry-javascript/issues/16542