### PR TITLE
refactor(anthropic): update system prompt for agent summary generation to improve clarity and character limits

### DIFF
--- a/apps/web/src/lib/clients/anthropic.client.ts
+++ b/apps/web/src/lib/clients/anthropic.client.ts
@@ -23,8 +23,12 @@ export const anthropicClient = (() => {
         .map(([key, value]) => `${key} => ${JSON.stringify(value)}`)
         .join(", ");
 
-      const systemPrompt =
-        "You are an assistant that generates concise, descriptive job titles. The title should not exceed 80 characters and must be in the same language as the input data. The input data takes precedence over the agent name and description. Aim to create unique titles based on the input data. Please respond with only the title, without any additional text. Do not repeat the agent name in your response.";
+      const systemPrompt = `Generate a descriptive agent summary following these rules:
+        - Length: 90-110 characters (including spaces and punctuation)
+        - Language: Match the input
+        - Format: Single sentence, no agent name
+        - Output: Summary only, no other text
+      `;
       const userPrompt = `Agent: ${agent.name} ${agent.description ? ` - ${agent.description}` : ""}\nInput: ${inputSummary}`;
 
       try {


### PR DESCRIPTION
## Summary

This PR refactors the system prompt used in the Anthropic client's `generateJobName` method to improve clarity, structure, and adjust character length requirements.

## Key Changes

- **Restructured system prompt**: Converted from a single long sentence to a clear, multi-line format with bullet points for better readability
- **Character limit adjustment**: Updated from "not exceed 80 characters" to a range of "90-110 characters" to provide more flexibility for agent summaries
- **Improved formatting**: The new format uses structured rules that are easier to understand and maintain
- **Enhanced clarity**: Explicitly states output format requirements (single sentence, no agent name, summary only)

## Technical Details

### Modified Files
- `apps/web/src/lib/clients/anthropic.client.ts`: Updated the system prompt for the `generateJobName` method

### Changes
- Replaced verbose single-line prompt with structured multi-line template literal
- Adjusted character length requirement from 80 max to 90-110 range
- Improved prompt clarity with explicit formatting rules

## Testing

- [ ] Verify that agent summary generation still works correctly
- [ ] Confirm generated summaries fall within the 90-110 character range
- [ ] Test with various input data formats and languages
- [ ] Ensure no breaking changes to existing functionality