### PR TITLE
feat(stripe): add scheduled sync job for retroactive Stripe customer creation

### DIFF
--- a/web-app/src/app/api/sync/stripe-customers/route.ts
+++ b/web-app/src/app/api/sync/stripe-customers/route.ts
@@ -1,0 +1,135 @@
+import { after, NextResponse } from "next/server";
+import pLimit from "p-limit";
+import pTimeout from "p-timeout";
+
+import { getEnvSecrets } from "@/config/env.secrets";
+import { authenticateCronSecret } from "@/lib/auth/utils";
+import {
+  lockRepository,
+  organizationRepository,
+  userRepository,
+} from "@/lib/db/repositories";
+import { lockService, stripeService } from "@/lib/services";
+import { Lock } from "@/prisma/generated/client";
+
+const LOCK_KEY = "stripe-customers-sync";
+
+export async function GET(request: Request) {
+  const authResult = authenticateCronSecret(request);
+  if (!authResult.ok) return authResult.response;
+  return await stripeCustomersSync();
+}
+
+async function stripeCustomersSync(): Promise<Response> {
+  // Start a transaction to ensure atomicity
+  let lock: Lock;
+  try {
+    lock = await lockService.acquireLock(LOCK_KEY, getEnvSecrets().INSTANCE_ID);
+  } catch (error) {
+    if (error instanceof Error && error.message === "LOCK_IS_LOCKED") {
+      return NextResponse.json(
+        { message: "Syncing already in progress" },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(
+      { message: "Failed to acquire lock" },
+      { status: 500 },
+    );
+  }
+
+  after(async () => {
+    try {
+      const timingStart = Date.now();
+      await pTimeout(syncAllStripeCustomers(), {
+        milliseconds:
+          // give some buffer to unlock the lock before the timeout
+          getEnvSecrets().LOCK_TIMEOUT - getEnvSecrets().LOCK_TIMEOUT_BUFFER,
+      });
+      const timingEnd = Date.now();
+      console.info(
+        "Stripe customers sync took",
+        (timingEnd - timingStart) / 1000,
+        "seconds",
+      );
+    } catch (error) {
+      console.error("Error in sync operation:", error);
+    } finally {
+      try {
+        await lockRepository.unlockByKey(lock.key);
+      } catch (error) {
+        console.error("Failed to unlock lock:", error);
+      }
+    }
+  });
+
+  return NextResponse.json({ message: "Syncing started" }, { status: 200 });
+}
+
+async function syncAllStripeCustomers(): Promise<void> {
+  const runningUpdates: Promise<void>[] = [];
+
+  // Get all users without Stripe customer IDs
+  const usersWithoutStripeCustomer =
+    await userRepository.getUsersWithoutStripeCustomerId();
+
+  // Get all organizations without Stripe customer IDs
+  const organizationsWithoutStripeCustomer =
+    await organizationRepository.getOrganizationsWithoutStripeCustomerId();
+
+  console.info(
+    "Syncing",
+    usersWithoutStripeCustomer.length,
+    "users and",
+    organizationsWithoutStripeCustomer.length,
+    "organizations without Stripe customers",
+  );
+
+  // Process 5 entities at a time
+  const limit = pLimit(5);
+
+  // Process users
+  for (const user of usersWithoutStripeCustomer) {
+    runningUpdates.push(
+      limit(async () => {
+        try {
+          await stripeService.createStripeCustomerForUser(user.id);
+          console.info(`Created Stripe customer for user ${user.id}`);
+        } catch (error) {
+          console.error(
+            `Failed to create Stripe customer for user ${user.id}:`,
+            error,
+          );
+        }
+      }),
+    );
+  }
+
+  // Process organizations
+  for (const organization of organizationsWithoutStripeCustomer) {
+    runningUpdates.push(
+      limit(async () => {
+        try {
+          await stripeService.createStripeCustomerForOrganization(
+            organization.id,
+          );
+          console.info(
+            `Created Stripe customer for organization ${organization.id}`,
+          );
+        } catch (error) {
+          console.error(
+            `Failed to create Stripe customer for organization ${organization.id}:`,
+            error,
+          );
+        }
+      }),
+    );
+  }
+
+  try {
+    await Promise.allSettled(runningUpdates);
+  } catch (error) {
+    console.error("Error in sync operation:", error);
+    throw error;
+  }
+}

--- a/web-app/src/lib/db/repositories/organization.repository.ts
+++ b/web-app/src/lib/db/repositories/organization.repository.ts
@@ -163,4 +163,20 @@ export const organizationRepository = {
       where: { stripeCustomerId },
     });
   },
+
+  /**
+   * Retrieves all organizations that do not have a Stripe customer ID.
+   *
+   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
+   * @returns A promise that resolves to an array of Organization objects without Stripe customer IDs.
+   */
+  async getOrganizationsWithoutStripeCustomerId(
+    tx: Prisma.TransactionClient = prisma,
+  ): Promise<Organization[]> {
+    return await tx.organization.findMany({
+      where: {
+        stripeCustomerId: null,
+      },
+    });
+  },
 };

--- a/web-app/src/lib/db/repositories/user.repository.ts
+++ b/web-app/src/lib/db/repositories/user.repository.ts
@@ -68,4 +68,20 @@ export const userRepository = {
       where: { stripeCustomerId },
     });
   },
+
+  /**
+   * Retrieves all users that do not have a Stripe customer ID.
+   *
+   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
+   * @returns A promise that resolves to an array of User objects without Stripe customer IDs.
+   */
+  getUsersWithoutStripeCustomerId: async (
+    tx: Prisma.TransactionClient = prisma,
+  ): Promise<User[]> => {
+    return tx.user.findMany({
+      where: {
+        stripeCustomerId: null,
+      },
+    });
+  },
 };

--- a/web-app/vercel.json
+++ b/web-app/vercel.json
@@ -8,6 +8,10 @@
     {
       "path": "/api/sync/jobs",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/sync/stripe-customers",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR introduces a new scheduled sync job to retroactively create Stripe customers for existing users and organizations that don't have them. This ensures all entities have associated Stripe customers for billing operations.

## Key Changes

### New API Endpoint
- **`/api/sync/stripe-customers`** - Scheduled sync job similar to existing job/agent sync endpoints
- Runs hourly via Vercel cron (configured in `vercel.json`)
- Protected by `CRON_SECRET` authentication

### Repository Methods
- **`userRepository.getUsersWithoutStripeCustomerId()`** - Retrieves users missing Stripe customer IDs
- **`organizationRepository.getOrganizationsWithoutStripeCustomerId()`** - Retrieves organizations missing Stripe customer IDs

### Architecture Benefits

- **Consistent Pattern**: Follows the exact same pattern as existing sync endpoints (`/api/sync/jobs`, `/api/sync/agents`)
- **Reuses Existing Logic**: Leverages existing atomic Stripe customer creation methods from database hooks
- **Robust Error Handling**: Uses `Promise.allSettled` for graceful error handling per entity
- **Concurrency Control**: Lock mechanism prevents multiple sync instances from running simultaneously
- **Performance Optimized**: Batch processing with 5 concurrent operations using `pLimit`

### Technical Details

- **Lock Key**: `stripe-customers-sync` prevents concurrent executions
- **Timeout Handling**: Uses `pTimeout` with configurable timeouts
- **Monitoring**: Comprehensive logging for timing and progress tracking
- **Atomic Operations**: Each Stripe customer creation is handled in its own transaction

### Testing

- ✅ Linting passes with zero warnings
- ✅ TypeScript compilation successful
- ✅ Build generates optimized production bundle
- ✅ Code follows project formatting standards

## Schedule

The sync job runs hourly (`0 * * * *`) to ensure timely creation of missing Stripe customers without overwhelming the system.

🤖 Generated with [Claude Code](https://claude.ai/code)