### PR TITLE
feat(web): persist welcome compose and create-task coworker choices

### DIFF
--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -234,6 +234,9 @@ export default function ChatInterface({
   const welcomeTaskCreationInFlightRef = useRef(false);
 
   const welcomePrefsHydratedRef = useRef(false);
+  const previousWelcomeCoworkerSlugRef = useRef<string | null>(
+    welcomeCoworkerSlug,
+  );
   const welcomeSelectedCoworkerRef = useRef<Coworker | null>(null);
   const welcomeSelectedModelRef = useRef<{
     id: string;
@@ -292,19 +295,22 @@ export default function ChatInterface({
   const previousSelectedChatIdForComposeRef = useRef<string | null>(
     selectedChatId,
   );
-  useEffect(() => {
-    const previous = previousSelectedChatIdForComposeRef.current;
-    previousSelectedChatIdForComposeRef.current = selectedChatId;
-    if (previous !== null && selectedChatId === null) {
+  // Invalidate stored welcome prefs during render so the hydration
+  // `useLayoutEffect` runs before paint (avoids one frame of stale welcome UI).
+  const previousComposeSelectedChatId =
+    previousSelectedChatIdForComposeRef.current;
+  if (previousComposeSelectedChatId !== selectedChatId) {
+    if (previousComposeSelectedChatId !== null && selectedChatId === null) {
       welcomePrefsHydratedRef.current = false;
     }
-  }, [selectedChatId]);
-
-  useEffect(() => {
+    previousSelectedChatIdForComposeRef.current = selectedChatId;
+  }
+  if (previousWelcomeCoworkerSlugRef.current !== welcomeCoworkerSlug) {
     welcomePrefsHydratedRef.current = false;
-  }, [welcomeCoworkerSlug]);
+    previousWelcomeCoworkerSlugRef.current = welcomeCoworkerSlug;
+  }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (selectedChatId !== null) return;
     if (coworkers.length === 0) return;
     if (welcomePrefsHydratedRef.current) return;

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -35,6 +35,12 @@ import type {
   ChatComposeSubmitOptions,
   Coworker,
 } from "@/app/chat/utils/types";
+import {
+  buildWelcomeComposeStoredSnapshot,
+  readWelcomeComposePreferences,
+  resolveHydratedWelcomeSelection,
+  writeWelcomeComposePreferences,
+} from "@/app/chat/utils/welcome-compose-preferences";
 import { useChatCreation } from "@/app/chat-ui/hooks/use-chat-creation";
 import { useChatSelection } from "@/app/chat-ui/hooks/use-chat-selection";
 import {
@@ -222,23 +228,66 @@ export default function ChatInterface({
         ? initialWelcomeCoworker
         : (welcomeSelectedCoworker ?? initialWelcomeCoworker);
 
-  const handleWelcomeCoworkerChange = useCallback((coworker: Coworker) => {
-    setWelcomeSelectedCoworker(coworker);
-    setWelcomeSelectedModel(null);
-  }, []);
-
-  const handleWelcomeModelChange = useCallback(
-    (model: { id: string; name: string } | null) => {
-      setWelcomeSelectedModel(model);
-      if (model) setWelcomeSelectedCoworker(null);
-    },
-    [],
-  );
-
   const [welcomeComposeKind, setWelcomeComposeKind] =
     useState<ChatComposeKind>("chat");
   const [isWelcomeTaskSubmitting, setIsWelcomeTaskSubmitting] = useState(false);
   const welcomeTaskCreationInFlightRef = useRef(false);
+
+  const welcomePrefsHydratedRef = useRef(false);
+  const welcomeSelectedCoworkerRef = useRef<Coworker | null>(null);
+  const welcomeSelectedModelRef = useRef<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const welcomeComposeKindRef = useRef<ChatComposeKind>("chat");
+  welcomeSelectedCoworkerRef.current = welcomeSelectedCoworker;
+  welcomeSelectedModelRef.current = welcomeSelectedModel;
+  welcomeComposeKindRef.current = welcomeComposeKind;
+
+  const writeWelcomePrefsFromRefs = useCallback(() => {
+    if (selectedChatId !== null) return;
+    if (welcomeCoworkerSlug) return;
+    writeWelcomeComposePreferences(
+      buildWelcomeComposeStoredSnapshot({
+        composeKind: welcomeComposeKindRef.current,
+        coworker: welcomeSelectedCoworkerRef.current,
+        model: welcomeSelectedModelRef.current,
+      }),
+    );
+  }, [selectedChatId, welcomeCoworkerSlug]);
+
+  const handleWelcomeComposeKindChange = useCallback(
+    (kind: ChatComposeKind) => {
+      setWelcomeComposeKind(kind);
+      welcomeComposeKindRef.current = kind;
+      writeWelcomePrefsFromRefs();
+    },
+    [writeWelcomePrefsFromRefs],
+  );
+
+  const handleWelcomeCoworkerChange = useCallback(
+    (coworker: Coworker) => {
+      setWelcomeSelectedCoworker(coworker);
+      setWelcomeSelectedModel(null);
+      welcomeSelectedCoworkerRef.current = coworker;
+      welcomeSelectedModelRef.current = null;
+      writeWelcomePrefsFromRefs();
+    },
+    [writeWelcomePrefsFromRefs],
+  );
+
+  const handleWelcomeModelChange = useCallback(
+    (model: { id: string; name: string } | null) => {
+      setWelcomeSelectedModel(model);
+      if (model) {
+        setWelcomeSelectedCoworker(null);
+        welcomeSelectedCoworkerRef.current = null;
+      }
+      welcomeSelectedModelRef.current = model;
+      writeWelcomePrefsFromRefs();
+    },
+    [writeWelcomePrefsFromRefs],
+  );
 
   const previousSelectedChatIdForComposeRef = useRef<string | null>(
     selectedChatId,
@@ -247,16 +296,49 @@ export default function ChatInterface({
     const previous = previousSelectedChatIdForComposeRef.current;
     previousSelectedChatIdForComposeRef.current = selectedChatId;
     if (previous !== null && selectedChatId === null) {
-      setWelcomeComposeKind("chat");
+      welcomePrefsHydratedRef.current = false;
     }
   }, [selectedChatId]);
 
   useEffect(() => {
-    if (isRouteDriven && !urlConversationId && isChatPath) {
-      setWelcomeSelectedCoworker(null);
+    welcomePrefsHydratedRef.current = false;
+  }, [welcomeCoworkerSlug]);
+
+  useEffect(() => {
+    if (selectedChatId !== null) return;
+    if (coworkers.length === 0) return;
+    if (welcomePrefsHydratedRef.current) return;
+    welcomePrefsHydratedRef.current = true;
+
+    const stored = readWelcomeComposePreferences();
+    const resolved = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: welcomeCoworkerSlug != null,
+    });
+
+    setWelcomeComposeKind(resolved.composeKind);
+    welcomeComposeKindRef.current = resolved.composeKind;
+
+    if (welcomeCoworkerSlug != null) {
       setWelcomeSelectedModel(null);
+      setWelcomeSelectedCoworker(null);
+      return;
     }
-  }, [isChatPath, isRouteDriven, urlConversationId]);
+
+    if (resolved.model) {
+      setWelcomeSelectedModel(resolved.model);
+      setWelcomeSelectedCoworker(null);
+      return;
+    }
+
+    if (resolved.coworker) {
+      setWelcomeSelectedCoworker(resolved.coworker);
+      setWelcomeSelectedModel(null);
+      return;
+    }
+
+    setWelcomeSelectedCoworker(null);
+    setWelcomeSelectedModel(null);
+  }, [selectedChatId, coworkers, welcomeCoworkerSlug]);
 
   const selectedModelRef = useRef<{ id: string; name: string } | null>(null);
   const chatMessagesRef = useRef<Map<string, unknown[]>>(new Map());
@@ -288,9 +370,7 @@ export default function ChatInterface({
     setSelectedModel(null);
     selectedModelRef.current = null;
     setInput("");
-    setWelcomeSelectedCoworker(null);
-    setWelcomeSelectedModel(null);
-    setWelcomeComposeKind("chat");
+    welcomePrefsHydratedRef.current = false;
   }, [controlledConversationId, isRouteDriven, setSelectedModel]);
 
   useEffect(() => {
@@ -1447,7 +1527,7 @@ export default function ChatInterface({
             showGreetingAndSuggestions={showGreetingAndSuggestions}
             userName={userName?.split(" ")[0] ?? userName}
             welcomeComposeKind={welcomeComposeKind}
-            onWelcomeComposeKindChange={setWelcomeComposeKind}
+            onWelcomeComposeKindChange={handleWelcomeComposeKindChange}
             welcomeSendBlocked={isWelcomeTaskSubmitting}
             onSendMessage={handleSendMessage}
             isTransitioning={isWelcomeTransitioning}

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -299,6 +299,9 @@ export default function ChatInterface({
   const previousSelectedChatIdForComposeRef = useRef<string | null>(
     selectedChatId,
   );
+  const previousControlledConversationIdRef = useRef<string | null>(
+    controlledConversationId,
+  );
   // Invalidate stored welcome prefs during render so the hydration
   // `useLayoutEffect` runs before paint (avoids one frame of stale welcome UI).
   const previousComposeSelectedChatId =
@@ -365,14 +368,19 @@ export default function ChatInterface({
 
   useEffect(() => {
     if (isRouteDriven) {
+      previousControlledConversationIdRef.current = controlledConversationId;
       return;
     }
 
+    const previousControlled = previousControlledConversationIdRef.current;
     setSelectedChatId(controlledConversationId);
 
     if (controlledConversationId !== null) {
+      previousControlledConversationIdRef.current = controlledConversationId;
       return;
     }
+
+    previousControlledConversationIdRef.current = null;
 
     loadingConversationIdRef.current = null;
     currentChatIdRef.current = null;
@@ -380,7 +388,11 @@ export default function ChatInterface({
     setSelectedModel(null);
     selectedModelRef.current = null;
     setInput("");
-    welcomePrefsHydratedRef.current = false;
+    // Only invalidate welcome hydration when leaving a conversation for welcome;
+    // initial mount with null must not clear the flag after useLayoutEffect hydrated.
+    if (previousControlled !== null) {
+      welcomePrefsHydratedRef.current = false;
+    }
   }, [controlledConversationId, isRouteDriven, setSelectedModel]);
 
   useEffect(() => {

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -243,13 +243,17 @@ export default function ChatInterface({
     name: string;
   } | null>(null);
   const welcomeComposeKindRef = useRef<ChatComposeKind>("chat");
+  const welcomePrefsWriteSelectedChatIdRef = useRef<string | null>(null);
+  const welcomePrefsWriteWelcomeCoworkerSlugRef = useRef<string | null>(null);
   welcomeSelectedCoworkerRef.current = welcomeSelectedCoworker;
   welcomeSelectedModelRef.current = welcomeSelectedModel;
   welcomeComposeKindRef.current = welcomeComposeKind;
+  welcomePrefsWriteSelectedChatIdRef.current = selectedChatId;
+  welcomePrefsWriteWelcomeCoworkerSlugRef.current = welcomeCoworkerSlug;
 
   const writeWelcomePrefsFromRefs = useCallback(() => {
-    if (selectedChatId !== null) return;
-    if (welcomeCoworkerSlug != null) return;
+    if (welcomePrefsWriteSelectedChatIdRef.current !== null) return;
+    if (welcomePrefsWriteWelcomeCoworkerSlugRef.current != null) return;
     writeWelcomeComposePreferences(
       buildWelcomeComposeStoredSnapshot({
         composeKind: welcomeComposeKindRef.current,
@@ -257,7 +261,7 @@ export default function ChatInterface({
         model: welcomeSelectedModelRef.current,
       }),
     );
-  }, [selectedChatId, welcomeCoworkerSlug]);
+  }, []);
 
   const handleWelcomeComposeKindChange = useCallback(
     (kind: ChatComposeKind) => {

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -246,7 +246,7 @@ export default function ChatInterface({
 
   const writeWelcomePrefsFromRefs = useCallback(() => {
     if (selectedChatId !== null) return;
-    if (welcomeCoworkerSlug) return;
+    if (welcomeCoworkerSlug != null) return;
     writeWelcomeComposePreferences(
       buildWelcomeComposeStoredSnapshot({
         composeKind: welcomeComposeKindRef.current,

--- a/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
@@ -205,4 +205,51 @@ describe("resolveHydratedWelcomeSelection", () => {
     expect(r.coworker?.capabilities?.includes("tasks")).toBe(true);
     expect(r.coworker?.slug).toBe("alex");
   });
+
+  it("for task compose with null coworkerSlugOrId, picks first tasks-capable coworker", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "task" as const,
+      modelId: null,
+      coworkerSlugOrId: null,
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("task");
+    expect(r.coworker?.capabilities?.includes("tasks")).toBe(true);
+    expect(r.coworker?.slug).toBe("alex");
+  });
+
+  it("for task compose when stored coworker id/slug is unknown, picks first tasks-capable coworker", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "task" as const,
+      modelId: null,
+      coworkerSlugOrId: "missing-coworker",
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("task");
+    expect(r.coworker?.capabilities?.includes("tasks")).toBe(true);
+    expect(r.coworker?.slug).toBe("alex");
+  });
+
+  it("for task compose with no tasks-capable coworkers, returns null coworker", () => {
+    const chatOnly = [
+      baseCoworker({ id: "b", slug: "no-tasks", capabilities: ["chat"] }),
+    ];
+    const stored = {
+      v: 1 as const,
+      composeKind: "task" as const,
+      modelId: null,
+      coworkerSlugOrId: null,
+    };
+    const r = resolveHydratedWelcomeSelection(chatOnly, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("task");
+    expect(r.coworker).toBeNull();
+  });
 });

--- a/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Coworker } from "../types";
+import {
+  buildWelcomeComposeStoredSnapshot,
+  readWelcomeComposePreferences,
+  resolveHydratedWelcomeSelection,
+  WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY,
+  writeWelcomeComposePreferences,
+} from "../welcome-compose-preferences";
+
+function baseCoworker(over: Partial<Coworker> = {}): Coworker {
+  return {
+    id: "cow_1",
+    name: "Alex",
+    description: "d",
+    useCase: "u",
+    slug: "alex",
+    ...over,
+  };
+}
+
+describe("readWelcomeComposePreferences", () => {
+  afterEach(() => {
+    window.localStorage.removeItem(WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY);
+  });
+
+  it("returns null for missing, invalid JSON, wrong version, or invalid composeKind", () => {
+    expect(readWelcomeComposePreferences()).toBeNull();
+    window.localStorage.setItem(WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY, "{");
+    expect(readWelcomeComposePreferences()).toBeNull();
+    window.localStorage.setItem(
+      WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({ v: 2, composeKind: "chat" }),
+    );
+    expect(readWelcomeComposePreferences()).toBeNull();
+    window.localStorage.setItem(
+      WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        v: 1,
+        composeKind: "email",
+        modelId: null,
+        coworkerSlugOrId: null,
+      }),
+    );
+    expect(readWelcomeComposePreferences()).toBeNull();
+  });
+
+  it("parses a valid v1 payload", () => {
+    window.localStorage.setItem(
+      WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        v: 1,
+        composeKind: "task",
+        modelId: "x",
+        coworkerSlugOrId: "alex",
+      }),
+    );
+    expect(readWelcomeComposePreferences()).toEqual({
+      v: 1,
+      composeKind: "task",
+      modelId: "x",
+      coworkerSlugOrId: "alex",
+    });
+  });
+});
+
+describe("writeWelcomeComposePreferences", () => {
+  afterEach(() => {
+    window.localStorage.removeItem(WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY);
+  });
+
+  it("round-trips through readWelcomeComposePreferences", () => {
+    writeWelcomeComposePreferences({
+      composeKind: "chat",
+      modelId: "kimi-k2-5",
+      coworkerSlugOrId: null,
+    });
+    expect(readWelcomeComposePreferences()).toMatchObject({
+      v: 1,
+      composeKind: "chat",
+      modelId: "kimi-k2-5",
+      coworkerSlugOrId: null,
+    });
+  });
+});
+
+describe("buildWelcomeComposeStoredSnapshot", () => {
+  it("stores model id only for chat compose", () => {
+    expect(
+      buildWelcomeComposeStoredSnapshot({
+        composeKind: "task",
+        coworker: baseCoworker(),
+        model: { id: "kimi-k2-5", name: "Kimi" },
+      }).modelId,
+    ).toBeNull();
+  });
+
+  it("stores coworker slug when present", () => {
+    expect(
+      buildWelcomeComposeStoredSnapshot({
+        composeKind: "chat",
+        coworker: baseCoworker({ slug: "pat", id: "id-1" }),
+        model: null,
+      }).coworkerSlugOrId,
+    ).toBe("pat");
+  });
+
+  it("falls back to coworker id when slug is empty", () => {
+    expect(
+      buildWelcomeComposeStoredSnapshot({
+        composeKind: "chat",
+        coworker: baseCoworker({ slug: "", id: "only-id" }),
+        model: null,
+      }).coworkerSlugOrId,
+    ).toBe("only-id");
+  });
+});
+
+describe("resolveHydratedWelcomeSelection", () => {
+  const coworkers = [
+    baseCoworker({ id: "a", slug: "alex", capabilities: ["chat", "tasks"] }),
+    baseCoworker({
+      id: "b",
+      slug: "no-tasks",
+      capabilities: ["chat"],
+    }),
+    baseCoworker({
+      id: "c",
+      slug: "tasky",
+      capabilities: ["tasks"],
+    }),
+  ];
+
+  it("returns defaults when stored is null", () => {
+    expect(
+      resolveHydratedWelcomeSelection(coworkers, null, {
+        urlCoworkerSlug: false,
+      }),
+    ).toEqual({
+      composeKind: "chat",
+      coworker: null,
+      model: null,
+    });
+  });
+
+  it("resolves a stored chat model id", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "chat" as const,
+      modelId: "kimi-k2-5",
+      coworkerSlugOrId: "alex",
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("chat");
+    expect(r.coworker).toBeNull();
+    expect(r.model).toEqual({ id: "kimi-k2-5", name: "Kimi K2.5" });
+  });
+
+  it("when urlCoworkerSlug is true, keeps composeKind but clears model and coworker", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "task" as const,
+      modelId: null,
+      coworkerSlugOrId: "alex",
+    };
+    expect(
+      resolveHydratedWelcomeSelection(coworkers, stored, {
+        urlCoworkerSlug: true,
+      }),
+    ).toEqual({
+      composeKind: "task",
+      coworker: null,
+      model: null,
+    });
+  });
+
+  it("falls back from invalid model id to coworker match", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "chat" as const,
+      modelId: "unknown-model",
+      coworkerSlugOrId: "alex",
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.model).toBeNull();
+    expect(r.coworker?.slug).toBe("alex");
+  });
+
+  it("for task compose, picks a tasks-capable fallback when stored coworker cannot do tasks", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "task" as const,
+      modelId: null,
+      coworkerSlugOrId: "no-tasks",
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("task");
+    expect(r.coworker?.capabilities?.includes("tasks")).toBe(true);
+    expect(r.coworker?.slug).toBe("alex");
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
+++ b/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
@@ -1,0 +1,137 @@
+import { CHAT_MODELS } from "@sokosumi/chat";
+
+import type { ChatComposeKind, Coworker } from "./types";
+
+export const WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY =
+  "sokosumi-welcome-compose-prefs";
+
+export type WelcomeComposeStoredV1 = {
+  v: 1;
+  composeKind: ChatComposeKind;
+  modelId: string | null;
+  coworkerSlugOrId: string | null;
+};
+
+function isChatComposeKind(v: unknown): v is ChatComposeKind {
+  return v === "chat" || v === "task";
+}
+
+export function readWelcomeComposePreferences(): WelcomeComposeStoredV1 | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(
+      WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY,
+    );
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as { v?: unknown }).v !== 1
+    ) {
+      return null;
+    }
+    const o = parsed as Record<string, unknown>;
+    const composeKind = o.composeKind;
+    if (!isChatComposeKind(composeKind)) return null;
+    const modelId =
+      typeof o.modelId === "string" && o.modelId.length > 0 ? o.modelId : null;
+    const coworkerSlugOrId =
+      typeof o.coworkerSlugOrId === "string" && o.coworkerSlugOrId.length > 0
+        ? o.coworkerSlugOrId
+        : null;
+    return { v: 1, composeKind, modelId, coworkerSlugOrId };
+  } catch {
+    return null;
+  }
+}
+
+export function writeWelcomeComposePreferences(
+  snapshot: Omit<WelcomeComposeStoredV1, "v">,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: WelcomeComposeStoredV1 = { v: 1, ...snapshot };
+    window.localStorage.setItem(
+      WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(payload),
+    );
+  } catch {
+    // Ignore quota / private mode.
+  }
+}
+
+export function buildWelcomeComposeStoredSnapshot(p: {
+  composeKind: ChatComposeKind;
+  coworker: Coworker | null;
+  model: { id: string; name: string } | null;
+}): WelcomeComposeStoredV1 {
+  const modelId =
+    p.composeKind === "chat" && p.model != null ? p.model.id : null;
+  const coworkerSlugOrId =
+    p.coworker != null ? p.coworker.slug || p.coworker.id : null;
+  return {
+    v: 1,
+    composeKind: p.composeKind,
+    modelId,
+    coworkerSlugOrId,
+  };
+}
+
+export function resolveHydratedWelcomeSelection(
+  coworkers: Coworker[],
+  stored: WelcomeComposeStoredV1 | null,
+  options: { urlCoworkerSlug: boolean },
+): {
+  composeKind: ChatComposeKind;
+  coworker: Coworker | null;
+  model: { id: string; name: string } | null;
+} {
+  const defaultCompose: ChatComposeKind = "chat";
+  if (!stored) {
+    return { composeKind: defaultCompose, coworker: null, model: null };
+  }
+
+  const composeKind: ChatComposeKind = isChatComposeKind(stored.composeKind)
+    ? stored.composeKind
+    : defaultCompose;
+
+  if (options.urlCoworkerSlug) {
+    return { composeKind, coworker: null, model: null };
+  }
+
+  if (composeKind === "chat" && stored.modelId) {
+    const model = CHAT_MODELS.find((m) => m.id === stored.modelId);
+    if (model) {
+      return {
+        composeKind: "chat",
+        coworker: null,
+        model: { id: model.id, name: model.name },
+      };
+    }
+  }
+
+  const key = stored.coworkerSlugOrId;
+  if (key) {
+    const c = coworkers.find(
+      (x) =>
+        x.id === key ||
+        x.slug?.toLowerCase() === key.toLowerCase() ||
+        x.id.toLowerCase() === key.toLowerCase(),
+    );
+    if (c) {
+      if (composeKind === "task") {
+        if (c.capabilities?.includes("tasks")) {
+          return { composeKind: "task", coworker: c, model: null };
+        }
+        const fallback = coworkers.find((x) =>
+          x.capabilities?.includes("tasks"),
+        );
+        return { composeKind: "task", coworker: fallback ?? null, model: null };
+      }
+      return { composeKind: "chat", coworker: c, model: null };
+    }
+  }
+
+  return { composeKind, coworker: null, model: null };
+}

--- a/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
+++ b/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
@@ -16,6 +16,12 @@ function isChatComposeKind(v: unknown): v is ChatComposeKind {
   return v === "chat" || v === "task";
 }
 
+function firstCoworkerWithTasksCapability(
+  coworkers: Coworker[],
+): Coworker | null {
+  return coworkers.find((x) => x.capabilities?.includes("tasks")) ?? null;
+}
+
 export function readWelcomeComposePreferences(): WelcomeComposeStoredV1 | null {
   if (typeof window === "undefined") return null;
   try {
@@ -124,13 +130,22 @@ export function resolveHydratedWelcomeSelection(
         if (c.capabilities?.includes("tasks")) {
           return { composeKind: "task", coworker: c, model: null };
         }
-        const fallback = coworkers.find((x) =>
-          x.capabilities?.includes("tasks"),
-        );
-        return { composeKind: "task", coworker: fallback ?? null, model: null };
+        return {
+          composeKind: "task",
+          coworker: firstCoworkerWithTasksCapability(coworkers),
+          model: null,
+        };
       }
       return { composeKind: "chat", coworker: c, model: null };
     }
+  }
+
+  if (composeKind === "task") {
+    return {
+      composeKind: "task",
+      coworker: firstCoworkerWithTasksCapability(coworkers),
+      model: null,
+    };
   }
 
   return { composeKind, coworker: null, model: null };

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
@@ -5,6 +5,7 @@ import { forwardRef, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TaskForm } from "@/app/tasks/components/task-form";
+import { writeCreateTaskModalLastCoworkerId } from "@/app/tasks/utils/create-task-modal-preferences";
 import { createTask, updateTask } from "@/lib/actions/task/action";
 import { DEFAULT_TASK_NAME_MAX_LENGTH } from "@/lib/utils/task-transformer";
 
@@ -303,6 +304,31 @@ describe("TaskForm", () => {
     const sokoButton = screen.getByRole("button", { name: /Soko/i });
     expect(elenaButton).toHaveAttribute("aria-pressed", "true");
     expect(sokoButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("applies stored create-modal coworker from localStorage after mount", async () => {
+    writeCreateTaskModalLastCoworkerId("coworker-1");
+    render(
+      <TaskForm
+        variant="modal"
+        mode="create"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Soko/i })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+    expect(screen.getByRole("button", { name: /Elena/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 
   it("passes agent mention options to MarkdownEditor", () => {

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
@@ -306,7 +306,7 @@ describe("TaskForm", () => {
     expect(sokoButton).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("applies stored create-modal coworker from localStorage after mount", async () => {
+  it("applies stored create-modal coworker from localStorage on first render", () => {
     writeCreateTaskModalLastCoworkerId("coworker-1");
     render(
       <TaskForm
@@ -319,12 +319,10 @@ describe("TaskForm", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Soko/i })).toHaveAttribute(
-        "aria-pressed",
-        "true",
-      );
-    });
+    expect(screen.getByRole("button", { name: /Soko/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(screen.getByRole("button", { name: /Elena/i })).toHaveAttribute(
       "aria-pressed",
       "false",

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
@@ -161,6 +161,11 @@ describe("TaskForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     markdownEditorPropsSpy.mockClear();
+    try {
+      window.localStorage.clear();
+    } catch {
+      // Ignore environments without localStorage.
+    }
   });
 
   function getHiddenFileInput(container: HTMLElement): HTMLInputElement {

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -125,13 +125,25 @@ export function TaskForm({
     const elenaCoworker = coworkerOptions.find(
       (option) => option.slug === "elena",
     );
-    return (
+    const fallback =
       initialValues?.coworkerId ??
       elenaCoworker?.id ??
       coworkerOptions[0]?.id ??
-      ""
-    );
-  }, [coworkerOptions, initialValues?.coworkerId]);
+      "";
+
+    const hasExplicitInitialCoworker =
+      initialValues?.coworkerId != null && initialValues.coworkerId !== "";
+
+    if (!isModal || mode !== "create" || hasExplicitInitialCoworker) {
+      return fallback;
+    }
+
+    const stored = readCreateTaskModalLastCoworkerId();
+    if (stored && coworkerOptions.some((o) => o.id === stored)) {
+      return stored;
+    }
+    return fallback;
+  }, [coworkerOptions, initialValues?.coworkerId, isModal, mode]);
 
   const coworkerTouchedRef = useRef(false);
   const [coworkerId, setCoworkerId] = useState(defaultCoworkerId);
@@ -140,18 +152,6 @@ export function TaskForm({
     if (coworkerTouchedRef.current) return;
     setCoworkerId(defaultCoworkerId);
   }, [defaultCoworkerId]);
-
-  useEffect(() => {
-    if (!isModal || mode !== "create") return;
-    if (initialValues?.coworkerId != null && initialValues.coworkerId !== "") {
-      return;
-    }
-    if (coworkerTouchedRef.current) return;
-    const stored = readCreateTaskModalLastCoworkerId();
-    if (stored && coworkerOptions.some((o) => o.id === stored)) {
-      setCoworkerId(stored);
-    }
-  }, [coworkerOptions, initialValues?.coworkerId, isModal, mode]);
   const [status, setStatus] = useState<TaskStatus>(originalStatus);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmittingDraft, setIsSubmittingDraft] = useState(false);

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -4,11 +4,22 @@ import { TaskStatus } from "@sokosumi/database";
 import { ArrowLeft, Command, CornerDownLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 
 import { CoworkerCard } from "@/app/tasks/new/components/coworker-card";
 import { convertAgentNamesToMentionOptions } from "@/app/tasks/utils/agent-names";
+import {
+  readCreateTaskModalLastCoworkerId,
+  writeCreateTaskModalLastCoworkerId,
+} from "@/app/tasks/utils/create-task-modal-preferences";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
 import {
@@ -110,19 +121,35 @@ export function TaskForm({
   const [description, setDescription] = useState(
     initialValues?.description ?? "",
   );
-  const defaultCoworkerId = (() => {
+  const defaultCoworkerId = useMemo(() => {
     const elenaCoworker = coworkerOptions.find(
       (option) => option.slug === "elena",
     );
-    return (
+    const fallback =
       initialValues?.coworkerId ??
       elenaCoworker?.id ??
       coworkerOptions[0]?.id ??
-      ""
-    );
-  })();
+      "";
+    if (!isModal || mode !== "create") {
+      return fallback;
+    }
+    if (initialValues?.coworkerId != null && initialValues.coworkerId !== "") {
+      return initialValues.coworkerId;
+    }
+    const stored = readCreateTaskModalLastCoworkerId();
+    if (stored && coworkerOptions.some((o) => o.id === stored)) {
+      return stored;
+    }
+    return fallback;
+  }, [coworkerOptions, initialValues?.coworkerId, isModal, mode]);
 
-  const [coworkerId, setCoworkerId] = useState<string>(defaultCoworkerId);
+  const coworkerTouchedRef = useRef(false);
+  const [coworkerId, setCoworkerId] = useState(defaultCoworkerId);
+
+  useLayoutEffect(() => {
+    if (coworkerTouchedRef.current) return;
+    setCoworkerId(defaultCoworkerId);
+  }, [defaultCoworkerId]);
   const [status, setStatus] = useState<TaskStatus>(originalStatus);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmittingDraft, setIsSubmittingDraft] = useState(false);
@@ -143,6 +170,17 @@ export function TaskForm({
   useEffect(() => {
     onSubmittingChange?.(isSubmittingAny);
   }, [isSubmittingAny, onSubmittingChange]);
+
+  const handleCoworkerSelect = useCallback(
+    (id: string) => {
+      coworkerTouchedRef.current = true;
+      setCoworkerId(id);
+      if (isModal && mode === "create") {
+        writeCreateTaskModalLastCoworkerId(id);
+      }
+    },
+    [isModal, mode],
+  );
 
   const abortActiveUploads = useCallback(() => {
     for (const controller of activeUploadControllersRef.current) {
@@ -441,7 +479,7 @@ export function TaskForm({
                     key={option.id}
                     option={option}
                     isSelected={coworkerId === option.id}
-                    onSelect={() => setCoworkerId(option.id)}
+                    onSelect={() => handleCoworkerSelect(option.id)}
                   />
                 ))}
               </div>

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -136,10 +136,6 @@ export function TaskForm({
     if (initialValues?.coworkerId != null && initialValues.coworkerId !== "") {
       return initialValues.coworkerId;
     }
-    const stored = readCreateTaskModalLastCoworkerId();
-    if (stored && coworkerOptions.some((o) => o.id === stored)) {
-      return stored;
-    }
     return fallback;
   }, [coworkerOptions, initialValues?.coworkerId, isModal, mode]);
 
@@ -150,6 +146,18 @@ export function TaskForm({
     if (coworkerTouchedRef.current) return;
     setCoworkerId(defaultCoworkerId);
   }, [defaultCoworkerId]);
+
+  useEffect(() => {
+    if (!isModal || mode !== "create") return;
+    if (initialValues?.coworkerId != null && initialValues.coworkerId !== "") {
+      return;
+    }
+    if (coworkerTouchedRef.current) return;
+    const stored = readCreateTaskModalLastCoworkerId();
+    if (stored && coworkerOptions.some((o) => o.id === stored)) {
+      setCoworkerId(stored);
+    }
+  }, [coworkerOptions, initialValues?.coworkerId, isModal, mode]);
   const [status, setStatus] = useState<TaskStatus>(originalStatus);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmittingDraft, setIsSubmittingDraft] = useState(false);

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -125,19 +125,13 @@ export function TaskForm({
     const elenaCoworker = coworkerOptions.find(
       (option) => option.slug === "elena",
     );
-    const fallback =
+    return (
       initialValues?.coworkerId ??
       elenaCoworker?.id ??
       coworkerOptions[0]?.id ??
-      "";
-    if (!isModal || mode !== "create") {
-      return fallback;
-    }
-    if (initialValues?.coworkerId != null && initialValues.coworkerId !== "") {
-      return initialValues.coworkerId;
-    }
-    return fallback;
-  }, [coworkerOptions, initialValues?.coworkerId, isModal, mode]);
+      ""
+    );
+  }, [coworkerOptions, initialValues?.coworkerId]);
 
   const coworkerTouchedRef = useRef(false);
   const [coworkerId, setCoworkerId] = useState(defaultCoworkerId);

--- a/apps/web/src/app/(app)/tasks/utils/create-task-modal-preferences.ts
+++ b/apps/web/src/app/(app)/tasks/utils/create-task-modal-preferences.ts
@@ -1,0 +1,32 @@
+/**
+ * Last coworker picked in the "new task" modal (`CreateTaskModal` / `TaskForm` variant modal).
+ * Separate from chat welcome prefs (`sokosumi-welcome-compose-prefs`) and draft keys.
+ */
+export const CREATE_TASK_MODAL_LAST_COWORKER_STORAGE_KEY =
+  "sokosumi-tasks-create-modal-last-coworker-id";
+
+export function readCreateTaskModalLastCoworkerId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(
+      CREATE_TASK_MODAL_LAST_COWORKER_STORAGE_KEY,
+    );
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "string" && parsed.length > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCreateTaskModalLastCoworkerId(coworkerId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CREATE_TASK_MODAL_LAST_COWORKER_STORAGE_KEY,
+      JSON.stringify(coworkerId),
+    );
+  } catch {
+    // Ignore quota / private mode.
+  }
+}


### PR DESCRIPTION
## Summary

Persist user choices on the chat welcome screen (compose mode, model, coworker) and the last coworker selected in the create-task modal using `localStorage`, so returning to an empty chat state or reopening the modal restores sensible defaults.

## Key changes

- **Chat welcome (`ChatInterface`)**: Introduced `welcome-compose-preferences` helpers to read/write a versioned snapshot (`sokosumi-welcome-compose-prefs`). Hydration runs when no chat is selected and coworkers are available; URL-driven welcome coworker slug still wins and skips restoring stored selection. Compose kind changes and coworker/model changes update storage via refs to avoid stale closures.
- **Create task modal (`TaskForm`)**: For modal create mode, default coworker falls back to stored id (`sokosumi-tasks-create-modal-last-coworker-id`) when valid; selection writes back on user change. `useLayoutEffect` keeps `coworkerId` in sync with computed default until the user touches the field.
- **Tests**: New unit tests for welcome preference read/write/resolve; `TaskForm` tests clear `localStorage` in `beforeEach` for isolation.

## Technical notes

- Welcome prefs use schema `v: 1` with `composeKind`, `modelId`, and `coworkerSlugOrId`; model is only stored for chat compose. Resolution validates coworkers (including task capability when compose is task).
- Storage writes are best-effort (quota / private mode ignored).

## Testing

- `pnpm exec vitest run apps/web/src/app/\(app\)/chat/utils/__tests__/welcome-compose-preferences.test.ts`
- `pnpm exec vitest run apps/web/src/app/\(app\)/tasks/components/__tests__/task-form.test.tsx`

(Adjust with your usual web package test command if different.)
