### PR TITLE
fix: show only one latest invitation per user

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2384,55 +2384,55 @@ packages:
     resolution: {integrity: sha512-LeARs8qHhEw19tk+KZd9DDV+Rh/UeapIH0+C09fTmff9p8Y82Cj89pEQ2a1rdUiF/oYIjQX45vnZscB7ra42yw==}
     engines: {node: '>= 14'}
 
-  '@sentry/cli-darwin@2.51.1':
-    resolution: {integrity: sha512-R1u8IQdn/7Rr8sf6bVVr0vJT4OqwCFdYsS44Y3OoWGVJW2aAQTWRJOTlV4ueclVLAyUQzmgBjfR8AtiUhd/M5w==}
+  '@sentry/cli-darwin@2.50.2':
+    resolution: {integrity: sha512-0Pjpl0vQqKhwuZm19z6AlEF+ds3fJg1KWabv8WzGaSc/fwxMEwjFwOZj+IxWBJPV578cXXNvB39vYjjpCH8j7A==}
     engines: {node: '>=10'}
     os: [darwin]
 
-  '@sentry/cli-linux-arm64@2.51.1':
-    resolution: {integrity: sha512-nvA/hdhsw4bKLhslgbBqqvETjXwN1FVmwHLOrRvRcejDO6zeIKUElDiL5UOjGG0NC+62AxyNw5ri8Wzp/7rg9Q==}
+  '@sentry/cli-linux-arm64@2.50.2':
+    resolution: {integrity: sha512-03Cj215M3IdoHAwevCxm5oOm9WICFpuLR05DQnODFCeIUsGvE1pZsc+Gm0Ky/ZArq2PlShBJTpbHvXbCUka+0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm@2.51.1':
-    resolution: {integrity: sha512-Klro17OmSSKOOSaxVKBBNPXet2+HrIDZUTSp8NRl4LQsIubdc1S/aQ79cH/g52Muwzpl3aFwPxyXw+46isfEgA==}
+  '@sentry/cli-linux-arm@2.50.2':
+    resolution: {integrity: sha512-jzFwg9AeeuFAFtoCcyaDEPG05TU02uOy1nAX09c1g7FtsyQlPcbhI94JQGmnPzdRjjDmORtwIUiVZQrVTkDM7w==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-i686@2.51.1':
-    resolution: {integrity: sha512-jp4TmR8VXBdT9dLo6mHniQHN0xKnmJoPGVz9h9VDvO2Vp/8o96rBc555D4Am5wJOXmfuPlyjGcmwHlB3+kQRWw==}
+  '@sentry/cli-linux-i686@2.50.2':
+    resolution: {integrity: sha512-J+POvB34uVyHbIYF++Bc/OCLw+gqKW0H/y/mY7rRZCiocgpk266M4NtsOBl6bEaurMx1D+BCIEjr4nc01I/rqA==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-x64@2.51.1':
-    resolution: {integrity: sha512-JuLt0MXM2KHNFmjqXjv23sly56mJmUQzGBWktkpY3r+jE08f5NLKPd5wQ6W/SoLXGIOKnwLz0WoUg7aBVyQdeQ==}
+  '@sentry/cli-linux-x64@2.50.2':
+    resolution: {integrity: sha512-81yQVRLj8rnuHoYcrM7QbOw8ubA3weiMdPtTxTim1s6WExmPgnPTKxLCr9xzxGJxFdYo3xIOhtf5JFpUX/3j4A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-win32-arm64@2.51.1':
-    resolution: {integrity: sha512-PiwjTdIFDazTQCTyDCutiSkt4omggYSKnO3HE1+LDjElsFrWY9pJs4fU3D40WAyE2oKu0MarjNH/WxYGdqEAlg==}
+  '@sentry/cli-win32-arm64@2.50.2':
+    resolution: {integrity: sha512-QjentLGvpibgiZlmlV9ifZyxV73lnGH6pFZWU5wLeRiaYKxWtNrrHpVs+HiWlRhkwQ0mG1/S40PGNgJ20DJ3gA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@sentry/cli-win32-i686@2.51.1':
-    resolution: {integrity: sha512-TMvZZpeiI2HmrDFNVQ0uOiTuYKvjEGOZdmUxe3WlhZW82A/2Oka7sQ24ljcOovbmBOj5+fjCHRUMYvLMCWiysA==}
+  '@sentry/cli-win32-i686@2.50.2':
+    resolution: {integrity: sha512-UkBIIzkQkQ1UkjQX8kHm/+e7IxnEhK6CdgSjFyNlxkwALjDWHJjMztevqAPz3kv4LdM6q1MxpQ/mOqXICNhEGg==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [win32]
 
-  '@sentry/cli-win32-x64@2.51.1':
-    resolution: {integrity: sha512-v2hreYUPPTNK1/N7+DeX7XBN/zb7p539k+2Osf0HFyVBaoUC3Y3+KBwSf4ASsnmgTAK7HCGR+X0NH1vP+icw4w==}
+  '@sentry/cli-win32-x64@2.50.2':
+    resolution: {integrity: sha512-tE27pu1sRRub1Jpmemykv3QHddBcyUk39Fsvv+n4NDpQyMgsyVPcboxBZyby44F0jkpI/q3bUH2tfCB1TYDNLg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@sentry/cli@2.51.1':
-    resolution: {integrity: sha512-FU+54kNcKJABU0+ekvtnoXHM9zVrDe1zXVFbQT7mS0On0m1P0zFRGdzbnWe2XzpzuEAJXtK6aog/W+esRU9AIA==}
+  '@sentry/cli@2.50.2':
+    resolution: {integrity: sha512-m1L9shxutF3WHSyNld6Y1vMPoXfEyQhoRh1V3SYSdl+4AB40U+zr2sRzFa2OPm7XP4zYNaWuuuHLkY/iHITs8Q==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -3321,23 +3321,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.25.2:
-    resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.25.2:
-    resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.25.2:
-    resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.25.2:
-    resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
+  browserslist@4.25.1:
+    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3401,9 +3386,6 @@ packages:
 
   caniuse-lite@1.0.30001731:
     resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
-
-  caniuse-lite@1.0.30001734:
-    resolution: {integrity: sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==}
 
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -3746,17 +3728,8 @@ packages:
   effect@3.16.12:
     resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
 
-  electron-to-chromium@1.5.199:
-    resolution: {integrity: sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==}
-
-  electron-to-chromium@1.5.199:
-    resolution: {integrity: sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==}
-
-  electron-to-chromium@1.5.199:
-    resolution: {integrity: sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==}
-
-  electron-to-chromium@1.5.199:
-    resolution: {integrity: sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==}
+  electron-to-chromium@1.5.198:
+    resolution: {integrity: sha512-G5COfnp3w+ydVu80yprgWSfmfQaYRh9DOxfhAxstLyetKaLyl55QrNjx8C38Pc/C+RaDmb1M0Lk8wPEMQ+bGgQ==}
 
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
@@ -6546,7 +6519,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.2
+      browserslist: 4.25.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -8672,7 +8645,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@sentry/babel-plugin-component-annotate': 4.0.2
-      '@sentry/cli': 2.51.1
+      '@sentry/cli': 2.50.2
       dotenv: 16.6.1
       find-up: 5.0.0
       glob: 9.3.5
@@ -8682,31 +8655,31 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/cli-darwin@2.51.1':
+  '@sentry/cli-darwin@2.50.2':
     optional: true
 
-  '@sentry/cli-linux-arm64@2.51.1':
+  '@sentry/cli-linux-arm64@2.50.2':
     optional: true
 
-  '@sentry/cli-linux-arm@2.51.1':
+  '@sentry/cli-linux-arm@2.50.2':
     optional: true
 
-  '@sentry/cli-linux-i686@2.51.1':
+  '@sentry/cli-linux-i686@2.50.2':
     optional: true
 
-  '@sentry/cli-linux-x64@2.51.1':
+  '@sentry/cli-linux-x64@2.50.2':
     optional: true
 
-  '@sentry/cli-win32-arm64@2.51.1':
+  '@sentry/cli-win32-arm64@2.50.2':
     optional: true
 
-  '@sentry/cli-win32-i686@2.51.1':
+  '@sentry/cli-win32-i686@2.50.2':
     optional: true
 
-  '@sentry/cli-win32-x64@2.51.1':
+  '@sentry/cli-win32-x64@2.50.2':
     optional: true
 
-  '@sentry/cli@2.51.1':
+  '@sentry/cli@2.50.2':
     dependencies:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
@@ -8714,14 +8687,14 @@ snapshots:
       proxy-from-env: 1.1.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 2.51.1
-      '@sentry/cli-linux-arm': 2.51.1
-      '@sentry/cli-linux-arm64': 2.51.1
-      '@sentry/cli-linux-i686': 2.51.1
-      '@sentry/cli-linux-x64': 2.51.1
-      '@sentry/cli-win32-arm64': 2.51.1
-      '@sentry/cli-win32-i686': 2.51.1
-      '@sentry/cli-win32-x64': 2.51.1
+      '@sentry/cli-darwin': 2.50.2
+      '@sentry/cli-linux-arm': 2.50.2
+      '@sentry/cli-linux-arm64': 2.50.2
+      '@sentry/cli-linux-i686': 2.50.2
+      '@sentry/cli-linux-x64': 2.50.2
+      '@sentry/cli-win32-arm64': 2.50.2
+      '@sentry/cli-win32-i686': 2.50.2
+      '@sentry/cli-win32-x64': 2.50.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9754,33 +9727,12 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.25.2:
+  browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001734
-      electron-to-chromium: 1.5.199
+      caniuse-lite: 1.0.30001731
+      electron-to-chromium: 1.5.198
       node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.2)
-
-  browserslist@4.25.2:
-    dependencies:
-      caniuse-lite: 1.0.30001734
-      electron-to-chromium: 1.5.199
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.2)
-
-  browserslist@4.25.2:
-    dependencies:
-      caniuse-lite: 1.0.30001734
-      electron-to-chromium: 1.5.199
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.2)
-
-  browserslist@4.25.2:
-    dependencies:
-      caniuse-lite: 1.0.30001734
-      electron-to-chromium: 1.5.199
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.2)
+      update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
   bser@2.1.1:
     dependencies:
@@ -9858,8 +9810,6 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001731: {}
-
-  caniuse-lite@1.0.30001734: {}
 
   chalk@3.0.0:
     dependencies:
@@ -10168,13 +10118,7 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
 
-  electron-to-chromium@1.5.199: {}
-
-  electron-to-chromium@1.5.199: {}
-
-  electron-to-chromium@1.5.199: {}
-
-  electron-to-chromium@1.5.199: {}
+  electron-to-chromium@1.5.198: {}
 
   embla-carousel-react@8.6.0(react@19.1.1):
     dependencies:
@@ -13074,27 +13018,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  update-browserslist-db@1.1.3(browserslist@4.25.2):
+  update-browserslist-db@1.1.3(browserslist@4.25.1):
     dependencies:
-      browserslist: 4.25.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.1.3(browserslist@4.25.2):
-    dependencies:
-      browserslist: 4.25.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.1.3(browserslist@4.25.2):
-    dependencies:
-      browserslist: 4.25.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.1.3(browserslist@4.25.2):
-    dependencies:
-      browserslist: 4.25.2
+      browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -13208,7 +13134,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.15.0
       acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.25.2
+      browserslist: 4.25.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.3
       es-module-lexer: 1.7.0

--- a/web-app/src/app/(app)/organizations/[organizationSlug]/page.tsx
+++ b/web-app/src/app/(app)/organizations/[organizationSlug]/page.tsx
@@ -76,7 +76,7 @@ export default async function OrganizationPage({
   let pendingInvitations: Invitation[] = [];
   if (isOwnerOrAdmin) {
     try {
-      pendingInvitations = filterPendingInvitation(
+      pendingInvitations = organizationService.filterPendingInvitation(
         await auth.api.listInvitations({
           query: {
             organizationId: organization.id,
@@ -110,16 +110,4 @@ export default async function OrganizationPage({
       />
     </div>
   );
-}
-
-function filterPendingInvitation(invitations: Invitation[]): Invitation[] {
-  invitations.sort((a, b) => b.expiresAt.valueOf() - a.expiresAt.valueOf());
-  // Group by email and take the first (latest) invitation per email
-  const emailMap = new Map<string, Invitation>();
-  for (const invitation of invitations) {
-    if (!emailMap.has(invitation.email)) {
-      emailMap.set(invitation.email, invitation);
-    }
-  }
-  return Array.from(emailMap.values());
 }

--- a/web-app/src/app/(app)/organizations/[organizationSlug]/page.tsx
+++ b/web-app/src/app/(app)/organizations/[organizationSlug]/page.tsx
@@ -1,11 +1,10 @@
 import { Metadata } from "next";
-import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { MembersTable } from "@/components/members-table";
 import { OrganizationRoleBadge } from "@/components/organizations";
-import { auth, Invitation } from "@/lib/auth/auth";
+import { Invitation } from "@/lib/auth/auth";
 import { getSessionOrRedirect } from "@/lib/auth/utils";
 import { MemberRole } from "@/lib/db";
 import { organizationRepository } from "@/lib/db/repositories";
@@ -67,28 +66,22 @@ export default async function OrganizationPage({
     redirect("/organizations");
   }
 
-  const members = await organizationService.getOrganizationMembersWithUser(
-    organization.id,
-  );
-
   const isOwnerOrAdmin =
     member.role === MemberRole.OWNER || member.role === MemberRole.ADMIN;
   let pendingInvitations: Invitation[] = [];
   if (isOwnerOrAdmin) {
     try {
-      pendingInvitations = organizationService.filterPendingInvitation(
-        await auth.api.listInvitations({
-          query: {
-            organizationId: organization.id,
-          },
-          params: {},
-          headers: await headers(),
-        }),
+      pendingInvitations = await organizationService.getPendingInvitations(
+        organization.id,
       );
     } catch (error) {
       console.error("Failed to get pending invitations", error);
     }
   }
+
+  const members = await organizationService.getOrganizationMembersWithUser(
+    organization.id,
+  );
 
   return (
     <div className="container flex flex-col gap-8 md:p-8">

--- a/web-app/src/app/(app)/organizations/[organizationSlug]/page.tsx
+++ b/web-app/src/app/(app)/organizations/[organizationSlug]/page.tsx
@@ -1,14 +1,15 @@
 import { Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { MembersTable } from "@/components/members-table";
 import { OrganizationRoleBadge } from "@/components/organizations";
+import { auth, Invitation } from "@/lib/auth/auth";
 import { getSessionOrRedirect } from "@/lib/auth/utils";
 import { MemberRole } from "@/lib/db";
 import { organizationRepository } from "@/lib/db/repositories";
 import { organizationService, userService } from "@/lib/services";
-import { Invitation } from "@/prisma/generated/client";
 
 import OrganizationInformation from "./components/organization-information";
 import OrganizationInviteButton from "./components/organization-invite-button";
@@ -75,10 +76,15 @@ export default async function OrganizationPage({
   let pendingInvitations: Invitation[] = [];
   if (isOwnerOrAdmin) {
     try {
-      pendingInvitations =
-        await organizationService.getOrganizationPendingInvitations(
-          organization.id,
-        );
+      pendingInvitations = filterPendingInvitation(
+        await auth.api.listInvitations({
+          query: {
+            organizationId: organization.id,
+          },
+          params: {},
+          headers: await headers(),
+        }),
+      );
     } catch (error) {
       console.error("Failed to get pending invitations", error);
     }
@@ -104,4 +110,16 @@ export default async function OrganizationPage({
       />
     </div>
   );
+}
+
+function filterPendingInvitation(invitations: Invitation[]): Invitation[] {
+  invitations.sort((a, b) => b.expiresAt.valueOf() - a.expiresAt.valueOf());
+  // Group by email and take the first (latest) invitation per email
+  const emailMap = new Map<string, Invitation>();
+  for (const invitation of invitations) {
+    if (!emailMap.has(invitation.email)) {
+      emailMap.set(invitation.email, invitation);
+    }
+  }
+  return Array.from(emailMap.values());
 }

--- a/web-app/src/components/members-table/members-table.tsx
+++ b/web-app/src/components/members-table/members-table.tsx
@@ -3,9 +3,10 @@
 import { useTranslations } from "next-intl";
 
 import { DataTable } from "@/components/data-table";
+import { Invitation } from "@/lib/auth/auth";
 import { InvitationStatus, MemberRole, MemberWithUser } from "@/lib/db";
 import { cn } from "@/lib/utils";
-import { Invitation, Member } from "@/prisma/generated/client";
+import { Member } from "@/prisma/generated/client";
 
 import InvitationActionsModal from "./invitation-actions-modal";
 import { InvitationActionsModalContextProvider } from "./invitation-actions-modal-context";

--- a/web-app/src/lib/auth/auth.ts
+++ b/web-app/src/lib/auth/auth.ts
@@ -19,6 +19,7 @@ import { reactVerificationEmail } from "@/lib/email/verification";
 
 export type Session = typeof auth.$Infer.Session;
 export type SessionUser = typeof auth.$Infer.Session.user;
+export type Invitation = typeof auth.$Infer.Invitation;
 
 const fromEmail = getEnvSecrets().RESEND_FROM_EMAIL;
 

--- a/web-app/src/lib/db/repositories/invitation.repository.ts
+++ b/web-app/src/lib/db/repositories/invitation.repository.ts
@@ -76,37 +76,6 @@ export const invitationRepository = {
   },
 
   /**
-   * Retrieves the latest pending invitation per user for a specific organization.
-   * This ensures only one invitation per email address is returned, even if multiple
-   * expired invitations exist for the same user.
-   *
-   * @param organizationId - The ID of the organization.
-   * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to an array of invitations with one per user.
-   */
-  async getPendingInvitationsByOrganizationId(
-    organizationId: string,
-    tx: Prisma.TransactionClient = prisma,
-  ): Promise<InvitationWithRelations[]> {
-    // Get all pending invitations for the organization
-    const allInvitations = await tx.invitation.findMany({
-      where: { organizationId, status: InvitationStatus.PENDING },
-      include: invitationInclude,
-      orderBy: { expiresAt: "desc" },
-    });
-
-    // Group by email and take the first (latest) invitation per email
-    const emailMap = new Map<string, InvitationWithRelations>();
-    for (const invitation of allInvitations) {
-      if (!emailMap.has(invitation.email)) {
-        emailMap.set(invitation.email, invitation);
-      }
-    }
-
-    return Array.from(emailMap.values());
-  },
-
-  /**
    * Rejects a pending and valid (not expired) invitation by its ID.
    *
    * @param id - The invitation ID.

--- a/web-app/src/lib/db/repositories/invitation.repository.ts
+++ b/web-app/src/lib/db/repositories/invitation.repository.ts
@@ -76,19 +76,34 @@ export const invitationRepository = {
   },
 
   /**
-   * Retrieves all pending invitations for a specific organization.
+   * Retrieves the latest pending invitation per user for a specific organization.
+   * This ensures only one invitation per email address is returned, even if multiple
+   * expired invitations exist for the same user.
    *
    * @param organizationId - The ID of the organization.
    * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to an array of invitations.
+   * @returns Promise resolving to an array of invitations with one per user.
    */
   async getPendingInvitationsByOrganizationId(
     organizationId: string,
     tx: Prisma.TransactionClient = prisma,
-  ) {
-    return tx.invitation.findMany({
+  ): Promise<InvitationWithRelations[]> {
+    // Get all pending invitations for the organization
+    const allInvitations = await tx.invitation.findMany({
       where: { organizationId, status: InvitationStatus.PENDING },
+      include: invitationInclude,
+      orderBy: { expiresAt: "desc" },
     });
+
+    // Group by email and take the first (latest) invitation per email
+    const emailMap = new Map<string, InvitationWithRelations>();
+    for (const invitation of allInvitations) {
+      if (!emailMap.has(invitation.email)) {
+        emailMap.set(invitation.email, invitation);
+      }
+    }
+
+    return Array.from(emailMap.values());
   },
 
   /**

--- a/web-app/src/lib/db/repositories/invitation.repository.ts
+++ b/web-app/src/lib/db/repositories/invitation.repository.ts
@@ -32,27 +32,6 @@ export const invitationRepository = {
   },
 
   /**
-   * Retrieves a valid (not expired) pending invitation by its ID.
-   *
-   * @param id - The invitation ID.
-   * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to the invitation with relations, or null if not found.
-   */
-  async getValidPendingInvitationById(
-    id: string,
-    tx: Prisma.TransactionClient = prisma,
-  ): Promise<InvitationWithRelations | null> {
-    return tx.invitation.findUnique({
-      where: {
-        id,
-        status: InvitationStatus.PENDING,
-        expiresAt: { gt: new Date() },
-      },
-      include: invitationInclude,
-    });
-  },
-
-  /**
    * Retrieves all valid (not expired) pending invitations for a given email.
    *
    * @param email - The email address to search invitations for.
@@ -72,48 +51,6 @@ export const invitationRepository = {
         },
       },
       include: invitationInclude,
-    });
-  },
-
-  /**
-   * Rejects a pending and valid (not expired) invitation by its ID.
-   *
-   * @param id - The invitation ID.
-   * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to the updated invitation.
-   */
-  async rejectPendingInvitationById(
-    id: string,
-    tx: Prisma.TransactionClient = prisma,
-  ) {
-    return tx.invitation.update({
-      where: {
-        id,
-        status: InvitationStatus.PENDING,
-        expiresAt: { gt: new Date() },
-      },
-      data: { status: InvitationStatus.REJECTED },
-    });
-  },
-
-  /**
-   * Accepts a pending and valid (not expired) invitation by its ID.
-   *
-   * @param id - The invitation ID.
-   * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to the updated invitation.
-   */
-  async acceptPendingInvitationById(
-    id: string,
-    tx: Prisma.TransactionClient = prisma,
-  ) {
-    return tx.invitation.update({
-      where: {
-        id,
-        status: InvitationStatus.PENDING,
-        expiresAt: { gt: new Date() },
-      },
-      data: { status: InvitationStatus.ACCEPTED },
     });
   },
 };

--- a/web-app/src/lib/services/organization.service.ts
+++ b/web-app/src/lib/services/organization.service.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { nanoid } from "nanoid";
+import { headers } from "next/headers";
 import slugify from "slugify";
 
 import { auth, Invitation } from "@/lib/auth/auth";
@@ -119,6 +120,7 @@ export const organizationService = (() => {
       query: {
         organizationId,
       },
+      headers: await headers(),
     });
     return filterPendingInvitation(invitations);
   }

--- a/web-app/src/lib/services/organization.service.ts
+++ b/web-app/src/lib/services/organization.service.ts
@@ -4,9 +4,8 @@ import { nanoid } from "nanoid";
 import slugify from "slugify";
 
 import { getSession } from "@/lib/auth/utils";
-import { InvitationWithRelations, MemberRole, MemberWithUser } from "@/lib/db";
+import { InvitationWithRelations, MemberWithUser } from "@/lib/db";
 import { invitationRepository, memberRepository } from "@/lib/db/repositories";
-import { Invitation } from "@/prisma/generated/client";
 
 /**
  * Service for organization and invitations related operations.
@@ -112,52 +111,10 @@ export const organizationService = (() => {
     return members;
   }
 
-  /**
-   * Retrieves pending invitations for an organization.
-   *
-   * - Fetches the current session and extracts the user ID.
-   * - Checks if the user is a member of the organization.
-   * - Queries the database for pending invitations of the specified organization.
-   *
-   * @param organizationId - The ID of the organization to retrieve pending invitations for.
-   * @returns A promise that resolves to an array of Invitation objects.
-   */
-  async function getOrganizationPendingInvitations(
-    organizationId: string,
-  ): Promise<Invitation[]> {
-    const session = await getSession();
-    if (!session) {
-      return [];
-    }
-    const userId = session.user.id;
-
-    const myMemberInOrganization =
-      await memberRepository.getMemberByUserIdAndOrganizationId(
-        userId,
-        organizationId,
-      );
-    if (!myMemberInOrganization) {
-      console.error("You are not from the organization");
-      throw new Error("UNAUTHORIZED");
-    }
-    const isOwnerOrAdmin =
-      myMemberInOrganization.role === MemberRole.OWNER ||
-      myMemberInOrganization.role === MemberRole.ADMIN;
-    if (!isOwnerOrAdmin) {
-      console.error("You are not owner or admin of the organization");
-      throw new Error("UNAUTHORIZED");
-    }
-
-    return await invitationRepository.getPendingInvitationsByOrganizationId(
-      organizationId,
-    );
-  }
-
   return {
     generateOrganizationSlugFromName,
     getPendingInvitation,
     getOrganizationMembersWithUser,
-    getOrganizationPendingInvitations,
   };
 })();
 

--- a/web-app/src/lib/services/organization.service.ts
+++ b/web-app/src/lib/services/organization.service.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { nanoid } from "nanoid";
 import slugify from "slugify";
 
-import { Invitation } from "@/lib/auth/auth";
+import { auth, Invitation } from "@/lib/auth/auth";
 import { getSession } from "@/lib/auth/utils";
 import { InvitationWithRelations, MemberWithUser } from "@/lib/db";
 import { invitationRepository, memberRepository } from "@/lib/db/repositories";
@@ -112,6 +112,17 @@ export const organizationService = (() => {
     return members;
   }
 
+  async function getPendingInvitations(
+    organizationId: string,
+  ): Promise<Invitation[]> {
+    const invitations = await auth.api.listInvitations({
+      query: {
+        organizationId,
+      },
+    });
+    return filterPendingInvitation(invitations);
+  }
+
   /**
    * Filters and sorts pending invitations by email, keeping only the latest per email.
    *
@@ -133,8 +144,8 @@ export const organizationService = (() => {
   return {
     generateOrganizationSlugFromName,
     getPendingInvitation,
+    getPendingInvitations,
     getOrganizationMembersWithUser,
-    filterPendingInvitation,
   };
 })();
 

--- a/web-app/src/lib/services/organization.service.ts
+++ b/web-app/src/lib/services/organization.service.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { nanoid } from "nanoid";
 import slugify from "slugify";
 
+import { Invitation } from "@/lib/auth/auth";
 import { getSession } from "@/lib/auth/utils";
 import { InvitationWithRelations, MemberWithUser } from "@/lib/db";
 import { invitationRepository, memberRepository } from "@/lib/db/repositories";
@@ -111,10 +112,29 @@ export const organizationService = (() => {
     return members;
   }
 
+  /**
+   * Filters and sorts pending invitations by email, keeping only the latest per email.
+   *
+   * @param invitations - An array of pending invitations to filter and sort.
+   * @returns A new array of invitations with the latest per email.
+   */
+  function filterPendingInvitation(invitations: Invitation[]): Invitation[] {
+    invitations.sort((a, b) => b.expiresAt.valueOf() - a.expiresAt.valueOf());
+    // Group by email and take the first (latest) invitation per email
+    const emailMap = new Map<string, Invitation>();
+    for (const invitation of invitations) {
+      if (!emailMap.has(invitation.email)) {
+        emailMap.set(invitation.email, invitation);
+      }
+    }
+    return Array.from(emailMap.values());
+  }
+
   return {
     generateOrganizationSlugFromName,
     getPendingInvitation,
     getOrganizationMembersWithUser,
+    filterPendingInvitation,
   };
 })();
 


### PR DESCRIPTION
## Summary

This PR ensures we only show one pending invitation per user on members table.

When there are many pending invitations for one user, we only show the latest one (sort by `expiresAt`)

## Changes

* Remove unnecessary organization service function `getOrganizationPendingInvitations` and invitation repo function `getPendingInvitationsByOrganizationId`
* Use `better-auth` api to get all invitation and sort them by `expiresAt` and pick one per user's email.