### PR TITLE
refactor: disable cookie cache when call getSession

### DIFF
--- a/web-app/src/lib/auth/utils.ts
+++ b/web-app/src/lib/auth/utils.ts
@@ -9,6 +9,9 @@ import { UnAuthenticatedError } from "./errors";
 
 export async function getSession(): Promise<Session | null> {
   const session = await auth.api.getSession({
+    query: {
+      disableCookieCache: true,
+    },
     headers: await headers(),
   });
 


### PR DESCRIPTION
## Summary

This PR get session from database every time not from cache.

## Rationale

Because we face `UnAuthenticated` Error sometimes.
And we think the reason is that the cookie’s signature or expiration isn’t consistent.
Such as when the session data and its signature use slightly different expiry values, the session check can fail, causing `getSession` to return null.

## Reference

https://github.com/better-auth/better-auth/pull/3283