### PR TITLE
feat(ai-provider): map file parts to Responses API multimodal input

### DIFF
--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildResponsesApiWarnings,
   lastTurnToResponsesInput,
   promptToResponsesInput,
 } from "./to-responses-input.js";
@@ -46,6 +47,194 @@ describe("promptToResponsesInput", () => {
     ]);
     expect(input).toEqual([]);
   });
+
+  it("concatenates adjacent user text parts into one input_text", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello" },
+          { type: "text", text: " " },
+          { type: "text", text: "world" },
+        ],
+      },
+    ]);
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Hello world" }],
+      },
+    ]);
+  });
+
+  it("maps image urls and file data to multimodal responses content", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Please review these." },
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new URL("https://example.com/image.png"),
+          },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+            data: "JVBERi0xLjcK",
+          },
+        ],
+      },
+    ]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Please review these." },
+          {
+            type: "input_image",
+            image_url: "https://example.com/image.png",
+            detail: "auto",
+          },
+          {
+            type: "input_file",
+            file_data: "JVBERi0xLjcK",
+            filename: "brief.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("maps non-image file parts with https blob URL string to input_file file_url", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+            data: "https://storage.example.com/containers/blobs/abc123.pdf",
+          },
+        ],
+      },
+    ]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_file",
+            file_url: "https://storage.example.com/containers/blobs/abc123.pdf",
+            filename: "brief.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("throws for non-base64 file data urls that cannot be mapped safely", () => {
+    expect(() =>
+      promptToResponsesInput([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "application/pdf",
+              filename: "brief.pdf",
+              data: "data:application/pdf,plain-text",
+            },
+          ],
+        },
+      ]),
+    ).toThrowError(/base64/i);
+  });
+
+  it("throws for image file parts with non-http(s) URL strings", () => {
+    expect(() =>
+      promptToResponsesInput([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "image/png",
+              data: "file:///tmp/x.png",
+            },
+          ],
+        },
+      ]),
+    ).toThrowError(/http\(s\)/i);
+  });
+});
+
+describe("buildResponsesApiWarnings", () => {
+  it("warns for assistant file parts and non-http(s) document URLs", () => {
+    const warnings = buildResponsesApiWarnings([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "See attached." },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "x.pdf",
+            data: new URL("file:///tmp/x.pdf"),
+          },
+        ],
+      },
+    ]);
+
+    expect(warnings).toEqual([
+      {
+        type: "compatibility",
+        feature: "assistant file parts",
+        details:
+          "File parts on assistant messages are forwarded to the Responses input. Confirm your model endpoint accepts multimodal assistant turns.",
+      },
+      {
+        type: "compatibility",
+        feature: "non-HTTP(S) file URL",
+        details:
+          'A file part uses URL "file:///tmp/x.pdf" as file_url. Only http(s) and data payloads are fully supported; other schemes may be rejected or mishandled by the upstream API.',
+      },
+    ]);
+  });
+
+  it("dedupes repeated assistant-file warnings for one message", () => {
+    const warnings = buildResponsesApiWarnings([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            data: "JVBERi0xLjcK",
+          },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            data: "JVBERi0xLjcK",
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      warnings.filter(
+        (w) =>
+          w.type === "compatibility" && w.feature === "assistant file parts",
+      ),
+    ).toHaveLength(1);
+  });
 });
 
 describe("lastTurnToResponsesInput", () => {
@@ -85,5 +274,38 @@ describe("lastTurnToResponsesInput", () => {
       },
     ]);
     expect(input.some((m) => m.role === "system")).toBe(true);
+  });
+
+  it("keeps image-only user turns", () => {
+    const input = lastTurnToResponsesInput([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Show me the image." }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new URL("https://example.com/image.png"),
+          },
+        ],
+      },
+    ]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_image",
+            image_url: "https://example.com/image.png",
+            detail: "auto",
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -110,6 +110,47 @@ describe("promptToResponsesInput", () => {
     ]);
   });
 
+  it("accepts data URLs with empty mediatype before ;base64 (blob-style)", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "application/octet-stream",
+            filename: "blob.bin",
+            data: "data:;base64,SGVsbG8=",
+          },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "from-url.pdf",
+            data: new URL("data:;base64,JVBERi0xLjcK"),
+          },
+        ],
+      },
+    ]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_file",
+            file_data: "SGVsbG8=",
+            filename: "blob.bin",
+          },
+          {
+            type: "input_file",
+            file_data: "JVBERi0xLjcK",
+            filename: "from-url.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+
   it("maps non-image file parts with https blob URL string to input_file file_url", () => {
     const input = promptToResponsesInput([
       {

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -41,10 +41,10 @@ export function buildResponsesApiWarnings(
     if (message.role !== "user" && message.role !== "assistant") {
       continue;
     }
-      for (const part of message.content) {
+    for (const part of message.content) {
       if (part.type !== "file") {
         continue;
-        }
+      }
       if (message.role === "assistant") {
         warnings.push({
           type: "compatibility",
@@ -65,8 +65,8 @@ export function buildResponsesApiWarnings(
           feature: "non-HTTP(S) file URL",
           details: `A file part uses URL "${url.slice(0, 120)}${url.length > 120 ? "…" : ""}" as file_url. Only http(s) and data payloads are fully supported; other schemes may be rejected or mishandled by the upstream API.`,
         });
+      }
     }
-  }
   }
   return dedupeWarnings(warnings);
 }

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -315,7 +315,8 @@ function extractBase64DataFromDataUrl(
   value: string,
   part: LanguageModelV3FilePart,
 ): string {
-  const match = /^data:[^;,]+(?:;[^;,=]+=[^;,]+)*(;base64)?,(.*)$/i.exec(value);
+  // RFC 2397: mediatype may be empty (`data:;base64,...` is valid).
+  const match = /^data:[^;,]*(?:;[^;,=]+=[^;,]+)*(;base64)?,(.*)$/i.exec(value);
 
   if (match?.[1] !== ";base64") {
     throw invalidFilePartError(

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -1,53 +1,122 @@
-import type { LanguageModelV3Prompt, SharedV3Warning } from "@ai-sdk/provider";
+import {
+  InvalidPromptError,
+  type LanguageModelV3FilePart,
+  type LanguageModelV3Prompt,
+  type SharedV3Warning,
+} from "@ai-sdk/provider";
+
+interface OpenRouterResponsesInputTextItem {
+  type: "input_text";
+  text: string;
+}
+
+interface OpenRouterResponsesInputImageItem {
+  type: "input_image";
+  image_url: string;
+  detail: "auto";
+}
+
+interface OpenRouterResponsesInputFileItem {
+  type: "input_file";
+  file_data?: string;
+  file_url?: string;
+  filename?: string;
+}
 
 export type OpenRouterResponsesInputMessage = {
   type: "message";
   role: string;
-  content: Array<{ type: "input_text"; text: string }>;
+  content: Array<
+    | OpenRouterResponsesInputTextItem
+    | OpenRouterResponsesInputImageItem
+    | OpenRouterResponsesInputFileItem
+  >;
 };
 
 export function buildResponsesApiWarnings(
   prompt: LanguageModelV3Prompt,
 ): SharedV3Warning[] {
-  let sawUnsupportedFile = false;
+  const warnings: SharedV3Warning[] = [];
   for (const message of prompt) {
-    if (message.role === "system") {
+    if (message.role !== "user" && message.role !== "assistant") {
       continue;
     }
-    if (message.role === "user" || message.role === "assistant") {
       for (const part of message.content) {
-        if (part.type === "file") {
-          sawUnsupportedFile = true;
-          break;
+      if (part.type !== "file") {
+        continue;
         }
+      if (message.role === "assistant") {
+        warnings.push({
+          type: "compatibility",
+          feature: "assistant file parts",
+          details:
+            "File parts on assistant messages are forwarded to the Responses input. Confirm your model endpoint accepts multimodal assistant turns.",
+        });
       }
+      const url = toUrlString(part.data);
+      if (
+        url !== null &&
+        !url.startsWith("data:") &&
+        !isWebUrl(url) &&
+        !part.mediaType.startsWith("image/")
+      ) {
+        warnings.push({
+          type: "compatibility",
+          feature: "non-HTTP(S) file URL",
+          details: `A file part uses URL "${url.slice(0, 120)}${url.length > 120 ? "…" : ""}" as file_url. Only http(s) and data payloads are fully supported; other schemes may be rejected or mishandled by the upstream API.`,
+        });
     }
   }
-  if (!sawUnsupportedFile) {
-    return [];
   }
-  return [
-    {
-      type: "unsupported",
-      feature: "file parts",
-      details:
-        "File parts are omitted from the OpenRouter / coworker Responses input; only text is sent.",
-    },
-  ];
+  return dedupeWarnings(warnings);
 }
 
-function userAssistantText(
+function dedupeWarnings(warnings: SharedV3Warning[]): SharedV3Warning[] {
+  const seen = new Set<string>();
+  const out: SharedV3Warning[] = [];
+  for (const w of warnings) {
+    const key =
+      w.type === "other"
+        ? `other:${w.message}`
+        : `${w.type}:${w.feature}:${w.details ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(w);
+  }
+  return out;
+}
+
+function userAssistantContent(
   message:
     | Extract<LanguageModelV3Prompt[number], { role: "user" }>
     | Extract<LanguageModelV3Prompt[number], { role: "assistant" }>,
-): string {
-  let text = "";
+): OpenRouterResponsesInputMessage["content"] {
+  const content: OpenRouterResponsesInputMessage["content"] = [];
+  let textRun = "";
+
+  const flushTextRun = () => {
+    if (textRun.trim().length > 0) {
+      content.push({ type: "input_text", text: textRun });
+    }
+    textRun = "";
+  };
+
   for (const part of message.content) {
     if (part.type === "text") {
-      text += part.text;
+      textRun += part.text;
+      continue;
+    }
+
+    if (part.type === "file") {
+      flushTextRun();
+      content.push(filePartToResponsesContent(part));
     }
   }
-  return text;
+  flushTextRun();
+
+  return content;
 }
 
 function toolMessageText(
@@ -82,24 +151,24 @@ export function promptToResponsesInput(
     }
 
     if (message.role === "user") {
-      const text = userAssistantText(message);
-      if (text.trim().length > 0) {
+      const content = userAssistantContent(message);
+      if (content.length > 0) {
         input.push({
           type: "message",
           role: "user",
-          content: [{ type: "input_text", text }],
+          content,
         });
       }
       continue;
     }
 
     if (message.role === "assistant") {
-      const text = userAssistantText(message);
-      if (text.trim().length > 0) {
+      const content = userAssistantContent(message);
+      if (content.length > 0) {
         input.push({
           type: "message",
           role: "assistant",
-          content: [{ type: "input_text", text }],
+          content,
         });
       }
       continue;
@@ -117,6 +186,155 @@ export function promptToResponsesInput(
     }
   }
   return input;
+}
+
+function filePartToResponsesContent(
+  part: LanguageModelV3FilePart,
+): OpenRouterResponsesInputImageItem | OpenRouterResponsesInputFileItem {
+  if (part.mediaType.startsWith("image/")) {
+    return {
+      type: "input_image",
+      image_url: toImageUrl(part),
+      detail: "auto",
+    };
+  }
+
+  const url = toUrlString(part.data);
+  if (url !== null && !url.startsWith("data:")) {
+    return {
+      type: "input_file",
+      file_url: url,
+      filename: part.filename,
+    };
+  }
+
+  return {
+    type: "input_file",
+    file_data: toFileData(part),
+    filename: part.filename,
+  };
+}
+
+function toImageUrl(part: LanguageModelV3FilePart): string {
+  const url = toUrlString(part.data);
+
+  if (url !== null) {
+    if (url.startsWith("data:") || isWebUrl(url)) {
+      return url;
+    }
+    throw invalidFilePartError(
+      part,
+      "Image file parts only support http(s) URLs, data URLs, or raw bytes / base64 string payloads.",
+    );
+  }
+
+  return toDataUrl(part);
+}
+
+function toFileData(part: LanguageModelV3FilePart): string {
+  if (part.data instanceof Uint8Array) {
+    return Buffer.from(part.data).toString("base64");
+  }
+
+  if (part.data instanceof URL) {
+    const url = part.data.toString();
+    if (url.startsWith("data:")) {
+      return extractBase64DataFromDataUrl(url, part);
+    }
+    throw invalidFilePartError(
+      part,
+      "URL-based file parts must be sent as file_url.",
+    );
+  }
+
+  if (typeof part.data === "string") {
+    if (isWebUrl(part.data)) {
+      throw invalidFilePartError(
+        part,
+        "URL-based file parts must be sent as file_url.",
+      );
+    }
+    if (part.data.startsWith("data:")) {
+      return extractBase64DataFromDataUrl(part.data, part);
+    }
+    return part.data;
+  }
+
+  throw invalidFilePartError(
+    part,
+    `Unsupported file data type "${typeof part.data}".`,
+  );
+}
+
+function toUrlString(data: LanguageModelV3FilePart["data"]): string | null {
+  if (data instanceof URL) {
+    return data.toString();
+  }
+
+  if (typeof data !== "string") {
+    return null;
+  }
+
+  try {
+    return new URL(data).toString();
+  } catch {
+    return null;
+  }
+}
+
+function isWebUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function toDataUrl(part: LanguageModelV3FilePart): string {
+  if (part.data instanceof Uint8Array) {
+    return `data:${part.mediaType};base64,${Buffer.from(part.data).toString("base64")}`;
+  }
+
+  if (typeof part.data === "string") {
+    if (part.data.startsWith("data:")) {
+      return part.data;
+    }
+    if (isWebUrl(part.data)) {
+      return part.data;
+    }
+    return `data:${part.mediaType};base64,${part.data}`;
+  }
+
+  if (part.data instanceof URL) {
+    return part.data.toString();
+  }
+
+  throw invalidFilePartError(
+    part,
+    `Unsupported image data type "${typeof part.data}".`,
+  );
+}
+
+function extractBase64DataFromDataUrl(
+  value: string,
+  part: LanguageModelV3FilePart,
+): string {
+  const match = /^data:[^;,]+(?:;[^;,=]+=[^;,]+)*(;base64)?,(.*)$/i.exec(value);
+
+  if (match?.[1] !== ";base64") {
+    throw invalidFilePartError(
+      part,
+      "Only base64 data URLs are supported for file inputs.",
+    );
+  }
+
+  return match[2] ?? "";
+}
+
+function invalidFilePartError(
+  part: LanguageModelV3FilePart,
+  reason: string,
+): InvalidPromptError {
+  return new InvalidPromptError({
+    prompt: part,
+    message: `Sokosumi provider: cannot map file part (${part.mediaType}) to Responses API input. ${reason}`,
+  });
 }
 
 export function lastTurnToResponsesInput(

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -7,6 +7,7 @@ import {
   type LanguageModelV3Content,
   type LanguageModelV3GenerateResult,
   type LanguageModelV3StreamResult,
+  type SharedV3Warning,
 } from "@ai-sdk/provider";
 import { getModelIdentifier } from "@sokosumi/chat";
 import { parseSokosumiProviderOptions } from "./parse-provider-options.js";
@@ -48,7 +49,7 @@ export function createSokosumiLanguageModel(
     const content: LanguageModelV3Content[] = [];
     let textBuffer = "";
     let reasoningBuffer = "";
-    let warnings = buildResponsesApiWarnings(options.prompt);
+    let warnings: SharedV3Warning[] = [];
     let finishReason = finishStop();
     let usage = emptyUsage();
 
@@ -119,7 +120,7 @@ export function createSokosumiLanguageModel(
       if (responsesInput.length === 0) {
         throw new APICallError({
           message:
-            "Sokosumi provider: prompt produced an empty Responses API input (no text to send).",
+            "Sokosumi provider: prompt produced an empty Responses API input (no supported content to send).",
           url: OPENROUTER_RESPONSES_URL,
           requestBodyValues: { responsesInput },
           isRetryable: false,
@@ -152,7 +153,7 @@ async function streamOpenRouter(
   modelId: string | null,
   config: CreateSokosumiOptions,
   responsesInput: ReturnType<typeof promptToResponsesInput>,
-  promptWarnings: ReturnType<typeof buildResponsesApiWarnings>,
+  promptWarnings: SharedV3Warning[],
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
   options: LanguageModelV3CallOptions,
 ): Promise<LanguageModelV3StreamResult> {
@@ -222,7 +223,7 @@ async function streamOpenRouter(
 }
 
 async function streamCoworker(
-  promptWarnings: ReturnType<typeof buildResponsesApiWarnings>,
+  promptWarnings: SharedV3Warning[],
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
   options: LanguageModelV3CallOptions,
 ): Promise<LanguageModelV3StreamResult> {
@@ -234,7 +235,7 @@ async function streamCoworker(
   if (responsesInput.length === 0) {
     throw new APICallError({
       message:
-        "Sokosumi provider: prompt produced an empty Responses API input (no text to send).",
+        "Sokosumi provider: prompt produced an empty Responses API input (no supported content to send).",
       url: `${(sokosumiOpts.coworkerBaseUrl ?? "").replace(/\/$/, "")}/responses`,
       requestBodyValues: { responsesInput },
       isRetryable: false,


### PR DESCRIPTION
## Summary

Maps V3 `file` parts on user and assistant turns into OpenRouter Responses API multimodal input (`input_image`, `input_file`, alongside `input_text`) instead of stripping files and emitting a blanket unsupported warning.

## Key changes

- **`promptToResponsesInput`**: Builds structured message `content` arrays; merges adjacent text parts into `input_text`; maps image parts to `input_image` (http(s), data URLs, or byte/base64 payloads); maps documents to `input_file` via `file_url` for web URLs or `file_data` for base64 payloads; rejects ambiguous or unsupported payloads with `InvalidPromptError`.
- **`buildResponsesApiWarnings`**: Replaces the generic “file parts omitted” warning with compatibility warnings for assistant file parts and non-HTTP(S) document URLs; deduplicates repeated warnings.
- **`lastTurnToResponsesInput`**: Keeps image-only user turns when trimming history.
- **`createSokosumiLanguageModel`**: Types stream warnings as `SharedV3Warning[]`, relies on `stream-start` for runtime warnings, and passes `promptWarnings` from `buildResponsesApiWarnings` into streaming helpers; empty-input error copy now refers to “supported content” rather than text only.

## Technical notes

- Image URLs are restricted to http(s), data URLs, or inline base64; non-web URL strings for images throw.
- Non-image files with string data that parses as a URL use `file_url`; otherwise `file_data` (base64). Data URLs must declare `;base64,`.

## Testing

- Extended Vitest coverage in `packages/ai-provider/src/prompt/to-responses-input.test.ts` for multimodal mapping, edge cases, validation errors, warning deduplication, and `lastTurnToResponsesInput` image-only behavior.

## Tracking

Related to Linear **DEV-922** (non-closing).
