### PR TITLE
fix: job sync query to pick not finished free jobs

### DIFF
--- a/web-app/src/lib/db/repositories/job.repository.ts
+++ b/web-app/src/lib/db/repositories/job.repository.ts
@@ -658,15 +658,14 @@ const jobsNotFinishedWhereQuery = (
     {
       onChainStatus: { not: OnChainJobStatus.DISPUTED },
       externalDisputeUnlockTime: {
+        not: null,
         lt: cutoffTime,
       },
     },
     // Filter out jobs that have no on-chain status and have a payByTime that is less than the cutoff time
     {
       onChainStatus: null,
-      payByTime: {
-        lt: cutoffTime,
-      },
+      payByTime: { not: null, lt: cutoffTime },
     },
     // Filter out demo jobs
     {
@@ -676,6 +675,7 @@ const jobsNotFinishedWhereQuery = (
     {
       jobType: JobType.FREE,
       agentJobStatus: {
+        not: null,
         in: [AgentJobStatus.COMPLETED, AgentJobStatus.FAILED],
       },
     },


### PR DESCRIPTION
## fix(db): add null checks to job repository query filters

### Description

Adds explicit `not: null` checks to job repository query conditions before applying comparison operators. This will ensure that Free Jobs (who has `null` for time-related fields) are synced.

### Changes

- Added `not: null` check for `externalDisputeUnlockTime` before `lt` comparison
- Added `not: null` check for `payByTime` before `lt` comparison  
- Added `not: null` check for `agentJobStatus` before `in` operator

These changes ensure that Prisma only applies comparison operators on non-null values, making the query more robust and preventing edge cases where null values might cause unexpected behavior.

Any compare operation with `null` value returns `null` (not `true` or `false`)
