### PR TITLE
refactor: rename JobStatusData to JobIndicatorStatus for improved clarity and consistency across the codebase

### DIFF
--- a/web-app/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/web-app/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
@@ -6,7 +6,7 @@ import { useFormatter, useTranslations } from "next-intl";
 import { DataTableColumnHeader } from "@/components/data-table";
 import { MiddleTruncate } from "@/components/middle-truncate";
 import useAgentJobStatus from "@/hooks/use-agent-job-status";
-import { JobStatusData } from "@/lib/ably";
+import { JobIndicatorStatus } from "@/lib/ably";
 import { JobWithStatus } from "@/lib/db";
 
 import JobStatusBadge from "./job-status-badge";
@@ -50,8 +50,8 @@ export function getJobColumns(
             agentId={row.original.agentId}
             userId={userId}
             jobId={row.original.id}
-            initialJobStatusData={{
-              id: row.original.id,
+            initialJobIndicatorStatus={{
+              jobId: row.original.id,
               jobStatus: row.original.status,
               jobStatusSettled: row.original.jobStatusSettled,
             }}
@@ -90,26 +90,28 @@ function RealTimeJobStatusBadge({
   agentId,
   userId,
   jobId,
-  initialJobStatusData,
+  initialJobIndicatorStatus,
   className,
 }: {
   agentId: string;
   userId: string;
   jobId: string;
-  initialJobStatusData: JobStatusData;
+  initialJobIndicatorStatus: JobIndicatorStatus;
   className?: string;
 }) {
   const realTimeJobStatus = useAgentJobStatus(
     agentId,
     userId,
     jobId,
-    initialJobStatusData,
+    initialJobIndicatorStatus,
     true,
   );
 
   return (
     <JobStatusBadge
-      status={realTimeJobStatus?.jobStatus ?? initialJobStatusData.jobStatus}
+      status={
+        realTimeJobStatus?.jobStatus ?? initialJobIndicatorStatus.jobStatus
+      }
       className={className}
     />
   );

--- a/web-app/src/app/(app)/components/sidebar/components/agent-job-status-indicator.tsx
+++ b/web-app/src/app/(app)/components/sidebar/components/agent-job-status-indicator.tsx
@@ -9,21 +9,21 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import useAgentJobStatus from "@/hooks/use-agent-job-status";
-import { JobStatusData } from "@/lib/ably";
+import { JobIndicatorStatus } from "@/lib/ably";
 import { JobStatus } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
 interface AgentJobStatusIndicatorProps {
   agentId: string;
   userId: string;
-  initialJobStatusData: JobStatusData | null;
+  initialJobIndicatorStatus: JobIndicatorStatus | null;
   className?: string | undefined;
 }
 
 export default function AgentJobStatusIndicator({
   agentId,
   userId,
-  initialJobStatusData,
+  initialJobIndicatorStatus: initialJobStatusData,
   className,
 }: AgentJobStatusIndicatorProps) {
   const jobStatusData = useAgentJobStatus(
@@ -41,25 +41,25 @@ export default function AgentJobStatusIndicator({
     <Tooltip>
       <TooltipTrigger>
         <AgentJobStatusIndicatorIcon
-          jobStatusData={jobStatusData}
+          jobIndicatorStatus={jobStatusData}
           className={className}
         />
       </TooltipTrigger>
       <TooltipContent>
-        <AgentJobStatusIndicatorContent jobStatusData={jobStatusData} />
+        <AgentJobStatusIndicatorContent jobIndicatorStatus={jobStatusData} />
       </TooltipContent>
     </Tooltip>
   );
 }
 
 function AgentJobStatusIndicatorIcon({
-  jobStatusData,
+  jobIndicatorStatus,
   className,
 }: {
-  jobStatusData: JobStatusData;
+  jobIndicatorStatus: JobIndicatorStatus;
   className?: string | undefined;
 }) {
-  const { jobStatus, jobStatusSettled } = jobStatusData;
+  const { jobStatus, jobStatusSettled } = jobIndicatorStatus;
   if (jobStatusSettled) {
     return null;
   }
@@ -86,13 +86,13 @@ function AgentJobStatusIndicatorIcon({
 }
 
 function AgentJobStatusIndicatorContent({
-  jobStatusData,
+  jobIndicatorStatus,
 }: {
-  jobStatusData: JobStatusData;
+  jobIndicatorStatus: JobIndicatorStatus;
 }) {
   const t = useTranslations("App.Sidebar.Content.AgentLists.Statuses");
 
-  const { jobStatus, jobStatusSettled } = jobStatusData;
+  const { jobStatus, jobStatusSettled } = jobIndicatorStatus;
   if (jobStatusSettled) {
     return null;
   }

--- a/web-app/src/app/(app)/components/sidebar/components/agent-lists.client.tsx
+++ b/web-app/src/app/(app)/components/sidebar/components/agent-lists.client.tsx
@@ -15,7 +15,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import DynamicAblyProvider from "@/contexts/alby-provider.dynamic";
-import { JobStatusData, makeAgentJobsChannel } from "@/lib/ably";
+import { JobIndicatorStatus, makeAgentJobsChannel } from "@/lib/ably";
 import { AgentWithAvailability, getAgentName } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
@@ -26,7 +26,7 @@ interface AgentListsClientProps {
     groupKey: string;
     title: string;
     agents: AgentWithAvailability[];
-    initialJobStatusDataList: (JobStatusData | null)[];
+    initialJobIndicatorStatuses: (JobIndicatorStatus | null)[];
     noAgentsType: string;
   }[];
   userId: string;
@@ -48,7 +48,7 @@ export default function AgentListsClient({
           groupKey,
           title,
           agents,
-          initialJobStatusDataList,
+          initialJobIndicatorStatuses,
           noAgentsType,
         }) => (
           <SidebarGroup key={groupKey} className="w-72 md:w-64">
@@ -58,8 +58,8 @@ export default function AgentListsClient({
                 <SidebarMenu>
                   {agents.map((agentWithAvailability, index) => {
                     const { agent, isAvailable } = agentWithAvailability;
-                    const initialJobStatusData =
-                      initialJobStatusDataList[index];
+                    const initialJobIndicatorStatus =
+                      initialJobIndicatorStatuses[index];
 
                     return (
                       <SidebarMenuItem key={agent.id}>
@@ -95,7 +95,9 @@ export default function AgentListsClient({
                                   <AgentJobStatusIndicator
                                     agentId={agent.id}
                                     userId={userId}
-                                    initialJobStatusData={initialJobStatusData}
+                                    initialJobIndicatorStatus={
+                                      initialJobIndicatorStatus
+                                    }
                                     className={cn("h-4 w-4", {
                                       "text-primary-foreground":
                                         agentId === agent.id,

--- a/web-app/src/app/(app)/components/sidebar/components/agent-lists.tsx
+++ b/web-app/src/app/(app)/components/sidebar/components/agent-lists.tsx
@@ -69,14 +69,12 @@ async function AgentListsContent() {
     favoriteAgents,
   );
 
-  const [favoriteAgentsJobStatusDataList, hiredAgentsJobStatusDataList] =
+  const [favoriteAgentsJobIndicatorStatuses, hiredAgentsJobIndicatorStatuses] =
     await Promise.all([
-      jobService.getJobStatusIndicatorStatuses(
+      jobService.getJobIndicatorStatuses(
         favoriteAgents.map((agent) => agent.id),
       ),
-      jobService.getJobStatusIndicatorStatuses(
-        hiredAgents.map((agent) => agent.id),
-      ),
+      jobService.getJobIndicatorStatuses(hiredAgents.map((agent) => agent.id)),
     ]);
 
   // Determine availability for each agent
@@ -102,14 +100,14 @@ async function AgentListsContent() {
       groupKey: "favorite-agents",
       title: t("pinnedTitle"),
       agents: favoriteAgentsWithAvailability,
-      initialJobIndicatorStatuses: favoriteAgentsJobStatusDataList,
+      initialJobIndicatorStatuses: favoriteAgentsJobIndicatorStatuses,
       noAgentsType: t("pinnedType"),
     },
     {
       groupKey: "hired-agents",
       title: t("hiredTitle"),
       agents: hiredAgentsWithAvailability,
-      initialJobIndicatorStatuses: hiredAgentsJobStatusDataList,
+      initialJobIndicatorStatuses: hiredAgentsJobIndicatorStatuses,
       noAgentsType: t("hiredType"),
     },
   ];

--- a/web-app/src/app/(app)/components/sidebar/components/agent-lists.tsx
+++ b/web-app/src/app/(app)/components/sidebar/components/agent-lists.tsx
@@ -71,10 +71,10 @@ async function AgentListsContent() {
 
   const [favoriteAgentsJobStatusDataList, hiredAgentsJobStatusDataList] =
     await Promise.all([
-      jobService.getAgentJobStatusDataListByAgentIds(
+      jobService.getJobStatusIndicatorStatuses(
         favoriteAgents.map((agent) => agent.id),
       ),
-      jobService.getAgentJobStatusDataListByAgentIds(
+      jobService.getJobStatusIndicatorStatuses(
         hiredAgents.map((agent) => agent.id),
       ),
     ]);
@@ -102,14 +102,14 @@ async function AgentListsContent() {
       groupKey: "favorite-agents",
       title: t("pinnedTitle"),
       agents: favoriteAgentsWithAvailability,
-      initialJobStatusDataList: favoriteAgentsJobStatusDataList,
+      initialJobIndicatorStatuses: favoriteAgentsJobStatusDataList,
       noAgentsType: t("pinnedType"),
     },
     {
       groupKey: "hired-agents",
       title: t("hiredTitle"),
       agents: hiredAgentsWithAvailability,
-      initialJobStatusDataList: hiredAgentsJobStatusDataList,
+      initialJobIndicatorStatuses: hiredAgentsJobStatusDataList,
       noAgentsType: t("hiredType"),
     },
   ];

--- a/web-app/src/hooks/use-agent-job-status.ts
+++ b/web-app/src/hooks/use-agent-job-status.ts
@@ -3,8 +3,8 @@ import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
 import {
-  JobStatusData,
-  jobStatusDataSchema,
+  JobIndicatorStatus,
+  jobIndicatorStatusSchema,
   makeAgentJobsChannel,
 } from "@/lib/ably";
 
@@ -12,19 +12,19 @@ export default function useAgentJobStatus(
   agentId: string,
   userId: string,
   currentJobId: string | null,
-  initialJobStatusData: JobStatusData | null,
+  initialJobIndicatorStatus: JobIndicatorStatus | null,
   refresh: boolean = false,
 ) {
   const pathname = usePathname();
   const router = useRouter();
-  const [jobStatusData, setJobStatusData] = useState<JobStatusData | null>(
-    initialJobStatusData,
+  const [jobStatusData, setJobStatusData] = useState<JobIndicatorStatus | null>(
+    initialJobIndicatorStatus,
   );
 
   useChannel(makeAgentJobsChannel(agentId, userId), (message) => {
-    const parsedResult = jobStatusDataSchema.safeParse(message.data);
+    const parsedResult = jobIndicatorStatusSchema.safeParse(message.data);
     if (parsedResult.success) {
-      const jobId = parsedResult.data.id;
+      const jobId = parsedResult.data.jobId;
       if (currentJobId && jobId !== currentJobId) {
         return;
       }

--- a/web-app/src/lib/ably/publish.ts
+++ b/web-app/src/lib/ably/publish.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { getJobStatusData } from "@/lib/db";
+import { getJobIndicatorStatus } from "@/lib/db";
 import { Job } from "@/prisma/generated/client";
 
 import { getRestClient } from "./client";
@@ -11,5 +11,5 @@ export default async function publishJobStatusData(job: Job) {
   const channel = client.channels.get(
     makeAgentJobsChannel(job.agentId, job.userId),
   );
-  await channel.publish(getAgentJobsChannelName(), getJobStatusData(job));
+  await channel.publish(getAgentJobsChannelName(), getJobIndicatorStatus(job));
 }

--- a/web-app/src/lib/ably/schema.ts
+++ b/web-app/src/lib/ably/schema.ts
@@ -2,10 +2,10 @@ import { z } from "zod";
 
 import { JobStatus } from "@/lib/db";
 
-export const jobStatusDataSchema = z.object({
-  id: z.string().min(1),
+export const jobIndicatorStatusSchema = z.object({
+  jobId: z.string().min(1),
   jobStatus: z.nativeEnum(JobStatus),
   jobStatusSettled: z.boolean(),
 });
 
-export type JobStatusData = z.infer<typeof jobStatusDataSchema>;
+export type JobIndicatorStatus = z.infer<typeof jobIndicatorStatusSchema>;

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -1,4 +1,4 @@
-import { JobStatusData } from "@/lib/ably";
+import { JobIndicatorStatus } from "@/lib/ably";
 import { JobStatus } from "@/lib/db/types";
 import {
   AgentJobStatus,
@@ -120,9 +120,9 @@ export function computeJobStatus(job: Job): JobStatus {
  * @param job - The job to get the status data for.
  * @returns The job status data.
  */
-export function getJobStatusData(job: Job): JobStatusData {
+export function getJobIndicatorStatus(job: Job): JobIndicatorStatus {
   return {
-    id: job.id,
+    jobId: job.id,
     jobStatus: computeJobStatus(job),
     jobStatusSettled: new Date() > job.externalDisputeUnlockTime,
   };

--- a/web-app/src/lib/services/job.service.ts
+++ b/web-app/src/lib/services/job.service.ts
@@ -4,14 +4,14 @@ import * as Sentry from "@sentry/nextjs";
 import { v4 as uuidv4 } from "uuid";
 
 import publishJobStatusData from "@/lib/ably/publish";
-import { JobStatusData } from "@/lib/ably/schema";
+import { JobIndicatorStatus } from "@/lib/ably/schema";
 import { JobError, JobErrorCode } from "@/lib/actions/types/error-codes/job";
 import { getSession } from "@/lib/auth/utils";
 import { agentClient, paymentClient } from "@/lib/clients";
 import { anthropicClient } from "@/lib/clients/anthropic.client";
 import {
   computeJobStatus,
-  getJobStatusData,
+  getJobIndicatorStatus,
   JobStatus,
   JobWithStatus,
 } from "@/lib/db";
@@ -800,10 +800,10 @@ export const jobService = (() => {
    *
    * If the user session is not found, returns an empty array.
    */
-  const getAgentJobStatusDataListByAgentIds = async (
+  const getJobStatusIndicatorStatuses = async (
     agentIds: string[],
     tx: Prisma.TransactionClient = prisma,
-  ): Promise<(JobStatusData | null)[]> => {
+  ): Promise<(JobIndicatorStatus | null)[]> => {
     const session = await getSession();
     if (!session) {
       return [];
@@ -823,7 +823,7 @@ export const jobService = (() => {
         if (!latestJob) {
           return null;
         }
-        return getJobStatusData(latestJob);
+        return getJobIndicatorStatus(latestJob);
       }),
     );
   };
@@ -832,6 +832,6 @@ export const jobService = (() => {
     startJob,
     requestRefund,
     syncJob,
-    getAgentJobStatusDataListByAgentIds,
+    getJobStatusIndicatorStatuses,
   };
 })();

--- a/web-app/src/lib/services/job.service.ts
+++ b/web-app/src/lib/services/job.service.ts
@@ -800,7 +800,7 @@ export const jobService = (() => {
    *
    * If the user session is not found, returns an empty array.
    */
-  const getJobStatusIndicatorStatuses = async (
+  const getJobIndicatorStatuses = async (
     agentIds: string[],
     tx: Prisma.TransactionClient = prisma,
   ): Promise<(JobIndicatorStatus | null)[]> => {
@@ -832,6 +832,6 @@ export const jobService = (() => {
     startJob,
     requestRefund,
     syncJob,
-    getJobStatusIndicatorStatuses,
+    getJobIndicatorStatuses,
   };
 })();


### PR DESCRIPTION
## Summary

This PR renames `JobStatusData` to `JobIndicatorStatus` throughout the codebase to improve naming clarity and consistency. The rename better reflects the data structure's purpose as status information specifically used for job indicators in the UI.

## Key Changes

- **Type Rename**: `JobStatusData` → `JobIndicatorStatus`
- **Schema Update**: `jobStatusDataSchema` → `jobIndicatorStatusSchema` 
- **Property Rename**: `id` → `jobId` in the status object for better semantic clarity
- **Function Rename**: `getJobStatusData()` → `getJobIndicatorStatus()`
- **Service Method**: `getAgentJobStatusDataListByAgentIds()` → `getJobStatusIndicatorStatuses()`

## Files Modified

- `src/lib/ably/schema.ts` - Core type and schema definitions
- `src/lib/db/helpers/job.ts` - Helper function rename
- `src/lib/services/job.service.ts` - Service method updates
- `src/hooks/use-agent-job-status.ts` - Hook implementation updates
- `src/lib/ably/publish.ts` - Publishing logic updates
- Multiple UI components updated to use new naming:
  - `agent-job-status-indicator.tsx`
  - `agent-lists.client.tsx` 
  - `agent-lists.tsx`
  - `job-columns.tsx`

## Benefits

- **Improved Clarity**: The new name `JobIndicatorStatus` more clearly indicates its purpose for UI status indicators
- **Better Semantics**: `jobId` property name is more descriptive than generic `id`
- **Consistency**: Aligns naming convention with the component and feature it serves
- **Maintainability**: More intuitive for developers working with job status UI components

🤖 Generated with [Claude Code](https://claude.ai/code)