### PR TITLE
chore: add .neon and .vercel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ node_modules
 .DS_Store
 *.pem
 .env
+.neon
+.vercel
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
## Summary

Updates the root .gitignore to exclude Neon and Vercel configuration files from version control.

## Changes

- **/.gitignore**:
  - Added `.neon` - Neon database configuration file
  - Added `.vercel` - Vercel deployment configuration directory

## Rationale

These files contain environment-specific configuration and should not be committed to the repository:
- `.neon` - Contains Neon database connection details and project-specific configuration
- `.vercel` - Contains Vercel deployment settings and build artifacts

## Testing

No functional changes - purely configuration updates.