### PR TITLE
feat(web): add task filters and read-only workspace task views

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1309,6 +1309,31 @@
       "List": {
         "placeholder": "Keine Tasks"
       },
+      "Filters": {
+        "title": "Filter",
+        "searchPlaceholder": "Filtern…",
+        "emptyResults": "Keine Treffer.",
+        "all": "Alle",
+        "scopeLabel": "Bereich",
+        "scopeOwned": "Meine Tasks",
+        "scopeWorkspace": "Workspace",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Status",
+        "statusOptions": {
+          "DRAFT": "Entwurf",
+          "READY": "Bereit",
+          "INPUT_REQUIRED": "Eingabe erforderlich",
+          "AUTHENTICATION_REQUIRED": "Authentifizierung erforderlich",
+          "OUT_OF_CREDITS": "Keine Credits mehr",
+          "CREDITS_TOPPED_UP": "Credits aufgeladen",
+          "RUNNING": "Läuft",
+          "AWAITING_EXTERNAL": "Wartet auf Externes",
+          "COMPLETED": "Abgeschlossen",
+          "FAILED": "Fehlgeschlagen",
+          "CANCEL_REQUESTED": "Abbruch angefordert",
+          "CANCELED": "Abgebrochen"
+        }
+      },
       "Jobs": {
         "filterButton": "Status",
         "filterHideFailed": "Fehlgeschlagene ausblenden",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "No tasks"
       },
+      "Filters": {
+        "title": "Filters",
+        "searchPlaceholder": "Filter...",
+        "emptyResults": "No results found.",
+        "all": "All",
+        "scopeLabel": "Scope",
+        "scopeOwned": "My tasks",
+        "scopeWorkspace": "Workspace",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Status",
+        "statusOptions": {
+          "DRAFT": "Draft",
+          "READY": "Ready",
+          "INPUT_REQUIRED": "Input required",
+          "AUTHENTICATION_REQUIRED": "Authentication required",
+          "OUT_OF_CREDITS": "Out of credits",
+          "CREDITS_TOPPED_UP": "Credits topped up",
+          "RUNNING": "Running",
+          "AWAITING_EXTERNAL": "Awaiting external",
+          "COMPLETED": "Completed",
+          "FAILED": "Failed",
+          "CANCEL_REQUESTED": "Cancel requested",
+          "CANCELED": "Canceled"
+        }
+      },
       "Jobs": {
         "filterButton": "Status",
         "filterHideFailed": "Hide failed",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1309,6 +1309,31 @@
       "List": {
         "placeholder": "Sin Tasks"
       },
+      "Filters": {
+        "title": "Filtros",
+        "searchPlaceholder": "Filtrar…",
+        "emptyResults": "No se encontraron resultados.",
+        "all": "Todas",
+        "scopeLabel": "Ámbito",
+        "scopeOwned": "Mis tareas",
+        "scopeWorkspace": "Espacio de trabajo",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Estado",
+        "statusOptions": {
+          "DRAFT": "Borrador",
+          "READY": "Listo",
+          "INPUT_REQUIRED": "Entrada requerida",
+          "AUTHENTICATION_REQUIRED": "Autenticación requerida",
+          "OUT_OF_CREDITS": "Sin créditos",
+          "CREDITS_TOPPED_UP": "Créditos recargados",
+          "RUNNING": "En ejecución",
+          "AWAITING_EXTERNAL": "Esperando externo",
+          "COMPLETED": "Completado",
+          "FAILED": "Fallido",
+          "CANCEL_REQUESTED": "Cancelación solicitada",
+          "CANCELED": "Cancelado"
+        }
+      },
       "Jobs": {
         "filterButton": "Estado",
         "filterHideFailed": "Ocultar fallidos",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "Aucune tâche"
       },
+      "Filters": {
+        "title": "Filtres",
+        "searchPlaceholder": "Filtrer…",
+        "emptyResults": "Aucun résultat.",
+        "all": "Tous",
+        "scopeLabel": "Portée",
+        "scopeOwned": "Mes tâches",
+        "scopeWorkspace": "Espace de travail",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Statut",
+        "statusOptions": {
+          "DRAFT": "Brouillon",
+          "READY": "Prêt",
+          "INPUT_REQUIRED": "Saisie requise",
+          "AUTHENTICATION_REQUIRED": "Authentification requise",
+          "OUT_OF_CREDITS": "Plus de crédits",
+          "CREDITS_TOPPED_UP": "Crédits rechargés",
+          "RUNNING": "En cours",
+          "AWAITING_EXTERNAL": "En attente externe",
+          "COMPLETED": "Terminé",
+          "FAILED": "Échoué",
+          "CANCEL_REQUESTED": "Annulation demandée",
+          "CANCELED": "Annulé"
+        }
+      },
       "Jobs": {
         "filterButton": "Statut",
         "filterHideFailed": "Masquer les échecs",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "Nessun task"
       },
+      "Filters": {
+        "title": "Filtri",
+        "searchPlaceholder": "Filtra…",
+        "emptyResults": "Nessun risultato.",
+        "all": "Tutti",
+        "scopeLabel": "Ambito",
+        "scopeOwned": "Le mie attività",
+        "scopeWorkspace": "Spazio di lavoro",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Stato",
+        "statusOptions": {
+          "DRAFT": "Bozza",
+          "READY": "Pronto",
+          "INPUT_REQUIRED": "Input richiesto",
+          "AUTHENTICATION_REQUIRED": "Autenticazione richiesta",
+          "OUT_OF_CREDITS": "Crediti esauriti",
+          "CREDITS_TOPPED_UP": "Crediti ricaricati",
+          "RUNNING": "In esecuzione",
+          "AWAITING_EXTERNAL": "In attesa esterno",
+          "COMPLETED": "Completato",
+          "FAILED": "Non riuscito",
+          "CANCEL_REQUESTED": "Annullamento richiesto",
+          "CANCELED": "Annullato"
+        }
+      },
       "Jobs": {
         "filterButton": "Stato",
         "filterHideFailed": "Nascondi falliti",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "タスクはありません"
       },
+      "Filters": {
+        "title": "フィルター",
+        "searchPlaceholder": "絞り込み…",
+        "emptyResults": "該当する結果がありません。",
+        "all": "すべて",
+        "scopeLabel": "範囲",
+        "scopeOwned": "自分のタスク",
+        "scopeWorkspace": "ワークスペース",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "ステータス",
+        "statusOptions": {
+          "DRAFT": "下書き",
+          "READY": "準備完了",
+          "INPUT_REQUIRED": "入力が必要",
+          "AUTHENTICATION_REQUIRED": "認証が必要",
+          "OUT_OF_CREDITS": "クレジット不足",
+          "CREDITS_TOPPED_UP": "クレジットを追加済み",
+          "RUNNING": "実行中",
+          "AWAITING_EXTERNAL": "外部待ち",
+          "COMPLETED": "完了",
+          "FAILED": "失敗",
+          "CANCEL_REQUESTED": "キャンセル要求済み",
+          "CANCELED": "キャンセル済み"
+        }
+      },
       "Jobs": {
         "filterButton": "ステータス",
         "filterHideFailed": "失敗を非表示",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "Sem tarefas"
       },
+      "Filters": {
+        "title": "Filtros",
+        "searchPlaceholder": "Filtrar…",
+        "emptyResults": "Nenhum resultado encontrado.",
+        "all": "Todas",
+        "scopeLabel": "Escopo",
+        "scopeOwned": "Minhas tarefas",
+        "scopeWorkspace": "Espaço de trabalho",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Status",
+        "statusOptions": {
+          "DRAFT": "Rascunho",
+          "READY": "Pronto",
+          "INPUT_REQUIRED": "Entrada necessária",
+          "AUTHENTICATION_REQUIRED": "Autenticação necessária",
+          "OUT_OF_CREDITS": "Sem créditos",
+          "CREDITS_TOPPED_UP": "Créditos recarregados",
+          "RUNNING": "Em execução",
+          "AWAITING_EXTERNAL": "Aguardando externo",
+          "COMPLETED": "Concluído",
+          "FAILED": "Falhou",
+          "CANCEL_REQUESTED": "Cancelamento solicitado",
+          "CANCELED": "Cancelado"
+        }
+      },
       "Jobs": {
         "filterButton": "Status",
         "filterHideFailed": "Ocultar falhados",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "Sem tarefas"
       },
+      "Filters": {
+        "title": "Filtros",
+        "searchPlaceholder": "Filtrar…",
+        "emptyResults": "Nenhum resultado encontrado.",
+        "all": "Todas",
+        "scopeLabel": "Âmbito",
+        "scopeOwned": "As minhas tarefas",
+        "scopeWorkspace": "Espaço de trabalho",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "Estado",
+        "statusOptions": {
+          "DRAFT": "Rascunho",
+          "READY": "Pronto",
+          "INPUT_REQUIRED": "Entrada necessária",
+          "AUTHENTICATION_REQUIRED": "Autenticação necessária",
+          "OUT_OF_CREDITS": "Sem créditos",
+          "CREDITS_TOPPED_UP": "Créditos recarregados",
+          "RUNNING": "Em execução",
+          "AWAITING_EXTERNAL": "À espera de externo",
+          "COMPLETED": "Concluído",
+          "FAILED": "Falhou",
+          "CANCEL_REQUESTED": "Cancelamento pedido",
+          "CANCELED": "Cancelado"
+        }
+      },
       "Jobs": {
         "filterButton": "Estado",
         "filterHideFailed": "Ocultar falhados",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1340,6 +1340,31 @@
       "List": {
         "placeholder": "暂无任务"
       },
+      "Filters": {
+        "title": "筛选",
+        "searchPlaceholder": "筛选…",
+        "emptyResults": "未找到结果。",
+        "all": "全部",
+        "scopeLabel": "范围",
+        "scopeOwned": "我的任务",
+        "scopeWorkspace": "工作区",
+        "coworkerLabel": "Coworker",
+        "statusLabel": "状态",
+        "statusOptions": {
+          "DRAFT": "草稿",
+          "READY": "就绪",
+          "INPUT_REQUIRED": "需要输入",
+          "AUTHENTICATION_REQUIRED": "需要认证",
+          "OUT_OF_CREDITS": "积分不足",
+          "CREDITS_TOPPED_UP": "积分已充值",
+          "RUNNING": "运行中",
+          "AWAITING_EXTERNAL": "等待外部",
+          "COMPLETED": "已完成",
+          "FAILED": "失败",
+          "CANCEL_REQUESTED": "已请求取消",
+          "CANCELED": "已取消"
+        }
+      },
       "Jobs": {
         "filterButton": "状态",
         "filterHideFailed": "隐藏失败",

--- a/apps/web/src/app/(app)/tasks/(root)/page.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/page.tsx
@@ -1,3 +1,4 @@
+import { TaskStatus } from "@sokosumi/database";
 import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 
@@ -9,6 +10,7 @@ import {
 } from "@/app/tasks/utils/coworker-options";
 import { mapJobsToTasksViewData } from "@/app/tasks/utils/jobs-view-data";
 import { getTasksColumnPage } from "@/app/tasks/utils/tasks-column-page";
+import { parseTasksFilters } from "@/app/tasks/utils/tasks-filters";
 import { TASKS_COLUMN_PAGE_LIMIT } from "@/app/tasks/utils/tasks-pagination";
 import { getSession } from "@/lib/auth/utils";
 import { agentService } from "@/lib/services";
@@ -22,7 +24,13 @@ import {
 } from "@/lib/ui-preferences/tasks-view-mode";
 
 interface TasksPageProps {
-  searchParams: Promise<{ create?: string; coworker?: string }>;
+  searchParams: Promise<{
+    create?: string;
+    coworker?: string;
+    scope?: string;
+    coworkerId?: string;
+    status?: string;
+  }>;
 }
 
 export const metadata = {
@@ -30,7 +38,13 @@ export const metadata = {
 };
 
 export default async function TasksPage({ searchParams }: TasksPageProps) {
-  const { create, coworker: coworkerSlugParam } = await searchParams;
+  const {
+    create,
+    coworker: coworkerSlugParam,
+    scope,
+    coworkerId,
+    status,
+  } = await searchParams;
   const [t, tColumns, cookieStore, session] = await Promise.all([
     getTranslations("App.Tasks"),
     getTranslations("App.Tasks.Columns"),
@@ -40,6 +54,11 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
   const defaultViewMode =
     parseTasksViewMode(cookieStore.get(TASKS_VIEW_MODE_COOKIE_NAME)?.value) ??
     "board";
+  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
+  const filters = parseTasksFilters(
+    { scope, coworkerId, status },
+    activeOrganizationId,
+  );
 
   const [taskCoworkers, agents, jobsPage] = await Promise.all([
     coworkerService.listCoworkers("tasks"),
@@ -47,19 +66,30 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
     userService.listMyJobsForActiveContextPaginated({ limit: 20, session }),
   ]);
 
-  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
-
   const coworkersById = new Map(
     taskCoworkers.map((coworker) => [coworker.id, coworker]),
   );
   const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
   const agentNameById = buildAgentNameById(agents);
+  const validCoworkerIds = new Set(
+    taskCoworkers.map((coworker) => coworker.id),
+  );
+  const activeFilters = {
+    ...filters,
+    coworkerId:
+      filters.coworkerId && validCoworkerIds.has(filters.coworkerId)
+        ? filters.coworkerId
+        : null,
+  };
   const columnPages = await Promise.all(
     KANBAN_COLUMNS.map(async (column) => {
       const page = await getTasksColumnPage({
         columnId: column.id,
         cursor: null,
         limit: TASKS_COLUMN_PAGE_LIMIT,
+        scope: activeFilters.scope,
+        coworkerId: activeFilters.coworkerId,
+        status: activeFilters.status,
         coworkersById,
         agentsById,
       });
@@ -114,6 +144,7 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
         agentNameById={agentNameById}
         userId={session?.user.id ?? null}
         activeOrganizationId={activeOrganizationId}
+        initialFilters={activeFilters}
         defaultViewMode={defaultViewMode}
         initialCreateTaskOpen={initialCreateTaskOpen}
         initialCoworkerId={initialCoworkerId}
@@ -122,6 +153,43 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
           tabs: {
             tasks: t("Tabs.tasks"),
             jobs: t("Tabs.jobs"),
+          },
+          filters: {
+            title: t("Filters.title"),
+            searchPlaceholder: t("Filters.searchPlaceholder"),
+            emptyResults: t("Filters.emptyResults"),
+            all: t("Filters.all"),
+            scopeLabel: t("Filters.scopeLabel"),
+            scopeOwned: t("Filters.scopeOwned"),
+            scopeWorkspace: t("Filters.scopeWorkspace"),
+            coworkerLabel: t("Filters.coworkerLabel"),
+            statusLabel: t("Filters.statusLabel"),
+            statusOptions: {
+              [TaskStatus.DRAFT]: t("Filters.statusOptions.DRAFT"),
+              [TaskStatus.READY]: t("Filters.statusOptions.READY"),
+              [TaskStatus.INPUT_REQUIRED]: t(
+                "Filters.statusOptions.INPUT_REQUIRED",
+              ),
+              [TaskStatus.AUTHENTICATION_REQUIRED]: t(
+                "Filters.statusOptions.AUTHENTICATION_REQUIRED",
+              ),
+              [TaskStatus.OUT_OF_CREDITS]: t(
+                "Filters.statusOptions.OUT_OF_CREDITS",
+              ),
+              [TaskStatus.CREDITS_TOPPED_UP]: t(
+                "Filters.statusOptions.CREDITS_TOPPED_UP",
+              ),
+              [TaskStatus.RUNNING]: t("Filters.statusOptions.RUNNING"),
+              [TaskStatus.AWAITING_EXTERNAL]: t(
+                "Filters.statusOptions.AWAITING_EXTERNAL",
+              ),
+              [TaskStatus.COMPLETED]: t("Filters.statusOptions.COMPLETED"),
+              [TaskStatus.FAILED]: t("Filters.statusOptions.FAILED"),
+              [TaskStatus.CANCEL_REQUESTED]: t(
+                "Filters.statusOptions.CANCEL_REQUESTED",
+              ),
+              [TaskStatus.CANCELED]: t("Filters.statusOptions.CANCELED"),
+            },
           },
           columns: columnLabels,
           add: t("Actions.add"),

--- a/apps/web/src/app/(app)/tasks/(root)/page.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/page.tsx
@@ -27,9 +27,9 @@ interface TasksPageProps {
   searchParams: Promise<{
     create?: string;
     coworker?: string;
-    scope?: string;
-    coworkerId?: string;
-    status?: string;
+    scope?: string | string[];
+    coworkerId?: string | string[];
+    status?: string | string[];
   }>;
 }
 

--- a/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
@@ -267,6 +267,8 @@ async function TaskDetailActionsSlot({
     agentNameById,
     coworkerOptions,
   } = buildTaskDetailContext(task, coworkers, agents);
+  const isReadOnlyWorkspaceView =
+    task.workspace.organizationId !== null && session?.user.id !== task.userId;
   const personalWorkspaceMoveLabel =
     session?.user?.name?.trim() ||
     session?.user?.email?.trim() ||
@@ -285,6 +287,7 @@ async function TaskDetailActionsSlot({
       currentOrganizationId={task.workspace.organizationId ?? null}
       organizations={members}
       personalWorkspaceLabel={personalWorkspaceMoveLabel}
+      isReadOnly={isReadOnlyWorkspaceView}
       actionsMenuLabel={tMembersTableHeader("actions")}
       labels={{
         edit: t("actions.edit"),
@@ -357,6 +360,8 @@ async function TaskActivitySectionContent({
   ]);
   const { agentNameById } = buildTaskDetailContext(task, coworkers, agents);
   const isFreePlan = currentPlan === "free";
+  const isReadOnlyWorkspaceView =
+    task.workspace.organizationId !== null && session?.user.id !== task.userId;
   const currentUser = session?.user
     ? {
         id: session.user.id,
@@ -395,6 +400,7 @@ async function TaskActivitySectionContent({
       expandLabel={t("expand")}
       collapseLabel={t("collapse")}
       isFreePlan={isFreePlan}
+      canComment={!isReadOnlyWorkspaceView}
     />
   );
 }

--- a/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
@@ -78,4 +78,27 @@ describe("loadMoreTasksColumn", () => {
       nextCursor: "next-column-cursor",
     });
   });
+
+  it("ignores coworkerId that is not in the current tasks coworker list", async () => {
+    const coworker = { id: "coworker-1", name: "Coworker" };
+    listCoworkersMock.mockResolvedValue([coworker]);
+    getAvailableAgentsWithCreditsPriceMock.mockResolvedValue([]);
+    getTasksColumnPageMock.mockResolvedValue({
+      tasks: [],
+      nextCursor: null,
+    });
+
+    await loadMoreTasksColumn({
+      columnId: "todo",
+      cursor: null,
+      scope: "owned",
+      coworkerId: "removed-coworker",
+      status: null,
+    });
+
+    expect(getTasksColumnPageMock).toHaveBeenCalledTimes(1);
+    expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
+      coworkerId: null,
+    });
+  });
 });

--- a/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
@@ -1,3 +1,4 @@
+import { TaskStatus } from "@sokosumi/database";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const listCoworkersMock = vi.fn();
@@ -153,6 +154,48 @@ describe("loadMoreTasksColumn", () => {
 
     expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
       scope: "owned",
+    });
+  });
+
+  it("ignores status that is not a valid TaskStatus value", async () => {
+    listCoworkersMock.mockResolvedValue([]);
+    getAvailableAgentsWithCreditsPriceMock.mockResolvedValue([]);
+    getTasksColumnPageMock.mockResolvedValue({
+      tasks: [],
+      nextCursor: null,
+    });
+
+    await loadMoreTasksColumn({
+      columnId: "todo",
+      cursor: null,
+      scope: "owned",
+      coworkerId: null,
+      status: "malicious" as never,
+    });
+
+    expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
+      status: null,
+    });
+  });
+
+  it("passes through a valid TaskStatus string", async () => {
+    listCoworkersMock.mockResolvedValue([]);
+    getAvailableAgentsWithCreditsPriceMock.mockResolvedValue([]);
+    getTasksColumnPageMock.mockResolvedValue({
+      tasks: [],
+      nextCursor: null,
+    });
+
+    await loadMoreTasksColumn({
+      columnId: "todo",
+      cursor: null,
+      scope: "owned",
+      coworkerId: null,
+      status: TaskStatus.READY,
+    });
+
+    expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
+      status: TaskStatus.READY,
     });
   });
 });

--- a/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
@@ -27,11 +27,20 @@ vi.mock("../utils/tasks-column-page", () => ({
   getTasksColumnPage: (...args: unknown[]) => getTasksColumnPageMock(...args),
 }));
 
+const getSessionMock = vi.fn();
+
+vi.mock("@/lib/auth/utils", () => ({
+  getSession: (...args: unknown[]) => getSessionMock(...args),
+}));
+
 import { loadMoreTasksColumn } from "../actions";
 
 describe("loadMoreTasksColumn", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({
+      session: { activeOrganizationId: "org-1" },
+    });
   });
 
   it("loads one column page and returns mapped cursor result", async () => {
@@ -99,6 +108,51 @@ describe("loadMoreTasksColumn", () => {
     expect(getTasksColumnPageMock).toHaveBeenCalledTimes(1);
     expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
       coworkerId: null,
+    });
+  });
+
+  it("falls back to default scope when scope is not a valid TasksScope value", async () => {
+    listCoworkersMock.mockResolvedValue([]);
+    getAvailableAgentsWithCreditsPriceMock.mockResolvedValue([]);
+    getTasksColumnPageMock.mockResolvedValue({
+      tasks: [],
+      nextCursor: null,
+    });
+
+    await loadMoreTasksColumn({
+      columnId: "todo",
+      cursor: null,
+      scope: "malicious" as never,
+      coworkerId: null,
+      status: null,
+    });
+
+    expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
+      scope: "workspace",
+    });
+  });
+
+  it("rejects workspace scope when there is no active organization", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { activeOrganizationId: null },
+    });
+    listCoworkersMock.mockResolvedValue([]);
+    getAvailableAgentsWithCreditsPriceMock.mockResolvedValue([]);
+    getTasksColumnPageMock.mockResolvedValue({
+      tasks: [],
+      nextCursor: null,
+    });
+
+    await loadMoreTasksColumn({
+      columnId: "todo",
+      cursor: null,
+      scope: "workspace",
+      coworkerId: null,
+      status: null,
+    });
+
+    expect(getTasksColumnPageMock.mock.calls[0][0]).toMatchObject({
+      scope: "owned",
     });
   });
 });

--- a/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
@@ -54,6 +54,9 @@ describe("loadMoreTasksColumn", () => {
     const result = await loadMoreTasksColumn({
       columnId: "todo",
       cursor: "current-column-cursor",
+      scope: "workspace",
+      coworkerId: "coworker-1",
+      status: null,
     });
 
     expect(getTasksColumnPageMock).toHaveBeenCalledTimes(1);
@@ -62,6 +65,9 @@ describe("loadMoreTasksColumn", () => {
       columnId: "todo",
       cursor: "current-column-cursor",
       limit: 20,
+      scope: "workspace",
+      coworkerId: "coworker-1",
+      status: null,
     });
     expect(callArg.coworkersById).toBeInstanceOf(Map);
     expect(callArg.agentsById).toBeInstanceOf(Map);

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -1,10 +1,9 @@
 "use server";
 
-import type { TaskStatus } from "@sokosumi/database";
-
 import { mapJobsToTasksViewData } from "@/app/tasks/utils/jobs-view-data";
 import {
   sanitizeTasksScopeInput,
+  sanitizeTasksStatusInput,
   type TasksScope,
 } from "@/app/tasks/utils/tasks-filters";
 import { TASKS_COLUMN_PAGE_LIMIT } from "@/app/tasks/utils/tasks-pagination";
@@ -21,7 +20,8 @@ interface LoadMoreTasksColumnParams {
   cursor: string | null;
   scope: TasksScope;
   coworkerId: string | null;
-  status: TaskStatus | null;
+  /** Untrusted client input; normalized before use. */
+  status: unknown;
 }
 
 export async function loadMoreTasksColumn({
@@ -46,13 +46,14 @@ export async function loadMoreTasksColumn({
   const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
   const sanitizedCoworkerId =
     coworkerId && coworkersById.has(coworkerId) ? coworkerId : null;
+  const sanitizedStatus = sanitizeTasksStatusInput(status);
   const page = await getTasksColumnPage({
     columnId,
     cursor,
     limit: TASKS_COLUMN_PAGE_LIMIT,
     scope: sanitizedScope,
     coworkerId: sanitizedCoworkerId,
-    status,
+    status: sanitizedStatus,
     coworkersById,
     agentsById,
   });

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -13,8 +13,8 @@ import { coworkerService } from "@/lib/services/coworker.service";
 import { userService } from "@/lib/services/user.service";
 import type { KanbanColumnId } from "@/lib/types/task";
 
-import { getTasksColumnPage } from "./utils/tasks-column-page";
 import { TaskStatus } from "./components/task-detail-api-types";
+import { getTasksColumnPage } from "./utils/tasks-column-page";
 
 interface LoadMoreTasksColumnParams {
   columnId: KanbanColumnId;

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -1,6 +1,9 @@
 "use server";
 
+import type { TaskStatus } from "@sokosumi/database";
+
 import { mapJobsToTasksViewData } from "@/app/tasks/utils/jobs-view-data";
+import type { TasksScope } from "@/app/tasks/utils/tasks-filters";
 import { TASKS_COLUMN_PAGE_LIMIT } from "@/app/tasks/utils/tasks-pagination";
 import { agentService } from "@/lib/services/agent.service";
 import { coworkerService } from "@/lib/services/coworker.service";
@@ -12,14 +15,20 @@ import { getTasksColumnPage } from "./utils/tasks-column-page";
 interface LoadMoreTasksColumnParams {
   columnId: KanbanColumnId;
   cursor: string | null;
+  scope: TasksScope;
+  coworkerId: string | null;
+  status: TaskStatus | null;
 }
 
 export async function loadMoreTasksColumn({
   columnId,
   cursor,
+  scope,
+  coworkerId,
+  status,
 }: LoadMoreTasksColumnParams) {
   const [coworkers, agents] = await Promise.all([
-    coworkerService.listCoworkers(),
+    coworkerService.listCoworkers("tasks"),
     agentService.getAvailableAgentsWithCreditsPrice(),
   ]);
 
@@ -31,6 +40,9 @@ export async function loadMoreTasksColumn({
     columnId,
     cursor,
     limit: TASKS_COLUMN_PAGE_LIMIT,
+    scope,
+    coworkerId,
+    status,
     coworkersById,
     agentsById,
   });

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -8,12 +8,12 @@ import {
 } from "@/app/tasks/utils/tasks-filters";
 import { TASKS_COLUMN_PAGE_LIMIT } from "@/app/tasks/utils/tasks-pagination";
 import { getSession } from "@/lib/auth/utils";
+import type { Task } from "@/lib/clients/generated/core";
 import { agentService } from "@/lib/services/agent.service";
 import { coworkerService } from "@/lib/services/coworker.service";
 import { userService } from "@/lib/services/user.service";
 import type { KanbanColumnId } from "@/lib/types/task";
 
-import { TaskStatus } from "./components/task-detail-api-types";
 import { getTasksColumnPage } from "./utils/tasks-column-page";
 
 interface LoadMoreTasksColumnParams {
@@ -21,7 +21,7 @@ interface LoadMoreTasksColumnParams {
   cursor: string | null;
   scope: TasksScope | null;
   coworkerId: string | null;
-  status: TaskStatus | null;
+  status: Task["status"] | null;
 }
 
 export async function loadMoreTasksColumn({

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -36,12 +36,14 @@ export async function loadMoreTasksColumn({
     coworkers.map((coworker) => [coworker.id, coworker]),
   );
   const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
+  const sanitizedCoworkerId =
+    coworkerId && coworkersById.has(coworkerId) ? coworkerId : null;
   const page = await getTasksColumnPage({
     columnId,
     cursor,
     limit: TASKS_COLUMN_PAGE_LIMIT,
     scope,
-    coworkerId,
+    coworkerId: sanitizedCoworkerId,
     status,
     coworkersById,
     agentsById,

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -3,8 +3,12 @@
 import type { TaskStatus } from "@sokosumi/database";
 
 import { mapJobsToTasksViewData } from "@/app/tasks/utils/jobs-view-data";
-import type { TasksScope } from "@/app/tasks/utils/tasks-filters";
+import {
+  sanitizeTasksScopeInput,
+  type TasksScope,
+} from "@/app/tasks/utils/tasks-filters";
 import { TASKS_COLUMN_PAGE_LIMIT } from "@/app/tasks/utils/tasks-pagination";
+import { getSession } from "@/lib/auth/utils";
 import { agentService } from "@/lib/services/agent.service";
 import { coworkerService } from "@/lib/services/coworker.service";
 import { userService } from "@/lib/services/user.service";
@@ -27,10 +31,14 @@ export async function loadMoreTasksColumn({
   coworkerId,
   status,
 }: LoadMoreTasksColumnParams) {
-  const [coworkers, agents] = await Promise.all([
+  const [session, coworkers, agents] = await Promise.all([
+    getSession(),
     coworkerService.listCoworkers("tasks"),
     agentService.getAvailableAgentsWithCreditsPrice(),
   ]);
+
+  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
+  const sanitizedScope = sanitizeTasksScopeInput(scope, activeOrganizationId);
 
   const coworkersById = new Map(
     coworkers.map((coworker) => [coworker.id, coworker]),
@@ -42,7 +50,7 @@ export async function loadMoreTasksColumn({
     columnId,
     cursor,
     limit: TASKS_COLUMN_PAGE_LIMIT,
-    scope,
+    scope: sanitizedScope,
     coworkerId: sanitizedCoworkerId,
     status,
     coworkersById,

--- a/apps/web/src/app/(app)/tasks/actions.ts
+++ b/apps/web/src/app/(app)/tasks/actions.ts
@@ -4,7 +4,7 @@ import { mapJobsToTasksViewData } from "@/app/tasks/utils/jobs-view-data";
 import {
   sanitizeTasksScopeInput,
   sanitizeTasksStatusInput,
-  type TasksScope,
+  TasksScope,
 } from "@/app/tasks/utils/tasks-filters";
 import { TASKS_COLUMN_PAGE_LIMIT } from "@/app/tasks/utils/tasks-pagination";
 import { getSession } from "@/lib/auth/utils";
@@ -14,14 +14,14 @@ import { userService } from "@/lib/services/user.service";
 import type { KanbanColumnId } from "@/lib/types/task";
 
 import { getTasksColumnPage } from "./utils/tasks-column-page";
+import { TaskStatus } from "./components/task-detail-api-types";
 
 interface LoadMoreTasksColumnParams {
   columnId: KanbanColumnId;
   cursor: string | null;
-  scope: TasksScope;
+  scope: TasksScope | null;
   coworkerId: string | null;
-  /** Untrusted client input; normalized before use. */
-  status: unknown;
+  status: TaskStatus | null;
 }
 
 export async function loadMoreTasksColumn({

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
@@ -163,6 +163,7 @@ const baseProps = {
     name: "User",
     image: null,
   },
+  canComment: true,
 };
 
 describe("TaskActivitySection", () => {
@@ -189,6 +190,17 @@ describe("TaskActivitySection", () => {
 
     return render(renderToast("task-upload-toast"));
   }
+
+  it("hides the composer in read-only mode", () => {
+    render(<TaskActivitySection {...baseProps} canComment={false} />);
+
+    expect(
+      screen.queryByPlaceholderText("Write a comment..."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Submit" }),
+    ).not.toBeInTheDocument();
+  });
 
   it("does not show auth button when latest status is not AUTHENTICATION_REQUIRED", () => {
     const events: TaskEvent[] = [

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -549,6 +549,7 @@ function renderActions(
       labels={labels}
       organizations={sampleOrganizations}
       personalWorkspaceLabel={personalWorkspaceLabel}
+      isReadOnly={false}
       {...props}
     />,
   );
@@ -579,6 +580,19 @@ describe("TaskDetailActions", () => {
       screen.queryByRole("button", { name: actionsMenuLabel }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: labels.share })).toBeVisible();
+  });
+
+  it("hides share and overflow actions in read-only workspace mode", () => {
+    renderActions({
+      isReadOnly: true,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: labels.share }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: actionsMenuLabel }),
+    ).not.toBeInTheDocument();
   });
 
   it("disables the actions trigger while a status update is pending", async () => {

--- a/apps/web/src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx
@@ -1,0 +1,104 @@
+import { TaskStatus } from "@sokosumi/database";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const filterDropdownMenuMock = vi.fn();
+
+vi.mock("@/components/common/filter-dropdown-menu", () => ({
+  FilterDropdownMenu: (props: unknown) => {
+    filterDropdownMenuMock(props);
+    return <div data-testid="filter-dropdown-menu" />;
+  },
+}));
+
+import { TasksViewFilters } from "../tasks-view-filters";
+
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/tasks",
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const labels = {
+  title: "Filters",
+  searchPlaceholder: "Filter...",
+  emptyResults: "No results found.",
+  all: "All",
+  scopeLabel: "Scope",
+  scopeOwned: "My tasks",
+  scopeWorkspace: "Workspace",
+  coworkerLabel: "Coworker",
+  statusLabel: "Status",
+  statusOptions: {
+    [TaskStatus.DRAFT]: "Draft",
+    [TaskStatus.READY]: "Ready",
+    [TaskStatus.INPUT_REQUIRED]: "Input required",
+    [TaskStatus.AUTHENTICATION_REQUIRED]: "Authentication required",
+    [TaskStatus.OUT_OF_CREDITS]: "Out of credits",
+    [TaskStatus.CREDITS_TOPPED_UP]: "Credits topped up",
+    [TaskStatus.RUNNING]: "Running",
+    [TaskStatus.AWAITING_EXTERNAL]: "Awaiting external",
+    [TaskStatus.COMPLETED]: "Completed",
+    [TaskStatus.FAILED]: "Failed",
+    [TaskStatus.CANCEL_REQUESTED]: "Cancel requested",
+    [TaskStatus.CANCELED]: "Canceled",
+  },
+} as const;
+
+function renderTasksViewFilters(activeOrganizationId: string | null) {
+  render(
+    <TasksViewFilters
+      filters={{
+        scope: activeOrganizationId ? "workspace" : "owned",
+        coworkerId: null,
+        status: null,
+      }}
+      activeOrganizationId={activeOrganizationId}
+      coworkerOptions={[
+        {
+          id: "coworker-1",
+          slug: "elena",
+          name: "Elena",
+          image: "elena.png",
+        },
+      ]}
+      labels={labels}
+    />,
+  );
+
+  return filterDropdownMenuMock.mock.calls.at(-1)?.[0] as {
+    buttonLabel: string;
+    sections: Array<{ id: string; label: string }>;
+  };
+}
+
+describe("TasksViewFilters", () => {
+  beforeEach(() => {
+    filterDropdownMenuMock.mockClear();
+    replaceMock.mockClear();
+  });
+
+  it("shows scope and coworker sections in workspace context", () => {
+    const props = renderTasksViewFilters("org-1");
+
+    expect(props.buttonLabel).toBe("Filters");
+    expect(props.sections.map((section) => section.id)).toEqual([
+      "scope",
+      "coworker",
+      "status",
+    ]);
+  });
+
+  it("only shows coworker and status sections in personal context", () => {
+    const props = renderTasksViewFilters(null);
+
+    expect(props.sections.map((section) => section.id)).toEqual([
+      "coworker",
+      "status",
+    ]);
+  });
+});

--- a/apps/web/src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx
@@ -52,11 +52,6 @@ const labels = {
 function renderTasksViewFilters(activeOrganizationId: string | null) {
   render(
     <TasksViewFilters
-      filters={{
-        scope: activeOrganizationId ? "workspace" : "owned",
-        coworkerId: null,
-        status: null,
-      }}
       activeOrganizationId={activeOrganizationId}
       coworkerOptions={[
         {

--- a/apps/web/src/app/(app)/tasks/components/create-task-modal.tsx
+++ b/apps/web/src/app/(app)/tasks/components/create-task-modal.tsx
@@ -99,7 +99,10 @@ export function CreateTaskModal({
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     if (params.has("create") || params.has("coworker")) {
-      router.replace(pathname);
+      params.delete("create");
+      params.delete("coworker");
+      const nextQuery = params.toString();
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
     }
   }, [pathname, router]);
 

--- a/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
+++ b/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
@@ -21,6 +21,7 @@ interface KanbanBoardProps {
   };
   columnFooterById?: Partial<Record<KanbanColumnId, React.ReactNode>>;
   isDragEnabled?: boolean;
+  canDragTask?: (task: TaskWithCoworker) => boolean;
 }
 
 export function KanbanBoard({
@@ -29,6 +30,7 @@ export function KanbanBoard({
   labels,
   columnFooterById,
   isDragEnabled = true,
+  canDragTask = () => true,
 }: KanbanBoardProps) {
   return (
     <div className="-mx-2 flex h-full min-h-[calc(100svh-8.5rem)] flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4">
@@ -61,7 +63,7 @@ export function KanbanBoard({
             emptyLabel={labels.emptyColumn}
             footer={footer}
             renderTask={(task) =>
-              isDraggableColumn ? (
+              isDraggableColumn && canDragTask(task) ? (
                 <DraggableTask
                   key={task.id}
                   id={task.id}

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -84,6 +84,7 @@ interface TaskActivityProps {
   expandLabel?: string;
   collapseLabel?: string;
   isFreePlan?: boolean;
+  canComment?: boolean;
 }
 
 function getEventTimestamp(event: TaskEvent): number {
@@ -142,6 +143,7 @@ export function TaskActivitySection({
   expandLabel = "Expand",
   collapseLabel = "Show less",
   isFreePlan = true,
+  canComment = true,
 }: TaskActivityProps) {
   const t = useTranslations("App.Tasks.Detail");
   const { formatTimeAgo } = useLocalizedDateTime();
@@ -191,6 +193,7 @@ export function TaskActivitySection({
   const trimmedComment = comment.trim();
   const isUploadingAttachments = uploadingAttachmentsCount > 0;
   const isSubmitDisabled =
+    !canComment ||
     isPending ||
     trimmedComment.length === 0 ||
     !currentUser?.id ||
@@ -295,90 +298,92 @@ export function TaskActivitySection({
     <section className="space-y-4">
       <h2 className="text-muted-foreground/60 text-xs font-medium">{title}</h2>
 
-      <form
-        ref={formRef}
-        onSubmit={handleSubmit}
-        className="border-border/50 rounded-lg border p-3"
-      >
-        <FileUpload
-          value={pendingUploadFiles}
-          onValueChange={setPendingUploadFiles}
-          onAccept={(files) => {
-            void handleAttachFiles(files);
-          }}
-          multiple
+      {canComment ? (
+        <form
+          ref={formRef}
+          onSubmit={handleSubmit}
+          className="border-border/50 rounded-lg border p-3"
         >
-          <FileUploadDropzone
-            className="data-dragging:bg-accent/20 w-full items-stretch justify-start border-0 p-0 hover:bg-transparent"
-            onClick={(event) => event.preventDefault()}
+          <FileUpload
+            value={pendingUploadFiles}
+            onValueChange={setPendingUploadFiles}
+            onAccept={(files) => {
+              void handleAttachFiles(files);
+            }}
+            multiple
           >
-            <MarkdownEditor
-              ref={markdownEditorRef}
-              placeholder={placeholder}
-              className="border-border/50 bg-muted-foreground/5 w-full rounded-lg border"
-              value={comment}
-              onChange={setComment}
-              onSubmitShortcut={() => formRef.current?.requestSubmit()}
-              onAttachClick={() => attachmentTriggerRef.current?.click()}
-              attachLabel={_attachLabel}
-              isAttachmentUploading={isUploadingAttachments}
-              mentions={mentionOptions}
-            />
-            <FileUploadTrigger asChild>
-              <button
-                ref={attachmentTriggerRef}
-                type="button"
-                className="sr-only"
-                aria-label={_attachLabel}
-              >
-                {_attachLabel}
-              </button>
-            </FileUploadTrigger>
-          </FileUploadDropzone>
-        </FileUpload>
-        {attachmentUrls.length > 0 ? (
-          <div className="mt-2 flex flex-wrap gap-3">
-            {attachmentUrls.map((url) => (
-              <FileChipMiniPreviewWithMetadata
-                key={url}
-                url={url}
-                onRemove={() =>
-                  setComment((prev) => removeTaskAttachmentLinks(prev, [url]))
-                }
-                removeLabel={t("removeAttachment")}
+            <FileUploadDropzone
+              className="data-dragging:bg-accent/20 w-full items-stretch justify-start border-0 p-0 hover:bg-transparent"
+              onClick={(event) => event.preventDefault()}
+            >
+              <MarkdownEditor
+                ref={markdownEditorRef}
+                placeholder={placeholder}
+                className="border-border/50 bg-muted-foreground/5 w-full rounded-lg border"
+                value={comment}
+                onChange={setComment}
+                onSubmitShortcut={() => formRef.current?.requestSubmit()}
+                onAttachClick={() => attachmentTriggerRef.current?.click()}
+                attachLabel={_attachLabel}
+                isAttachmentUploading={isUploadingAttachments}
+                mentions={mentionOptions}
               />
-            ))}
-          </div>
-        ) : null}
-        <div className="mt-2 flex items-center gap-3">
-          {!isMobile ? (
-            <div className="text-muted-foreground flex items-center gap-2 text-xs">
-              <span>{t("sendWith")}</span>
-              <div className="flex items-center gap-0.5 opacity-60">
-                {os === "MacOS" ? (
-                  <Command className="size-3" aria-hidden />
-                ) : (
-                  <span className="text-xs">{t("ctrl")}</span>
-                )}
-                <CornerDownLeft className="size-3" aria-hidden />
-              </div>
+              <FileUploadTrigger asChild>
+                <button
+                  ref={attachmentTriggerRef}
+                  type="button"
+                  className="sr-only"
+                  aria-label={_attachLabel}
+                >
+                  {_attachLabel}
+                </button>
+              </FileUploadTrigger>
+            </FileUploadDropzone>
+          </FileUpload>
+          {attachmentUrls.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-3">
+              {attachmentUrls.map((url) => (
+                <FileChipMiniPreviewWithMetadata
+                  key={url}
+                  url={url}
+                  onRemove={() =>
+                    setComment((prev) => removeTaskAttachmentLinks(prev, [url]))
+                  }
+                  removeLabel={t("removeAttachment")}
+                />
+              ))}
             </div>
           ) : null}
-          <Button
-            size="icon"
-            className="ml-auto size-7 rounded-full"
-            aria-label={submitLabel}
-            type="submit"
-            disabled={isSubmitDisabled}
-          >
-            {isPending ? (
-              <Loader2 className="size-3.5 animate-spin" aria-hidden />
-            ) : (
-              <ArrowUp className="size-3.5" aria-hidden />
-            )}
-          </Button>
-        </div>
-      </form>
+          <div className="mt-2 flex items-center gap-3">
+            {!isMobile ? (
+              <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                <span>{t("sendWith")}</span>
+                <div className="flex items-center gap-0.5 opacity-60">
+                  {os === "MacOS" ? (
+                    <Command className="size-3" aria-hidden />
+                  ) : (
+                    <span className="text-xs">{t("ctrl")}</span>
+                  )}
+                  <CornerDownLeft className="size-3" aria-hidden />
+                </div>
+              </div>
+            ) : null}
+            <Button
+              size="icon"
+              className="ml-auto size-7 rounded-full"
+              aria-label={submitLabel}
+              type="submit"
+              disabled={isSubmitDisabled}
+            >
+              {isPending ? (
+                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              ) : (
+                <ArrowUp className="size-3.5" aria-hidden />
+              )}
+            </Button>
+          </div>
+        </form>
+      ) : null}
 
       {orderedEvents.length > 0 ? (
         <div className="space-y-3">

--- a/apps/web/src/app/(app)/tasks/components/task-card.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-card.tsx
@@ -22,6 +22,7 @@ export function TaskCard({ task, dragHandleProps }: TaskCardProps) {
     <div
       className={cn(
         "group",
+        dragHandleProps && "cursor-grab",
         dragHandleProps?.isDragging && "scale-[1.02] opacity-60",
       )}
       {...handleProps}

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -106,6 +106,7 @@ interface TaskDetailActionsProps {
   currentOrganizationId?: string | null;
   organizations?: MemberWithOrganization[];
   personalWorkspaceLabel: string;
+  isReadOnly?: boolean;
 }
 
 export function TaskDetailActions({
@@ -122,6 +123,7 @@ export function TaskDetailActions({
   currentOrganizationId,
   organizations,
   personalWorkspaceLabel,
+  isReadOnly = false,
 }: TaskDetailActionsProps) {
   const tApp = useTranslations("App");
   const tDetailActions = useTranslations("App.Tasks.Detail.actions");
@@ -161,17 +163,19 @@ export function TaskDetailActions({
     null,
   );
 
-  const statusActions = getTaskStatusActions(status, labels);
+  const statusActions = isReadOnly ? [] : getTaskStatusActions(status, labels);
 
   const canEditOrDelete =
-    status === TASK_STATUS.DRAFT || status === TASK_STATUS.READY;
+    !isReadOnly &&
+    (status === TASK_STATUS.DRAFT || status === TASK_STATUS.READY);
   const isFinalized =
     status === TASK_STATUS.COMPLETED ||
     status === TASK_STATUS.FAILED ||
     status === TASK_STATUS.CANCELED ||
     status === TASK_STATUS.CANCEL_REQUESTED;
-  const canManageRelations = !isFinalized;
+  const canManageRelations = !isReadOnly && !isFinalized;
   const canMove =
+    !isReadOnly &&
     !isFinalized &&
     getWorkspaceMoveTargetCount(currentOrganizationId, organizations) > 0;
   const parentLinks = useMemo(
@@ -366,13 +370,15 @@ export function TaskDetailActions({
 
   return (
     <div className="flex items-center gap-2">
-      <TaskShareButton
-        task={{ id: taskId, share }}
-        label={labels.share}
-        variant="ghost"
-        size="icon"
-        className="size-7"
-      />
+      {!isReadOnly ? (
+        <TaskShareButton
+          task={{ id: taskId, share }}
+          label={labels.share}
+          variant="ghost"
+          size="icon"
+          className="size-7"
+        />
+      ) : null}
       {hasOverflowMenuActions ? (
         <DropdownMenu
           open={isDropdownOpen}

--- a/apps/web/src/app/(app)/tasks/components/task-list-item.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-list-item.tsx
@@ -27,6 +27,7 @@ export function TaskListItem({
     <div
       className={cn(
         "group",
+        dragHandleProps && "cursor-grab",
         (dragHandleProps?.isDragging || isOverlay) && "opacity-60",
       )}
       {...handleProps}

--- a/apps/web/src/app/(app)/tasks/components/task-list-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-list-view.tsx
@@ -19,6 +19,7 @@ interface TaskListViewProps {
   };
   sectionFooterById?: Partial<Record<KanbanColumnId, React.ReactNode>>;
   isDragEnabled?: boolean;
+  canDragTask?: (task: TaskWithCoworker) => boolean;
 }
 
 export function TaskListView({
@@ -27,6 +28,7 @@ export function TaskListView({
   labels,
   sectionFooterById,
   isDragEnabled = true,
+  canDragTask = () => true,
 }: TaskListViewProps) {
   const orderedColumns = [...columns].reverse();
   const hasAnyTasks = tasks.length > 0;
@@ -50,7 +52,7 @@ export function TaskListView({
                 emptyLabel={labels.emptySection}
                 footer={sectionFooterById?.[column.id]}
                 renderTask={(task) =>
-                  isDraggableColumn ? (
+                  isDraggableColumn && canDragTask(task) ? (
                     <DraggableTask
                       key={task.id}
                       id={task.id}

--- a/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { TaskStatus } from "@sokosumi/database";
+import { Building2, CircleDashed, Sparkles } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import {
+  buildTasksFiltersSearchParams,
+  type TasksFilters,
+} from "@/app/tasks/utils/tasks-filters";
+import {
+  FilterDropdownMenu,
+  type FilterDropdownMenuSection,
+} from "@/components/common/filter-dropdown-menu";
+import type { CoworkerOption } from "@/lib/types/coworker";
+
+interface TasksViewFiltersProps {
+  filters: TasksFilters;
+  activeOrganizationId: string | null;
+  coworkerOptions: CoworkerOption[];
+  labels: {
+    title: string;
+    searchPlaceholder: string;
+    emptyResults: string;
+    all: string;
+    scopeLabel: string;
+    scopeOwned: string;
+    scopeWorkspace: string;
+    coworkerLabel: string;
+    statusLabel: string;
+    statusOptions: Record<TaskStatus, string>;
+  };
+}
+
+export function TasksViewFilters({
+  filters,
+  activeOrganizationId,
+  coworkerOptions,
+  labels,
+}: TasksViewFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const handleFilterChange = useCallback(
+    (nextFilters: TasksFilters) => {
+      const nextSearchParams = buildTasksFiltersSearchParams(
+        searchParams,
+        nextFilters,
+        activeOrganizationId,
+      );
+      const nextQuery = nextSearchParams.toString();
+
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
+    },
+    [activeOrganizationId, pathname, router, searchParams],
+  );
+
+  const sections = useMemo<FilterDropdownMenuSection[]>(() => {
+    const nextSections: FilterDropdownMenuSection[] = [];
+
+    if (activeOrganizationId !== null) {
+      nextSections.push({
+        id: "scope",
+        label: labels.scopeLabel,
+        icon: Building2,
+        value: filters.scope,
+        onChange: (scope) =>
+          handleFilterChange({
+            ...filters,
+            scope: (scope as TasksFilters["scope"]) ?? "workspace",
+          }),
+        options: [
+          {
+            value: "workspace",
+            label: labels.scopeWorkspace,
+          },
+          {
+            value: "owned",
+            label: labels.scopeOwned,
+          },
+        ],
+      });
+    }
+
+    nextSections.push({
+      id: "coworker",
+      label: labels.coworkerLabel,
+      icon: Sparkles,
+      value: filters.coworkerId,
+      allLabel: labels.all,
+      onChange: (coworkerId) =>
+        handleFilterChange({
+          ...filters,
+          coworkerId,
+        }),
+      options: coworkerOptions.map((coworker) => ({
+        value: coworker.id,
+        label: coworker.name,
+        avatarLabel: coworker.name,
+        image: coworker.image,
+        searchKeywords: [coworker.slug],
+      })),
+    });
+
+    nextSections.push({
+      id: "status",
+      label: labels.statusLabel,
+      icon: CircleDashed,
+      value: filters.status,
+      allLabel: labels.all,
+      onChange: (status) =>
+        handleFilterChange({
+          ...filters,
+          status: (status as TaskStatus | null) ?? null,
+        }),
+      options: Object.values(TaskStatus).map((status) => ({
+        value: status,
+        label: labels.statusOptions[status],
+      })),
+    });
+
+    return nextSections;
+  }, [
+    activeOrganizationId,
+    coworkerOptions,
+    filters,
+    handleFilterChange,
+    labels.all,
+    labels.coworkerLabel,
+    labels.scopeLabel,
+    labels.scopeOwned,
+    labels.scopeWorkspace,
+    labels.statusLabel,
+    labels.statusOptions,
+  ]);
+
+  return (
+    <FilterDropdownMenu
+      buttonLabel={labels.title}
+      searchPlaceholder={labels.searchPlaceholder}
+      emptyResultsLabel={labels.emptyResults}
+      sections={sections}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import {
   buildTasksFiltersSearchParams,
+  getTasksFiltersFromSearchParams,
   type TasksFilters,
 } from "@/app/tasks/utils/tasks-filters";
 import {
@@ -15,7 +16,6 @@ import {
 import type { CoworkerOption } from "@/lib/types/coworker";
 
 interface TasksViewFiltersProps {
-  filters: TasksFilters;
   activeOrganizationId: string | null;
   coworkerOptions: CoworkerOption[];
   labels: {
@@ -33,7 +33,6 @@ interface TasksViewFiltersProps {
 }
 
 export function TasksViewFilters({
-  filters,
   activeOrganizationId,
   coworkerOptions,
   labels,
@@ -42,10 +41,31 @@ export function TasksViewFilters({
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const handleFilterChange = useCallback(
-    (nextFilters: TasksFilters) => {
-      const nextSearchParams = buildTasksFiltersSearchParams(
+  const filters = useMemo(
+    () =>
+      getTasksFiltersFromSearchParams(
         searchParams,
+        activeOrganizationId,
+        coworkerOptions,
+      ),
+    [activeOrganizationId, coworkerOptions, searchParams],
+  );
+
+  const handleFilterChange = useCallback(
+    (patch: Partial<TasksFilters>) => {
+      const paramsForMerge = new URLSearchParams(
+        typeof window !== "undefined"
+          ? window.location.search
+          : searchParams.toString(),
+      );
+      const current = getTasksFiltersFromSearchParams(
+        paramsForMerge,
+        activeOrganizationId,
+        coworkerOptions,
+      );
+      const nextFilters: TasksFilters = { ...current, ...patch };
+      const nextSearchParams = buildTasksFiltersSearchParams(
+        paramsForMerge,
         nextFilters,
         activeOrganizationId,
       );
@@ -53,7 +73,7 @@ export function TasksViewFilters({
 
       router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
     },
-    [activeOrganizationId, pathname, router, searchParams],
+    [activeOrganizationId, coworkerOptions, pathname, router, searchParams],
   );
 
   const sections = useMemo<FilterDropdownMenuSection[]>(() => {
@@ -67,7 +87,6 @@ export function TasksViewFilters({
         value: filters.scope,
         onChange: (scope) =>
           handleFilterChange({
-            ...filters,
             scope: (scope as TasksFilters["scope"]) ?? "workspace",
           }),
         options: [
@@ -91,7 +110,6 @@ export function TasksViewFilters({
       allLabel: labels.all,
       onChange: (coworkerId) =>
         handleFilterChange({
-          ...filters,
           coworkerId,
         }),
       options: coworkerOptions.map((coworker) => ({
@@ -111,7 +129,6 @@ export function TasksViewFilters({
       allLabel: labels.all,
       onChange: (status) =>
         handleFilterChange({
-          ...filters,
           status: (status as TaskStatus | null) ?? null,
         }),
       options: Object.values(TaskStatus).map((status) => ({

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -12,7 +12,7 @@ import {
 import { SokosumiJobStatus, TaskStatus } from "@sokosumi/database";
 import { ChannelProvider, useChannel } from "ably/react";
 import { CircleHelp, Plus } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -28,6 +28,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { loadMoreJobs, loadMoreTasksColumn } from "@/app/tasks/actions";
 import { TASKS_ROUTE_REFRESH_DEBOUNCE_MS } from "@/app/tasks/constants";
 import {
+  getTasksFiltersFromSearchParams,
   getTasksFiltersResetKey,
   isTaskOwnerEditable,
   type TasksFilters,
@@ -281,6 +282,16 @@ export function TasksView({
   labels,
 }: TasksViewProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const routeFilters = useMemo(
+    () =>
+      getTasksFiltersFromSearchParams(
+        searchParams,
+        activeOrganizationId,
+        coworkerOptions,
+      ),
+    [activeOrganizationId, coworkerOptions, searchParams],
+  );
   const [viewMode, setViewMode] = useState<TasksViewMode>(
     defaultViewMode ?? "board",
   );
@@ -586,9 +597,9 @@ export function TasksView({
         const result = await loadMoreTasksColumn({
           columnId,
           cursor,
-          scope: initialFilters.scope,
-          coworkerId: initialFilters.coworkerId,
-          status: initialFilters.status,
+          scope: routeFilters.scope,
+          coworkerId: routeFilters.coworkerId,
+          status: routeFilters.status,
         });
         setItems((prev) => appendUniqueTasks(prev, result.tasks));
         const nextCursor = result.nextCursor;
@@ -618,10 +629,10 @@ export function TasksView({
       }
     },
     [
-      initialFilters.coworkerId,
-      initialFilters.scope,
-      initialFilters.status,
       labels.loadMoreError,
+      routeFilters.coworkerId,
+      routeFilters.scope,
+      routeFilters.status,
     ],
   );
 
@@ -809,7 +820,6 @@ export function TasksView({
           ) : null}
           {activeTab === "tasks" ? (
             <TasksViewFilters
-              filters={initialFilters}
               activeOrganizationId={activeOrganizationId}
               coworkerOptions={coworkerOptions}
               labels={labels.filters}
@@ -868,7 +878,7 @@ export function TasksView({
                       isTaskOwnerEditable(
                         task,
                         userId,
-                        initialFilters,
+                        routeFilters,
                         activeOrganizationId,
                       )
                     }
@@ -887,7 +897,7 @@ export function TasksView({
                       isTaskOwnerEditable(
                         task,
                         userId,
-                        initialFilters,
+                        routeFilters,
                         activeOrganizationId,
                       )
                     }

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -9,7 +9,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/database";
 import { ChannelProvider, useChannel } from "ably/react";
 import { CircleHelp, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -27,6 +27,11 @@ import { useDebouncedCallback } from "use-debounce";
 
 import { loadMoreJobs, loadMoreTasksColumn } from "@/app/tasks/actions";
 import { TASKS_ROUTE_REFRESH_DEBOUNCE_MS } from "@/app/tasks/constants";
+import {
+  getTasksFiltersResetKey,
+  isTaskOwnerEditable,
+  type TasksFilters,
+} from "@/app/tasks/utils/tasks-filters";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DynamicAblyProvider from "@/contexts/alby-provider.dynamic";
@@ -50,7 +55,6 @@ import {
   type TasksViewMode,
 } from "@/lib/ui-preferences/tasks-view-mode";
 import { cn } from "@/lib/utils";
-
 import {
   CreateTaskModal,
   CreateTaskModalProvider,
@@ -68,6 +72,7 @@ import { TaskListItem } from "./task-list-item";
 import { TaskListView } from "./task-list-view";
 import { shouldShowTasksEmptyStateOverlay } from "./tasks-empty-state";
 import { TasksEmptyStateOverlay } from "./tasks-empty-state-overlay";
+import { TasksViewFilters } from "./tasks-view-filters";
 import { ViewModeSwitch } from "./view-mode-switch";
 
 function HeaderAddButton({ label }: { label: string }) {
@@ -190,6 +195,7 @@ interface TasksViewProps {
   agentNameById: Map<string, string>;
   userId?: string | null;
   activeOrganizationId: string | null;
+  initialFilters: TasksFilters;
   defaultViewMode?: TasksViewMode;
   initialCreateTaskOpen?: boolean;
   initialCoworkerId?: string | null;
@@ -198,6 +204,18 @@ interface TasksViewProps {
     tabs: {
       tasks: string;
       jobs: string;
+    };
+    filters: {
+      title: string;
+      searchPlaceholder: string;
+      emptyResults: string;
+      all: string;
+      scopeLabel: string;
+      scopeOwned: string;
+      scopeWorkspace: string;
+      coworkerLabel: string;
+      statusLabel: string;
+      statusOptions: Record<TaskStatus, string>;
     };
     columns: Record<KanbanColumnId, string>;
     add: string;
@@ -255,6 +273,7 @@ export function TasksView({
   agentNameById,
   userId,
   activeOrganizationId,
+  initialFilters,
   defaultViewMode,
   initialCreateTaskOpen = false,
   initialCoworkerId = null,
@@ -334,8 +353,11 @@ export function TasksView({
     () => router.refresh(),
     TASKS_ROUTE_REFRESH_DEBOUNCE_MS,
   );
-  const scopeKey = activeOrganizationId ?? "personal";
-  const previousScopeKeyRef = useRef(scopeKey);
+  const filtersResetKey = getTasksFiltersResetKey(
+    initialFilters,
+    activeOrganizationId,
+  );
+  const previousFiltersResetKeyRef = useRef(filtersResetKey);
   const handleEventUpdate = (_data: TaskEventData) => {
     refreshRoute();
   };
@@ -374,9 +396,9 @@ export function TasksView({
   }, [jobsFailedFilterMode]);
 
   useEffect(() => {
-    if (previousScopeKeyRef.current === scopeKey) return;
+    if (previousFiltersResetKeyRef.current === filtersResetKey) return;
 
-    previousScopeKeyRef.current = scopeKey;
+    previousFiltersResetKeyRef.current = filtersResetKey;
     moveVersionRef.current = 0;
     pendingMoveVersionByTaskIdRef.current.clear();
     isRefetchingJobsRef.current = false;
@@ -399,7 +421,7 @@ export function TasksView({
     initialColumnNextCursorById,
     initialJobsNextCursor,
     jobs,
-    scopeKey,
+    filtersResetKey,
     tasks,
   ]);
 
@@ -561,7 +583,13 @@ export function TasksView({
       setLoadingColumnIds(nextLoading);
 
       try {
-        const result = await loadMoreTasksColumn({ columnId, cursor });
+        const result = await loadMoreTasksColumn({
+          columnId,
+          cursor,
+          scope: initialFilters.scope,
+          coworkerId: initialFilters.coworkerId,
+          status: initialFilters.status,
+        });
         setItems((prev) => appendUniqueTasks(prev, result.tasks));
         const nextCursor = result.nextCursor;
         setColumnCursorById((prev) => ({
@@ -589,7 +617,12 @@ export function TasksView({
         setLoadingColumnIds(afterLoading);
       }
     },
-    [labels.loadMoreError],
+    [
+      initialFilters.coworkerId,
+      initialFilters.scope,
+      initialFilters.status,
+      labels.loadMoreError,
+    ],
   );
 
   const handleViewModeChange = (next: TasksViewMode) => {
@@ -775,6 +808,14 @@ export function TasksView({
             </Button>
           ) : null}
           {activeTab === "tasks" ? (
+            <TasksViewFilters
+              filters={initialFilters}
+              activeOrganizationId={activeOrganizationId}
+              coworkerOptions={coworkerOptions}
+              labels={labels.filters}
+            />
+          ) : null}
+          {activeTab === "tasks" ? (
             <ViewModeSwitch
               value={viewMode}
               onChange={handleViewModeChange}
@@ -823,6 +864,14 @@ export function TasksView({
                     tasks={items}
                     columns={columns}
                     columnFooterById={columnFooterById}
+                    canDragTask={(task) =>
+                      isTaskOwnerEditable(
+                        task,
+                        userId,
+                        initialFilters,
+                        activeOrganizationId,
+                      )
+                    }
                     labels={{
                       columns: labels.columns,
                       addTask: labels.addTask,
@@ -834,6 +883,14 @@ export function TasksView({
                     tasks={items}
                     columns={columns}
                     sectionFooterById={columnFooterById}
+                    canDragTask={(task) =>
+                      isTaskOwnerEditable(
+                        task,
+                        userId,
+                        initialFilters,
+                        activeOrganizationId,
+                      )
+                    }
                     labels={{
                       columns: labels.columns,
                       emptyList: labels.listPlaceholder,

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -16,6 +16,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -30,7 +31,7 @@ import { TASKS_ROUTE_REFRESH_DEBOUNCE_MS } from "@/app/tasks/constants";
 import {
   getTasksFiltersFromSearchParams,
   getTasksFiltersResetKey,
-  isTaskOwnerEditable,
+  isTaskDraggableForViewFilters,
   type TasksFilters,
 } from "@/app/tasks/utils/tasks-filters";
 import { Button } from "@/components/ui/button";
@@ -411,7 +412,7 @@ export function TasksView({
     }
   }, [jobsFailedFilterMode]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousFiltersResetKeyRef.current === serverFiltersResetKey) return;
 
     previousFiltersResetKeyRef.current = serverFiltersResetKey;
@@ -531,6 +532,20 @@ export function TasksView({
     const activeId = event.active.id;
     const overId = event.over?.id;
     if (typeof activeId !== "string" || typeof overId !== "string") return;
+
+    const draggedTask = itemsRef.current.find((task) => task.id === activeId);
+    if (
+      !draggedTask ||
+      !isTaskDraggableForViewFilters(
+        draggedTask,
+        userId,
+        routeFilters,
+        initialFilters,
+        activeOrganizationId,
+      )
+    ) {
+      return;
+    }
 
     const toColumn = overId as KanbanColumnId;
     if (!isDnDColumn(toColumn)) return;
@@ -884,10 +899,11 @@ export function TasksView({
                     columns={columns}
                     columnFooterById={columnFooterById}
                     canDragTask={(task) =>
-                      isTaskOwnerEditable(
+                      isTaskDraggableForViewFilters(
                         task,
                         userId,
                         routeFilters,
+                        initialFilters,
                         activeOrganizationId,
                       )
                     }
@@ -903,10 +919,11 @@ export function TasksView({
                     columns={columns}
                     sectionFooterById={columnFooterById}
                     canDragTask={(task) =>
-                      isTaskOwnerEditable(
+                      isTaskDraggableForViewFilters(
                         task,
                         userId,
                         routeFilters,
+                        initialFilters,
                         activeOrganizationId,
                       )
                     }

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -364,11 +364,16 @@ export function TasksView({
     () => router.refresh(),
     TASKS_ROUTE_REFRESH_DEBOUNCE_MS,
   );
-  const filtersResetKey = getTasksFiltersResetKey(
-    initialFilters,
-    activeOrganizationId,
+  const serverFiltersResetKey = useMemo(
+    () => getTasksFiltersResetKey(initialFilters, activeOrganizationId),
+    [activeOrganizationId, initialFilters],
   );
-  const previousFiltersResetKeyRef = useRef(filtersResetKey);
+  const routeFiltersResetKey = useMemo(
+    () => getTasksFiltersResetKey(routeFilters, activeOrganizationId),
+    [activeOrganizationId, routeFilters],
+  );
+  const isTaskPaginationInSync = routeFiltersResetKey === serverFiltersResetKey;
+  const previousFiltersResetKeyRef = useRef(serverFiltersResetKey);
   const handleEventUpdate = (_data: TaskEventData) => {
     refreshRoute();
   };
@@ -407,9 +412,9 @@ export function TasksView({
   }, [jobsFailedFilterMode]);
 
   useEffect(() => {
-    if (previousFiltersResetKeyRef.current === filtersResetKey) return;
+    if (previousFiltersResetKeyRef.current === serverFiltersResetKey) return;
 
-    previousFiltersResetKeyRef.current = filtersResetKey;
+    previousFiltersResetKeyRef.current = serverFiltersResetKey;
     moveVersionRef.current = 0;
     pendingMoveVersionByTaskIdRef.current.clear();
     isRefetchingJobsRef.current = false;
@@ -432,7 +437,7 @@ export function TasksView({
     initialColumnNextCursorById,
     initialJobsNextCursor,
     jobs,
-    filtersResetKey,
+    serverFiltersResetKey,
     tasks,
   ]);
 
@@ -585,6 +590,8 @@ export function TasksView({
 
   const handleLoadMoreColumn = useCallback(
     async (columnId: KanbanColumnId) => {
+      if (!isTaskPaginationInSync) return;
+
       const cursor = columnCursorByIdRef.current[columnId] ?? null;
       if (cursor === null || loadingColumnIdsRef.current.has(columnId)) return;
 
@@ -629,6 +636,7 @@ export function TasksView({
       }
     },
     [
+      isTaskPaginationInSync,
       labels.loadMoreError,
       routeFilters.coworkerId,
       routeFilters.scope,
@@ -749,7 +757,7 @@ export function TasksView({
             className="text-muted-foreground hover:text-foreground w-full text-xs"
             variant="outline"
             onClick={() => void handleLoadMoreColumn(column.id)}
-            disabled={isLoading}
+            disabled={isLoading || !isTaskPaginationInSync}
           >
             {isLoading ? labels.loading : labels.loadMore}
           </Button>
@@ -762,6 +770,7 @@ export function TasksView({
     columnCursorById,
     columns,
     handleLoadMoreColumn,
+    isTaskPaginationInSync,
     labels.loadMore,
     labels.loading,
     loadingColumnIds,

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts
@@ -63,6 +63,9 @@ describe("getTasksColumnPage", () => {
       columnId: "done",
       cursor: null,
       limit: 2,
+      scope: "workspace",
+      coworkerId: "coworker-1",
+      status: null,
       coworkersById: new Map(),
       agentsById: new Map(),
     });
@@ -72,6 +75,8 @@ describe("getTasksColumnPage", () => {
     expect(listTasksMock).toHaveBeenCalledTimes(1);
     expect(listTasksMock).toHaveBeenCalledWith({
       status: [TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELED],
+      scope: "workspace",
+      coworkerId: "coworker-1",
       cursor: null,
       limit: 2,
     });
@@ -93,6 +98,9 @@ describe("getTasksColumnPage", () => {
       columnId: "backlog",
       cursor: "cursor-1",
       limit: 1,
+      scope: "owned",
+      coworkerId: null,
+      status: null,
       coworkersById: new Map(),
       agentsById: new Map(),
     });
@@ -101,6 +109,8 @@ describe("getTasksColumnPage", () => {
     expect(page.nextCursor).toBeNull();
     expect(listTasksMock).toHaveBeenCalledWith({
       status: [TaskStatus.DRAFT],
+      scope: "owned",
+      coworkerId: undefined,
       cursor: "cursor-1",
       limit: 1,
     });
@@ -122,10 +132,32 @@ describe("getTasksColumnPage", () => {
       columnId: "todo",
       cursor: null,
       limit: 10,
+      scope: "owned",
+      coworkerId: null,
+      status: null,
       coworkersById: new Map(),
       agentsById: new Map(),
     });
 
     expect(page.nextCursor).toBeNull();
+  });
+
+  it("returns an empty page when the selected status is outside the column", async () => {
+    const page = await getTasksColumnPage({
+      columnId: "backlog",
+      cursor: null,
+      limit: 10,
+      scope: "workspace",
+      coworkerId: null,
+      status: TaskStatus.COMPLETED,
+      coworkersById: new Map(),
+      agentsById: new Map(),
+    });
+
+    expect(page).toEqual({
+      tasks: [],
+      nextCursor: null,
+    });
+    expect(listTasksMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -78,6 +78,23 @@ describe("tasks-filters", () => {
     });
   });
 
+  it("uses the first value when a filter key is repeated (App Router searchParams)", () => {
+    expect(
+      parseTasksFilters(
+        {
+          scope: ["workspace", "owned"],
+          coworkerId: ["coworker-1", "coworker-2"],
+          status: [TaskStatus.READY, TaskStatus.FAILED],
+        },
+        "org-1",
+      ),
+    ).toEqual({
+      scope: "workspace",
+      coworkerId: "coworker-1",
+      status: TaskStatus.READY,
+    });
+  });
+
   it("builds URL params without losing unrelated query state", () => {
     const currentSearchParams = new URLSearchParams({
       create: "true",

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -6,9 +6,11 @@ import {
   getDefaultTasksScope,
   getTasksFiltersFromSearchParams,
   getTasksFiltersResetKey,
+  isTaskDraggableForViewFilters,
   isTaskOwnerEditable,
   parseTasksFilters,
   sanitizeTasksScopeInput,
+  sanitizeTasksStatusInput,
 } from "@/app/tasks/utils/tasks-filters";
 
 describe("tasks-filters", () => {
@@ -49,6 +51,25 @@ describe("tasks-filters", () => {
     it("allows workspace only when an organization is active", () => {
       expect(sanitizeTasksScopeInput("workspace", "org-1")).toBe("workspace");
       expect(sanitizeTasksScopeInput("workspace", null)).toBe("owned");
+    });
+  });
+
+  describe("sanitizeTasksStatusInput", () => {
+    it("returns null for non-strings and unknown labels", () => {
+      expect(sanitizeTasksStatusInput(undefined)).toBeNull();
+      expect(sanitizeTasksStatusInput(null)).toBeNull();
+      expect(sanitizeTasksStatusInput(123)).toBeNull();
+      expect(sanitizeTasksStatusInput({})).toBeNull();
+      expect(sanitizeTasksStatusInput("not-a-status")).toBeNull();
+      expect(sanitizeTasksStatusInput("")).toBeNull();
+      expect(sanitizeTasksStatusInput("   ")).toBeNull();
+    });
+
+    it("accepts valid TaskStatus string values", () => {
+      expect(sanitizeTasksStatusInput(TaskStatus.READY)).toBe(TaskStatus.READY);
+      expect(sanitizeTasksStatusInput(` ${TaskStatus.DRAFT} `)).toBe(
+        TaskStatus.DRAFT,
+      );
     });
   });
 
@@ -202,5 +223,46 @@ describe("tasks-filters", () => {
         null,
       ),
     ).toBe(true);
+  });
+
+  describe("isTaskDraggableForViewFilters", () => {
+    const workspaceFilters = {
+      scope: "workspace" as const,
+      coworkerId: null,
+      status: null,
+    };
+    const ownedFilters = {
+      scope: "owned" as const,
+      coworkerId: null,
+      status: null,
+    };
+
+    it("disallows drag when the URL implies owned but the server list was still workspace (coworker task)", () => {
+      const coworkerTask = { userId: "user-2" };
+
+      expect(
+        isTaskDraggableForViewFilters(
+          coworkerTask,
+          "user-1",
+          ownedFilters,
+          workspaceFilters,
+          "org-1",
+        ),
+      ).toBe(false);
+    });
+
+    it("allows drag when route and initial filters agree for the viewer's task", () => {
+      const myTask = { userId: "user-1" };
+
+      expect(
+        isTaskDraggableForViewFilters(
+          myTask,
+          "user-1",
+          ownedFilters,
+          ownedFilters,
+          "org-1",
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -8,6 +8,7 @@ import {
   getTasksFiltersResetKey,
   isTaskOwnerEditable,
   parseTasksFilters,
+  sanitizeTasksScopeInput,
 } from "@/app/tasks/utils/tasks-filters";
 
 describe("tasks-filters", () => {
@@ -34,6 +35,20 @@ describe("tasks-filters", () => {
       scope: "owned",
       coworkerId: null,
       status: null,
+    });
+  });
+
+  describe("sanitizeTasksScopeInput", () => {
+    it("returns default scope for non-strings and unknown labels", () => {
+      expect(sanitizeTasksScopeInput(undefined, "org-1")).toBe("workspace");
+      expect(sanitizeTasksScopeInput(123, "org-1")).toBe("workspace");
+      expect(sanitizeTasksScopeInput("not-a-scope", "org-1")).toBe("workspace");
+      expect(sanitizeTasksScopeInput("", "org-1")).toBe("workspace");
+    });
+
+    it("allows workspace only when an organization is active", () => {
+      expect(sanitizeTasksScopeInput("workspace", "org-1")).toBe("workspace");
+      expect(sanitizeTasksScopeInput("workspace", null)).toBe("owned");
     });
   });
 

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildTasksFiltersSearchParams,
   getDefaultTasksScope,
+  getTasksFiltersFromSearchParams,
   getTasksFiltersResetKey,
   isTaskOwnerEditable,
   parseTasksFilters,
@@ -33,6 +34,30 @@ describe("tasks-filters", () => {
       scope: "owned",
       coworkerId: null,
       status: null,
+    });
+  });
+
+  it("maps URL search params to filters with coworker allowlist", () => {
+    const params = new URLSearchParams({
+      scope: "owned",
+      coworkerId: "coworker-1",
+      status: TaskStatus.READY,
+    });
+
+    expect(
+      getTasksFiltersFromSearchParams(params, "org-1", [{ id: "coworker-1" }]),
+    ).toEqual({
+      scope: "owned",
+      coworkerId: "coworker-1",
+      status: TaskStatus.READY,
+    });
+
+    expect(
+      getTasksFiltersFromSearchParams(params, "org-1", [{ id: "other" }]),
+    ).toEqual({
+      scope: "owned",
+      coworkerId: null,
+      status: TaskStatus.READY,
     });
   });
 

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -5,7 +5,6 @@ import {
   buildTasksFiltersSearchParams,
   getDefaultTasksScope,
   getTasksFiltersResetKey,
-  hasActiveTasksFilters,
   isTaskOwnerEditable,
   parseTasksFilters,
 } from "@/app/tasks/utils/tasks-filters";
@@ -92,29 +91,6 @@ describe("tasks-filters", () => {
     );
 
     expect(nextSearchParams.toString()).toBe("");
-  });
-
-  it("tracks active filters against the default scope", () => {
-    expect(
-      hasActiveTasksFilters(
-        {
-          scope: "workspace",
-          coworkerId: null,
-          status: null,
-        },
-        "org-1",
-      ),
-    ).toBe(false);
-    expect(
-      hasActiveTasksFilters(
-        {
-          scope: "owned",
-          coworkerId: null,
-          status: null,
-        },
-        "org-1",
-      ),
-    ).toBe(true);
   });
 
   it("derives stable reset keys", () => {

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -1,0 +1,173 @@
+import { TaskStatus } from "@sokosumi/database";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTasksFiltersSearchParams,
+  getDefaultTasksScope,
+  getTasksFiltersResetKey,
+  hasActiveTasksFilters,
+  isTaskOwnerEditable,
+  parseTasksFilters,
+} from "@/app/tasks/utils/tasks-filters";
+
+describe("tasks-filters", () => {
+  it("defaults to workspace scope when an organization is active", () => {
+    expect(getDefaultTasksScope("org-1")).toBe("workspace");
+    expect(parseTasksFilters({}, "org-1")).toEqual({
+      scope: "workspace",
+      coworkerId: null,
+      status: null,
+    });
+  });
+
+  it("defaults to owned scope in personal context", () => {
+    expect(getDefaultTasksScope(null)).toBe("owned");
+    expect(parseTasksFilters({}, null)).toEqual({
+      scope: "owned",
+      coworkerId: null,
+      status: null,
+    });
+  });
+
+  it("coerces invalid workspace scope back to owned in personal context", () => {
+    expect(parseTasksFilters({ scope: "workspace" }, null)).toEqual({
+      scope: "owned",
+      coworkerId: null,
+      status: null,
+    });
+  });
+
+  it("keeps explicit coworker and status filters", () => {
+    expect(
+      parseTasksFilters(
+        {
+          scope: "owned",
+          coworkerId: "coworker-1",
+          status: TaskStatus.READY,
+        },
+        "org-1",
+      ),
+    ).toEqual({
+      scope: "owned",
+      coworkerId: "coworker-1",
+      status: TaskStatus.READY,
+    });
+  });
+
+  it("builds URL params without losing unrelated query state", () => {
+    const currentSearchParams = new URLSearchParams({
+      create: "true",
+      coworker: "elena",
+    });
+
+    const nextSearchParams = buildTasksFiltersSearchParams(
+      currentSearchParams,
+      {
+        scope: "owned",
+        coworkerId: "coworker-1",
+        status: TaskStatus.READY,
+      },
+      "org-1",
+    );
+
+    expect(nextSearchParams.toString()).toBe(
+      "create=true&coworker=elena&scope=owned&coworkerId=coworker-1&status=READY",
+    );
+  });
+
+  it("removes default filters from the query string", () => {
+    const currentSearchParams = new URLSearchParams({
+      coworkerId: "coworker-1",
+      status: TaskStatus.READY,
+    });
+
+    const nextSearchParams = buildTasksFiltersSearchParams(
+      currentSearchParams,
+      {
+        scope: "workspace",
+        coworkerId: null,
+        status: null,
+      },
+      "org-1",
+    );
+
+    expect(nextSearchParams.toString()).toBe("");
+  });
+
+  it("tracks active filters against the default scope", () => {
+    expect(
+      hasActiveTasksFilters(
+        {
+          scope: "workspace",
+          coworkerId: null,
+          status: null,
+        },
+        "org-1",
+      ),
+    ).toBe(false);
+    expect(
+      hasActiveTasksFilters(
+        {
+          scope: "owned",
+          coworkerId: null,
+          status: null,
+        },
+        "org-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("derives stable reset keys", () => {
+    expect(
+      getTasksFiltersResetKey(
+        {
+          scope: "workspace",
+          coworkerId: "coworker-1",
+          status: TaskStatus.READY,
+        },
+        "org-1",
+      ),
+    ).toBe("org-1:workspace:coworker-1:READY");
+  });
+
+  it("allows only owners to edit tasks in workspace scope", () => {
+    const task = { userId: "user-1" };
+
+    expect(
+      isTaskOwnerEditable(
+        task,
+        "user-1",
+        {
+          scope: "workspace",
+          coworkerId: null,
+          status: null,
+        },
+        "org-1",
+      ),
+    ).toBe(true);
+    expect(
+      isTaskOwnerEditable(
+        task,
+        "user-2",
+        {
+          scope: "workspace",
+          coworkerId: null,
+          status: null,
+        },
+        "org-1",
+      ),
+    ).toBe(false);
+    expect(
+      isTaskOwnerEditable(
+        task,
+        "user-2",
+        {
+          scope: "owned",
+          coworkerId: null,
+          status: null,
+        },
+        null,
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/app/(app)/tasks/utils/tasks-column-page.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-column-page.ts
@@ -1,7 +1,9 @@
 import "server-only";
 
 import type { AgentWithCreditsPrice } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/database";
 
+import type { TasksScope } from "@/app/tasks/utils/tasks-filters";
 import type { Coworker } from "@/lib/clients/generated/core";
 import { taskService } from "@/lib/services/task.service";
 import type { KanbanColumnId, TaskWithCoworker } from "@/lib/types/task";
@@ -14,6 +16,9 @@ interface GetTasksColumnPageParams {
   columnId: KanbanColumnId;
   cursor: ColumnCursor;
   limit: number;
+  scope: TasksScope;
+  coworkerId: string | null;
+  status: TaskStatus | null;
   coworkersById: Map<string, Coworker>;
   agentsById: Map<string, AgentWithCreditsPrice>;
 }
@@ -27,11 +32,27 @@ export async function getTasksColumnPage({
   columnId,
   cursor,
   limit,
+  scope,
+  coworkerId,
+  status,
   coworkersById,
   agentsById,
 }: GetTasksColumnPageParams): Promise<GetTasksColumnPageResult> {
+  const statuses = COLUMN_TASK_STATUSES[columnId].filter(
+    (columnStatus) => status === null || columnStatus === status,
+  );
+
+  if (statuses.length === 0) {
+    return {
+      tasks: [],
+      nextCursor: null,
+    };
+  }
+
   const result = await taskService.listTasks({
-    status: COLUMN_TASK_STATUSES[columnId],
+    status: statuses,
+    scope,
+    coworkerId: coworkerId ?? undefined,
     cursor,
     limit,
   });

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -12,10 +12,13 @@ export interface TasksFilters {
   status: TaskStatus | null;
 }
 
+/** App Router `searchParams` values can be `string | string[]` when a key is repeated. */
+export type TasksFilterQueryParam = string | string[] | undefined;
+
 export interface TasksFiltersSearchParams {
-  scope?: string;
-  coworkerId?: string;
-  status?: string;
+  scope?: TasksFilterQueryParam;
+  coworkerId?: TasksFilterQueryParam;
+  status?: TasksFilterQueryParam;
 }
 
 export const TASKS_FILTER_PARAM_KEYS = {
@@ -26,8 +29,19 @@ export const TASKS_FILTER_PARAM_KEYS = {
 
 type SearchParamsLike = Pick<URLSearchParams, "toString">;
 
-function normalizeOptionalString(value: string | undefined): string | null {
-  const normalized = value?.trim();
+/** Matches `URLSearchParams#get`: first value wins when the key is repeated. */
+function firstQueryString(value: TasksFilterQueryParam): string | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) {
+    const first = value.find((entry) => typeof entry === "string");
+    return first;
+  }
+  return value;
+}
+
+function normalizeOptionalString(value: TasksFilterQueryParam): string | null {
+  const raw = firstQueryString(value);
+  const normalized = raw?.trim();
   return normalized ? normalized : null;
 }
 
@@ -76,7 +90,7 @@ export function parseTasksFilters(
   activeOrganizationId: string | null,
 ): TasksFilters {
   const defaultScope = getDefaultTasksScope(activeOrganizationId);
-  const requestedScope = searchParams.scope;
+  const requestedScope = firstQueryString(searchParams.scope);
   const scope =
     requestedScope &&
     TASKS_SCOPE_VALUES.includes(requestedScope as TasksScope) &&

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -1,0 +1,133 @@
+import { TaskStatus } from "@sokosumi/database";
+
+import type { TaskWithCoworker } from "@/lib/types/task";
+
+export const TASKS_SCOPE_VALUES = ["owned", "workspace"] as const;
+
+export type TasksScope = (typeof TASKS_SCOPE_VALUES)[number];
+
+export interface TasksFilters {
+  scope: TasksScope;
+  coworkerId: string | null;
+  status: TaskStatus | null;
+}
+
+export interface TasksFiltersSearchParams {
+  scope?: string;
+  coworkerId?: string;
+  status?: string;
+}
+
+export const TASKS_FILTER_PARAM_KEYS = {
+  scope: "scope",
+  coworkerId: "coworkerId",
+  status: "status",
+} as const;
+
+type SearchParamsLike = Pick<URLSearchParams, "toString">;
+
+function normalizeOptionalString(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function isTaskStatusValue(value: string | null): value is TaskStatus {
+  return (
+    value !== null && Object.values(TaskStatus).includes(value as TaskStatus)
+  );
+}
+
+export function getDefaultTasksScope(
+  activeOrganizationId: string | null,
+): TasksScope {
+  return activeOrganizationId ? "workspace" : "owned";
+}
+
+export function parseTasksFilters(
+  searchParams: TasksFiltersSearchParams,
+  activeOrganizationId: string | null,
+): TasksFilters {
+  const defaultScope = getDefaultTasksScope(activeOrganizationId);
+  const requestedScope = searchParams.scope;
+  const scope =
+    requestedScope &&
+    TASKS_SCOPE_VALUES.includes(requestedScope as TasksScope) &&
+    (requestedScope !== "workspace" || activeOrganizationId)
+      ? (requestedScope as TasksScope)
+      : defaultScope;
+  const coworkerId = normalizeOptionalString(searchParams.coworkerId);
+  const rawStatus = normalizeOptionalString(searchParams.status);
+  const status = isTaskStatusValue(rawStatus) ? rawStatus : null;
+
+  return {
+    scope,
+    coworkerId,
+    status,
+  };
+}
+
+export function hasActiveTasksFilters(
+  filters: TasksFilters,
+  activeOrganizationId: string | null,
+): boolean {
+  return (
+    filters.scope !== getDefaultTasksScope(activeOrganizationId) ||
+    filters.coworkerId !== null ||
+    filters.status !== null
+  );
+}
+
+export function buildTasksFiltersSearchParams(
+  currentSearchParams: URLSearchParams | SearchParamsLike,
+  filters: TasksFilters,
+  activeOrganizationId: string | null,
+): URLSearchParams {
+  const nextSearchParams = new URLSearchParams(currentSearchParams.toString());
+  const defaultScope = getDefaultTasksScope(activeOrganizationId);
+
+  if (filters.scope === defaultScope) {
+    nextSearchParams.delete(TASKS_FILTER_PARAM_KEYS.scope);
+  } else {
+    nextSearchParams.set(TASKS_FILTER_PARAM_KEYS.scope, filters.scope);
+  }
+
+  if (filters.coworkerId) {
+    nextSearchParams.set(
+      TASKS_FILTER_PARAM_KEYS.coworkerId,
+      filters.coworkerId,
+    );
+  } else {
+    nextSearchParams.delete(TASKS_FILTER_PARAM_KEYS.coworkerId);
+  }
+
+  if (filters.status) {
+    nextSearchParams.set(TASKS_FILTER_PARAM_KEYS.status, filters.status);
+  } else {
+    nextSearchParams.delete(TASKS_FILTER_PARAM_KEYS.status);
+  }
+
+  return nextSearchParams;
+}
+
+export function getTasksFiltersResetKey(
+  filters: TasksFilters,
+  activeOrganizationId: string | null,
+): string {
+  return `${activeOrganizationId ?? "personal"}:${filters.scope}:${filters.coworkerId ?? "all"}:${filters.status ?? "all"}`;
+}
+
+export function isTaskOwnerEditable(
+  task: Pick<TaskWithCoworker, "userId">,
+  userId: string | null | undefined,
+  filters: TasksFilters,
+  activeOrganizationId: string | null,
+): boolean {
+  const isWorkspaceScope =
+    activeOrganizationId !== null && filters.scope === "workspace";
+
+  if (!isWorkspaceScope) {
+    return true;
+  }
+
+  return userId != null && task.userId === userId;
+}

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -51,6 +51,24 @@ function isTaskStatusValue(value: string | null): value is TaskStatus {
   );
 }
 
+/**
+ * Validates `status` from untrusted input (e.g. server-action JSON). Mirrors
+ * {@link parseTasksFilters} so URL state and load-more stay aligned.
+ */
+export function sanitizeTasksStatusInput(raw: unknown): TaskStatus | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const normalized = raw.trim();
+  if (!normalized) {
+    return null;
+  }
+  return isTaskStatusValue(normalized) ? normalized : null;
+}
+
 export function getDefaultTasksScope(
   activeOrganizationId: string | null,
 ): TasksScope {
@@ -120,7 +138,7 @@ export function parseTasksFilters(
   );
   const coworkerId = normalizeOptionalString(searchParams.coworkerId);
   const rawStatus = normalizeOptionalString(searchParams.status);
-  const status = isTaskStatusValue(rawStatus) ? rawStatus : null;
+  const status = sanitizeTasksStatusInput(rawStatus);
 
   return {
     scope,
@@ -182,4 +200,23 @@ export function isTaskOwnerEditable(
   }
 
   return userId != null && task.userId === userId;
+}
+
+/**
+ * Drag permissions must stay consistent with both the URL (route) and the last
+ * server render (initial). When those disagree during a filter transition,
+ * `isTaskOwnerEditable` can be wrong for stale list rows (e.g. workspace rows
+ * while the URL already says owned). Require both to allow drag.
+ */
+export function isTaskDraggableForViewFilters(
+  task: Pick<TaskWithCoworker, "userId">,
+  userId: string | null | undefined,
+  routeFilters: TasksFilters,
+  initialFilters: TasksFilters,
+  activeOrganizationId: string | null,
+): boolean {
+  return (
+    isTaskOwnerEditable(task, userId, routeFilters, activeOrganizationId) &&
+    isTaskOwnerEditable(task, userId, initialFilters, activeOrganizationId)
+  );
 }

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -57,6 +57,31 @@ export function getDefaultTasksScope(
   return activeOrganizationId ? "workspace" : "owned";
 }
 
+/**
+ * Validates `scope` from untrusted input (e.g. server-action JSON). Mirrors
+ * {@link parseTasksFilters} so URL state and load-more stay aligned.
+ */
+export function sanitizeTasksScopeInput(
+  raw: unknown,
+  activeOrganizationId: string | null,
+): TasksScope {
+  const defaultScope = getDefaultTasksScope(activeOrganizationId);
+  if (typeof raw !== "string") {
+    return defaultScope;
+  }
+  const requestedScope = raw.trim();
+  if (
+    !requestedScope ||
+    !TASKS_SCOPE_VALUES.includes(requestedScope as TasksScope)
+  ) {
+    return defaultScope;
+  }
+  if (requestedScope === "workspace" && !activeOrganizationId) {
+    return defaultScope;
+  }
+  return requestedScope as TasksScope;
+}
+
 export function getTasksFiltersFromSearchParams(
   searchParams: URLSearchParams,
   activeOrganizationId: string | null,
@@ -89,14 +114,10 @@ export function parseTasksFilters(
   searchParams: TasksFiltersSearchParams,
   activeOrganizationId: string | null,
 ): TasksFilters {
-  const defaultScope = getDefaultTasksScope(activeOrganizationId);
-  const requestedScope = firstQueryString(searchParams.scope);
-  const scope =
-    requestedScope &&
-    TASKS_SCOPE_VALUES.includes(requestedScope as TasksScope) &&
-    (requestedScope !== "workspace" || activeOrganizationId)
-      ? (requestedScope as TasksScope)
-      : defaultScope;
+  const scope = sanitizeTasksScopeInput(
+    firstQueryString(searchParams.scope),
+    activeOrganizationId,
+  );
   const coworkerId = normalizeOptionalString(searchParams.coworkerId);
   const rawStatus = normalizeOptionalString(searchParams.status);
   const status = isTaskStatusValue(rawStatus) ? rawStatus : null;

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -43,6 +43,34 @@ export function getDefaultTasksScope(
   return activeOrganizationId ? "workspace" : "owned";
 }
 
+export function getTasksFiltersFromSearchParams(
+  searchParams: URLSearchParams,
+  activeOrganizationId: string | null,
+  coworkerOptions: ReadonlyArray<{ id: string }>,
+): TasksFilters {
+  const parsed = parseTasksFilters(
+    {
+      scope: searchParams.get(TASKS_FILTER_PARAM_KEYS.scope) ?? undefined,
+      coworkerId:
+        searchParams.get(TASKS_FILTER_PARAM_KEYS.coworkerId) ?? undefined,
+      status: searchParams.get(TASKS_FILTER_PARAM_KEYS.status) ?? undefined,
+    },
+    activeOrganizationId,
+  );
+  const validCoworkerIds = new Set(
+    coworkerOptions.map((coworker) => coworker.id),
+  );
+  const coworkerId =
+    parsed.coworkerId && validCoworkerIds.has(parsed.coworkerId)
+      ? parsed.coworkerId
+      : null;
+
+  return {
+    ...parsed,
+    coworkerId,
+  };
+}
+
 export function parseTasksFilters(
   searchParams: TasksFiltersSearchParams,
   activeOrganizationId: string | null,

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -66,17 +66,6 @@ export function parseTasksFilters(
   };
 }
 
-export function hasActiveTasksFilters(
-  filters: TasksFilters,
-  activeOrganizationId: string | null,
-): boolean {
-  return (
-    filters.scope !== getDefaultTasksScope(activeOrganizationId) ||
-    filters.coworkerId !== null ||
-    filters.status !== null
-  );
-}
-
 export function buildTasksFiltersSearchParams(
   currentSearchParams: URLSearchParams | SearchParamsLike,
   filters: TasksFilters,

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -105,22 +105,15 @@ function FilterDropdownMenuSectionItem({
   );
   const optionItems = useMemo(() => {
     if (!section.allLabel) {
-      return section.options.map((option) => ({
-        ...option,
-        itemValue: option.label,
-      }));
+      return section.options;
     }
 
     return [
       {
         value: ALL_FILTER_VALUE,
         label: section.allLabel,
-        itemValue: section.allLabel,
       },
-      ...section.options.map((option) => ({
-        ...option,
-        itemValue: option.label,
-      })),
+      ...section.options,
     ];
   }, [section.allLabel, section.options]);
 
@@ -153,12 +146,16 @@ function FilterDropdownMenuSectionItem({
               const isSelected = isAllOption
                 ? section.value === null
                 : option.value === section.value;
+              const filterKeywords = [
+                option.label,
+                ...(option.searchKeywords ?? []),
+              ];
 
               return (
                 <CommandItem
                   key={option.value}
-                  value={option.itemValue}
-                  keywords={option.searchKeywords}
+                  value={option.value}
+                  keywords={filterKeywords}
                   onSelect={() => {
                     section.onChange(isAllOption ? null : option.value);
                     onSelect();

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { Check, ListFilter, type LucideIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+export interface FilterDropdownMenuOption {
+  value: string;
+  label: string;
+  avatarLabel?: string;
+  image?: string | null;
+  searchKeywords?: string[];
+}
+
+export interface FilterDropdownMenuSection {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  value: string | null;
+  options: FilterDropdownMenuOption[];
+  allLabel?: string;
+  onChange: (value: string | null) => void;
+}
+
+interface FilterDropdownMenuProps {
+  buttonLabel: string;
+  searchPlaceholder: string;
+  emptyResultsLabel: string;
+  sections: FilterDropdownMenuSection[];
+}
+
+const ALL_FILTER_VALUE = "__all__";
+
+export function FilterDropdownMenu({
+  buttonLabel,
+  searchPlaceholder,
+  emptyResultsLabel,
+  sections,
+}: FilterDropdownMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <ListFilter className="size-4" aria-hidden />
+          <span className="hidden sm:inline">{buttonLabel}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        {sections.map((section) => (
+          <FilterDropdownMenuSectionItem
+            key={section.id}
+            section={section}
+            searchPlaceholder={searchPlaceholder}
+            emptyResultsLabel={emptyResultsLabel}
+            onSelect={() => setOpen(false)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface FilterDropdownMenuSectionItemProps {
+  section: FilterDropdownMenuSection;
+  searchPlaceholder: string;
+  emptyResultsLabel: string;
+  onSelect: () => void;
+}
+
+function FilterDropdownMenuSectionItem({
+  section,
+  searchPlaceholder,
+  emptyResultsLabel,
+  onSelect,
+}: FilterDropdownMenuSectionItemProps) {
+  const [submenuOpen, setSubmenuOpen] = useState(false);
+  const selectedOption = useMemo(
+    () =>
+      section.options.find((option) => option.value === section.value) ?? null,
+    [section.options, section.value],
+  );
+  const optionItems = useMemo(() => {
+    if (!section.allLabel) {
+      return section.options.map((option) => ({
+        ...option,
+        itemValue: option.label,
+      }));
+    }
+
+    return [
+      {
+        value: ALL_FILTER_VALUE,
+        label: section.allLabel,
+        itemValue: section.allLabel,
+      },
+      ...section.options.map((option) => ({
+        ...option,
+        itemValue: option.label,
+      })),
+    ];
+  }, [section.allLabel, section.options]);
+
+  return (
+    <DropdownMenuSub
+      open={submenuOpen}
+      onOpenChange={(nextOpen) => setSubmenuOpen(nextOpen)}
+    >
+      <DropdownMenuSubTrigger className="gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <section.icon
+              className="size-4 text-muted-foreground"
+              aria-hidden
+            />
+            <span className="truncate">{section.label}</span>
+          </div>
+          <span className="max-w-28 truncate text-right text-xs text-muted-foreground">
+            {selectedOption?.label ?? section.allLabel}
+          </span>
+        </div>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-72 p-0">
+        <Command className="**:data-[slot=command-list]:max-h-72" shouldFilter>
+          <CommandInput autoFocus placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyResultsLabel}</CommandEmpty>
+            {optionItems.map((option) => {
+              const isAllOption = option.value === ALL_FILTER_VALUE;
+              const isSelected = isAllOption
+                ? section.value === null
+                : option.value === section.value;
+
+              return (
+                <CommandItem
+                  key={option.value}
+                  value={option.itemValue}
+                  keywords={option.searchKeywords}
+                  onSelect={() => {
+                    section.onChange(isAllOption ? null : option.value);
+                    onSelect();
+                  }}
+                >
+                  <FilterDropdownMenuOptionAvatar option={option} />
+                  <span className="flex-1 truncate">{option.label}</span>
+                  <Check
+                    className={cn(
+                      "size-4",
+                      isSelected ? "opacity-100" : "opacity-0",
+                    )}
+                    aria-hidden
+                  />
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+function FilterDropdownMenuOptionAvatar({
+  option,
+}: {
+  option: Pick<FilterDropdownMenuOption, "avatarLabel" | "image">;
+}) {
+  if (!option.avatarLabel) {
+    return null;
+  }
+
+  const fallback = option.avatarLabel.trim().charAt(0).toUpperCase() || "?";
+
+  return (
+    <Avatar className="size-5 shrink-0">
+      {option.image ? (
+        <AvatarImage src={option.image} alt={option.avatarLabel} />
+      ) : null}
+      <AvatarFallback className="bg-muted text-[10px] font-medium">
+        {fallback}
+      </AvatarFallback>
+    </Avatar>
+  );
+}


### PR DESCRIPTION
## Summary

Adds URL-driven **task list filters** (scope, coworker, status) on the Tasks page, wires filtering through column pagination and “load more,” and introduces a **read-only** experience when viewing another user’s task in an organization workspace (comments, share, overflow actions, and drag-and-drop respect ownership).

Tracks work for **SOK-448** (this PR is intentionally **not** linked to auto-close the issue).

## Key changes

- **Filters UI**: New `TasksViewFilters` plus shared `filter-dropdown-menu`; filter state is parsed from `searchParams` and passed as `initialFilters` into `TasksView`.
- **Data path**: `getTasksColumnPage` and `loadMoreTasksColumn` accept `scope`, `coworkerId`, and `status` so server pagination matches the active filters; invalid coworker IDs are ignored when building column pages.
- **Client reset behavior**: Replaces the previous organization-only “scope key” reset with `getTasksFiltersResetKey` so changing filters clears optimistic move state consistently.
- **Workspace read-only**: For org tasks where the current user is not the task owner, detail actions hide share/overflow where appropriate, comments are disabled, and Kanban/list drag is gated via `canDragTask` / `isTaskOwnerEditable`.
- **Create task modal**: Clearing `create` / `coworker` query params preserves other search params (e.g. filters).
- **i18n**: New `App.Tasks.Filters.*` strings across supported locales.
- **Tests**: Unit tests for filter parsing, `TasksViewFilters`, column page wiring, and updated action/component tests.

## Technical notes

- Filter types and helpers live in `apps/web/src/app/(app)/tasks/utils/tasks-filters.ts`.
- `coworkerService.listCoworkers("tasks")` is used in `loadMoreTasksColumn` to align with the tasks page coworker list.

## Testing

- `pnpm exec vitest run` (from `apps/web`) for:
  - `src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts`
  - `src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx`
  - `src/app/(app)/tasks/__tests__/actions.test.ts`
  - `src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts`

Recommended before merge: `pnpm --filter web test` and `pnpm web:check`.

## Risk / follow-ups

- Confirm product expectations for **which** actions remain visible in read-only workspace view (only share/overflow/composer/drag were gated in this branch).
