### PR TITLE
chore(auth): remove redundant Better Auth appName inline comments

### DIFF
--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -86,7 +86,7 @@ async function ensureWorkspaceForCreatedOrganization(organization: {
 }
 
 export const auth = betterAuth({
-  appName: "Sokosumi", // Define the name of your application
+  appName: "Sokosumi",
   advanced: {
     cookiePrefix: betterAuthCookiePrefix,
     ...(env.BETTER_AUTH_COOKIE_DOMAIN

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -245,7 +245,7 @@ const betterAuthCookiePrefixParams = {
 };
 
 export const auth = betterAuth({
-  appName: "Sokosumi", // Define the name of your application
+  appName: "Sokosumi",
   baseURL: betterAuthBaseUrl,
   advanced: {
     cookiePrefix: resolveBetterAuthCookiePrefix(betterAuthCookiePrefixParams),


### PR DESCRIPTION
## Summary

Removes the placeholder-style inline comment next to `appName` in the Better Auth configuration for both the Core API and web app. The value is self-explanatory and the comment added no product or operational value.

## Changes

- **apps/core**: Strip `// Define the name of your application` from `betterAuth({ appName: "Sokosumi", ... })`.
- **apps/web**: Same cleanup in the web app Better Auth setup.

## Testing

- No behavior change; auth configuration values are unchanged.
- Recommend running existing auth-related smoke tests or `pnpm check` if you want CI parity before merge.

## Notes

Existing commit on the branch: `fix(auth): remove comment from appName in betterAuth configuration in core and web`.

Made with [Cursor](https://cursor.com)