### PR TITLE
feat(web): show copyable Stripe customer ID on billing balance card

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1683,6 +1683,7 @@
       "balanceDescriptionPersonal": "Deine aktuellen Credits im persönlichen Account.",
       "balanceDescriptionOrganization": "Aktuelle Credits für {organization}. {members, plural, =1 {# Mitglied} other {# Mitglieder}}, {seats, plural, =1 {# Seat} other {# Seats}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {Keine Credits} =1 {# Credit} other {# Credits}}",
+      "stripeCustomerIdLabel": "Stripe-Kunden-ID",
       "tabs": {
         "subscription": "Abonnement",
         "credits": "Credits",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1744,6 +1744,7 @@
       "balanceDescriptionPersonal": "Your current credits in personal account.",
       "balanceDescriptionOrganization": "Current credits for {organization}. {members, plural, =1 {# member} other {# members}}, {seats, plural, =1 {# seat} other {# seats}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {No credits} =1 {# credit} other {# credits}}",
+      "stripeCustomerIdLabel": "Stripe customer ID",
       "tabs": {
         "subscription": "Subscription",
         "credits": "Credits",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1683,6 +1683,7 @@
       "balanceDescriptionPersonal": "Tus Credits actuales en la cuenta personal.",
       "balanceDescriptionOrganization": "Credits actuales para {organization}. {members, plural, =1 {# miembro} other {# miembros}}, {seats, plural, =1 {# Seat} other {# Seats}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {Sin Credits} =1 {# Credit} other {# Credits}}",
+      "stripeCustomerIdLabel": "ID de cliente de Stripe",
       "tabs": {
         "subscription": "Suscripción",
         "credits": "Credits",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1744,6 +1744,7 @@
       "balanceDescriptionPersonal": "Vos crédits actuels sur votre compte personnel.",
       "balanceDescriptionOrganization": "Crédits actuels pour {organization}. {members, plural, =1 {# membre} other {# membres}}, {seats, plural, =1 {# siège} other {# sièges}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {Aucun crédit} =1 {# crédit} other {# crédits}}",
+      "stripeCustomerIdLabel": "ID client Stripe",
       "tabs": {
         "subscription": "Abonnement",
         "credits": "Crédits",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1745,6 +1745,7 @@
       "balanceDescriptionPersonal": "I crediti attuali nel tuo account personale.",
       "balanceDescriptionOrganization": "Crediti attuali per {organization}. {members, plural, =1 {# membro} other {# membri}}, {seats, plural, =1 {# postazione} other {# postazioni}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {Nessun credito} =1 {# credito} other {# crediti}}",
+      "stripeCustomerIdLabel": "ID cliente Stripe",
       "tabs": {
         "subscription": "Abbonamento",
         "credits": "Crediti",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1745,6 +1745,7 @@
       "balanceDescriptionPersonal": "個人アカウントの現在のクレジットです。",
       "balanceDescriptionOrganization": "{organization} の現在のクレジットです。{members, plural, =1 {# メンバー} other {# メンバー}}、{seats, plural, =1 {# シート} other {# シート}}。",
       "balanceCreditsLabel": "{credits, plural, =0 {クレジットなし} =1 {# クレジット} other {# クレジット}}",
+      "stripeCustomerIdLabel": "Stripe 顧客 ID",
       "tabs": {
         "subscription": "サブスクリプション",
         "credits": "クレジット",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1744,6 +1744,7 @@
       "balanceDescriptionPersonal": "Seus créditos atuais na conta pessoal.",
       "balanceDescriptionOrganization": "Créditos atuais para {organization}. {members, plural, =1 {# membro} other {# membros}}, {seats, plural, =1 {# assento} other {# assentos}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {Sem créditos} =1 {# crédito} other {# créditos}}",
+      "stripeCustomerIdLabel": "ID do cliente Stripe",
       "tabs": {
         "subscription": "Assinatura",
         "credits": "Créditos",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1745,6 +1745,7 @@
       "balanceDescriptionPersonal": "Os seus créditos atuais na conta pessoal.",
       "balanceDescriptionOrganization": "Créditos atuais para {organization}. {members, plural, =1 {# membro} other {# membros}}, {seats, plural, =1 {# lugar} other {# lugares}}.",
       "balanceCreditsLabel": "{credits, plural, =0 {Sem créditos} =1 {# crédito} other {# créditos}}",
+      "stripeCustomerIdLabel": "ID de cliente Stripe",
       "tabs": {
         "subscription": "Subscrição",
         "credits": "Créditos",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1744,6 +1744,7 @@
       "balanceDescriptionPersonal": "您个人账户的当前积分。",
       "balanceDescriptionOrganization": "{organization} 的当前积分。{members, plural, =1 {# 名成员} other {# 名成员}}, {seats, plural, =1 {# 个席位} other {# 个席位}}。",
       "balanceCreditsLabel": "{credits, plural, =0 {无积分} =1 {# 积分} other {# 积分}}",
+      "stripeCustomerIdLabel": "Stripe 客户 ID",
       "tabs": {
         "subscription": "订阅",
         "credits": "积分",

--- a/apps/web/src/app/(app)/billing/page.tsx
+++ b/apps/web/src/app/(app)/billing/page.tsx
@@ -168,6 +168,8 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             creditsLabel={t("balanceCreditsLabel", {
               credits: displayCredits,
             })}
+            stripeCustomerId={activeOrganization.stripeCustomerId}
+            stripeCustomerLabel={t("stripeCustomerIdLabel")}
           />
 
           <BillingTabs
@@ -276,6 +278,8 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
           creditsLabel={t("balanceCreditsLabel", {
             credits: displayCredits,
           })}
+          stripeCustomerId={user?.stripeCustomerId ?? null}
+          stripeCustomerLabel={t("stripeCustomerIdLabel")}
         />
 
         <BillingTabs

--- a/apps/web/src/components/billing/balance-section.tsx
+++ b/apps/web/src/components/billing/balance-section.tsx
@@ -1,3 +1,4 @@
+import { BalanceStripeCustomerRow } from "@/components/billing/balance-stripe-customer-row";
 import {
   Card,
   CardContent,
@@ -9,12 +10,16 @@ import {
 interface BalanceSectionProps {
   creditsLabel: string;
   description: string;
+  stripeCustomerId?: null | string;
+  stripeCustomerLabel?: string;
   title: string;
 }
 
 export function BalanceSection({
   creditsLabel,
   description,
+  stripeCustomerId,
+  stripeCustomerLabel,
   title,
 }: BalanceSectionProps) {
   return (
@@ -23,7 +28,14 @@ export function BalanceSection({
         <CardTitle>{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
+        {stripeCustomerId && stripeCustomerLabel ? (
+          <BalanceStripeCustomerRow
+            key={stripeCustomerId}
+            label={stripeCustomerLabel}
+            stripeCustomerId={stripeCustomerId}
+          />
+        ) : null}
         <p className="text-2xl font-semibold">{creditsLabel}</p>
       </CardContent>
     </Card>

--- a/apps/web/src/components/billing/balance-section.tsx
+++ b/apps/web/src/components/billing/balance-section.tsx
@@ -1,11 +1,11 @@
 import { BalanceStripeCustomerRow } from "@/components/billing/balance-stripe-customer-row";
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 interface BalanceSectionProps {
   creditsLabel: string;
@@ -22,22 +22,38 @@ export function BalanceSection({
   stripeCustomerLabel,
   title,
 }: BalanceSectionProps) {
+  const stripeRow =
+    stripeCustomerId != null && stripeCustomerLabel != null
+      ? { ariaLabel: stripeCustomerLabel, id: stripeCustomerId }
+      : null;
+
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {stripeCustomerId && stripeCustomerLabel ? (
-          <BalanceStripeCustomerRow
-            key={stripeCustomerId}
-            label={stripeCustomerLabel}
-            stripeCustomerId={stripeCustomerId}
-          />
+      <CardHeader className="grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-1.5">
+        <div className="col-start-1 row-span-2 flex min-w-0 flex-col gap-1">
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </div>
+        <p
+          className={cn(
+            "col-start-2 justify-self-end text-right text-3xl font-semibold tracking-tight tabular-nums",
+            stripeRow
+              ? "row-start-1 self-start"
+              : "row-span-2 row-start-1 self-start",
+          )}
+        >
+          {creditsLabel}
+        </p>
+        {stripeRow ? (
+          <div className="col-start-2 row-start-2 justify-self-end self-start">
+            <BalanceStripeCustomerRow
+              key={stripeRow.id}
+              ariaLabel={stripeRow.ariaLabel}
+              stripeCustomerId={stripeRow.id}
+            />
+          </div>
         ) : null}
-        <p className="text-2xl font-semibold">{creditsLabel}</p>
-      </CardContent>
+      </CardHeader>
     </Card>
   );
 }

--- a/apps/web/src/components/billing/balance-stripe-customer-row.tsx
+++ b/apps/web/src/components/billing/balance-stripe-customer-row.tsx
@@ -1,52 +1,28 @@
 "use client";
 
-import { Copy } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { toast } from "sonner";
-
-import { MiddleTruncate } from "@/components/middle-truncate";
-import { Button } from "@/components/ui/button";
+import { CopyableValue } from "@/components/copyable-value";
 
 export interface BalanceStripeCustomerRowProps {
-  label: string;
+  /** Shown only to assistive tech; there is no visible label. */
+  ariaLabel: string;
   stripeCustomerId: string;
 }
 
 export function BalanceStripeCustomerRow({
-  label,
+  ariaLabel,
   stripeCustomerId,
 }: BalanceStripeCustomerRowProps) {
-  const t = useTranslations("Components.HashValue");
-
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(stripeCustomerId);
-      toast.success(t("copySuccess"));
-    } catch {
-      toast.error(t("copyError"));
-    }
-  }
-
   return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-sm">
-      <span className="shrink-0">{label}</span>
-      <div className="flex min-w-0 max-w-full flex-1 items-center gap-1">
-        <MiddleTruncate
-          className="min-w-0 font-mono text-xs"
-          text={stripeCustomerId}
-        />
-        <Button
-          variant="ghost"
-          size="icon"
-          type="button"
-          onClick={() => void handleCopy()}
-          className="text-muted-foreground shrink-0"
-          title={t("copy")}
-          aria-label={t("copy")}
-        >
-          <Copy className="size-4" />
-        </Button>
-      </div>
+    <div className="inline-flex max-w-full min-w-0 items-center justify-end text-right">
+      <span className="sr-only">{ariaLabel}: </span>
+      <CopyableValue
+        copiedFeedback
+        presentation="inline-code"
+        value={stripeCustomerId}
+        buttonClassName="size-7"
+        codeClassName="text-muted-foreground text-xs"
+        containerClassName="min-w-0 justify-end gap-1"
+      />
     </div>
   );
 }

--- a/apps/web/src/components/billing/balance-stripe-customer-row.tsx
+++ b/apps/web/src/components/billing/balance-stripe-customer-row.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Copy } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { MiddleTruncate } from "@/components/middle-truncate";
+import { Button } from "@/components/ui/button";
+
+export interface BalanceStripeCustomerRowProps {
+  label: string;
+  stripeCustomerId: string;
+}
+
+export function BalanceStripeCustomerRow({
+  label,
+  stripeCustomerId,
+}: BalanceStripeCustomerRowProps) {
+  const t = useTranslations("Components.HashValue");
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(stripeCustomerId);
+      toast.success(t("copySuccess"));
+    } catch {
+      toast.error(t("copyError"));
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-sm">
+      <span className="shrink-0">{label}</span>
+      <div className="flex min-w-0 max-w-full flex-1 items-center gap-1">
+        <MiddleTruncate
+          className="min-w-0 font-mono text-xs"
+          text={stripeCustomerId}
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          type="button"
+          onClick={() => void handleCopy()}
+          className="text-muted-foreground shrink-0"
+          title={t("copy")}
+          aria-label={t("copy")}
+        >
+          <Copy className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the Stripe customer ID to the billing Balance card (between the description and the credit total). The value follows the active workspace: organization `stripeCustomerId` when an org workspace is selected, otherwise the signed-in user’s `stripeCustomerId`. A copy button copies the full ID to the clipboard and reuses the existing copy success/error toasts (`Components.HashValue`).

## Verification

- `pnpm --filter web test src/app/(app)/billing/__tests__/page.test.tsx`
- `pnpm exec biome check --write` on touched TSX files (from `apps/web`)

## Notes

- The row is hidden when no Stripe customer exists yet for that context (`null`).
- New i18n key: `App.Billing.stripeCustomerIdLabel` (synced across all locale catalogs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaca5838-0ccb-4106-b191-f14a61b82a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaca5838-0ccb-4106-b191-f14a61b82a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

