### PR TITLE
fix(sidebar): hide empty state text in collapsed icon mode

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/agent-lists.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/agent-lists.client.tsx
@@ -169,7 +169,7 @@ export default function AgentListsClient({
                         })}
                       </SidebarMenu>
                     ) : (
-                      <p className="text-muted-foreground px-4 py-2 text-sm">
+                      <p className="text-muted-foreground px-4 py-2 text-sm group-data-[collapsible=icon]:hidden">
                         {t("noAgents", { type: noAgentsType })}
                       </p>
                     )}


### PR DESCRIPTION
## Summary

Fixes the issue where "No pinned agents yet" and "No hired agents yet" text was visible when the sidebar was collapsed to icon mode, even when the collapsible section was expanded.

## Changes

- Added `group-data-[collapsible=icon]:hidden` class to the empty state paragraph in `agent-lists.client.tsx`
- This follows the same pattern used for hiding other elements in the sidebar's icon mode

## Technical Details

The sidebar has two collapsible states:
1. **Sidebar collapsed** (icon mode): Controlled by `group-data-[collapsible=icon]`
2. **Section collapsed** (chevron): Controlled by `CollapsibleContent`

The issue occurred when the section was expanded but the sidebar was in icon mode. The empty state text would show, which looked awkward.

## Testing

- Verify that the empty state text appears normally when sidebar is expanded
- Verify that the empty state text is hidden when sidebar is collapsed to icon mode
- Verify that icons remain in fixed positions and don't shift between states