### PR TITLE
fix(web): avoid New Task sidebar active state under /tasks

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
@@ -44,8 +44,8 @@ export default function NewChatTaskActions() {
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
-            {/* Tasks nav owns `/tasks/*` (menu-items); never duplicate active state here. */}
-            <SidebarMenuButton asChild isActive={false}>
+            {/* New Task is never shown as the active sidebar item (Tasks nav covers `/tasks/*`). */}
+            <SidebarMenuButton asChild>
               <SheetClose asChild>
                 <Link
                   href="/tasks/new"

--- a/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
@@ -19,8 +19,6 @@ export default function NewChatTaskActions() {
   const tChat = useTranslations("App.Chat.Chat");
   const pathname = usePathname();
   const isChatActive = pathname === "/chat" || pathname.startsWith("/chat/");
-  const isNewTaskActive =
-    pathname === "/tasks/new" || pathname.startsWith("/tasks/new/");
 
   return (
     <SidebarGroup className="w-full">
@@ -46,16 +44,14 @@ export default function NewChatTaskActions() {
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
-            <SidebarMenuButton asChild isActive={isNewTaskActive}>
+            {/* Tasks nav owns `/tasks/*` (menu-items); never duplicate active state here. */}
+            <SidebarMenuButton asChild isActive={false}>
               <SheetClose asChild>
                 <Link
                   href="/tasks/new"
-                  aria-current={isNewTaskActive ? "page" : undefined}
                   className={cn(
                     "flex min-h-auto w-full items-center gap-2 px-3",
-                    isNewTaskActive
-                      ? "text-primary-foreground"
-                      : "text-tertiary-foreground dark:text-muted-foreground hover:text-primary-foreground dark:hover:text-primary-foreground",
+                    "text-tertiary-foreground dark:text-muted-foreground hover:text-primary-foreground dark:hover:text-primary-foreground",
                   )}
                 >
                   <ListPlus className="size-4" aria-hidden />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The sidebar **New Task** shortcut must never appear as the active item. The **Tasks** nav item already covers all `/tasks/*` routes (including `/tasks/new`), so the shortcut should stay visually neutral.

## Changes

- Do not pass `isActive` on the New Task `SidebarMenuButton` (component default is `false`, so `data-active` is never true).
- Use default link styling only; no `aria-current="page"` on that link.
- Comment documents the invariant for future edits.

## Verification

- `pnpm exec biome check apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce3390f7-40ae-4478-bde3-c00781e75c9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce3390f7-40ae-4478-bde3-c00781e75c9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

