### PR TITLE
fix(ci): prevent duplicate dependabot PRs in monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,20 @@
 version: 2
 updates:
-  # Root directory - workspace-level dev dependencies
+  # Root directory - workspace-level tooling only
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
       time: "06:00"
       timezone: "Europe/Berlin"
-    groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "eslint-config-prettier"
-          - "eslint-plugin-*"
-      prettier:
-        patterns:
-          - "prettier"
-      typescript:
-        patterns:
-          - "typescript-eslint"
-    open-pull-requests-limit: 10
+    allow:
+      - dependency-name: "eslint"
+      - dependency-name: "eslint-config-*"
+      - dependency-name: "eslint-plugin-*"
+      - dependency-name: "husky"
+      - dependency-name: "prettier"
+      - dependency-name: "typescript-eslint"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
 
@@ -47,6 +42,10 @@ updates:
           - "react-*"
           - "embla-carousel-react"
           - "vaul"
+        exclude-patterns:
+          - "react"
+          - "react-dom"
+          - "react-hook-form"
       radix:
         patterns:
           - "@radix-ui/*"


### PR DESCRIPTION
## Summary

This PR fixes the issue where Dependabot was creating duplicate pull requests for the same dependency updates in our pnpm monorepo setup.

## Problem

Dependabot was opening two PRs for the same updates:
- One from the root directory scanner picking up workspace dependencies
- Another from the workspace-specific scanners (`/apps/web`, `/packages/database`)

Additionally, some dependencies matched multiple group patterns, causing further duplicates (e.g., `react-hook-form` matched both `react-components` and `forms` groups).

## Solution

### 1. Root Configuration with Allow List
- Converted root config from using `groups` to using `allow` allowlist
- Restricts root scanner to **only** workspace-level tooling packages:
  - `eslint` and plugins
  - `prettier`
  - `husky`
  - `typescript-eslint`
- Prevents root scanner from detecting workspace dependencies entirely

### 2. Fixed Overlapping Group Patterns
- Added `exclude-patterns` to `react-components` group
- Excludes `react`, `react-dom` (managed by `react` group)
- Excludes `react-hook-form` (managed by `forms` group)

### 3. Optimized PR Limits
- Reduced root config `open-pull-requests-limit` from 10 to 5
- Appropriate for the smaller number of root dependencies

## Benefits

✅ Eliminates duplicate PRs completely
✅ Clear separation: root manages tooling, workspaces manage app dependencies
✅ Cleaner PR list with proper grouping
✅ Easier to maintain with explicit allowlist

## Testing

- Close duplicate PRs manually after merge
- Monitor next Dependabot run to verify only one PR per update
- Verify root dependencies (eslint, prettier, etc.) still get updates