### PR TITLE
chore(config): fix Sentry deprecation warnings in next.config.ts

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -53,15 +53,19 @@ export default withSentryConfig(withNextIntl(nextConfig), {
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-side errors will fail.
   tunnelRoute: true, // Generates a random route for each build (recommended)
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
+  webpack: {
+    treeshake: {
+      // Automatically tree-shake Sentry logger statements to reduce bundle size
+      removeDebugLogging: true,
+    },
 
-  // Automatically instrument Next.js middleware with error and performance monitoring.
-  // disable it on `dev mode` to reduce large middleware bundle size
-  autoInstrumentMiddleware: process.env.NODE_ENV === "production",
+    // Enable React component annotation for better error messages
+    reactComponentAnnotation: {
+      enabled: true,
+    },
 
-  // Enable React component annotation for better error messages
-  reactComponentAnnotation: {
-    enabled: true,
+    // Automatically instrument Next.js middleware with error and performance monitoring.
+    // disable it on `dev mode` to reduce large middleware bundle size
+    autoInstrumentMiddleware: process.env.NODE_ENV === "production",
   },
 });


### PR DESCRIPTION
## Summary

This PR fixes deprecation warnings from `@sentry/nextjs` by updating the Sentry configuration in `next.config.ts` to use the new API structure.

## Key Changes

- **Moved `autoInstrumentMiddleware` to `webpack.autoInstrumentMiddleware`**: Addresses the deprecation warning `autoInstrumentMiddleware is deprecated and will be removed in a future version. Use webpack.autoInstrumentMiddleware instead.`
- **Replaced `disableLogger` with `webpack.treeshake.removeDebugLogging`**: Updates to the new API for tree-shaking Sentry logger statements
- **Reorganized webpack configuration**: Consolidated all webpack-related Sentry options under the `webpack` object for better organization, including `reactComponentAnnotation`

## Technical Details

The changes maintain the same functionality:
- Middleware instrumentation remains enabled only in production (`process.env.NODE_ENV === "production"`)
- React component annotation remains enabled
- Logger tree-shaking continues to work with the new `treeshake.removeDebugLogging` API

## Testing

- [x] Verified no linting errors
- [x] Configuration structure matches Sentry Next.js SDK requirements
- [x] All deprecation warnings should be resolved

## Related

Fixes Sentry deprecation warnings that appear during build/dev server startup.