### PR TITLE
fix(job): use shouldSync helper return values to avoid null assertion bugs

### DIFF
--- a/web-app/src/lib/services/job.service.ts
+++ b/web-app/src/lib/services/job.service.ts
@@ -78,8 +78,10 @@ export const jobService = (() => {
   /**
    * Helper function to determine if Masumi payment status should be synchronized for a job.
    */
-  function shouldSyncMasumiStatus(job: Job): boolean {
-    return job.refundedCreditTransactionId === null;
+  function shouldSyncMasumiStatus(job: Job): string | null {
+    return job.refundedCreditTransactionId === null && job.purchaseId !== null
+      ? job.purchaseId
+      : null;
   }
 
   /**

--- a/web-app/src/lib/services/job.service.ts
+++ b/web-app/src/lib/services/job.service.ts
@@ -78,10 +78,8 @@ export const jobService = (() => {
   /**
    * Helper function to determine if Masumi payment status should be synchronized for a job.
    */
-  function shouldSyncMasumiStatus(job: Job): string | null {
-    return job.refundedCreditTransactionId === null && job.purchaseId !== null
-      ? job.purchaseId
-      : null;
+  function shouldSyncMasumiStatus(job: Job): boolean {
+    return job.refundedCreditTransactionId === null && job.purchaseId !== null;
   }
 
   /**
@@ -773,10 +771,10 @@ export const jobService = (() => {
     const [agentJobStatusResult, onChainPurchaseResult] = await Promise.all([
       shouldSyncAgentStatus(job)
         ? await agentClient.fetchAgentJobStatus(job.agent, job.agentJobId)
-        : null,
+        : Promise.resolve(null),
       shouldSyncMasumiStatus(job)
         ? await paymentClient.getPurchaseById(job.purchaseId!)
-        : null,
+        : Promise.resolve(null),
     ]);
 
     const newJobStatus = await prisma.$transaction(

--- a/web-app/src/lib/services/job.service.ts
+++ b/web-app/src/lib/services/job.service.ts
@@ -62,24 +62,30 @@ export const jobService = (() => {
   /**
    * Helper function to determine if agent status should be synchronized for a job.
    */
-  function shouldSyncAgentStatus(job: Job): boolean {
+  function shouldSyncAgentStatus(job: Job): string | null {
     if (job.refundedCreditTransactionId) {
-      return false;
+      return null;
     }
     if (
       job.onChainStatus === OnChainJobStatus.RESULT_SUBMITTED &&
       job.agentJobStatus === AgentJobStatus.COMPLETED
     ) {
-      return false;
+      return null;
     }
-    return true;
+    return job.agentJobId;
   }
 
   /**
    * Helper function to determine if Masumi payment status should be synchronized for a job.
    */
-  function shouldSyncMasumiStatus(job: Job): boolean {
-    return job.refundedCreditTransactionId === null && job.purchaseId !== null;
+  function shouldSyncMasumiStatus(job: Job): string | null {
+    if (job.refundedCreditTransactionId) {
+      return null;
+    }
+    if (job.purchaseId === null) {
+      return null;
+    }
+    return job.purchaseId;
   }
 
   /**
@@ -768,12 +774,15 @@ export const jobService = (() => {
         );
       }
     }
+    const agentJobIdToSync = shouldSyncAgentStatus(job);
+    const purchaseIdToSync = shouldSyncMasumiStatus(job);
+
     const [agentJobStatusResult, onChainPurchaseResult] = await Promise.all([
-      shouldSyncAgentStatus(job)
-        ? await agentClient.fetchAgentJobStatus(job.agent, job.agentJobId)
+      agentJobIdToSync
+        ? await agentClient.fetchAgentJobStatus(job.agent, agentJobIdToSync)
         : Promise.resolve(null),
-      shouldSyncMasumiStatus(job)
-        ? await paymentClient.getPurchaseById(job.purchaseId!)
+      purchaseIdToSync
+        ? await paymentClient.getPurchaseById(purchaseIdToSync)
         : Promise.resolve(null),
     ]);
 


### PR DESCRIPTION
## Summary

This PR fixes a potential bug in the `syncJob` function where non-null assertions were used on potentially null values, and improves the overall robustness of the job synchronization logic.

## Key Changes

### 1. Enhanced shouldSync Helper Functions
- **shouldSyncAgentStatus**: Now returns `string | null` instead of `boolean`
  - Returns `job.agentJobId` when sync should occur
  - Returns `null` when sync should be skipped
- **shouldSyncMasumiStatus**: Now returns `string | null` instead of `boolean`
  - Returns `job.purchaseId` when sync should occur
  - Returns `null` when sync should be skipped (including when `purchaseId` is null)

### 2. Fixed syncJob Implementation
- Removed dangerous non-null assertion `job.purchaseId!`
- Now uses the actual return values from helper functions
- Ensures external API calls only happen with valid identifiers

## Architecture Benefits

### Type Safety
- Eliminates non-null assertions that could throw runtime errors
- Properly handles edge cases where fields exist but sync should be skipped
- Uses explicit null checks instead of implicit boolean coercion

### Defensive Programming
- Guards against cases where `purchaseId` might be null despite other conditions
- Prevents API calls with invalid identifiers
- Maintains consistency between guard logic and actual usage

## Technical Details

### Before (Problematic)
```typescript
const [agentJobStatusResult, onChainPurchaseResult] = await Promise.all([
  shouldSyncAgentStatus(job)
    ? await agentClient.fetchAgentJobStatus(job.agent, job.agentJobId)
    : Promise.resolve(null),
  shouldSyncMasumiStatus(job)
    ? await paymentClient.getPurchaseById(job.purchaseId!) // ❌ Non-null assertion
    : Promise.resolve(null),
]);
```

### After (Fixed)
```typescript
const agentJobIdToSync = shouldSyncAgentStatus(job);
const purchaseIdToSync = shouldSyncMasumiStatus(job);

const [agentJobStatusResult, onChainPurchaseResult] = await Promise.all([
  agentJobIdToSync
    ? await agentClient.fetchAgentJobStatus(job.agent, agentJobIdToSync)
    : Promise.resolve(null),
  purchaseIdToSync
    ? await paymentClient.getPurchaseById(purchaseIdToSync) // ✅ Uses returned value
    : Promise.resolve(null),
]);
```

## Testing

- ✅ Linting passes with no errors
- ✅ TypeScript compilation successful
- ✅ Production build completes without issues
- ✅ No breaking changes to existing functionality

## Impact

This fix prevents potential runtime errors when `purchaseId` is null and ensures that the job synchronization logic is more robust and type-safe.