### PR TITLE
feat(web): use AgentIcon in jobs filter dropdown

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/jobs-view-filters.tsx
+++ b/apps/web/src/app/(app)/tasks/components/jobs-view-filters.tsx
@@ -121,6 +121,7 @@ export function JobsViewFilters({
         label: agent.name,
         avatarLabel: agent.name,
         image: agent.image,
+        useAgentIcon: true,
       })),
     });
 

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -2,6 +2,7 @@
 
 import { Check, ListFilter, type LucideIcon } from "lucide-react";
 import { useMemo, useState } from "react";
+import AgentIcon from "@/components/agents/agent-icon";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ export interface FilterDropdownMenuOption {
   label: string;
   avatarLabel?: string;
   image?: string | null;
+  useAgentIcon?: boolean;
   searchKeywords?: string[];
 }
 
@@ -183,10 +185,27 @@ function FilterDropdownMenuSectionItem({
 function FilterDropdownMenuOptionAvatar({
   option,
 }: {
-  option: Pick<FilterDropdownMenuOption, "avatarLabel" | "image">;
+  option: Pick<
+    FilterDropdownMenuOption,
+    "avatarLabel" | "image" | "useAgentIcon"
+  >;
 }) {
   if (!option.avatarLabel) {
     return null;
+  }
+
+  if (option.useAgentIcon) {
+    return (
+      <span className="flex size-5 shrink-0 items-center justify-center text-current">
+        <AgentIcon
+          agent={{
+            name: option.avatarLabel,
+            icon: option.image ?? null,
+          }}
+          className="size-4 shrink-0"
+        />
+      </span>
+    );
   }
 
   const fallback = option.avatarLabel.trim().charAt(0).toUpperCase() || "?";


### PR DESCRIPTION
## Summary

Job filter options for agents now use the shared `AgentIcon` component so filter chips and the dropdown match agent branding used elsewhere in the app.

## Key changes

- Add optional `useAgentIcon` to `FilterDropdownMenuOption` in `filter-dropdown-menu.tsx`.
- When set, `FilterDropdownMenuOptionAvatar` renders `AgentIcon` (name + icon) inside a fixed-size wrapper instead of the generic `Avatar` image/fallback.
- Tasks jobs view agent filter options pass `useAgentIcon: true` when building dropdown options.

## Technical notes

- `AgentIcon` receives `agent: { name, icon }` where `icon` maps from the existing `image` option field (nullable).

## Testing

- [ ] Open **Tasks** (jobs view), open the filter menu, and expand the agent filter: each option should show the same agent icon treatment as other agent surfaces.
- [ ] Smoke: other filter dropdowns that do not set `useAgentIcon` should still use the previous avatar/fallback behavior.
