### PR TITLE
chore(deps): align pnpm version and type packages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -137,7 +137,7 @@
     "@types/react-dom": "19.2.2",
     "@types/react-file-icon": "1.0.4",
     "@types/react-window": "2.0.0",
-    "@types/sanitize-html": "^2.14.0",
+    "@types/sanitize-html": "2.16.0",
     "eslint-config-next": "16.0.1",
     "eslint-plugin-i18next": "6.1.3",
     "eslint-plugin-no-relative-import-paths": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokosumi",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.20.0",
+  "packageManager": "pnpm@10.21.0",
   "scripts": {
     "dev": "pnpm -r dev",
     "web:dev": "pnpm --filter web dev",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "22.19.0",
-    "@types/pg": "^8.15.6",
+    "@types/pg": "8.15.6",
     "dotenv": "17.2.3",
     "prisma": "6.19.0",
     "tsx": "4.20.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,7 +358,7 @@ importers:
         specifier: 2.0.0
         version: 2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/sanitize-html':
-        specifier: ^2.14.0
+        specifier: 2.16.0
         version: 2.16.0
       eslint-config-next:
         specifier: 16.0.1
@@ -419,7 +419,7 @@ importers:
         specifier: 22.19.0
         version: 22.19.0
       '@types/pg':
-        specifier: ^8.15.6
+        specifier: 8.15.6
         version: 8.15.6
       dotenv:
         specifier: 17.2.3
@@ -14263,7 +14263,7 @@ snapshots:
   next-intl@4.5.0(@swc/helpers@0.5.17)(next@16.0.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
-      '@swc/core': 1.15.0(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.1(@swc/helpers@0.5.17)
       negotiator: 1.0.0
       next: 16.0.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0


### PR DESCRIPTION
## Summary
- align repository packageManager metadata with pnpm 10.21.0 for consistent CLI usage
- pin type definition dependencies in web and database workspaces to the resolved versions to avoid caret drift

## Technical Details
- updated pnpm-lock.yaml to capture the resolved @swc/core 1.15.1 snapshot pulled through next-intl
- ensures deterministic installs across workspaces after the pnpm upgrade step

## Testing
- [ ] Not run (dependency metadata only)
