### PR TITLE
feat(ci): add checkout step to Claude workflow for code access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,9 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Run Claude Code
         id: claude
         continue-on-error: false


### PR DESCRIPTION
## Summary

- Add missing checkout step to Claude workflow to ensure code is available during execution

## Changes

- Added `actions/checkout@v4` step to the Claude workflow before running Claude Code
- This ensures the repository code is accessible to Claude during workflow execution

## Context

The Claude workflow was missing the essential checkout step, which prevented Claude from accessing the repository code when triggered. This change adds the standard checkout action to make the codebase available for Claude's operations.

🤖 Generated with [Claude Code](https://claude.ai/code)