### PR TITLE
chore: update CODEOWNERS to remove @golddydev as an owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # They are default owners
 
-*       @mrgrauel @golddydev @francisluz
+*       @mrgrauel @francisluz


### PR DESCRIPTION
## Summary

This PR updates the CODEOWNERS file to remove @golddydev as a default code owner, leaving @mrgrauel and @francisluz as the default owners for all files in the repository.

## Changes

- Removed @golddydev from the default owners list in `.github/CODEOWNERS`
- Updated owners to: @mrgrauel @francisluz

## Technical Details

The CODEOWNERS file is used by GitHub to automatically request reviews from code owners when files matching the patterns are modified. This change ensures that only the current active maintainers are notified for code review requests.

## Testing

- [x] Verified CODEOWNERS syntax is valid
- [x] Confirmed the file follows GitHub CODEOWNERS format

## Related

This is a maintenance change to keep the code ownership configuration up to date.