### PR TITLE
fix: remove disabled path option from better auth

### DIFF
--- a/web-app/src/lib/auth/auth.ts
+++ b/web-app/src/lib/auth/auth.ts
@@ -83,7 +83,6 @@ export const auth = betterAuth({
       }
     }),
   },
-  disabledPaths: ["/sign-up/email", "/sign-in"],
   emailAndPassword: {
     enabled: true,
     maxPasswordLength: getEnvPublicConfig().NEXT_PUBLIC_PASSWORD_MAX_LENGTH,

--- a/web-app/src/lib/auth/utils.ts
+++ b/web-app/src/lib/auth/utils.ts
@@ -9,9 +9,6 @@ import { UnAuthenticatedError } from "./errors";
 
 export async function getSession(): Promise<Session | null> {
   const session = await auth.api.getSession({
-    query: {
-      disableCookieCache: true,
-    },
     headers: await headers(),
   });
 


### PR DESCRIPTION
## Changes

* Remove `disabledPath` options from better auth which may cause us `UnAuthenticated` Error.