### PR TITLE
fix(header): change default auth button from SignIn to SignUp on landing page

### DIFF
--- a/web-app/src/app/(landing)/components/header/auth-buttons.tsx
+++ b/web-app/src/app/(landing)/components/header/auth-buttons.tsx
@@ -17,5 +17,5 @@ export default function AuthButtons({ className }: AuthButtonsProps) {
   if (pathname.startsWith("/register"))
     return <SignInButton className={className} />;
 
-  return <SignInButton className={className} />;
+  return <SignUpButton className={className} />;
 }


### PR DESCRIPTION
  ## Summary
  - Changed the default authentication button in the landing page header from "Sign In" to "Sign Up" to better guide new users towards registration
  - Maintains existing logic to show "Sign In" when users are on the registration page

  ## Changes
  - Updated `auth-buttons.tsx` to return `SignUpButton` by default instead of `SignInButton`
  - This encourages new visitors to register rather than assuming they already have an account