### PR TITLE
chore(deps): downgrade @types/node and clean up pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3479,11 +3479,8 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node@20.19.25':
-    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
-
-  '@types/node@20.19.25':
-    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
+  '@types/node@20.19.24':
+    resolution: {integrity: sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==}
 
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
@@ -5326,10 +5323,6 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
-
-  happy-dom@20.0.11:
-    resolution: {integrity: sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==}
-    engines: {node: '>=20.0.0'}
 
   happy-dom@20.0.11:
     resolution: {integrity: sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==}
@@ -11144,11 +11137,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.1
 
-  '@types/node@20.19.25':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@20.19.25':
+  '@types/node@20.19.24':
     dependencies:
       undici-types: 6.21.0
 
@@ -13243,13 +13232,7 @@ snapshots:
 
   happy-dom@20.0.11:
     dependencies:
-      '@types/node': 20.19.25
-      '@types/whatwg-mimetype': 3.0.2
-      whatwg-mimetype: 3.0.0
-
-  happy-dom@20.0.11:
-    dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.24
       '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
 


### PR DESCRIPTION
## Summary

This PR fixes the pnpm-lock.yaml file by downgrading `@types/node` from 20.19.25 to 20.19.24 and removing duplicate package entries.

## Changes

- Downgraded `@types/node` from 20.19.25 to 20.19.24
- Removed duplicate entries for `@types/node@20.19.25` in the packages section
- Removed duplicate entry for `happy-dom@20.0.11` in the packages section
- Updated `happy-dom@20.0.11` snapshot to use `@types/node@20.19.24` instead of `20.19.25`

## Technical Details

The pnpm-lock.yaml file had duplicate entries that were causing inconsistencies. This change:
- Consolidates `@types/node` to version 20.19.24
- Removes redundant package resolutions
- Ensures all dependent packages (like `happy-dom`) reference the correct version

## Testing

- [ ] Verify `pnpm install` completes successfully
- [ ] Confirm no TypeScript errors after the change
- [ ] Check that all packages resolve correctly