### PR TITLE
chore(deps): bump pnpm from 10.17.0 to 10.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokosumi",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.17.0",
+  "packageManager": "pnpm@10.17.1",
   "workspaces": [
     "web-app"
   ],

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sokosumi-web",
   "version": "0.1.0",
-  "packageManager": "pnpm@10.17.0",
+  "packageManager": "pnpm@10.17.1",
   "engines": {
     "node": ">=22.0.0 <23.0.0"
   },


### PR DESCRIPTION
## Summary

Upgrade pnpm package manager from version 10.17.0 to 10.17.1 across the monorepo.

## Changes

- Updated `packageManager` field in root `package.json` from `pnpm@10.17.0` to `pnpm@10.17.1`
- Updated `packageManager` field in `web-app/package.json` from `pnpm@10.17.0` to `pnpm@10.17.1`

## Benefits

- Keeps package manager up to date with latest patch version
- May include bug fixes and minor improvements from pnpm upstream
- Maintains consistency across the monorepo workspace

## Testing

- [ ] Verify pnpm commands work correctly
- [ ] Ensure dependency installation works as expected
- [ ] Confirm workspace functionality is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)