### PR TITLE
chore(deps): bump pnpm from 10.21.0 to 10.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokosumi",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@10.22.0",
   "scripts": {
     "dev": "pnpm -r dev",
     "web:dev": "pnpm --filter web dev",


### PR DESCRIPTION
## Summary

This PR upgrades pnpm from version 10.21.0 to 10.22.0 in the package manager configuration.

## Changes

- Updated `packageManager` field in root `package.json` from `pnpm@10.21.0` to `pnpm@10.22.0`

## Technical Details

This is a minor version bump of the pnpm package manager. The change ensures all developers and CI/CD pipelines use the latest stable version of pnpm.

## Testing

- [x] Verified the change updates only the package manager version
- [ ] Run `pnpm install` to ensure compatibility
- [ ] Verify all workspace scripts continue to work correctly
- [ ] Confirm CI/CD pipelines can use the new pnpm version

## Related

- Commit: 55e17a04