### PR TITLE
chore(api): remove debug console.log from job formatter

### DIFF
--- a/apps/web/src/lib/api/formatters/job.ts
+++ b/apps/web/src/lib/api/formatters/job.ts
@@ -12,7 +12,6 @@ import { formatJobShareResponse } from "./job-share";
  * Formats job data for API response
  */
 export function formatJobResponse(job: JobWithStatus): JobResponse {
-  console.log("job", job);
   const formatted = {
     id: job.id,
     createdAt: dateToISO(job.createdAt),


### PR DESCRIPTION
## Summary

Removes a debug console.log statement from the job formatter that was left in the codebase.

## Changes

- Removed console.log from formatJobResponse function in apps/web/src/lib/api/formatters/job.ts

## Technical Details

This is a simple cleanup change that removes debugging code that should not be in production. The console.log was outputting the entire job object during API response formatting.

## Testing

- Code compiles without errors
- No functional changes (only debug code removal)

## Type

chore - Code cleanup and maintenance