### PR TITLE
fix(job): remove duplicate job failure notification dispatch

### DIFF
--- a/apps/web/src/lib/services/job.service.ts
+++ b/apps/web/src/lib/services/job.service.ts
@@ -1038,7 +1038,6 @@ export const jobService = (() => {
       },
     );
 
-    await dispatchJobFailureNotification(job);
     // if job status changed, publish to job status to channel
     if (newJobStatus !== oldJobStatus) {
       console.log(


### PR DESCRIPTION
## Summary

Removes an incorrect unconditional call to `dispatchJobFailureNotification` that was triggering failure notifications regardless of job status changes.

## Problem

The job service was calling `dispatchJobFailureNotification(job)` unconditionally after every job status computation transaction, even when:
- The job status hadn't changed
- The job wasn't in a failed state

This caused spurious failure notifications to be sent to users.

## Solution

Removed the unconditional `dispatchJobFailureNotification` call at line 1041. The proper notification logic already exists in the conditional block (lines 1052-1054) which correctly:
1. Checks if the job status actually changed (`newJobStatus !== oldJobStatus`)
2. Verifies the new status is a failed state (`failedJobStatuses.has(newJobStatus)`)
3. Only then dispatches the failure notification

## Changes

- **Removed**: Unconditional `await dispatchJobFailureNotification(job);` call
- **Impact**: Job failure notifications will now only be sent when jobs actually transition to a failed state

## Testing

- [ ] Verify that failure notifications are still sent when jobs fail
- [ ] Verify that notifications are NOT sent when job status doesn't change
- [ ] Verify that notifications are NOT sent for non-failed job statuses

## Files Changed

- `apps/web/src/lib/services/job.service.ts`