### PR TITLE
fix(billing): no default free-credit expiry when ttl_days omitted

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1764,7 +1764,7 @@
       },
       "paidSubscriptionRequiredDescription": "Du benötigst ein kostenpflichtiges Abonnement, um zusätzliche Credits zu kaufen.",
       "paidSubscriptionRequiredHint": "Wähle im Tab „Abonnement“ einen kostenpflichtigen Plan, um das Aufladen von Credits freizuschalten.",
-      "couponExpiryNotice": "Credits verfallen nach {days, plural, one {# Tag} other {# Tagen}}."
+      "couponExpiryPolicyNotice": "Credits verfallen nur, wenn der Gutschein ein positives ttl_days setzt (Tage bis zum Verfall)."
     },
     "Connections": {
       "tabs": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "Choose an amount or enter a custom value",
       "paidSubscriptionRequiredDescription": "A paid subscription is required to buy additional credits.",
       "paidSubscriptionRequiredHint": "Choose a paid plan in the Subscription tab to unlock credit top-ups.",
-      "couponExpiryNotice": "Credits expire after {days, plural, one {# day} other {# days}}.",
+      "couponExpiryPolicyNotice": "Credits do not expire unless the coupon sets a positive ttl_days (days until expiry).",
       "costPerCredit": "{cost} per credit",
       "creditAmount": "{count, plural, one {# credit} other {# credits}}",
       "creditsLabel": "Number of credits",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1764,7 +1764,7 @@
       },
       "paidSubscriptionRequiredDescription": "Se requiere una suscripción de pago para comprar créditos adicionales.",
       "paidSubscriptionRequiredHint": "Elige un plan de pago en la pestaña Suscripción para desbloquear las recargas de créditos.",
-      "couponExpiryNotice": "Los créditos vencen después de {days, plural, one {# día} other {# días}}."
+      "couponExpiryPolicyNotice": "Los créditos no caducan a menos que el cupón defina un ttl_days positivo (días hasta el vencimiento)."
     },
     "Connections": {
       "tabs": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "Choisissez un montant ou saisissez une valeur personnalisée",
       "paidSubscriptionRequiredDescription": "Un abonnement payant est nécessaire pour acheter des crédits supplémentaires.",
       "paidSubscriptionRequiredHint": "Choisissez une offre payante dans l’onglet Abonnement pour débloquer les recharges de crédits.",
-      "couponExpiryNotice": "Les crédits expirent après {days, plural, one {# jour} other {# jours}}.",
+      "couponExpiryPolicyNotice": "Les crédits n'expirent pas sauf si le bon définit un ttl_days positif (jours avant expiration).",
       "costPerCredit": "{cost} par crédit",
       "creditAmount": "{count, plural, one {# crédit} other {# crédits}}",
       "creditsLabel": "Nombre de crédits",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1774,7 +1774,7 @@
       "topUpDescription": "Scegli un importo o inserisci un valore personalizzato",
       "paidSubscriptionRequiredDescription": "È necessario un abbonamento a pagamento per acquistare crediti aggiuntivi.",
       "paidSubscriptionRequiredHint": "Scegli un piano a pagamento nella scheda Abbonamento per sbloccare le ricariche di crediti.",
-      "couponExpiryNotice": "I crediti scadono dopo {days, plural, one {# giorno} other {# giorni}}.",
+      "couponExpiryPolicyNotice": "I crediti non scadono a meno che il coupon imposti un ttl_days positivo (giorni alla scadenza).",
       "costPerCredit": "{cost} per credito",
       "creditAmount": "{count, plural, one {# credito} other {# crediti}}",
       "creditsLabel": "Numero di crediti",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1774,7 +1774,7 @@
       "topUpDescription": "金額を選択するか、任意の値を入力してください",
       "paidSubscriptionRequiredDescription": "追加のクレジットを購入するには有料サブスクリプションが必要です。",
       "paidSubscriptionRequiredHint": "クレジットの追加購入を利用するには、サブスクリプションタブで有料プランを選択してください。",
-      "couponExpiryNotice": "クレジットは{days, plural, one {# 日} other {# 日}}後に失効します。",
+      "couponExpiryPolicyNotice": "クーポンに正の ttl_days（失効までの日数）がない限り、クレジットは失効しません。",
       "costPerCredit": "1クレジットあたり{cost}",
       "creditAmount": "{count, plural, one {# クレジット} other {# クレジット}}",
       "creditsLabel": "クレジット数",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "Escolha um valor ou digite um valor personalizado",
       "paidSubscriptionRequiredDescription": "É necessária uma assinatura paga para comprar créditos adicionais.",
       "paidSubscriptionRequiredHint": "Escolha um plano pago na aba Assinatura para desbloquear as recargas de créditos.",
-      "couponExpiryNotice": "Os créditos expiram após {days, plural, one {# dia} other {# dias}}.",
+      "couponExpiryPolicyNotice": "Os créditos não expiram a menos que o cupom defina um ttl_days positivo (dias até expirar).",
       "costPerCredit": "{cost} por crédito",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Quantidade de créditos",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1774,7 +1774,7 @@
       "topUpDescription": "Escolha um montante ou introduza um valor personalizado",
       "paidSubscriptionRequiredDescription": "É necessária uma subscrição paga para comprar créditos adicionais.",
       "paidSubscriptionRequiredHint": "Escolha um plano pago no separador Subscrição para desbloquear os carregamentos de créditos.",
-      "couponExpiryNotice": "Os créditos expiram após {days, plural, one {# dia} other {# dias}}.",
+      "couponExpiryPolicyNotice": "Os créditos não expiram a menos que o cupão defina um ttl_days positivo (dias até expirar).",
       "costPerCredit": "{cost} por crédito",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Número de créditos",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "选择金额或输入自定义数值",
       "paidSubscriptionRequiredDescription": "购买额外积分需要付费订阅。",
       "paidSubscriptionRequiredHint": "请在“订阅”标签页选择付费套餐以解锁积分充值。",
-      "couponExpiryNotice": "积分将在 {days, plural, one {# 天} other {# 天}}后过期。",
+      "couponExpiryPolicyNotice": "除非优惠券设置了正数的 ttl_days（距离过期的天数），否则积分不会过期。",
       "costPerCredit": "{cost} / 积分",
       "creditAmount": "{count, plural, one {# 积分} other {# 积分}}",
       "creditsLabel": "积分数量",

--- a/apps/web/src/components/credits/__tests__/coupon-form.test.tsx
+++ b/apps/web/src/components/credits/__tests__/coupon-form.test.tsx
@@ -16,9 +16,9 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string, values?: { days?: number }) => {
-    if (key === "couponExpiryNotice") {
-      return `Credits expire after ${values?.days} days.`;
+  useTranslations: () => (key: string) => {
+    if (key === "couponExpiryPolicyNotice") {
+      return "Coupon credits only expire when ttl_days is set on the coupon.";
     }
     return key;
   },
@@ -72,7 +72,9 @@ describe("CouponForm", () => {
     render(<CouponForm organization={null} />);
 
     expect(
-      screen.getByText("Credits expire after 30 days."),
+      screen.getByText(
+        "Coupon credits only expire when ttl_days is set on the coupon.",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/credits/coupon-form.tsx
+++ b/apps/web/src/components/credits/coupon-form.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Organization } from "@sokosumi/database";
-import { FREE_CREDITS_EXPIRY_DAYS } from "@sokosumi/utils";
 import { Building2, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -170,9 +169,7 @@ export default function CouponForm({
               {organization ? t("couponButtonOrganization") : t("couponButton")}
             </Button>
             <p className="text-muted-foreground text-right text-xs">
-              {t("couponExpiryNotice", {
-                days: FREE_CREDITS_EXPIRY_DAYS,
-              })}
+              {t("couponExpiryPolicyNotice")}
             </p>
           </CardFooter>
         </form>

--- a/apps/web/src/lib/stripe/__tests__/webhook-handlers.test.ts
+++ b/apps/web/src/lib/stripe/__tests__/webhook-handlers.test.ts
@@ -5,7 +5,6 @@ import {
   escapeStringForLike,
   getCreditExpiryDate,
 } from "@sokosumi/database/helpers";
-import { FREE_CREDITS_EXPIRY_DAYS } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -961,7 +960,7 @@ describe("handleInvoicePaidEvent", () => {
     );
   });
 
-  it("classifies free top-up invoices as STRIPE_FREE with 30-day expiry", async () => {
+  it("classifies free top-up invoices as STRIPE_FREE with no expiry when ttl_days is omitted", async () => {
     const { handleInvoicePaidEvent } = await import("../webhook-handlers");
 
     await handleInvoicePaidEvent(
@@ -989,12 +988,7 @@ describe("handleInvoicePaidEvent", () => {
     expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
       "STRIPE_FREE",
     );
-    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
-      getCreditExpiryDate(
-        new Date(DEFAULT_INVOICE_CREATED_UNIX * 1000),
-        FREE_CREDITS_EXPIRY_DAYS,
-      ),
-    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
   });
 
   it("uses ttl_days invoice metadata for free top-up expiry", async () => {
@@ -1065,7 +1059,7 @@ describe("handleInvoicePaidEvent", () => {
     expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
   });
 
-  it("falls back to default free expiry for invalid ttl_days metadata", async () => {
+  it("sets no expiry for free top-up when ttl_days metadata is invalid", async () => {
     const { handleInvoicePaidEvent } = await import("../webhook-handlers");
 
     await handleInvoicePaidEvent(
@@ -1094,12 +1088,7 @@ describe("handleInvoicePaidEvent", () => {
     expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
       "STRIPE_FREE",
     );
-    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
-      getCreditExpiryDate(
-        new Date(DEFAULT_PERIOD_END_UNIX * 1000),
-        FREE_CREDITS_EXPIRY_DAYS,
-      ),
-    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
   });
 
   it("splits top-up and subscription credits into separate buckets when both are present", async () => {

--- a/apps/web/src/lib/stripe/webhook-handlers.ts
+++ b/apps/web/src/lib/stripe/webhook-handlers.ts
@@ -27,7 +27,6 @@ import {
 import {
   convertCentsToCredits,
   convertCreditsToCents,
-  FREE_CREDITS_EXPIRY_DAYS,
   getOrganizationMetadata,
 } from "@sokosumi/utils";
 import Stripe from "stripe";
@@ -155,30 +154,27 @@ function getTopUpCreditsFromInvoiceMetadata(
   return credits;
 }
 
+/**
+ * Reads `ttl_days` from invoice metadata for free (zero-amount) credit grants.
+ * - Missing, empty, invalid, negative, or zero → no expiry (`expiresAt` null).
+ * - Positive integer → expiry after that many days from the invoice time.
+ */
 function getTopUpExpiryDaysFromInvoiceMetadata(
   invoice: Stripe.Invoice,
-): number | null | undefined {
+): number | null {
   const ttlDaysRaw = invoice.metadata?.ttl_days;
   if (ttlDaysRaw === undefined) {
-    return undefined;
+    return null;
   }
 
   const normalizedTtlDays = ttlDaysRaw.trim();
   if (!normalizedTtlDays) {
-    return undefined;
-  }
-
-  const ttlDays = Number(normalizedTtlDays);
-  if (!Number.isInteger(ttlDays)) {
-    return undefined;
-  }
-
-  if (ttlDays === 0) {
     return null;
   }
 
-  if (ttlDays < 0) {
-    return undefined;
+  const ttlDays = Number(normalizedTtlDays);
+  if (!Number.isInteger(ttlDays) || ttlDays <= 0) {
+    return null;
   }
 
   return ttlDays;
@@ -209,10 +205,7 @@ function resolveTopUpGrantPolicy(invoice: Stripe.Invoice): {
     expiresAt:
       freeTopUpExpiryDays === null
         ? null
-        : getCreditExpiryDate(
-            invoiceCreatedAt,
-            freeTopUpExpiryDays ?? FREE_CREDITS_EXPIRY_DAYS,
-          ),
+        : getCreditExpiryDate(invoiceCreatedAt, freeTopUpExpiryDays),
     referenceType: CreditBucketReferenceType.STRIPE_FREE,
   };
 }

--- a/packages/database/src/helpers/credit.test.ts
+++ b/packages/database/src/helpers/credit.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 
-import { FREE_CREDITS_EXPIRY_DAYS } from "@sokosumi/utils";
 import { describe, it } from "vitest";
 
 import {
@@ -120,10 +119,6 @@ describe("invoice credit reference builders", () => {
 });
 
 describe("credit expiration policy", () => {
-  it("defines expected expiration day constants", () => {
-    assert.equal(FREE_CREDITS_EXPIRY_DAYS, 30);
-  });
-
   it("calculates expiration date from a base date and day count", () => {
     const baseDate = new Date("2026-02-27T00:00:00.000Z");
     const expiryDate = getCreditExpiryDate(baseDate, 30);

--- a/packages/utils/src/__tests__/credit.test.ts
+++ b/packages/utils/src/__tests__/credit.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  convertCentsToCredits,
-  convertCreditsToCents,
-  FREE_CREDITS_EXPIRY_DAYS,
-} from "../credit";
+import { convertCentsToCredits, convertCreditsToCents } from "../credit";
 
 describe("convertCentsToCredits", () => {
   it("converts cents to credits", () => {
@@ -25,11 +21,5 @@ describe("convertCreditsToCents", () => {
 
   it("rounds half up when more than 10 decimal places are provided", () => {
     expect(convertCreditsToCents(0.12345678905)).toBe(1_234_567_891n);
-  });
-});
-
-describe("FREE_CREDITS_EXPIRY_DAYS", () => {
-  it("keeps the shared expiry window", () => {
-    expect(FREE_CREDITS_EXPIRY_DAYS).toBe(30);
   });
 });

--- a/packages/utils/src/credit.ts
+++ b/packages/utils/src/credit.ts
@@ -1,7 +1,6 @@
 import { Decimal } from "decimal.js";
 
 const CREDITS_BASE = 10 ** 10;
-export const FREE_CREDITS_EXPIRY_DAYS = 30;
 
 export function convertCentsToCredits(cents: bigint): number {
   if (cents > BigInt(Number.MAX_SAFE_INTEGER)) {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,11 +13,7 @@ export {
   resolveBetterAuthProductionUrl,
   resolveBetterAuthPublicBaseUrl,
 } from "./better-auth-public-url.js";
-export {
-  convertCentsToCredits,
-  convertCreditsToCents,
-  FREE_CREDITS_EXPIRY_DAYS,
-} from "./credit.js";
+export { convertCentsToCredits, convertCreditsToCents } from "./credit.js";
 export {
   FILE_EXTENSION_ALLOWLIST,
   getExtensionFromUrl,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Free (zero-amount) Stripe credit grants (`STRIPE_FREE`) no longer use a 30-day default when `invoice.metadata.ttl_days` is missing. Omitted, empty, invalid, or non-positive `ttl_days` now maps to `expiresAt: null` (no expiry). A positive integer `ttl_days` still sets expiry relative to the invoice time.

## Changes

- `getTopUpExpiryDaysFromInvoiceMetadata` in `webhook-handlers.ts`: unified semantics — only positive integers produce a day count; everything else is treated as no expiry.
- Removed `FREE_CREDITS_EXPIRY_DAYS` from `@sokosumi/utils` (no remaining consumers).
- Coupon form: replaced fixed-day notice with `couponExpiryPolicyNotice` in all locale files.

## Verification

- `pnpm --filter @sokosumi/utils test`
- `pnpm --filter web exec vitest run src/lib/stripe/__tests__/webhook-handlers.test.ts src/components/credits/__tests__/coupon-form.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-712d18c4-028c-4487-bfd3-b9425123da8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-712d18c4-028c-4487-bfd3-b9425123da8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

