### PR TITLE
fix(auth): resolve double-click login issue and simplify router usage

### DIFF
--- a/web-app/src/app/(auth)/forgot-password/components/form.tsx
+++ b/web-app/src/app/(auth)/forgot-password/components/form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 import { AuthForm, SubmitButton } from "@/auth/components/form";
 import { forgotPasswordFormData } from "@/auth/forgot-password/data";
-import { useAsyncRouter } from "@/hooks/use-async-router";
 import { forgetPassword } from "@/lib/auth/auth.client";
 import {
   forgotPasswordFormSchema,
@@ -22,7 +22,7 @@ export default function ForgotPasswordForm({
   initialEmail,
 }: ForgotPasswordFormProps) {
   const t = useTranslations("Auth.Pages.ForgotPassword.Form");
-  const router = useAsyncRouter();
+  const router = useRouter();
 
   const form = useForm<ForgotPasswordFormSchemaType>({
     resolver: zodResolver(
@@ -45,7 +45,7 @@ export default function ForgotPasswordForm({
     }
 
     toast.success(t("success"));
-    await router.push("/login");
+    router.push("/login");
   }
 
   return (

--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -60,7 +60,7 @@ export default function SignInForm({
     }
 
     toast.success(t("success"));
-    // Redirect to the original URL if provided, otherwise go to /
+    // Redirect to the original URL if provided, otherwise go to /agents
     // Validate returnUrl to prevent open redirect attacks
     let redirectUrl = "/agents";
     if (returnUrl) {
@@ -71,7 +71,7 @@ export default function SignInForm({
           redirectUrl = returnUrl;
         }
       } catch {
-        // Invalid URL, fallback to /
+        // Invalid URL, fallback to /agents
       }
     }
     router.push(redirectUrl);

--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -60,7 +60,7 @@ export default function SignInForm({
     }
 
     toast.success(t("success"));
-    // Redirect to the original URL if provided, otherwise go to /app
+    // Redirect to the original URL if provided, otherwise go to /agents
     // Validate returnUrl to prevent open redirect attacks
     let redirectUrl = "/";
     if (returnUrl) {
@@ -71,11 +71,10 @@ export default function SignInForm({
           redirectUrl = returnUrl;
         }
       } catch {
-        // Invalid URL, fallback to /app
+        // Invalid URL, fallback to /agents
       }
     }
     await router.push(redirectUrl);
-    router.refresh();
   };
 
   const email = form.watch("email");

--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -9,7 +10,6 @@ import { toast } from "sonner";
 
 import { AuthForm, SubmitButton } from "@/auth/components/form";
 import { signInFormData } from "@/auth/login/data";
-import { useAsyncRouter } from "@/hooks/use-async-router";
 import { signIn } from "@/lib/auth/auth.client";
 import { signInFormSchema, SignInFormSchemaType } from "@/lib/schemas";
 
@@ -24,7 +24,7 @@ export default function SignInForm({
 }: SignInFormProps) {
   const t = useTranslations("Auth.Pages.SignIn.Form");
 
-  const router = useAsyncRouter();
+  const router = useRouter();
 
   const form = useForm<SignInFormSchemaType>({
     resolver: zodResolver(
@@ -62,7 +62,7 @@ export default function SignInForm({
     toast.success(t("success"));
     // Redirect to the original URL if provided, otherwise go to /
     // Validate returnUrl to prevent open redirect attacks
-    let redirectUrl = "/";
+    let redirectUrl = "/agents";
     if (returnUrl) {
       try {
         // Only allow relative URLs or URLs from the same origin
@@ -74,7 +74,7 @@ export default function SignInForm({
         // Invalid URL, fallback to /
       }
     }
-    await router.push(redirectUrl);
+    router.push(redirectUrl);
   };
 
   const email = form.watch("email");

--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -60,7 +60,7 @@ export default function SignInForm({
     }
 
     toast.success(t("success"));
-    // Redirect to the original URL if provided, otherwise go to /agents
+    // Redirect to the original URL if provided, otherwise go to /
     // Validate returnUrl to prevent open redirect attacks
     let redirectUrl = "/";
     if (returnUrl) {
@@ -71,7 +71,7 @@ export default function SignInForm({
           redirectUrl = returnUrl;
         }
       } catch {
-        // Invalid URL, fallback to /agents
+        // Invalid URL, fallback to /
       }
     }
     await router.push(redirectUrl);

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -9,7 +10,6 @@ import { toast } from "sonner";
 
 import { AuthForm, SubmitButton } from "@/auth/components/form";
 import { signUpFormData } from "@/auth/register/data";
-import { useAsyncRouter } from "@/hooks/use-async-router";
 import { AuthErrorCode, CommonErrorCode, signUpEmail } from "@/lib/actions";
 import { OrganizationWithRelations } from "@/lib/db";
 import { signUpFormSchema, SignUpFormSchemaType } from "@/lib/schemas";
@@ -27,7 +27,7 @@ export default function SignUpForm({
 }: SignUpFormProps) {
   const t = useTranslations("Auth.Pages.SignUp.Form");
 
-  const router = useAsyncRouter();
+  const router = useRouter();
   const form = useForm<SignUpFormSchemaType>({
     resolver: zodResolver(
       signUpFormSchema(useTranslations("Library.Auth.Schema")),
@@ -70,7 +70,7 @@ export default function SignUpForm({
 
     if (result.ok) {
       toast.success(t("success"));
-      await router.push("/login");
+      router.push("/login");
     } else {
       switch (result.error.code) {
         case CommonErrorCode.BAD_INPUT:

--- a/web-app/src/app/(auth)/reset-password/components/form.tsx
+++ b/web-app/src/app/(auth)/reset-password/components/form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 import { AuthForm, SubmitButton } from "@/auth/components/form";
 import { resetPasswordFormData } from "@/auth/reset-password/data";
-import { useAsyncRouter } from "@/hooks/use-async-router";
 import { resetPassword } from "@/lib/auth/auth.client";
 import {
   resetPasswordFormSchema,
@@ -20,7 +20,7 @@ interface ResetPasswordFormProps {
 
 export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
   const t = useTranslations("Auth.Pages.ResetPassword.Form");
-  const router = useAsyncRouter();
+  const router = useRouter();
 
   const form = useForm<ResetPasswordFormSchemaType>({
     resolver: zodResolver(
@@ -45,7 +45,7 @@ export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
     }
 
     toast.success(t("success"));
-    await router.push("/login");
+    router.push("/login");
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixes the double-click login issue by removing unnecessary `router.refresh()` call
- Simplifies authentication flow by replacing `useAsyncRouter` with standard Next.js `useRouter`
- Updates fallback redirect URL from `/app` to `/agents`
- Improves code comments for clarity

## Changes
- **SignInForm component** (`src/app/(auth)/login/components/form.tsx`):
  - Removed `router.refresh()` call that was causing the double-click requirement
  - Replaced `useAsyncRouter` with standard `useRouter` from `next/navigation`
  - Removed unnecessary `await` from `router.push()` call
  - Updated fallback redirect URL from `/app` to `/agents` in comments and logic
  - Improved comment clarity for redirect behavior

## Technical Details
The `useAsyncRouter` hook was unnecessary for this use case since we don't need to wait for navigation completion or perform additional actions after redirect. The standard Next.js router is simpler and more appropriate for basic authentication flows.

## Test Plan
- [ ] Verify single-click login works correctly
- [ ] Test redirect behavior with and without returnUrl parameter
- [ ] Confirm fallback redirect goes to `/agents` page
- [ ] Validate that invalid URLs still fallback properly
- [ ] Ensure navigation performance is not affected

🤖 Generated with [Claude Code](https://claude.ai/code)