### PR TITLE
feat(chat): propagate multimodal payloads through compose and resend

### DIFF
--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -98,8 +98,35 @@ function hasSendMessageContent(message: ChatComposeMessage): boolean {
 }
 
 function toChatSendMessage(message: ChatComposeMessage): ChatSendMessage {
-  if (typeof message !== "string") return message;
-  return { text: message.trim() } as ChatSendMessage;
+  if (typeof message === "string") {
+    return { text: message.trim() } as ChatSendMessage;
+  }
+
+  const m = message as Record<string, unknown>;
+  const hasText = typeof m.text === "string";
+  const hasParts = Array.isArray(m.parts);
+  if (!hasText && !hasParts) {
+    return message;
+  }
+
+  const next: Record<string, unknown> = { ...m };
+  if (hasText) {
+    next.text = (m.text as string).trim();
+  }
+  if (hasParts) {
+    next.parts = (m.parts as unknown[]).map((part: unknown) => {
+      if (!part || typeof part !== "object") return part;
+      const p = part as Record<string, unknown>;
+      if (p.type !== "text") return part;
+      if (typeof p.text === "string") return { ...p, text: p.text.trim() };
+      if (typeof p.content === "string") {
+        return { ...p, content: p.content.trim() };
+      }
+      return part;
+    });
+  }
+
+  return next as ChatSendMessage;
 }
 
 function buildResendMessage(message: UIMessage): ChatSendMessage | null {
@@ -1032,6 +1059,7 @@ export default function ChatInterface({
 
   const sendInConversation = useCallback(
     (conversationId: string, message: ChatSendMessage): boolean => {
+      const payload = toChatSendMessage(message);
       let slot = conversationToSlot.get(conversationId);
       if (slot === undefined) {
         const freeSlot = getOrAssignSlot(conversationId);
@@ -1067,11 +1095,11 @@ export default function ChatInterface({
         );
         const slotToSend = slot;
         queueMicrotask(() => {
-          sendMessageSlots[slotToSend](message);
+          sendMessageSlots[slotToSend](payload);
         });
         return true;
       }
-      sendMessageSlots[slot](message);
+      sendMessageSlots[slot](payload);
       return true;
     },
     [

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -1447,7 +1447,9 @@ export default function ChatInterface({
     (message?: ChatSendMessage) => {
       const cid = selectedChatId ?? currentChatIdRef.current;
       if (!cid) return Promise.resolve();
-      if (message) sendInConversation(cid, message);
+      if (message && hasSendMessageContent(message)) {
+        sendInConversation(cid, message);
+      }
       return Promise.resolve();
     },
     [selectedChatId, sendInConversation],

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -32,7 +32,9 @@ import { useCoworkerPostRefreshAssistantPoll } from "@/app/chat/hooks/use-cowork
 import type {
   Chat,
   ChatComposeKind,
+  ChatComposeMessage,
   ChatComposeSubmitOptions,
+  ChatSendMessage,
   Coworker,
 } from "@/app/chat/utils/types";
 import {
@@ -52,6 +54,7 @@ import {
 import {
   extractMessageContent,
   extractReasoningStepMessages,
+  hasMessageTextOrFileParts,
   mergeAssistantThoughtMetadataFromDb,
 } from "@/app/chat-ui/utils/message-utils";
 import { useConversationsContext } from "@/contexts/conversations-context";
@@ -81,6 +84,32 @@ const CHAT_NO_RESUMABLE_STREAM_PATH = "/api/chat/no-resumable-stream";
 
 /** Stable no-op for inputs that do not wire `useChat` stop; avoids breaking memo equality on `stop`. */
 function noopChatComposerStop() {}
+
+function getSendMessageText(message: ChatComposeMessage): string {
+  if (typeof message === "string") return message.trim();
+  return extractMessageContent(message).trim();
+}
+
+function hasSendMessageContent(message: ChatComposeMessage): boolean {
+  if (getSendMessageText(message).length > 0) return true;
+  return typeof message === "string"
+    ? false
+    : hasMessageTextOrFileParts(message);
+}
+
+function toChatSendMessage(message: ChatComposeMessage): ChatSendMessage {
+  if (typeof message !== "string") return message;
+  return { text: message.trim() } as ChatSendMessage;
+}
+
+function buildResendMessage(message: UIMessage): ChatSendMessage | null {
+  if (hasMessageTextOrFileParts(message)) {
+    return { parts: message.parts } as ChatSendMessage;
+  }
+
+  const text = extractMessageContent(message).trim();
+  return text ? ({ text } as ChatSendMessage) : null;
+}
 
 interface SlotPayload {
   conversationId: string | null;
@@ -1002,7 +1031,7 @@ export default function ChatInterface({
   ]);
 
   const sendInConversation = useCallback(
-    (conversationId: string, text: string): boolean => {
+    (conversationId: string, message: ChatSendMessage): boolean => {
       let slot = conversationToSlot.get(conversationId);
       if (slot === undefined) {
         const freeSlot = getOrAssignSlot(conversationId);
@@ -1038,11 +1067,11 @@ export default function ChatInterface({
         );
         const slotToSend = slot;
         queueMicrotask(() => {
-          sendMessageSlots[slotToSend]({ text });
+          sendMessageSlots[slotToSend](message);
         });
         return true;
       }
-      sendMessageSlots[slot]({ text });
+      sendMessageSlots[slot](message);
       return true;
     },
     [
@@ -1244,20 +1273,25 @@ export default function ChatInterface({
 
   const handleSendMessage = useCallback(
     async (
-      messageText: string,
+      message: ChatComposeMessage,
       coworker?: Coworker,
       model?: { id: string; name: string },
       options?: ChatComposeSubmitOptions,
     ): Promise<boolean> => {
-      if (!messageText.trim() || isLoading) {
+      if (!hasSendMessageContent(message) || isLoading) {
         return false;
       }
 
-      const trimmedMessage = messageText.trim();
+      const messageText = getSendMessageText(message);
+      const sendPayload = toChatSendMessage(message);
       const composeKind = options?.kind ?? "task";
 
       if (!selectedChatId) {
         if (composeKind === "task") {
+          if (!messageText) {
+            return false;
+          }
+
           if (welcomeTaskCreationInFlightRef.current) {
             return false;
           }
@@ -1278,7 +1312,7 @@ export default function ChatInterface({
           setIsWelcomeTaskSubmitting(true);
           try {
             const result = await createTask({
-              description: trimmedMessage,
+              description: messageText,
               coworkerId: selectedTaskCoworker.id,
               status:
                 options?.taskStatus === "DRAFT"
@@ -1332,7 +1366,7 @@ export default function ChatInterface({
         }
 
         const cid = currentChatIdRef.current ?? conversationId;
-        const sent = cid ? sendInConversation(cid, trimmedMessage) : false;
+        const sent = cid ? sendInConversation(cid, sendPayload) : false;
         if (sent) setInput("");
         return sent;
       }
@@ -1352,7 +1386,7 @@ export default function ChatInterface({
         );
       }
 
-      const sent = sendInConversation(selectedChatId, trimmedMessage);
+      const sent = sendInConversation(selectedChatId, sendPayload);
       if (sent) setInput("");
       return sent;
     },
@@ -1382,17 +1416,10 @@ export default function ChatInterface({
   }, [selectedChatId, conversationToSlot, slotStatuses]);
 
   const sendMessageForInput = useCallback(
-    (message?: { text?: string } | { parts?: unknown[] } | UIMessage) => {
+    (message?: ChatSendMessage) => {
       const cid = selectedChatId ?? currentChatIdRef.current;
       if (!cid) return Promise.resolve();
-      const text =
-        message &&
-        typeof message === "object" &&
-        "text" in message &&
-        typeof (message as { text?: string }).text === "string"
-          ? (message as { text: string }).text
-          : undefined;
-      if (text) sendInConversation(cid, text);
+      if (message) sendInConversation(cid, message);
       return Promise.resolve();
     },
     [selectedChatId, sendInConversation],
@@ -1411,8 +1438,10 @@ export default function ChatInterface({
   );
 
   const handleResendLastMessage = useCallback(
-    async (text: string) => {
-      if (!selectedChatId || !text.trim()) return;
+    async (message: UIMessage) => {
+      if (!selectedChatId) return;
+      const sendPayload = buildResendMessage(message);
+      if (!sendPayload) return;
       const list = await refreshConversations();
       const conv = list?.find((c) => c.id === selectedChatId);
       const pid = readPreviousResponseIdFromMetadata(
@@ -1421,7 +1450,7 @@ export default function ChatInterface({
       if (pid) {
         resendPreviousResponseIdOverrideRef.current.set(selectedChatId, pid);
       }
-      sendInConversation(selectedChatId, text.trim());
+      sendInConversation(selectedChatId, sendPayload);
     },
     [selectedChatId, sendInConversation, refreshConversations],
   );

--- a/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
@@ -25,6 +25,7 @@ import {
   extractMessageContent,
   extractReasoningStepMessages,
   getThoughtTimingMsFromMessage,
+  hasMessageTextOrFileParts,
 } from "@/app/chat-ui/utils/message-utils";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -72,7 +73,7 @@ interface MessageListProps {
   reasoningStartedAt?: number;
   reasoningEndedAt?: number;
   isCoworker?: boolean;
-  onResendLastMessage?: (lastUserMessageText: string) => void;
+  onResendLastMessage?: (lastUserMessage: UIMessage) => void;
   userTailRecoveryFailed?: boolean;
 }
 
@@ -184,26 +185,33 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     const modelName = selectedChat?.model?.name;
     const modelId = selectedChat?.model?.id;
 
-    const lastUserMessageText = (() => {
+    const lastUserMessage = (() => {
       for (let i = messagesWithTimestamps.length - 1; i >= 0; i--) {
         const msg = messagesWithTimestamps[i];
         if ((msg.role as string) === "user") {
-          const text = extractMessageContent(msg).trim();
-          if (text) return text;
-          return "";
+          return msg;
         }
       }
-      return "";
+      return null;
     })();
+    const lastUserMessageText = lastUserMessage
+      ? extractMessageContent(lastUserMessage).trim()
+      : "";
+    const lastUserMessageHasParts =
+      lastUserMessage != null && hasMessageTextOrFileParts(lastUserMessage);
+    const lastUserMessageHasContent =
+      lastUserMessageText.length > 0 || lastUserMessageHasParts;
 
     const showUserTailRecoveryError =
       userTailRecoveryFailed &&
       lastMessage?.role === "user" &&
-      Boolean(lastUserMessageText);
+      lastUserMessageHasContent;
     const showPendingOrTailError =
       showPendingError || showUserTailRecoveryError;
     const canResendPendingOrTail = Boolean(
-      showPendingOrTailError && onResendLastMessage && lastUserMessageText,
+      showPendingOrTailError &&
+        onResendLastMessage &&
+        lastUserMessageHasContent,
     );
 
     const pendingErrorMessage = t("pendingResponseFailed");
@@ -228,7 +236,9 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
           {canResendPendingOrTail && (
             <Button
               className="bg-foreground text-background hover:bg-foreground/90 w-fit"
-              onClick={() => onResendLastMessage?.(lastUserMessageText)}
+              onClick={() => {
+                if (lastUserMessage) onResendLastMessage?.(lastUserMessage);
+              }}
               size="sm"
             >
               {t("resend")}
@@ -378,7 +388,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     return (
       <div
         ref={setWrapperRef}
-        className="absolute inset-x-0 top-0 bottom-[8rem] overflow-hidden"
+        className="absolute inset-x-0 top-0 bottom-32 overflow-hidden"
       >
         <div
           ref={scrollContainerRef}

--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
@@ -7,6 +7,7 @@ import {
   extractMessageContent,
   extractReasoningStepMessages,
   getThoughtTimingMsFromMessage,
+  hasMessageTextOrFileParts,
   mergeAssistantThoughtMetadataFromDb,
 } from "../message-utils";
 
@@ -67,6 +68,35 @@ describe("extractMessageContent", () => {
         content: [{ type: "text" as const, text: "visible" }],
       }),
     ).toBe("visible");
+  });
+});
+
+describe("hasMessageTextOrFileParts", () => {
+  it("returns false for synthetic empty text fallback parts", () => {
+    expect(
+      hasMessageTextOrFileParts({
+        id: "u1",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for file-only user messages", () => {
+    expect(
+      hasMessageTextOrFileParts({
+        id: "u2",
+        role: "user" as const,
+        parts: [
+          {
+            type: "file" as const,
+            url: "https://example.com/brief.pdf",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/app/(app)/chat-ui/utils/message-utils.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/message-utils.ts
@@ -23,6 +23,19 @@ function appendVisibleTextFromPart(part: Record<string, unknown>): string {
   return "";
 }
 
+function hasMeaningfulUiPart(part: unknown): boolean {
+  if (!part || typeof part !== "object") {
+    return false;
+  }
+
+  const record = part as Record<string, unknown>;
+  if (record.type === "file") {
+    return true;
+  }
+
+  return appendVisibleTextFromPart(record).trim().length > 0;
+}
+
 /** Visible assistant text only (text parts only; excludes reasoning, tools, etc.). */
 export function extractMessageContent(message: unknown): string {
   const messageAny = message as Record<string, unknown>;
@@ -75,6 +88,16 @@ export function extractMessageContent(message: unknown): string {
   }
 
   return content.trim();
+}
+
+export function hasMessageTextOrFileParts(message: unknown): boolean {
+  const messageAny = message as Record<string, unknown>;
+  const parts = messageAny.parts;
+  if (!Array.isArray(parts)) {
+    return false;
+  }
+
+  return parts.some((part) => hasMeaningfulUiPart(part));
 }
 
 /** Reasoning parts from a UIMessage (for ThoughtSummaryBar / loaders). */

--- a/apps/web/src/app/(app)/chat/components/chat-input-container.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-input-container.tsx
@@ -5,6 +5,7 @@ import type { UIMessage } from "ai";
 import type { Dispatch, SetStateAction } from "react";
 
 import type {
+  ChatComposeMessage,
   ChatComposeSubmitOptions,
   Coworker,
 } from "@/app/chat/utils/types";
@@ -20,7 +21,7 @@ interface ChatInputContainerProps {
   setMessages: UseChatHelpers<UIMessage>["setMessages"];
   sendMessage: UseChatHelpers<UIMessage>["sendMessage"];
   onSendMessage: (
-    message: string,
+    message: ChatComposeMessage,
     coworker?: Coworker,
     model?: { id: string; name: string },
     options?: ChatComposeSubmitOptions,

--- a/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
+++ b/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
@@ -7,6 +7,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { getCoworkerImageUrl } from "@/app/chat/utils/coworker-utils";
 import type {
   ChatComposeKind,
+  ChatComposeMessage,
   ChatComposeSubmitOptions,
   Coworker,
 } from "@/app/chat/utils/types";
@@ -21,7 +22,7 @@ interface WelcomeScreenProps {
   showGreetingAndSuggestions?: boolean;
   userName?: string;
   onSendMessage: (
-    message: string,
+    message: ChatComposeMessage,
     coworker?: Coworker,
     model?: { id: string; name: string },
     options?: ChatComposeSubmitOptions,

--- a/apps/web/src/app/(app)/chat/utils/types.ts
+++ b/apps/web/src/app/(app)/chat/utils/types.ts
@@ -1,8 +1,15 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+
 import type { CoworkerMetadata } from "@/lib/clients/generated/core/types.gen";
 
 export type ChatStatus = "active" | "awaiting" | "resolved";
 export type ChatComposeKind = "chat" | "task";
 export type TaskSubmitStatus = "DRAFT" | "READY";
+export type ChatSendMessage = Parameters<
+  UseChatHelpers<UIMessage>["sendMessage"]
+>[0];
+export type ChatComposeMessage = string | ChatSendMessage;
 
 export interface ChatComposeSubmitOptions {
   kind: ChatComposeKind;

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -17,7 +17,9 @@ import { toast } from "sonner";
 import { getCoworkerImageUrl } from "@/app/chat/utils/coworker-utils";
 import type {
   ChatComposeKind,
+  ChatComposeMessage,
   ChatComposeSubmitOptions,
+  ChatSendMessage,
   Coworker,
   TaskSubmitStatus,
 } from "@/app/chat/utils/types";
@@ -74,7 +76,7 @@ interface MultimodalInputProps {
   setMessages: UseChatHelpers<UIMessage>["setMessages"];
   sendMessage: UseChatHelpers<UIMessage>["sendMessage"];
   onSendMessage?: (
-    message: string,
+    message: ChatComposeMessage,
     coworker?: Coworker,
     model?: { id: string; name: string },
     options?: ChatComposeSubmitOptions,
@@ -431,11 +433,13 @@ function PureMultimodalInput({
       }
     }
 
+    const chatMessage = { text: input } as ChatSendMessage;
+
     // Use onSendMessage if provided (for welcome screen to create conversation)
     // Otherwise use sendMessage from useChat hook
     if (onSendMessage) {
       const sendResult = await onSendMessage(
-        input,
+        composeKind === "chat" ? chatMessage : input,
         selectedCoworker ?? undefined,
         selectedModel ?? undefined,
         {
@@ -447,7 +451,7 @@ function PureMultimodalInput({
         return;
       }
     } else {
-      sendMessage({ text: input } as never);
+      sendMessage(chatMessage);
     }
 
     setLocalStorageValue("chat-input", "");

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -433,13 +433,13 @@ function PureMultimodalInput({
       }
     }
 
-    const chatMessage = { text: input.trim() } as ChatSendMessage;
+    const sendPayload = { text: input.trim() } as ChatSendMessage;
 
     // Use onSendMessage if provided (for welcome screen to create conversation)
     // Otherwise use sendMessage from useChat hook
     if (onSendMessage) {
       const sendResult = await onSendMessage(
-        composeKind === "chat" ? chatMessage : input,
+        sendPayload,
         selectedCoworker ?? undefined,
         selectedModel ?? undefined,
         {
@@ -451,7 +451,7 @@ function PureMultimodalInput({
         return;
       }
     } else {
-      sendMessage(chatMessage);
+      sendMessage(sendPayload);
     }
 
     setLocalStorageValue("chat-input", "");

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -433,7 +433,7 @@ function PureMultimodalInput({
       }
     }
 
-    const chatMessage = { text: input } as ChatSendMessage;
+    const chatMessage = { text: input.trim() } as ChatSendMessage;
 
     // Use onSendMessage if provided (for welcome screen to create conversation)
     // Otherwise use sendMessage from useChat hook


### PR DESCRIPTION
## Summary

This change threads **multimodal chat payloads** (text and file parts) through the compose → send path and the **resend last message** flow, instead of collapsing everything to a plain string. User messages that are file-only or mix files with text are now treated as having content where appropriate, and resend preserves `UIMessage` parts for the backend.

## Key changes

- **Types** (`apps/web/src/app/(app)/chat/utils/types.ts`): Introduced `ChatSendMessage` (first argument to `useChat`’s `sendMessage`) and `ChatComposeMessage` (`string | ChatSendMessage`) so callers can pass the same shapes the AI SDK expects.
- **Message utilities** (`message-utils.ts`): Added `hasMessageTextOrFileParts` and tests to detect meaningful text or `file` parts (excluding empty synthetic text parts).
- **Chat interface**: `sendInConversation`, `handleSendMessage`, `sendMessageForInput`, and `handleResendLastMessage` now pass structured messages; helpers normalize string vs object compose input and build resend payloads from the last user `UIMessage`.
- **Message list**: `onResendLastMessage` receives the full last user `UIMessage`; pending/tail error and resend affordances use the new content heuristic. Minor layout: scroll area bottom spacing uses `bottom-32` instead of `bottom-[8rem]`.
- **Multimodal input / welcome / chat input container**: `onSendMessage` accepts `ChatComposeMessage`; chat compose path passes a typed `{ text }` payload where needed.

## Technical notes

- New-task creation from the welcome flow still requires non-empty **trimmed text** (`messageText`); file-only compose without text remains blocked for that path by design.
- Resend builds `{ parts }` when the message has text/file parts; otherwise falls back to `{ text }` when extractable trimmed text exists.

## Testing

- `pnpm --filter web test src/app/\(app\)/chat-ui/utils/__tests__/message-utils.test.ts`
- Recommend a quick manual pass: send text-only, attach file-only (if supported in UI), resend after a failed/pending tail, and welcome “task” vs “chat” compose.
