### PR TITLE
feat(agents): add organization-level agent blacklist

### DIFF
--- a/web-app/prisma/migrations/20251006113201_add_agent_blacklist/migration.sql
+++ b/web-app/prisma/migrations/20251006113201_add_agent_blacklist/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "_AgentBlacklist" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_AgentBlacklist_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_AgentBlacklist_B_index" ON "_AgentBlacklist"("B");
+
+-- AddForeignKey
+ALTER TABLE "_AgentBlacklist" ADD CONSTRAINT "_AgentBlacklist_A_fkey" FOREIGN KEY ("A") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AgentBlacklist" ADD CONSTRAINT "_AgentBlacklist_B_fkey" FOREIGN KEY ("B") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/web-app/prisma/schema.prisma
+++ b/web-app/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Organization {
   members            Member[]
   invitations        Invitation[]
   agents             Agent[]
+  blacklistedAgents  Agent[] @relation("AgentBlacklist")
   jobs               Job[]
   creditTransactions CreditTransaction[]
   fiatTransactions   FiatTransaction[]
@@ -348,6 +349,7 @@ model Agent {
   agentLists      AgentList[]
   jobs            Job[]
   organizations   Organization[]
+  blacklistedOrganizations Organization[] @relation("AgentBlacklist")
 
   tags         Tag[] @relation("AgentTag")
   overrideTags Tag[] @relation("AgentTagOverride")

--- a/web-app/src/lib/db/types/agent.ts
+++ b/web-app/src/lib/db/types/agent.ts
@@ -34,6 +34,7 @@ export const agentJobsInclude = {
 
 export const agentOrganizationsInclude = {
   organizations: true,
+  blacklistedOrganizations: true,
 } as const;
 
 export const agentInclude = {

--- a/web-app/src/lib/services/agent.service.ts
+++ b/web-app/src/lib/services/agent.service.ts
@@ -45,6 +45,13 @@ export const agentService = (() => {
     agent: AgentWithOrganizations,
     userOrganizationIds: string[],
   ): boolean {
+    // Blacklist: deny if user belongs to any organization that blacklisted this agent
+    const isBlacklisted = agent.blacklistedOrganizations.some((org) =>
+      userOrganizationIds.includes(org.id),
+    );
+    if (isBlacklisted) return false;
+
+    // Visibility: deny if agent is not shown
     if (!agent.isShown) return false;
     if (agent.organizations.length === 0) return true;
     if (userOrganizationIds.length === 0) return false;


### PR DESCRIPTION
## Summary
Adds organization-to-agent blacklist support and enforces it in visibility checks so organizations can hide specific agents across the app.

## Key Changes
- Prisma schema: add `Organization.blacklistedAgents` and `Agent.blacklistedOrganizations` using relation "AgentBlacklist".
- Migration: `web-app/prisma/migrations/20251006113201_add_agent_blacklist`.
- Types: include `blacklistedOrganizations` in `agentOrganizationsInclude`.
- Service: short-circuit deny when a user belongs to any organization that blacklisted the agent, before other visibility checks.

## Rationale / Architecture
- Provides org-level control to suppress undesired agents without affecting other orgs.
- Keeps logic in the service layer while persisting relationships in Prisma, consistent with the repository/services/actions pattern.

## Technical Details
- Schema updates in `web-app/prisma/schema.prisma` under relation name `AgentBlacklist`.
- Visibility check updated in `web-app/src/lib/services/agent.service.ts` to prioritize blacklist.
- `web-app/src/lib/db/types/agent.ts` now exposes `blacklistedOrganizations` in include helpers.

## Testing
- Run local migration and codegen:
  - `pnpm prisma:migrate:dev`
  - `pnpm prisma:generate`
- Unit scenarios:
  - Agent visible when not blacklisted and `isShown` is true.
  - Agent hidden when user is in any org that blacklisted it (takes precedence over `isShown`).
  - Agent visibility respects blacklist even if the agent is assigned to the user’s org.
- Build & tests:
  - `pnpm test`
  - `pnpm build`

## Verification Steps
1. Create an org, an agent, and link them normally.
2. Add the org to the agent’s `blacklistedOrganizations`.
3. As a member of that org, confirm the agent no longer appears in listings or is actionable.

## Notes
- No breaking API changes expected.
- If issues arise, rollback by removing the relation and reverting migration.