### PR TITLE
refactor(auth): remove email domain validation from sign-up process

### DIFF
--- a/apps/web/src/config/env.secrets.ts
+++ b/apps/web/src/config/env.secrets.ts
@@ -17,10 +17,6 @@ const envSecretsSchema = z.object({
   // Database
   DATABASE_URL: z.url(),
   MIN_FEE_CREDITS: z.coerce.number().min(0).default(1),
-  ALLOWED_EMAIL_DOMAINS: z
-    .string()
-    .transform((val: string) => (val.trim() === "" ? [] : val.split(",")))
-    .default([]),
 
   // Usercentrics
   USER_CENTRICS_DATA_SETTINGS_ID: z.string().min(1).optional(),

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -127,17 +127,6 @@ export const auth = betterAuth({
     before: createAuthMiddleware(async (ctx) => {
       switch (ctx.path) {
         case "/sign-up/email": {
-          const allowedEmailDomains = getEnvSecrets().ALLOWED_EMAIL_DOMAINS;
-          if (
-            allowedEmailDomains.length !== 0 &&
-            !allowedEmailDomains.includes(ctx.body?.email.split("@")[1])
-          ) {
-            throw new APIError("BAD_REQUEST", {
-              code: "EMAIL_DOMAIN_NOT_ALLOWED",
-              message: allowedEmailDomains.join(", "),
-            });
-          }
-
           if (!ctx.body?.termsAccepted) {
             throw new APIError("BAD_REQUEST", {
               code: "TERMS_NOT_ACCEPTED",


### PR DESCRIPTION
## Summary

This PR removes the email domain validation feature from the authentication sign-up process. Users can now sign up with any email domain, removing the previous restriction that limited sign-ups to specific allowed domains.

## Changes

- **Removed environment variable**: Deleted `ALLOWED_EMAIL_DOMAINS` configuration from `env.secrets.ts`
  - The env var previously accepted a comma-separated list of allowed domains
  - Defaulted to an empty array if not provided
  
- **Removed validation logic**: Eliminated email domain validation check from the sign-up middleware in `auth.ts`
  - Previously checked if the email domain was in the allowed list
  - Threw `EMAIL_DOMAIN_NOT_ALLOWED` error for disallowed domains

## Technical Details

The removal simplifies the authentication flow by eliminating:
1. Environment variable parsing and transformation logic
2. Domain validation middleware that checked email domains against an allowed list
3. Error handling for domain restrictions

## Testing

- [ ] Verify sign-up works with any email domain
- [ ] Confirm no breaking changes to existing authentication flows
- [ ] Test that terms acceptance validation still works correctly
- [ ] Verify no environment variable errors occur in deployment

## Migration Notes

If this environment variable was previously set in production/staging environments, it can be safely removed from the environment configuration as it is no longer referenced in the codebase.