### PR TITLE
feat(credits): surface billing portal shortcut

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1077,6 +1077,7 @@
     "Credits": {
       "title": "Credits",
       "description": "Manage your credit balance and top-ups",
+      "billingPortalCta": "Manage purchases in Stripe",
       "topUpTitle": "Top up your credits",
       "topUpDescription": "Choose an amount or enter a custom value",
       "costPerCredit": "{cost} per credit",

--- a/apps/web/src/app/(app)/credits/page.tsx
+++ b/apps/web/src/app/(app)/credits/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 import CreditsForm from "@/components/credits/credits-form";
@@ -31,9 +32,18 @@ export default async function CreditsPage({ searchParams }: CreditsPageProps) {
 
   return (
     <div className="w-full space-y-12 px-2">
-      <div className="space-y-2">
+      <div className="space-y-1">
         <h1 className="text-2xl font-light md:text-3xl">{t("title")}</h1>
         <p className="text-muted-foreground">{t("description")}</p>
+        <Link
+          href="https://billing.stripe.com/p/login/00w28r02bac4cNR8mDgIo00"
+          target="_blank"
+          rel="noopener noreferrer"
+          prefetch={false}
+          className="text-primary text-sm font-medium underline-offset-4 hover:underline"
+        >
+          {t("billingPortalCta")}
+        </Link>
       </div>
       <div className="max-w-3xl">
         <CreditsForm price={price} organization={activeOrganization} />


### PR DESCRIPTION
## Summary
- Add a localized Stripe billing portal shortcut on the credits page
- Give customers a clear path to manage invoices outside the app

## Key Changes
- Added `App.Credits.billingPortalCta` translation string for the billing portal link
- Linked the Stripe billing portal near the credits header and tightened the heading spacing

## Technical Details
- Uses Next.js `Link` with `prefetch={false}` and `rel="noopener noreferrer"` to open Stripe in a new tab securely

## Testing
- [ ] pnpm sokosumi-web:test
- [ ] pnpm sokosumi-web:lint
- [ ] Manual verification of `/credits`
