### PR TITLE
chore(deps): update @asteasolutions/zod-to-openapi to 8.2.0 and @types/node to 20.19.26

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,8 +537,8 @@ packages:
   '@apm-js-collab/tracing-hooks@0.3.1':
     resolution: {integrity: sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==}
 
-  '@asteasolutions/zod-to-openapi@8.1.0':
-    resolution: {integrity: sha512-tQFxVs05J/6QXXqIzj6rTRk3nj1HFs4pe+uThwE95jL5II2JfpVXkK+CqkO7aT0Do5AYqO6LDrKpleLUFXgY+g==}
+  '@asteasolutions/zod-to-openapi@8.2.0':
+    resolution: {integrity: sha512-u05zNUirlukJAf9oEHmxSF31L1XQhz9XdpVILt7+xhrz65oQqBpiOWFkGvRWL0IpjOUJ878idKoNmYPxrFnkeg==}
     peerDependencies:
       zod: ^4.0.0
 
@@ -3368,8 +3368,8 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node@20.19.25':
-    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
+  '@types/node@20.19.26':
+    resolution: {integrity: sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==}
 
   '@types/node@24.10.2':
     resolution: {integrity: sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==}
@@ -8090,7 +8090,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@asteasolutions/zod-to-openapi@8.1.0(zod@4.1.13)':
+  '@asteasolutions/zod-to-openapi@8.2.0(zod@4.1.13)':
     dependencies:
       openapi3-ts: 4.5.0
       zod: 4.1.13
@@ -8594,7 +8594,7 @@ snapshots:
 
   '@hono/zod-openapi@1.1.5(hono@4.10.8)(zod@4.1.13)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 8.1.0(zod@4.1.13)
+      '@asteasolutions/zod-to-openapi': 8.2.0(zod@4.1.13)
       '@hono/zod-validator': 0.7.5(hono@4.10.8)(zod@4.1.13)
       hono: 4.10.8
       openapi3-ts: 4.5.0
@@ -11072,7 +11072,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.2
 
-  '@types/node@20.19.25':
+  '@types/node@20.19.26':
     dependencies:
       undici-types: 6.21.0
 
@@ -13138,7 +13138,7 @@ snapshots:
 
   happy-dom@20.0.11:
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.26
       '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
 


### PR DESCRIPTION
## Summary

This PR updates two dependencies in the pnpm lockfile:
- `@asteasolutions/zod-to-openapi`: 8.1.0 → 8.2.0
- `@types/node`: 20.19.25 → 20.19.26

## Changes

- Updated `pnpm-lock.yaml` with the latest dependency versions
- All changes are lockfile-only (no package.json modifications)

## Technical Details

- **@asteasolutions/zod-to-openapi**: Minor version update (8.1.0 → 8.2.0)
- **@types/node**: Patch version update (20.19.25 → 20.19.26)

## Testing

- [ ] Verify lockfile is valid: `pnpm install`
- [ ] Ensure no breaking changes in dependencies
- [ ] Run tests to confirm compatibility