### PR TITLE
chore(prisma): migrate from package.json config to prisma.config.ts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
+      dotenv:
+        specifier: ^17.2.1
+        version: 17.2.1
       embla-carousel-react:
         specifier: 8.6.0
         version: 8.6.0(react@19.1.1)
@@ -3717,6 +3720,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -10058,6 +10065,8 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@16.6.1: {}
+
+  dotenv@17.2.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -6,9 +6,6 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "private": true,
-  "prisma": {
-    "seed": "tsx ./prisma/seed.ts"
-  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -54,6 +51,7 @@
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "date-fns": "4.1.0",
+    "dotenv": "^17.2.1",
     "embla-carousel-react": "8.6.0",
     "gravatar-url": "4.0.1",
     "humanize-duration": "3.33.0",

--- a/web-app/prisma.config.ts
+++ b/web-app/prisma.config.ts
@@ -1,0 +1,13 @@
+import "dotenv/config";
+
+import path from "node:path";
+
+import type { PrismaConfig } from "prisma";
+
+export default {
+  schema: path.join("prisma", "schema.prisma"),
+  migrations: {
+    path: path.join("prisma", "migrations"),
+    seed: "tsx ./prisma/seed.ts",
+  },
+} satisfies PrismaConfig;


### PR DESCRIPTION
## Summary

Migrate Prisma configuration from deprecated `package.json#prisma` section to the new `prisma.config.ts` file format to resolve deprecation warnings.

## Changes Made

- ✅ **Created `prisma.config.ts`**: New Prisma configuration file using TypeScript
- ✅ **Removed deprecated config**: Deleted `prisma` section from `package.json`
- ✅ **Added dotenv support**: Imported `dotenv/config` to ensure environment variables are available
- ✅ **Preserved functionality**: Maintained existing seed script configuration

## Technical Details

### Migration Benefits
- Eliminates deprecation warning: `The configuration property package.json#prisma is deprecated and will be removed in Prisma 7`
- Provides type-safe configuration using TypeScript
- Better separation of concerns with dedicated config file
- Future-proof against Prisma 7 breaking changes

### Configuration Structure
```typescript
export default {
  schema: path.join("prisma", "schema.prisma"),
  migrations: {
    path: path.join("prisma", "migrations"),
    seed: "tsx ./prisma/seed.ts",
  },
} satisfies PrismaConfig;
```

### Dependencies Added
- `dotenv@^17.2.1`: Required for environment variable loading in the config file

## Testing

- [x] Configuration loads without deprecation warnings
- [x] Environment variables (DATABASE_URL) are accessible
- [x] Seed functionality remains unchanged
- [x] Build process unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)