### PR TITLE
fix(jobs): show failed status immediately when agent job fails

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1010,7 +1010,7 @@
           "Output": {
             "title": "Output",
             "failedToParseOutput": "Failed to parse output",
-            "none": "No result data",
+            "none": "No output available",
             "download": "Download",
             "copy": "Copy",
             "copySuccess": "Output copied to clipboard",

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1031,11 +1031,15 @@
               "Tooltip": {
                 "available": {
                   "title": "Refund available",
-                  "description": "You can request a manual refund starting {unlockAt}. If no result is submitted, an automatic refund will be processed at that time."
+                  "description": "You can request a refund until {unlockAt}."
                 },
                 "unavailable": {
-                  "title": "Refund not yet available",
-                  "description": "Manual refund will be available at {unlockAt}. If the agent doesn't submit a result by then, an automatic refund will be processed."
+                  "title": "Refund no longer available",
+                  "description": "You could have requested a refund until {unlockAt}."
+                },
+                "failed": {
+                  "title": "Automatic refund pending",
+                  "description": "An automatic refund will be processed at {unlockAt}"
                 }
               },
               "Errors": {

--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1031,11 +1031,11 @@
               "Tooltip": {
                 "available": {
                   "title": "Refund available",
-                  "description": "You can request a refund until {unlockAt}."
+                  "description": "You can request a manual refund starting {unlockAt}. If no result is submitted, an automatic refund will be processed at that time."
                 },
                 "unavailable": {
-                  "title": "Refund no longer available",
-                  "description": "You could have requested a refund until {unlockAt}."
+                  "title": "Refund not yet available",
+                  "description": "Manual refund will be available at {unlockAt}. If the agent doesn't submit a result by then, an automatic refund will be processed."
                 }
               },
               "Errors": {

--- a/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -199,67 +199,70 @@ export default function RequestRefundButton({
     setIsDialogOpen(false);
   };
 
-  const buttonElement = (
-    <div>
-      <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <AlertDialogTrigger asChild>
-          <ButtonBase
-            disabled={
-              isLoading || isRefundDisabled || isRefundRequested || isFailed
-            }
-            className={className}
-          >
-            {isLoading ? (
-              <LoaderCircle className="h-4 w-4 animate-spin" />
-            ) : (
-              <HandCoins className="h-4 w-4" />
-            )}
-            {t("request")}
-          </ButtonBase>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("confirmDescription")}
-              <div className="mt-2">
-                <a
-                  href="https://docs.masumi.network/core-concepts/refunds-and-disputes"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary flex items-center gap-1 hover:underline"
-                >
-                  {t("learnMore")}
-                  <ExternalLink className="h-3 w-3" />
-                </a>
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleRefundRequest}>
-              {t("confirm")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-      {error && <p className="text-xs text-red-500">{t("error")}</p>}
-    </div>
-  );
-
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span tabIndex={0}>{buttonElement}</span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <div className="space-y-1">
-            <h4 className="text-sm font-medium">{title}</h4>
-            <p className="text-muted-foreground text-xs">{description}</p>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0}>
+              <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+                <AlertDialogTrigger asChild>
+                  <ButtonBase
+                    disabled={
+                      isLoading ||
+                      isRefundDisabled ||
+                      isRefundRequested ||
+                      isFailed
+                    }
+                    className={className}
+                  >
+                    {isLoading ? (
+                      <LoaderCircle className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <HandCoins className="h-4 w-4" />
+                    )}
+                    {t("request")}
+                  </ButtonBase>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t("confirmDescription")}
+                      <span className="mt-2 block">
+                        <a
+                          href="https://docs.masumi.network/core-concepts/refunds-and-disputes"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary flex items-center gap-1 hover:underline"
+                        >
+                          {t("learnMore")}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </span>
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleRefundRequest}>
+                      {t("confirm")}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="space-y-1">
+              <h4 className="text-sm font-medium">{title}</h4>
+              <p className="text-muted-foreground text-xs">{description}</p>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      {error && (
+        <p className="text-semantic-destructive text-xs">{t("error")}</p>
+      )}
+    </>
   );
 }

--- a/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -204,7 +204,9 @@ export default function RequestRefundButton({
       <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <AlertDialogTrigger asChild>
           <ButtonBase
-            disabled={isLoading || isRefundDisabled || isRefundRequested}
+            disabled={
+              isLoading || isRefundDisabled || isRefundRequested || isFailed
+            }
             className={className}
           >
             {isLoading ? (

--- a/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -67,11 +67,11 @@ function ButtonBase({
 
 function makeTitleAndDescription(
   isRefundDisabled: boolean,
-  unlockTime: Date,
+  refundAvailableTime: Date,
   t: IntlTranslation<"App.Agents.Jobs.JobDetails.Output.Refund">,
   formatter: IntlDateFormatter,
 ) {
-  const unlockTimeFormatted = formatter.dateTime(unlockTime, {
+  const refundAvailableTimeFormatted = formatter.dateTime(refundAvailableTime, {
     dateStyle: "medium",
     timeStyle: "short",
   });
@@ -80,13 +80,13 @@ function makeTitleAndDescription(
     ? {
         title: t("Tooltip.unavailable.title"),
         description: t("Tooltip.unavailable.description", {
-          unlockAt: unlockTimeFormatted,
+          unlockAt: refundAvailableTimeFormatted,
         }),
       }
     : {
         title: t("Tooltip.available.title"),
         description: t("Tooltip.available.description", {
-          unlockAt: unlockTimeFormatted,
+          unlockAt: refundAvailableTimeFormatted,
         }),
       };
 
@@ -129,10 +129,15 @@ export default function RequestRefundButton({
     );
   }
 
-  const isRefundDisabled = job.unlockTime.getTime() < Date.now();
+  const FIVE_MINUTES_MS = 5 * 60 * 1000;
+  const isRefundDisabled =
+    job.submitResultTime.getTime() + FIVE_MINUTES_MS > Date.now();
+  const submitResultTimeWithBuffer = new Date(
+    job.submitResultTime.getTime() + FIVE_MINUTES_MS,
+  );
   const { title, description } = makeTitleAndDescription(
     isRefundDisabled,
-    job.unlockTime,
+    submitResultTimeWithBuffer,
     t,
     formatter,
   );

--- a/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
+++ b/web-app/src/app/(app)/agents/[agentId]/jobs/@right/components/job-details/refund-request.tsx
@@ -30,7 +30,7 @@ import {
   JobErrorCode,
   requestRefundJobByBlockchainIdentifier,
 } from "@/lib/actions";
-import { JobWithStatus } from "@/lib/db";
+import { JobStatus, JobWithStatus } from "@/lib/db";
 import { cn } from "@/lib/utils";
 import { NextJobAction, OnChainJobStatus } from "@/prisma/generated/client";
 
@@ -67,11 +67,29 @@ function ButtonBase({
 
 function makeTitleAndDescription(
   isRefundDisabled: boolean,
-  refundAvailableTime: Date,
+  isFailed: boolean,
+  unlockTime: Date,
+  submitResultTime: Date,
   t: IntlTranslation<"App.Agents.Jobs.JobDetails.Output.Refund">,
   formatter: IntlDateFormatter,
 ) {
-  const refundAvailableTimeFormatted = formatter.dateTime(refundAvailableTime, {
+  if (isFailed) {
+    // Use submitResultTime for failed jobs (automatic refund timing)
+    const submitResultTimeFormatted = formatter.dateTime(submitResultTime, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+
+    return {
+      title: t("Tooltip.failed.title"),
+      description: t("Tooltip.failed.description", {
+        unlockAt: submitResultTimeFormatted,
+      }),
+    };
+  }
+
+  // Use unlockTime for available/unavailable states
+  const unlockTimeFormatted = formatter.dateTime(unlockTime, {
     dateStyle: "medium",
     timeStyle: "short",
   });
@@ -80,13 +98,13 @@ function makeTitleAndDescription(
     ? {
         title: t("Tooltip.unavailable.title"),
         description: t("Tooltip.unavailable.description", {
-          unlockAt: refundAvailableTimeFormatted,
+          unlockAt: unlockTimeFormatted,
         }),
       }
     : {
         title: t("Tooltip.available.title"),
         description: t("Tooltip.available.description", {
-          unlockAt: refundAvailableTimeFormatted,
+          unlockAt: unlockTimeFormatted,
         }),
       };
 
@@ -129,15 +147,13 @@ export default function RequestRefundButton({
     );
   }
 
-  const FIVE_MINUTES_MS = 5 * 60 * 1000;
-  const isRefundDisabled =
-    job.submitResultTime.getTime() + FIVE_MINUTES_MS > Date.now();
-  const submitResultTimeWithBuffer = new Date(
-    job.submitResultTime.getTime() + FIVE_MINUTES_MS,
-  );
+  const isRefundDisabled = job.unlockTime.getTime() < Date.now();
+  const isFailed = job.status === JobStatus.FAILED;
   const { title, description } = makeTitleAndDescription(
     isRefundDisabled,
-    submitResultTimeWithBuffer,
+    isFailed,
+    job.unlockTime,
+    job.submitResultTime,
     t,
     formatter,
   );

--- a/web-app/src/lib/db/helpers/job.ts
+++ b/web-app/src/lib/db/helpers/job.ts
@@ -32,6 +32,8 @@ function getFundsLockedJobStatus(
       return JobStatus.INPUT_REQUIRED;
     case AgentJobStatus.COMPLETED:
       return JobStatus.COMPLETED;
+    case AgentJobStatus.FAILED:
+      return JobStatus.FAILED;
     default:
       // Check for FAILED status first (highest priority)
       if (

--- a/web-app/src/lib/db/types/job.ts
+++ b/web-app/src/lib/db/types/job.ts
@@ -47,6 +47,7 @@ export const finalizedOnChainJobStatuses: OnChainJobStatus[] = [
 
 export const finalizedAgentJobStatuses: AgentJobStatus[] = [
   AgentJobStatus.COMPLETED,
+  AgentJobStatus.FAILED,
 ];
 
 export type JobWithStatus = JobWithRelations & {


### PR DESCRIPTION
## Summary

This PR fixes issue DEV-405 where agent jobs that fail don't update their status correctly in the UI. When the agent API returns "failed" status, the UI now immediately shows the failed state instead of continuing to show "processing".

## Key Changes

### 1. Job Status Computation (`src/lib/db/helpers/job.ts`)
- Added `AgentJobStatus.FAILED` case to `getFundsLockedJobStatus()` to immediately return `JobStatus.FAILED` when agent reports failure
- This ensures failed jobs are properly recognized in the UI instead of showing as "processing"

### 2. Refund Button Logic (`refund-request.tsx`)
- Added special "failed" state for tooltip that uses `submitResultTime` to show when automatic refund will occur
- Disabled refund button for failed jobs (since automatic refund is pending)
- Fixed HTML validation error by replacing `<div>` with `<span className="mt-2 block">` inside AlertDialogDescription

### 3. Output Display (`outputs.tsx`) 
- Show refund button for failed jobs even when no output is generated
- This ensures users can see refund status for all failed jobs

### 4. Internationalization (`messages/en.json`)
- Added new tooltip messages for failed job state explaining automatic refund timing
- Updated "No result data" to "No output available" for clarity

### 5. Type Updates (`src/lib/db/types/job.ts`)
- Added `AgentJobStatus.FAILED` to `finalizedAgentJobStatuses` array for consistency

## Technical Details

The core issue was that when an agent job failed (API returned status "failed"), the `getFundsLockedJobStatus()` function didn't handle this case explicitly. It would fall through to the default case and only mark jobs as failed after timeout periods expired. 

Now when `agentJobStatus === AgentJobStatus.FAILED`, we immediately return `JobStatus.FAILED`, ensuring the UI reflects the actual job state in real-time.

The refund button tooltip now has three states:
1. **Available**: Manual refund can be requested (before `unlockTime`)
2. **Unavailable**: Manual refund period expired (after `unlockTime`)  
3. **Failed**: Automatic refund pending (shows `submitResultTime`)

## Testing

To test these changes:
1. Submit a job that will fail
2. Verify the job immediately shows "Failed" status when the agent returns failure
3. Check that the refund button is visible but disabled with appropriate tooltip
4. Verify the refund dialog opens without HTML validation errors
5. Confirm automatic refund messaging shows the correct timing

## Linear Issue

Fixes [DEV-405](https://linear.app/masumi-network/issue/DEV-405/agent-status-failed-not-updating-correctly)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>