### PR TITLE
feat(core): attachment-aware titles and coworker user messages

### DIFF
--- a/apps/core/src/helpers/__tests__/message-content.test.ts
+++ b/apps/core/src/helpers/__tests__/message-content.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildConversationContentParts,
+  buildMessageTitleSource,
   extractMessageText,
   extractPersistableUiParts,
   extractReasoningPartsFromMessage,
   extractUiMessageParts,
+  hasModelVisibleMessageContent,
   readReasoningPartsFromMetadata,
 } from "../message-content";
 
@@ -244,6 +246,92 @@ describe("extractPersistableUiParts", () => {
         mediaType: "application/pdf",
       },
     ]);
+  });
+});
+
+describe("hasModelVisibleMessageContent", () => {
+  it("returns true for attachment-only file messages", () => {
+    expect(
+      hasModelVisibleMessageContent({
+        parts: [
+          {
+            type: "file",
+            url: "https://example.com/brief.pdf",
+            mediaType: "application/pdf",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for blank text-only messages", () => {
+    expect(
+      hasModelVisibleMessageContent({
+        parts: [{ type: "text", text: "   " }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildMessageTitleSource", () => {
+  it("prefers extracted text when present", () => {
+    expect(
+      buildMessageTitleSource({
+        content: "Summarize this image",
+        parts: [
+          {
+            type: "file",
+            url: "https://example.com/cat.png",
+            mediaType: "image/png",
+          },
+        ],
+      }),
+    ).toBe("Summarize this image");
+  });
+
+  it("falls back to the first attachment filename", () => {
+    expect(
+      buildMessageTitleSource({
+        parts: [
+          {
+            type: "file",
+            url: "https://example.com/uploads/brief.pdf",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+          },
+        ],
+      }),
+    ).toBe("brief.pdf");
+  });
+
+  it("skips blank text parts before attachment fallbacks", () => {
+    expect(
+      buildMessageTitleSource({
+        parts: [
+          { type: "text", text: "   " },
+          {
+            type: "file",
+            url: "https://example.com/uploads/brief.pdf",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+          },
+        ],
+      }),
+    ).toBe("brief.pdf");
+  });
+
+  it("uses an image fallback label when no filename is available", () => {
+    expect(
+      buildMessageTitleSource({
+        parts: [
+          {
+            type: "file",
+            url: "https://example.com/uploads/cat.png",
+            mediaType: "image/png",
+          },
+        ],
+      }),
+    ).toBe("Image message");
   });
 });
 

--- a/apps/core/src/helpers/message-content.ts
+++ b/apps/core/src/helpers/message-content.ts
@@ -294,6 +294,65 @@ export function extractPersistableUiParts(
     .filter((part): part is PersistedChatUiPart => part !== null);
 }
 
+export function hasModelVisibleMessageContent(
+  message: Record<string, unknown>,
+): boolean {
+  if (extractMessageText(message).trim().length > 0) {
+    return true;
+  }
+
+  return extractPersistableUiParts(message).some((part) => {
+    if (part.type === "file") {
+      return true;
+    }
+
+    return part.text.trim().length > 0;
+  });
+}
+
+function buildTitleSourceFromFilePart(part: PersistedChatUiFilePart): string {
+  const filename = part.filename?.trim();
+  if (filename) {
+    return filename;
+  }
+
+  if (part.mediaType.toLowerCase().startsWith("image/")) {
+    return "Image message";
+  }
+
+  try {
+    const url = new URL(part.url);
+    const lastPathSegment = url.pathname.split("/").filter(Boolean).pop();
+    return lastPathSegment && lastPathSegment.length > 0
+      ? lastPathSegment
+      : url.hostname;
+  } catch {
+    return "File message";
+  }
+}
+
+export function buildMessageTitleSource(
+  message: Record<string, unknown>,
+): string | null {
+  const extractedText = extractMessageText(message).trim();
+  if (extractedText.length > 0) {
+    return extractedText;
+  }
+
+  for (const uiPart of extractPersistableUiParts(message)) {
+    if (uiPart.type === "file") {
+      return buildTitleSourceFromFilePart(uiPart);
+    }
+
+    const partText = uiPart.text.trim();
+    if (partText.length > 0) {
+      return partText;
+    }
+  }
+
+  return null;
+}
+
 /** Reasoning segments from structured `content` / `parts` (for persisting `metadata.reasoning`). */
 export function extractReasoningPartsFromMessage(
   message: Record<string, unknown>,

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -347,6 +347,43 @@ describe("POST /chat", () => {
     );
   });
 
+  it("rejects attachment-only system messages for coworker chats", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { coworker_slug: "ops-agent" },
+      providerConversationId: null,
+    });
+    coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        messages: [
+          {
+            role: "system",
+            parts: [
+              {
+                type: "file",
+                url: "https://example.com/brief.pdf",
+                mediaType: "application/pdf",
+                filename: "brief.pdf",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(createCoworkerConversationMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
   it("rejects coworker auth without delegation headers for user-scoped chat", async () => {
     const app = createApp({
       authContext: {

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -384,6 +384,34 @@ describe("POST /chat", () => {
     expect(streamTextMock).not.toHaveBeenCalled();
   });
 
+  it("accepts coworker chat when the last user message uses string content only", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { coworker_slug: "ops-agent" },
+      providerConversationId: "conv_remote_1",
+    });
+    coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        messages: [{ role: "user", content: "Hello from string content" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(streamTextMock).toHaveBeenCalledOnce();
+    const call = streamTextMock.mock.calls[0]![0] as {
+      providerOptions?: { sokosumi?: { mode?: string } };
+    };
+    expect(call.providerOptions?.sokosumi?.mode).toBe("coworker");
+  });
+
   it("rejects coworker auth without delegation headers for user-scoped chat", async () => {
     const app = createApp({
       authContext: {

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -24,6 +24,7 @@ import {
   unprocessableEntity,
 } from "@/helpers/error";
 import {
+  buildMessageTitleSource,
   extractMessageText,
   extractPersistableUiParts,
   extractReasoningPartsFromMessage,
@@ -69,6 +70,7 @@ async function persistUserOrSystemTurnForConversation(params: {
 
   const reasoningParts = extractReasoningPartsFromMessage(lastMessage);
   const uiParts = extractPersistableUiParts(lastMessage);
+  const titleSource = buildMessageTitleSource(lastMessage);
   const metadata =
     reasoningParts.length > 0 || uiParts.length > 0
       ? {
@@ -93,7 +95,7 @@ async function persistUserOrSystemTurnForConversation(params: {
     const isFirstUserMessage =
       itemCountBefore === 0 &&
       lastMessage.role === "user" &&
-      extractedText.trim().length > 0;
+      titleSource !== null;
 
     await tx.conversationMessage.create({
       data: {
@@ -112,8 +114,9 @@ async function persistUserOrSystemTurnForConversation(params: {
     waitUntil(
       (async () => {
         try {
-          const generatedTitle =
-            await openrouterClient.generateChatTitle(extractedText);
+          const generatedTitle = await openrouterClient.generateChatTitle(
+            titleSource ?? extractedText,
+          );
           if (generatedTitle) {
             await prisma.conversation.update({
               where: { id: conversationId },
@@ -248,6 +251,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
               return extractMessageText(lastMessage as Record<string, unknown>);
             })()
           : null;
+      const lastMessageHasCoworkerCompatibleContent =
+        incomingLast &&
+        (incomingLast.role === "user" || incomingLast.role === "system")
+          ? incomingLast.role === "user"
+            ? extractPersistableUiParts(
+                incomingLast as Record<string, unknown>,
+              ).some((part) =>
+                part.type === "file" ? true : part.text.trim().length > 0,
+              )
+            : (lastUserMessageText?.trim().length ?? 0) > 0
+          : false;
 
       const metadata = (conversation?.metadata ?? null) as Record<
         string,
@@ -283,9 +297,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       const useCoworker = Boolean(internalConversationId) && Boolean(coworker);
 
       if (useCoworker) {
-        if (lastUserMessageText === null || lastUserMessageText.trim() === "") {
+        if (!lastMessageHasCoworkerCompatibleContent) {
           throw badRequest(
-            "Coworker chat requires a user or system message to respond to; send at least one message with text.",
+            "Coworker chat requires a user or system message to respond to; send a user message with text or an attachment, or a system message with text.",
           );
         }
         if (!coworker?.baseURL?.trim()) {

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -28,6 +28,7 @@ import {
   extractMessageText,
   extractPersistableUiParts,
   extractReasoningPartsFromMessage,
+  hasModelVisibleMessageContent,
 } from "@/helpers/message-content";
 import { jsonErrorResponse } from "@/helpers/openapi";
 import { persistAssistantFromAiSdk } from "@/helpers/persist-assistant-from-ai-sdk";
@@ -255,10 +256,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         incomingLast &&
         (incomingLast.role === "user" || incomingLast.role === "system")
           ? incomingLast.role === "user"
-            ? extractPersistableUiParts(
+            ? hasModelVisibleMessageContent(
                 incomingLast as Record<string, unknown>,
-              ).some((part) =>
-                part.type === "file" ? true : part.text.trim().length > 0,
               )
             : (lastUserMessageText?.trim().length ?? 0) > 0
           : false;


### PR DESCRIPTION
## Summary

Improves how the core chat API derives conversation titles and validates the last message for coworker conversations when users send attachments without body text.

## Key changes

- **`buildMessageTitleSource`** (`message-content.ts`): After trimmed message text, walks persistable UI parts and uses the first file part’s filename, an image fallback label (`Image message`), URL path segment / hostname, or `File message` when the URL is invalid; otherwise uses non-blank text from other UI parts.
- **`hasModelVisibleMessageContent`**: Used in tests to document behavior for attachment-only vs whitespace-only user payloads.
- **Persistence / titles** (`post.ts`): First-user detection and async title generation use `titleSource` so attachment-only first turns still create a message row and get an OpenRouter-generated title from a sensible string (e.g. filename).
- **Coworker validation**: The last incoming user or system message is accepted for coworker flow when the user message has at least one file part or non-blank text part; **system** messages still require non-blank extracted text. Attachment-only **system** messages return **400** and do not start streaming (covered in `post.test.ts`).

## Technical notes

- Coworker branch uses `extractPersistableUiParts` for user-role checks and existing `lastUserMessageText` / `extractMessageText` for system-role checks, keeping system prompts text-only while allowing multimodal user turns.

## Testing

- `pnpm --filter core test src/helpers/__tests__/message-content.test.ts src/routes/v1/chat/post.test.ts` (45 tests passed locally).

## Risk

- Low: behavior is additive for normal text chats; coworker system messages with files only are now explicitly rejected where they were previously rejected for “empty text” in a similar way.
