### PR TITLE
feat(seo): add robots.txt and noindex meta tag for non-mainnet environments

### DIFF
--- a/web-app/src/app/layout.tsx
+++ b/web-app/src/app/layout.tsx
@@ -23,7 +23,15 @@ const inter = Inter({
 });
 
 export function generateMetadata(): Metadata {
+  const isMainnet = getEnvPublicConfig().NEXT_PUBLIC_NETWORK === "Mainnet";
+
   return {
+    ...(!isMainnet && {
+      robots: {
+        index: false,
+        follow: false,
+      },
+    }),
     other: {
       ...Sentry.getTraceData(),
     },

--- a/web-app/src/app/robots.ts
+++ b/web-app/src/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+import { getEnvPublicConfig } from "@/config/env.public";
+
+export default function robots(): MetadataRoute.Robots {
+  const isMainnet = getEnvPublicConfig().NEXT_PUBLIC_NETWORK === "Mainnet";
+  if (!isMainnet) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    };
+  }
+
+  // Mainnet environment - allow all crawlers
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Implements robots.txt configuration that blocks crawlers on non-mainnet environments
- Adds noindex/nofollow meta tags to page metadata for non-mainnet deployments
- Ensures only production (mainnet) instances are indexed by search engines

## Key Changes

### 1. Dynamic robots.txt Generation (`web-app/src/app/robots.ts`)
- Created new robots.txt route handler using Next.js metadata API
- Returns `Disallow: /` for all non-mainnet environments (preprod, testnet, etc.)
- Returns `Allow: /` for mainnet environment to enable crawling

### 2. Conditional Robots Meta Tag (`web-app/src/app/layout.tsx`)
- Added conditional robots metadata to the root layout
- Sets `index: false, follow: false` for non-mainnet environments
- No robots meta tag for mainnet (allows default indexing behavior)

## Technical Details

Both implementations check the `NEXT_PUBLIC_NETWORK` environment variable to determine if the current deployment is on mainnet. This ensures consistent behavior across all SEO-related configurations.

## Testing

- ✅ Verify robots.txt returns correct rules based on environment
- ✅ Check page source for robots meta tag on non-mainnet environments
- ✅ Confirm no robots meta tag present on mainnet deployment
- ✅ Test with various crawler user agents

🤖 Generated with [Claude Code](https://claude.ai/code)