### PR TITLE
refactor(mcp): remove setup demo gif from empty state

### DIFF
--- a/apps/web/src/app/(app)/mcp/components/mcp-empty-state.tsx
+++ b/apps/web/src/app/(app)/mcp/components/mcp-empty-state.tsx
@@ -1,5 +1,4 @@
 import { Loader2 } from "lucide-react";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
@@ -18,23 +17,6 @@ export function McpEmptyState({ onGenerate, isLoading }: McpEmptyStateProps) {
         {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
         {t("generateButton")}
       </Button>
-
-      {/* Setup Preview */}
-      <div className="space-y-3">
-        <h4 className="text-muted-foreground text-sm font-medium">
-          {t("setupPreviewTitle")}
-        </h4>
-        <div className="bg-muted/30 rounded-lg border p-4">
-          <Image
-            src="/images/mcp-setup-demo.gif"
-            alt="MCP Setup Demo - Visual guide showing how to connect Claude to Sokosumi"
-            width={600}
-            height={400}
-            className="w-full rounded-md"
-            unoptimized // Allows GIFs to animate
-          />
-        </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Removes the setup preview gif from the MCP empty state component to simplify the UI.

## Key Changes

- Removed the setup preview section displaying the MCP demo gif
- Removed unused `Image` import from `next/image`
- Simplified the empty state to focus on the primary action (generate button)

## Technical Details

**Modified Files:**
- `apps/web/src/app/(app)/mcp/components/mcp-empty-state.tsx`

**Changes:**
- Removed 20+ lines of code including the setup preview container
- Cleaned up unused imports
- Maintained all existing functionality

## Testing

- ✅ No linter errors
- ✅ Component still renders correctly with generate button
- ✅ All existing functionality preserved

## UI Impact

The MCP empty state page now displays only the generate button without the visual setup guide. This creates a cleaner, more focused interface.