### PR TITLE
feat(credits): show savings and totals on top-up quick amounts (DEV-913)

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1712,6 +1712,7 @@
       "topUpTitle": "Credits aufladen",
       "topUpDescription": "Wähle einen Betrag oder gib einen eigenen Wert ein",
       "costPerCredit": "{cost} pro Credit",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# Credit} other {# Credits}}",
       "creditsLabel": "Anzahl Credits",
       "creditsPlaceholder": "Betrag eingeben",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1711,8 +1711,11 @@
       "billingPortalCta": "Käufe verwalten",
       "topUpTitle": "Credits aufladen",
       "topUpDescription": "Wähle einen Betrag oder gib einen eigenen Wert ein",
+      "paidSubscriptionRequiredDescription": "Du benötigst ein kostenpflichtiges Abonnement, um zusätzliche Credits zu kaufen.",
+      "paidSubscriptionRequiredHint": "Wähle im Tab „Abonnement“ einen kostenpflichtigen Plan, um das Aufladen von Credits freizuschalten.",
+      "couponExpiryPolicyNotice": "Aktionsguthaben kann verfallen; die Bedingungen hängen vom jeweiligen Gutschein oder Angebot ab.",
       "costPerCredit": "{cost} pro Credit",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "Spare {amount}",
       "creditAmount": "{count, plural, one {# Credit} other {# Credits}}",
       "creditsLabel": "Anzahl Credits",
       "creditsPlaceholder": "Betrag eingeben",
@@ -1763,10 +1766,7 @@
         "unauthorizedOrganization": "Du bist nicht berechtigt, Credits für diese Organisation zu kaufen",
         "unauthorizedPersonal": "Du bist nicht berechtigt, Credits zu kaufen",
         "unknownError": "Etwas ist schiefgelaufen"
-      },
-      "paidSubscriptionRequiredDescription": "Du benötigst ein kostenpflichtiges Abonnement, um zusätzliche Credits zu kaufen.",
-      "paidSubscriptionRequiredHint": "Wähle im Tab „Abonnement“ einen kostenpflichtigen Plan, um das Aufladen von Credits freizuschalten.",
-      "couponExpiryPolicyNotice": "Aktionsguthaben kann verfallen; die Bedingungen hängen vom jeweiligen Gutschein oder Angebot ab."
+      }
     },
     "Connections": {
       "tabs": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1776,6 +1776,7 @@
       "paidSubscriptionRequiredHint": "Choose a paid plan in the Subscription tab to unlock credit top-ups.",
       "couponExpiryPolicyNotice": "Promotional credits may expire; terms vary by coupon or offer.",
       "costPerCredit": "{cost} per credit",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# credit} other {# credits}}",
       "creditsLabel": "Number of credits",
       "creditsPlaceholder": "Enter amount",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1711,9 +1711,12 @@
       "billingPortalCta": "Gestionar compras",
       "topUpTitle": "Recargar Credits",
       "topUpDescription": "Elige un importe o introduce uno personalizado",
+      "paidSubscriptionRequiredDescription": "Se requiere una suscripción de pago para comprar créditos adicionales.",
+      "paidSubscriptionRequiredHint": "Elige un plan de pago en la pestaña Suscripción para desbloquear las recargas de créditos.",
+      "couponExpiryPolicyNotice": "Los créditos promocionales pueden caducar; las condiciones dependen del cupón o de la oferta.",
       "costPerCredit": "{cost} por Credit",
-      "youSaveLabel": "Save {amount}",
-      "creditAmount": "{count, plural, one {# Credit} other {# Credits}}",
+      "youSaveLabel": "Ahorra {amount}",
+      "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Cantidad de Credits",
       "creditsPlaceholder": "Introduce el importe",
       "topUpButton": "Continuar",
@@ -1763,10 +1766,7 @@
         "unauthorizedOrganization": "No tienes permiso para comprar Credits para esta organización",
         "unauthorizedPersonal": "No tienes permiso para comprar Credits",
         "unknownError": "Algo salió mal"
-      },
-      "paidSubscriptionRequiredDescription": "Se requiere una suscripción de pago para comprar créditos adicionales.",
-      "paidSubscriptionRequiredHint": "Elige un plan de pago en la pestaña Suscripción para desbloquear las recargas de créditos.",
-      "couponExpiryPolicyNotice": "Los créditos promocionales pueden caducar; las condiciones dependen del cupón o de la oferta."
+      }
     },
     "Connections": {
       "tabs": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1712,6 +1712,7 @@
       "topUpTitle": "Recargar Credits",
       "topUpDescription": "Elige un importe o introduce uno personalizado",
       "costPerCredit": "{cost} por Credit",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# Credit} other {# Credits}}",
       "creditsLabel": "Cantidad de Credits",
       "creditsPlaceholder": "Introduce el importe",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1776,7 +1776,7 @@
       "paidSubscriptionRequiredHint": "Choisissez une offre payante dans l’onglet Abonnement pour débloquer les recharges de crédits.",
       "couponExpiryPolicyNotice": "Les crédits promotionnels peuvent expirer ; les conditions varient selon le bon ou l'offre.",
       "costPerCredit": "{cost} par crédit",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "Économisez {amount}",
       "creditAmount": "{count, plural, one {# crédit} other {# crédits}}",
       "creditsLabel": "Nombre de crédits",
       "creditsPlaceholder": "Saisissez un montant",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1776,6 +1776,7 @@
       "paidSubscriptionRequiredHint": "Choisissez une offre payante dans l’onglet Abonnement pour débloquer les recharges de crédits.",
       "couponExpiryPolicyNotice": "Les crédits promotionnels peuvent expirer ; les conditions varient selon le bon ou l'offre.",
       "costPerCredit": "{cost} par crédit",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# crédit} other {# crédits}}",
       "creditsLabel": "Nombre de crédits",
       "creditsPlaceholder": "Saisissez un montant",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1777,6 +1777,7 @@
       "paidSubscriptionRequiredHint": "Scegli un piano a pagamento nella scheda Abbonamento per sbloccare le ricariche di crediti.",
       "couponExpiryPolicyNotice": "I crediti promozionali possono scadere; le condizioni dipendono dal coupon o dall'offerta.",
       "costPerCredit": "{cost} per credito",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# credito} other {# crediti}}",
       "creditsLabel": "Numero di crediti",
       "creditsPlaceholder": "Inserisci l’importo",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1777,7 +1777,7 @@
       "paidSubscriptionRequiredHint": "Scegli un piano a pagamento nella scheda Abbonamento per sbloccare le ricariche di crediti.",
       "couponExpiryPolicyNotice": "I crediti promozionali possono scadere; le condizioni dipendono dal coupon o dall'offerta.",
       "costPerCredit": "{cost} per credito",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "Risparmia {amount}",
       "creditAmount": "{count, plural, one {# credito} other {# crediti}}",
       "creditsLabel": "Numero di crediti",
       "creditsPlaceholder": "Inserisci l’importo",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1777,6 +1777,7 @@
       "paidSubscriptionRequiredHint": "クレジットの追加購入を利用するには、サブスクリプションタブで有料プランを選択してください。",
       "couponExpiryPolicyNotice": "プロモーションクレジットには有効期限がある場合があります。条件はクーポンやオファーによって異なります。",
       "costPerCredit": "1クレジットあたり{cost}",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# クレジット} other {# クレジット}}",
       "creditsLabel": "クレジット数",
       "creditsPlaceholder": "数量を入力",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1777,7 +1777,7 @@
       "paidSubscriptionRequiredHint": "クレジットの追加購入を利用するには、サブスクリプションタブで有料プランを選択してください。",
       "couponExpiryPolicyNotice": "プロモーションクレジットには有効期限がある場合があります。条件はクーポンやオファーによって異なります。",
       "costPerCredit": "1クレジットあたり{cost}",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "{amount}お得",
       "creditAmount": "{count, plural, one {# クレジット} other {# クレジット}}",
       "creditsLabel": "クレジット数",
       "creditsPlaceholder": "数量を入力",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1776,7 +1776,7 @@
       "paidSubscriptionRequiredHint": "Escolha um plano pago na aba Assinatura para desbloquear as recargas de créditos.",
       "couponExpiryPolicyNotice": "Os créditos promocionais podem expirar; os termos variam conforme o cupom ou a oferta.",
       "costPerCredit": "{cost} por crédito",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "Economize {amount}",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Quantidade de créditos",
       "creditsPlaceholder": "Digite o valor",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1776,6 +1776,7 @@
       "paidSubscriptionRequiredHint": "Escolha um plano pago na aba Assinatura para desbloquear as recargas de créditos.",
       "couponExpiryPolicyNotice": "Os créditos promocionais podem expirar; os termos variam conforme o cupom ou a oferta.",
       "costPerCredit": "{cost} por crédito",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Quantidade de créditos",
       "creditsPlaceholder": "Digite o valor",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1777,7 +1777,7 @@
       "paidSubscriptionRequiredHint": "Escolha um plano pago no separador Subscrição para desbloquear os carregamentos de créditos.",
       "couponExpiryPolicyNotice": "Os créditos promocionais podem expirar; os termos variam consoante o cupão ou a oferta.",
       "costPerCredit": "{cost} por crédito",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "Poupe {amount}",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Número de créditos",
       "creditsPlaceholder": "Introduza o montante",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1777,6 +1777,7 @@
       "paidSubscriptionRequiredHint": "Escolha um plano pago no separador Subscrição para desbloquear os carregamentos de créditos.",
       "couponExpiryPolicyNotice": "Os créditos promocionais podem expirar; os termos variam consoante o cupão ou a oferta.",
       "costPerCredit": "{cost} por crédito",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# crédito} other {# créditos}}",
       "creditsLabel": "Número de créditos",
       "creditsPlaceholder": "Introduza o montante",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1776,6 +1776,7 @@
       "paidSubscriptionRequiredHint": "请在“订阅”标签页选择付费套餐以解锁积分充值。",
       "couponExpiryPolicyNotice": "促销积分可能会过期，具体条款因优惠券或活动而异。",
       "costPerCredit": "{cost} / 积分",
+      "youSaveLabel": "Save {amount}",
       "creditAmount": "{count, plural, one {# 积分} other {# 积分}}",
       "creditsLabel": "积分数量",
       "creditsPlaceholder": "输入数量",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1776,7 +1776,7 @@
       "paidSubscriptionRequiredHint": "请在“订阅”标签页选择付费套餐以解锁积分充值。",
       "couponExpiryPolicyNotice": "促销积分可能会过期，具体条款因优惠券或活动而异。",
       "costPerCredit": "{cost} / 积分",
-      "youSaveLabel": "Save {amount}",
+      "youSaveLabel": "立省 {amount}",
       "creditAmount": "{count, plural, one {# 积分} other {# 积分}}",
       "creditsLabel": "积分数量",
       "creditsPlaceholder": "输入数量",

--- a/apps/web/src/components/credits/__tests__/credits-form.test.tsx
+++ b/apps/web/src/components/credits/__tests__/credits-form.test.tsx
@@ -69,6 +69,9 @@ vi.mock("@/lib/gtm-events", () => ({
   },
 }));
 
+/** Footer summary uses `text-sm`; quick-pick cards use `text-xs`. */
+const customAmountPerCreditSelector = "p.text-muted-foreground.text-sm";
+
 const priceCatalog: CreditTopUpPriceCatalog = {
   credit_0_margin: {
     id: "price_0",
@@ -101,7 +104,7 @@ describe("CreditsForm", () => {
     const user = userEvent.setup();
     render(<CreditsForm priceCatalog={priceCatalog} organization={null} />);
 
-    expect(screen.getByText("usd:0.0120 per credit")).toBeInTheDocument();
+    expect(screen.getByText("USD:0.0120 per credit")).toBeInTheDocument();
 
     const creditsInput = screen.getByRole("spinbutton", {
       name: "creditsLabel",
@@ -109,11 +112,15 @@ describe("CreditsForm", () => {
 
     await user.clear(creditsInput);
     await user.type(creditsInput, "10000");
-    expect(screen.getByText("usd:0.0115 per credit")).toBeInTheDocument();
+    expect(
+      screen.getByText("USD:0.0115 per credit", {
+        selector: customAmountPerCreditSelector,
+      }),
+    ).toBeInTheDocument();
 
     await user.clear(creditsInput);
     await user.type(creditsInput, "100000");
-    expect(screen.getByText("usd:0.0110 per credit")).toBeInTheDocument();
+    expect(screen.getByText("USD:0.0110 per credit")).toBeInTheDocument();
     expect(
       screen.queryByText("Credits expire after 180 days."),
     ).not.toBeInTheDocument();
@@ -129,7 +136,7 @@ describe("CreditsForm", () => {
       />,
     );
 
-    expect(screen.getByText("usd:0.0100 per credit")).toBeInTheDocument();
+    expect(screen.getAllByText("USD:0.0100 per credit")).toHaveLength(4);
 
     const creditsInput = screen.getByRole("spinbutton", {
       name: "creditsLabel",
@@ -137,11 +144,19 @@ describe("CreditsForm", () => {
 
     await user.clear(creditsInput);
     await user.type(creditsInput, "10000");
-    expect(screen.getByText("usd:0.0100 per credit")).toBeInTheDocument();
+    expect(
+      screen.getByText("USD:0.0100 per credit", {
+        selector: customAmountPerCreditSelector,
+      }),
+    ).toBeInTheDocument();
 
     await user.clear(creditsInput);
     await user.type(creditsInput, "250000");
-    expect(screen.getByText("usd:0.0100 per credit")).toBeInTheDocument();
+    expect(
+      screen.getByText("USD:0.0100 per credit", {
+        selector: customAmountPerCreditSelector,
+      }),
+    ).toBeInTheDocument();
   });
 
   it("allows single-credit granularity without a hard max", () => {

--- a/apps/web/src/components/credits/credits-form.tsx
+++ b/apps/web/src/components/credits/credits-form.tsx
@@ -347,7 +347,7 @@ export default function CreditsForm({
                         className={cn(
                           "h-auto min-h-36 w-full flex-col items-start justify-between gap-6 whitespace-normal rounded-xl px-4 py-4 text-left",
                           isSelected
-                            ? "border-primary ring-primary bg-primary/5 border-1 shadow-sm ring-1 hover:bg-primary/5"
+                            ? "border-primary ring-primary bg-primary/5 border shadow-sm ring-1 hover:bg-primary/5"
                             : "hover:bg-accent/40",
                         )}
                       >

--- a/apps/web/src/components/credits/credits-form.tsx
+++ b/apps/web/src/components/credits/credits-form.tsx
@@ -42,25 +42,13 @@ import {
   BASE_CREDIT_TOPUP_LOOKUP_KEY,
   type CreditTopUpLookupKey,
   getCreditTopUpLookupKeyByCredits,
+  getCreditTopUpTotalMinorUnits,
   isPositiveIntegerCredits,
 } from "@/lib/stripe/credit-topup-pricing";
 import { cn } from "@/lib/utils";
 
 function hasValidCreditsInput(credits: number | null | undefined): boolean {
   return isPositiveIntegerCredits(credits ?? Number.NaN);
-}
-
-function getCreditTopUpTotalMinorUnits(
-  credits: number,
-  amountPerCredit: number,
-): number {
-  const totalMinorUnits = Math.ceil(credits * amountPerCredit);
-
-  if (!Number.isFinite(totalMinorUnits) || totalMinorUnits < 1) {
-    throw new Error("Computed credit top-up total is invalid");
-  }
-
-  return totalMinorUnits;
 }
 
 interface CreditPricingSummary {

--- a/apps/web/src/components/credits/credits-form.tsx
+++ b/apps/web/src/components/credits/credits-form.tsx
@@ -33,7 +33,10 @@ import {
   CreditsErrorCode,
   purchaseCredits,
 } from "@/lib/actions";
-import type { CreditTopUpPriceCatalog } from "@/lib/clients/stripe.client";
+import type {
+  CreditTopUpPriceCatalog,
+  Price,
+} from "@/lib/clients/stripe.client";
 import { fireGTMEvent } from "@/lib/gtm-events";
 import {
   BASE_CREDIT_TOPUP_LOOKUP_KEY,
@@ -41,9 +44,77 @@ import {
   getCreditTopUpLookupKeyByCredits,
   isPositiveIntegerCredits,
 } from "@/lib/stripe/credit-topup-pricing";
+import { cn } from "@/lib/utils";
 
 function hasValidCreditsInput(credits: number | null | undefined): boolean {
   return isPositiveIntegerCredits(credits ?? Number.NaN);
+}
+
+function getCreditTopUpTotalMinorUnits(
+  credits: number,
+  amountPerCredit: number,
+): number {
+  const totalMinorUnits = Math.ceil(credits * amountPerCredit);
+
+  if (!Number.isFinite(totalMinorUnits) || totalMinorUnits < 1) {
+    throw new Error("Computed credit top-up total is invalid");
+  }
+
+  return totalMinorUnits;
+}
+
+interface CreditPricingSummary {
+  baseTierTotalMinorUnits: number;
+  hasDiscountComparison: boolean;
+  price: Price;
+  savingsMinorUnits: number | null;
+  totalMinorUnits: number;
+}
+
+function getCreditPricingSummary(
+  credits: number,
+  priceCatalog: CreditTopUpPriceCatalog,
+  priceLookupKeyOverride?: CreditTopUpLookupKey,
+): CreditPricingSummary {
+  const selectedLookupKey = getCreditTopUpLookupKeyByCredits(
+    credits,
+    priceLookupKeyOverride,
+  );
+  const price = priceCatalog[selectedLookupKey];
+
+  if (!price) {
+    throw new Error(`Missing credit top-up price for ${selectedLookupKey}`);
+  }
+
+  const baseTierPrice = priceCatalog[BASE_CREDIT_TOPUP_LOOKUP_KEY];
+
+  if (!baseTierPrice) {
+    throw new Error(
+      `Missing credit top-up price for ${BASE_CREDIT_TOPUP_LOOKUP_KEY}`,
+    );
+  }
+
+  const totalMinorUnits = getCreditTopUpTotalMinorUnits(
+    credits,
+    price.amountPerCredit,
+  );
+  const baseTierTotalMinorUnits = getCreditTopUpTotalMinorUnits(
+    credits,
+    baseTierPrice.amountPerCredit,
+  );
+  const hasDiscountComparison =
+    baseTierPrice.currency === price.currency &&
+    baseTierTotalMinorUnits > totalMinorUnits;
+
+  return {
+    baseTierTotalMinorUnits,
+    hasDiscountComparison,
+    price,
+    savingsMinorUnits: hasDiscountComparison
+      ? baseTierTotalMinorUnits - totalMinorUnits
+      : null,
+    totalMinorUnits,
+  };
 }
 
 const creditsFormSchema = (t: IntlTranslation<"App.Credits">) =>
@@ -79,6 +150,7 @@ export default function CreditsForm({
   priceLookupKeyOverride,
   returnPath,
 }: CreditsFormProps) {
+  const quickAmounts = [5_000, 20_000, 50_000, 100_000];
   const t = useTranslations("App.Credits");
   const formatter = useFormatter();
   const router = useRouter();
@@ -171,17 +243,43 @@ export default function CreditsForm({
   const { isSubmitting } = form.formState;
   const hasValidCreditsValue =
     hasValidCreditsInput(credits) && isPurchaseEnabled;
-  const selectedLookupKey = isPositiveIntegerCredits(credits ?? Number.NaN)
-    ? getCreditTopUpLookupKeyByCredits(
-        credits as number,
-        priceLookupKeyOverride,
-      )
-    : (priceLookupKeyOverride ?? BASE_CREDIT_TOPUP_LOOKUP_KEY);
-  const selectedPrice = priceCatalog[selectedLookupKey];
-
-  if (!selectedPrice) {
-    throw new Error(`Missing credit top-up price for ${selectedLookupKey}`);
-  }
+  const selectedCredits = hasValidCreditsValue ? (credits as number) : null;
+  const selectedPricing =
+    selectedCredits === null
+      ? null
+      : getCreditPricingSummary(
+          selectedCredits,
+          priceCatalog,
+          priceLookupKeyOverride,
+        );
+  const selectedPrice = selectedPricing?.price ?? null;
+  const formattedSelectedTotal =
+    selectedPricing === null
+      ? null
+      : formatter.number(selectedPricing.totalMinorUnits / 100, {
+          style: "currency",
+          currency: selectedPricing.price.currency.toUpperCase(),
+          notation: "compact",
+        });
+  const formattedBaseTierTotal =
+    selectedPricing === null || !selectedPricing.hasDiscountComparison
+      ? null
+      : formatter.number(selectedPricing.baseTierTotalMinorUnits / 100, {
+          style: "currency",
+          currency: selectedPricing.price.currency.toUpperCase(),
+          notation: "compact",
+        });
+  const formattedSavings =
+    selectedPricing?.savingsMinorUnits === null ||
+    selectedPricing?.savingsMinorUnits === undefined
+      ? null
+      : formatter.number(selectedPricing.savingsMinorUnits / 100, {
+          style: "currency",
+          currency: selectedPricing.price.currency.toUpperCase(),
+          notation: "compact",
+        });
+  const isQuickAmountSelected =
+    selectedCredits !== null && quickAmounts.includes(selectedCredits);
 
   return (
     <Card>
@@ -207,18 +305,94 @@ export default function CreditsForm({
           <CardContent className="space-y-4">
             {isPurchaseEnabled ? (
               <>
-                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                  {[5_000, 20_000, 50_000, 100_000].map((amount) => (
-                    <Button
-                      key={amount}
-                      type="button"
-                      variant="outline"
-                      onClick={() => handleQuickAmount(amount)}
-                      disabled={isSubmitting}
-                    >
-                      {t("creditAmount", { count: amount })}
-                    </Button>
-                  ))}
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                  {quickAmounts.map((amount) => {
+                    const pricing = getCreditPricingSummary(
+                      amount,
+                      priceCatalog,
+                      priceLookupKeyOverride,
+                    );
+                    const formattedTotal = formatter.number(
+                      pricing.totalMinorUnits / 100,
+                      {
+                        style: "currency",
+                        currency: pricing.price.currency.toUpperCase(),
+                        notation: "compact",
+                      },
+                    );
+                    const formattedCompareAt = pricing.hasDiscountComparison
+                      ? formatter.number(
+                          pricing.baseTierTotalMinorUnits / 100,
+                          {
+                            style: "currency",
+                            currency: pricing.price.currency.toUpperCase(),
+                            notation: "compact",
+                          },
+                        )
+                      : null;
+                    const formattedPerCredit = formatter.number(
+                      pricing.price.amountPerCredit / 100,
+                      {
+                        style: "currency",
+                        currency: pricing.price.currency.toUpperCase(),
+                        maximumFractionDigits: 4,
+                      },
+                    );
+                    const formattedCardSavings =
+                      pricing.savingsMinorUnits === null
+                        ? null
+                        : formatter.number(pricing.savingsMinorUnits / 100, {
+                            style: "currency",
+                            currency: pricing.price.currency.toUpperCase(),
+                            notation: "compact",
+                          });
+                    const isSelected = selectedCredits === amount;
+
+                    return (
+                      <Button
+                        key={amount}
+                        type="button"
+                        variant="outline"
+                        aria-pressed={isSelected}
+                        onClick={() => handleQuickAmount(amount)}
+                        disabled={isSubmitting}
+                        className={cn(
+                          "h-auto min-h-36 w-full flex-col items-start justify-between gap-6 whitespace-normal rounded-xl px-4 py-4 text-left",
+                          isSelected
+                            ? "border-primary ring-primary bg-primary/5 border-1 shadow-sm ring-1 hover:bg-primary/5"
+                            : "hover:bg-accent/40",
+                        )}
+                      >
+                        <div className="space-y-2">
+                          <p className="text-sm font-medium">
+                            {t("creditAmount", { count: amount })}
+                          </p>
+                          <p className="text-2xl font-medium md:text-3xl">
+                            {formattedTotal}
+                          </p>
+                          {formattedCompareAt ? (
+                            <p className="text-muted-foreground text-xs line-through">
+                              {formattedCompareAt}
+                            </p>
+                          ) : null}
+                        </div>
+                        <div className="space-y-1">
+                          {formattedCardSavings ? (
+                            <p className="text-primary text-xl font-medium">
+                              {t("youSaveLabel", {
+                                amount: formattedCardSavings,
+                              })}
+                            </p>
+                          ) : null}
+                          <p className="text-muted-foreground text-xs">
+                            {t("costPerCredit", {
+                              cost: formattedPerCredit,
+                            })}
+                          </p>
+                        </div>
+                      </Button>
+                    );
+                  })}
                 </div>
                 <FormField
                   control={form.control}
@@ -260,7 +434,14 @@ export default function CreditsForm({
             )}
           </CardContent>
           {isPurchaseEnabled ? (
-            <CardFooter className="flex items-center justify-between pt-6">
+            <CardFooter
+              className={cn(
+                "gap-4 pt-6",
+                isQuickAmountSelected
+                  ? "justify-start"
+                  : "flex items-start justify-between",
+              )}
+            >
               <Button
                 type="submit"
                 disabled={isSubmitting || !hasValidCreditsValue}
@@ -270,20 +451,39 @@ export default function CreditsForm({
                 )}
                 {organization ? t("topUpButtonOrganization") : t("topUpButton")}
               </Button>
-              <div className="text-right">
-                <p className="text-muted-foreground text-sm">
-                  {t("costPerCredit", {
-                    cost: formatter.number(
-                      selectedPrice.amountPerCredit / 100,
-                      {
-                        style: "currency",
-                        currency: selectedPrice.currency,
-                        maximumFractionDigits: 4,
-                      },
-                    ),
-                  })}
-                </p>
-              </div>
+              {!isQuickAmountSelected &&
+              selectedCredits !== null &&
+              selectedPrice ? (
+                <div className="space-y-1 text-right">
+                  {formattedSelectedTotal ? (
+                    <p className="text-2xl font-medium md:text-3xl">
+                      {formattedSelectedTotal}
+                    </p>
+                  ) : null}
+                  {formattedBaseTierTotal ? (
+                    <p className="text-muted-foreground text-sm line-through">
+                      {formattedBaseTierTotal}
+                    </p>
+                  ) : null}
+                  {formattedSavings ? (
+                    <p className="text-primary text-sm font-medium">
+                      {t("youSaveLabel", { amount: formattedSavings })}
+                    </p>
+                  ) : null}
+                  <p className="text-muted-foreground text-sm">
+                    {t("costPerCredit", {
+                      cost: formatter.number(
+                        selectedPrice.amountPerCredit / 100,
+                        {
+                          style: "currency",
+                          currency: selectedPrice.currency.toUpperCase(),
+                          maximumFractionDigits: 4,
+                        },
+                      ),
+                    })}
+                  </p>
+                </div>
+              ) : null}
             </CardFooter>
           ) : null}
         </form>

--- a/apps/web/src/lib/clients/stripe.client.ts
+++ b/apps/web/src/lib/clients/stripe.client.ts
@@ -8,6 +8,7 @@ import {
   CREDIT_TOPUP_LOOKUP_KEYS,
   type CreditTopUpLookupKey,
   getCreditTopUpLookupKeyByCredits,
+  getCreditTopUpTotalMinorUnits,
   type StandardCreditTopUpLookupKey,
 } from "@/lib/stripe/credit-topup-pricing";
 import { getCreditsForCoupon } from "@/lib/utils/credits";
@@ -92,15 +93,6 @@ export const stripeClient = (() => {
       amountPerCredit,
       currency: price.currency,
     };
-  }
-
-  function getCheckoutUnitAmount(credits: number, price: Price): number {
-    const totalMinorUnits = Math.ceil(credits * price.amountPerCredit);
-    if (!Number.isFinite(totalMinorUnits) || totalMinorUnits < 1) {
-      throw new Error("Computed checkout amount is invalid");
-    }
-
-    return totalMinorUnits;
   }
 
   function normalizeCheckoutReturnPath(returnPath: string): string {
@@ -436,7 +428,10 @@ export const stripeClient = (() => {
         );
       }
       const env = getEnvSecrets();
-      const checkoutUnitAmount = getCheckoutUnitAmount(credits, price);
+      const checkoutUnitAmount = getCreditTopUpTotalMinorUnits(
+        credits,
+        price.amountPerCredit,
+      );
       const creditsLabel = credits.toLocaleString("en-US");
       const checkoutBaseUrl = (
         origin ??

--- a/apps/web/src/lib/stripe/__tests__/credit-topup-pricing.test.ts
+++ b/apps/web/src/lib/stripe/__tests__/credit-topup-pricing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   BASE_CREDIT_TOPUP_LOOKUP_KEY,
   getCreditTopUpLookupKeyByCredits,
+  getCreditTopUpTotalMinorUnits,
   isPositiveIntegerCredits,
   ZERO_MARGIN_CREDIT_TOPUP_LOOKUP_KEY,
 } from "../credit-topup-pricing";
@@ -35,6 +36,23 @@ describe("credit-topup-pricing", () => {
         ZERO_MARGIN_CREDIT_TOPUP_LOOKUP_KEY,
       ),
     ).toBe("credit_0_margin");
+  });
+
+  it("computes top-up total minor units with ceiling rounding", () => {
+    expect(getCreditTopUpTotalMinorUnits(100, 1.2)).toBe(120);
+    expect(getCreditTopUpTotalMinorUnits(1, 115)).toBe(115);
+  });
+
+  it("rejects invalid top-up totals", () => {
+    expect(() => getCreditTopUpTotalMinorUnits(Number.NaN, 100)).toThrow(
+      "Computed credit top-up total is invalid",
+    );
+    expect(() => getCreditTopUpTotalMinorUnits(100, Number.NaN)).toThrow(
+      "Computed credit top-up total is invalid",
+    );
+    expect(() => getCreditTopUpTotalMinorUnits(0, 100)).toThrow(
+      "Computed credit top-up total is invalid",
+    );
   });
 
   it("rejects invalid credit amounts", () => {

--- a/apps/web/src/lib/stripe/credit-topup-pricing.ts
+++ b/apps/web/src/lib/stripe/credit-topup-pricing.ts
@@ -23,6 +23,23 @@ export function isPositiveIntegerCredits(credits: number): boolean {
   return Number.isFinite(credits) && Number.isInteger(credits) && credits > 0;
 }
 
+/**
+ * Total charge for a credit top-up in the smallest currency unit (Stripe minor units).
+ * Must stay aligned with checkout line-item amount computation.
+ */
+export function getCreditTopUpTotalMinorUnits(
+  credits: number,
+  amountPerCredit: number,
+): number {
+  const totalMinorUnits = Math.ceil(credits * amountPerCredit);
+
+  if (!Number.isFinite(totalMinorUnits) || totalMinorUnits < 1) {
+    throw new Error("Computed credit top-up total is invalid");
+  }
+
+  return totalMinorUnits;
+}
+
 export function getCreditTopUpLookupKeyByCredits(
   credits: number,
   lookupKeyOverride?: CreditTopUpLookupKey,


### PR DESCRIPTION
## Summary

Improves the credit top-up experience by surfacing **total price**, **compare-at (base tier) pricing**, and **estimated savings** for preset quick-amount options, and by tightening how totals are derived for display and checkout alignment.

Closes DEV-913.

## Key changes

- **Preset amount cards**: Each quick amount (5k / 20k / 50k / 100k credits) now shows credit count, compact currency total, optional strikethrough base-tier total when the selected tier is cheaper than the base catalog price, per-credit cost, and a primary “Save {amount}” callout when savings apply.
- **Pricing logic**: Introduces `getCreditTopUpTotalMinorUnits` (ceiling of `credits × amountPerCredit` in minor units) and `getCreditPricingSummary` to compare the resolved tier price against the base tier **only when currencies match** and the base total is higher.
- **Footer layout**: When a quick amount is selected, the footer emphasizes the primary CTA; for custom amounts, the right-hand summary shows total, optional compare-at, savings, and per-credit cost (currency codes normalized to uppercase for `Intl` formatting).
- **i18n**: Adds `App.Credits.youSaveLabel` in all shipped locales (non-English catalogs currently mirror the English string so keys stay in sync; follow-up copy is welcome).

## Technical notes

- Quick-amount buttons use `aria-pressed` for the selected state and `cn()` for selection vs hover styles.
- `Price` type is imported from the Stripe client module alongside `CreditTopUpPriceCatalog`.

## Testing

- [ ] `pnpm --filter web check` (or `pnpm web:check`)
- [ ] Manual: Credits / top-up UI with org vs personal, preset vs custom credit entry, locales with different currency formatting
