### PR TITLE
feat(chat): upgrade opus model to 4.7

### DIFF
--- a/packages/chat/src/models/chat-models.test.ts
+++ b/packages/chat/src/models/chat-models.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { CHAT_MODELS, getModelIdentifier } from "./chat-models.js";
+
+describe("chat models", () => {
+  it("registers Claude Opus 4.7 with the OpenRouter slug", () => {
+    const opusModel = CHAT_MODELS.find(
+      (model) => model.id === "claude-opus-4-7",
+    );
+
+    expect(opusModel).toMatchObject({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      openRouterId: "anthropic/claude-opus-4.7",
+    });
+  });
+
+  it("maps the old Opus 4.6 model id to Opus 4.7", () => {
+    expect(getModelIdentifier("claude-opus-4-6")).toBe(
+      "anthropic/claude-opus-4.7",
+    );
+  });
+});

--- a/packages/chat/src/models/chat-models.ts
+++ b/packages/chat/src/models/chat-models.ts
@@ -31,10 +31,10 @@ export const CHAT_MODELS = [
     openRouterId: "deepseek/deepseek-v3.2",
   },
   {
-    id: "claude-opus-4-6",
-    name: "Claude Opus 4.6",
+    id: "claude-opus-4-7",
+    name: "Claude Opus 4.7",
     iconProvider: "anthropic",
-    openRouterId: "anthropic/claude-opus-4.6",
+    openRouterId: "anthropic/claude-opus-4.7",
   },
   {
     id: "grok-4-1-fast",
@@ -56,6 +56,8 @@ export const DEFAULT_CHAT_MODEL_ID: ChatModelId = "gpt-5-2";
 
 const CHAT_MODEL_MAP = new Map<string, string>([
   ...CHAT_MODELS.map((model) => [model.id, model.openRouterId] as const),
+  // Keep persisted Opus 4.6 selections working after the model upgrade.
+  ["claude-opus-4-6", "anthropic/claude-opus-4.7"],
   ["gpt4o", "openai/gpt-4o"],
   ["gpt-4o", "openai/gpt-4o"],
   ["gpt-4o-mini", "openai/gpt-4o-mini"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the shared Claude Opus 4.6 chat model entry with Claude Opus 4.7
- update the OpenRouter model slug to `anthropic/claude-opus-4.7`
- keep legacy `claude-opus-4-6` selections resolving to the new model and cover it with a focused test

## Verification
- confirmed OpenRouter resolves `/anthropic/claude-opus-4.7`
- `pnpm --filter @sokosumi/chat test`
- `pnpm --filter @sokosumi/chat check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a90026e-5a28-482e-ba4f-8434ca885e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a90026e-5a28-482e-ba4f-8434ca885e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

