### PR TITLE
chore(deps): update zod to v4.1.9 and @types/node to v22.18.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: 30.1.3
-        version: 30.1.3(@types/node@22.18.1)
+        version: 30.1.3(@types/node@22.18.5)
       jest-environment-jsdom:
         specifier: 30.1.2
         version: 30.1.2
@@ -319,7 +319,7 @@ importers:
         version: 2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       stripe:
         specifier: 18.5.0
-        version: 18.5.0(@types/node@22.18.1)
+        version: 18.5.0(@types/node@22.18.5)
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1
@@ -342,8 +342,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       zod:
-        specifier: 4.1.5
-        version: 4.1.5
+        specifier: 4.1.9
+        version: 4.1.9
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: 0.83.1
@@ -352,8 +352,8 @@ importers:
         specifier: 3.27.4
         version: 3.27.4
       '@types/node':
-        specifier: 22.18.1
-        version: 22.18.1
+        specifier: 22.18.5
+        version: 22.18.5
       '@types/react':
         specifier: 19.1.13
         version: 19.1.13
@@ -3109,6 +3109,9 @@ packages:
 
   '@types/node@22.18.1':
     resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
+
+  '@types/node@22.18.5':
+    resolution: {integrity: sha512-g9BpPfJvxYBXUWI9bV37j6d6LTMNQ88hPwdWWUeYZnMhlo66FIg9gCc1/DZb15QylJSKwOZjwrckvOTWpOiChg==}
 
   '@types/node@24.4.0':
     resolution: {integrity: sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==}
@@ -7590,8 +7593,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.5:
-    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+  zod@4.1.9:
+    resolution: {integrity: sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8229,7 +8232,7 @@ snapshots:
   '@jest/console@30.1.2':
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       chalk: 4.1.2
       jest-message-util: 30.1.0
       jest-util: 30.0.5
@@ -8243,14 +8246,14 @@ snapshots:
       '@jest/test-result': 30.1.3
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.3.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.1.3(@types/node@22.18.1)
+      jest-config: 30.1.3(@types/node@22.18.5)
       jest-haste-map: 30.1.0
       jest-message-util: 30.1.0
       jest-regex-util: 30.0.1
@@ -8279,7 +8282,7 @@ snapshots:
       '@jest/fake-timers': 30.1.2
       '@jest/types': 30.0.5
       '@types/jsdom': 21.1.7
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       jest-mock: 30.0.5
       jest-util: 30.0.5
       jsdom: 26.1.0
@@ -8288,7 +8291,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       jest-mock: 30.0.5
 
   '@jest/expect-utils@30.1.2':
@@ -8306,7 +8309,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.0.5
       '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       jest-message-util: 30.1.0
       jest-mock: 30.0.5
       jest-util: 30.0.5
@@ -8324,7 +8327,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.1.3':
@@ -8335,7 +8338,7 @@ snapshots:
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit-x: 0.2.2
@@ -8412,7 +8415,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -10380,12 +10383,12 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       '@types/responselike': 1.0.3
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
 
   '@types/d3-array@3.2.2': {}
 
@@ -10547,7 +10550,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -10559,7 +10562,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -10569,9 +10572,13 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
 
   '@types/node@22.18.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.18.5':
     dependencies:
       undici-types: 6.21.0
 
@@ -10585,7 +10592,7 @@ snapshots:
 
   '@types/pg@8.15.5':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
@@ -10610,7 +10617,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
 
   '@types/shimmer@1.2.0': {}
 
@@ -10618,7 +10625,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -10635,7 +10642,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)':
@@ -11210,7 +11217,7 @@ snapshots:
       jose: 6.1.0
       kysely: 0.28.7
       nanostores: 1.0.1
-      zod: 4.1.5
+      zod: 4.1.9
     optionalDependencies:
       next: 15.5.3(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
@@ -13007,7 +13014,7 @@ snapshots:
       '@jest/expect': 30.1.2
       '@jest/test-result': 30.1.3
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0
@@ -13027,7 +13034,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.1.3(@types/node@22.18.1):
+  jest-cli@30.1.3(@types/node@22.18.5):
     dependencies:
       '@jest/core': 30.1.3
       '@jest/test-result': 30.1.3
@@ -13035,7 +13042,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.1.3(@types/node@22.18.1)
+      jest-config: 30.1.3(@types/node@22.18.5)
       jest-util: 30.0.5
       jest-validate: 30.1.0
       yargs: 17.7.2
@@ -13046,7 +13053,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.1.3(@types/node@22.18.1):
+  jest-config@30.1.3(@types/node@22.18.5):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/get-type': 30.1.0
@@ -13073,7 +13080,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13114,7 +13121,7 @@ snapshots:
       '@jest/environment': 30.1.2
       '@jest/fake-timers': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       jest-mock: 30.0.5
       jest-util: 30.0.5
       jest-validate: 30.1.0
@@ -13122,7 +13129,7 @@ snapshots:
   jest-haste-map@30.1.0:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13161,7 +13168,7 @@ snapshots:
   jest-mock@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       jest-util: 30.0.5
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.1.3):
@@ -13195,7 +13202,7 @@ snapshots:
       '@jest/test-result': 30.1.3
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -13224,7 +13231,7 @@ snapshots:
       '@jest/test-result': 30.1.3
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       chalk: 4.1.2
       cjs-module-lexer: 2.1.0
       collect-v8-coverage: 1.0.2
@@ -13271,7 +13278,7 @@ snapshots:
   jest-util@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11
@@ -13290,7 +13297,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.1.3
       '@jest/types': 30.0.5
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -13299,24 +13306,24 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.1.0:
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.0.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.1.3(@types/node@22.18.1):
+  jest@30.1.3(@types/node@22.18.5):
     dependencies:
       '@jest/core': 30.1.3
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.1.3(@types/node@22.18.1)
+      jest-cli: 30.1.3(@types/node@22.18.5)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15251,11 +15258,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  stripe@18.5.0(@types/node@22.18.1):
+  stripe@18.5.0(@types/node@22.18.5):
     dependencies:
       qs: 6.14.0
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.18.5
 
   styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.1.1):
     dependencies:
@@ -15861,6 +15868,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.1.5: {}
+  zod@4.1.9: {}
 
   zwitch@2.0.4: {}

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -118,12 +118,12 @@
     "use-debounce": "10.0.6",
     "uuid": "13.0.0",
     "vaul": "1.1.2",
-    "zod": "4.1.5"
+    "zod": "4.1.9"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "0.83.1",
     "@types/humanize-duration": "3.27.4",
-    "@types/node": "22.18.1",
+    "@types/node": "22.18.5",
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
     "@types/react-file-icon": "1.0.4",


### PR DESCRIPTION
## Summary
- Update zod from v4.1.5 to v4.1.9 (patch release)
- Update @types/node from v22.18.1 to v22.18.5 (patch release)

## Key Changes
- Minor version bumps for improved stability and bug fixes
- No breaking changes expected with these patch updates
- Dependency lock files updated accordingly

## Technical Details
This PR updates two key dependencies to their latest patch versions:
- **zod**: Schema validation library patch update
- **@types/node**: Node.js TypeScript definitions patch update

Both updates are patch releases focusing on bug fixes and minor improvements without breaking changes.

## Testing
- No functional changes expected
- Existing test suite should pass without modifications
- Type checking remains compatible

🤖 Generated with [Claude Code](https://claude.ai/code)