### PR TITLE
feat(job-input): support input schema default values

### DIFF
--- a/apps/core/src/routes/v1/agents/[id]/input-schema/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/input-schema/get.ts
@@ -64,7 +64,60 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw unprocessableEntity(inputSchemaResult.error);
     }
 
-    const inputSchema = inputSchemaSchema.parse(inputSchemaResult.value);
+    const mockInputSchema = {
+      input_data: [
+        {
+          id: "info",
+          type: "none",
+          name: "Information",
+          data: {
+            description:
+              "# AI Campaign Generator with Auto-Extraction\n\n    Provide your website URL and basic campaign details.\n    We'll automatically extract your business information for your review.",
+          },
+          validations: null,
+        },
+        {
+          id: "website",
+          type: "text",
+          name: "Website URL",
+          data: { placeholder: "https://www.yourwebsite.com" },
+          validations: null,
+        },
+        {
+          id: "language",
+          type: "text",
+          name: "Campaign Language",
+          data: {
+            placeholder: "English, Spanish, French, etc.",
+            default: "English",
+          },
+          validations: null,
+        },
+        {
+          id: "goal",
+          type: "textarea",
+          name: "Primary Campaign Goal",
+          data: {
+            placeholder: "e.g., Brand awareness, lead generation, drive sales",
+            default: "Generate leads and increase brand awareness",
+          },
+          validations: null,
+        },
+        {
+          id: "logo",
+          type: "file",
+          name: "Logo URL (PNG, JPG)",
+          data: {
+            placeholder: "https://example.com/logo.png",
+            outputFormat: "url",
+            accept: "image/*",
+          },
+          validations: null,
+        },
+      ],
+    };
+
+    const inputSchema = mockInputSchema; //inputSchemaSchema.parse(mockInputSchema);
     return ok(c, inputSchema);
   });
 }

--- a/apps/core/src/routes/v1/agents/[id]/input-schema/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/input-schema/get.ts
@@ -64,60 +64,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       throw unprocessableEntity(inputSchemaResult.error);
     }
 
-    const mockInputSchema = {
-      input_data: [
-        {
-          id: "info",
-          type: "none",
-          name: "Information",
-          data: {
-            description:
-              "# AI Campaign Generator with Auto-Extraction\n\n    Provide your website URL and basic campaign details.\n    We'll automatically extract your business information for your review.",
-          },
-          validations: null,
-        },
-        {
-          id: "website",
-          type: "text",
-          name: "Website URL",
-          data: { placeholder: "https://www.yourwebsite.com" },
-          validations: null,
-        },
-        {
-          id: "language",
-          type: "text",
-          name: "Campaign Language",
-          data: {
-            placeholder: "English, Spanish, French, etc.",
-            default: "English",
-          },
-          validations: null,
-        },
-        {
-          id: "goal",
-          type: "textarea",
-          name: "Primary Campaign Goal",
-          data: {
-            placeholder: "e.g., Brand awareness, lead generation, drive sales",
-            default: "Generate leads and increase brand awareness",
-          },
-          validations: null,
-        },
-        {
-          id: "logo",
-          type: "file",
-          name: "Logo URL (PNG, JPG)",
-          data: {
-            placeholder: "https://example.com/logo.png",
-            outputFormat: "url",
-            accept: "image/*",
-          },
-          validations: null,
-        },
-      ],
-    };
-
-    const inputSchema = mockInputSchema; //inputSchemaSchema.parse(mockInputSchema);
+    const inputSchema = inputSchemaSchema.parse(inputSchemaResult.value);
     return ok(c, inputSchema);
   });
 }

--- a/apps/web/src/components/create-job-modal/job-input/inputs/text-input.tsx
+++ b/apps/web/src/components/create-job-modal/job-input/inputs/text-input.tsx
@@ -11,6 +11,7 @@ export function TextInput({
   jobInputSchema,
 }: JobInputComponentProps<InputType.TEXT, InputTextSchemaType>) {
   const { data } = jobInputSchema;
+  const defaultValue = data?.default ?? "";
 
   return (
     <Input
@@ -18,7 +19,7 @@ export function TextInput({
       placeholder={data?.placeholder ?? undefined}
       type="text"
       {...field}
-      value={typeof field.value === "string" ? field.value : ""}
+      value={typeof field.value === "string" ? field.value : defaultValue}
     />
   );
 }

--- a/apps/web/src/components/create-job-modal/job-input/inputs/textarea-input.tsx
+++ b/apps/web/src/components/create-job-modal/job-input/inputs/textarea-input.tsx
@@ -11,13 +11,14 @@ export function TextareaInput({
   jobInputSchema,
 }: JobInputComponentProps<InputType.TEXTAREA, InputTextareaSchemaType>) {
   const { data } = jobInputSchema;
+  const defaultValue = data?.default ?? "";
 
   return (
     <Textarea
       id={id}
       placeholder={data?.placeholder ?? undefined}
       {...field}
-      value={typeof field.value === "string" ? field.value : ""}
+      value={typeof field.value === "string" ? field.value : defaultValue}
     />
   );
 }

--- a/apps/web/src/components/jobs/job-details/__tests__/inputs.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/inputs.test.tsx
@@ -118,6 +118,44 @@ describe("JobDetailsInputs", () => {
     expect(markdownValues[2]).toHaveTextContent("Readonly with `inline code`");
   });
 
+  it("renders schema defaults for missing text and textarea values", () => {
+    const input = JSON.stringify({});
+
+    const inputSchema = JSON.stringify({
+      input_data: [
+        {
+          id: "language",
+          type: "text",
+          name: "Campaign Language",
+          data: {
+            default: "English",
+          },
+          validations: [],
+        },
+        {
+          id: "goal",
+          type: "textarea",
+          name: "Primary Campaign Goal",
+          data: {
+            default: "Generate leads and increase brand awareness",
+          },
+          validations: [],
+        },
+      ],
+    });
+
+    render(<JobDetailsInputs input={input} inputSchema={inputSchema} />);
+
+    expect(screen.getByText("Campaign Language")).toBeInTheDocument();
+    expect(screen.getByText("Primary Campaign Goal")).toBeInTheDocument();
+
+    const markdownValues = screen.getAllByTestId("markdown-mock");
+    expect(markdownValues[0]).toHaveTextContent("English");
+    expect(markdownValues[1]).toHaveTextContent(
+      "Generate leads and increase brand awareness",
+    );
+  });
+
   it("renders boolean values with humanized labels", () => {
     const input = JSON.stringify({
       acceptedTerms: true,

--- a/apps/web/src/components/jobs/job-details/__tests__/inputs.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/inputs.test.tsx
@@ -156,6 +156,52 @@ describe("JobDetailsInputs", () => {
     );
   });
 
+  it("does not reparse raw input on unrelated rerenders", () => {
+    const input = JSON.stringify({
+      title: "Persisted title",
+    });
+    const inputSchema = JSON.stringify({
+      input_data: [
+        {
+          id: "title",
+          type: "text",
+          name: "Title",
+          data: {},
+          validations: [],
+        },
+      ],
+    });
+    const originalParse = JSON.parse;
+    const parseSpy = vi
+      .spyOn(JSON, "parse")
+      .mockImplementation(((text, reviver) =>
+        originalParse(text, reviver)) as typeof JSON.parse);
+
+    try {
+      const { rerender } = render(
+        <JobDetailsInputs input={input} inputSchema={inputSchema} />,
+      );
+
+      expect(
+        parseSpy.mock.calls.filter(([value]) => value === input),
+      ).toHaveLength(1);
+
+      rerender(
+        <JobDetailsInputs
+          input={input}
+          inputSchema={inputSchema}
+          inputHash="updated-hash"
+        />,
+      );
+
+      expect(
+        parseSpy.mock.calls.filter(([value]) => value === input),
+      ).toHaveLength(1);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
   it("renders boolean values with humanized labels", () => {
     const input = JSON.stringify({
       acceptedTerms: true,

--- a/apps/web/src/components/jobs/job-details/inputs.tsx
+++ b/apps/web/src/components/jobs/job-details/inputs.tsx
@@ -73,6 +73,16 @@ function extractOptionValues(item: InputFieldSchemaType): string[] | undefined {
   return undefined;
 }
 
+function extractTextDefaultValue(
+  item: InputFieldSchemaType,
+): string | undefined {
+  if (item.type === InputType.TEXT || item.type === InputType.TEXTAREA) {
+    return item.data?.default ?? undefined;
+  }
+
+  return undefined;
+}
+
 function mapIndexToLabel(index: unknown, values: string[]): string {
   if (
     typeof index === "number" &&
@@ -182,7 +192,6 @@ function JobDetailsInputsInner({
   const inputContentRef = useRef<HTMLDivElement | null>(null);
 
   const input = rawInput ? JSON.parse(rawInput) : {};
-  const hasInputs = Object.keys(input).length > 0;
 
   const calculatedInputHash = useMemo(() => {
     if (!identifierFromPurchaser || !rawInput) return null;
@@ -191,7 +200,7 @@ function JobDetailsInputsInner({
 
   const inputsMap: Record<
     string,
-    { name: string; type: InputType; values?: string[] }
+    { name: string; type: InputType; values?: string[]; defaultValue?: string }
   > = useMemo(() => {
     if (!rawInputSchema) return {};
 
@@ -206,16 +215,23 @@ function JobDetailsInputsInner({
       return flatInputs.reduce(
         (acc, item) => {
           const values = extractOptionValues(item);
+          const defaultValue = extractTextDefaultValue(item);
           acc[item.id] = {
             name: item.name,
             type: item.type,
             ...(values && { values }),
+            ...(defaultValue !== undefined && { defaultValue }),
           };
           return acc;
         },
         {} as Record<
           string,
-          { name: string; type: InputType; values?: string[] }
+          {
+            name: string;
+            type: InputType;
+            values?: string[];
+            defaultValue?: string;
+          }
         >,
       );
     } catch (error) {
@@ -224,9 +240,32 @@ function JobDetailsInputsInner({
     }
   }, [rawInputSchema]);
 
+  const displayInputEntries = useMemo(() => {
+    const schemaKeys = new Set(Object.keys(inputsMap));
+    const schemaEntries = Object.entries(inputsMap).flatMap(
+      ([key, schemaEntry]) => {
+        const value = input[key];
+        if (value !== undefined) {
+          return [[key, value] as const];
+        }
+
+        if (schemaEntry.defaultValue !== undefined) {
+          return [[key, schemaEntry.defaultValue] as const];
+        }
+
+        return [];
+      },
+    );
+    const extraEntries = Object.entries(input).filter(
+      ([key]) => !schemaKeys.has(key),
+    );
+
+    return [...schemaEntries, ...extraEntries];
+  }, [input, inputsMap]);
+
   useEffect(() => {
     const element = inputContentRef.current;
-    if (!element || open || !hasInputs) {
+    if (!element || open || displayInputEntries.length === 0) {
       return;
     }
 
@@ -243,7 +282,9 @@ function JobDetailsInputsInner({
     return () => {
       observer.disconnect();
     };
-  }, [hasInputs, open, rawInput]);
+  }, [displayInputEntries.length, open, rawInput]);
+
+  const hasInputs = displayInputEntries.length > 0;
 
   const shouldFade = !open && isExpandable;
 
@@ -262,7 +303,7 @@ function JobDetailsInputsInner({
                     "mask-[linear-gradient(to_bottom,black_60%,transparent_100%)] [-webkit-mask-image:linear-gradient(to_bottom,black_60%,transparent_100%)]",
                 )}
               >
-                {Object.entries(input).map(([key, value]) => {
+                {displayInputEntries.map(([key, value]) => {
                   const schemaEntry = inputsMap[key];
                   const label = schemaEntry?.name ?? key;
                   const type = schemaEntry?.type ?? InputType.NONE;

--- a/apps/web/src/components/jobs/job-details/inputs.tsx
+++ b/apps/web/src/components/jobs/job-details/inputs.tsx
@@ -191,7 +191,13 @@ function JobDetailsInputsInner({
   const [isExpandable, setIsExpandable] = useState(false);
   const inputContentRef = useRef<HTMLDivElement | null>(null);
 
-  const input = rawInput ? JSON.parse(rawInput) : {};
+  const input = useMemo<Record<string, unknown>>(() => {
+    if (!rawInput) {
+      return {};
+    }
+
+    return JSON.parse(rawInput) as Record<string, unknown>;
+  }, [rawInput]);
 
   const calculatedInputHash = useMemo(() => {
     if (!identifierFromPurchaser || !rawInput) return null;

--- a/apps/web/src/lib/job-input/__tests__/form.test.ts
+++ b/apps/web/src/lib/job-input/__tests__/form.test.ts
@@ -1,5 +1,11 @@
+import { InputType } from "@sokosumi/masumi/types";
 import { describe, expect, it } from "vitest";
-import { JobInputsFormSchemaType, prepareInputValues } from "@/lib/job-input";
+
+import {
+  defaultValues,
+  JobInputsFormSchemaType,
+  prepareInputValues,
+} from "@/lib/job-input";
 
 describe("prepareInputValues", () => {
   it("keeps date and datetime-local strings and removes null/undefined entries", () => {
@@ -18,6 +24,108 @@ describe("prepareInputValues", () => {
       startAt: "2026-02-01T10:00",
       dateRange: ["2026-01-19", "2026-02-01"],
       count: 2,
+    });
+  });
+});
+
+describe("defaultValues", () => {
+  it("seeds text and textarea defaults from the input schema", () => {
+    const result = defaultValues([
+      {
+        id: "language",
+        type: InputType.TEXT,
+        name: "Campaign Language",
+        data: {
+          default: "English",
+        },
+        validations: null,
+      },
+      {
+        id: "goal",
+        type: InputType.TEXTAREA,
+        name: "Primary Campaign Goal",
+        data: {
+          default: "Generate leads and increase brand awareness",
+        },
+        validations: null,
+      },
+    ]);
+
+    expect(result).toEqual({
+      language: "English",
+      goal: "Generate leads and increase brand awareness",
+    });
+  });
+
+  it("seeds spec-supported defaults for scalar inputs and radio groups", () => {
+    const inputSchemas = [
+      {
+        id: "count",
+        type: InputType.NUMBER,
+        name: "Count",
+        data: {
+          default: 3,
+        },
+        validations: null,
+      },
+      {
+        id: "acceptedTerms",
+        type: InputType.BOOLEAN,
+        name: "Accepted Terms",
+        data: {
+          default: true,
+        },
+        validations: null,
+      },
+      {
+        id: "contactEmail",
+        type: InputType.EMAIL,
+        name: "Contact Email",
+        data: {
+          default: "hello@example.com",
+        },
+        validations: null,
+      },
+      {
+        id: "startDate",
+        type: InputType.DATE,
+        name: "Start Date",
+        data: {
+          default: "2026-01-19",
+        },
+        validations: null,
+      },
+      {
+        id: "paymentMethod",
+        type: InputType.RADIO_GROUP,
+        name: "Payment Method",
+        data: {
+          values: ["Credit Card", "PayPal", "Bank Transfer"],
+          default: "PayPal",
+        },
+        validations: null,
+      },
+      {
+        id: "invalidRadioDefault",
+        type: InputType.RADIO_GROUP,
+        name: "Invalid Radio Default",
+        data: {
+          values: ["One", "Two"],
+          default: "Three",
+        },
+        validations: null,
+      },
+    ] as unknown as Parameters<typeof defaultValues>[0];
+
+    const result = defaultValues(inputSchemas);
+
+    expect(result).toEqual({
+      count: 3,
+      acceptedTerms: true,
+      contactEmail: "hello@example.com",
+      startDate: "2026-01-19",
+      paymentMethod: [1],
+      invalidRadioDefault: null,
     });
   });
 });

--- a/apps/web/src/lib/job-input/form.ts
+++ b/apps/web/src/lib/job-input/form.ts
@@ -1,9 +1,5 @@
 import type {
-  InputCheckboxSchemaType,
-  InputColorSchemaType,
   InputFieldSchemaType,
-  InputHiddenSchemaType,
-  InputRangeSchemaType,
   InputSchemaType,
 } from "@sokosumi/masumi/schemas";
 import { InputType } from "@sokosumi/masumi/types";
@@ -148,35 +144,73 @@ export function isInputSchemaValue(
  */
 type DefaultValueExtractor = (schema: InputFieldSchemaType) => unknown | null;
 
+function getSchemaDefaultValue(schema: InputFieldSchemaType): unknown {
+  if (
+    !schema.data ||
+    typeof schema.data !== "object" ||
+    !("default" in schema.data)
+  ) {
+    return undefined;
+  }
+
+  return schema.data.default;
+}
+
 /**
  * Extract default value for boolean types (BOOLEAN, CHECKBOX)
  */
 const getBooleanDefault: DefaultValueExtractor = (schema) => {
-  if (schema.type === InputType.CHECKBOX) {
-    return (schema as InputCheckboxSchemaType).data?.default ?? false;
-  }
-  return false;
+  const defaultValue = getSchemaDefaultValue(schema);
+  return typeof defaultValue === "boolean" ? defaultValue : false;
 };
 
 /**
  * Extract default value for color type
  */
 const getColorDefault: DefaultValueExtractor = (schema) => {
-  return (schema as InputColorSchemaType).data?.default ?? "#000000";
+  const defaultValue = getSchemaDefaultValue(schema);
+  return typeof defaultValue === "string" ? defaultValue : "#000000";
 };
 
 /**
- * Extract default value for range type
+ * Extract default value for numeric types
  */
-const getRangeDefault: DefaultValueExtractor = (schema) => {
-  return (schema as InputRangeSchemaType).data?.default ?? null;
+const getNumericDefault: DefaultValueExtractor = (schema) => {
+  const defaultValue = getSchemaDefaultValue(schema);
+  return typeof defaultValue === "number" ? defaultValue : null;
 };
 
 /**
  * Extract default value for hidden type
  */
 const getHiddenDefault: DefaultValueExtractor = (schema) => {
-  return (schema as InputHiddenSchemaType).data?.value ?? "";
+  return schema.type === InputType.HIDDEN ? (schema.data?.value ?? "") : "";
+};
+
+/**
+ * Extract default value for string-based inputs
+ */
+const getStringDefault: DefaultValueExtractor = (schema) => {
+  const defaultValue = getSchemaDefaultValue(schema);
+  return typeof defaultValue === "string" ? defaultValue : null;
+};
+
+/**
+ * Extract default value for radio group inputs.
+ * The form stores the selected option as an array containing the option index.
+ */
+const getRadioGroupDefault: DefaultValueExtractor = (schema) => {
+  if (schema.type !== InputType.RADIO_GROUP) {
+    return null;
+  }
+
+  const defaultValue = getSchemaDefaultValue(schema);
+  if (typeof defaultValue !== "string") {
+    return null;
+  }
+
+  const selectedIndex = schema.data.values.indexOf(defaultValue);
+  return selectedIndex >= 0 ? [selectedIndex] : null;
 };
 
 /**
@@ -191,8 +225,21 @@ const DEFAULT_VALUE_EXTRACTORS: Partial<
   [InputType.CHECKBOX]: getBooleanDefault,
   // Special types with data defaults
   [InputType.COLOR]: getColorDefault,
-  [InputType.RANGE]: getRangeDefault,
+  [InputType.NUMBER]: getNumericDefault,
+  [InputType.RANGE]: getNumericDefault,
   [InputType.HIDDEN]: getHiddenDefault,
+  [InputType.TEXT]: getStringDefault,
+  [InputType.TEXTAREA]: getStringDefault,
+  [InputType.EMAIL]: getStringDefault,
+  [InputType.TEL]: getStringDefault,
+  [InputType.URL]: getStringDefault,
+  [InputType.DATE]: getStringDefault,
+  [InputType.DATETIME]: getStringDefault,
+  [InputType.TIME]: getStringDefault,
+  [InputType.MONTH]: getStringDefault,
+  [InputType.WEEK]: getStringDefault,
+  [InputType.SEARCH]: getStringDefault,
+  [InputType.RADIO_GROUP]: getRadioGroupDefault,
 };
 
 /**

--- a/apps/web/src/queries/__tests__/agents.test.ts
+++ b/apps/web/src/queries/__tests__/agents.test.ts
@@ -65,6 +65,65 @@ describe("getAgentInputSchemaQueryOptions", () => {
     expect(getAgentInputSchemaMock).toHaveBeenCalledWith("agent-1");
   });
 
+  it("preserves text and textarea defaults from the raw schema response", async () => {
+    getAgentInputSchemaMock.mockResolvedValue({
+      data: {
+        input_data: [
+          {
+            id: "language",
+            name: "Campaign Language",
+            type: "text",
+            data: {
+              default: "English",
+            },
+          },
+          {
+            id: "goal",
+            name: "Primary Campaign Goal",
+            type: "textarea",
+            data: {
+              default: "Generate leads and increase brand awareness",
+            },
+          },
+        ],
+      },
+    });
+
+    const options = getAgentInputSchemaQueryOptions("agent-1");
+    const queryFn = options.queryFn;
+
+    if (!queryFn) {
+      throw new Error("queryFn is required");
+    }
+
+    await expect(queryFn({} as never)).resolves.toEqual({
+      input_data: [
+        {
+          id: "language",
+          name: "Campaign Language",
+          type: "text",
+          data: {
+            default: "English",
+            description: undefined,
+            placeholder: undefined,
+          },
+          validations: undefined,
+        },
+        {
+          id: "goal",
+          name: "Primary Campaign Goal",
+          type: "textarea",
+          data: {
+            default: "Generate leads and increase brand awareness",
+            description: undefined,
+            placeholder: undefined,
+          },
+          validations: undefined,
+        },
+      ],
+    });
+  });
+
   it("maps 401 responses to UnAuthenticatedError", async () => {
     getAgentInputSchemaMock.mockRejectedValue(
       new MockCoreApiRequestError("Please sign in", { status: 401 }),

--- a/packages/masumi/src/schemas/input/__tests__/input.test.ts
+++ b/packages/masumi/src/schemas/input/__tests__/input.test.ts
@@ -133,12 +133,71 @@ describe("inputDataSchema", () => {
     });
   });
 
+  describe("Text input type", () => {
+    const validTextInput = {
+      id: "text-id",
+      type: InputType.TEXT,
+      name: "Test Text Input",
+      data: {
+        placeholder: "Enter text",
+        description: "Test text description",
+        default: "Default text",
+      },
+    };
+
+    it("should validate a text input with a default value", () => {
+      const result = inputDataSchema.safeParse({
+        input_data: [validTextInput],
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        input_data: [
+          {
+            data: {
+              default: "Default text",
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe("Textarea input type", () => {
+    const validTextareaInput = {
+      id: "textarea-id",
+      type: InputType.TEXTAREA,
+      name: "Test Textarea Input",
+      data: {
+        placeholder: "Enter a longer description",
+        description: "Test textarea description",
+        default: "Default textarea content",
+      },
+    };
+
+    it("should validate a textarea input with a default value", () => {
+      const result = inputDataSchema.safeParse({
+        input_data: [validTextareaInput],
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        input_data: [
+          {
+            data: {
+              default: "Default textarea content",
+            },
+          },
+        ],
+      });
+    });
+  });
+
   describe("Number input type", () => {
     const validNumberInput = {
       id: "number-id",
       type: InputType.NUMBER,
       name: "Test Number Input",
       data: {
+        default: 42,
         placeholder: "Enter number",
         description: "Test number description",
       },
@@ -149,6 +208,15 @@ describe("inputDataSchema", () => {
         input_data: [validNumberInput],
       });
       expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        input_data: [
+          {
+            data: {
+              default: 42,
+            },
+          },
+        ],
+      });
     });
 
     it("should not fail with undefined data", () => {
@@ -203,6 +271,7 @@ describe("inputDataSchema", () => {
       type: InputType.BOOLEAN,
       name: "Test Boolean Input",
       data: {
+        default: true,
         description: "Test boolean description",
       },
     };
@@ -212,6 +281,15 @@ describe("inputDataSchema", () => {
         input_data: [validBooleanInput],
       });
       expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        input_data: [
+          {
+            data: {
+              default: true,
+            },
+          },
+        ],
+      });
     });
 
     it("should not fail with undefined data", () => {
@@ -535,12 +613,21 @@ describe("inputDataSchema", () => {
       id: "rg-id",
       type: InputType.RADIO_GROUP,
       name: "RG",
-      data: { values: ["a", "b"] },
+      data: { values: ["a", "b"], default: "b" },
     };
 
     it("should validate radio group schema", () => {
       const result = inputDataSchema.safeParse({ input_data: [rg] });
       expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        input_data: [
+          {
+            data: {
+              default: "b",
+            },
+          },
+        ],
+      });
     });
 
     it("should allow empty value in values array", () => {

--- a/packages/masumi/src/schemas/input/input.schema.ts
+++ b/packages/masumi/src/schemas/input/input.schema.ts
@@ -56,6 +56,7 @@ export const inputTextSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -80,6 +81,7 @@ export const inputTextareaSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -102,6 +104,7 @@ export const inputNumberSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.coerce.number().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -124,6 +127,7 @@ export const inputBooleanSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.boolean().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -139,6 +143,7 @@ export const inputEmailSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -184,6 +189,7 @@ export const inputTelSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -206,6 +212,7 @@ export const inputUrlSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -229,6 +236,7 @@ export const inputDateSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -248,6 +256,7 @@ export const inputDatetimeSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -267,6 +276,7 @@ export const inputTimeSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -286,6 +296,7 @@ export const inputMonthSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -305,6 +316,7 @@ export const inputWeekSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -394,6 +406,7 @@ export const inputSearchSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
+      default: z.string().nullish(),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -429,6 +442,7 @@ export const inputRadioGroupSchema = z.object({
   type: z.enum([InputType.RADIO_GROUP]),
   name: z.string().min(1),
   data: z.object({
+    default: z.string().nullish(),
     values: z
       .array(z.string())
       .min(1)


### PR DESCRIPTION
## Summary

This change lets agent input schemas declare optional `default` values for supported field types, and uses those defaults when building the create-job form and when rendering stored job inputs in job details.

**Linear:** DEV-917

## Scope

Changes are limited to **`@sokosumi/masumi`** (Zod input schemas and tests) and **`apps/web`** (form defaults, text/textarea controlled values, job details display, query normalization tests). The Core API agent input-schema route is unchanged: it still fetches the agent schema and validates with `inputSchemaSchema.parse` as on `main`.

## Key changes

- **`@sokosumi/masumi`**: Optional `data.default` on relevant input types (text-like fields, number with coercion, boolean, radio group); tests extended in `packages/masumi/src/schemas/input/__tests__/input.test.ts`.
- **Web – job form** (`apps/web/src/lib/job-input/form.ts`): `defaultValues()` reads schema defaults for additional scalar types and maps radio group string defaults to the internal index-array shape; `text-input` / `textarea-input` use the schema default when the field value is not yet a string.
- **Web – job details** (`apps/web/src/components/jobs/job-details/inputs.tsx`): When submitted JSON omits a key but the schema defines a default for **text** or **textarea**, the UI shows that default; expand/collapse logic uses displayed entries instead of only raw input keys.
- **Queries**: `getAgentInputSchemaQueryOptions` test asserts text/textarea defaults survive normalization.

## Technical notes

- Radio group defaults are validated against `data.values`; invalid defaults resolve to `null` in form seeding (see `form.test.ts`).
- Job details applies schema defaults for **text** and **textarea** only when the submitted value is missing, matching the DEV-917 use case.

## Testing

- `pnpm masumi:test`
- `pnpm --filter web test apps/web/src/lib/job-input/__tests__/form.test.ts apps/web/src/components/jobs/job-details/__tests__/inputs.test.tsx apps/web/src/queries/__tests__/agents.test.ts`

(Or `pnpm web:test` for the full web suite.)
