### PR TITLE
chore(core): upgrade @hono/node-server and i18next

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -17,7 +17,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@hono/node-server": "1.19.6",
+    "@hono/node-server": "1.19.7",
     "@hono/zod-openapi": "1.1.5",
     "@scalar/hono-api-reference": "0.9.26",
     "@sentry/node": "10.29.0",
@@ -29,7 +29,7 @@
     "decimal.js": "10.6.0",
     "dotenv": "17.2.3",
     "hono": "4.10.7",
-    "i18next": "25.7.1",
+    "i18next": "25.7.2",
     "i18next-fs-backend": "2.6.1",
     "postmark": "4.0.5",
     "stripe": "20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
   apps/core:
     dependencies:
       '@hono/node-server':
-        specifier: 1.19.6
-        version: 1.19.6(hono@4.10.7)
+        specifier: 1.19.7
+        version: 1.19.7(hono@4.10.7)
       '@hono/zod-openapi':
         specifier: 1.1.5
         version: 1.1.5(hono@4.10.7)(zod@4.1.13)
@@ -69,8 +69,8 @@ importers:
         specifier: 4.10.7
         version: 4.10.7
       i18next:
-        specifier: 25.7.1
-        version: 25.7.1(typescript@5.9.3)
+        specifier: 25.7.2
+        version: 25.7.2(typescript@5.9.3)
       i18next-fs-backend:
         specifier: 2.6.1
         version: 2.6.1
@@ -1060,6 +1060,12 @@ packages:
 
   '@hono/node-server@1.19.6':
     resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-server@1.19.7':
+    resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -5356,8 +5362,8 @@ packages:
   i18next-fs-backend@2.6.1:
     resolution: {integrity: sha512-eYWTX7QT7kJ0sZyCPK6x1q+R63zvNKv2D6UdbMf15A8vNb2ZLyw4NNNZxPFwXlIv/U+oUtg8SakW6ZgJZcoqHQ==}
 
-  i18next@25.7.1:
-    resolution: {integrity: sha512-XbTnkh1yCZWSAZGnA9xcQfHcYNgZs2cNxm+c6v1Ma9UAUGCeJPplRe1ILia6xnDvXBjk0uXU+Z8FYWhA19SKFw==}
+  i18next@25.7.2:
+    resolution: {integrity: sha512-58b4kmLpLv1buWUEwegMDUqZVR5J+rT+WTRFaBGL7lxDuJQQ0NrJFrq+eT2N94aYVR1k1Sr13QITNOL88tZCuw==}
     peerDependencies:
       typescript: ^5
     peerDependenciesMeta:
@@ -8611,7 +8617,7 @@ snapshots:
     dependencies:
       hono: 4.10.6
 
-  '@hono/node-server@1.19.6(hono@4.10.7)':
+  '@hono/node-server@1.19.7(hono@4.10.7)':
     dependencies:
       hono: 4.10.7
 
@@ -13366,7 +13372,7 @@ snapshots:
 
   i18next-fs-backend@2.6.1: {}
 
-  i18next@25.7.1(typescript@5.9.3):
+  i18next@25.7.2(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.28.4
     optionalDependencies:


### PR DESCRIPTION
## Summary

This PR upgrades two dependencies in the Core API service to their latest patch versions.

## Changes

- **@hono/node-server**: 1.19.6 → 1.19.7
- **i18next**: 25.7.1 → 25.7.2

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Dependency update
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Technical Details

Both updates are patch version bumps that likely include bug fixes and minor improvements:

- **@hono/node-server**: Server adapter for running Hono with Node.js runtime
- **i18next**: Internationalization framework used for API response translations

## Testing

- [ ] Existing tests pass
- [ ] Manual testing completed
- [ ] No breaking changes expected

## Verification Steps

```bash
# Install updated dependencies
pnpm install

# Build the core API
pnpm core:build

# Run development server
pnpm core:dev
```

## Notes

These are patch-level updates that should be safe to merge. No API changes or breaking changes are expected.