### PR TITLE
refactor(web): route updateJobName through Core API

### DIFF
--- a/apps/web/src/lib/actions/job/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/job/__tests__/action.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CommonErrorCode } from "@/lib/actions/errors/error-codes/common";
+import { JobErrorCode } from "@/lib/actions/errors/error-codes/job";
+
+vi.mock("@/lib/actions", () => ({
+  CommonErrorCode,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+  withScope: async (
+    callback: (scope: {
+      setTag: typeof vi.fn;
+      setContext: typeof vi.fn;
+    }) => Promise<unknown> | unknown,
+  ) =>
+    await callback({
+      setTag: vi.fn(),
+      setContext: vi.fn(),
+    }),
+}));
+
+vi.mock("@/middleware/auth-middleware", () => ({
+  withSession:
+    <TParams extends Record<string, unknown>, TResult>(
+      handler: (params: TParams) => Promise<TResult>,
+    ) =>
+    async (params: TParams) => {
+      const nextParams =
+        "session" in params
+          ? params
+          : {
+              ...params,
+              session: {
+                user: { id: "user-1", email: "ada@example.com" },
+                session: { activeOrganizationId: null },
+              },
+            };
+
+      return await handler(nextParams as TParams);
+    },
+}));
+
+const patchJobMock = vi.fn();
+const toCoreApiActionErrorMock = vi.fn();
+
+class MockCoreApiRequestError extends Error {
+  status?: number;
+
+  constructor(message: string, options?: { status?: number }) {
+    super(message);
+    this.name = "CoreApiRequestError";
+    this.status = options?.status;
+  }
+}
+
+vi.mock("@/lib/clients/core.client", () => ({
+  CoreApiRequestError: MockCoreApiRequestError,
+  coreClient: {
+    patchJob: (...args: unknown[]) => patchJobMock(...args),
+  },
+  toCoreApiActionError: (...args: unknown[]) =>
+    toCoreApiActionErrorMock(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {},
+}));
+
+vi.mock("@/lib/services", () => ({
+  callAgentHiredWebHook: vi.fn(),
+  jobService: {
+    moveJobToWorkspace: vi.fn(),
+    provideJobInput: vi.fn(),
+    requestRefund: vi.fn(),
+    startDemoJob: vi.fn(),
+    startJob: vi.fn(),
+  },
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  jobRepository: {
+    getJobByBlockchainIdentifier: vi.fn(),
+  },
+  userRepository: {
+    getUserById: vi.fn(),
+  },
+}));
+
+describe("updateJobName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toCoreApiActionErrorMock.mockReturnValue({
+      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      message: "Failed to communicate with Core API",
+    });
+  });
+
+  it("updates the job name through the core client", async () => {
+    patchJobMock.mockResolvedValue({ data: { id: "job-1" } });
+
+    const { updateJobName } = await import("../action");
+    const result = await updateJobName({
+      jobId: "job-1",
+      data: { name: "Renamed Job" },
+    });
+
+    expect(patchJobMock).toHaveBeenCalledWith("job-1", {
+      name: "Renamed Job",
+    });
+    expect(result).toEqual({ ok: true, data: undefined });
+  });
+
+  it("normalizes an empty name to null before calling core", async () => {
+    patchJobMock.mockResolvedValue({ data: { id: "job-1" } });
+
+    const { updateJobName } = await import("../action");
+    await updateJobName({
+      jobId: "job-1",
+      data: { name: "" },
+    });
+
+    expect(patchJobMock).toHaveBeenCalledWith("job-1", {
+      name: null,
+    });
+  });
+
+  it("returns bad input when validation fails", async () => {
+    const { updateJobName } = await import("../action");
+    const result = await updateJobName({
+      jobId: "job-1",
+      data: { name: "a" },
+    });
+
+    expect(patchJobMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        message: "Bad Input",
+        code: CommonErrorCode.BAD_INPUT,
+      },
+    });
+  });
+
+  it.each([
+    401, 403,
+  ])("returns unauthorized when core rejects with %i", async (status) => {
+    patchJobMock.mockRejectedValue(
+      new MockCoreApiRequestError("Unauthorized", { status }),
+    );
+
+    const { updateJobName } = await import("../action");
+    const result = await updateJobName({
+      jobId: "job-1",
+      data: { name: "Renamed Job" },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        message: "Unauthorized",
+        code: CommonErrorCode.UNAUTHORIZED,
+      },
+    });
+  });
+
+  it("returns job not found when core returns 404", async () => {
+    patchJobMock.mockRejectedValue(
+      new MockCoreApiRequestError("Job not found", { status: 404 }),
+    );
+
+    const { updateJobName } = await import("../action");
+    const result = await updateJobName({
+      jobId: "job-1",
+      data: { name: "Renamed Job" },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        message: "Job not found",
+        code: JobErrorCode.JOB_NOT_FOUND,
+      },
+    });
+  });
+
+  it("falls back to generic core error mapping for other failures", async () => {
+    patchJobMock.mockRejectedValue(new Error("service unavailable"));
+    toCoreApiActionErrorMock.mockReturnValue({
+      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      message: "The service is currently unavailable.",
+    });
+
+    const { updateJobName } = await import("../action");
+    const result = await updateJobName({
+      jobId: "job-1",
+      data: { name: "Renamed Job" },
+    });
+
+    expect(toCoreApiActionErrorMock).toHaveBeenCalledWith(expect.any(Error));
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+        message: "The service is currently unavailable.",
+      },
+    });
+  });
+});

--- a/apps/web/src/lib/actions/job/action.ts
+++ b/apps/web/src/lib/actions/job/action.ts
@@ -7,7 +7,11 @@ import { revalidatePath } from "next/cache";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions";
 import { isJobError, JobErrorCode } from "@/lib/actions/errors/error-codes/job";
-import { toCoreApiActionError } from "@/lib/clients/core.client";
+import {
+  CoreApiRequestError,
+  coreClient,
+  toCoreApiActionError,
+} from "@/lib/clients/core.client";
 import prisma from "@/lib/db/prisma";
 import {
   type JobDetailsNameFormSchemaType,
@@ -350,9 +354,7 @@ interface UpdateJobNameParameters extends AuthenticatedRequest {
 export const updateJobName = withSession<
   UpdateJobNameParameters,
   Result<void, ActionError>
->(async ({ jobId, data, session }) => {
-  const userId = session.user.id;
-
+>(async ({ jobId, data }) => {
   const parsedResult = jobDetailsNameFormSchema().safeParse(data);
   if (!parsedResult.success) {
     return Err({
@@ -362,29 +364,31 @@ export const updateJobName = withSession<
   }
   const parsed = parsedResult.data;
 
-  const job = await jobRepository.getJobById(jobId, prisma);
-  if (!job) {
-    return Err({
-      message: "Job not found",
-      code: JobErrorCode.JOB_NOT_FOUND,
+  try {
+    await coreClient.patchJob(jobId, {
+      name: parsed.name === "" ? null : parsed.name,
     });
-  }
 
-  // check job user id is same as authenticated user
-  if (job.userId !== userId) {
-    return Err({
-      message: "Unauthorized",
-      code: CommonErrorCode.UNAUTHORIZED,
-    });
-  }
+    return Ok();
+  } catch (error) {
+    if (error instanceof CoreApiRequestError) {
+      if (error.status === 404) {
+        return Err({
+          message: "Job not found",
+          code: JobErrorCode.JOB_NOT_FOUND,
+        });
+      }
 
-  // update job name
-  await jobRepository.updateJobNameById(
-    jobId,
-    parsed.name === "" ? null : parsed.name,
-    prisma,
-  );
-  return Ok();
+      if (error.status === 401 || error.status === 403) {
+        return Err({
+          message: "Unauthorized",
+          code: CommonErrorCode.UNAUTHORIZED,
+        });
+      }
+    }
+
+    return Err(toCoreApiActionError(error));
+  }
 });
 
 interface RequestRefundJobByBlockchainIdentifierParameters

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -13,6 +13,7 @@ import type {
   GetShareByTokenError,
   GetTasksData,
   PaginationMetadata,
+  PatchJobsByIdData,
   PostTasksByIdLinksData,
   PostUsersMeUploadsData,
   PutJobsByIdShareError,
@@ -40,6 +41,7 @@ import {
   getUsersMeOrganizations as coreGetUsersMeOrganizations,
   patchConversationsById as corePatchConversationsById,
   patchConversationsByIdArchive as corePatchConversationsByIdArchive,
+  patchJobsById as corePatchJobsById,
   patchTasksById as corePatchTasksById,
   postConversations as corePostConversations,
   postConversationsByIdItems as corePostConversationsByIdItems,
@@ -389,6 +391,22 @@ export function createCoreClient(getClient: GetClient) {
           cache: "no-store",
         }),
       "Failed to fetch job",
+    );
+  }
+
+  async function patchJob(
+    id: string,
+    body: NonNullable<PatchJobsByIdData["body"]>,
+  ) {
+    return executeOperation(
+      getClient,
+      (client) =>
+        corePatchJobsById({
+          client,
+          path: { id },
+          body,
+        }),
+      "Failed to update job",
     );
   }
 
@@ -857,6 +875,7 @@ export function createCoreClient(getClient: GetClient) {
     getSharedResourceByToken,
     moveJobToWorkspace,
     moveTaskToWorkspace,
+    patchJob,
     getTaskById,
     getTaskLinks,
     getTasks,


### PR DESCRIPTION
## Summary

Routes the `updateJobName` server action through the Core API (`PATCH /jobs/:id`) instead of updating the job directly via the web app database. Adds `patchJob` to the shared Core client and maps Core HTTP errors to existing action error codes.

## Key changes

- **Core client** (`apps/web/src/lib/clients/core.shared.ts`): Exposes `patchJob`, wrapping the generated `patchJobsById` OpenAPI operation with the existing `executeOperation` helper.
- **`updateJobName`** (`apps/web/src/lib/actions/job/action.ts`): Calls `coreClient.patchJob` with `name` (empty string normalized to `null`); removes the local Prisma job fetch and `userId` ownership check in favor of Core-side authorization; handles `CoreApiRequestError` for 404 (job not found), 401/403 (unauthorized), and falls back to `toCoreApiActionError` for other failures.
- **Tests** (`apps/web/src/lib/actions/job/__tests__/action.test.ts`): Covers success paths, validation, 401/403/404, and generic error mapping with mocked Core client.

## Architecture

Keeps job mutations behind the Core API boundary so authorization and persistence stay aligned with the Hono service rather than duplicating checks in the web layer.

## Testing

```bash
pnpm --filter web test src/lib/actions/job/__tests__/action.test.ts
```

## Related

Ref: **SOK-448** (linked for traceability; this PR does not close the issue.)
