### PR TITLE
feat(core): build workspace dependencies before core bundle

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -13,6 +13,9 @@
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "build:workspace-deps": "pnpm --filter @sokosumi/utils run build && pnpm --filter @sokosumi/masumi run build && pnpm --filter @sokosumi/database run prisma:generate && pnpm --filter @sokosumi/database run build && pnpm --filter @sokosumi/chat run build && pnpm --filter @sokosumi/ai-provider run build && pnpm --filter @sokosumi/email run build",
+    "prepare": "pnpm run build:workspace-deps",
+    "prebuild": "pnpm run build:workspace-deps",
     "build": "tsup",
     "start": "node dist/index.js",
     "format": "biome format --write .",

--- a/apps/core/tsup.config.ts
+++ b/apps/core/tsup.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   dts: false,
+  noExternal: [
+    "@sokosumi/ai-provider",
+    "@sokosumi/chat",
+    "@sokosumi/database",
+    "@sokosumi/email",
+    "@sokosumi/masumi",
+    "@sokosumi/utils",
+  ],
   esbuildOptions(options) {
     options.alias = {
       "@": "./src",

--- a/apps/core/tsup.config.ts
+++ b/apps/core/tsup.config.ts
@@ -8,14 +8,6 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   dts: false,
-  noExternal: [
-    "@sokosumi/ai-provider",
-    "@sokosumi/chat",
-    "@sokosumi/database",
-    "@sokosumi/email",
-    "@sokosumi/masumi",
-    "@sokosumi/utils",
-  ],
   esbuildOptions(options) {
     options.alias = {
       "@": "./src",


### PR DESCRIPTION
## Summary

Ensure `@sokosumi/*` workspace packages are built **before** Core’s `tsup` step runs, and refresh them after **`pnpm install`** when Core is installed in isolation. This avoids missing or stale `dist` / Prisma client output when the deploy context does not run a full monorepo build first.

## Key changes

- Add **`build:workspace-deps`** in `apps/core/package.json`: an ordered `pnpm --filter` chain for `@sokosumi/utils`, `@sokosumi/masumi`, `@sokosumi/database` (including `prisma:generate` then `build`), `@sokosumi/chat`, `@sokosumi/ai-provider`, and `@sokosumi/email`.
- Add **`prepare`** → `build:workspace-deps` so installing Core triggers sibling package builds when appropriate.
- Add **`prebuild`** → `build:workspace-deps` so `pnpm core:build` / `tsup` always runs after up-to-date workspace artifacts.

`apps/core/tsup.config.ts` is **unchanged** vs `main` (no `noExternal`); bundling strategy stays the default tsup behavior.

## Why (instead of `noExternal`)

An earlier revision used `tsup` `noExternal` to inline workspace packages. That was **removed** in favor of explicit build ordering: keeps the Core bundle scope unchanged, avoids a larger single bundle, and still fixes “workspace package not built yet” failures in constrained environments.

## Technical notes

- **`prepare`** runs after installs that execute lifecycle scripts; keep the chain lean because it runs often.
- **`@sokosumi/database`**: `prisma:generate` runs before `database` `build` so generated client is present.

## Testing

- [ ] `pnpm install` (with Core in scope) and confirm `prepare` / workspace builds succeed
- [ ] `pnpm core:build`
- [ ] `pnpm core:start` (smoke on built output)
