### PR TITLE
feat(ui): place menu button before logo on mobile

### DIFF
--- a/web-app/src/app/(app)/components/header.tsx
+++ b/web-app/src/app/(app)/components/header.tsx
@@ -21,7 +21,8 @@ export default function Header({ session, className }: HeaderProps) {
         className,
       )}
     >
-      <div className="flex w-full items-center justify-between gap-2 p-2 md:w-auto">
+      <div className="flex w-full items-center gap-2 p-2 pl-0 md:w-auto md:pl-2">
+        <CustomTrigger when="invisible" />
         <Link href="/" className="md:hidden">
           <ThemedLogo
             LogoComponent={SokosumiLogo}
@@ -30,7 +31,6 @@ export default function Header({ session, className }: HeaderProps) {
             height={16}
           />
         </Link>
-        <CustomTrigger when="invisible" />
       </div>
 
       <div className="hidden flex-1 flex-row gap-2 sm:flex">


### PR DESCRIPTION
### Summary

- Places the sidebar/menu trigger to the left of the logo on mobile for better reachability and alignment with common patterns.

### Key Changes
- Update `web-app/src/app/(app)/components/header.tsx`:
  - Move `CustomTrigger` before the logo in the mobile-only section.
  - Adjust padding classes (use `pl-0` on mobile, keep `md:pl-2`).

### Technical Details
- Affects only mobile layout (md breakpoint and below).
- No logic changes; RSC-safe UI-only edit following Tailwind and Shadcn conventions.

### Testing
- Run `pnpm sokosumi-web:dev`.
- Narrow viewport to <768px.
- Verify the menu trigger renders left of the Sokosumi logo and spacing looks correct in both light and dark themes.

### Checklist
- [x] Conventional commit message
- [x] Lint and tests pass (`pnpm -r lint`, `pnpm -r test:ci`)
- [x] No i18n strings changed
