### PR TITLE
fix(webhook): improve reliability with retry logic and timeout (SOKOSUMI-9J)

### DIFF
--- a/apps/web/src/lib/services/gtm.service.ts
+++ b/apps/web/src/lib/services/gtm.service.ts
@@ -4,9 +4,144 @@ import * as Sentry from "@sentry/nextjs";
 
 import { getEnvSecrets } from "@/config/env.secrets";
 
+// Webhook configuration constants
+const WEBHOOK_TIMEOUT_MS = 10000; // 10 seconds
+const WEBHOOK_MAX_RETRIES = 3;
+const WEBHOOK_RETRY_DELAYS = [1000, 2000, 4000]; // Exponential backoff: 1s, 2s, 4s
+
+/**
+ * Helper function to sleep for a given number of milliseconds.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Consumes the response body to prevent connection leaks.
+ * Reads the body even if we don't use it.
+ */
+async function consumeResponseBody(response: Response): Promise<string | null> {
+  try {
+    const text = await response.text();
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calls a webhook with retry logic, timeout, and proper error handling.
+ * Implements exponential backoff retry strategy.
+ *
+ * @param webhookUrl - The webhook URL to call
+ * @param payload - The payload to send
+ * @param webhookType - The type of webhook for error reporting
+ * @param userId - The user ID for error reporting
+ * @returns Promise that resolves when the webhook call succeeds or all retries are exhausted
+ * @private
+ */
+async function callWebHookWithRetry(
+  webhookUrl: string,
+  payload: Record<string, unknown>,
+  webhookType: "userCreated" | "userUpdated" | "accountCreated" | "agentHired",
+  userId: string,
+): Promise<void> {
+  let lastError: Error | null = null;
+  let lastResponse: Response | null = null;
+  let lastResponseBody: string | null = null;
+
+  for (let attempt = 0; attempt <= WEBHOOK_MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "Sokosumi-Webhook/1.0",
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      // Consume response body to prevent connection leaks
+      lastResponseBody = await consumeResponseBody(response);
+      lastResponse = response;
+
+      if (response.ok) {
+        // Success - no need to retry
+        return;
+      }
+
+      // Non-ok response - will retry
+      lastError = new Error(
+        `Response is not okay from ${webhookType} webhook: ${response.status} ${response.statusText}`,
+      );
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (error instanceof Error) {
+        if (error.name === "AbortError") {
+          lastError = new Error(
+            `Webhook request timed out after ${WEBHOOK_TIMEOUT_MS}ms`,
+          );
+        } else {
+          lastError = error;
+        }
+      } else {
+        lastError = new Error(String(error));
+      }
+    }
+
+    // If this was the last attempt, break and report error
+    if (attempt === WEBHOOK_MAX_RETRIES) {
+      break;
+    }
+
+    // Wait before retrying (exponential backoff)
+    const delay =
+      WEBHOOK_RETRY_DELAYS[attempt] ??
+      WEBHOOK_RETRY_DELAYS[WEBHOOK_RETRY_DELAYS.length - 1];
+    await sleep(delay);
+  }
+
+  // All retries exhausted - report to Sentry with detailed context
+  const errorContext: Record<string, unknown> = {
+    webhookType,
+    webhookUrl,
+    userId,
+    attempts: WEBHOOK_MAX_RETRIES + 1,
+    error: lastError?.message ?? "Unknown error",
+  };
+
+  if (lastResponse) {
+    errorContext.responseStatus = lastResponse.status;
+    errorContext.responseStatusText = lastResponse.statusText;
+    if (lastResponseBody) {
+      // Truncate response body if too long (max 500 chars)
+      errorContext.responseBody =
+        lastResponseBody.length > 500
+          ? `${lastResponseBody.substring(0, 500)}... (truncated)`
+          : lastResponseBody;
+    }
+  }
+
+  Sentry.captureMessage(`Failed to call ${webhookType} webhook`, {
+    level: "warning",
+    user: {
+      userId,
+    },
+    extra: errorContext,
+  });
+}
+
 /**
  * Base function to call marketing and analytics webhooks.
  * Handles webhook URL resolution and error reporting via Sentry.
+ * Uses retry logic with exponential backoff and timeout protection.
  *
  * @param userId - The unique identifier of the user triggering the webhook
  * @param payload - Additional data to include in the webhook payload
@@ -17,7 +152,7 @@ async function callWebHook(
   userId: string,
   payload: Record<string, unknown>,
   webhookType: "userCreated" | "userUpdated" | "accountCreated" | "agentHired",
-) {
+): Promise<void> {
   let webhookUrl: string | undefined;
   switch (webhookType) {
     case "userCreated":
@@ -35,25 +170,12 @@ async function callWebHook(
   }
   if (!webhookUrl) return;
 
-  try {
-    const res = await fetch(webhookUrl, {
-      method: "POST",
-      body: JSON.stringify({ userId, ...payload }),
-    });
-    if (!res.ok) {
-      throw new Error(`Response is not okay from ${webhookType} webhook`);
-    }
-  } catch (error) {
-    Sentry.captureMessage(`Failed to call ${webhookType} webhook`, {
-      level: "warning",
-      user: {
-        userId,
-      },
-      extra: {
-        error: String(error),
-      },
-    });
-  }
+  await callWebHookWithRetry(
+    webhookUrl,
+    { userId, ...payload },
+    webhookType,
+    userId,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Improves webhook reliability by adding timeout protection, retry logic with exponential backoff, proper HTTP headers, and enhanced error reporting. This fixes Sentry issue SOKOSUMI-9J where webhook calls were failing intermittently.

## Problem

The `userUpdated` webhook (and other webhooks) were failing intermittently, causing Sentry warnings. Issues included:

1. **No timeout**: Fetch requests could hang indefinitely
2. **Missing headers**: No `Content-Type` header set
3. **No retry logic**: Single attempt, then failure
4. **Response body not consumed**: May cause connection leaks
5. **Limited error context**: Error messages didn't include response details

## Solution

Implemented comprehensive webhook reliability improvements:

- **Timeout protection**: 10-second timeout using `AbortController`
- **Retry logic**: Up to 3 retries with exponential backoff (1s, 2s, 4s delays)
- **Proper headers**: `Content-Type: application/json` and `User-Agent` headers
- **Connection leak prevention**: Response bodies are consumed even on errors
- **Enhanced error reporting**: Detailed context including response status, body, and retry attempts

## Changes

- **Added** webhook configuration constants (`WEBHOOK_TIMEOUT_MS`, `WEBHOOK_MAX_RETRIES`, `WEBHOOK_RETRY_DELAYS`)
- **Created** `callWebHookWithRetry` helper function with retry logic and timeout
- **Added** `consumeResponseBody` helper to prevent connection leaks
- **Updated** `callWebHook` to use the new retry logic
- **Enhanced** Sentry error reporting with detailed context

## Technical Details

### Retry Strategy
- Maximum 3 retry attempts (4 total attempts including initial)
- Exponential backoff: 1s, 2s, 4s delays between retries
- Retries on both network errors and non-OK HTTP responses

### Timeout Handling
- 10-second timeout per request attempt
- Uses `AbortController` to cancel hanging requests
- Proper cleanup of timeout handlers

### Error Context
Sentry errors now include:
- Webhook type and URL
- Response status code and status text
- Response body (truncated to 500 chars if too long)
- Number of retry attempts
- Detailed error messages

## Non-Blocking Behavior

- Webhook calls remain **fire-and-forget** (not awaited in auth hooks)
- Better Auth hooks don't block on webhook failures
- All errors are caught and logged to Sentry without affecting user operations

## Testing

- ✅ No linting errors
- ✅ Backward compatible - same function signatures
- ⚠️ Manual testing recommended to verify:
  - Timeout behavior with slow/unresponsive endpoints
  - Retry logic with intermittent failures
  - Error reporting in Sentry

## Related

- **Sentry Issue**: [SOKOSUMI-9J](https://sentry.io/organizations/masumi/issues/70970885/) (Issue ID: 70970885)
- **Error Type**: "Failed to call userUpdated webhook"
- **Level**: Warning