### PR TITLE
fix(web): clarify task manager empty state chat title

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1294,7 +1294,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "Oder nutze den Chat, um eine Aufgabe zu starten",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "Or use the chat to start a task",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1294,7 +1294,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "O usa el chat para empezar una tarea",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "Ou utilisez le chat pour lancer une tâche",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "Oppure usa la chat per avviare un'attività",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "またはチャットでタスクを開始する",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "Ou use o chat para iniciar uma tarefa",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "Ou use o chat para iniciar uma tarefa",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1325,7 +1325,7 @@
       "EmptyState": {
         "title": "Welcome to Task Manager",
         "description": "Start by creating your first task so Elena has clear context to execute.",
-        "chatTitle": "Then use chat to refine the plan",
+        "chatTitle": "或使用聊天开始任务",
         "chatDescription": "Try asking Elena: \"Create a research task about my company, including competitors, positioning, and quick wins.\"",
         "getStartedTitle": "You're all set!",
         "getStartedDescription": "Start creating tasks and chatting with your AI coworkers. Elena is ready to help you get things done.",


### PR DESCRIPTION
## Summary

Updates the Task Manager empty state `EmptyState.chatTitle` string so it matches the intended user flow: starting a task from chat, rather than only “refining the plan.”

## Key changes

- **English (`en`)**: “Then use chat to refine the plan” → “Or use the chat to start a task”
- **Localized equivalents** updated for `de`, `es`, `fr`, `it`, `ja`, `pt`, `pt-BR`, and `zh-Hans` under the same `TaskManager` → `EmptyState` → `chatTitle` key

## Technical notes

- Scope is limited to `apps/web/messages/*.json`; no code or schema changes.
- Other `EmptyState` strings (e.g. `chatDescription`) are unchanged.

## Testing

- Not run (copy-only). Recommend a quick visual check of the Task Manager empty state in one non-English locale if available.

## Risk

- Low: single translation key per locale; no runtime behavior change beyond displayed text.
