### PR TITLE
chore(zod): standardize imports to use namespace syntax

### DIFF
--- a/web-app/src/config/env.public.ts
+++ b/web-app/src/config/env.public.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-properties */
-import z from "zod";
+import * as z from "zod";
 
 const envPublicConfigSchema = z.object({
   NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID: z.string().optional(),

--- a/web-app/src/config/env.secrets.ts
+++ b/web-app/src/config/env.secrets.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 /* eslint-disable no-restricted-properties */
 import { v4 as uuidv4 } from "uuid";
-import z from "zod";
+import * as z from "zod";
 
 /**
  * Specify your environment variables schema here.

--- a/web-app/src/lib/form/index.ts
+++ b/web-app/src/lib/form/index.ts
@@ -1,5 +1,6 @@
 import { MessageKeys, NestedKeyOf, NestedValueOf } from "next-intl";
-import { z, ZodSchema } from "zod";
+import * as z from "zod";
+import { ZodSchema } from "zod";
 
 type EndsWithFormString<T extends string> = T extends `${infer _Key}.Form`
   ? T

--- a/web-app/src/lib/schemas/account.ts
+++ b/web-app/src/lib/schemas/account.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import * as z from "zod";
 
 import {
   confirmPasswordSchema,

--- a/web-app/src/lib/utils/utm.ts
+++ b/web-app/src/lib/utils/utm.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import * as z from "zod";
 
 export interface UTMParams {
   utm_source: string;


### PR DESCRIPTION
## Summary

Standardizes Zod imports across the codebase by converting from default imports (`import z from "zod"`) to namespace imports (`import * as z from "zod"`). This change improves consistency and follows TypeScript best practices for library imports.

## Changes Made

- **Environment Configuration** (`src/config/env.public.ts`, `src/config/env.secrets.ts`): Updated Zod imports to namespace syntax
- **Form Utilities** (`src/lib/form/index.ts`): Updated Zod import and explicitly imported `ZodSchema` type
- **Schema Definitions** (`src/lib/schemas/account.ts`): Standardized Zod import syntax
- **Utility Functions** (`src/lib/utils/utm.ts`): Updated Zod import to namespace syntax

## Technical Benefits

- **Consistency**: All Zod imports now follow the same pattern across the codebase
- **Type Safety**: Namespace imports provide better TypeScript support and IntelliSense
- **Future-proofing**: Aligns with modern TypeScript and library import best practices
- **Maintainability**: Reduces cognitive load when working with Zod across different files

## Testing

- ✅ No functional changes - this is a pure refactoring
- ✅ TypeScript compilation passes
- ✅ All existing validation logic remains intact
- ✅ Import changes maintain identical runtime behavior

🤖 Generated with [Claude Code](https://claude.ai/code)