### PR TITLE
feat(core): add PATCH /v1/jobs/{id} for job name updates

### DIFF
--- a/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
@@ -1,0 +1,288 @@
+import { AgentJobStatus, JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenAPIHonoWithAuth } from "@/lib/hono";
+import { patchJobRequestSchema } from "@/schemas/job.schema";
+
+import mountPatchJobById from "./patch";
+
+const {
+  authContextState,
+  prismaTransactionMock,
+  jobFindUniqueMock,
+  jobUpdateMock,
+  mapJobWithStatusMock,
+  serializeJobDetailsMock,
+} = vi.hoisted(() => ({
+  authContextState: {
+    current: {
+      actor: "user",
+      userId: "user_123",
+      organizationId: "org_123",
+    } as {
+      actor: "user";
+      userId: string;
+      organizationId: string | null;
+    } | null,
+  },
+  prismaTransactionMock: vi.fn(),
+  jobFindUniqueMock: vi.fn(),
+  jobUpdateMock: vi.fn(),
+  mapJobWithStatusMock: vi.fn(),
+  serializeJobDetailsMock: vi.fn(),
+}));
+
+vi.mock("@/middleware/auth", () => ({
+  authMiddleware: async (
+    c: {
+      json: (body: unknown, status: number) => unknown;
+      req: { path: string; method: string };
+      set: (key: string, value: unknown) => void;
+    },
+    next: () => Promise<unknown>,
+  ) => {
+    if (!authContextState.current) {
+      return c.json(
+        {
+          error: "Unauthorized",
+          message: "Unauthorized",
+          meta: {
+            timestamp: new Date().toISOString(),
+            requestId: "req_123",
+            path: c.req.path,
+            method: c.req.method,
+          },
+        },
+        401,
+      );
+    }
+
+    c.set("isAuthenticated", true);
+    c.set("authContext", authContextState.current);
+    return await next();
+  },
+  requireUserAuthContext: (authContext: unknown) => authContext,
+}));
+
+vi.mock("@sokosumi/database/helpers", () => ({
+  mapJobWithStatus: (...args: unknown[]) => mapJobWithStatusMock(...args),
+}));
+
+vi.mock("@/types/job", () => ({
+  serializeJobDetails: (...args: unknown[]) => serializeJobDetailsMock(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: (...args: unknown[]) => prismaTransactionMock(...args),
+  },
+}));
+
+function createSerializedJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "job_123",
+    createdAt: "2026-03-26T10:00:00.000Z",
+    updatedAt: "2026-03-26T10:05:00.000Z",
+    completedAt: null,
+    agentId: "agent_123",
+    userId: "user_123",
+    organizationId: "org_123",
+    taskId: null,
+    name: "Renamed job",
+    jobType: JobType.PAID,
+    status: SokosumiJobStatus.PROCESSING,
+    credits: 5,
+    onChainStatus: null,
+    onChainTransactionHash: null,
+    result: null,
+    resultHash: null,
+    input: "{}",
+    inputHash: null,
+    inputSchema: null,
+    agentJobId: "agent_job_123",
+    identifierFromPurchaser: null,
+    workspace: {
+      id: "11111111-1111-7111-8111-111111111111",
+      organizationId: "org_123",
+      organization: {
+        id: "org_123",
+        name: "Acme Labs",
+        slug: "acme-labs",
+      },
+    },
+    user: {
+      id: "user_123",
+      name: "Ada Lovelace",
+      image: null,
+    },
+    organization: {
+      id: "org_123",
+      name: "Acme Labs",
+      slug: "acme-labs",
+    },
+    agent: {
+      id: "agent_123",
+      name: "Research Agent",
+      overrideName: null,
+      icon: null,
+      image: null,
+      overrideImage: null,
+      legalPrivacyPolicy: null,
+      overrideLegalPrivacyPolicy: null,
+      legalTerms: null,
+      overrideLegalTerms: null,
+      legalDpa: null,
+      overrideLegalDpa: null,
+      legalOther: null,
+      overrideLegalOther: null,
+    },
+    events: [
+      {
+        id: "event_1",
+        createdAt: "2026-03-26T10:00:00.000Z",
+        updatedAt: "2026-03-26T10:00:00.000Z",
+        status: AgentJobStatus.INITIATED,
+        inputSchema: null,
+        input: null,
+        result: null,
+        blobs: [],
+        links: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createApp() {
+  const app = new OpenAPIHonoWithAuth({ includeOrganizationHeader: false });
+  mountPatchJobById(app);
+  return app;
+}
+
+describe("patchJobRequestSchema", () => {
+  it("trims string names before length checks", () => {
+    const result = patchJobRequestSchema.parse({ name: "  My job  " });
+    expect(result.name).toBe("My job");
+  });
+
+  it("rejects whitespace-only strings (use null to clear the name)", () => {
+    expect(() => patchJobRequestSchema.parse({ name: "   " })).toThrow();
+  });
+
+  it("accepts null to clear the name", () => {
+    const result = patchJobRequestSchema.parse({ name: null });
+    expect(result.name).toBeNull();
+  });
+
+  it("rejects unknown keys", () => {
+    expect(() =>
+      patchJobRequestSchema.parse({ name: "ok", extra: 1 }),
+    ).toThrow();
+  });
+});
+
+describe("PATCH /jobs/{id}", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authContextState.current = {
+      actor: "user",
+      userId: "user_123",
+      organizationId: "org_123",
+    };
+    prismaTransactionMock.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) =>
+        await callback({
+          job: {
+            findUnique: jobFindUniqueMock,
+            update: jobUpdateMock,
+          },
+        }),
+    );
+    jobFindUniqueMock
+      .mockResolvedValueOnce({
+        id: "job_123",
+        userId: "user_123",
+      })
+      .mockResolvedValueOnce({ id: "job_123" });
+    jobUpdateMock.mockResolvedValue({ id: "job_123" });
+    mapJobWithStatusMock.mockReturnValue({});
+    serializeJobDetailsMock.mockReturnValue(createSerializedJob());
+  });
+
+  it("updates the name of an owned job", async () => {
+    const app = createApp();
+
+    const response = await app.request("http://localhost/job_123", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "Renamed job" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(jobUpdateMock).toHaveBeenCalledWith({
+      where: { id: "job_123" },
+      data: { name: "Renamed job" },
+    });
+    expect(body.data).toMatchObject({
+      id: "job_123",
+      name: "Renamed job",
+    });
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    authContextState.current = null;
+    const app = createApp();
+
+    const response = await app.request("http://localhost/job_123", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "Renamed job" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(jobUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the job is owned by another user", async () => {
+    jobFindUniqueMock.mockReset();
+    jobFindUniqueMock.mockResolvedValueOnce({
+      id: "job_123",
+      userId: "other_user",
+    });
+    const app = createApp();
+
+    const response = await app.request("http://localhost/job_123", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "Renamed job" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(jobUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the job does not exist", async () => {
+    jobFindUniqueMock.mockReset();
+    jobFindUniqueMock.mockResolvedValueOnce(null);
+    const app = createApp();
+
+    const response = await app.request("http://localhost/job_123", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "Renamed job" }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(jobUpdateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
@@ -199,12 +199,10 @@ describe("PATCH /jobs/{id}", () => {
           },
         }),
     );
-    jobFindUniqueMock
-      .mockResolvedValueOnce({
-        id: "job_123",
-        userId: "user_123",
-      })
-      .mockResolvedValueOnce({ id: "job_123" });
+    jobFindUniqueMock.mockResolvedValueOnce({
+      id: "job_123",
+      userId: "user_123",
+    });
     jobUpdateMock.mockResolvedValue({ id: "job_123" });
     mapJobWithStatusMock.mockReturnValue({});
     serializeJobDetailsMock.mockReturnValue(createSerializedJob());
@@ -223,10 +221,13 @@ describe("PATCH /jobs/{id}", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(jobUpdateMock).toHaveBeenCalledWith({
-      where: { id: "job_123" },
-      data: { name: "Renamed job" },
-    });
+    expect(jobUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "job_123" },
+        data: { name: "Renamed job" },
+        include: expect.any(Object),
+      }),
+    );
     expect(body.data).toMatchObject({
       id: "job_123",
       name: "Renamed job",

--- a/apps/core/src/routes/v1/jobs/[id]/patch.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.ts
@@ -1,0 +1,86 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { jobInclude } from "@sokosumi/database";
+import { mapJobWithStatus } from "@sokosumi/database/helpers";
+
+import { forbidden, notFound } from "@/helpers/error.js";
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import {
+  type OpenAPIHonoWithAuth,
+  withGlobalHeaderParameters,
+} from "@/lib/hono";
+import { requireUserAuthContext } from "@/middleware/auth";
+import { jobSchema, patchJobRequestSchema } from "@/schemas/job.schema.js";
+import { serializeJobDetails } from "@/types/job";
+
+const paramsSchema = z.object({
+  id: z.string().openapi({
+    param: { name: "id", in: "path" },
+    example: "job_123",
+  }),
+});
+
+const route = withGlobalHeaderParameters(
+  createRoute({
+    method: "patch",
+    path: "/{id}",
+    description:
+      "Partially update a job. Only client-editable fields are accepted; omit read-only attributes.",
+    tags: ["Jobs"],
+    request: {
+      params: paramsSchema,
+      body: {
+        content: {
+          "application/json": {
+            schema: patchJobRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: jsonSuccessResponse(jobSchema, "Job updated"),
+      400: jsonErrorResponse("Bad Request"),
+      401: jsonErrorResponse("Unauthorized"),
+      403: jsonErrorResponse("Forbidden"),
+      404: jsonErrorResponse("Not Found"),
+      422: jsonErrorResponse("Unprocessable Entity"),
+    },
+  }),
+);
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    const authContext = requireUserAuthContext(c.var.authContext);
+    const { id } = c.req.valid("param");
+    const { name } = c.req.valid("json");
+
+    const job = await prisma.$transaction(async (tx) => {
+      const existing = await tx.job.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          userId: true,
+        },
+      });
+
+      if (!existing) {
+        throw notFound("Job not found");
+      }
+
+      if (existing.userId !== authContext.userId) {
+        throw forbidden("You can only update your own jobs");
+      }
+
+      const job = await tx.job.update({
+        where: { id },
+        data: { name },
+        include: jobInclude,
+      });
+
+      return serializeJobDetails(mapJobWithStatus(job));
+    });
+
+    return ok(c, jobSchema.parse(job));
+  });
+}

--- a/apps/core/src/routes/v1/jobs/index.test.ts
+++ b/apps/core/src/routes/v1/jobs/index.test.ts
@@ -40,7 +40,7 @@ describe("jobs routes OpenAPI scope contract", () => {
     expect(getScopeDescriptionFromGetOperation(doc, "/{id}")).toBe("");
   });
 
-  it("documents dedicated share mutation routes", () => {
+  it("documents share, workspace, and job patch routes", () => {
     const doc = jobsRouter.getOpenAPI31Document({
       openapi: "3.1.0",
       info: {
@@ -54,6 +54,7 @@ describe("jobs routes OpenAPI scope contract", () => {
     expect(doc.paths?.["/{id}/workspace"]?.put?.responses).toHaveProperty(
       "409",
     );
+    expect(doc.paths?.["/{id}"]?.patch?.responses).toHaveProperty("200");
   });
 
   it("uses summary schema for lists and details schema for single-job reads", () => {

--- a/apps/core/src/routes/v1/jobs/index.ts
+++ b/apps/core/src/routes/v1/jobs/index.ts
@@ -5,6 +5,7 @@ import mountGetJobById from "./[id]/get.js";
 import mountGetInputRequestByJobId from "./[id]/input-request/get.js";
 import mountPostInputsByJobId from "./[id]/inputs/post.js";
 import mountGetLinksByJobId from "./[id]/links/get.js";
+import mountPatchJobById from "./[id]/patch.js";
 import mountDeleteJobShareById from "./[id]/share/delete.js";
 import mountPutJobShareById from "./[id]/share/put.js";
 import mountPutJobWorkspaceById from "./[id]/workspace/put.js";
@@ -16,6 +17,7 @@ const app = new OpenAPIHonoWithAuth({
 
 mountGetJobs(app);
 mountGetJobById(app);
+mountPatchJobById(app);
 mountGetFilesByJobId(app);
 mountGetLinksByJobId(app);
 mountGetInputRequestByJobId(app);

--- a/apps/core/src/schemas/job.schema.ts
+++ b/apps/core/src/schemas/job.schema.ts
@@ -208,6 +208,13 @@ export const jobSchema = z
   })
   .openapi("Job");
 
+/** Body for `PATCH /jobs/{id}`. Add optional fields here as more attributes become editable. */
+export const patchJobRequestSchema = z
+  .object({
+    name: z.union([z.string().trim().min(1).max(80), z.null()]),
+  })
+  .strict();
+
 export const createJobRequestSchema = z.object({
   inputSchema: inputSchemaSchema,
   inputData: z.record(


### PR DESCRIPTION
Adds `PATCH /v1/jobs/{id}` so authenticated job owners can update the display `name` (or clear it with `null`). Request body uses `patchJobRequestSchema` with `.strict()` for unknown keys.

Includes route tests and OpenAPI contract coverage in jobs router tests.

Made with [Cursor](https://cursor.com)