### PR TITLE
fix(layout): update sidebar state logic to handle 'false' value correctly

### DIFF
--- a/web-app/src/app/(app)/layout.tsx
+++ b/web-app/src/app/(app)/layout.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function AppLayout({ children }: AppLayoutProps) {
   const cookieStore = await cookies();
-  const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
+  const defaultOpen = cookieStore.get("sidebar_state")?.value !== "false";
 
   await getSessionOrRedirect();
 


### PR DESCRIPTION
## Summary
- Fixed sidebar default state logic to properly handle the 'false' string value from cookies
- Changed from checking equality with 'true' to checking inequality with 'false'
- This ensures the sidebar defaults to open unless explicitly set to 'false'

## Changes
- Updated `web-app/src/app/(app)/layout.tsx:31` to use `\!== "false"` instead of `=== "true"`

## Test plan
- [x] Verify sidebar opens by default when no cookie is set
- [x] Verify sidebar stays closed when cookie is explicitly set to 'false'
- [x] Verify sidebar opens when cookie is set to 'true' or any other value

🤖 Generated with [Claude Code](https://claude.ai/code)