### PR TITLE
fix(i18n): generic coupon credit expiry notice copy

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1764,7 +1764,7 @@
       },
       "paidSubscriptionRequiredDescription": "Du benötigst ein kostenpflichtiges Abonnement, um zusätzliche Credits zu kaufen.",
       "paidSubscriptionRequiredHint": "Wähle im Tab „Abonnement“ einen kostenpflichtigen Plan, um das Aufladen von Credits freizuschalten.",
-      "couponExpiryPolicyNotice": "Credits verfallen nur, wenn der Gutschein ein positives ttl_days setzt (Tage bis zum Verfall)."
+      "couponExpiryPolicyNotice": "Aktionsguthaben kann verfallen; die Bedingungen hängen vom jeweiligen Gutschein oder Angebot ab."
     },
     "Connections": {
       "tabs": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "Choose an amount or enter a custom value",
       "paidSubscriptionRequiredDescription": "A paid subscription is required to buy additional credits.",
       "paidSubscriptionRequiredHint": "Choose a paid plan in the Subscription tab to unlock credit top-ups.",
-      "couponExpiryPolicyNotice": "Credits do not expire unless the coupon sets a positive ttl_days (days until expiry).",
+      "couponExpiryPolicyNotice": "Promotional credits may expire; terms vary by coupon or offer.",
       "costPerCredit": "{cost} per credit",
       "creditAmount": "{count, plural, one {# credit} other {# credits}}",
       "creditsLabel": "Number of credits",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1764,7 +1764,7 @@
       },
       "paidSubscriptionRequiredDescription": "Se requiere una suscripción de pago para comprar créditos adicionales.",
       "paidSubscriptionRequiredHint": "Elige un plan de pago en la pestaña Suscripción para desbloquear las recargas de créditos.",
-      "couponExpiryPolicyNotice": "Los créditos no caducan a menos que el cupón defina un ttl_days positivo (días hasta el vencimiento)."
+      "couponExpiryPolicyNotice": "Los créditos promocionales pueden caducar; las condiciones dependen del cupón o de la oferta."
     },
     "Connections": {
       "tabs": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "Choisissez un montant ou saisissez une valeur personnalisée",
       "paidSubscriptionRequiredDescription": "Un abonnement payant est nécessaire pour acheter des crédits supplémentaires.",
       "paidSubscriptionRequiredHint": "Choisissez une offre payante dans l’onglet Abonnement pour débloquer les recharges de crédits.",
-      "couponExpiryPolicyNotice": "Les crédits n'expirent pas sauf si le bon définit un ttl_days positif (jours avant expiration).",
+      "couponExpiryPolicyNotice": "Les crédits promotionnels peuvent expirer ; les conditions varient selon le bon ou l'offre.",
       "costPerCredit": "{cost} par crédit",
       "creditAmount": "{count, plural, one {# crédit} other {# crédits}}",
       "creditsLabel": "Nombre de crédits",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1774,7 +1774,7 @@
       "topUpDescription": "Scegli un importo o inserisci un valore personalizzato",
       "paidSubscriptionRequiredDescription": "È necessario un abbonamento a pagamento per acquistare crediti aggiuntivi.",
       "paidSubscriptionRequiredHint": "Scegli un piano a pagamento nella scheda Abbonamento per sbloccare le ricariche di crediti.",
-      "couponExpiryPolicyNotice": "I crediti non scadono a meno che il coupon imposti un ttl_days positivo (giorni alla scadenza).",
+      "couponExpiryPolicyNotice": "I crediti promozionali possono scadere; le condizioni dipendono dal coupon o dall'offerta.",
       "costPerCredit": "{cost} per credito",
       "creditAmount": "{count, plural, one {# credito} other {# crediti}}",
       "creditsLabel": "Numero di crediti",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1774,7 +1774,7 @@
       "topUpDescription": "金額を選択するか、任意の値を入力してください",
       "paidSubscriptionRequiredDescription": "追加のクレジットを購入するには有料サブスクリプションが必要です。",
       "paidSubscriptionRequiredHint": "クレジットの追加購入を利用するには、サブスクリプションタブで有料プランを選択してください。",
-      "couponExpiryPolicyNotice": "クーポンに正の ttl_days（失効までの日数）がない限り、クレジットは失効しません。",
+      "couponExpiryPolicyNotice": "プロモーションクレジットには有効期限がある場合があります。条件はクーポンやオファーによって異なります。",
       "costPerCredit": "1クレジットあたり{cost}",
       "creditAmount": "{count, plural, one {# クレジット} other {# クレジット}}",
       "creditsLabel": "クレジット数",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "Escolha um valor ou digite um valor personalizado",
       "paidSubscriptionRequiredDescription": "É necessária uma assinatura paga para comprar créditos adicionais.",
       "paidSubscriptionRequiredHint": "Escolha um plano pago na aba Assinatura para desbloquear as recargas de créditos.",
-      "couponExpiryPolicyNotice": "Os créditos não expiram a menos que o cupom defina um ttl_days positivo (dias até expirar).",
+      "couponExpiryPolicyNotice": "Os créditos promocionais podem expirar; os termos variam conforme o cupom ou a oferta.",
       "costPerCredit": "{cost} por crédito",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Quantidade de créditos",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1774,7 +1774,7 @@
       "topUpDescription": "Escolha um montante ou introduza um valor personalizado",
       "paidSubscriptionRequiredDescription": "É necessária uma subscrição paga para comprar créditos adicionais.",
       "paidSubscriptionRequiredHint": "Escolha um plano pago no separador Subscrição para desbloquear os carregamentos de créditos.",
-      "couponExpiryPolicyNotice": "Os créditos não expiram a menos que o cupão defina um ttl_days positivo (dias até expirar).",
+      "couponExpiryPolicyNotice": "Os créditos promocionais podem expirar; os termos variam consoante o cupão ou a oferta.",
       "costPerCredit": "{cost} por crédito",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Número de créditos",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1773,7 +1773,7 @@
       "topUpDescription": "选择金额或输入自定义数值",
       "paidSubscriptionRequiredDescription": "购买额外积分需要付费订阅。",
       "paidSubscriptionRequiredHint": "请在“订阅”标签页选择付费套餐以解锁积分充值。",
-      "couponExpiryPolicyNotice": "除非优惠券设置了正数的 ttl_days（距离过期的天数），否则积分不会过期。",
+      "couponExpiryPolicyNotice": "促销积分可能会过期，具体条款因优惠券或活动而异。",
       "costPerCredit": "{cost} / 积分",
       "creditAmount": "{count, plural, one {# 积分} other {# 积分}}",
       "creditsLabel": "积分数量",

--- a/apps/web/src/components/credits/__tests__/coupon-form.test.tsx
+++ b/apps/web/src/components/credits/__tests__/coupon-form.test.tsx
@@ -18,7 +18,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => {
     if (key === "couponExpiryPolicyNotice") {
-      return "Coupon credits only expire when ttl_days is set on the coupon.";
+      return "Promotional credits may expire; terms vary by coupon or offer.";
     }
     return key;
   },
@@ -73,7 +73,7 @@ describe("CouponForm", () => {
 
     expect(
       screen.getByText(
-        "Coupon credits only expire when ttl_days is set on the coupon.",
+        "Promotional credits may expire; terms vary by coupon or offer.",
       ),
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Updates `App.Credits.couponExpiryPolicyNotice` across locales to neutral wording: promotional credits may expire; terms vary by coupon or offer (no fixed-day / `ttl_days` phrasing).

## Changes

- **Messages**: `apps/web/messages/*.json` — refreshed copy for `couponExpiryPolicyNotice`
- **Tests**: `coupon-form.test.tsx` — mock and assertion aligned with the English string

## Verification

- `pnpm --filter web test apps/web/src/components/credits/__tests__/coupon-form.test.tsx` (or full web test suite as needed)

Made with [Cursor](https://cursor.com)