### PR TITLE
chore(deps): reorganize dependencies to web-app workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,19 +26,6 @@
     "sokosumi-web:prisma:migrate:dev": "pnpm --filter sokosumi-web prisma:migrate:dev"
   },
   "devDependencies": {
-    "@noble/hashes": "2.0.1",
-    "@swc/core": "1.13.5",
-    "@swc/helpers": "0.5.17",
-    "@tailwindcss/postcss": "4.1.16",
-    "@tailwindcss/typography": "0.5.19",
-    "@testing-library/jest-dom": "6.9.1",
-    "@testing-library/react": "16.3.0",
-    "@types/jest": "30.0.0",
-    "jest": "30.2.0",
-    "jest-environment-jsdom": "30.2.0",
-    "postcss": "8.5.6",
-    "tailwindcss": "4.1.16",
-    "tsx": "4.20.6",
-    "typescript": "5.9.3"
+    "husky": "9.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,48 +8,9 @@ importers:
 
   .:
     devDependencies:
-      '@noble/hashes':
-        specifier: 2.0.1
-        version: 2.0.1
-      '@swc/core':
-        specifier: 1.13.5
-        version: 1.13.5(@swc/helpers@0.5.17)
-      '@swc/helpers':
-        specifier: 0.5.17
-        version: 0.5.17
-      '@tailwindcss/postcss':
-        specifier: 4.1.16
-        version: 4.1.16
-      '@tailwindcss/typography':
-        specifier: 0.5.19
-        version: 0.5.19(tailwindcss@4.1.16)
-      '@testing-library/jest-dom':
-        specifier: 6.9.1
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: 16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@types/jest':
-        specifier: 30.0.0
-        version: 30.0.0
-      jest:
-        specifier: 30.2.0
-        version: 30.2.0(@types/node@22.18.12)
-      jest-environment-jsdom:
-        specifier: 30.2.0
-        version: 30.2.0
-      postcss:
-        specifier: 8.5.6
-        version: 8.5.6
-      tailwindcss:
-        specifier: 4.1.16
-        version: 4.1.16
-      tsx:
-        specifier: 4.20.6
-        version: 4.20.6
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
 
   web-app:
     dependencies:
@@ -333,9 +294,33 @@ importers:
       '@hey-api/openapi-ts':
         specifier: 0.86.6
         version: 0.86.6(typescript@5.9.3)
+      '@noble/hashes':
+        specifier: 2.0.1
+        version: 2.0.1
+      '@swc/core':
+        specifier: 1.13.5
+        version: 1.13.5(@swc/helpers@0.5.17)
+      '@swc/helpers':
+        specifier: 0.5.17
+        version: 0.5.17
+      '@tailwindcss/postcss':
+        specifier: 4.1.16
+        version: 4.1.16
+      '@tailwindcss/typography':
+        specifier: 0.5.19
+        version: 0.5.19(tailwindcss@4.1.16)
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/humanize-duration':
         specifier: 3.27.4
         version: 3.27.4
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/jsdom':
         specifier: 27.0.0
         version: 27.0.0
@@ -378,12 +363,21 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 4.3.0
         version: 4.3.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
+      jest:
+        specifier: 30.2.0
+        version: 30.2.0(@types/node@22.18.12)
+      jest-environment-jsdom:
+        specifier: 30.2.0
+        version: 30.2.0
       jsdom:
         specifier: 27.0.0
         version: 27.0.0(postcss@8.5.6)
       next-openapi-gen:
         specifier: 0.8.0
         version: 0.8.0
+      postcss:
+        specifier: 8.5.6
+        version: 8.5.6
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -396,6 +390,15 @@ importers:
       puppeteer:
         specifier: 24.24.1
         version: 24.24.1(typescript@5.9.3)
+      tailwindcss:
+        specifier: 4.1.16
+        version: 4.1.16
+      tsx:
+        specifier: 4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -4972,9 +4975,6 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.12.0:
-    resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
-
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
@@ -5129,6 +5129,11 @@ packages:
 
   humanize-duration@3.33.1:
     resolution: {integrity: sha512-hwzSCymnRdFx9YdRkQQ0OYequXiVAV6ZGQA2uzocwB0F4309Ke6pO8dg0P8LHhRQJyVjGteRTAA/zNfEcpXn8A==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5813,9 +5818,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-string@0.30.19:
-    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -10500,7 +10502,7 @@ snapshots:
       enhanced-resolve: 5.18.3
       jiti: 2.6.1
       lightningcss: 1.30.2
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.1.16
 
@@ -12812,10 +12814,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.12.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -13008,6 +13006,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   humanize-duration@3.33.1: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -13882,10 +13882,6 @@ snapshots:
       react: 19.2.0
 
   lz-string@1.5.0: {}
-
-  magic-string@0.30.19:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.21:
     dependencies:
@@ -15744,7 +15740,7 @@ snapshots:
   tsx@4.20.6:
     dependencies:
       esbuild: 0.25.11
-      get-tsconfig: 4.12.0
+      get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
 

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -128,7 +128,15 @@
   "devDependencies": {
     "@eslint/eslintrc": "3.3.1",
     "@hey-api/openapi-ts": "0.86.6",
+    "@noble/hashes": "2.0.1",
+    "@swc/core": "1.13.5",
+    "@swc/helpers": "0.5.17",
+    "@tailwindcss/postcss": "4.1.16",
+    "@tailwindcss/typography": "0.5.19",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.0",
     "@types/humanize-duration": "3.27.4",
+    "@types/jest": "30.0.0",
     "@types/jsdom": "27.0.0",
     "@types/node": "22.18.12",
     "@types/pg": "^8.15.5",
@@ -143,11 +151,17 @@
     "eslint-plugin-no-relative-import-paths": "1.6.1",
     "eslint-plugin-simple-import-sort": "12.1.1",
     "eslint-plugin-unused-imports": "4.3.0",
+    "jest": "30.2.0",
+    "jest-environment-jsdom": "30.2.0",
     "jsdom": "27.0.0",
     "next-openapi-gen": "0.8.0",
     "prettier": "3.6.2",
     "prettier-plugin-tailwindcss": "0.7.1",
     "prisma": "6.18.0",
-    "puppeteer": "24.24.1"
+    "puppeteer": "24.24.1",
+    "postcss": "8.5.6",
+    "tailwindcss": "4.1.16",
+    "tsx": "4.20.6",
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Summary

This PR reorganizes the monorepo's dependency structure by moving development dependencies from the root package.json to the web-app workspace where they are actually used, and adds Husky for Git hooks management at the root level.

## Key Changes

- **Moved to web-app workspace**: 
  - Build tools: `@swc/core`, `@swc/helpers`, `tsx`
  - Testing utilities: `@testing-library/jest-dom`, `@testing-library/react`, `@types/jest`, `jest`, `jest-environment-jsdom`
  - Styling tools: `@tailwindcss/postcss`, `@tailwindcss/typography`, `tailwindcss`, `postcss`
  - Other: `@noble/hashes`, `typescript`

- **Added to root**:
  - `husky@9.1.7` for Git hooks management

## Architecture Benefits

This change improves the monorepo structure by:
1. **Clear dependency ownership**: Dependencies are now declared where they are actually consumed
2. **Reduced root complexity**: The root package.json is now focused on workspace-level tooling
3. **Better isolation**: Makes it clearer which dependencies belong to which workspace
4. **Future scalability**: Easier to add new workspaces without dependency conflicts

## Technical Details

- All moved dependencies maintain their exact versions
- The `pnpm-lock.yaml` reflects the dependency tree reorganization
- No functional changes to the application
- Husky is appropriately placed at root for repository-wide Git hooks

## Testing

```bash
# Verify dependencies are correctly resolved
pnpm install

# Ensure build works
pnpm build

# Verify tests still run
pnpm test

# Check linting
pnpm lint
```