### PR TITLE
chore(deps): upgrade pnpm to 10.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokosumi",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.25.0",
   "scripts": {
     "dev": "pnpm -r dev",
     "web:dev": "pnpm --filter web dev",


### PR DESCRIPTION
## Summary

This PR upgrades the package manager requirement from pnpm@10.24.0 to pnpm@10.25.0.

## Changes

- Updated `packageManager` field in `package.json` from `pnpm@10.24.0` to `pnpm@10.25.0`

## Benefits

- Ensures all developers and CI/CD pipelines use the latest pnpm version
- Includes bug fixes and improvements from pnpm 10.25.0 release
- Maintains consistency across the development environment

## Technical Details

This change only affects the `packageManager` field, which is used by:
- Corepack to automatically install the correct pnpm version
- CI/CD pipelines to ensure version consistency
- Developers when running `pnpm install` (if Corepack is enabled)

No code changes or dependency updates are included in this PR.

## Testing

- [ ] Verified that `pnpm install` works correctly with pnpm@10.25.0
- [ ] Confirmed all workspace scripts continue to function as expected
- [ ] Checked that CI/CD pipeline will use the updated version