### PR TITLE
feat(cors): add permissive CORS for /api/v1

### DIFF
--- a/web-app/src/middleware.ts
+++ b/web-app/src/middleware.ts
@@ -19,6 +19,30 @@ const EXCLUDED_PATHS = [
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  const isApiV1Path = pathname.startsWith("/api/v1");
+
+  // Handle CORS for public API v1 endpoints
+  if (isApiV1Path) {
+    const corsHeaders = new Headers({
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Content-Type, Authorization, X-Requested-With, x-api-key",
+      "Access-Control-Max-Age": "86400",
+    });
+
+    if (request.method === "OPTIONS") {
+      return new NextResponse(null, { status: 204, headers: corsHeaders });
+    }
+
+    const response = NextResponse.next();
+    corsHeaders.forEach((value, key) => {
+      response.headers.set(key, value);
+    });
+
+    return response;
+  }
+
   // Skip middleware for excluded paths
   if (EXCLUDED_PATHS.some((path) => pathname.startsWith(path))) {
     return NextResponse.next();


### PR DESCRIPTION
### Summary
Enable permissive CORS for public `api/v1` endpoints. Adds preflight `OPTIONS` handling and attaches CORS headers to responses.

### Changes
- Add CORS handling in `src/middleware.ts` for paths starting with `/api/v1`
  - `Access-Control-Allow-Origin: *`
  - `Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS`
  - `Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, x-api-key`
  - `Access-Control-Max-Age: 86400`
- Return `204` for preflight `OPTIONS` requests.

### Rationale
Third-party clients should be able to call our public API without browser cross-origin restrictions.

### How to test
- Preflight:
  - `curl -i -X OPTIONS https://<host>/api/v1/agents -H "Origin: https://example.com" -H "Access-Control-Request-Method: GET"`
  - Expect: `204` and the CORS headers above.
- Actual request:
  - `curl -i https://<host>/api/v1/agents -H "Origin: https://example.com"`
  - Expect: `200` and the same `Access-Control-*` headers.

### Risks/Notes
- This enables `*` for all origins (public API behavior). If we need to restrict later, we can implement an allowlist and reflect the `Origin` header dynamically.
- Credentials are not permitted (no `Access-Control-Allow-Credentials`), which aligns with API key usage via headers.