### PR TITLE
feat(billing): refactor free credits with dynamic promotion code calculation

### DIFF
--- a/web-app/src/lib/actions/billing/action.ts
+++ b/web-app/src/lib/actions/billing/action.ts
@@ -7,6 +7,7 @@ import { CouponError } from "@/lib/errors/coupon-errors";
 import {
   createStripeCheckoutSession,
   getCreditsForCoupon,
+  getCreditsForPromotionCode,
   getMyMemberInOrganization,
   getPriceFromPriceId,
   getPriceFromProductId,
@@ -29,12 +30,13 @@ export async function claimFreeCredits(
     const price = await getPriceFromProductId(
       getEnvSecrets().STRIPE_PRODUCT_ID,
     );
+    const credits = await getCreditsForPromotionCode(promotionCode, price);
 
     // Create the checkout session
     const { url } = await createStripeCheckoutSession(
       session.user.id,
       null,
-      30,
+      credits,
       price,
       promotionCode,
     );

--- a/web-app/src/lib/errors/coupon-errors.ts
+++ b/web-app/src/lib/errors/coupon-errors.ts
@@ -14,6 +14,15 @@ export class CouponNotFoundError extends CouponError {
   }
 }
 
+export class PromotionCodeNotFoundError extends CouponError {
+  constructor(promotionCode: string) {
+    super(
+      `Promotion code ${promotionCode} not found`,
+      "PROMOTION_CODE_NOT_FOUND",
+    );
+  }
+}
+
 export class CouponTypeError extends CouponError {
   constructor(message: string) {
     super(message, "COUPON_TYPE_ERROR");

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -21,6 +21,7 @@ import {
 import {
   createCheckoutSession,
   getCouponById,
+  getCouponByPromotionCode,
   getOrCreatePromotionCode,
   getOrCreateStripeCustomer,
   getPromotionCodeByCustomerAndCouponId,
@@ -137,6 +138,17 @@ export async function getPromotionCode(
     maxRedemptions,
     metadata,
   );
+}
+
+export async function getCreditsForPromotionCode(
+  promotionCode: string,
+  price: Price,
+): Promise<number> {
+  const coupon = await getCouponByPromotionCode(promotionCode);
+  if (!coupon) {
+    throw new CouponNotFoundError(promotionCode);
+  }
+  return getCreditsForCoupon(coupon.id, price);
 }
 
 export async function getCreditsForCoupon(

--- a/web-app/src/lib/services/stripe/service.ts
+++ b/web-app/src/lib/services/stripe/service.ts
@@ -16,6 +16,7 @@ import {
   CouponCurrencyError,
   CouponNotFoundError,
   CouponTypeError,
+  PromotionCodeNotFoundError,
 } from "@/lib/errors/coupon-errors";
 
 import {
@@ -146,7 +147,7 @@ export async function getCreditsForPromotionCode(
 ): Promise<number> {
   const coupon = await getCouponByPromotionCode(promotionCode);
   if (!coupon) {
-    throw new CouponNotFoundError(promotionCode);
+    throw new PromotionCodeNotFoundError(promotionCode);
   }
   return getCreditsForCoupon(coupon.id, price);
 }

--- a/web-app/src/lib/services/stripe/third-party.ts
+++ b/web-app/src/lib/services/stripe/third-party.ts
@@ -298,6 +298,16 @@ export async function getOrCreatePromotionCode(
   }
 }
 
+export async function getCouponByPromotionCode(
+  code: string,
+): Promise<Stripe.Coupon | null> {
+  const promotionCode = await stripe.promotionCodes.retrieve(code);
+  if (!promotionCode.coupon) {
+    return null;
+  }
+  return promotionCode.coupon;
+}
+
 export async function getCouponById(
   couponId: string,
 ): Promise<Stripe.Coupon | null> {


### PR DESCRIPTION
## Summary
- Add support for dynamic credit calculation based on promotion codes
- Refactor `claimFreeCredits` action to use `getCreditsForPromotionCode` instead of hardcoded 30 credits
- Add new `PromotionCodeNotFoundError` for better error handling
- Implement `getCouponByPromotionCode` utility function for Stripe promotion code lookup

## Changes Made
- **billing/action.ts**: Updated `claimFreeCredits` to dynamically calculate credits using promotion codes
- **coupon-errors.ts**: Added `PromotionCodeNotFoundError` class for specific error handling
- **stripe/service.ts**: Added `getCreditsForPromotionCode` function to calculate credits from promotion codes
- **stripe/third-party.ts**: Added `getCouponByPromotionCode` utility to retrieve coupons by promotion code

## Test Plan
- [ ] Verify promotion code validation works correctly
- [ ] Test error handling for invalid promotion codes
- [ ] Ensure credit calculation matches coupon configuration
- [ ] Test checkout session creation with dynamic credit amounts

🤖 Generated with [Claude Code](https://claude.ai/code)