### PR TITLE
feat(jobs): show pending output hash verification state

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -284,7 +284,8 @@
         },
         "VerificationBadge": {
           "verified": "{direction} hash is verified. Click here to learn more",
-          "unverified": "{direction} hash is unverified. Click here to learn more"
+          "unverified": "{direction} hash is unverified. Click here to learn more",
+          "pending": "{direction} hash verification is pending. Click here to learn more"
         },
         "Input": {
           "title": "Input",

--- a/web-app/src/components/jobs/job-details/job-verification-badge.tsx
+++ b/web-app/src/components/jobs/job-details/job-verification-badge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCheck, X } from "lucide-react";
+import { CheckCheck, Loader2, X } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
@@ -13,6 +13,11 @@ import {
 import { siteConfig } from "@/config/site";
 import type { JobWithStatus } from "@/lib/db";
 import { cn, isJobVerified } from "@/lib/utils";
+
+interface VerificationState {
+  isPending: boolean;
+  isVerified: boolean;
+}
 
 interface JobVerificationBadgeProps {
   direction: "input" | "output";
@@ -31,16 +36,29 @@ export function JobVerificationBadge({
 
   const identifier = job.identifierFromPurchaser;
 
-  const isVerified = useMemo(() => {
-    if (!identifier) return false;
-    return isJobVerified(direction, job, identifier);
+  const verificationState = useMemo<VerificationState>(() => {
+    if (!identifier) {
+      return { isPending: false, isVerified: false };
+    }
+    const verified = isJobVerified(direction, job, identifier);
+    const pending =
+      direction === "output" && job.resultSubmittedAt == null && !verified;
+    return { isPending: pending, isVerified: verified };
   }, [direction, job, identifier]);
 
-  const Icon = isVerified ? CheckCheck : X;
-  const colorClass = isVerified ? "text-green-500" : "text-red-500";
-  const label = isVerified
-    ? t("VerificationBadge.verified", { direction: directionText })
-    : t("VerificationBadge.unverified", { direction: directionText });
+  const { isPending, isVerified } = verificationState;
+
+  const Icon = isPending ? Loader2 : isVerified ? CheckCheck : X;
+  const colorClass = isPending
+    ? "text-primary"
+    : isVerified
+      ? "text-green-500"
+      : "text-red-500";
+  const label = isPending
+    ? t("VerificationBadge.pending", { direction: directionText })
+    : isVerified
+      ? t("VerificationBadge.verified", { direction: directionText })
+      : t("VerificationBadge.unverified", { direction: directionText });
 
   return (
     <div className="inline-flex items-center pl-4">
@@ -49,13 +67,20 @@ export function JobVerificationBadge({
           <span
             aria-label={label}
             className={cn("inline-flex items-center", className)}
+            aria-busy={isPending}
           >
-            <Icon className={cn("h-4 w-4", colorClass)} />
+            <Icon
+              className={cn(
+                "h-4 w-4",
+                colorClass,
+                isPending ? "animate-spin" : undefined,
+              )}
+            />
           </span>
         </TooltipTrigger>
         <TooltipContent>
           <Link
-            href={siteConfig.links.mip004Docs}
+            href={siteConfig.links.decisionLoggingDocs}
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/web-app/src/config/site.ts
+++ b/web-app/src/config/site.ts
@@ -5,7 +5,8 @@ export const siteConfig = {
   links: {
     twitter: "https://twitter.com/sokosumi",
     github: "https://github.com/masumi-network/sokosumi",
-    mip004Docs: "https://docs.masumi.network/mips/_mip-004",
+    decisionLoggingDocs:
+      "https://docs.masumi.network/core-concepts/decision-logging",
   },
 };
 


### PR DESCRIPTION
 ### 📋 Summary
  Enhances the job verification badge component to display a pending state for output hash verification, providing better user feedback during the verification process.

  ### 🔄 Changes
  - **✨ Added pending verification state**: Introduced a new pending state that shows a loading spinner when output hash verification is in progress (when `job.resultSubmittedAt
  == null`)
  - **🎨 Updated UI indicators**:
    - Pending state uses primary color with animated spinner (Loader2 icon)
    - Added `aria-busy` attribute for accessibility
    - New translation key for pending state message
  - **🏗️ Improved state management**: Refactored verification logic with a dedicated `VerificationState` interface for cleaner code organization
  - **📚 Updated documentation link**: Changed from MIP-004 docs to more relevant decision logging documentation

  ### ⚙️ Technical Details
  - Modified `job-verification-badge.tsx` to handle three states: verified, unverified, and pending
  - Added "pending" translation in `en.json` messages
  - Updated site configuration to point to decision logging documentation

  ### ✅ Testing Checklist
  - [ ] Verify pending state displays correctly when `resultSubmittedAt` is null for output verification
  - [ ] Confirm spinner animation works properly
  - [ ] Test all three states (verified/unverified/pending) display appropriate icons and colors
  - [ ] Verify tooltip links redirect to correct documentation
  - [ ] Check accessibility with screen readers for `aria-busy` attribute
  - [ ] Ensure backward compatibility with existing job verification logic