### PR TITLE
fix(tasks): require and forward identifierFromPurchaser for Masumi payments

### DIFF
--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -70,6 +70,7 @@ const COWORKER_ID = "cow_123";
 
 const validMasumiPaymentBody = {
   blockchainIdentifier: "0b00e04c0860a60c61066056281180462d0b12",
+  identifierFromPurchaser: "aabbccddeeff00112233",
   agentIdentifier: "7e8bdaf2b2b919a3a4b94002cafb50086c0c845fe535d07a77ab7f77",
   sellerVkey: "0bde475ace6b116298363b268309fa62172f7208625a9a83eeaffdbd",
   submitResultTime: "1775681853000",
@@ -443,6 +444,7 @@ describe("POST /{id}/events", () => {
     expect(createPurchaseFromMasumiTaskPaymentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         blockchainIdentifier: validMasumiPaymentBody.blockchainIdentifier,
+        identifierFromPurchaser: validMasumiPaymentBody.identifierFromPurchaser,
         Amounts: validMasumiPaymentBody.Amounts,
         metadata: expect.stringContaining(TASK_ID),
       }),

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -3,7 +3,6 @@ import * as Sentry from "@sentry/node";
 import { Prisma } from "@sokosumi/database";
 import { convertCentsToCredits, convertCreditsToCents } from "@sokosumi/utils";
 import { waitUntil } from "@vercel/functions";
-import { v4 as uuidv4 } from "uuid";
 
 import { paymentClient } from "@/clients/masumi-payment.client";
 import { LIMITS } from "@/config/constants";
@@ -224,9 +223,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     if (masumiPayment != null) {
       const taskEventId = event.id;
-      const identifierFromPurchaser = uuidv4()
-        .replace(/-/g, "")
-        .substring(0, 20);
 
       Sentry.addBreadcrumb({
         category: "task_masumi_purchase",
@@ -257,7 +253,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           externalDisputeUnlockTime: masumiPayment.externalDisputeUnlockTime,
           inputHash: masumiPayment.inputHash,
           Amounts: masumiPayment.Amounts,
-          identifierFromPurchaser,
+          identifierFromPurchaser: masumiPayment.identifierFromPurchaser,
           metadata: JSON.stringify({
             taskId,
             taskEventId,

--- a/apps/core/src/routes/v1/tasks/[id]/events/schema.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/schema.test.ts
@@ -9,6 +9,7 @@ const taskEventRequestSchema = createTaskEventRequestSchema();
 
 const validMasumiPayment = {
   blockchainIdentifier: "0b00e04c0860a60c61066056281180462d0b12",
+  identifierFromPurchaser: "aabbccddeeff00112233",
   agentIdentifier: "7e8bdaf2b2b919a3a4b94002cafb50086c0c845fe535d07a77ab7f77",
   sellerVkey: "0bde475ace6b116298363b268309fa62172f7208625a9a83eeaffdbd",
   submitResultTime: "1775681853000",

--- a/apps/core/src/routes/v1/tasks/[id]/events/schema.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/schema.ts
@@ -29,6 +29,9 @@ const masumiPaymentPayloadSchema = z
     blockchainIdentifier: z.string().min(1).openapi({
       example: "0b00e04c0860a60c61066056281180462d0b12",
     }),
+    identifierFromPurchaser: z.string().min(1).openapi({
+      example: "1234567890",
+    }),
     agentIdentifier: z.string().min(1).openapi({
       example: "7e8bdaf2b2b919a3a4b94002cafb50086c0c845fe535d07a77ab7f77",
     }),


### PR DESCRIPTION
## Summary

Task events that register a Masumi purchase previously generated `identifierFromPurchaser` on the server. That nonce must be the same one used when computing `inputHash` on the purchaser/agent side. Generating it server-side could desync verification from the on-chain purchase metadata.

## Key changes

- Require `identifierFromPurchaser` on the `masumiPayment` object in the task event request schema (documented in OpenAPI).
- Forward the client-supplied value to `createPurchaseFromMasumiTaskPayment` instead of deriving a UUID substring.
- Drop the unused `uuid` import from the route handler.
- Extend schema and route tests; assert the payment client receives `identifierFromPurchaser`.

## Testing

From `apps/core`:

```bash
pnpm exec vitest run "src/routes/v1/tasks/[id]/events/schema.test.ts" "src/routes/v1/tasks/[id]/events/post.test.ts"
```

## API note

Callers that send `masumiPayment` must include `identifierFromPurchaser` and must use the same value they used for Masumi input hashing.
