### PR TITLE
feat(chat): upgrade OpenRouter catalog and legacy model mappings

### DIFF
--- a/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
@@ -73,13 +73,13 @@ describe("writeWelcomeComposePreferences", () => {
   it("round-trips through readWelcomeComposePreferences", () => {
     writeWelcomeComposePreferences({
       composeKind: "chat",
-      modelId: "kimi-k2-5",
+      modelId: "kimi-k2-6",
       coworkerSlugOrId: null,
     });
     expect(readWelcomeComposePreferences()).toMatchObject({
       v: 1,
       composeKind: "chat",
-      modelId: "kimi-k2-5",
+      modelId: "kimi-k2-6",
       coworkerSlugOrId: null,
     });
   });
@@ -91,7 +91,7 @@ describe("buildWelcomeComposeStoredSnapshot", () => {
       buildWelcomeComposeStoredSnapshot({
         composeKind: "task",
         coworker: baseCoworker(),
-        model: { id: "kimi-k2-5", name: "Kimi" },
+        model: { id: "kimi-k2-6", name: "Kimi" },
       }).modelId,
     ).toBeNull();
   });
@@ -148,7 +148,7 @@ describe("resolveHydratedWelcomeSelection", () => {
     const stored = {
       v: 1 as const,
       composeKind: "chat" as const,
-      modelId: "kimi-k2-5",
+      modelId: "kimi-k2-6",
       coworkerSlugOrId: "alex",
     };
     const r = resolveHydratedWelcomeSelection(coworkers, stored, {
@@ -156,7 +156,7 @@ describe("resolveHydratedWelcomeSelection", () => {
     });
     expect(r.composeKind).toBe("chat");
     expect(r.coworker).toBeNull();
-    expect(r.model).toEqual({ id: "kimi-k2-5", name: "Kimi K2.5" });
+    expect(r.model).toEqual({ id: "kimi-k2-6", name: "Kimi K2.6" });
   });
 
   it("when urlCoworkerSlug is true, keeps composeKind but clears model and coworker", () => {

--- a/packages/chat/src/models/chat-models.test.ts
+++ b/packages/chat/src/models/chat-models.test.ts
@@ -3,6 +3,33 @@ import { describe, expect, it } from "vitest";
 import { CHAT_MODELS, getModelIdentifier } from "./chat-models.js";
 
 describe("chat models", () => {
+  it("registers upgraded OpenRouter model slugs", () => {
+    expect(CHAT_MODELS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "mimo-v2-pro",
+          name: "MiMo-V2-Pro",
+          openRouterId: "xiaomi/mimo-v2-pro",
+        }),
+        expect.objectContaining({
+          id: "kimi-k2-6",
+          name: "Kimi K2.6",
+          openRouterId: "moonshotai/kimi-k2.6",
+        }),
+        expect.objectContaining({
+          id: "deepseek-v4-pro",
+          name: "DeepSeek V4 Pro",
+          openRouterId: "deepseek/deepseek-v4-pro",
+        }),
+        expect.objectContaining({
+          id: "gpt-5-4",
+          name: "GPT-5.4",
+          openRouterId: "openai/gpt-5.4",
+        }),
+      ]),
+    );
+  });
+
   it("registers Claude Opus 4.7 with the OpenRouter slug", () => {
     const opusModel = CHAT_MODELS.find(
       (model) => model.id === "claude-opus-4-7",
@@ -19,5 +46,14 @@ describe("chat models", () => {
     expect(getModelIdentifier("claude-opus-4-6")).toBe(
       "anthropic/claude-opus-4.7",
     );
+  });
+
+  it("maps upgraded legacy model ids to current OpenRouter slugs", () => {
+    expect(getModelIdentifier("minimax-m2-5")).toBe("xiaomi/mimo-v2-pro");
+    expect(getModelIdentifier("kimi-k2-5")).toBe("moonshotai/kimi-k2.6");
+    expect(getModelIdentifier("deepseek-v3-2")).toBe(
+      "deepseek/deepseek-v4-pro",
+    );
+    expect(getModelIdentifier("gpt-5-2")).toBe("openai/gpt-5.4");
   });
 });

--- a/packages/chat/src/models/chat-models.ts
+++ b/packages/chat/src/models/chat-models.ts
@@ -7,16 +7,16 @@ export interface ChatModel {
 
 export const CHAT_MODELS = [
   {
-    id: "minimax-m2-5",
-    name: "MiniMax M2.5",
-    iconProvider: "minimax",
-    openRouterId: "minimax/minimax-m2.5",
+    id: "mimo-v2-pro",
+    name: "MiMo-V2-Pro",
+    iconProvider: "xiaomi",
+    openRouterId: "xiaomi/mimo-v2-pro",
   },
   {
-    id: "kimi-k2-5",
-    name: "Kimi K2.5",
+    id: "kimi-k2-6",
+    name: "Kimi K2.6",
     iconProvider: "moonshot",
-    openRouterId: "moonshotai/kimi-k2.5",
+    openRouterId: "moonshotai/kimi-k2.6",
   },
   {
     id: "gemini-3-flash-preview",
@@ -25,10 +25,10 @@ export const CHAT_MODELS = [
     openRouterId: "google/gemini-3-flash-preview",
   },
   {
-    id: "deepseek-v3-2",
-    name: "DeepSeek V3.2",
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
     iconProvider: "deepseek",
-    openRouterId: "deepseek/deepseek-v3.2",
+    openRouterId: "deepseek/deepseek-v4-pro",
   },
   {
     id: "claude-opus-4-7",
@@ -43,19 +43,24 @@ export const CHAT_MODELS = [
     openRouterId: "x-ai/grok-4.1-fast",
   },
   {
-    id: "gpt-5-2",
-    name: "GPT-5.2",
+    id: "gpt-5-4",
+    name: "GPT-5.4",
     iconProvider: "openai",
-    openRouterId: "openai/gpt-5.2",
+    openRouterId: "openai/gpt-5.4",
   },
 ] as const satisfies ReadonlyArray<ChatModel>;
 
 export type ChatModelId = (typeof CHAT_MODELS)[number]["id"];
 
-export const DEFAULT_CHAT_MODEL_ID: ChatModelId = "gpt-5-2";
+export const DEFAULT_CHAT_MODEL_ID: ChatModelId = "gpt-5-4";
 
 const CHAT_MODEL_MAP = new Map<string, string>([
   ...CHAT_MODELS.map((model) => [model.id, model.openRouterId] as const),
+  // Keep persisted selections working after model upgrades.
+  ["minimax-m2-5", "xiaomi/mimo-v2-pro"],
+  ["kimi-k2-5", "moonshotai/kimi-k2.6"],
+  ["deepseek-v3-2", "deepseek/deepseek-v4-pro"],
+  ["gpt-5-2", "openai/gpt-5.4"],
   // Keep persisted Opus 4.6 selections working after the model upgrade.
   ["claude-opus-4-6", "anthropic/claude-opus-4.7"],
   ["gpt4o", "openai/gpt-4o"],
@@ -73,7 +78,7 @@ function getDefaultOpenRouterModelId(): string {
     (model) => model.id === DEFAULT_CHAT_MODEL_ID,
   );
 
-  return defaultModel?.openRouterId ?? "openai/gpt-5.2";
+  return defaultModel?.openRouterId ?? "openai/gpt-5.4";
 }
 
 export function getModelIdentifier(modelId: string | null): string {


### PR DESCRIPTION
## Summary

Updates the `@sokosumi/chat` model catalog to newer OpenRouter-backed models, switches the default chat model to **GPT-5.4**, and keeps **persisted legacy model ids** resolving to the correct OpenRouter slugs after upgrades.

## Key changes

- **Catalog**: `minimax-m2-5` → `mimo-v2-pro` (Xiaomi MiMo-V2-Pro), `kimi-k2-5` → `kimi-k2-6`, `deepseek-v3-2` → `deepseek-v4-pro`, `gpt-5-2` → `gpt-5-4` with matching `openRouterId` and display names / icon providers where applicable.
- **Default**: `DEFAULT_CHAT_MODEL_ID` and `getDefaultOpenRouterModelId` fallback now target **gpt-5.4** / **openai/gpt-5.4**.
- **Compatibility**: `CHAT_MODEL_MAP` entries map old ids (`minimax-m2-5`, `kimi-k2-5`, `deepseek-v3-2`, `gpt-5-2`) to the new OpenRouter identifiers so stored preferences and URLs keep working.
- **Tests**: `chat-models.test.ts` asserts the new registrations and legacy `getModelIdentifier` mappings; web welcome compose preference tests use **kimi-k2-6** / **Kimi K2.6** where the prior slug was **kimi-k2-5**.

## Technical notes

- `getModelIdentifier` behavior is unchanged for current ids; legacy ids are additive map entries only.
- No database or API contract changes beyond what clients already send as `modelId` strings.

## Testing

- `pnpm --filter @sokosumi/chat test src/models/chat-models.test.ts`
- `pnpm --filter web test "src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts"`

(Verified locally: both pass.)

## Risk / follow-up

- Any code or config outside this map that still hardcodes removed ids should be updated in follow-up PRs if discovered in CI or production.
