### PR TITLE
fix(auth): add Vercel URLs to trusted origins for better authentication

### DIFF
--- a/web-app/src/lib/auth/auth.ts
+++ b/web-app/src/lib/auth/auth.ts
@@ -35,7 +35,11 @@ export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),
-  trustedOrigins: getEnvSecrets().BETTER_AUTH_TRUSTED_ORIGINS,
+  trustedOrigins: [
+    ...getEnvSecrets().BETTER_AUTH_TRUSTED_ORIGINS,
+    `https://${process.env.VERCEL_BRANCH_URL}`, // eslint-disable-line no-restricted-properties
+    `https://${process.env.VERCEL_URL}`, // eslint-disable-line no-restricted-properties
+  ],
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
       switch (ctx.path) {


### PR DESCRIPTION
## Summary
  - Add Vercel branch and deployment URLs to Better Auth trusted origins configuration
  - Ensures authentication works properly on Vercel preview deployments and production

  ## Changes
  - Modified `auth.ts` to include `VERCEL_BRANCH_URL` and `VERCEL_URL` environment variables in trusted origins
  - Added ESLint disable comments for restricted properties rule compliance

  ## Test plan
  - Verify authentication works on Vercel preview deployments
  - Confirm authentication continues to work on production domain
  - Test login/logout flows on branch deployments