### PR TITLE
refactor(components): generalize HashValue to CopyableValue component

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -520,7 +520,7 @@
       "copySuccess": "Copied to clipboard",
       "copyError": "Failed to copy"
     },
-    "Utils": {  
+    "Utils": {
       "HumanReadableDate": {
         "today": "Today",
         "yesterday": "Yesterday"

--- a/web-app/src/components/copyable-value.tsx
+++ b/web-app/src/components/copyable-value.tsx
@@ -7,11 +7,11 @@ import { toast } from "sonner";
 import { MiddleTruncate } from "@/components/middle-truncate";
 import { Button } from "@/components/ui/button";
 
-export interface HashValueProps {
+export interface CopyableValueProps {
   value: string | null;
 }
 
-export function HashValue({ value }: HashValueProps) {
+export function CopyableValue({ value }: CopyableValueProps) {
   const t = useTranslations("Components.HashValue");
   if (!value) return <span>{"-"}</span>;
 
@@ -35,7 +35,7 @@ export function HashValue({ value }: HashValueProps) {
         title={t("copy")}
         aria-label={t("copy")}
       >
-        <Copy className="h-4 w-4" />
+        <Copy className="size-4" />
       </Button>
     </div>
   );

--- a/web-app/src/components/jobs/job-details/job-meta-details.tsx
+++ b/web-app/src/components/jobs/job-details/job-meta-details.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useFormatter, useTranslations } from "next-intl";
 import { Fragment, ReactNode, useMemo, useState } from "react";
 
-import { HashValue } from "@/components/hash-value";
+import { CopyableValue } from "@/components/copyable-value";
 import { MiddleTruncate } from "@/components/middle-truncate";
 import {
   Collapsible,
@@ -77,7 +77,7 @@ export function JobMetaDetails({ job }: JobMetaDetailsProps) {
       key: "jobId",
       label: t("jobId"),
       rowClassName: "pb-1",
-      content: <MiddleTruncate text={job.id} />,
+      content: <CopyableValue value={job.agentJobId} />,
     },
     {
       key: "txId",
@@ -239,7 +239,7 @@ function HashGroupRow({
         <span className="font-bold break-all md:col-span-1">{label}</span>
         <div className="break-all md:col-span-2">
           <div className="flex items-center gap-2">
-            <HashValue value={onChainHash} />
+            <CopyableValue value={onChainHash} />
             <JobVerificationBadge direction={direction} job={job} />
           </div>
         </div>
@@ -259,7 +259,7 @@ function HashGroupRow({
           <span className="font-bold break-all md:col-span-1">{label}</span>
           <div className="flex items-center justify-between gap-2 break-all md:col-span-2">
             <div className="flex items-center gap-2">
-              <HashValue value={onChainHash ?? calculatedHash} />
+              <CopyableValue value={onChainHash ?? calculatedHash} />
               <JobVerificationBadge direction={direction} job={job} />
             </div>
             <span className="text-muted-foreground inline-flex h-4 w-4 flex-shrink-0 items-center justify-center">
@@ -279,7 +279,7 @@ function HashGroupRow({
           </span>
           <div className="break-all md:col-span-2">
             {onChainHash ? (
-              <HashValue value={onChainHash} />
+              <CopyableValue value={onChainHash} />
             ) : (
               <span className="text-destructive inline-flex items-center gap-1">
                 {tMissing}
@@ -292,7 +292,7 @@ function HashGroupRow({
             {tLabelCalculated}
           </span>
           <div className="break-all md:col-span-2">
-            <HashValue value={calculatedHash} />
+            <CopyableValue value={calculatedHash} />
           </div>
         </div>
       </CollapsibleContent>


### PR DESCRIPTION
## Summary

Refactored the `HashValue` component into a more generic `CopyableValue` component that can be reused for any copyable text values, not just hashes. This improves code maintainability and enables the job ID to have the same copy functionality as hash values.

## Key Changes

- **Component Refactoring**: Renamed `HashValue` to `CopyableValue` for better semantic clarity
  - Renamed `hash-value.tsx` → `copyable-value.tsx`
  - Updated interface: `HashValueProps` → `CopyableValueProps`
  - Updated component function name
- **Job ID Enhancement**: Job ID now displays with copy-to-clipboard functionality using the refactored component
  - Changed from plain `MiddleTruncate` to `CopyableValue` component
  - Uses `agentJobId` instead of internal `id`
- **Icon Sizing Fix**: Updated icon sizing from `h-4 w-4` to `size-4` following project conventions
- **Consistent UX**: All copyable values (job ID, hashes) now share the same UI and behavior

## Architecture Benefits

- **DRY Principle**: Single source of truth for all copyable values
- **Maintainability**: Changes to copy behavior only need to be made in one place
- **Better Naming**: `CopyableValue` accurately describes the component's purpose
- **Reusability**: Component can be easily reused for any future copyable values

## Technical Details

### Files Modified
- `web-app/src/components/copyable-value.tsx` (renamed from hash-value.tsx)
- `web-app/src/components/jobs/job-details/job-meta-details.tsx`
- `web-app/messages/en.json` (whitespace cleanup)

### Component Usage
The component is now used for:
- Job ID (`agentJobId`)
- On-chain input hash
- Calculated input hash
- On-chain result hash
- Calculated result hash

## Testing

- ✅ No linter errors
- ✅ Code properly formatted with Prettier
- ✅ Consistent behavior across all copyable values
- ✅ Toast notifications work correctly on copy success/failure