### PR TITLE
fix(billing): reduce Stripe checkout session amount from 100 to 30 credits

### DIFF
--- a/web-app/src/lib/actions/billing/action.ts
+++ b/web-app/src/lib/actions/billing/action.ts
@@ -34,7 +34,7 @@ export async function claimFreeCredits(
     const { url } = await createStripeCheckoutSession(
       session.user.id,
       null,
-      100,
+      30,
       price,
       promotionCode,
     );


### PR DESCRIPTION
## Summary
- Reduced the default Stripe checkout session credit amount from 100 to 30 credits in the claimFreeCredits action

## Changes
- Updated `src/lib/actions/billing/action.ts` to use 30 credits instead of 100 credits when creating Stripe checkout sessions
- This adjustment better aligns with the intended free credit offering and reduces potential costs

## Test plan
- [x] Verify that free credit claiming still works correctly with the new 30 credit amount
- [x] Test Stripe checkout session creation with the updated credit value
- [x] Confirm billing calculations are accurate with the new amount

🤖 Generated with [Claude Code](https://claude.ai/code)