### PR TITLE
fix(tasks): await Masumi task purchase with waitUntil and add payment logs

### DIFF
--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -91,7 +91,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id: taskId } = c.req.valid("param");
     const body = c.req.valid("json");
 
-    const { event, userId, masumiAsyncPurchase } = await prisma.$transaction(
+    const { event, userId, masumiPayment } = await prisma.$transaction(
       async (tx) => {
         const task = await requireTaskAccess(authContext, taskId, tx);
         const {
@@ -118,6 +118,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             isTaskStatusSpendable(status)
           ) {
             if (masumiPayment) {
+              console.info("[tasks] masumi task payment: using masumiPayment", {
+                masumiPayment,
+              });
               const creditCosts = await getCreditCostsOrThrow(tx);
               cents = calculateCentsFromMasumiAmountStrings(
                 masumiPayment.Amounts,
@@ -177,17 +180,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             throw conflict("Task status was changed by another request");
           }
 
-          const masumiAsync =
+          const payment =
             masumiPayment !== undefined &&
             isCoworkerAuthContext(authContext) &&
             isTaskStatusSpendable(status)
-              ? { taskEventId: createdEvent.id, payment: masumiPayment }
+              ? masumiPayment
               : null;
 
           return {
             event: mapTaskEvent(createdEvent),
             userId: task.userId,
-            masumiAsyncPurchase: masumiAsync,
+            masumiPayment: payment,
           };
         }
 
@@ -210,7 +213,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         return {
           event: mapTaskEvent(createdEvent),
           userId: task.userId,
-          masumiAsyncPurchase: null,
+          masumiPayment: null,
         };
       },
       {
@@ -218,9 +221,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       },
     );
 
-    if (masumiAsyncPurchase !== null) {
-      const mp = masumiAsyncPurchase.payment;
-      const taskEventId = masumiAsyncPurchase.taskEventId;
+    if (masumiPayment != null) {
+      const taskEventId = event.id;
       const identifierFromPurchaser = uuidv4()
         .replace(/-/g, "")
         .substring(0, 20);
@@ -232,21 +234,28 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         data: {
           taskId,
           taskEventId,
-          blockchainIdentifier: mp.blockchainIdentifier,
+          blockchainIdentifier: masumiPayment.blockchainIdentifier,
         },
       });
 
-      void paymentClient()
+      console.info("[tasks] masumi task payment: scheduling async purchase", {
+        taskId,
+        taskEventId,
+        blockchainIdentifier: masumiPayment.blockchainIdentifier,
+        agentIdentifier: masumiPayment.agentIdentifier,
+      });
+
+      paymentClient()
         .createPurchaseFromMasumiTaskPayment({
-          blockchainIdentifier: mp.blockchainIdentifier,
-          agentIdentifier: mp.agentIdentifier,
-          sellerVkey: mp.sellerVkey,
-          submitResultTime: mp.submitResultTime,
-          payByTime: mp.payByTime,
-          unlockTime: mp.unlockTime,
-          externalDisputeUnlockTime: mp.externalDisputeUnlockTime,
-          inputHash: mp.inputHash,
-          Amounts: mp.Amounts,
+          blockchainIdentifier: masumiPayment.blockchainIdentifier,
+          agentIdentifier: masumiPayment.agentIdentifier,
+          sellerVkey: masumiPayment.sellerVkey,
+          submitResultTime: masumiPayment.submitResultTime,
+          payByTime: masumiPayment.payByTime,
+          unlockTime: masumiPayment.unlockTime,
+          externalDisputeUnlockTime: masumiPayment.externalDisputeUnlockTime,
+          inputHash: masumiPayment.inputHash,
+          Amounts: masumiPayment.Amounts,
           identifierFromPurchaser,
           metadata: JSON.stringify({
             taskId,
@@ -255,6 +264,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         })
         .then((createPurchaseResult) => {
           if (createPurchaseResult.isErr()) {
+            console.error(
+              "[tasks] masumi task payment: purchase creation failed",
+              {
+                taskId,
+                taskEventId,
+                blockchainIdentifier: masumiPayment.blockchainIdentifier,
+                error: createPurchaseResult.error,
+              },
+            );
             Sentry.captureMessage(
               `Task purchase creation failed: ${createPurchaseResult.error}`,
               {
@@ -266,7 +284,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
                   task_purchase_creation: {
                     taskId,
                     taskEventId,
-                    blockchainIdentifier: mp.blockchainIdentifier,
+                    blockchainIdentifier: masumiPayment.blockchainIdentifier,
                     error: createPurchaseResult.error,
                   },
                 },
@@ -274,6 +292,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             );
             return;
           }
+
+          console.info("[tasks] masumi task payment: purchase created", {
+            taskId,
+            taskEventId,
+            purchaseId: createPurchaseResult.value.id,
+            blockchainIdentifier:
+              createPurchaseResult.value.blockchainIdentifier,
+          });
 
           Sentry.addBreadcrumb({
             category: "task_masumi_purchase",
@@ -286,6 +312,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           });
         })
         .catch((error: unknown) => {
+          console.error("[tasks] masumi task payment: unexpected error", {
+            taskId,
+            taskEventId,
+            blockchainIdentifier: masumiPayment.blockchainIdentifier,
+            error,
+          });
           Sentry.captureException(error, {
             tags: {
               error_type: "task_masumi_purchase_unexpected",

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import * as Sentry from "@sentry/node";
 import { Prisma } from "@sokosumi/database";
 import { convertCentsToCredits, convertCreditsToCents } from "@sokosumi/utils";
+import { waitUntil } from "@vercel/functions";
 import { v4 as uuidv4 } from "uuid";
 
 import { paymentClient } from "@/clients/masumi-payment.client";
@@ -245,7 +246,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         agentIdentifier: masumiPayment.agentIdentifier,
       });
 
-      paymentClient()
+      const masumiPurchasePromise = paymentClient()
         .createPurchaseFromMasumiTaskPayment({
           blockchainIdentifier: masumiPayment.blockchainIdentifier,
           agentIdentifier: masumiPayment.agentIdentifier,
@@ -325,6 +326,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             extra: { taskId, taskEventId },
           });
         });
+
+      waitUntil(masumiPurchasePromise);
     }
 
     try {

--- a/apps/core/src/routes/v1/tasks/[id]/events/schema.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/schema.ts
@@ -49,7 +49,7 @@ const masumiPaymentPayloadSchema = z
     Amounts: z.array(masumiPaymentAmountSchema).min(1).openapi({ example: [] }),
     PaymentSource: masumiPaymentSourceSchema.optional(),
   })
-  .openapi("MasumiTaskPayment");
+  .openapi("MasumiPayment");
 
 export function createTaskEventRequestSchema(
   params: { serverNetwork: "Preprod" | "Mainnet" } = {

--- a/packages/masumi/src/clients/masumi-payment.client.ts
+++ b/packages/masumi/src/clients/masumi-payment.client.ts
@@ -163,6 +163,16 @@ export function createPaymentClient(
     async createPurchaseFromMasumiTaskPayment(
       input: MasumiTaskPurchaseInput,
     ): Promise<Result<PostPurchaseResponses["200"]["data"], string>> {
+      const logLabel = "[masumi-payment] createPurchaseFromMasumiTaskPayment";
+      console.info(`${logLabel} request`, {
+        network,
+        blockchainIdentifier: input.blockchainIdentifier,
+        agentIdentifier: input.agentIdentifier,
+        identifierFromPurchaser: input.identifierFromPurchaser,
+        amountsCount: input.Amounts.length,
+        hasMetadata: input.metadata !== undefined,
+      });
+
       try {
         const response = await postPurchase({
           client: client(),
@@ -185,15 +195,28 @@ export function createPaymentClient(
         });
 
         if (response.error || !response.data) {
-          console.error(
-            "Failed to create task purchase request",
-            response.error,
-          );
+          console.error(`${logLabel} payment API error`, {
+            network,
+            blockchainIdentifier: input.blockchainIdentifier,
+            error: response.error,
+          });
           return err("Failed to create purchase request");
         }
 
-        return ok(response.data.data);
+        const data = response.data.data;
+        console.info(`${logLabel} success`, {
+          network,
+          purchaseId: data.id,
+          blockchainIdentifier: data.blockchainIdentifier,
+        });
+
+        return ok(data);
       } catch (error) {
+        console.error(`${logLabel} unexpected error`, {
+          network,
+          blockchainIdentifier: input.blockchainIdentifier,
+          error,
+        });
         return err(String(error) || "Failed to create purchase request");
       }
     },


### PR DESCRIPTION
## Summary

Hardens the asynchronous Masumi purchase path when posting task events on Vercel and improves observability across the Core API handler and `@sokosumi/masumi` payment client.

## Key changes

- **Vercel / async completion**: Register the purchase `Promise` with `waitUntil` from `@vercel/functions` so the serverless invocation stays alive until `createPurchaseFromMasumiTaskPayment` settles, instead of relying on untracked fire-and-forget work after the response is sent.
- **Handler refactor**: Rename `masumiAsyncPurchase` to `masumiPayment`, simplify the transaction return value (use the mapped event `id` for `taskEventId`), and add structured `console.info` / `console.error` around scheduling, success, API errors, and unexpected failures (existing Sentry reporting preserved).
- **Payment client**: Add structured request/success/error logging for `createPurchaseFromMasumiTaskPayment` without logging sensitive payload fields.
- **OpenAPI**: Rename the Zod OpenAPI component id from `MasumiTaskPayment` to `MasumiPayment` for consistency.

## Testing

- [ ] `pnpm --filter core test` (or full `pnpm test` if preferred)
- [ ] Manual: post a task event that triggers a Masumi payment on a Vercel deployment and confirm purchase creation completes and logs appear as expected.


Made with [Cursor](https://cursor.com)