### PR TITLE
refactor(database): uuid(7) defaults and Better Auth UUID id generation

### DIFF
--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -188,6 +188,10 @@ Environment variables are accessed via `process.env`, validated at startup with 
 
 Cross-origin calls from the web app require the web deployment to use a hostname that satisfies both checks (e.g. `*.sokosumi.com` in hosted environments).
 
+### Better Auth ID generation
+
+- `src/lib/auth.ts` sets `advanced.database.generateId: "uuid"` so Better Auth–managed rows get UUID-shaped primary keys, consistent with `@sokosumi/database` Prisma models. Do not remove this without aligning the shared schema and any database migrations.
+
 ### Authentication Context
 
 Routes using `HonoWithAuth` or `OpenAPIHonoWithAuth` have access to `AuthContext`:

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -88,6 +88,9 @@ async function ensureWorkspaceForCreatedOrganization(organization: {
 export const auth = betterAuth({
   appName: "Sokosumi",
   advanced: {
+    database: {
+      generateId: "uuid",
+    },
     cookiePrefix: betterAuthCookiePrefix,
     ...(env.BETTER_AUTH_COOKIE_DOMAIN
       ? {

--- a/apps/core/src/routes/debug/pkce/post.ts
+++ b/apps/core/src/routes/debug/pkce/post.ts
@@ -26,51 +26,6 @@ async function generateCodeChallenge(verifier: string): Promise<string> {
   return base64Url.encode(new Uint8Array(hash), { padding: false });
 }
 
-// const pkceResponseSchema = z.object({
-//   codeVerifier: z.string().openapi({
-//     example: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-//     description:
-//       "PKCE code verifier (43-128 characters, URL-safe base64 encoded)",
-//   }),
-//   codeChallenge: z.string().openapi({
-//     example: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-//     description:
-//       "PKCE code challenge (SHA256 hash of code verifier, base64url encoded)",
-//   }),
-//   state: z.string().uuid().openapi({
-//     example: "550e8400-e29b-41d4-a716-446655440000",
-//     description: "OAuth state parameter (UUID)",
-//   }),
-// });
-
-// const route = createRoute({
-//   method: "post",
-//   path: "/pkce",
-//   tags: ["OAuth"],
-//   summary: "Generate PKCE (Debug)",
-//   description:
-//     "Generates PKCE (Proof Key for Code Exchange) values including code verifier, code challenge, and state for OAuth 2.1 authorization flow debugging.",
-//   responses: {
-//     201: jsonSuccessResponse(
-//       pkceResponseSchema,
-//       "PKCE values generated successfully",
-//       {
-//         data: {
-//           codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-//           codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-//           state: "550e8400-e29b-41d4-a716-446655440000",
-//         },
-//         meta: {
-//           timestamp: "2025-01-15T12:00:00.000Z",
-//           requestId: "550e8400-e29b-41d4-a716-446655440000",
-//         },
-//       },
-//     ),
-//     401: jsonErrorResponse("Unauthorized"),
-//     500: jsonErrorResponse("Internal Server Error"),
-//   },
-// });
-
 export default function mount(app: Hono) {
   app.post("/pkce", async (c) => {
     // Generate PKCE parameters for OAuth 2.1 authorization code flow with PKCE

--- a/apps/core/src/routes/v1/conversations/post.ts
+++ b/apps/core/src/routes/v1/conversations/post.ts
@@ -1,5 +1,5 @@
 import { createRoute } from "@hono/zod-openapi";
-import { v7 as uuidv7 } from "uuid";
+import { v4 as uuidv4 } from "uuid";
 
 import { conflict, internalServerError } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -60,7 +60,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       // Database is the source of truth - create conversation directly in DB
       // Use provided openaiId or generate a new one
-      const openaiId = body.openaiId || uuidv7();
+      const openaiId = body.openaiId || uuidv4();
 
       const conversation = await prisma.$transaction(async (tx) => {
         // Check if conversation with this ID already exists (shouldn't happen with UUID, but safety check)

--- a/apps/core/src/routes/v1/conversations/post.ts
+++ b/apps/core/src/routes/v1/conversations/post.ts
@@ -1,5 +1,5 @@
 import { createRoute } from "@hono/zod-openapi";
-import { randomUUID } from "crypto";
+import { v7 as uuidv7 } from "uuid";
 
 import { conflict, internalServerError } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -60,7 +60,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       // Database is the source of truth - create conversation directly in DB
       // Use provided openaiId or generate a new one
-      const openaiId = body.openaiId || randomUUID();
+      const openaiId = body.openaiId || uuidv7();
 
       const conversation = await prisma.$transaction(async (tx) => {
         // Check if conversation with this ID already exists (shouldn't happen with UUID, but safety check)

--- a/apps/core/src/services/sync-lock.service.ts
+++ b/apps/core/src/services/sync-lock.service.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-
+import { v7 as uuidv7 } from "uuid";
 import { getEnv } from "@/config/env";
 import prisma from "@/lib/db/prisma";
 
@@ -21,7 +20,7 @@ export const syncLockService = {
       const lockExpirationThreshold = new Date(
         lockAcquiredAt.getTime() - getEnv().LOCK_TIMEOUT,
       );
-      const ownerToken = `${getEnv().INSTANCE_ID}:${randomUUID()}`;
+      const ownerToken = `${getEnv().INSTANCE_ID}:${uuidv7()}`;
 
       const acquireResult = await tx.lock.updateMany({
         where: {

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -172,6 +172,10 @@ import { JobsList } from "src/app/(app)/agents/[agentId]/jobs/components/jobs-li
 - Never access Prisma directly from components
 - Use server actions for mutations
 
+### Better Auth ID generation
+
+- `src/lib/auth/auth.ts` sets `advanced.database.generateId: "uuid"` so Better Auth–managed rows get UUID-shaped primary keys, consistent with `@sokosumi/database` Prisma models. Do not remove this without aligning the shared schema and any database migrations.
+
 ### Stripe: Sandbox (test) vs production
 
 Stripe **test mode** and **live mode** are separate environments. The app does not switch modes in code; it uses whatever `STRIPE_*` env vars are set.

--- a/apps/web/src/lib/api/utils.ts
+++ b/apps/web/src/lib/api/utils.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { APIError } from "better-auth/api";
 import { NextResponse } from "next/server";
-import { v4 as uuidv4 } from "uuid";
+import { v7 as uuidv7 } from "uuid";
 import * as z from "zod";
 
 import {
@@ -43,7 +43,7 @@ export function handleApiError(
     requestId?: string;
   } = {},
 ): NextResponse {
-  const requestId = options.requestId ?? uuidv4();
+  const requestId = options.requestId ?? uuidv7();
 
   console.error(`[${requestId}] Error in ${operation}:`, error);
 

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -248,6 +248,9 @@ export const auth = betterAuth({
   appName: "Sokosumi",
   baseURL: betterAuthBaseUrl,
   advanced: {
+    database: {
+      generateId: "uuid",
+    },
     cookiePrefix: resolveBetterAuthCookiePrefix(betterAuthCookiePrefixParams),
     ...(secrets.BETTER_AUTH_COOKIE_DOMAIN
       ? {

--- a/packages/database/AGENTS.md
+++ b/packages/database/AGENTS.md
@@ -137,6 +137,13 @@ export const userRepository = {
 - Define custom types in `src/types/` for complex relationships
 - Export types from the main entry point for browser safety
 
+### Primary keys and UUIDs
+
+- **`@default(uuid(7))`**: Primary keys on `String` ids use Prisma’s UUID v7 default for new rows when no `id` is provided. Do not switch back to `cuid()` or plain `uuid()` without an explicit migration and product decision.
+- **`@db.Uuid`**: `Workspace.id` and `Job.workspaceId`, `JobSchedule.workspaceId`, and `Task.workspaceId` use native PostgreSQL `UUID` where the database has been migrated. Do not drop `@db.Uuid` (or change those columns to untyped `text`) without a coordinated SQL migration.
+- **Better Auth**: Web and Core Better Auth configs set `advanced.database.generateId: "uuid"` so adapter inserts use UUID-shaped ids compatible with these columns. Keep Prisma defaults and Better Auth `generateId` aligned when changing either.
+- **Legacy data**: Bulk rekey or type-change migrations are separate from schema defaults; see migration history and team runbooks before altering id strategy for existing rows.
+
 ### Migrations
 
 - Create migrations with `pnpm prisma:migrate:dev`

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -15,7 +15,7 @@ datasource db {
 }
 
 model User {
-  id            String    @id @default(uuid())
+  id            String    @id @default(uuid(7))
   name          String
   email         String
   emailVerified Boolean
@@ -83,7 +83,7 @@ model User {
 }
 
 model Session {
-  id             String   @id
+  id             String   @id @default(uuid(7))
   expiresAt      DateTime
   token          String
   createdAt      DateTime
@@ -104,7 +104,7 @@ model Session {
 }
 
 model Account {
-  id                    String    @id
+  id                    String    @id @default(uuid(7))
   accountId             String
   providerId            String
   userId                String
@@ -123,7 +123,7 @@ model Account {
 }
 
 model Verification {
-  id         String    @id
+  id         String    @id @default(uuid(7))
   identifier String
   value      String
   expiresAt  DateTime
@@ -134,7 +134,7 @@ model Verification {
 }
 
 model Passkey {
-  id           String   @id
+  id           String   @id @default(uuid(7))
   name         String?
   publicKey    String
   userId       String
@@ -154,7 +154,7 @@ model Passkey {
 }
 
 model Subscription {
-  id                   String    @id
+  id                   String    @id @default(uuid(7))
   createdAt            DateTime  @default(now())
   updatedAt            DateTime  @updatedAt
   plan                 String
@@ -181,7 +181,7 @@ model Subscription {
 }
 
 model Organization {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   name      String
   slug      String
   logo      String?
@@ -226,7 +226,7 @@ model Workspace {
 }
 
 model Member {
-  id             String       @id @default(cuid())
+  id             String       @id @default(uuid(7))
   userId         String
   user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   organizationId String
@@ -239,7 +239,7 @@ model Member {
 }
 
 model Invitation {
-  id             String       @id @default(cuid())
+  id             String       @id @default(uuid(7))
   createdAt      DateTime     @default(now())
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -254,7 +254,7 @@ model Invitation {
 }
 
 model UTMAttribution {
-  id String @id @default(cuid())
+  id String @id @default(uuid(7))
 
   // User
   userId String @unique
@@ -284,7 +284,7 @@ model UTMAttribution {
 }
 
 model Notice {
-  id           String     @id @default(cuid())
+  id           String     @id @default(uuid(7))
   kind         NoticeKind @default(ANNOUNCEMENT)
   bodyMarkdown String
   effectiveAt  DateTime   @default(now())
@@ -299,7 +299,7 @@ model Notice {
 }
 
 model NoticeAcknowledgment {
-  id             String   @id @default(cuid())
+  id             String   @id @default(uuid(7))
   userId         String
   noticeId       String
   acknowledgedAt DateTime @default(now())
@@ -319,7 +319,7 @@ enum NoticeKind {
 }
 
 model RateLimit {
-  id          String  @id
+  id          String  @id @default(uuid(7))
   key         String?
   count       Int?
   lastRequest BigInt?
@@ -328,7 +328,7 @@ model RateLimit {
 }
 
 model UnitValue {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   unit      String
@@ -341,7 +341,7 @@ model UnitValue {
 }
 
 model AgentPricing {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -358,7 +358,7 @@ enum PricingType {
 }
 
 model AgentFixedPricing {
-  id           String        @id @default(cuid())
+  id           String        @id @default(uuid(7))
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   agentPricing AgentPricing?
@@ -366,7 +366,7 @@ model AgentFixedPricing {
 }
 
 model ExampleOutput {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String
@@ -380,7 +380,7 @@ model ExampleOutput {
 }
 
 model UserAgentRating {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   rating    Int
@@ -398,7 +398,7 @@ model UserAgentRating {
 }
 
 model Agent {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -486,7 +486,7 @@ model Agent {
 }
 
 model Category {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -518,7 +518,7 @@ enum RiskClassification {
 }
 
 model Lock {
-  id        String    @id @default(cuid())
+  id        String    @id @default(uuid(7))
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   key       String    @unique
@@ -528,7 +528,7 @@ model Lock {
 }
 
 model Tag {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   name      String   @unique
@@ -538,7 +538,7 @@ model Tag {
 }
 
 model SyncMetadata {
-  id           String   @id @default(cuid())
+  id           String   @id @default(uuid(7))
   key          String   @unique
   lastSyncedAt DateTime
   cursorId     String?
@@ -556,7 +556,7 @@ enum AgentStatus {
 }
 
 model AgentList {
-  id     String        @id @default(cuid())
+  id     String        @id @default(uuid(7))
   user   User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String
   type   AgentListType
@@ -570,7 +570,7 @@ enum AgentListType {
 }
 
 model Transaction {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -594,7 +594,7 @@ model Transaction {
 }
 
 model CreditBucket {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -633,7 +633,7 @@ enum CreditBucketReferenceType {
 }
 
 model CreditConsumption {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
 
   // Amount consumed from this bucket (in cents, always positive)
@@ -660,7 +660,7 @@ enum JobType {
 }
 
 model Job {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -720,7 +720,7 @@ model Job {
 }
 
 model JobPurchase {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -748,7 +748,7 @@ model JobPurchase {
 }
 
 model JobEvent {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -772,7 +772,7 @@ model JobEvent {
 }
 
 model JobInput {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -837,7 +837,7 @@ enum AgentJobStatus {
 }
 
 model CreditCost {
-  id           String   @id @default(cuid())
+  id           String   @id @default(uuid(7))
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   unit         String   @unique
@@ -845,7 +845,7 @@ model CreditCost {
 }
 
 model Apikey {
-  id                  String    @id
+  id                  String    @id @default(uuid(7))
   configId            String    @default("default")
   name                String?
   start               String?
@@ -875,7 +875,7 @@ model Apikey {
 }
 
 model Blob {
-  id        String   @id @default(uuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -896,7 +896,7 @@ model Blob {
 }
 
 model Link {
-  id        String   @id @default(uuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -918,7 +918,7 @@ enum BlobStatus {
 }
 
 model PublicShare {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -938,7 +938,7 @@ model PublicShare {
 }
 
 model JobSchedule {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -990,7 +990,7 @@ enum ShareAccessType {
 }
 
 model OauthClient {
-  id        String    @id @default(cuid())
+  id        String    @id @default(uuid(7))
   createdAt DateTime? @default(now())
   updatedAt DateTime? @updatedAt
 
@@ -1032,7 +1032,7 @@ model OauthClient {
 }
 
 model OauthAccessToken {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1057,7 +1057,7 @@ model OauthAccessToken {
 }
 
 model OauthRefreshToken {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1082,7 +1082,7 @@ model OauthRefreshToken {
 }
 
 model OauthConsent {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1097,7 +1097,7 @@ model OauthConsent {
 }
 
 model Jwks {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1109,7 +1109,7 @@ model Jwks {
 }
 
 model Coworker {
-  id         String    @id @default(cuid())
+  id         String    @id @default(uuid(7))
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
   archivedAt DateTime?
@@ -1143,7 +1143,7 @@ model Coworker {
 }
 
 model CoworkerApiKey {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1163,7 +1163,7 @@ model CoworkerApiKey {
 }
 
 model Task {
-  id         String    @id @default(cuid())
+  id         String    @id @default(uuid(7))
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
   archivedAt DateTime?
@@ -1211,7 +1211,7 @@ enum TaskLinkType {
 /// At most one row per unordered task pair (any direction or `TaskLinkType`).
 /// Enforced by DB index `task_link_task_pair_key` (see migration); Prisma cannot express LEAST/GREATEST unique constraints.
 model TaskLink {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1260,7 +1260,7 @@ enum TaskEventOrigin {
 }
 
 model TaskEvent {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1288,7 +1288,7 @@ model TaskEvent {
 }
 
 model CoworkerUsage {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1315,7 +1315,7 @@ model CoworkerUsage {
 }
 
 model Conversation {
-  id         String             @id @default(uuid())
+  id         String             @id @default(uuid(7))
   openaiId   String             @unique
   userId     String
   user       User               @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -1333,7 +1333,7 @@ model Conversation {
 }
 
 model ConversationItem {
-  id                     String       @id @default(uuid())
+  id                     String       @id @default(uuid(7))
   conversationId         String
   conversation           Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
   role                   String // "user" | "assistant" | "system"

--- a/packages/database/src/helpers/subscription.test.ts
+++ b/packages/database/src/helpers/subscription.test.ts
@@ -325,12 +325,10 @@ describe("ensureInitialLocalFreeSubscriptionPeriod", () => {
     assert.equal(createSubscriptionMock.mock.calls.length, 1);
     const createdPersonalSubscription =
       createSubscriptionMock.mock.calls[0]?.[0].data;
-    assert.equal(typeof createdPersonalSubscription.id, "string");
     assert.deepEqual(createdPersonalSubscription, {
       billingInterval: "month",
       cancelAtPeriodEnd: false,
       createdAt: new Date("2026-04-01T10:00:00.000Z"),
-      id: createdPersonalSubscription.id,
       periodEnd: new Date("2026-05-01T10:00:00.000Z"),
       periodStart: new Date("2026-04-01T10:00:00.000Z"),
       plan: "free",
@@ -397,12 +395,10 @@ describe("ensureInitialLocalFreeSubscriptionPeriod", () => {
     assert.equal(createSubscriptionMock.mock.calls.length, 1);
     const createdOrganizationSubscription =
       createSubscriptionMock.mock.calls[0]?.[0].data;
-    assert.equal(typeof createdOrganizationSubscription.id, "string");
     assert.deepEqual(createdOrganizationSubscription, {
       billingInterval: "month",
       cancelAtPeriodEnd: false,
       createdAt: new Date("2026-04-01T10:00:00.000Z"),
-      id: createdOrganizationSubscription.id,
       periodEnd: new Date("2026-05-01T10:00:00.000Z"),
       periodStart: new Date("2026-04-01T10:00:00.000Z"),
       plan: "free",

--- a/packages/database/src/helpers/subscription.ts
+++ b/packages/database/src/helpers/subscription.ts
@@ -1,5 +1,4 @@
 import { convertCreditsToCents } from "@sokosumi/utils";
-import { v4 as uuidv4 } from "uuid";
 import {
   CreditBucketReferenceType,
   type Prisma,
@@ -398,7 +397,6 @@ export async function ensureLocalFreeSubscriptionPeriod(
         billingInterval: MONTHLY_BILLING_INTERVAL,
         cancelAtPeriodEnd: false,
         createdAt: params.billingAnchorDate,
-        id: uuidv4(),
         periodEnd: params.periodEnd,
         periodStart: params.periodStart,
         plan: FREE_SUBSCRIPTION_PLAN,


### PR DESCRIPTION
## Summary

Aligns primary-key generation with UUID v7 in Prisma, configures Better Auth to emit UUID-shaped identifiers for adapter-managed tables, and standardizes a few app-generated identifiers (UUID v7 where we want time-sortable correlation/lease tokens, UUID v4 where we align with external or legacy expectations). New DB rows use consistent defaults where applicable, without requiring a migration solely for default-expression churn when the physical schema already matches.

## Key changes

### Prisma (`packages/database/prisma/schema.prisma`)

- Replace `@default(cuid())` and `@default(uuid())` with `@default(uuid(7))` on model primary keys where applicable.
- Add `@default(uuid(7))` on `@id` fields that previously had no default (e.g. Session, Account, Verification, Passkey, RateLimit, Apikey, Subscription).
- Keeps existing `Workspace` / `workspaceId` `@db.Uuid` mapping where already migrated in the database.

### Better Auth

- **`apps/web/src/lib/auth/auth.ts`** and **`apps/core/src/lib/auth.ts`**: `advanced.database.generateId: "uuid"` so Better Auth generates UUID ids for records inserted through the Prisma adapter.

### Subscription helper and tests (`packages/database`)

- **`src/helpers/subscription.ts`**: initial free `subscription.create` omits `id` so Prisma applies `@default(uuid(7))`.
- **`src/helpers/subscription.test.ts`**: expectations updated so create payloads no longer include `id`.

### Other explicit UUID generation

- **`apps/core/src/services/sync-lock.service.ts`**: lock `ownerToken` suffix uses **UUID v7** (with `INSTANCE_ID` prefix).
- **`apps/web/src/lib/api/utils.ts`**: `handleApiError` default `requestId` uses **UUID v7**.
- **`apps/core/src/routes/v1/conversations/post.ts`**: default `openaiId` uses **UUID v4** (`uuidv4()`) when not provided (OpenAI-facing id shape).

### Debug / cleanup

- **`apps/core/src/routes/debug/pkce/post.ts`**: removed commented-out route and schema definitions; active PKCE helper unchanged (`state` still uses `randomUUID()` from Node).

### Documentation

- **`packages/database/AGENTS.md`**, **`apps/web/AGENTS.md`**, **`apps/core/AGENTS.md`**: notes on primary keys / UUIDs and Better Auth ID generation.

## Technical notes

- Prisma `uuid(7)` defaults apply when the client creates rows without an explicit `id`; they complement Better Auth `generateId: "uuid"` for auth tables.
- Protocol- and product-specific ids (e.g. Masumi `identifierFromPurchaser`, public share tokens, org slug suffixes) intentionally remain separate; see AGENTS.md and code comments where relevant.
- No new SQL migration is required solely for these Prisma default and app-config changes if the physical schema already matches; confirm with `prisma migrate diff` against your target database if unsure.

## Testing

- [x] `pnpm --filter @sokosumi/database exec prisma validate`
- [x] `pnpm --filter @sokosumi/database test`
- [ ] `pnpm --filter @sokosumi/database exec prisma generate` (run in CI / locally after pull)
- [ ] Smoke sign-in / session flows on web and core as appropriate