### PR TITLE
fix(database): make Category.priority column non-nullable

### DIFF
--- a/packages/database/prisma/migrations/20251105141407_fix_category_priority_not_null/migration.sql
+++ b/packages/database/prisma/migrations/20251105141407_fix_category_priority_not_null/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Made the column `priority` on table `Category` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- Set default priority for any existing NULL values
+UPDATE "Category" SET "priority" = 9999 WHERE "priority" IS NULL;
+
+-- AlterTable
+ALTER TABLE "Category" ALTER COLUMN "priority" SET NOT NULL;


### PR DESCRIPTION
## Summary

Fixes a schema mismatch between the Prisma schema and database migrations where the `Category.priority` column was nullable in the database but defined as required in `schema.prisma`.

## Problem

The migration `20251104162246_add_priority_to_category` added the `priority` column without a `NOT NULL` constraint, but the Prisma schema defined it as `Int` (required, not `Int?`). This mismatch could cause runtime errors when querying categories.

## Changes

- Created migration `20251105141407_fix_category_priority_not_null`
- Sets default priority value of 9999 for any existing NULL values
- Adds `NOT NULL` constraint to the `priority` column

## Technical Details

The migration safely handles existing data by:
1. First updating any NULL values to 9999 (ensuring low priority for uncategorized items)
2. Then applying the `NOT NULL` constraint

This ensures the database schema matches the Prisma schema definition:
```prisma
model Category {
  // ...
  priority    Int
  // ...
}
```

## Testing

- [x] Migration created with `prisma migrate dev --create-only`
- [x] Migration successfully applied with `prisma migrate deploy`
- [x] No existing NULL values in production data