### PR TITLE
fix(job-input): update form schema to allow nullable optional fields

### DIFF
--- a/web-app/src/lib/job-input/form-schema.ts
+++ b/web-app/src/lib/job-input/form-schema.ts
@@ -103,7 +103,7 @@ const makeZodSchemaFromJobInputColorSchema = (
       canBeOptional = value === "true";
   });
 
-  return canBeOptional ? defaultSchema.optional().nullable() : defaultSchema;
+  return canBeOptional ? defaultSchema.nullish() : defaultSchema;
 };
 
 const makeZodSchemaFromJobInputTextareaSchema = (
@@ -143,7 +143,7 @@ const makeZodSchemaFromJobInputTextareaSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputStringSchema = (
@@ -196,7 +196,7 @@ const makeZodSchemaFromJobInputStringSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputTelSchema = (
@@ -243,7 +243,7 @@ const makeZodSchemaFromJobInputTelSchema = (
       error: t?.("String.max", { name, value: String(max) }),
     });
 
-  return canBeOptional ? withLength.optional().nullable() : withLength;
+  return canBeOptional ? withLength.nullish() : withLength;
 };
 
 const makeZodSchemaFromJobInputNumberSchema = (
@@ -283,7 +283,7 @@ const makeZodSchemaFromJobInputNumberSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 // For Boolean Schema we can ignore validations
@@ -356,7 +356,7 @@ const makeZodSchemaFromJobInputOptionSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputFileSchema = (
@@ -428,7 +428,7 @@ const makeZodSchemaFromJobInputDateSchema = (
     schema = schema.max(maxDate, {
       error: t?.("Date.max", { name, value: maxDate.toLocaleDateString() }),
     });
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputDatetimeSchema = (
@@ -460,7 +460,7 @@ const makeZodSchemaFromJobInputDatetimeSchema = (
     schema = schema.max(maxDate, {
       error: t?.("Date.max", { name, value: maxDate.toLocaleString() }),
     });
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputMonthSchema = (
@@ -507,7 +507,7 @@ const makeZodSchemaFromJobInputMonthSchema = (
       { error: t?.("Date.max", { name, value: max }) },
     );
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputWeekSchema = (
@@ -555,7 +555,7 @@ const makeZodSchemaFromJobInputWeekSchema = (
       { error: t?.("Date.max", { name, value: max }) },
     );
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputTimeSchema = (
@@ -618,7 +618,7 @@ const makeZodSchemaFromJobInputTimeSchema = (
       error: t?.("Number.max", { name, value: maxHours ?? "" }),
     });
 
-  return canBeOptional ? schema.optional().nullable() : schema;
+  return canBeOptional ? schema.nullish() : schema;
 };
 
 const makeZodSchemaFromJobInputRangeSchema = (
@@ -674,5 +674,5 @@ const makeZodSchemaFromJobInputRangeSchema = (
         )
       : schema;
 
-  return canBeOptional ? withStep.optional().nullable() : withStep;
+  return canBeOptional ? withStep.nullish() : withStep;
 };

--- a/web-app/src/lib/job-input/form-schema.ts
+++ b/web-app/src/lib/job-input/form-schema.ts
@@ -103,7 +103,7 @@ const makeZodSchemaFromJobInputColorSchema = (
       canBeOptional = value === "true";
   });
 
-  return canBeOptional ? defaultSchema.optional() : defaultSchema;
+  return canBeOptional ? defaultSchema.optional().nullable() : defaultSchema;
 };
 
 const makeZodSchemaFromJobInputTextareaSchema = (
@@ -143,7 +143,7 @@ const makeZodSchemaFromJobInputTextareaSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputStringSchema = (
@@ -196,7 +196,7 @@ const makeZodSchemaFromJobInputStringSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputTelSchema = (
@@ -243,7 +243,7 @@ const makeZodSchemaFromJobInputTelSchema = (
       error: t?.("String.max", { name, value: String(max) }),
     });
 
-  return canBeOptional ? withLength.optional() : withLength;
+  return canBeOptional ? withLength.optional().nullable() : withLength;
 };
 
 const makeZodSchemaFromJobInputNumberSchema = (
@@ -283,7 +283,7 @@ const makeZodSchemaFromJobInputNumberSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 // For Boolean Schema we can ignore validations
@@ -356,7 +356,7 @@ const makeZodSchemaFromJobInputOptionSchema = (
     }
   }, defaultSchema);
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputFileSchema = (
@@ -428,7 +428,7 @@ const makeZodSchemaFromJobInputDateSchema = (
     schema = schema.max(maxDate, {
       error: t?.("Date.max", { name, value: maxDate.toLocaleDateString() }),
     });
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputDatetimeSchema = (
@@ -460,7 +460,7 @@ const makeZodSchemaFromJobInputDatetimeSchema = (
     schema = schema.max(maxDate, {
       error: t?.("Date.max", { name, value: maxDate.toLocaleString() }),
     });
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputMonthSchema = (
@@ -507,7 +507,7 @@ const makeZodSchemaFromJobInputMonthSchema = (
       { error: t?.("Date.max", { name, value: max }) },
     );
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputWeekSchema = (
@@ -555,7 +555,7 @@ const makeZodSchemaFromJobInputWeekSchema = (
       { error: t?.("Date.max", { name, value: max }) },
     );
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputTimeSchema = (
@@ -618,7 +618,7 @@ const makeZodSchemaFromJobInputTimeSchema = (
       error: t?.("Number.max", { name, value: maxHours ?? "" }),
     });
 
-  return canBeOptional ? schema.optional() : schema;
+  return canBeOptional ? schema.optional().nullable() : schema;
 };
 
 const makeZodSchemaFromJobInputRangeSchema = (
@@ -674,5 +674,5 @@ const makeZodSchemaFromJobInputRangeSchema = (
         )
       : schema;
 
-  return canBeOptional ? withStep.optional() : withStep;
+  return canBeOptional ? withStep.optional().nullable() : withStep;
 };

--- a/web-app/src/lib/job-input/form.ts
+++ b/web-app/src/lib/job-input/form.ts
@@ -28,7 +28,9 @@ export function filterOutNullValues(
   values: JobInputsFormSchemaType,
 ): JobInputData {
   return new Map(
-    Object.entries(values).filter(([_, value]) => value !== null) as [
+    Object.entries(values).filter(
+      ([_, value]) => value !== null && value !== undefined,
+    ) as [
       string,
       (
         | string
@@ -55,41 +57,17 @@ export const defaultValues = (jobInputSchemas: JobInputSchemaType[]) => {
 const getDefaultValue = (jobInputSchema: JobInputSchemaType) => {
   const { type } = jobInputSchema;
   switch (type) {
-    case ValidJobInputTypes.STRING:
-      return null;
-    case ValidJobInputTypes.TEL:
-      return null;
-    case ValidJobInputTypes.RANGE:
-      return jobInputSchema.data?.default ?? null;
-    case ValidJobInputTypes.COLOR:
-      return jobInputSchema.data?.default ?? "#000000";
-    case ValidJobInputTypes.HIDDEN:
-      return jobInputSchema.data?.value ?? "";
     case ValidJobInputTypes.BOOLEAN:
       return false;
+    case ValidJobInputTypes.COLOR:
+      return jobInputSchema.data?.default ?? "#000000";
+    case ValidJobInputTypes.RANGE:
+      return jobInputSchema.data?.default ?? null;
+    case ValidJobInputTypes.HIDDEN:
+      return jobInputSchema.data?.value ?? "";
     case ValidJobInputTypes.CHECKBOX:
-      return (
-        (jobInputSchema.data as { default?: boolean } | undefined)?.default ??
-        false
-      );
-    case ValidJobInputTypes.NUMBER:
-      return null;
-    case ValidJobInputTypes.OPTION:
-      return null;
-    case ValidJobInputTypes.FILE:
-      return null;
-    case ValidJobInputTypes.MULTISELECT:
-      return null;
-    // checkbox group removed
-    case ValidJobInputTypes.RADIO_GROUP:
-      return null;
-    case ValidJobInputTypes.DATE:
-      return null;
-    case ValidJobInputTypes.DATETIME:
-      return null;
-    case ValidJobInputTypes.TIME:
-      return null;
-    case ValidJobInputTypes.NONE:
+      return jobInputSchema.data?.default ?? false;
+    default:
       return null;
   }
 };


### PR DESCRIPTION
## Changes

- This PR allows `null` value for optional field (`null` is default value for most of Input types)

## NOTE:

- By the zod v4 migration, we are using deprecated functions (`z.string().email()`, `z.string().url()`, ...), which will be fixed by follow-up PR