### PR TITLE
chore: remove scheduled Stripe customers cleanup job

### DIFF
--- a/web-app/src/lib/clients/stripe.client.ts
+++ b/web-app/src/lib/clients/stripe.client.ts
@@ -90,6 +90,9 @@ export const stripeClient = (() => {
 
         const response: Stripe.ApiList<Stripe.Customer> =
           await stripe.customers.list({
+            created: {
+              gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5).getTime(), // 5 days ago
+            },
             limit: requestLimit,
             starting_after: currentStartingAfter,
           });

--- a/web-app/src/lib/clients/stripe.client.ts
+++ b/web-app/src/lib/clients/stripe.client.ts
@@ -90,9 +90,6 @@ export const stripeClient = (() => {
 
         const response: Stripe.ApiList<Stripe.Customer> =
           await stripe.customers.list({
-            created: {
-              gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5).getTime(), // 5 days ago
-            },
             limit: requestLimit,
             starting_after: currentStartingAfter,
           });

--- a/web-app/vercel.json
+++ b/web-app/vercel.json
@@ -12,10 +12,6 @@
     {
       "path": "/api/sync/stripe-customers",
       "schedule": "0 * * * *"
-    },
-    {
-      "path": "/api/sync/stripe-customers-cleanup",
-      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
This PR removes the scheduled Stripe customers cleanup job that was running every 15 minutes.

## Key Changes
- **Remove cleanup job**: Removed the scheduled `/api/sync/stripe-customers-cleanup` cron job from `vercel.json`

## Technical Details
- Eliminated the cleanup job that was configured to run every 15 minutes (`*/15 * * * *`)
- Keeps the main customer sync job that runs hourly (`0 * * * *`)

## Benefits
- Reduced unnecessary background job execution
- Lower resource utilization and operational overhead
- Simplified cron job configuration

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>