### PR TITLE
feat(stripe): enable checkout invoice creation

### DIFF
--- a/apps/web/src/lib/clients/stripe.client.ts
+++ b/apps/web/src/lib/clients/stripe.client.ts
@@ -311,6 +311,9 @@ export const stripeClient = (() => {
             address: "auto",
             name: "auto",
           },
+          invoice_creation: {
+            enabled: true,
+          },
           billing_address_collection: "required",
           tax_id_collection: { enabled: true },
           success_url: `${origin ?? getEnvSecrets().VERCEL_URL}/credits?session_id={CHECKOUT_SESSION_ID}`,


### PR DESCRIPTION
## Summary
- Enable automatic invoice creation for Stripe Checkout sessions used in the credits purchase flow.

## Key Changes
- Set `invoice_creation.enabled` to `true` when initializing the Stripe Checkout session via `stripeClient`.

## Technical Notes
- Ensures Checkout sessions always generate invoices for accounting compliance without altering existing session options.

## Testing
- not run (not requested)
