### PR TITLE
feat(user-credits): introduce dynamic buy button threshold based on environment config

### DIFF
--- a/apps/web/src/app/(app)/components/user-credits.tsx
+++ b/apps/web/src/app/(app)/components/user-credits.tsx
@@ -4,6 +4,7 @@ import {
 } from "@sokosumi/database/repositories";
 import { getTranslations } from "next-intl/server";
 
+import { getEnvPublicConfig } from "@/config/env.public";
 import { Session } from "@/lib/auth/auth";
 import { convertCentsToCredits } from "@/lib/helpers/credit";
 import { userService } from "@/lib/services/user.service";
@@ -50,7 +51,10 @@ export default async function UserCredits({ session }: UserCreditsProps) {
 
   return (
     <div className="flex flex-1 flex-col-reverse gap-4 md:flex-initial md:flex-row md:items-center">
-      {credits <= 50.0 && <BuyCreditsButton label={t("buy")} path="/billing" />}
+      {credits <
+        getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD && (
+        <BuyCreditsButton label={t("buy")} path="/billing" />
+      )}
       <div className="flex items-center gap-2 md:flex-row-reverse">
         <UserAvatar session={session} />
         <div className="flex flex-col gap-0.5 md:items-end">

--- a/apps/web/src/config/env.public.ts
+++ b/apps/web/src/config/env.public.ts
@@ -23,6 +23,10 @@ const envPublicConfigSchema = z.object({
   NEXT_PUBLIC_FEE_PERCENTAGE: z.coerce.number().min(0).default(5),
   NEXT_PUBLIC_CREDITS_BASE: z.coerce.number().default(12),
   NEXT_PUBLIC_AGENT_NEW_THRESHOLD_DAYS: z.coerce.number().min(0).default(7),
+  NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD: z.coerce
+    .number()
+    .min(0)
+    .default(30),
 });
 
 let envPublicConfig: z.infer<typeof envPublicConfigSchema>;


### PR DESCRIPTION
## Summary

This PR introduces a configurable threshold for displaying the buy credits button in the user credits component. The threshold is now controlled via environment configuration instead of being hardcoded, making it easier to adjust across different environments.

## Key Changes

- **Added environment variable**: `NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD` with a default value of 30 credits
- **Updated UserCredits component**: Replaced hardcoded threshold (50.0) with environment-based configuration
- **Changed comparison operator**: Updated from `<=` to `<` for consistency

## Technical Details

### Files Modified

1. **`apps/web/src/config/env.public.ts`**
   - Added `NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD` to the Zod schema
   - Default value: 30 credits
   - Validation: Minimum value of 0

2. **`apps/web/src/app/(app)/components/user-credits.tsx`**
   - Imported `getEnvPublicConfig` function
   - Replaced hardcoded `50.0` threshold with `getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD`
   - Changed comparison from `credits <= 50.0` to `credits < threshold`

### Architecture Benefits

- **Environment-specific configuration**: Different thresholds can be set for development, staging, and production
- **Type safety**: Uses Zod schema validation for environment variables
- **Maintainability**: Centralized configuration following the established pattern in `env.public.ts`

## Environment Variable

To customize the threshold, set:
```
NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD=30
```

Default value is 30 credits if not specified.