### PR TITLE
feat(core): expose average job execution duration on agent metrics

### DIFF
--- a/apps/core/src/routes/v1/agents/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.test.ts
@@ -17,6 +17,7 @@ const {
   getAgentIconMock,
   getAgentImageMock,
   getAgentNameMock,
+  getAverageExecutionDurationByAgentIdMock,
   getCreditCostsOrThrowMock,
   prismaTransactionMock,
   agentFindFirstMock,
@@ -30,6 +31,7 @@ const {
   getAgentIconMock: vi.fn(),
   getAgentImageMock: vi.fn(),
   getAgentNameMock: vi.fn(),
+  getAverageExecutionDurationByAgentIdMock: vi.fn(),
   getCreditCostsOrThrowMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
   agentFindFirstMock: vi.fn(),
@@ -51,6 +53,13 @@ vi.mock("@/helpers/agent", () => ({
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: prismaTransactionMock,
+  },
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  jobRepository: {
+    getAverageExecutionDurationByAgentId:
+      getAverageExecutionDurationByAgentIdMock,
   },
 }));
 
@@ -99,6 +108,7 @@ describe("GET /agents/{id}", () => {
       total: 3,
       average: 4.5,
     });
+    getAverageExecutionDurationByAgentIdMock.mockResolvedValue(null);
     agentFindFirstMock.mockResolvedValue({
       id: "agent_123",
       createdAt: new Date("2026-03-17T10:00:00.000Z"),

--- a/apps/core/src/routes/v1/agents/[id]/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.ts
@@ -1,4 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
+import { jobRepository } from "@sokosumi/database/repositories";
 import { convertCentsToCredits } from "@sokosumi/utils";
 
 import {
@@ -93,10 +94,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         categories: (agent.categories ?? []).map(mapCategoryForApi),
       };
 
-      const averageExecutionTime = await calculateAverageExecutionTime(id, tx);
+      const [averageExecutionTime, averageExecutionDurationSeconds] =
+        await Promise.all([
+          calculateAverageExecutionTime(id, tx),
+          jobRepository.getAverageExecutionDurationByAgentId(id, tx),
+        ]);
       const executionMetrics = {
         count: agent._count.jobs,
         averageTime: averageExecutionTime ?? null,
+        averageExecutionDurationSeconds,
       };
 
       const ratingMetrics = await calculateAgentRating(id, tx);

--- a/apps/core/src/routes/v1/agents/get.test.ts
+++ b/apps/core/src/routes/v1/agents/get.test.ts
@@ -19,6 +19,7 @@ const {
   getAgentIconMock,
   getAgentImageMock,
   getAgentNameMock,
+  getAverageExecutionDurationByAgentIdsMock,
   getCreditCostsOrThrowMock,
   prismaTransactionMock,
 } = vi.hoisted(() => ({
@@ -33,6 +34,7 @@ const {
   getAgentIconMock: vi.fn(),
   getAgentImageMock: vi.fn(),
   getAgentNameMock: vi.fn(),
+  getAverageExecutionDurationByAgentIdsMock: vi.fn(),
   getCreditCostsOrThrowMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
 }));
@@ -53,6 +55,13 @@ vi.mock("@/helpers/agent", () => ({
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: prismaTransactionMock,
+  },
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  jobRepository: {
+    getAverageExecutionDurationByAgentIds:
+      getAverageExecutionDurationByAgentIdsMock,
   },
 }));
 
@@ -102,6 +111,7 @@ describe("GET /agents", () => {
     calculateAgentRatingsMock.mockResolvedValue(
       new Map([["agent_123", { total: 3, average: 4.5 }]]),
     );
+    getAverageExecutionDurationByAgentIdsMock.mockResolvedValue(new Map());
     agentFindManyMock.mockResolvedValue([
       {
         id: "agent_123",

--- a/apps/core/src/routes/v1/agents/get.ts
+++ b/apps/core/src/routes/v1/agents/get.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import type { Prisma } from "@sokosumi/database";
+import { jobRepository } from "@sokosumi/database/repositories";
 import { convertCentsToCredits } from "@sokosumi/utils";
 
 import {
@@ -192,10 +193,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       const agentIds = agentsWithCredits.map((agent) => agent.id);
 
-      const averageExecutionTimes = await calculateAverageExecutionTimes(
-        agentIds,
-        tx,
-      );
+      const [averageExecutionTimes, averageExecutionDurations] =
+        await Promise.all([
+          calculateAverageExecutionTimes(agentIds, tx),
+          jobRepository.getAverageExecutionDurationByAgentIds(agentIds, tx),
+        ]);
 
       const ratingsMap = await calculateAgentRatings(agentIds, tx);
 
@@ -207,6 +209,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             executions: {
               count: agent._count.jobs,
               averageTime: averageExecutionTimes.get(agent.id) ?? null,
+              averageExecutionDurationSeconds:
+                averageExecutionDurations.get(agent.id) ?? null,
             },
             ratings: {
               total: ratingMetrics?.total ?? 0,

--- a/apps/core/src/schemas/agent.schema.ts
+++ b/apps/core/src/schemas/agent.schema.ts
@@ -14,6 +14,11 @@ export const executionMetricsSchema = z
       example: 100000,
       description: "Average execution time in seconds",
     }),
+    averageExecutionDurationSeconds: z.number().nullable().openapi({
+      example: 42.5,
+      description:
+        "Average job duration in seconds from INITIATED to COMPLETED (non-demo jobs, last 90 days). Null when there is no qualifying data.",
+    }),
   })
   .openapi({
     description: "Execution metrics",

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -69,11 +69,20 @@ export const AgentSchema = {
                             ],
                             example: 100000,
                             description: 'Average execution time in seconds'
+                        },
+                        averageExecutionDurationSeconds: {
+                            type: [
+                                'number',
+                                'null'
+                            ],
+                            example: 42.5,
+                            description: 'Average job duration in seconds from INITIATED to COMPLETED (non-demo jobs, last 90 days). Null when there is no qualifying data.'
                         }
                     },
                     required: [
                         'count',
-                        'averageTime'
+                        'averageTime',
+                        'averageExecutionDurationSeconds'
                     ],
                     description: 'Execution metrics'
                 },

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -33,6 +33,10 @@ export type Agent = {
              * Average execution time in seconds
              */
             averageTime: number | null;
+            /**
+             * Average job duration in seconds from INITIATED to COMPLETED (non-demo jobs, last 90 days). Null when there is no qualifying data.
+             */
+            averageExecutionDurationSeconds: number | null;
         };
         /**
          * Rating metrics

--- a/packages/database/src/repositories/job.repository.ts
+++ b/packages/database/src/repositories/job.repository.ts
@@ -117,6 +117,56 @@ export const jobRepository = {
   },
 
   /**
+   * Batch variant of `getAverageExecutionDurationByAgentId` for many agents in one query.
+   */
+  async getAverageExecutionDurationByAgentIds(
+    agentIds: string[],
+    tx: Prisma.TransactionClient,
+  ): Promise<Map<string, number | null>> {
+    const result = new Map<string, number | null>();
+    if (agentIds.length === 0) {
+      return result;
+    }
+    for (const id of agentIds) {
+      result.set(id, null);
+    }
+
+    const rows = await tx.$queryRawUnsafe<
+      Array<{
+        agent_id: string;
+        avg_duration_seconds: Prisma.Decimal | null;
+      }>
+    >(
+      `
+    SELECT 
+      j."agentId" as agent_id,
+      COALESCE(AVG(EXTRACT(EPOCH FROM (completed."createdAt" - initiated."createdAt"))), 0) as avg_duration_seconds
+    FROM "Job" j
+    INNER JOIN "jobEvent" initiated ON initiated."jobId" = j.id
+      AND initiated."status" = 'INITIATED'::"AgentJobStatus"
+    INNER JOIN "jobEvent" completed ON completed."jobId" = j.id
+      AND completed."status" = 'COMPLETED'::"AgentJobStatus"
+    WHERE j."agentId" = ANY($1::text[])
+    AND j."jobType" != 'DEMO'
+    AND j."createdAt" >= NOW() - INTERVAL '90 days'
+    GROUP BY j."agentId"
+  `,
+      agentIds,
+    );
+
+    for (const row of rows) {
+      const averageDurationSeconds = row.avg_duration_seconds;
+      if (!averageDurationSeconds) {
+        result.set(row.agent_id, null);
+        continue;
+      }
+      result.set(row.agent_id, averageDurationSeconds.toNumber());
+    }
+
+    return result;
+  },
+
+  /**
    * Retrieves the number of executed jobs for a specific agent (not demo jobs)
    * @param agentId - The unique identifier of the agent
    * @returns Promise containing the number of executed jobs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agent API responses now include `metrics.executions.averageExecutionDurationSeconds`, matching the semantics of `jobRepository.getAverageExecutionDurationByAgentId` (non-demo jobs, last 90 days, duration from INITIATED to COMPLETED).

## Changes

- Extended `executionMetricsSchema` in `apps/core/src/schemas/agent.schema.ts` with the new nullable number field and OpenAPI description.
- Wired `GET /v1/agents` to load durations in one batch via new `jobRepository.getAverageExecutionDurationByAgentIds` in `packages/database`.
- Wired `GET /v1/agents/{id}` to call `getAverageExecutionDurationByAgentId` alongside the existing `calculateAverageExecutionTime` helper.
- Updated Vitest mocks for the agent route tests.
- Manually aligned `apps/web` generated Core client types/schemas because `pnpm web generate:core` requires a running Core server in this environment.

## Verification

- `pnpm --filter @sokosumi/core test src/routes/v1/agents/get.test.ts src/routes/v1/agents/[id]/get.test.ts`
- `pnpm --filter @sokosumi/database check` and `pnpm --filter @sokosumi/core check` (during development)

Note: Regenerate the web client with `pnpm web generate:core` when Core is available to fully refresh all generated files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1956c7df-9897-4447-b9cb-859de16a84a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1956c7df-9897-4447-b9cb-859de16a84a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

