### PR TITLE
fix(analytics): move agent hiring tracking to client-side

### DIFF
--- a/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
+++ b/web-app/src/components/create-job-modal/job-input/job-inputs-form.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { track } from "@vercel/analytics";
 import { Command, CornerDownLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -108,6 +109,11 @@ export default function JobInputsFormClient({
         getAgentName(agent),
         convertCentsToCredits(creditsPrice.cents),
       );
+      track("Agent hired", {
+        agentId: agentId,
+        credits: convertCentsToCredits(creditsPrice.cents),
+        jobId: result.data.jobId,
+      });
       // close modal
       handleClose();
       await router.push(`/agents/${agentId}/jobs/${result.data.jobId}`);

--- a/web-app/src/lib/actions/job/action.ts
+++ b/web-app/src/lib/actions/job/action.ts
@@ -1,12 +1,11 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
-import { track } from "@vercel/analytics/server";
 
 import { ActionError, CommonErrorCode } from "@/lib/actions";
 import { isJobError, JobErrorCode } from "@/lib/actions/errors/error-codes/job";
 import { OrganizationErrorCode } from "@/lib/actions/errors/error-codes/organization";
-import { convertCentsToCredits, PaidJobWithStatus } from "@/lib/db";
+import { PaidJobWithStatus } from "@/lib/db";
 import {
   jobRepository,
   jobShareRepository,
@@ -166,11 +165,6 @@ export const startJob = withAuthContext<
 
       // call after agent hired webhook
       callAgentHiredWebHook(userId, user.email);
-      await track("Agent hired", {
-        agentId: input.agentId,
-        credits: convertCentsToCredits(input.maxAcceptedCents),
-        jobId: job.id,
-      });
 
       return Ok({ jobId: job.id });
     } catch (error) {


### PR DESCRIPTION
## Summary

This PR fixes analytics tracking for agent hiring events by moving the tracking call from server-side to client-side.

## Key Changes

- Moved `track("Agent hired")` call from `src/lib/actions/job/action.ts` (server) to `src/components/create-job-modal/job-input/job-inputs-form.client.tsx` (client)
- Changed from `@vercel/analytics/server` to `@vercel/analytics` import
- Tracking now occurs after successful job creation and before modal close

## Technical Details

**Before**: Analytics tracking was performed server-side in the `startJob` action after calling the agent hired webhook.

**After**: Analytics tracking is now performed client-side in the job input form component, immediately after receiving a successful response from the job creation action.

### Benefits
- Client-side tracking provides more reliable event capture for user interactions
- Aligns with Vercel Analytics best practices for tracking user-initiated events
- Ensures tracking occurs in the user's session context

## Testing

- [ ] Verify "Agent hired" event is tracked in Vercel Analytics dashboard
- [ ] Confirm event includes correct `agentId`, `credits`, and `jobId` properties
- [ ] Test that job creation flow still works end-to-end
- [ ] Verify modal closes and redirects to job details page