### PR TITLE
fix: remove input description on create job modal

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1014,8 +1014,7 @@
             "title": "Information"
           },
           "Input": {
-            "title": "Input",
-            "description": "Ensure inputs are clear, specific, and relevant to the analysis, providing structured data on the reference company, target competitors, and market focus to generate precise, actionable insights in the output."
+            "title": "Input"
           }
         },
         "JobsTable": {

--- a/web-app/src/components/create-job-modal/create-job-section.tsx
+++ b/web-app/src/components/create-job-modal/create-job-section.tsx
@@ -106,7 +106,6 @@ function InputAccordionItem({
   return (
     <AccordionItemWrapper value="input" title={t("title")} disabled={disabled}>
       <div className="flex flex-col gap-6">
-        <p className="text-sm">{t("description")}</p>
         <JobInputsForm
           agentId={agent.id}
           agentCreditsPrice={agent.creditsPrice}


### PR DESCRIPTION
## Summary

This PR just removes input description from `create-job-modal`.