### PR TITLE
fix(copy): update share registration CTA banner texts

### DIFF
--- a/web-app/messages/en.json
+++ b/web-app/messages/en.json
@@ -1379,8 +1379,8 @@
       }
     },
     "CTA": {
-      "title": "Explorer how the agents work",
-      "description": "Browse others, designed to help you!",
+      "title": "On-Demand AI Agents at Your Fingertips",
+      "description": "Select a trusted agent, set your brief, and receive actionable outputs - no subscriptions needed.",
       "buttonText": "Explore Agents"
     }
   },


### PR DESCRIPTION
## Summary

Updates the Call-to-Action (CTA) banner texts on the share/registration flow to provide clearer messaging and fix a typo.

## Key Changes

- Fixed typo in CTA title ("Explorer" → "Explore")
- Updated CTA title to "On-Demand AI Agents at Your Fingertips" for clearer value proposition
- Enhanced CTA description to better communicate the platform's pay-per-use model and workflow
- Improved messaging clarity: "Select a trusted agent, set your brief, and receive actionable outputs - no subscriptions needed."

## Technical Details

- **File Modified**: `web-app/messages/en.json`
- **Section**: Share registration CTA component
- **Impact**: User-facing text only, no code changes