### PR TITLE
feat(chat): support delegated coworker context and delegation headers

### DIFF
--- a/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
@@ -30,7 +30,7 @@ describe("coworker-conversation", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("POSTs /conversations with metadata and Sokosumi headers", async () => {
+  it("POSTs /conversations with metadata and delegation headers", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -52,16 +52,18 @@ describe("coworker-conversation", () => {
         method: "POST",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          "X-Sokosumi-User-Id": "user_1",
+          "X-Delegation-User-Id": "user_1",
           "X-Coworker-Slug": "ops-agent",
-          "X-Sokosumi-Organization-Id": "org_1",
+          "X-Delegation-Organization-Id": "org_1",
         }),
       }),
     );
     const [, initWithOrg] = fetchMock.mock.calls[0] as [
       string,
-      { body: string },
+      { headers: Record<string, string>; body: string },
     ];
+    expect(initWithOrg.headers["X-Sokosumi-User-Id"]).toBeUndefined();
+    expect(initWithOrg.headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
     expect(JSON.parse(initWithOrg.body)).toEqual({
       metadata: {
         sokosumi_user_id: "user_1",
@@ -93,7 +95,8 @@ describe("coworker-conversation", () => {
       string,
       { headers: Record<string, string>; body: string },
     ];
-    expect(init.headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
+    expect(init.headers["X-Sokosumi-User-Id"]).toBeUndefined();
+    expect(init.headers["X-Delegation-Organization-Id"]).toBeUndefined();
     expect(JSON.parse(init.body)).toEqual({
       metadata: {
         sokosumi_user_id: "user_1",

--- a/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
@@ -52,8 +52,10 @@ describe("coworker-conversation", () => {
         method: "POST",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
+          "X-Sokosumi-User-Id": "user_1",
           "X-Delegation-User-Id": "user_1",
           "X-Coworker-Slug": "ops-agent",
+          "X-Sokosumi-Organization-Id": "org_1",
           "X-Delegation-Organization-Id": "org_1",
         }),
       }),
@@ -62,8 +64,8 @@ describe("coworker-conversation", () => {
       string,
       { headers: Record<string, string>; body: string },
     ];
-    expect(initWithOrg.headers["X-Sokosumi-User-Id"]).toBeUndefined();
-    expect(initWithOrg.headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
+    expect(initWithOrg.headers["X-Sokosumi-User-Id"]).toBe("user_1");
+    expect(initWithOrg.headers["X-Sokosumi-Organization-Id"]).toBe("org_1");
     expect(JSON.parse(initWithOrg.body)).toEqual({
       metadata: {
         sokosumi_user_id: "user_1",
@@ -95,7 +97,7 @@ describe("coworker-conversation", () => {
       string,
       { headers: Record<string, string>; body: string },
     ];
-    expect(init.headers["X-Sokosumi-User-Id"]).toBeUndefined();
+    expect(init.headers["X-Sokosumi-User-Id"]).toBe("user_1");
     expect(init.headers["X-Delegation-Organization-Id"]).toBeUndefined();
     expect(JSON.parse(init.body)).toEqual({
       metadata: {

--- a/apps/core/src/routes/v1/chat/coworker-conversation.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.ts
@@ -23,11 +23,16 @@ export async function createCoworkerConversation(
   const url = `${base}/conversations`;
   const requestHeaders: Record<string, string> = {
     "Content-Type": "application/json",
+    // keep both delegation headers for now to avoid breaking changes
     "X-Sokosumi-User-Id": options.sokosumiUserId,
+    "X-Delegation-User-Id": options.sokosumiUserId,
     "X-Coworker-Slug": options.coworkerSlug,
   };
   if (options.sokosumiOrganizationId) {
+    // keep both delegation headers for now to avoid breaking changes
     requestHeaders["X-Sokosumi-Organization-Id"] =
+      options.sokosumiOrganizationId;
+    requestHeaders["X-Delegation-Organization-Id"] =
       options.sokosumiOrganizationId;
   }
 

--- a/apps/core/src/routes/v1/chat/get.test.ts
+++ b/apps/core/src/routes/v1/chat/get.test.ts
@@ -35,7 +35,14 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-function createApp() {
+function createApp(
+  authContext: AuthVariables["authContext"] = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
+) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables;
   }>({
@@ -44,12 +51,7 @@ function createApp() {
 
   app.use("*", async (c, next) => {
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId: null,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     return await next();
   });
 
@@ -103,6 +105,36 @@ describe("GET /chat", () => {
     expect(body.data.messages[1]?.role).toBe("assistant");
     expect(body.meta.pagination.total).toBe(2);
     expect(body.meta.pagination.nextCursor).toBeNull();
+  });
+
+  it("allows delegated coworker auth to read the delegated user's chat", async () => {
+    conversationFindFirstMock.mockResolvedValueOnce({ id: cid });
+    conversationMessageCountMock.mockResolvedValueOnce(1);
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      { id: "m1", role: "user", contentText: "Hi" },
+    ]);
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: {
+        userId: "delegated_user_123",
+        organizationId: "delegated_org_123",
+      },
+    });
+    const response = await app.request(
+      `http://localhost/?conversationId=${cid}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(conversationFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        id: cid,
+        userId: "delegated_user_123",
+        archivedAt: null,
+      },
+      select: { id: true },
+    });
   });
 
   it("includes stored reasoning parts before assistant text", async () => {

--- a/apps/core/src/routes/v1/chat/get.ts
+++ b/apps/core/src/routes/v1/chat/get.ts
@@ -15,7 +15,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   getChatUiMessagesQuerySchema,
   getChatUiMessagesResponseDataSchema,
@@ -67,14 +67,14 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(withGlobalHeaderParameters(route), async (c) => {
     try {
-      const authContext = requireUserAuthContext(c.var.authContext);
+      const userContext = requireUserContext(c.var.authContext);
       const query = c.req.valid("query");
       const { conversationId } = query;
 
       const conversation = await prisma.conversation.findFirst({
         where: {
           id: conversationId,
-          userId: authContext.userId,
+          userId: userContext.userId,
           archivedAt: null,
         },
         select: { id: true },

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -119,9 +119,14 @@ vi.mock("@/lib/resumable-ui-stream-context", () => ({
 }));
 
 function createApp({
-  organizationId = null,
+  authContext = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
 }: {
-  organizationId?: string | null;
+  authContext?: AuthVariables["authContext"];
 } = {}) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables;
@@ -131,12 +136,7 @@ function createApp({
 
   app.use("*", async (c, next) => {
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     return await next();
   });
 
@@ -278,6 +278,95 @@ describe("POST /chat", () => {
     expect(streamTextMock).not.toHaveBeenCalled();
   });
 
+  it("accepts delegated coworker auth and uses the delegated user context", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { coworker_slug: "ops-agent" },
+      providerConversationId: null,
+    });
+    coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
+
+    const app = createApp({
+      authContext: {
+        actor: "coworker",
+        coworkerId: "cow_123",
+        delegation: {
+          userId: "delegated_user_123",
+          organizationId: "delegated_org_123",
+        },
+      },
+    });
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        messages: [{ role: "user", parts: [{ type: "text", text: "Hi" }] }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(conversationFindFirstMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: cid,
+          userId: "delegated_user_123",
+        }),
+      }),
+    );
+    expect(createCoworkerConversationMock).toHaveBeenCalledWith({
+      responsesApiBaseUrl: "https://responses.example.com/v1",
+      sokosumiUserId: "delegated_user_123",
+      sokosumiOrganizationId: "delegated_org_123",
+      coworkerSlug: "ops-agent",
+      sokosumiConversationId: cid,
+    });
+    expect(conversationUpdateManyMock).toHaveBeenCalledWith({
+      where: {
+        id: cid,
+        userId: "delegated_user_123",
+        providerConversationId: null,
+      },
+      data: { providerConversationId: "conv_test_1" },
+    });
+    const args = streamTextMock.mock.calls[0]![0] as {
+      providerOptions?: {
+        sokosumi?: {
+          sokosumiUserId?: string | null;
+          sokosumiOrganizationId?: string | null;
+        };
+      };
+    };
+    expect(args.providerOptions?.sokosumi?.sokosumiUserId).toBe(
+      "delegated_user_123",
+    );
+    expect(args.providerOptions?.sokosumi?.sokosumiOrganizationId).toBe(
+      "delegated_org_123",
+    );
+  });
+
+  it("rejects coworker auth without delegation headers for user-scoped chat", async () => {
+    const app = createApp({
+      authContext: {
+        actor: "coworker",
+        coworkerId: "cow_123",
+      },
+    });
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ role: "user", parts: [{ type: "text", text: "Hi" }] }],
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(conversationFindFirstMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
   it("returns 503 when OpenRouter chat key is missing for model chat", async () => {
     conversationFindFirstMock.mockResolvedValueOnce({
       id: "550e8400-e29b-41d4-a716-446655440000",
@@ -354,7 +443,14 @@ describe("POST /chat", () => {
     });
     coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
 
-    const app = createApp({ organizationId: "org_1" });
+    const app = createApp({
+      authContext: {
+        actor: "user",
+        userId: "user_123",
+        organizationId: "org_1",
+        role: "user",
+      },
+    });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -408,7 +504,14 @@ describe("POST /chat", () => {
     });
     coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
 
-    const app = createApp({ organizationId: "org_1" });
+    const app = createApp({
+      authContext: {
+        actor: "user",
+        userId: "user_123",
+        organizationId: "org_1",
+        role: "user",
+      },
+    });
     const response = await app.request("http://localhost/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -510,6 +613,33 @@ describe("POST /chat", () => {
     });
 
     expect(response.status).toBe(403);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when creating the remote coworker conversation fails", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { coworker_slug: "ops-agent" },
+      providerConversationId: null,
+    });
+    coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
+    createCoworkerConversationMock.mockRejectedValueOnce(
+      new Error("upstream unavailable"),
+    );
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        messages: [{ role: "user", parts: [{ type: "text", text: "Hi" }] }],
+      }),
+    });
+
+    expect(response.status).toBe(503);
     expect(streamTextMock).not.toHaveBeenCalled();
   });
 

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -47,7 +47,7 @@ import {
   getOpenRouterChatApiKeyForProvider,
   getSokosumiProvider,
 } from "@/lib/sokosumi-ai-provider";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   AI_SDK_CHAT_MESSAGES_REQUIREMENT,
   aiSdkChatRequestSchema,
@@ -179,7 +179,7 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(withGlobalHeaderParameters(route), async (c) => {
     try {
-      const authContext = requireUserAuthContext(c.var.authContext);
+      const userContext = requireUserContext(c.var.authContext);
 
       const {
         messages,
@@ -205,7 +205,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         conversation = await prisma.conversation.findFirst({
           where: {
             id: conversationId,
-            userId: authContext.userId,
+            userId: userContext.userId,
             archivedAt: null,
           },
         });
@@ -314,7 +314,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         if (internalConversationId && incomingLast) {
           await persistUserOrSystemTurnForConversation({
             conversationId: internalConversationId,
-            userId: authContext.userId,
+            userId: userContext.userId,
             lastMessage: incomingLast,
             extractedText: lastUserMessageText ?? "",
           });
@@ -353,7 +353,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         if (internalConversationId && incomingLast) {
           await persistUserOrSystemTurnForConversation({
             conversationId: internalConversationId,
-            userId: authContext.userId,
+            userId: userContext.userId,
             lastMessage: incomingLast,
             extractedText: lastUserMessageText ?? "",
           });
@@ -368,17 +368,24 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         internalConversationId &&
         !providerConversationId
       ) {
-        const created = await createCoworkerConversation({
-          responsesApiBaseUrl: coworker.baseURL!.trim(),
-          sokosumiUserId: authContext.userId,
-          sokosumiOrganizationId: authContext.organizationId ?? null,
-          coworkerSlug: coworker.slug,
-          sokosumiConversationId: internalConversationId,
-        });
+        let created: { id: string };
+        try {
+          created = await createCoworkerConversation({
+            responsesApiBaseUrl: coworker.baseURL!.trim(),
+            sokosumiUserId: userContext.userId,
+            sokosumiOrganizationId: userContext.organizationId ?? null,
+            coworkerSlug: coworker.slug,
+            sokosumiConversationId: internalConversationId,
+          });
+        } catch (error) {
+          throw serviceUnavailable(
+            `Coworker chat could not create a remote conversation: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         const updated = await prisma.conversation.updateMany({
           where: {
             id: internalConversationId,
-            userId: authContext.userId,
+            userId: userContext.userId,
             providerConversationId: null,
           },
           data: { providerConversationId: created.id },
@@ -387,7 +394,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           const refetched = await prisma.conversation.findFirst({
             where: {
               id: internalConversationId,
-              userId: authContext.userId,
+              userId: userContext.userId,
             },
             select: { providerConversationId: true },
           });
@@ -411,7 +418,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         try {
           await clearActiveUiStreamIdInMetadata({
             conversationId: internalConversationId,
-            userId: authContext.userId,
+            userId: userContext.userId,
           });
         } catch (error) {
           console.error(
@@ -446,7 +453,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             await prisma.conversation.update({
               where: {
                 id: conversationIdForInvalidProviderConv,
-                userId: authContext.userId,
+                userId: userContext.userId,
               },
               data: { providerConversationId: null },
             });
@@ -478,8 +485,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         mode: useCoworker ? "coworker" : "openrouter",
         coworkerBaseUrl: coworker?.baseURL ?? null,
         coworkerSlug: coworker?.slug ?? null,
-        sokosumiUserId: authContext.userId,
-        sokosumiOrganizationId: authContext.organizationId ?? null,
+        sokosumiUserId: userContext.userId,
+        sokosumiOrganizationId: userContext.organizationId ?? null,
         previousResponseId: resolvedCoworkerPreviousResponseId,
         providerConversationId: coworkerConversationsMode
           ? providerConversationId
@@ -492,7 +499,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           try {
             await persistPendingResponseId({
               conversationId: internalConversationId,
-              userId: authContext.userId,
+              userId: userContext.userId,
               responseId,
               coworkerSlug: coworker.slug,
               coworkerId: coworker.id,
@@ -508,7 +515,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           try {
             await clearPendingAndSetPrevious({
               conversationId: internalConversationId,
-              userId: authContext.userId,
+              userId: userContext.userId,
               responseId,
             });
           } catch (error) {
@@ -576,7 +583,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
                 : undefined;
             await persistAssistantFromAiSdk({
               conversationId: internalConversationId,
-              userId: authContext.userId,
+              userId: userContext.userId,
               text: finishEvent.text,
               responsesApiResponseId: responsesApiResponseIdRef.current,
               reasoning: useCoworker ? finishEvent.reasoning : undefined,
@@ -609,7 +616,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
               consumeSseStream: async ({ stream }) => {
                 const streamId = generateId();
                 const convId = internalConversationId;
-                const userId = authContext.userId;
+                const userId = userContext.userId;
                 const registration = (async () => {
                   try {
                     const ctx = getResumableUiStreamContext();
@@ -639,7 +646,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
                 }
                 const clearParams = {
                   conversationId: internalConversationId,
-                  userId: authContext.userId,
+                  userId: userContext.userId,
                 };
                 try {
                   await clearActiveUiStreamIdInMetadata(clearParams);

--- a/apps/core/src/routes/v1/chat/stream-get.test.ts
+++ b/apps/core/src/routes/v1/chat/stream-get.test.ts
@@ -40,7 +40,14 @@ vi.mock("@/helpers/active-ui-stream-metadata", () => ({
   clearActiveUiStreamIdInMetadata: clearActiveUiStreamIdInMetadataMock,
 }));
 
-function createApp() {
+function createApp(
+  authContext: AuthVariables["authContext"] = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
+) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables;
   }>({
@@ -49,12 +56,7 @@ function createApp() {
 
   app.use("*", async (c, next) => {
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId: null,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     return await next();
   });
 
@@ -147,5 +149,32 @@ describe("GET /chat/stream/:conversationId", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/event-stream");
     expect(resumeExistingStreamMock).toHaveBeenCalledWith("stream_1");
+  });
+
+  it("allows delegated coworker auth to resume the delegated user's stream", async () => {
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { active_ui_stream_id: "stream_1" },
+    });
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: {
+        userId: "delegated_user_123",
+        organizationId: "delegated_org_123",
+      },
+    });
+    const response = await app.request(`http://localhost/stream/${cid}`);
+
+    expect(response.status).toBe(200);
+    expect(conversationFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        id: cid,
+        userId: "delegated_user_123",
+        archivedAt: null,
+      },
+      select: { id: true, metadata: true },
+    });
   });
 });

--- a/apps/core/src/routes/v1/chat/stream-get.ts
+++ b/apps/core/src/routes/v1/chat/stream-get.ts
@@ -16,7 +16,7 @@ import {
   getResumableUiStreamContext,
   isUiStreamResumptionConfigured,
 } from "@/lib/resumable-ui-stream-context";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 
 const route = createRoute({
   method: "get",
@@ -55,13 +55,13 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(withGlobalHeaderParameters(route), async (c) => {
-    const authContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { conversationId } = c.req.valid("param");
 
     const conversation = await prisma.conversation.findFirst({
       where: {
         id: conversationId,
-        userId: authContext.userId,
+        userId: userContext.userId,
         archivedAt: null,
       },
       select: { id: true, metadata: true },
@@ -86,7 +86,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     if (resumed == null) {
       void clearActiveUiStreamIdInMetadata({
         conversationId,
-        userId: authContext.userId,
+        userId: userContext.userId,
       }).catch((error) => {
         console.error(
           "Failed to clear stale active UI stream id after resume miss:",

--- a/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
@@ -39,6 +39,7 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
     globalThis.fetch = vi.fn(async (_url, init) => {
       call++;
       const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const headers = (init?.headers ?? {}) as Record<string, string>;
       expect(body.conversation_id).toBe("conv_abc");
       expect(body.previous_response_id).toBeUndefined();
       expect(body.input).toEqual([
@@ -48,6 +49,11 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
           content: [{ type: "input_text", text: "Only last" }],
         },
       ]);
+      expect(headers["X-Delegation-User-Id"]).toBe("user-1");
+      expect(headers["X-Coworker-Slug"]).toBe("agent");
+      expect(headers["X-Delegation-Organization-Id"]).toBe("org-1");
+      expect(headers["X-Sokosumi-User-Id"]).toBeUndefined();
+      expect(headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
       return new Response(
         new ReadableStream({
           start(controller) {
@@ -86,6 +92,7 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
           coworkerBaseUrl: "https://cow.example/api",
           coworkerSlug: "agent",
           sokosumiUserId: "user-1",
+          sokosumiOrganizationId: "org-1",
           previousResponseId: "resp_old",
           providerConversationId: "conv_abc",
         },
@@ -101,6 +108,11 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
     globalThis.fetch = vi.fn(async (_url, init) => {
       call++;
       const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers["X-Delegation-User-Id"]).toBe("user-1");
+      expect(headers["X-Coworker-Slug"]).toBe("agent");
+      expect(headers["X-Delegation-Organization-Id"]).toBeUndefined();
+      expect(headers["X-Sokosumi-User-Id"]).toBeUndefined();
       if (call === 1) {
         expect(body.conversation_id).toBe("conv_bad");
         return new Response("invalid_conversation_id", { status: 400 });

--- a/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
@@ -52,8 +52,8 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
       expect(headers["X-Delegation-User-Id"]).toBe("user-1");
       expect(headers["X-Coworker-Slug"]).toBe("agent");
       expect(headers["X-Delegation-Organization-Id"]).toBe("org-1");
-      expect(headers["X-Sokosumi-User-Id"]).toBeUndefined();
-      expect(headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
+      expect(headers["X-Sokosumi-User-Id"]).toBe("user-1");
+      expect(headers["X-Sokosumi-Organization-Id"]).toBe("org-1");
       return new Response(
         new ReadableStream({
           start(controller) {
@@ -112,7 +112,8 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
       expect(headers["X-Delegation-User-Id"]).toBe("user-1");
       expect(headers["X-Coworker-Slug"]).toBe("agent");
       expect(headers["X-Delegation-Organization-Id"]).toBeUndefined();
-      expect(headers["X-Sokosumi-User-Id"]).toBeUndefined();
+      expect(headers["X-Sokosumi-User-Id"]).toBe("user-1");
+      expect(headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
       if (call === 1) {
         expect(body.conversation_id).toBe("conv_bad");
         return new Response("invalid_conversation_id", { status: 400 });

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -271,11 +271,16 @@ async function streamCoworker(
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    // keep both delegation headers for now to avoid breaking changes
     "X-Sokosumi-User-Id": sokosumiOpts.sokosumiUserId ?? "",
+    "X-Delegation-User-Id": sokosumiOpts.sokosumiUserId ?? "",
     "X-Coworker-Slug": sokosumiOpts.coworkerSlug ?? "",
   };
   if (sokosumiOpts.sokosumiOrganizationId?.trim()) {
+    // keep both delegation headers for now to avoid breaking changes
     headers["X-Sokosumi-Organization-Id"] =
+      sokosumiOpts.sokosumiOrganizationId.trim();
+    headers["X-Delegation-Organization-Id"] =
       sokosumiOpts.sokosumiOrganizationId.trim();
   }
   if (options.headers) {


### PR DESCRIPTION
## Summary

Chat routes and the Sokosumi AI provider now treat **delegated coworker** sessions like the delegated end user for data access, and outbound coworker requests include **`X-Delegation-*`** headers in addition to the existing **`X-Sokosumi-*`** headers so upstreams can migrate without a hard cutover.

## Key changes

- **Auth context**: `GET /chat`, `POST /chat`, and `GET /chat/stream/:conversationId` use `requireUserContext` instead of `requireUserAuthContext`, so when `actor` is `coworker` and delegation is present, Prisma filters and persistence use the **delegated** `userId` / organization.
- **Coworker HTTP**: `createCoworkerConversation` (core) and `streamCoworker` (ai-provider) set `X-Delegation-User-Id` and optional `X-Delegation-Organization-Id` while still sending `X-Sokosumi-User-Id` / `X-Sokosumi-Organization-Id`.
- **Resilience**: `POST /chat` wraps `createCoworkerConversation` in try/catch and responds with **503** when the remote conversation cannot be created.

## Technical notes

- Coworker auth **without** delegation headers remains rejected for user-scoped chat (existing 403 behavior covered by tests).
- Tests assert delegation headers on outbound fetches and that conversation lookups use the delegated user for coworker-delegated scenarios.

## Testing

- `pnpm --filter core test apps/core/src/routes/v1/chat/get.test.ts apps/core/src/routes/v1/chat/post.test.ts apps/core/src/routes/v1/chat/stream-get.test.ts apps/core/src/routes/v1/chat/coworker-conversation.test.ts`
- `pnpm --filter @sokosumi/ai-provider test packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts`

(Or run the full workspace test suite before merge.)
