### PR TITLE
fix: agent modal on job detail page

### DIFF
--- a/web-app/src/app/(app)/agents/[agentId]/jobs/components/header.tsx
+++ b/web-app/src/app/(app)/agents/[agentId]/jobs/components/header.tsx
@@ -95,7 +95,7 @@ export default function Header({
           showBackButton={true}
           showShareButton={false}
           showCloseButton={false}
-        ></AgentActionButtons>
+        />
         <Button
           className="text-sm leading-tight font-medium"
           variant="ghost"
@@ -109,7 +109,7 @@ export default function Header({
         <h1 className="text-2xl leading-none font-light tracking-tighter text-nowrap md:text-3xl">
           {getAgentName(agent)}
         </h1>
-        <div className="hidden md:flex">
+        <div className="hidden gap-2 md:flex">
           <Button
             className="text-sm leading-tight font-medium"
             variant="ghost"

--- a/web-app/src/components/agents/agent-card.tsx
+++ b/web-app/src/components/agents/agent-card.tsx
@@ -402,7 +402,7 @@ function AgentCard({
                     alt={`${getAgentName(agent)} author image`}
                     width={400}
                     height={100}
-                    className="h-8 w-auto object-contain"
+                    className="h-8 w-auto object-contain object-bottom-right"
                   />
                 ) : (
                   <Badge variant="default" className="max-w-full">

--- a/web-app/src/components/agents/agent-modal.tsx
+++ b/web-app/src/components/agents/agent-modal.tsx
@@ -21,7 +21,7 @@ export function AgentModal({ children, open }: AgentModalProps) {
         <DialogContent className="w-svw max-w-3xl! border-none bg-transparent p-0 focus:ring-0 focus:outline-none md:w-[80vw] [&>button]:hidden">
           <DialogTitle className="hidden" />
           <DialogDescription className="hidden" />
-          <ScrollArea className="max-h-svh pt-12 pr-4 pl-4 md:max-h-[90svh] md:p-0">
+          <ScrollArea className="max-h-svh w-svw p-4 pt-12 md:max-h-[90svh] md:p-0 [&>div>div]:block!">
             {children}
           </ScrollArea>
         </DialogContent>


### PR DESCRIPTION
## Changes

- Fix agent detail modal on job detail page to fit the screen width (use `display: block;` instead of `display: table;`)
- Fix agent author logo position to bottom right.