### PR TITLE
refactor: average jobs execution time for recent jobs

### DIFF
--- a/web-app/src/lib/db/repositories/job.repository.ts
+++ b/web-app/src/lib/db/repositories/job.repository.ts
@@ -90,14 +90,13 @@ export const jobRepository = {
     agentId: string,
     tx: Prisma.TransactionClient = prisma,
   ): Promise<number> {
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const result = await tx.$queryRaw<[{ avg_duration_seconds: number }]>`
     SELECT 
       AVG(EXTRACT(EPOCH FROM ("completedAt" - "startedAt"))) as avg_duration_seconds
     FROM "Job"
     WHERE "agentId" = ${agentId}
     AND "completedAt" IS NOT NULL
-    AND "createdAt" >= ${thirtyDaysAgo}
+    AND "createdAt" >= NOW() - INTERVAL '30 days'
   `;
 
     const averageDurationSeconds = result[0]?.avg_duration_seconds ?? 0;


### PR DESCRIPTION
## Summary

This PR only select recent jobs (the ones created 30 days ago) to calculate average jobs execution time.