### PR TITLE
feat(core): add agent reviews endpoint and agent detail fields

### DIFF
--- a/apps/core/src/helpers/agent.test.ts
+++ b/apps/core/src/helpers/agent.test.ts
@@ -11,6 +11,7 @@ import {
   calculateAgentRating,
   calculateAgentRatings,
   getCreditCostsOrThrow,
+  getRecentAgentReviews,
 } from "./agent";
 
 function createCreditCost(unit: string): CreditCost {
@@ -181,5 +182,64 @@ describe("calculateAgentRatings", () => {
         ],
       ]),
     );
+  });
+});
+
+describe("getRecentAgentReviews", () => {
+  it("filters out ratings without meaningful comments", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        id: "rating-1",
+        rating: 5,
+        comment: "Helpful review",
+        createdAt: new Date("2026-03-17T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+        user: {
+          id: "user-1",
+          name: "Jane Doe",
+          image: "https://example.com/avatar.png",
+        },
+      },
+    ]);
+    const tx = {
+      userAgentRating: {
+        findMany,
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const result = await getRecentAgentReviews("agent-1", 10, tx);
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        agentId: "agent-1",
+        isHidden: false,
+        AND: [{ comment: { not: null } }, { comment: { not: "" } }],
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 10,
+    });
+    expect(result).toEqual([
+      {
+        id: "rating-1",
+        rating: 5,
+        comment: "Helpful review",
+        createdAt: "2026-03-17T10:00:00.000Z",
+        updatedAt: "2026-03-17T10:00:00.000Z",
+        user: {
+          id: "user-1",
+          name: "Jane Doe",
+          image: "https://example.com/avatar.png",
+        },
+      },
+    ]);
   });
 });

--- a/apps/core/src/helpers/agent.ts
+++ b/apps/core/src/helpers/agent.ts
@@ -9,7 +9,11 @@ import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
 
 import { TIME } from "@/config/constants";
 import prisma from "@/lib/db/prisma";
-import { type RatingMetrics } from "@/schemas/agent.schema";
+import {
+  type AgentReview,
+  type RatingDistribution,
+  type RatingMetrics,
+} from "@/schemas/agent.schema";
 import type { AgentWithPricing } from "@/types/agent";
 
 import { internalServerError, unprocessableEntity } from "./error";
@@ -386,4 +390,75 @@ export const calculateAgentRatings = async (
     }
   }
   return ratingsMap;
+};
+
+export const getAgentRatingDistribution = async (
+  agentId: string,
+  tx: Prisma.TransactionClient,
+): Promise<RatingDistribution> => {
+  const ratings = await tx.userAgentRating.groupBy({
+    by: ["rating"],
+    where: {
+      agentId,
+      isHidden: false,
+    },
+    _count: { rating: true },
+  });
+
+  const distribution: RatingDistribution = {
+    "1": 0,
+    "2": 0,
+    "3": 0,
+    "4": 0,
+    "5": 0,
+  };
+
+  ratings.forEach((rating) => {
+    const key = String(rating.rating) as keyof RatingDistribution;
+    distribution[key] = rating._count.rating;
+  });
+
+  return distribution;
+};
+
+export const getRecentAgentReviews = async (
+  agentId: string,
+  limit: number,
+  tx: Prisma.TransactionClient,
+): Promise<AgentReview[]> => {
+  const ratings = await tx.userAgentRating.findMany({
+    where: {
+      agentId,
+      isHidden: false,
+      comment: {
+        not: null,
+      },
+    },
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          image: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+  return ratings.map((rating) => ({
+    id: rating.id,
+    rating: rating.rating,
+    comment: rating.comment,
+    createdAt: rating.createdAt,
+    updatedAt: rating.updatedAt,
+    user: {
+      id: rating.user.id,
+      name: rating.user.name,
+      image: rating.user.image
+        ? resolveIpfsOrHttpUrl(rating.user.image)
+        : rating.user.image,
+    },
+  }));
 };

--- a/apps/core/src/helpers/agent.ts
+++ b/apps/core/src/helpers/agent.ts
@@ -11,6 +11,7 @@ import { TIME } from "@/config/constants";
 import prisma from "@/lib/db/prisma";
 import {
   type AgentReview,
+  agentReviewSchema,
   type RatingDistribution,
   type RatingMetrics,
 } from "@/schemas/agent.schema";
@@ -430,9 +431,7 @@ export const getRecentAgentReviews = async (
     where: {
       agentId,
       isHidden: false,
-      comment: {
-        not: null,
-      },
+      AND: [{ comment: { not: null } }, { comment: { not: "" } }],
     },
     include: {
       user: {
@@ -447,18 +446,20 @@ export const getRecentAgentReviews = async (
     take: limit,
   });
 
-  return ratings.map((rating) => ({
-    id: rating.id,
-    rating: rating.rating,
-    comment: rating.comment,
-    createdAt: rating.createdAt,
-    updatedAt: rating.updatedAt,
-    user: {
-      id: rating.user.id,
-      name: rating.user.name,
-      image: rating.user.image
-        ? resolveIpfsOrHttpUrl(rating.user.image)
-        : rating.user.image,
-    },
-  }));
+  return ratings.map((rating) =>
+    agentReviewSchema.parse({
+      id: rating.id,
+      rating: rating.rating,
+      comment: rating.comment,
+      createdAt: rating.createdAt,
+      updatedAt: rating.updatedAt,
+      user: {
+        id: rating.user.id,
+        name: rating.user.name,
+        image: rating.user.image
+          ? resolveIpfsOrHttpUrl(rating.user.image)
+          : rating.user.image,
+      },
+    }),
+  );
 };

--- a/apps/core/src/routes/v1/agents/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.test.ts
@@ -108,6 +108,7 @@ describe("GET /agents/{id}", () => {
       image: null,
       icon: null,
       summary: "A short summary",
+      riskClassification: "HIGH",
       _count: { jobs: 2 },
       categories: [
         {
@@ -145,6 +146,28 @@ describe("GET /agents/{id}", () => {
       legalDpa: null,
       overrideLegalOther: null,
       legalOther: null,
+      tags: [
+        {
+          id: "tag_123",
+          createdAt: new Date("2026-03-17T10:00:00.000Z"),
+          updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+          name: "research",
+        },
+      ],
+      overrideTags: [],
+      exampleOutput: [
+        {
+          id: "example_123",
+          createdAt: new Date("2026-03-17T10:00:00.000Z"),
+          updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+          name: "Generated summary",
+          mimeType: "image/png",
+          url: "https://example.com/output.png",
+          agentId: "agent_123",
+          agentIdOverride: null,
+        },
+      ],
+      overrideExampleOutput: [],
     });
     prismaTransactionMock.mockImplementation(async (callback) => {
       return await callback({
@@ -170,5 +193,14 @@ describe("GET /agents/{id}", () => {
         },
       },
     });
+    expect(body.data.riskClassification).toBe("HIGH");
+    expect(body.data.tags).toEqual(["research"]);
+    expect(body.data.exampleOutputs).toEqual([
+      {
+        name: "Generated summary",
+        mimeType: "image/png",
+        url: "https://example.com/output.png",
+      },
+    ]);
   });
 });

--- a/apps/core/src/routes/v1/agents/[id]/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.ts
@@ -21,16 +21,14 @@ import {
   withGlobalHeaderParameters,
 } from "@/lib/hono";
 import {
-  agentSchema,
+  agentDetailSchema,
+  getAgentExampleOutputsFromAgent,
   getAgentLegalFromAgent,
+  getAgentTagsFromAgent,
   getAuthorFromAgent,
 } from "@/schemas/agent.schema";
 import { mapCategoryForApi } from "@/schemas/category.schema";
-import {
-  agentCategoriesInclude,
-  agentJobsCountInclude,
-  agentPricingInclude,
-} from "@/types/agent";
+import { agentDetailInclude } from "@/types/agent";
 
 const params = z.object({
   id: z.string().openapi({
@@ -49,7 +47,7 @@ const route = withGlobalHeaderParameters(
       params,
     },
     responses: {
-      200: jsonSuccessResponse(agentSchema, "Retrieve the agent by ID"),
+      200: jsonSuccessResponse(agentDetailSchema, "Retrieve the agent by ID"),
       401: jsonErrorResponse("Unauthorized"),
       404: jsonErrorResponse("Not Found"),
     },
@@ -68,11 +66,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           id,
           ...buildAvailableAgentWhereClause(creditCosts),
         },
-        include: {
-          ...agentPricingInclude,
-          ...agentJobsCountInclude,
-          ...agentCategoriesInclude,
-        },
+        include: agentDetailInclude,
       });
 
       if (!agent) {
@@ -91,6 +85,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         author: getAuthorFromAgent(agent),
         legal: getAgentLegalFromAgent(agent),
         categories: (agent.categories ?? []).map(mapCategoryForApi),
+        riskClassification: agent.riskClassification,
+        tags: getAgentTagsFromAgent(agent),
+        exampleOutputs: getAgentExampleOutputsFromAgent(agent),
       };
 
       const averageExecutionTime = await calculateAverageExecutionTime(id, tx);
@@ -109,6 +106,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         },
       };
     });
-    return ok(c, agentSchema.parse(agent));
+    return ok(c, agentDetailSchema.parse(agent));
   });
 }

--- a/apps/core/src/routes/v1/agents/[id]/reviews/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/get.test.ts
@@ -1,0 +1,143 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatZodErrorMessage, unprocessableEntity } from "@/helpers/error";
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import type { AuthVariables } from "@/middleware/auth";
+
+import mountGetAgentReviews from "./get";
+
+const {
+  agentFindFirstMock,
+  buildAvailableAgentWhereClauseMock,
+  getAgentRatingDistributionMock,
+  getCreditCostsOrThrowMock,
+  getRecentAgentReviewsMock,
+  prismaTransactionMock,
+} = vi.hoisted(() => ({
+  agentFindFirstMock: vi.fn(),
+  buildAvailableAgentWhereClauseMock: vi.fn(),
+  getAgentRatingDistributionMock: vi.fn(),
+  getCreditCostsOrThrowMock: vi.fn(),
+  getRecentAgentReviewsMock: vi.fn(),
+  prismaTransactionMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/agent", () => ({
+  buildAvailableAgentWhereClause: buildAvailableAgentWhereClauseMock,
+  getAgentRatingDistribution: getAgentRatingDistributionMock,
+  getCreditCostsOrThrow: getCreditCostsOrThrowMock,
+  getRecentAgentReviews: getRecentAgentReviewsMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: prismaTransactionMock,
+  },
+}));
+
+function createApp() {
+  const app = new OpenAPIHono<{
+    Variables: AuthVariables;
+  }>({
+    defaultHook: (result) => {
+      if (!result.success && result.error) {
+        throw unprocessableEntity(formatZodErrorMessage(result.error));
+      }
+    },
+  });
+
+  app.use("*", async (c, next) => {
+    c.set("requestId", "test-req-id");
+    c.set("isAuthenticated", true);
+    c.set("authContext", {
+      actor: "user",
+      userId: "user_123",
+      organizationId: null,
+    });
+    return await next();
+  });
+
+  mountGetAgentReviews(app as unknown as OpenAPIHonoWithAuth);
+  return app;
+}
+
+describe("GET /agents/{id}/reviews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    buildAvailableAgentWhereClauseMock.mockReturnValue({
+      isAvailable: true,
+    });
+    getCreditCostsOrThrowMock.mockResolvedValue([]);
+    agentFindFirstMock.mockResolvedValue({ id: "agent_123" });
+    getAgentRatingDistributionMock.mockResolvedValue({
+      "1": 0,
+      "2": 1,
+      "3": 2,
+      "4": 3,
+      "5": 4,
+    });
+    getRecentAgentReviewsMock.mockResolvedValue([
+      {
+        id: "rating_123",
+        rating: 5,
+        comment: "Great results.",
+        createdAt: new Date("2026-03-17T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+        user: {
+          id: "user_123",
+          name: "Jane Doe",
+          image: "https://example.com/avatar.png",
+        },
+      },
+    ]);
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      return await callback({
+        agent: {
+          findFirst: agentFindFirstMock,
+        },
+      });
+    });
+  });
+
+  it("returns public review distribution and recent comments", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/agent_123/reviews");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(agentFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        id: "agent_123",
+        isAvailable: true,
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(body.data).toEqual({
+      distribution: {
+        "1": 0,
+        "2": 1,
+        "3": 2,
+        "4": 3,
+        "5": 4,
+      },
+      ratingsWithComments: [
+        {
+          id: "rating_123",
+          rating: 5,
+          comment: "Great results.",
+          createdAt: "2026-03-17T10:00:00.000Z",
+          updatedAt: "2026-03-17T10:00:00.000Z",
+          user: {
+            id: "user_123",
+            name: "Jane Doe",
+            image: "https://example.com/avatar.png",
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/core/src/routes/v1/agents/[id]/reviews/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/get.ts
@@ -1,0 +1,82 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+import {
+  buildAvailableAgentWhereClause,
+  getAgentRatingDistribution,
+  getCreditCostsOrThrow,
+  getRecentAgentReviews,
+} from "@/helpers/agent";
+import { notFound } from "@/helpers/error";
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import {
+  type OpenAPIHonoWithAuth,
+  withGlobalHeaderParameters,
+} from "@/lib/hono";
+import { agentReviewsSchema } from "@/schemas/agent.schema";
+
+const RECENT_REVIEW_LIMIT = 10;
+
+const params = z.object({
+  id: z.string().openapi({
+    param: { name: "id", in: "path" },
+    example: "cmaeygqwa000e8i0s9s7wif8i",
+  }),
+});
+
+const route = withGlobalHeaderParameters(
+  createRoute({
+    method: "get",
+    path: "/{id}/reviews",
+    description: "Get public review details for an agent",
+    tags: ["Agents"],
+    request: {
+      params,
+    },
+    responses: {
+      200: jsonSuccessResponse(
+        agentReviewsSchema,
+        "Retrieve public reviews for the agent by ID",
+      ),
+      401: jsonErrorResponse("Unauthorized"),
+      404: jsonErrorResponse("Not Found"),
+    },
+  }),
+);
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    const { id } = c.req.valid("param");
+
+    const reviews = await prisma.$transaction(async (tx) => {
+      const creditCosts = await getCreditCostsOrThrow(tx);
+
+      const agent = await tx.agent.findFirst({
+        where: {
+          id,
+          ...buildAvailableAgentWhereClause(creditCosts),
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      if (!agent) {
+        throw notFound("Agent not found");
+      }
+
+      const [distribution, ratingsWithComments] = await Promise.all([
+        getAgentRatingDistribution(id, tx),
+        getRecentAgentReviews(id, RECENT_REVIEW_LIMIT, tx),
+      ]);
+
+      return {
+        distribution,
+        ratingsWithComments,
+      };
+    });
+
+    return ok(c, agentReviewsSchema.parse(reviews));
+  });
+}

--- a/apps/core/src/routes/v1/agents/get.test.ts
+++ b/apps/core/src/routes/v1/agents/get.test.ts
@@ -112,6 +112,7 @@ describe("GET /agents", () => {
         image: null,
         icon: null,
         summary: "A short summary",
+        riskClassification: "MINIMAL",
         _count: { jobs: 2 },
         categories: [
           {
@@ -195,6 +196,7 @@ describe("GET /agents", () => {
         },
       },
     });
+    expect(body.data[0]).not.toHaveProperty("riskClassification");
   });
 
   it("parses repeated and comma-separated category filters", async () => {

--- a/apps/core/src/routes/v1/agents/get.ts
+++ b/apps/core/src/routes/v1/agents/get.ts
@@ -32,7 +32,7 @@ import {
   withGlobalHeaderParameters,
 } from "@/lib/hono";
 import {
-  agentsSchema,
+  agentsSummarySchema,
   getAgentLegalFromAgent,
   getAuthorFromAgent,
 } from "@/schemas/agent.schema";
@@ -118,19 +118,23 @@ const route = withGlobalHeaderParameters(
       query: agentsListQuerySchema,
     },
     responses: {
-      200: jsonPaginatedSuccessResponse(agentsSchema, "Retrieve all agents", {
-        data: [],
-        meta: {
-          timestamp: "2025-01-15T12:00:00.000Z",
-          requestId: "550e8400-e29b-41d4-a716-446655440000",
-          pagination: {
-            cursor: null,
-            limit: 20,
-            total: 100,
-            nextCursor: "cmaeygqwa000e8i0s9s7wif8i",
+      200: jsonPaginatedSuccessResponse(
+        agentsSummarySchema,
+        "Retrieve all agents",
+        {
+          data: [],
+          meta: {
+            timestamp: "2025-01-15T12:00:00.000Z",
+            requestId: "550e8400-e29b-41d4-a716-446655440000",
+            pagination: {
+              cursor: null,
+              limit: 20,
+              total: 100,
+              nextCursor: "cmaeygqwa000e8i0s9s7wif8i",
+            },
           },
         },
-      }),
+      ),
       401: jsonErrorResponse("Unauthorized"),
       422: jsonErrorResponse("Unprocessable Entity"),
     },
@@ -231,6 +235,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       cursor,
     );
 
-    return ok(c, agentsSchema.parse(result.agents), paginationMeta);
+    return ok(c, agentsSummarySchema.parse(result.agents), paginationMeta);
   });
 }

--- a/apps/core/src/routes/v1/agents/index.test.ts
+++ b/apps/core/src/routes/v1/agents/index.test.ts
@@ -90,15 +90,64 @@ describe("agents routes OpenAPI scope contract", () => {
     expect(listGet).toBeDefined();
     expect(listGet?.responses?.["200"]).toBeDefined();
     const components = doc.components?.schemas;
-    const agentSchema =
-      components && typeof components === "object" && "Agent" in components
-        ? (components as { Agent?: { properties?: unknown } }).Agent
+    const agentSummarySchema =
+      components &&
+      typeof components === "object" &&
+      "AgentSummary" in components
+        ? (components as { AgentSummary?: { properties?: unknown } })
+            .AgentSummary
         : null;
-    expect(agentSchema?.properties).toBeDefined();
-    const props = agentSchema?.properties as
+    expect(agentSummarySchema?.properties).toBeDefined();
+    const props = agentSummarySchema?.properties as
       | { categories?: unknown }
       | undefined;
     expect(props?.categories).toBeDefined();
+  });
+
+  it("documents agent detail-only fields separately from the list schema", () => {
+    const doc = agentsRouter.getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: {
+        title: "Agents API",
+        version: "1.0.0",
+      },
+    });
+
+    const components = doc.components?.schemas as
+      | Record<string, { properties?: Record<string, unknown> }>
+      | undefined;
+
+    expect(
+      components?.AgentSummary?.properties?.riskClassification,
+    ).toBeFalsy();
+    expect(components?.AgentSummary?.properties?.tags).toBeFalsy();
+    expect(components?.AgentSummary?.properties?.exampleOutputs).toBeFalsy();
+
+    expect(
+      components?.AgentDetail?.properties?.riskClassification,
+    ).toBeDefined();
+    expect(components?.AgentDetail?.properties?.tags).toBeDefined();
+    expect(components?.AgentDetail?.properties?.exampleOutputs).toBeDefined();
+  });
+
+  it("documents the agent reviews endpoint", () => {
+    const doc = agentsRouter.getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: {
+        title: "Agents API",
+        version: "1.0.0",
+      },
+    });
+
+    expect(doc.paths?.["/{id}/reviews"]?.get).toBeDefined();
+
+    const components = doc.components?.schemas as
+      | Record<string, { properties?: Record<string, unknown> }>
+      | undefined;
+    expect(components?.AgentReviews?.properties?.distribution).toBeDefined();
+    expect(
+      components?.AgentReviews?.properties?.ratingsWithComments,
+    ).toBeDefined();
   });
 
   it("documents category styles as a structured object schema", () => {

--- a/apps/core/src/routes/v1/agents/index.ts
+++ b/apps/core/src/routes/v1/agents/index.ts
@@ -4,6 +4,7 @@ import mountGetAgentById from "./[id]/get.js";
 import mountGetAgentInputSchema from "./[id]/input-schema/get.js";
 import mountGetJobsByAgentId from "./[id]/jobs/get.js";
 import mountPostAgentJob from "./[id]/jobs/post.js";
+import mountGetAgentReviews from "./[id]/reviews/get.js";
 import mountGetAgents from "./get.js";
 
 const app = new OpenAPIHonoWithAuth({
@@ -12,6 +13,7 @@ const app = new OpenAPIHonoWithAuth({
 
 mountGetAgents(app);
 mountGetAgentById(app);
+mountGetAgentReviews(app);
 mountGetAgentInputSchema(app);
 mountGetJobsByAgentId(app);
 mountPostAgentJob(app);

--- a/apps/core/src/schemas/agent.schema.test.ts
+++ b/apps/core/src/schemas/agent.schema.test.ts
@@ -1,7 +1,16 @@
-import type { Agent } from "@sokosumi/database";
+import { type Agent, RiskClassification } from "@sokosumi/database";
 import { describe, expect, it } from "vitest";
 
-import { agentLegalSchema, getAgentLegalFromAgent } from "./agent.schema";
+import type { AgentWithExampleOutput, AgentWithTags } from "@/types/agent";
+
+import {
+  agentDetailSchema,
+  agentLegalSchema,
+  agentSummarySchema,
+  getAgentExampleOutputsFromAgent,
+  getAgentLegalFromAgent,
+  getAgentTagsFromAgent,
+} from "./agent.schema";
 
 function createMockAgent(overrides: Partial<Agent> = {}): Agent {
   const now = new Date();
@@ -91,5 +100,149 @@ describe("getAgentLegalFromAgent", () => {
       dpa: "https://example.com/override-dpa.pdf",
       other: null,
     });
+  });
+});
+
+const baseAgentResponse = {
+  id: "agent_123",
+  createdAt: new Date("2026-03-17T10:00:00.000Z"),
+  updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+  name: "Research Assistant",
+  image: null,
+  icon: null,
+  credits: 10,
+  summary: "Helpful summary",
+  description: "Detailed description",
+  metrics: {
+    executions: {
+      count: 2,
+      averageTime: 120,
+    },
+    ratings: {
+      total: 3,
+      average: 4.5,
+    },
+  },
+  author: {
+    name: "Jane Doe",
+    image: null,
+    organization: "Sokosumi",
+    email: "jane@example.com",
+    other: null,
+  },
+  legal: {
+    privacyPolicy: null,
+    terms: null,
+    dpa: null,
+    other: null,
+  },
+  categories: [],
+};
+
+describe("agent response schemas", () => {
+  it("keeps detail-only fields out of the summary schema", () => {
+    const parsed = agentSummarySchema.parse({
+      ...baseAgentResponse,
+      riskClassification: RiskClassification.MINIMAL,
+      tags: ["research"],
+      exampleOutputs: [
+        {
+          name: "Sample output",
+          mimeType: "image/png",
+          url: "https://example.com/output.png",
+        },
+      ],
+    });
+
+    expect(parsed).not.toHaveProperty("riskClassification");
+    expect(parsed).not.toHaveProperty("tags");
+    expect(parsed).not.toHaveProperty("exampleOutputs");
+  });
+
+  it("includes detail-only fields in the detail schema", () => {
+    expect(
+      agentDetailSchema.parse({
+        ...baseAgentResponse,
+        riskClassification: RiskClassification.HIGH,
+        tags: ["research", "analysis"],
+        exampleOutputs: [
+          {
+            name: "Sample output",
+            mimeType: "image/png",
+            url: "https://example.com/output.png",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      riskClassification: RiskClassification.HIGH,
+      tags: ["research", "analysis"],
+      exampleOutputs: [
+        {
+          name: "Sample output",
+          mimeType: "image/png",
+          url: "https://example.com/output.png",
+        },
+      ],
+    });
+  });
+});
+
+describe("getAgentTagsFromAgent", () => {
+  it("prefers override tags when present", () => {
+    const agent = {
+      tags: [{ name: "base-tag" }],
+      overrideTags: [{ name: "override-tag" }],
+    } as AgentWithTags;
+
+    expect(getAgentTagsFromAgent(agent)).toEqual(["override-tag"]);
+  });
+
+  it("falls back to default tags when overrides are absent", () => {
+    const agent = {
+      tags: [{ name: "base-tag" }],
+      overrideTags: [],
+    } as AgentWithTags;
+
+    expect(getAgentTagsFromAgent(agent)).toEqual(["base-tag"]);
+  });
+});
+
+describe("getAgentExampleOutputsFromAgent", () => {
+  it("prefers override example outputs when present", () => {
+    const now = new Date("2026-03-17T10:00:00.000Z");
+    const agent = {
+      exampleOutput: [
+        {
+          id: "example_base",
+          createdAt: now,
+          updatedAt: now,
+          name: "Base output",
+          mimeType: "image/png",
+          url: "https://example.com/base.png",
+          agentId: "agent_123",
+          agentIdOverride: null,
+        },
+      ],
+      overrideExampleOutput: [
+        {
+          id: "example_override",
+          createdAt: now,
+          updatedAt: now,
+          name: "Override output",
+          mimeType: "image/png",
+          url: "https://example.com/override.png",
+          agentId: null,
+          agentIdOverride: "agent_123",
+        },
+      ],
+    } as AgentWithExampleOutput;
+
+    expect(getAgentExampleOutputsFromAgent(agent)).toEqual([
+      {
+        name: "Override output",
+        mimeType: "image/png",
+        url: "https://example.com/override.png",
+      },
+    ]);
   });
 });

--- a/apps/core/src/schemas/agent.schema.ts
+++ b/apps/core/src/schemas/agent.schema.ts
@@ -1,9 +1,11 @@
 import { z } from "@hono/zod-openapi";
-import type { Agent } from "@sokosumi/database";
+import { type Agent, RiskClassification } from "@sokosumi/database";
+import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
 
 import { getAgentAuthorImage } from "@/helpers/agent";
 import { dateTimeSchema } from "@/helpers/datetime";
 import { categorySchema } from "@/schemas/category.schema";
+import type { AgentWithExampleOutput, AgentWithTags } from "@/types/agent";
 
 export const executionMetricsSchema = z
   .object({
@@ -105,37 +107,135 @@ export const getAgentLegalFromAgent = (agent: Agent) => {
   });
 };
 
-export const agentSchema = z
+export const agentExampleOutputSchema = z
   .object({
-    id: z.string().openapi({ example: "agent_123" }),
-    createdAt: dateTimeSchema,
-    updatedAt: dateTimeSchema,
-    name: z.string().openapi({ example: "Research Assistant" }),
+    name: z.string().openapi({ example: "Generated summary" }),
+    mimeType: z.string().openapi({ example: "image/png" }),
+    url: z.string().openapi({ example: "https://example.com/output.png" }),
+  })
+  .openapi("AgentExampleOutput");
+
+export type AgentExampleOutput = z.infer<typeof agentExampleOutputSchema>;
+
+export function getAgentExampleOutputsFromAgent(
+  agent: AgentWithExampleOutput,
+): AgentExampleOutput[] {
+  const exampleOutputs =
+    agent.overrideExampleOutput.length > 0
+      ? agent.overrideExampleOutput
+      : agent.exampleOutput;
+
+  return exampleOutputs.map((exampleOutput) =>
+    agentExampleOutputSchema.parse({
+      name: exampleOutput.name,
+      mimeType: exampleOutput.mimeType,
+      url: resolveIpfsOrHttpUrl(exampleOutput.url),
+    }),
+  );
+}
+
+export function getAgentTagsFromAgent(agent: AgentWithTags): string[] {
+  return agent.overrideTags.length > 0
+    ? agent.overrideTags.map((tag) => tag.name)
+    : agent.tags.map((tag) => tag.name);
+}
+
+const agentBaseSchema = z.object({
+  id: z.string().openapi({ example: "agent_123" }),
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
+  name: z.string().openapi({ example: "Research Assistant" }),
+  image: z
+    .string()
+    .nullable()
+    .openapi({ example: "https://example.com/image.png" }),
+  icon: z
+    .string()
+    .nullable()
+    .openapi({ example: "https://example.com/icon.svg" }),
+  credits: z.number().openapi({
+    example: 100,
+    description: "Price in credits",
+  }),
+  summary: z.string().nullable().openapi({
+    example: "A research assistant that can help you with your research",
+  }),
+  description: z.string().openapi({
+    example: "A research assistant that can help you with your research",
+  }),
+  metrics: metricsSchema,
+  author: authorSchema,
+  legal: agentLegalSchema,
+  categories: z.array(categorySchema).openapi({
+    description: "Categories this agent belongs to",
+  }),
+});
+
+export const agentSummarySchema = agentBaseSchema.openapi("AgentSummary");
+
+export const agentDetailSchema = agentBaseSchema
+  .extend({
+    riskClassification: z.nativeEnum(RiskClassification).openapi({
+      example: RiskClassification.MINIMAL,
+      description: "The agent's risk classification",
+    }),
+    tags: z.array(z.string()).openapi({
+      description:
+        "Resolved tags for the agent, using override tags when present",
+      example: ["research", "analysis"],
+    }),
+    exampleOutputs: z.array(agentExampleOutputSchema).openapi({
+      description:
+        "Resolved example outputs for the agent, using overrides when present",
+    }),
+  })
+  .openapi("AgentDetail");
+
+export const ratingDistributionSchema = z
+  .object({
+    "1": z.number().openapi({ example: 1 }),
+    "2": z.number().openapi({ example: 2 }),
+    "3": z.number().openapi({ example: 4 }),
+    "4": z.number().openapi({ example: 8 }),
+    "5": z.number().openapi({ example: 12 }),
+  })
+  .openapi("AgentRatingDistribution");
+
+export type RatingDistribution = z.infer<typeof ratingDistributionSchema>;
+
+export const agentReviewAuthorSchema = z
+  .object({
+    id: z.string().openapi({ example: "user_123" }),
+    name: z.string().openapi({ example: "Jane Doe" }),
     image: z
       .string()
       .nullable()
-      .openapi({ example: "https://example.com/image.png" }),
-    icon: z
-      .string()
-      .nullable()
-      .openapi({ example: "https://example.com/icon.svg" }),
-    credits: z.number().openapi({
-      example: 100,
-      description: "Price in credits",
-    }),
-    summary: z.string().nullable().openapi({
-      example: "A research assistant that can help you with your research",
-    }),
-    description: z.string().openapi({
-      example: "A research assistant that can help you with your research",
-    }),
-    metrics: metricsSchema,
-    author: authorSchema,
-    legal: agentLegalSchema,
-    categories: z.array(categorySchema).openapi({
-      description: "Categories this agent belongs to",
+      .openapi({ example: "https://example.com/avatar.png" }),
+  })
+  .openapi("AgentReviewAuthor");
+
+export const agentReviewSchema = z
+  .object({
+    id: z.string().openapi({ example: "rating_123" }),
+    rating: z.number().min(1).max(5).openapi({ example: 5 }),
+    comment: z.string().nullable().openapi({ example: "Great results." }),
+    createdAt: dateTimeSchema,
+    updatedAt: dateTimeSchema,
+    user: agentReviewAuthorSchema,
+  })
+  .openapi("AgentReview");
+
+export type AgentReview = z.infer<typeof agentReviewSchema>;
+
+export const agentReviewsSchema = z
+  .object({
+    distribution: ratingDistributionSchema,
+    ratingsWithComments: z.array(agentReviewSchema).openapi({
+      description: "Recent visible ratings that include comments",
     }),
   })
-  .openapi("Agent");
+  .openapi("AgentReviews");
 
-export const agentsSchema = z.array(agentSchema);
+export type AgentReviews = z.infer<typeof agentReviewsSchema>;
+
+export const agentsSummarySchema = z.array(agentSummarySchema);

--- a/apps/core/src/types/agent.ts
+++ b/apps/core/src/types/agent.ts
@@ -55,3 +55,47 @@ export const agentCategoriesInclude = {
 export type AgentWithCategories = Prisma.AgentGetPayload<{
   include: typeof agentCategoriesInclude;
 }>;
+
+export const agentTagsInclude = {
+  tags: {
+    orderBy: [{ name: "asc" }] as Prisma.TagOrderByWithRelationInput[],
+  },
+  overrideTags: {
+    orderBy: [{ name: "asc" }] as Prisma.TagOrderByWithRelationInput[],
+  },
+} as const;
+
+export type AgentWithTags = Prisma.AgentGetPayload<{
+  include: typeof agentTagsInclude;
+}>;
+
+export const agentExampleOutputInclude = {
+  exampleOutput: {
+    orderBy: [
+      { createdAt: "asc" },
+      { id: "asc" },
+    ] as Prisma.ExampleOutputOrderByWithRelationInput[],
+  },
+  overrideExampleOutput: {
+    orderBy: [
+      { createdAt: "asc" },
+      { id: "asc" },
+    ] as Prisma.ExampleOutputOrderByWithRelationInput[],
+  },
+} as const;
+
+export type AgentWithExampleOutput = Prisma.AgentGetPayload<{
+  include: typeof agentExampleOutputInclude;
+}>;
+
+export const agentDetailInclude = {
+  ...agentPricingInclude,
+  ...agentJobsCountInclude,
+  ...agentCategoriesInclude,
+  ...agentTagsInclude,
+  ...agentExampleOutputInclude,
+} as const;
+
+export type AgentWithDetailRelations = Prisma.AgentGetPayload<{
+  include: typeof agentDetailInclude;
+}>;


### PR DESCRIPTION
## Summary

This change extends the Core agents API with public review data, enriches the agent-by-id response, and separates list vs detail OpenAPI schemas so clients only see fields that each endpoint actually returns.

## Key changes

- **New endpoint**: `GET /agents/{id}/reviews` returns a `distribution` of 1–5 star counts (visible ratings only) and up to 10 recent `ratingsWithComments` (non-hidden ratings that include a comment), with basic author info and resolved avatar URLs where applicable.
- **Agent detail**: `GET /agents/{id}` now includes `riskClassification`, resolved `tags` (override tags when present), and `exampleOutputs` (override example outputs when present, URLs resolved for IPFS/HTTP).
- **Agent list**: `GET /agents` continues to return the slimmer payload; the response schema is now `AgentSummary` and explicitly omits detail-only fields (`riskClassification`, `tags`, `exampleOutputs`).
- **Implementation**: New Prisma includes in `agentDetailInclude`, helpers `getAgentRatingDistribution` and `getRecentAgentReviews`, and Zod/OpenAPI types for reviews and distributions. OpenAPI contract tests assert schema separation and the new reviews path.

## Testing

- `pnpm --filter core test`

## API / consumer notes

- OpenAPI component names change from a single `Agent` model to **`AgentSummary`** and **`AgentDetail`**. Regenerate any generated API clients after merge.
