### PR TITLE
fix(cors): apply matcher for /api/v1 and remove exclusion

### DIFF
--- a/web-app/src/middleware.ts
+++ b/web-app/src/middleware.ts
@@ -19,6 +19,30 @@ const EXCLUDED_PATHS = [
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  const isApiV1Path = pathname.startsWith("/api/v1");
+
+  // Handle CORS for public API v1 endpoints
+  if (isApiV1Path) {
+    const corsHeaders = new Headers({
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Content-Type, Authorization, X-Requested-With, x-api-key",
+      "Access-Control-Max-Age": "86400",
+    });
+
+    if (request.method === "OPTIONS") {
+      return new NextResponse(null, { status: 204, headers: corsHeaders });
+    }
+
+    const response = NextResponse.next();
+    corsHeaders.forEach((value, key) => {
+      response.headers.set(key, value);
+    });
+
+    return response;
+  }
+
   // Skip middleware for excluded paths
   if (EXCLUDED_PATHS.some((path) => pathname.startsWith(path))) {
     return NextResponse.next();

--- a/web-app/src/middleware.ts
+++ b/web-app/src/middleware.ts
@@ -9,7 +9,6 @@ const EXCLUDED_PATHS = [
   "/accept-invitation",
   "/share/jobs",
   "/health",
-  "/api/v1",
   "/api-docs",
   "/robots.txt",
   "/sitemap.xml",
@@ -78,5 +77,6 @@ export const config = {
      * - js directory in /public (public static js files)
      */
     "/((?!api|_next/static|_next/image|images|public|legal|js).*)",
+    "/api/v1/:path*",
   ],
 };


### PR DESCRIPTION
### Summary
Enable public cross-origin access for `api/v1` endpoints. Adds preflight `OPTIONS` handling and attaches CORS headers to all `api/v1` responses.

### Changes
- **CORS in middleware**: Add CORS logic for paths starting with `/api/v1` in `web-app/src/middleware.ts`.
- **Preflight support**: Return `204` for `OPTIONS` requests with CORS headers.
- **Headers added**:
  - `Access-Control-Allow-Origin: *`
  - `Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS`
  - `Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, x-api-key`
  - `Access-Control-Max-Age: 86400`
- **Matcher updated**: Include `'/api/v1/:path*'` in `middleware.config.matcher`.
- **Exclusion removed**: Remove `'/api/v1'` from middleware `EXCLUDED_PATHS`.

### Rationale
Allow third-party clients to call public API endpoints from browsers without cross-origin restrictions.

### How to test
- Preflight:
  - `curl -i -X OPTIONS https://<host>/api/v1/agents -H "Origin: https://example.com" -H "Access-Control-Request-Method: GET"`
  - Expect: `204` with the CORS headers above.
- Actual request:
  - `curl -i https://<host>/api/v1/agents -H "Origin: https://example.com"`
  - Expect: `200` (or applicable status) and the same `Access-Control-*` headers.

### Risks/Notes
- **Open CORS policy**: `*` allows any origin. This is intentional for a public API.
- **No credentials**: `Access-Control-Allow-Credentials` is not set; aligns with API key usage via headers.

### Follow-ups
- Optional: introduce an origin allowlist and reflect `Origin` dynamically if we need to restrict access later.