### PR TITLE
fix(credits): shorten billing portal call-to-action text

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1077,7 +1077,7 @@
     "Credits": {
       "title": "Credits",
       "description": "Manage your credit balance and top-ups",
-      "billingPortalCta": "Manage purchases in Stripe",
+      "billingPortalCta": "Manage purchases",
       "topUpTitle": "Top up your credits",
       "topUpDescription": "Choose an amount or enter a custom value",
       "costPerCredit": "{cost} per credit",


### PR DESCRIPTION
## Summary

Shortens the billing portal call-to-action text from "Manage purchases in Stripe" to "Manage purchases" for a cleaner, more concise UI.

## Changes

- Updated the `billingPortalCta` translation key in `apps/web/messages/en.json`
- Removed "in Stripe" suffix to make the CTA more concise and less vendor-specific

## Rationale

The shortened text:
- Reduces visual clutter in the UI
- Maintains clarity about the action (managing purchases)
- Removes vendor-specific language that may not be necessary for users
- Follows UI best practices for concise call-to-action text

## Technical Details

- **File Changed**: `apps/web/messages/en.json`
- **Translation Key**: `Credits.billingPortalCta`
- **Change**: `"Manage purchases in Stripe"` → `"Manage purchases"`

## Testing

- [ ] Verified the CTA text displays correctly in the credits page
- [ ] Confirmed the billing portal functionality remains unchanged
- [ ] Checked that the shortened text is clear and actionable