### PR TITLE
fix(core): restrict POST /v1/coworkers to admin users

### DIFF
--- a/apps/core/src/routes/v1/coworkers/coworker-management-auth.test.ts
+++ b/apps/core/src/routes/v1/coworkers/coworker-management-auth.test.ts
@@ -59,6 +59,14 @@ const RESTRICTED_ENDPOINTS: Array<{
   restriction: "creator-or-admin" | "admin-only";
 }> = [
   {
+    method: "POST",
+    path: "/",
+    body: {
+      name: "Ops Agent",
+    },
+    restriction: "admin-only",
+  },
+  {
     method: "PATCH",
     path: "/cow_123/whitelist",
     body: {
@@ -165,25 +173,6 @@ describe("coworker management endpoints auth guard", () => {
       method,
       headers: body ? { "Content-Type": "application/json" } : undefined,
       body: body ? JSON.stringify(body) : undefined,
-    });
-
-    expect(response.status).toBe(403);
-  });
-
-  it("returns 403 for coworker actor on POST /", async () => {
-    const app = createApp({
-      actor: "coworker",
-      coworkerId: "cow_123",
-    });
-
-    const response = await app.request("http://localhost/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Ops Agent",
-      }),
     });
 
     expect(response.status).toBe(403);

--- a/apps/core/src/routes/v1/coworkers/coworker-management.test.ts
+++ b/apps/core/src/routes/v1/coworkers/coworker-management.test.ts
@@ -139,7 +139,7 @@ describe("coworker management CRUD endpoints", () => {
 
     mockTransaction(tx);
 
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -154,7 +154,7 @@ describe("coworker management CRUD endpoints", () => {
     expect(coworkerCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          userId: "user_123",
+          userId: "admin_123",
           isWhitelisted: false,
           priority: 0,
           baseURL: null,
@@ -182,7 +182,7 @@ describe("coworker management CRUD endpoints", () => {
 
     mockTransaction(tx);
 
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -256,7 +256,7 @@ describe("coworker management CRUD endpoints", () => {
     expect(body.data.priority).toBe(10);
   });
 
-  it("rejects explicit priority on create for non-admin", async () => {
+  it("rejects create for non-admin", async () => {
     const app = createApp();
     const response = await app.request("http://localhost/", {
       method: "POST",
@@ -265,7 +265,6 @@ describe("coworker management CRUD endpoints", () => {
       },
       body: JSON.stringify({
         name: "Ops Agent",
-        priority: 10,
       }),
     });
 
@@ -292,7 +291,7 @@ describe("coworker management CRUD endpoints", () => {
 
     mockTransaction(tx);
 
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -339,7 +338,7 @@ describe("coworker management CRUD endpoints", () => {
 
     mockTransaction(tx);
 
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -378,7 +377,7 @@ describe("coworker management CRUD endpoints", () => {
 
     mockTransaction(tx);
 
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -420,7 +419,7 @@ describe("coworker management CRUD endpoints", () => {
 
     mockTransaction(tx);
 
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -435,7 +434,7 @@ describe("coworker management CRUD endpoints", () => {
   });
 
   it("rejects create when name is shorter than 3 characters", async () => {
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {
@@ -451,7 +450,7 @@ describe("coworker management CRUD endpoints", () => {
   });
 
   it("rejects create when companyLogo is not a valid HTTP URL", async () => {
-    const app = createApp();
+    const app = createApp({ userId: "admin_123", role: "admin" });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: {

--- a/apps/core/src/routes/v1/coworkers/post.ts
+++ b/apps/core/src/routes/v1/coworkers/post.ts
@@ -7,10 +7,7 @@ import { isSlugUniqueConstraintError } from "@/helpers/prisma";
 import { created } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import {
-  requireAdminAuthContext,
-  requireUserAuthContext,
-} from "@/middleware/auth";
+import { requireAdminAuthContext } from "@/middleware/auth";
 import { coworkerSchema } from "@/schemas/coworker.schema";
 import { normalizeCoworkerMetadata } from "./metadata";
 import { createCoworkerRequestSchema } from "./schema";
@@ -18,7 +15,7 @@ import { createCoworkerRequestSchema } from "./schema";
 const route = createRoute({
   method: "post",
   path: "/",
-  description: "Create coworker",
+  description: "Create coworker (admin only)",
   tags: ["Coworkers"],
   request: {
     body: {
@@ -68,12 +65,8 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
+    const userAuthContext = requireAdminAuthContext(c.var.authContext);
     const body = c.req.valid("json");
-    let userAuthContext = requireUserAuthContext(c.var.authContext);
-
-    if (body.priority !== undefined) {
-      userAuthContext = requireAdminAuthContext(c.var.authContext);
-    }
 
     const metadata = normalizeCoworkerMetadata(body.metadata);
     const slug = slugify(body.name, {

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -559,7 +559,7 @@ export const getCoworkers = <ThrowOnError extends boolean = false>(options?: Opt
 });
 
 /**
- * Create coworker
+ * Create coworker (admin only)
  */
 export const postCoworkers = <ThrowOnError extends boolean = false>(options?: Options<PostCoworkersData, ThrowOnError>) => (options?.client ?? client).post<PostCoworkersResponses, PostCoworkersErrors, ThrowOnError>({
     responseTransformer: postCoworkersResponseTransformer,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -7103,7 +7103,7 @@ export type PostCoworkersError = PostCoworkersErrors[keyof PostCoworkersErrors];
 
 export type PostCoworkersResponses = {
     /**
-     * Create coworker
+     * Create coworker (admin only)
      */
     201: {
         data: Coworker;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`POST /v1/coworkers` now requires an interactive user session whose `User.role` includes `admin`, using the same `requireAdminAuthContext` pattern as other admin-only routes (for example credit costs). Non-admin users receive `403` with message `Admin access required` before request body validation.

## Notes

- Coworkers are still created for the authenticated admin user (`userId` on the new row matches the session user).
- Updated Vitest coverage for create flows and auth matrix; merged the duplicate coworker POST auth test into the shared table.
- Synced the generated web client JSDoc for `postCoworkers` with the new OpenAPI description.

## Verification

- `pnpm test` (from `apps/core`) for `coworker-management.test.ts` and `coworker-management-auth.test.ts`
- `pnpm exec biome check` on touched core sources
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b03d839-701d-48e4-a68d-af5426516a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b03d839-701d-48e4-a68d-af5426516a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

