### PR TITLE
fix(masumi): treat blank numeric strings as unset before coercion

### DIFF
--- a/apps/web/src/lib/job-input/__tests__/form-schema.test.ts
+++ b/apps/web/src/lib/job-input/__tests__/form-schema.test.ts
@@ -1,8 +1,10 @@
 import {
   InputDateSchemaType,
   InputDatetimeSchemaType,
+  InputNumberSchemaType,
   InputOptionSchemaType,
   InputRadioGroupSchemaType,
+  InputRangeSchemaType,
 } from "@sokosumi/masumi/schemas";
 import { InputType, InputValidation } from "@sokosumi/masumi/types";
 import { describe, expect, it } from "vitest";
@@ -280,6 +282,64 @@ describe("jobInputsFormSchema date and datetime-local validation", () => {
 
       expect(schema.safeParse({ requiredOption: [] }).success).toBe(false);
       expect(schema.safeParse({ requiredOption: [0] }).success).toBe(true);
+    });
+  });
+
+  describe("NUMBER and RANGE", () => {
+    it("treats empty string as unset for optional number fields", () => {
+      const numberField: InputNumberSchemaType = {
+        id: "count",
+        type: InputType.NUMBER,
+        name: "Count",
+        validations: [{ validation: InputValidation.OPTIONAL, value: "true" }],
+      };
+      const schema = jobInputsFormSchema([numberField]);
+      const result = schema.safeParse({ count: "" });
+      expect(result.success).toBe(true);
+      expect(result.data?.count).toBeUndefined();
+    });
+
+    it("rejects empty string for required number fields", () => {
+      const numberField: InputNumberSchemaType = {
+        id: "count",
+        type: InputType.NUMBER,
+        name: "Count",
+      };
+      const schema = jobInputsFormSchema([numberField]);
+      expect(schema.safeParse({ count: "" }).success).toBe(false);
+    });
+
+    it("treats empty string as unset for optional range fields", () => {
+      const rangeField: InputRangeSchemaType = {
+        id: "volume",
+        type: InputType.RANGE,
+        name: "Volume",
+        data: { step: 1 },
+        validations: [
+          { validation: InputValidation.MIN, value: "0" },
+          { validation: InputValidation.MAX, value: "10" },
+          { validation: InputValidation.OPTIONAL, value: "true" },
+        ],
+      };
+      const schema = jobInputsFormSchema([rangeField]);
+      const result = schema.safeParse({ volume: "" });
+      expect(result.success).toBe(true);
+      expect(result.data?.volume).toBeUndefined();
+    });
+
+    it("rejects empty string for required range fields", () => {
+      const rangeField: InputRangeSchemaType = {
+        id: "volume",
+        type: InputType.RANGE,
+        name: "Volume",
+        data: { step: 1 },
+        validations: [
+          { validation: InputValidation.MIN, value: "0" },
+          { validation: InputValidation.MAX, value: "10" },
+        ],
+      };
+      const schema = jobInputsFormSchema([rangeField]);
+      expect(schema.safeParse({ volume: "" }).success).toBe(false);
     });
   });
 

--- a/apps/web/src/lib/job-input/form-schema-helpers.ts
+++ b/apps/web/src/lib/job-input/form-schema-helpers.ts
@@ -1,3 +1,4 @@
+import { preprocessBlankNumericInput } from "@sokosumi/masumi/schemas";
 import {
   InputFormat,
   InputType,
@@ -224,7 +225,9 @@ export function applyNumericValidations(
     }
   }
 
-  return parsed.canBeOptional ? result.nullish() : result;
+  const inner: z.ZodTypeAny = parsed.canBeOptional ? result.nullish() : result;
+
+  return z.preprocess(preprocessBlankNumericInput, inner);
 }
 
 function applyDateRangeRefinements(
@@ -748,5 +751,9 @@ export function applyRangeValidations(
     );
   }
 
-  return parsed.canBeOptional ? finalSchema.nullish() : finalSchema;
+  const inner: z.ZodTypeAny = parsed.canBeOptional
+    ? finalSchema.nullish()
+    : finalSchema;
+
+  return z.preprocess(preprocessBlankNumericInput, inner);
 }

--- a/packages/masumi/src/schemas/index.ts
+++ b/packages/masumi/src/schemas/index.ts
@@ -6,5 +6,6 @@ export * from "./agent/start_job.schema.js";
 export * from "./agent/status.schema.js";
 
 // Input schemas
+export * from "./input/blank-numeric-input.js";
 export * from "./input/input.schema.js";
 export * from "./input/validation.schema.js";

--- a/packages/masumi/src/schemas/input/__tests__/input.test.ts
+++ b/packages/masumi/src/schemas/input/__tests__/input.test.ts
@@ -250,6 +250,39 @@ describe("inputDataSchema", () => {
       expect(result.success).toBe(true);
     });
 
+    it("should treat blank string default as unset, not zero", () => {
+      const result = inputDataSchema.safeParse({
+        input_data: [
+          {
+            ...validNumberInput,
+            data: {
+              ...validNumberInput.data,
+              default: "",
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      const field = result.data?.input_data[0];
+      expect(field?.data?.default).toBeUndefined();
+    });
+
+    it("should treat whitespace-only default as unset", () => {
+      const result = inputDataSchema.safeParse({
+        input_data: [
+          {
+            ...validNumberInput,
+            data: {
+              ...validNumberInput.data,
+              default: "   ",
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.input_data[0]?.data?.default).toBeUndefined();
+    });
+
     it("should fail with invalid validations", () => {
       const result = inputDataSchema.safeParse({
         input_data: [
@@ -560,6 +593,25 @@ describe("inputDataSchema", () => {
         input_data: [validRange],
       });
       expect(result.success).toBe(true);
+    });
+
+    it("should treat blank string range default and step as unset", () => {
+      const result = inputDataSchema.safeParse({
+        input_data: [
+          {
+            ...validRange,
+            data: {
+              ...validRange.data,
+              default: "",
+              step: "",
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      const field = result.data?.input_data[0];
+      expect(field?.data?.default).toBeUndefined();
+      expect(field?.data?.step).toBeUndefined();
     });
   });
 

--- a/packages/masumi/src/schemas/input/__tests__/input.test.ts
+++ b/packages/masumi/src/schemas/input/__tests__/input.test.ts
@@ -16,6 +16,7 @@ import {
   type InputHiddenSchemaType,
   type InputMonthSchemaType,
   type InputMultiselectSchemaType,
+  type InputNumberSchemaType,
   type InputPasswordSchemaType,
   type InputRadioGroupSchemaType,
   type InputRangeSchemaType,
@@ -263,8 +264,8 @@ describe("inputDataSchema", () => {
         ],
       });
       expect(result.success).toBe(true);
-      const field = result.data?.input_data[0];
-      expect(field?.data?.default).toBeUndefined();
+      const field = result.data!.input_data[0] as InputNumberSchemaType;
+      expect(field.data?.default).toBeUndefined();
     });
 
     it("should treat whitespace-only default as unset", () => {
@@ -280,7 +281,9 @@ describe("inputDataSchema", () => {
         ],
       });
       expect(result.success).toBe(true);
-      expect(result.data?.input_data[0]?.data?.default).toBeUndefined();
+      const fieldWhitespace = result.data!
+        .input_data[0] as InputNumberSchemaType;
+      expect(fieldWhitespace.data?.default).toBeUndefined();
     });
 
     it("should fail with invalid validations", () => {
@@ -609,9 +612,9 @@ describe("inputDataSchema", () => {
         ],
       });
       expect(result.success).toBe(true);
-      const field = result.data?.input_data[0];
-      expect(field?.data?.default).toBeUndefined();
-      expect(field?.data?.step).toBeUndefined();
+      const field = result.data!.input_data[0] as InputRangeSchemaType;
+      expect(field.data?.default).toBeUndefined();
+      expect(field.data?.step).toBeUndefined();
     });
   });
 

--- a/packages/masumi/src/schemas/input/blank-numeric-input.ts
+++ b/packages/masumi/src/schemas/input/blank-numeric-input.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalizes blank string numeric payloads so `z.coerce.number()` does not
+ * treat `""` (or whitespace-only strings) as `0`.
+ */
+export function preprocessBlankNumericInput(value: unknown): unknown {
+  if (typeof value === "string" && value.trim() === "") {
+    return undefined;
+  }
+  return value;
+}

--- a/packages/masumi/src/schemas/input/input.schema.ts
+++ b/packages/masumi/src/schemas/input/input.schema.ts
@@ -1,6 +1,7 @@
 import * as z from "zod";
 
 import { InputType, OutputFormat } from "../../types/input-types.js";
+import { preprocessBlankNumericInput } from "./blank-numeric-input.js";
 import {
   acceptValidationSchema,
   formatEmailValidationSchema,
@@ -104,7 +105,10 @@ export const inputNumberSchema = z.object({
   name: z.string().min(1),
   data: z
     .object({
-      default: z.coerce.number().nullish(),
+      default: z.preprocess(
+        preprocessBlankNumericInput,
+        z.coerce.number().nullish(),
+      ),
       placeholder: z.string().nullish(),
       description: z.string().nullish(),
     })
@@ -352,8 +356,14 @@ export const inputRangeSchema = z.object({
   data: z
     .object({
       description: z.string().nullish(),
-      step: z.coerce.number().min(0).nullish(),
-      default: z.coerce.number().nullish(),
+      step: z.preprocess(
+        preprocessBlankNumericInput,
+        z.coerce.number().min(0).nullish(),
+      ),
+      default: z.preprocess(
+        preprocessBlankNumericInput,
+        z.coerce.number().nullish(),
+      ),
     })
     .nullish(),
   validations: z


### PR DESCRIPTION
## Summary

Fixes incorrect handling of empty and whitespace-only strings for numeric job inputs. Previously, `z.coerce.number()` could treat `""` as `0`; optional number and range fields now normalize blank strings to unset values consistently in Masumi schemas and the web job form layer.

**Linear:** DEV-918

## Key changes

- Add `preprocessBlankNumericInput` in `@sokosumi/masumi/schemas` to map blank strings to `undefined` before coercion.
- Apply preprocessing to NUMBER and RANGE `default` / RANGE `step` in `input.schema.ts`, and wrap web `applyNumericValidations` / `applyRangeValidations` schemas with the same preprocessor.
- Extend Vitest coverage for agent input data parsing and web `jobInputsFormSchema` (optional vs required empty string).

## Technical notes

- Shared preprocessor is exported from `packages/masumi/src/schemas/index.ts` for reuse by the web app.
- Optional fields: `""` parses as success with `undefined`; required fields still fail validation on empty string.

## Testing

- `pnpm --filter @sokosumi/masumi test src/schemas/input/__tests__/input.test.ts`
- `pnpm --filter web test src/lib/job-input/__tests__/form-schema.test.ts`

## Risk

Low: behavior change is limited to blank-string normalization; valid numeric strings and existing coercion paths are unchanged.
