### PR TITLE
refactor(coworker): remove duplicate X-Delegation-* request headers

### DIFF
--- a/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
@@ -30,7 +30,7 @@ describe("coworker-conversation", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("POSTs /conversations with metadata and delegation headers", async () => {
+  it("POSTs /conversations with metadata and Sokosumi identity headers", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -53,10 +53,8 @@ describe("coworker-conversation", () => {
         headers: expect.objectContaining({
           "Content-Type": "application/json",
           "X-Sokosumi-User-Id": "user_1",
-          "X-Delegation-User-Id": "user_1",
           "X-Coworker-Slug": "ops-agent",
           "X-Sokosumi-Organization-Id": "org_1",
-          "X-Delegation-Organization-Id": "org_1",
         }),
       }),
     );
@@ -98,7 +96,7 @@ describe("coworker-conversation", () => {
       { headers: Record<string, string>; body: string },
     ];
     expect(init.headers["X-Sokosumi-User-Id"]).toBe("user_1");
-    expect(init.headers["X-Delegation-Organization-Id"]).toBeUndefined();
+    expect(init.headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
     expect(JSON.parse(init.body)).toEqual({
       metadata: {
         sokosumi_user_id: "user_1",

--- a/apps/core/src/routes/v1/chat/coworker-conversation.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.ts
@@ -23,16 +23,11 @@ export async function createCoworkerConversation(
   const url = `${base}/conversations`;
   const requestHeaders: Record<string, string> = {
     "Content-Type": "application/json",
-    // keep both delegation headers for now to avoid breaking changes
     "X-Sokosumi-User-Id": options.sokosumiUserId,
-    "X-Delegation-User-Id": options.sokosumiUserId,
     "X-Coworker-Slug": options.coworkerSlug,
   };
   if (options.sokosumiOrganizationId) {
-    // keep both delegation headers for now to avoid breaking changes
     requestHeaders["X-Sokosumi-Organization-Id"] =
-      options.sokosumiOrganizationId;
-    requestHeaders["X-Delegation-Organization-Id"] =
       options.sokosumiOrganizationId;
   }
 

--- a/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
@@ -49,9 +49,7 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
           content: [{ type: "input_text", text: "Only last" }],
         },
       ]);
-      expect(headers["X-Delegation-User-Id"]).toBe("user-1");
       expect(headers["X-Coworker-Slug"]).toBe("agent");
-      expect(headers["X-Delegation-Organization-Id"]).toBe("org-1");
       expect(headers["X-Sokosumi-User-Id"]).toBe("user-1");
       expect(headers["X-Sokosumi-Organization-Id"]).toBe("org-1");
       return new Response(
@@ -109,9 +107,7 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
       call++;
       const body = init?.body ? JSON.parse(String(init.body)) : {};
       const headers = (init?.headers ?? {}) as Record<string, string>;
-      expect(headers["X-Delegation-User-Id"]).toBe("user-1");
       expect(headers["X-Coworker-Slug"]).toBe("agent");
-      expect(headers["X-Delegation-Organization-Id"]).toBeUndefined();
       expect(headers["X-Sokosumi-User-Id"]).toBe("user-1");
       expect(headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
       if (call === 1) {

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -271,16 +271,11 @@ async function streamCoworker(
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    // keep both delegation headers for now to avoid breaking changes
     "X-Sokosumi-User-Id": sokosumiOpts.sokosumiUserId ?? "",
-    "X-Delegation-User-Id": sokosumiOpts.sokosumiUserId ?? "",
     "X-Coworker-Slug": sokosumiOpts.coworkerSlug ?? "",
   };
   if (sokosumiOpts.sokosumiOrganizationId?.trim()) {
-    // keep both delegation headers for now to avoid breaking changes
     headers["X-Sokosumi-Organization-Id"] =
-      sokosumiOpts.sokosumiOrganizationId.trim();
-    headers["X-Delegation-Organization-Id"] =
       sokosumiOpts.sokosumiOrganizationId.trim();
   }
   if (options.headers) {


### PR DESCRIPTION
## Summary

Removes redundant `X-Delegation-User-Id` and `X-Delegation-Organization-Id` headers from coworker HTTP calls. Outbound requests now rely solely on `X-Sokosumi-User-Id` and `X-Sokosumi-Organization-Id`, matching the canonical Sokosumi naming used elsewhere.

## Key changes

- **`apps/core`**: `createCoworkerConversation` no longer sets delegation duplicate headers when calling the conversations API.
- **`packages/ai-provider`**: `streamCoworker` uses the same single-header set for streaming coworker requests.

## Technical notes

Previously both `X-Sokosumi-*` and `X-Delegation-*` were sent to avoid breaking consumers during a transition. This change assumes downstream services accept `X-Sokosumi-*` only (they already received these values in parallel).

## Testing

- [ ] `pnpm --filter @sokosumi/ai-provider test` (if present)
- [ ] `pnpm core:test` for routes touching coworker conversation
- [ ] Manual smoke: coworker create + stream against an environment that validates headers

## Risk

Low for in-repo callers if the receiving service prefers or equally accepts `X-Sokosumi-*`. **Medium** if any external or legacy integration reads **only** `X-Delegation-*` and ignores `X-Sokosumi-*`; coordinate before merge if such consumers exist.
