### PR TITLE
chore(build): update pnpm workspace config and add ignored dependency

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,9 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
 
 ignoredBuiltDependencies:
+  - "@parcel/watcher"
   - "@prisma/client"
   - "@prisma/engines"
   - "@sentry/cli"
@@ -30,4 +31,3 @@ publicHoistPattern:
   - pg-pool
   - eslint
   - prettier
-


### PR DESCRIPTION
## Summary

Updates the pnpm workspace configuration to improve formatting consistency and add `@parcel/watcher` to the ignored built dependencies list.

## Changes

- **Formatting**: Removed unnecessary quotes from package glob patterns (`"apps/*"` → `apps/*`)
- **Dependencies**: Added `@parcel/watcher` to `ignoredBuiltDependencies` to prevent pnpm from attempting to build this optional dependency
- **Cleanup**: Removed trailing newline at end of file

## Technical Details

The `@parcel/watcher` package is an optional dependency used by some build tools. Adding it to `ignoredBuiltDependencies` ensures pnpm doesn't attempt to build it during installation, which can cause issues in environments where native dependencies aren't available or needed.

## Testing

- [x] Verified pnpm workspace configuration is valid
- [x] Confirmed formatting changes are consistent with YAML best practices
- [x] Tested that `pnpm install` completes successfully with the updated configuration