### PR TITLE
feat(auth): create workspaces via workspaceRepository in web and core

### DIFF
--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -20,6 +20,7 @@ const {
   renderMagicLinkEmailMock,
   sentryCaptureExceptionMock,
   stripeCreateUserCustomerMock,
+  workspaceCreateMock,
 } = vi.hoisted(() => ({
   adminPluginMock: vi.fn(),
   apiKeyPluginMock: vi.fn(),
@@ -40,6 +41,7 @@ const {
   renderMagicLinkEmailMock: vi.fn(),
   sentryCaptureExceptionMock: vi.fn(),
   stripeCreateUserCustomerMock: vi.fn(),
+  workspaceCreateMock: vi.fn(),
 }));
 
 function getDefaultEnv() {
@@ -87,6 +89,12 @@ vi.mock("@better-auth/i18n", () => ({
 
 vi.mock("@sentry/node", () => ({
   captureException: (...args: unknown[]) => sentryCaptureExceptionMock(...args),
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  workspaceRepository: {
+    createWorkspace: (...args: unknown[]) => workspaceCreateMock(...args),
+  },
 }));
 
 vi.mock("@/clients/postmark.client", () => ({
@@ -146,6 +154,7 @@ describe("core auth config", () => {
     });
     sentryCaptureExceptionMock.mockReset();
     stripeCreateUserCustomerMock.mockResolvedValue({ id: "cus_123" });
+    workspaceCreateMock.mockResolvedValue({ id: "workspace_123" });
     betterAuthMock.mockReturnValue({ api: {}, handler: vi.fn() });
     getBetterAuthProductionUrlMock.mockReturnValue("https://example.com/auth");
   });
@@ -461,14 +470,16 @@ describe("core auth config", () => {
         email: " magic@example.com ",
         id: "user_123",
         name: "magic",
-        workspace: {
-          create: {},
-        },
       },
     });
 
     await config.databaseHooks.user.create.after(normalizedCreate.data);
 
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: null,
+      tx: { __prisma: true },
+      userId: "user_123",
+    });
     expect(stripeCreateUserCustomerMock).toHaveBeenCalledWith({
       email: " magic@example.com ",
       name: "magic",
@@ -514,9 +525,6 @@ describe("core auth config", () => {
         email: "@example.com",
         id: "user_123",
         name: "@example.com",
-        workspace: {
-          create: {},
-        },
       },
     });
   });
@@ -548,6 +556,11 @@ describe("core auth config", () => {
       name: "Andreas",
     });
 
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: null,
+      tx: { __prisma: true },
+      userId: "user_123",
+    });
     expect(stripeCreateUserCustomerMock).toHaveBeenCalledWith({
       email: "andreas@example.com",
       name: "Andreas",
@@ -587,6 +600,11 @@ describe("core auth config", () => {
     });
     await Promise.resolve();
 
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: null,
+      tx: { __prisma: true },
+      userId: "user_123",
+    });
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(expect.any(Error), {
       extra: {

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -199,6 +199,18 @@ export const auth = betterAuth({
           });
         },
       },
+      schema: {
+        organization: {
+          additionalFields: {
+            stripeCustomerId: {
+              type: "string",
+              required: false,
+              defaultValue: null,
+              input: false,
+            },
+          },
+        },
+      },
     }),
     oauthProvider({
       loginPage: `${webAppBaseUrl}/signin`,

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { i18n } from "@better-auth/i18n";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { prismaAdapter } from "@better-auth/prisma-adapter";
 import * as Sentry from "@sentry/node";
+import { workspaceRepository } from "@sokosumi/database/repositories";
 import { renderMagicLinkEmail } from "@sokosumi/email";
 import { authTranslations } from "@sokosumi/masumi/auth";
 import {
@@ -18,7 +19,6 @@ import {
   openAPI,
   organization,
 } from "better-auth/plugins";
-
 import { postmarkClient } from "@/clients/postmark.client";
 import { stripeClient } from "@/clients/stripe.client";
 import { getBetterAuthProductionUrl } from "@/config/better-auth-production-url";
@@ -72,13 +72,11 @@ export const auth = betterAuth({
             data: {
               ...user,
               name: getStoredUserName(user.name, user.email),
-              workspace: {
-                create: {},
-              },
             },
           };
         },
         after: async (user, _ctx) => {
+          await workspaceRepository.createWorkspace(user.id, null, prisma);
           stripeClient
             .createUserCustomer({
               email: user.email,
@@ -189,15 +187,12 @@ export const auth = betterAuth({
     jwt({ disableSettingJwtHeader: true }),
     organization({
       organizationHooks: {
-        beforeCreateOrganization: async ({ organization }) => {
-          return {
-            data: {
-              ...organization,
-              workspace: {
-                create: {},
-              },
-            },
-          };
+        afterCreateOrganization: async ({ organization }) => {
+          await workspaceRepository.createWorkspace(
+            null,
+            organization.id,
+            prisma,
+          );
         },
       },
       schema: {

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -76,7 +76,11 @@ export const auth = betterAuth({
           };
         },
         after: async (user, _ctx) => {
-          await workspaceRepository.createWorkspace(user.id, null, prisma);
+          await workspaceRepository.createWorkspace({
+            userId: user.id,
+            organizationId: null,
+            tx: prisma,
+          });
           stripeClient
             .createUserCustomer({
               email: user.email,
@@ -188,23 +192,11 @@ export const auth = betterAuth({
     organization({
       organizationHooks: {
         afterCreateOrganization: async ({ organization }) => {
-          await workspaceRepository.createWorkspace(
-            null,
-            organization.id,
-            prisma,
-          );
-        },
-      },
-      schema: {
-        organization: {
-          additionalFields: {
-            stripeCustomerId: {
-              type: "string",
-              required: false,
-              defaultValue: null,
-              input: false,
-            },
-          },
+          await workspaceRepository.createWorkspace({
+            userId: null,
+            organizationId: organization.id,
+            tx: prisma,
+          });
         },
       },
     }),

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -41,6 +41,7 @@ const handleCustomerCreatedEventMock = vi.fn();
 const handleCustomerUpdatedEventMock = vi.fn();
 const handleInvoicePaidEventMock = vi.fn();
 const handleSubscriptionDeletedEventMock = vi.fn();
+const workspaceCreateMock = vi.fn();
 
 function getDefaultEnvSecrets() {
   return {
@@ -155,6 +156,9 @@ vi.mock("@sokosumi/database/repositories", () => ({
     getMembersByOrganizationId: (...args: unknown[]) =>
       getMembersByOrganizationIdMock(...args),
     getMemberByUserIdAndOrganizationId: vi.fn(),
+  },
+  workspaceRepository: {
+    createWorkspace: (...args: unknown[]) => workspaceCreateMock(...args),
   },
 }));
 
@@ -307,6 +311,7 @@ describe("web auth config", () => {
       id: "cus_org_1",
     });
     stripeCreateUserCustomerMock.mockResolvedValue({ id: "cus_user_1" });
+    workspaceCreateMock.mockResolvedValue({ id: "workspace_123" });
     syncLocalFreeSeatsAndCreditsForCurrentMembersMock.mockResolvedValue(
       undefined,
     );
@@ -992,28 +997,24 @@ describe("web auth config", () => {
       data: {
         ...user,
         name: "magic",
-        workspace: {
-          create: {},
-        },
       },
     });
 
     await config.databaseHooks.user.create.after(normalizedUser);
     await config.databaseHooks.user.update.after(normalizedUser);
 
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: null,
+      tx: expect.objectContaining({ __prisma: true }),
+      userId: "user_123",
+    });
     expect(marketingOptInUserSchemaSafeParseMock).toHaveBeenNthCalledWith(1, {
       ...user,
       name: "magic",
-      workspace: {
-        create: {},
-      },
     });
     expect(marketingOptInUserSchemaSafeParseMock).toHaveBeenNthCalledWith(2, {
       ...user,
       name: "magic",
-      workspace: {
-        create: {},
-      },
     });
     expect(callUserCreatedWebHookMock).toHaveBeenCalledWith(
       "user_123",
@@ -1073,9 +1074,6 @@ describe("web auth config", () => {
         email: "@example.com",
         marketingOptIn: true,
         name: "@example.com",
-        workspace: {
-          create: {},
-        },
       },
     });
   });
@@ -1120,6 +1118,11 @@ describe("web auth config", () => {
       user: { id: "user-1" },
     });
 
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      tx: expect.objectContaining({ __prisma: true }),
+      userId: null,
+    });
     expect(ensureInitialLocalFreeSubscriptionPeriodMock).not.toHaveBeenCalled();
     expect(stripeCreateOrganizationCustomerMock).toHaveBeenCalledWith(
       "org-1",
@@ -1176,6 +1179,11 @@ describe("web auth config", () => {
     await Promise.resolve();
 
     expect(settled).toBe(true);
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: null,
+      tx: expect.objectContaining({ __prisma: true }),
+      userId: "user_123",
+    });
     expect(callUserCreatedWebHookMock).toHaveBeenCalledWith(
       "user_123",
       "magic@example.com",
@@ -1245,6 +1253,11 @@ describe("web auth config", () => {
     await Promise.resolve();
 
     expect(settled).toBe(true);
+    expect(workspaceCreateMock).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      tx: expect.objectContaining({ __prisma: true }),
+      userId: null,
+    });
     expect(stripeCreateOrganizationCustomerMock).toHaveBeenCalledWith(
       "org-1",
       "org-one",

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -1177,6 +1177,7 @@ describe("web auth config", () => {
     });
 
     await Promise.resolve();
+    await Promise.resolve();
 
     expect(settled).toBe(true);
     expect(workspaceCreateMock).toHaveBeenCalledWith({
@@ -1250,6 +1251,7 @@ describe("web auth config", () => {
       settled = true;
     });
 
+    await Promise.resolve();
     await Promise.resolve();
 
     expect(settled).toBe(true);

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -295,7 +295,11 @@ export const auth = betterAuth({
           };
         },
         after: async (user, _ctx) => {
-          await workspaceRepository.createWorkspace(user.id, null, prisma);
+          await workspaceRepository.createWorkspace({
+            userId: user.id,
+            organizationId: null,
+            tx: prisma,
+          });
           void ensureStripeCustomerForCreatedUser(user).catch((error) => {
             Sentry.captureException(error, {
               tags: {
@@ -545,7 +549,11 @@ export const auth = betterAuth({
     organization({
       organizationHooks: {
         afterCreateOrganization: async ({ organization }) => {
-          await workspaceRepository.createWorkspace(null, organization.id, prisma);
+          await workspaceRepository.createWorkspace({
+            userId: null,
+            organizationId: organization.id,
+            tx: prisma,
+          });
           void ensureStripeCustomerForCreatedOrganization(organization).catch(
             (error) => {
               Sentry.captureException(error, {

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -545,7 +545,11 @@ export const auth = betterAuth({
     organization({
       organizationHooks: {
         afterCreateOrganization: async ({ organization }) => {
-          await workspaceRepository.createWorkspace(null, organization.id, prisma);
+          await workspaceRepository.createWorkspace(
+            null,
+            organization.id,
+            prisma,
+          );
           void ensureStripeCustomerForCreatedOrganization(organization).catch(
             (error) => {
               Sentry.captureException(error, {

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -8,7 +8,10 @@ import { prismaAdapter } from "@better-auth/prisma-adapter";
 import { stripe } from "@better-auth/stripe";
 import * as Sentry from "@sentry/nextjs";
 import { MemberRole, type User } from "@sokosumi/database";
-import { memberRepository } from "@sokosumi/database/repositories";
+import {
+  memberRepository,
+  workspaceRepository,
+} from "@sokosumi/database/repositories";
 import {
   renderMagicLinkEmail,
   renderOrganizationInvitationEmail,
@@ -288,13 +291,11 @@ export const auth = betterAuth({
             data: {
               ...user,
               name: getStoredUserName(user.name, user.email),
-              workspace: {
-                create: {},
-              },
             },
           };
         },
         after: async (user, _ctx) => {
+          await workspaceRepository.createWorkspace(user.id, null, prisma);
           void ensureStripeCustomerForCreatedUser(user).catch((error) => {
             Sentry.captureException(error, {
               tags: {
@@ -543,17 +544,8 @@ export const auth = betterAuth({
     }),
     organization({
       organizationHooks: {
-        beforeCreateOrganization: async ({ organization }) => {
-          return {
-            data: {
-              ...organization,
-              workspace: {
-                create: {},
-              },
-            },
-          };
-        },
         afterCreateOrganization: async ({ organization }) => {
+          await workspaceRepository.createWorkspace(null, organization.id, prisma);
           void ensureStripeCustomerForCreatedOrganization(organization).catch(
             (error) => {
               Sentry.captureException(error, {

--- a/packages/database/src/repositories/workspace.repository.ts
+++ b/packages/database/src/repositories/workspace.repository.ts
@@ -41,11 +41,15 @@ export const workspaceRepository = {
     }
   },
 
-  async createWorkspace(
-    userId: string | null,
-    organizationId: string | null,
-    tx: Prisma.TransactionClient,
-  ): Promise<Workspace> {
+  async createWorkspace({
+    userId,
+    organizationId,
+    tx,
+  }: {
+    userId: string | null;
+    organizationId: string | null;
+    tx: Prisma.TransactionClient;
+  }): Promise<Workspace> {
     return await tx.workspace.create({
       data: {
         ...(userId && { userId }),

--- a/packages/database/src/repositories/workspace.repository.ts
+++ b/packages/database/src/repositories/workspace.repository.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "../generated/prisma/client.js";
+import type { Prisma, Workspace } from "../generated/prisma/client.js";
 import {
   type WorkspaceWithRelations,
   workspaceSummaryInclude,
@@ -39,5 +39,18 @@ export const workspaceRepository = {
     } else {
       return await this.findPersonalWorkspace(userId, tx);
     }
+  },
+
+  async createWorkspace(
+    userId: string | null,
+    organizationId: string | null,
+    tx: Prisma.TransactionClient,
+  ): Promise<Workspace> {
+    return await tx.workspace.create({
+      data: {
+        ...(userId && { userId }),
+        ...(organizationId && { organizationId }),
+      },
+    });
   },
 };


### PR DESCRIPTION
## Summary

Moves personal and organization workspace creation out of nested Prisma `create` payloads in Better Auth hooks and into an explicit `workspaceRepository.createWorkspace` call after user and organization creation, in both the web app and Core API auth configurations.

## Key changes

- **packages/database**: Add `workspaceRepository.createWorkspace(userId, organizationId, tx)` to insert a `Workspace` row with the appropriate `userId` and/or `organizationId`.
- **apps/web** (`auth.ts`): Remove nested `workspace: { create: {} }` from the user creation hook; call `createWorkspace` in the user `after` hook (personal workspace) and in `afterCreateOrganization` (org workspace).
- **apps/core** (`auth.ts`): Same pattern for Core Better Auth so API-originated sign-up and org creation stay aligned with the web app.

## Why

Centralizing workspace creation in the repository keeps a single place for how workspaces are created and avoids relying on nested creates inside adapter-driven flows, which can be harder to reason about and backfill.

## Testing

- [ ] `pnpm --filter @sokosumi/database build`
- [ ] `pnpm --filter web exec tsc --noEmit`
- [ ] `pnpm --filter core exec tsc --noEmit` (or equivalent core typecheck)
- [ ] Manual smoke: register a user and create an organization; confirm workspace rows exist as expected.


Made with [Cursor](https://cursor.com)