### PR TITLE
fix(agents): resolve star icon theme mismatch on initial load

### DIFF
--- a/web-app/src/components/agents/star-icon.tsx
+++ b/web-app/src/components/agents/star-icon.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { useId } from "react";
 
 import { cn } from "@/lib/utils";
@@ -19,14 +18,6 @@ export function StarIcon({
   // Generate stable unique gradient ID (prevents hydration mismatches)
   const uniqueId = useId();
   const gradientId = `star-gradient-${uniqueId}`;
-  const { resolvedTheme } = useTheme();
-
-  // Theme-aware colors
-  const isDark = resolvedTheme === "dark";
-  const filledColor = isDark ? "rgb(250, 250, 250)" : "rgb(10, 10, 10)";
-  const emptyColor = isDark
-    ? "rgba(255, 255, 255, 0.15)"
-    : "rgb(230, 230, 230)";
 
   const sizeMap = {
     xs: "size-2", // 8px
@@ -43,8 +34,14 @@ export function StarIcon({
     >
       <defs>
         <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset={`${fillPercentage}%`} stopColor={filledColor} />
-          <stop offset={`${fillPercentage}%`} stopColor={emptyColor} />
+          <stop
+            offset={`${fillPercentage}%`}
+            style={{ stopColor: "var(--foreground)" }}
+          />
+          <stop
+            offset={`${fillPercentage}%`}
+            style={{ stopColor: "var(--tertiary)" }}
+          />
         </linearGradient>
       </defs>
       <path


### PR DESCRIPTION
## Summary

Fixes the star rating icon displaying incorrectly in light mode during initial page load, even when the website is in dark mode.

## Problem

The `StarIcon` component was using the `useTheme()` hook to determine colors dynamically. During server-side rendering and initial hydration, the theme wasn't resolved yet, causing the component to always default to light mode colors on first render. Additionally, the component violated project conventions by using hardcoded RGB values instead of semantic colors from `globals.css`.

## Solution

- **Removed `useTheme()` dependency**: Eliminated JavaScript-based theme detection that caused hydration mismatches
- **Replaced hardcoded colors with semantic CSS variables**: 
  - Filled stars: `var(--foreground)`
  - Empty stars: `var(--tertiary)`
- **Used inline styles for SVG elements**: SVG `<stop>` elements require the `style` attribute to properly reference CSS custom properties

## Benefits

- ✅ Star icons display correctly in both light and dark modes from initial load
- ✅ No hydration mismatches or theme flashing
- ✅ Follows project conventions (no hardcoded colors)
- ✅ Automatic theme adaptation via CSS (no JavaScript required)
- ✅ Better performance (CSS-based instead of JS-based theming)

## Technical Details

The CSS custom properties automatically adapt to the current theme:
- **Light mode**: `--foreground` = `hsla(0, 0%, 4%, 1)`, `--tertiary` = `hsla(0, 0%, 4%, 0.2)`
- **Dark mode**: `--foreground` = `hsla(0, 0%, 98%, 1)`, `--tertiary` = `hsla(0, 0%, 100%, 0.3)`

## Testing

- [x] Verify star icons render correctly in light mode on initial load
- [x] Verify star icons render correctly in dark mode on initial load  
- [x] Verify no hydration warnings in console
- [x] Verify theme switching works seamlessly
- [x] Linter passes with no errors