### PR TITLE
fix(ui): disable React compiler memoization for data-table-pagination

### DIFF
--- a/apps/web/src/components/data-table/data-table-pagination.tsx
+++ b/apps/web/src/components/data-table/data-table-pagination.tsx
@@ -1,4 +1,5 @@
 "use client";
+"use no memo";
 
 import { Table } from "@tanstack/react-table";
 import {


### PR DESCRIPTION
## Summary

- Adds `"use no memo"` directive to the `data-table-pagination.tsx` component to opt-out of React 19 compiler's automatic memoization

## Problem

The React compiler's automatic memoization was causing pagination state issues in the DataTable component, resulting in unexpected behavior when navigating between pages.

## Solution

By adding the `"use no memo"` directive, we disable automatic memoization for this specific component, ensuring pagination state updates correctly.

## Changes

- `apps/web/src/components/data-table/data-table-pagination.tsx`: Added `"use no memo"` directive after `"use client"`

## Testing

- [ ] Verify pagination works correctly in DataTable components
- [ ] Test page navigation (first, previous, next, last)
- [ ] Confirm page size changes work as expected

Resolves SOK-340