### PR TITLE
refactor(auth): migrate Plausible events from CSS to JavaScript implementation

### DIFF
--- a/web-app/src/app/(auth)/components/form/auth-form.tsx
+++ b/web-app/src/app/(auth)/components/form/auth-form.tsx
@@ -16,7 +16,6 @@ interface AuthFormProps<T extends FieldValues> {
   prefilledOrganization?: OrganizationWithRelations | null;
   namespace: AuthNamespace;
   onSubmit: (values: T) => Promise<void>;
-  submitEventName?: string;
   organizations?: OrganizationWithRelations[] | undefined;
   children: ReactNode;
   className?: string;
@@ -28,18 +27,12 @@ export function AuthForm<T extends FieldValues>({
   prefilledOrganization,
   namespace,
   onSubmit,
-  submitEventName,
   children,
 
   className,
 }: AuthFormProps<T>) {
   return (
-    <BaseForm
-      form={form}
-      onSubmit={onSubmit}
-      submitEventName={submitEventName}
-      className={className}
-    >
+    <BaseForm form={form} onSubmit={onSubmit} className={className}>
       <FormFields
         form={form}
         formData={formData}

--- a/web-app/src/app/(auth)/components/form/base-form.tsx
+++ b/web-app/src/app/(auth)/components/form/base-form.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/utils";
 interface BaseFormProps<T extends FieldValues> {
   form: UseFormReturn<T>;
   onSubmit: (values: T) => Promise<void>;
-  submitEventName?: string;
   children: ReactNode;
   className?: string;
 }
@@ -17,19 +16,12 @@ interface BaseFormProps<T extends FieldValues> {
 export function BaseForm<T extends FieldValues>({
   form,
   onSubmit,
-  submitEventName,
   children,
   className,
 }: BaseFormProps<T>) {
   return (
     <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className={cn(
-          submitEventName && `plausible-event-name=${submitEventName}`,
-          className,
-        )}
-      >
+      <form onSubmit={form.handleSubmit(onSubmit)} className={cn(className)}>
         <fieldset
           disabled={form.formState.isSubmitting}
           className="flex flex-col gap-3"

--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { usePlausible } from "next-plausible";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -25,6 +26,7 @@ export default function SignInForm({
   const t = useTranslations("Auth.Pages.SignIn.Form");
 
   const router = useRouter();
+  const plausible = usePlausible();
 
   const form = useForm<SignInFormSchemaType>({
     resolver: zodResolver(
@@ -74,6 +76,7 @@ export default function SignInForm({
         // Invalid URL, fallback to /agents
       }
     }
+    plausible("SignIn");
     router.push(redirectUrl);
   };
 
@@ -90,7 +93,6 @@ export default function SignInForm({
       formData={signInFormData}
       namespace="Auth.Pages.SignIn.Form"
       onSubmit={handleSubmit}
-      submitEventName="SignIn"
     >
       <div className="flex flex-col gap-4">
         <SubmitButton form={form} label={t("submit")} className="w-full" />

--- a/web-app/src/app/(auth)/login/components/form.tsx
+++ b/web-app/src/app/(auth)/login/components/form.tsx
@@ -76,8 +76,7 @@ export default function SignInForm({
         // Invalid URL, fallback to /agents
       }
     }
-    plausible("SignIn");
-    router.push(redirectUrl);
+    plausible("SignIn", { callback: () => router.push(redirectUrl) });
   };
 
   const email = form.watch("email");

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -71,9 +71,8 @@ export default function SignUpForm({
     );
 
     if (result.ok) {
-      plausible("Signup");
+      plausible("Signup", { callback: () => router.push("/login") });
       toast.success(t("success"));
-      router.push("/login");
     } else {
       switch (result.error.code) {
         case CommonErrorCode.BAD_INPUT:

--- a/web-app/src/app/(auth)/register/components/form.tsx
+++ b/web-app/src/app/(auth)/register/components/form.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { usePlausible } from "next-plausible";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -28,6 +29,7 @@ export default function SignUpForm({
   const t = useTranslations("Auth.Pages.SignUp.Form");
 
   const router = useRouter();
+  const plausible = usePlausible();
   const form = useForm<SignUpFormSchemaType>({
     resolver: zodResolver(
       signUpFormSchema(useTranslations("Library.Auth.Schema")),
@@ -69,6 +71,7 @@ export default function SignUpForm({
     );
 
     if (result.ok) {
+      plausible("Signup");
       toast.success(t("success"));
       router.push("/login");
     } else {
@@ -116,7 +119,6 @@ export default function SignUpForm({
       prefilledOrganization={prefilledOrganization}
       namespace="Auth.Pages.SignUp.Form"
       onSubmit={handleSubmit}
-      submitEventName="Signup"
     >
       <div className="flex flex-col gap-4">
         <SubmitButton


### PR DESCRIPTION
## Summary

Refactored authentication forms to use Plausible's JavaScript API with callback-based navigation instead of CSS class-based event tracking. This ensures analytics events are properly tracked before navigation occurs and only fire on successful authentication.

Linear Issue: [DEV-427](https://linear.app/nmkr/issue/DEV-427/signup-event-is-not-tracked)

## Key Changes

- **Removed** `submitEventName` prop from `AuthForm` and `BaseForm` components (reduced prop drilling)
- **Updated** SignIn and SignUp forms to use `usePlausible` hook with callback pattern
- **Improved** event tracking reliability by using Plausible's callback feature for post-event navigation
- **Simplified** form components by removing unnecessary event tracking props

## Architecture Benefits

1. **Better Separation of Concerns**: Analytics tracking is now handled where the business logic resides (SignIn/SignUp components) rather than in generic form components
2. **More Accurate Analytics**: Events only fire on successful authentication, providing cleaner data
3. **Improved Reliability**: Using Plausible's callback ensures events are tracked before navigation

## Technical Implementation

### Before
```tsx
// Events tracked via CSS classes
<BaseForm submitEventName="SignIn" className="plausible-event-name=SignIn">
```

### After  
```tsx
// Events tracked programmatically with callbacks
plausible("SignIn", { callback: () => router.push(redirectTo) })
```

The callback pattern ensures the analytics event is sent before the user is redirected, preventing potential event loss during navigation.

## Files Changed

- `web-app/src/app/(auth)/components/form/auth-form.tsx` - Removed submitEventName prop
- `web-app/src/app/(auth)/components/form/base-form.tsx` - Removed event tracking logic
- `web-app/src/app/(auth)/login/components/form.tsx` - Added Plausible hook with callback
- `web-app/src/app/(auth)/register/components/form.tsx` - Added Plausible hook with callback

## Testing Checklist

- [x] Login form successfully tracks "SignIn" event on successful authentication
- [x] Registration form successfully tracks "Signup" event on successful registration  
- [x] Failed authentication attempts do not trigger analytics events
- [x] Navigation occurs after event tracking completes
- [x] Forms continue to function normally without regression

🤖 Generated with [Claude Code](https://claude.ai/code)