### PR TITLE
fix(lint): resolve ESLint plugin redefinition conflicts

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig, globalIgnores } from "eslint/config";
-import baseConfig from "../../eslint.config.mjs";
+import { sharedPlugins, sharedRules } from "../../eslint.config.mjs";
+import prettier from "eslint-config-prettier/flat";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import eslintNextPlugin from "eslint-config-next";
@@ -9,10 +10,11 @@ import noRelativeImportPaths from "eslint-plugin-no-relative-import-paths";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  ...baseConfig,
+  prettier,
   i18next.configs["flat/recommended"],
   {
     plugins: {
+      ...sharedPlugins,
       next: eslintNextPlugin,
       "no-relative-import-paths": noRelativeImportPaths,
     },
@@ -22,6 +24,7 @@ const eslintConfig = defineConfig([
       },
     },
     rules: {
+      ...sharedRules,
       "@next/next/no-html-link-for-pages": ["error", "src/app"],
       "no-restricted-properties": [
         "error",
@@ -32,7 +35,7 @@ const eslintConfig = defineConfig([
             "Please use our custom getEnvSecrets or getEnvConfig functions instead of process.env as it is validated on startup and type-safe.",
         },
       ],
-      // Enforce absolute imports for web app code (inherited from shared config)
+      // Enforce absolute imports for web app code
       "no-relative-import-paths/no-relative-import-paths": [
         "error",
         { allowSameFolder: true },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,38 +6,50 @@ import unusedImports from "eslint-plugin-unused-imports";
 import tseslint from "typescript-eslint";
 
 /**
+ * Shared plugins and rules for the Sokosumi monorepo.
+ * Can be composed with other configs without plugin conflicts.
+ * Note: Does not include import plugin as Next.js provides its own.
+ */
+export const sharedPlugins = {
+  "simple-import-sort": simpleImportSort,
+  "unused-imports": unusedImports,
+};
+
+export const sharedRules = {
+  // Import organization
+  "simple-import-sort/imports": "error",
+  "simple-import-sort/exports": "error",
+  "unused-imports/no-unused-imports": "error",
+  "import/first": "error",
+  "import/newline-after-import": "error",
+  "import/no-duplicates": "error",
+
+  // TypeScript
+  "@typescript-eslint/no-unused-vars": [
+    "warn",
+    {
+      varsIgnorePattern: "^_",
+      argsIgnorePattern: "^_",
+      caughtErrorsIgnorePattern: "^_",
+      destructuredArrayIgnorePattern: "^_",
+    },
+  ],
+};
+
+/**
  * Base ESLint configuration for the Sokosumi monorepo.
  * Extended by individual packages with their specific needs.
+ * For packages using Next.js, import sharedPlugins and sharedRules separately.
  */
 const baseConfig = defineConfig([
   ...tseslint.configs.recommended,
   prettier,
   {
     plugins: {
-      "simple-import-sort": simpleImportSort,
-      "unused-imports": unusedImports,
+      ...sharedPlugins,
       import: importPlugin,
     },
-    rules: {
-      // Import organization
-      "simple-import-sort/imports": "error",
-      "simple-import-sort/exports": "error",
-      "unused-imports/no-unused-imports": "error",
-      "import/first": "error",
-      "import/newline-after-import": "error",
-      "import/no-duplicates": "error",
-
-      // TypeScript
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        {
-          varsIgnorePattern: "^_",
-          argsIgnorePattern: "^_",
-          caughtErrorsIgnorePattern: "^_",
-          destructuredArrayIgnorePattern: "^_",
-        },
-      ],
-    },
+    rules: sharedRules,
   },
 ]);
 


### PR DESCRIPTION
## Summary

Fixes ESLint configuration errors caused by plugin redefinition conflicts in flat config format. The web app's ESLint setup was attempting to redefine plugins (`@typescript-eslint` and `import`) that were already defined in both the base config and Next.js configs, causing linting to fail completely.

## Problem

Running `pnpm web:lint` resulted in:
```
ConfigError: Config "typescript-eslint/base": Key "plugins": Cannot redefine plugin "@typescript-eslint".
```

The issue occurred because:
- Base config included `tseslint.configs.recommended` (defines `@typescript-eslint` plugin)
- Next.js configs also define `@typescript-eslint` plugin
- ESLint flat config format doesn't allow the same plugin to be registered multiple times

## Solution

Refactored the base ESLint configuration to support composition without plugin conflicts:

1. **Exported shared artifacts** from base config:
   - `sharedPlugins`: Common plugins that don't conflict (simple-import-sort, unused-imports)
   - `sharedRules`: Consistent rules applied across all packages

2. **Updated web app config** to avoid conflicts:
   - Import `sharedPlugins` and `sharedRules` instead of full `baseConfig`
   - Let Next.js provide `@typescript-eslint` and `import` plugins
   - Apply shared rules on top of Next.js configs

3. **Maintained backward compatibility**:
   - Database package continues using full `baseConfig` (includes TypeScript ESLint and import plugin)
   - No changes needed for non-Next.js packages

## Architecture Benefits

- **No duplication**: Rules defined once in `sharedRules`, applied everywhere
- **Flexible composition**: Packages can choose full base config or compose with their own plugin providers
- **Clear separation**: Base config for standard packages, shared rules for specialized configs
- **Maintainability**: Single source of truth for common linting rules

## Testing

All linting commands pass successfully:

```bash
✅ pnpm lint                    # Lints all packages
✅ pnpm web:lint                # Web app specific
✅ pnpm --filter database lint  # Database package specific
```

## Technical Details

### Files Changed
- `eslint.config.mjs`: Exported `sharedPlugins` and `sharedRules` for composition
- `apps/web/eslint.config.mjs`: Use shared artifacts instead of full base config

### Plugin Sources by Package
- **Database**: TypeScript ESLint + import plugin from base config
- **Web**: TypeScript ESLint + import plugin from Next.js configs

Both packages apply the same `sharedRules` for consistency.