### PR TITLE
refactor(job): update JobStatus references to SokosumiJobStatus in job routes and schema

### DIFF
--- a/apps/core/src/routes/v1/jobs/[id]/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { JobType } from "@sokosumi/database";
-import { JobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/database/types/job";
 
 import { requireJobAccess } from "@/helpers/access-control.js";
 import { convertCentsToCredits } from "@/helpers/credits.js";
@@ -34,7 +34,7 @@ const route = createRoute({
         organizationId: "organization_123",
         name: "Research Task",
         jobType: JobType.PAID,
-        status: JobStatus.COMPLETED,
+        status: SokosumiJobStatus.COMPLETED,
         completedAt: "2025-01-15T10:35:00.000Z",
         credits: 5,
         input: '{"prompt":"How many planets are in the solar system?"}',

--- a/apps/core/src/routes/v1/jobs/get.ts
+++ b/apps/core/src/routes/v1/jobs/get.ts
@@ -1,7 +1,7 @@
 import { createRoute } from "@hono/zod-openapi";
 import { JobType } from "@sokosumi/database";
 import { jobRepository } from "@sokosumi/database/repositories";
-import { JobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/database/types/job";
 
 import { convertCentsToCredits } from "@/helpers/credits";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -25,7 +25,7 @@ const route = createRoute({
           organizationId: "organization_123",
           name: "Research Task",
           jobType: JobType.PAID,
-          status: JobStatus.COMPLETED,
+          status: SokosumiJobStatus.COMPLETED,
           completedAt: "2025-01-15T10:35:00.000Z",
           credits: 5,
           input: '{"prompt":"How many planets are in the solar system?"}',
@@ -43,7 +43,7 @@ const route = createRoute({
           organizationId: null,
           name: "Analysis Job",
           jobType: JobType.FREE,
-          status: JobStatus.PROCESSING,
+          status: SokosumiJobStatus.PROCESSING,
           completedAt: null,
           credits: 0,
           input: '{"query":"Analyze market trends"}',

--- a/apps/core/src/schemas/job.schema.ts
+++ b/apps/core/src/schemas/job.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { JobType } from "@sokosumi/database";
-import { JobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/database/types/job";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 
@@ -17,7 +17,9 @@ export const jobSchema = z
       .openapi({ example: "organization_123" }),
     name: z.string().nullish().openapi({ example: "My Job" }),
     jobType: z.enum(JobType).openapi({ example: JobType.PAID }),
-    status: z.enum(JobStatus).openapi({ example: JobStatus.PROCESSING }),
+    status: z
+      .enum(SokosumiJobStatus)
+      .openapi({ example: SokosumiJobStatus.PROCESSING }),
     completedAt: dateTimeSchema.nullish(),
     credits: z.number().openapi({ example: 5 }),
     input: z.string().openapi({


### PR DESCRIPTION
## Summary

This PR updates all references from `JobStatus` to `SokosumiJobStatus` in the job-related routes and schema files to align with the updated type naming convention.

## Changes

- Updated import statements in job routes to use `SokosumiJobStatus` instead of `JobStatus`
- Updated OpenAPI example values to use `SokosumiJobStatus` enum values
- Updated job schema to reference `SokosumiJobStatus` enum

## Files Modified

- `apps/core/src/routes/v1/jobs/get.ts` - Updated import and example values
- `apps/core/src/routes/v1/jobs/[id]/get.ts` - Updated import and example value  
- `apps/core/src/schemas/job.schema.ts` - Updated import and enum reference

## Technical Details

This is a refactoring change that updates type references without changing functionality. The API behavior remains the same, but now uses the correctly named `SokosumiJobStatus` type throughout the codebase.

## Testing

- [x] Verify API endpoints return correct job status values
- [x] Confirm OpenAPI documentation examples are accurate
- [x] Test job listing and retrieval endpoints