### PR TITLE
fix(verification): pass correct options to isJobVerified function

### DIFF
--- a/apps/web/src/components/jobs/job-details/job-verification-badge.tsx
+++ b/apps/web/src/components/jobs/job-details/job-verification-badge.tsx
@@ -58,17 +58,29 @@ export function JobVerificationBadge({
         if (isFundsLocked) {
           return { isPending: true, isVerified: false, isNotApplicable: false };
         } else {
+          const resultVerificationOptions = {
+            identifierFromPurchaser: job.identifierFromPurchaser,
+            resultHash: job.purchase?.resultHash ?? null,
+            result: job.result,
+          };
+
           return {
             isPending: false,
-            isVerified: isJobVerified("result", job),
+            isVerified: isJobVerified("result", resultVerificationOptions),
             isNotApplicable: false,
           };
         }
       }
       case "input":
+        const inputVerificationOptions = {
+          identifierFromPurchaser: job.identifierFromPurchaser,
+          inputHash: job.inputHash ?? null,
+          input: job.input,
+        };
+
         return {
           isPending: false,
-          isVerified: isJobVerified("input", job),
+          isVerified: isJobVerified("input", inputVerificationOptions),
           isNotApplicable: false,
         };
       default:


### PR DESCRIPTION
## Summary

Fixes an issue where job result hash verification was not working correctly. The `isJobVerified` function was receiving the entire job object instead of the structured options object it expects.

## Changes

- **Result verification**: Now creates a `ResultVerificationOptions` object with `identifierFromPurchaser`, `resultHash` (from `job.purchase?.resultHash`), and `result`
- **Input verification**: Now creates an `InputVerificationOptions` object with `identifierFromPurchaser`, `inputHash`, and `input`

## Technical Details

The `isJobVerified` function signature expects specific options interfaces:
- `InputVerificationOptions`: `{ identifierFromPurchaser, inputHash, input }`
- `ResultVerificationOptions`: `{ identifierFromPurchaser, resultHash, result }`

Previously, the entire `job` object was being passed, which didn't match the expected structure. This caused verification to fail silently or behave incorrectly.

## Testing

- Verified that result hash verification now works correctly
- Verified that input hash verification continues to work correctly
- Existing tests in `apps/web/src/lib/utils/__tests__/index.test.ts` cover the `isJobVerified` function behavior

## Related

Fixes issue #786 (result hash verification not working)