### PR TITLE
fix: imageHash on auth.ts

### DIFF
--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -268,7 +268,6 @@ export const auth = betterAuth({
       imageHash: {
         type: "string",
         required: false,
-        defaultValue: null,
       },
     },
   },


### PR DESCRIPTION
## Changes

This PR removes the default value of `imageHash` on `auth.ts`, because that causes mismatch between `auth.ts` and `schema.prisma`.
And this causes sign-up with social provider fails.