### PR TITLE
feat(ui): add API documentation link to API keys section

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1082,6 +1082,7 @@
       "ApiKeys": {
         "title": "API Keys",
         "description": "Manage your API keys for programmatic access",
+        "apiDocsLink": "View API Documentation",
         "createButton": "Create",
         "loading": "Loading API keys...",
         "noKeysFound": "Create your first API key to get started.",

--- a/web-app/src/app/(app)/account/components/api-keys/api-keys-header.tsx
+++ b/web-app/src/app/(app)/account/components/api-keys/api-keys-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { ExternalLink, Plus } from "lucide-react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
@@ -20,10 +21,23 @@ export function ApiKeysHeader({ onCreateClick }: ApiKeysHeaderProps) {
       <div className="flex items-center justify-between">
         <div>
           <CardTitle>{t("title")}</CardTitle>
-          <CardDescription>{t("description")}</CardDescription>
+          <CardDescription className="space-y-1">
+            <div>{t("description")}</div>
+            <div>
+              <Link
+                href="https://docs.sokosumi.com/api-reference"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:text-primary/80 inline-flex items-center gap-1 text-sm underline underline-offset-4"
+              >
+                {t("apiDocsLink")}
+                <ExternalLink className="size-3" />
+              </Link>
+            </div>
+          </CardDescription>
         </div>
         <Button onClick={onCreateClick}>
-          <Plus className="h-4 w-4" />
+          <Plus className="size-4" />
           {t("createButton")}
         </Button>
       </div>


### PR DESCRIPTION
## Summary

Implement DEV-528 by adding a direct link to the Sokosumi API documentation in the API Keys management section. This enhancement improves the developer experience by providing immediate access to API documentation when users are managing their API keys.

## Changes Made

### 🎨 UI Components
- **API Keys Header**: Enhanced the header component to include an API documentation link
  - Added external link with proper icon and styling
  - Positioned below the description text for optimal user flow
  - Opens in new tab with security attributes (`target="_blank" rel="noopener noreferrer"`)

### 🌐 Internationalization
- **Translation Updates**: Added new translation key for the API documentation link
  - `apiDocsLink`: "View API Documentation"
  - Maintains consistency with existing i18n patterns

### 🔗 Technical Implementation
- **Link Component**: Utilizes Next.js `Link` component for optimal performance
- **Icon Integration**: Added `ExternalLink` icon from Lucide React for clear visual indication
- **Styling**: Applied consistent primary color theming with hover effects
- **Responsive Design**: Maintains existing responsive behavior

## Test Plan

- [x] Build verification: All TypeScript checks pass
- [x] Lint verification: ESLint passes with zero warnings
- [x] UI Integration: Link appears correctly in API Keys section
- [x] External Navigation: Link opens API documentation in new tab
- [x] Translation: Text displays correctly with i18n system
- [x] Visual Design: Consistent with existing design system

## Technical Details

**Files Modified:**
- `src/app/(app)/account/components/api-keys/api-keys-header.tsx`
- `messages/en.json`

**Dependencies:**
- No new dependencies added
- Uses existing Lucide React icons
- Leverages Next.js Link component

🤖 Generated with [Claude Code](https://claude.ai/code)