### PR TITLE
feat(chat): OpenRouter image generation and multimodal attachments

### DIFF
--- a/apps/core/src/helpers/__tests__/conversation-message-api-content.test.ts
+++ b/apps/core/src/helpers/__tests__/conversation-message-api-content.test.ts
@@ -99,6 +99,36 @@ describe("conversationMessageToApiContent", () => {
     ]);
   });
 
+  it("returns assistant generated image file parts without markdown content", () => {
+    expect(
+      conversationMessageToApiContent({
+        contentType: "output_text",
+        contentText: "Here's the generated image.",
+        metadata: {
+          ui_message_v1: {
+            parts: [
+              { type: "output_text", text: "Here's the generated image." },
+              {
+                type: "file",
+                url: "https://blob.example.com/generated.png",
+                mediaType: "image/png",
+                filename: "generated.png",
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual([
+      { type: "output_text", text: "Here's the generated image." },
+      {
+        type: "file",
+        url: "https://blob.example.com/generated.png",
+        mediaType: "image/png",
+        filename: "generated.png",
+      },
+    ]);
+  });
+
   it("falls back to a text body when file contentType has no persisted file metadata", () => {
     expect(
       conversationMessageToApiContent({

--- a/apps/core/src/helpers/__tests__/conversation-messages-to-ui-messages.test.ts
+++ b/apps/core/src/helpers/__tests__/conversation-messages-to-ui-messages.test.ts
@@ -4,6 +4,41 @@ import { describe, expect, it } from "vitest";
 import { conversationMessagesToUiMessages } from "../conversation-messages-to-ui-messages";
 
 describe("conversationMessagesToUiMessages", () => {
+  it("rehydrates assistant generated image file parts from metadata", async () => {
+    const messages = conversationMessagesToUiMessages([
+      {
+        id: "m1",
+        role: "assistant",
+        contentText: "Here's the generated image.",
+        metadata: {
+          ui_message_v1: {
+            parts: [
+              { type: "output_text", text: "Here's the generated image." },
+              {
+                type: "file",
+                url: "https://blob.example.com/generated.png",
+                mediaType: "image/png",
+                filename: "generated.png",
+              },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(messages[0]?.parts).toEqual([
+      { type: "text", text: "Here's the generated image." },
+      {
+        type: "file",
+        url: "https://blob.example.com/generated.png",
+        mediaType: "image/png",
+        filename: "generated.png",
+      },
+    ]);
+
+    await expect(validateUIMessages({ messages })).resolves.toBeDefined();
+  });
+
   it("rehydrates stored text and file ui parts from metadata", async () => {
     const messages = conversationMessagesToUiMessages([
       {
@@ -88,6 +123,25 @@ describe("conversationMessagesToUiMessages", () => {
     ]);
 
     expect(messages[0]?.parts).toEqual([{ type: "text", text: "Hi" }]);
+    await expect(validateUIMessages({ messages })).resolves.toBeDefined();
+  });
+
+  it("rehydrates image generation intent from user message metadata", async () => {
+    const messages = conversationMessagesToUiMessages([
+      {
+        id: "m1",
+        role: "user",
+        contentText: "Make an image",
+        metadata: {
+          image_generation: true,
+          ui_message_v1: {
+            parts: [{ type: "text", text: "Make an image" }],
+          },
+        },
+      },
+    ]);
+
+    expect(messages[0]?.metadata).toEqual({ imageGeneration: true });
     await expect(validateUIMessages({ messages })).resolves.toBeDefined();
   });
 });

--- a/apps/core/src/helpers/__tests__/persist-assistant-from-ai-sdk.test.ts
+++ b/apps/core/src/helpers/__tests__/persist-assistant-from-ai-sdk.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  conversationFindFirstMock,
+  conversationMessageCreateMock,
+  conversationMessageFindFirstMock,
+} = vi.hoisted(() => ({
+  conversationFindFirstMock: vi.fn(),
+  conversationMessageCreateMock: vi.fn(),
+  conversationMessageFindFirstMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    conversation: {
+      findFirst: conversationFindFirstMock,
+    },
+    conversationMessage: {
+      create: conversationMessageCreateMock,
+      findFirst: conversationMessageFindFirstMock,
+    },
+  },
+}));
+
+import { persistAssistantFromAiSdk } from "../persist-assistant-from-ai-sdk";
+
+describe("persistAssistantFromAiSdk", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists slim caption text with structured ui file parts", async () => {
+    conversationFindFirstMock.mockResolvedValue({
+      id: "conversation-1",
+      metadata: null,
+    });
+
+    await persistAssistantFromAiSdk({
+      conversationId: "conversation-1",
+      userId: "user-1",
+      text: "Here's the generated image.",
+      responsesApiResponseId: null,
+      uiParts: [
+        { type: "text", text: "Here's the generated image." },
+        {
+          type: "file",
+          url: "https://blob.example.com/generated.png",
+          mediaType: "image/png",
+          filename: "generated.png",
+        },
+      ],
+    });
+
+    expect(conversationMessageCreateMock).toHaveBeenCalledWith({
+      data: {
+        conversationId: "conversation-1",
+        role: "assistant",
+        contentType: "output_text",
+        contentText: "Here's the generated image.",
+        metadata: {
+          ui_message_v1: {
+            parts: [
+              { type: "text", text: "Here's the generated image." },
+              {
+                type: "file",
+                url: "https://blob.example.com/generated.png",
+                mediaType: "image/png",
+                filename: "generated.png",
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
+  it("persists file-only assistant output instead of dropping the message", async () => {
+    conversationFindFirstMock.mockResolvedValue({
+      id: "conversation-1",
+      metadata: null,
+    });
+
+    await persistAssistantFromAiSdk({
+      conversationId: "conversation-1",
+      userId: "user-1",
+      text: "",
+      responsesApiResponseId: null,
+      uiParts: [
+        {
+          type: "file",
+          url: "https://blob.example.com/generated.png",
+          mediaType: "image/png",
+          filename: "generated.png",
+        },
+      ],
+    });
+
+    expect(conversationMessageCreateMock).toHaveBeenCalledWith({
+      data: {
+        conversationId: "conversation-1",
+        role: "assistant",
+        contentType: "output_text",
+        contentText: "",
+        metadata: {
+          ui_message_v1: {
+            parts: [
+              {
+                type: "file",
+                url: "https://blob.example.com/generated.png",
+                mediaType: "image/png",
+                filename: "generated.png",
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
+  it("skips empty assistant output when no reasoning or ui parts exist", async () => {
+    await persistAssistantFromAiSdk({
+      conversationId: "conversation-1",
+      userId: "user-1",
+      text: "   ",
+      responsesApiResponseId: null,
+    });
+
+    expect(conversationFindFirstMock).not.toHaveBeenCalled();
+    expect(conversationMessageCreateMock).not.toHaveBeenCalled();
+    expect(conversationMessageFindFirstMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/helpers/conversation-message-api-content.ts
+++ b/apps/core/src/helpers/conversation-message-api-content.ts
@@ -55,6 +55,11 @@ export function thoughtTimingFromMessageMetadata(metadata: unknown):
   return undefined;
 }
 
+export function imageGenerationFromMessageMetadata(metadata: unknown): boolean {
+  const meta = metadata as { image_generation?: unknown } | null;
+  return meta?.image_generation === true;
+}
+
 /** Builds paginated message `content`; reasoning entries precede final assistant text. */
 export function conversationMessageToApiContent(item: {
   contentType: string | null;

--- a/apps/core/src/helpers/conversation-messages-to-ui-messages.ts
+++ b/apps/core/src/helpers/conversation-messages-to-ui-messages.ts
@@ -1,6 +1,9 @@
 import type { UIMessage } from "ai";
 
-import { thoughtTimingFromMessageMetadata } from "@/helpers/conversation-message-api-content";
+import {
+  imageGenerationFromMessageMetadata,
+  thoughtTimingFromMessageMetadata,
+} from "@/helpers/conversation-message-api-content";
 import {
   buildConversationContentParts,
   type PersistedConversationContentPart,
@@ -78,19 +81,27 @@ export function conversationMessagesToUiMessages(
         : ([{ type: "text" as const, text: "" }] satisfies UIMessage["parts"]);
 
     const timing = thoughtTimingFromMessageMetadata(message.metadata);
+    const isImageGeneration =
+      validRole === "user" &&
+      imageGenerationFromMessageMetadata(message.metadata);
+    const metadata =
+      timing != null || isImageGeneration
+        ? {
+            ...(timing != null
+              ? {
+                  thoughtStartedAtMs: timing.startedAtMs,
+                  thoughtEndedAtMs: timing.endedAtMs,
+                }
+              : {}),
+            ...(isImageGeneration ? { imageGeneration: true } : {}),
+          }
+        : undefined;
 
     return {
       id: message.id,
       role: validRole,
       parts,
-      ...(timing != null
-        ? {
-            metadata: {
-              thoughtStartedAtMs: timing.startedAtMs,
-              thoughtEndedAtMs: timing.endedAtMs,
-            },
-          }
-        : {}),
+      ...(metadata != null ? { metadata } : {}),
     };
   });
 }

--- a/apps/core/src/helpers/persist-assistant-from-ai-sdk.ts
+++ b/apps/core/src/helpers/persist-assistant-from-ai-sdk.ts
@@ -1,5 +1,6 @@
 import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
+import type { PersistedChatUiPart } from "./message-content";
 
 function reasoningPartsToMetadata(
   reasoning: unknown,
@@ -25,6 +26,7 @@ function reasoningPartsToMetadata(
 function buildAssistantMessageMetadata(
   reasoningSteps: Array<{ type: string; text: string }> | undefined,
   thoughtTiming: { startedAtMs: number; endedAtMs: number } | undefined,
+  uiParts: PersistedChatUiPart[] | undefined,
 ): Record<string, unknown> | undefined {
   const out: Record<string, unknown> = {};
   if (reasoningSteps && reasoningSteps.length > 0) {
@@ -40,6 +42,31 @@ function buildAssistantMessageMetadata(
       end: thoughtTiming.endedAtMs,
     };
   }
+  if (uiParts && uiParts.length > 0) {
+    /**
+     * Persisted assistant UI payload, version 1:
+     * {
+     *   "ui_message_v1": {
+     *     "parts": [
+     *       { "type": "text", "text": "Caption shown to the model and user" },
+     *       {
+     *         "type": "file",
+     *         "url": "https://...blob.vercel-storage.com/generated.png",
+     *         "mediaType": "image/png",
+     *         "filename": "generated.png"
+     *       }
+     *     ]
+     *   }
+     * }
+     *
+     * `contentText` remains the slim caption. Generated images live here as
+     * file parts with blob URLs so conversation reloads do not replay base64
+     * data inside text context.
+     */
+    out.ui_message_v1 = {
+      parts: uiParts,
+    };
+  }
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -50,6 +77,7 @@ export async function persistAssistantFromAiSdk(params: {
   responsesApiResponseId: string | null;
   reasoning?: unknown;
   thoughtTiming?: { startedAtMs: number; endedAtMs: number };
+  uiParts?: PersistedChatUiPart[];
 }): Promise<void> {
   const {
     conversationId,
@@ -58,9 +86,11 @@ export async function persistAssistantFromAiSdk(params: {
     responsesApiResponseId,
     reasoning,
     thoughtTiming,
+    uiParts,
   } = params;
   const reasoningSteps = reasoningPartsToMetadata(reasoning);
-  if (!text.trim() && !reasoningSteps?.length) {
+  const hasUiParts = uiParts != null && uiParts.length > 0;
+  if (!text.trim() && !reasoningSteps?.length && !hasUiParts) {
     return;
   }
 
@@ -107,6 +137,7 @@ export async function persistAssistantFromAiSdk(params: {
           metadata: buildAssistantMessageMetadata(
             reasoningSteps,
             thoughtTiming,
+            uiParts,
           ),
         },
       });
@@ -125,7 +156,11 @@ export async function persistAssistantFromAiSdk(params: {
       role: "assistant",
       contentType: "output_text",
       contentText: text,
-      metadata: buildAssistantMessageMetadata(reasoningSteps, thoughtTiming),
+      metadata: buildAssistantMessageMetadata(
+        reasoningSteps,
+        thoughtTiming,
+        uiParts,
+      ),
     },
   });
 }

--- a/apps/core/src/lib/blob.test.ts
+++ b/apps/core/src/lib/blob.test.ts
@@ -4,6 +4,7 @@ import {
   createUserFileUploadSession,
   listUserUploads,
   uploadGeneratedChatImage,
+  uploadProfileImage,
 } from "./blob";
 
 const {
@@ -225,6 +226,27 @@ describe("listUserUploads", () => {
 
     await expect(listUserUploads("user_123", "token_123")).rejects.toThrow(
       "Blob list pagination is invalid: hasMore=true without cursor",
+    );
+  });
+});
+
+describe("uploadProfileImage", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("sends a canonical lowercase image contentType for case-variant data URIs", async () => {
+    getEnvMock.mockReturnValue({ BLOB_READ_WRITE_TOKEN: "rw_token" });
+    putMock.mockResolvedValue({
+      url: "https://blob.example/profile-hash.png",
+    });
+
+    const dataUrl = `Data:Image/PNG;Base64,${Buffer.from("hello").toString("base64")}`;
+    const url = await uploadProfileImage(dataUrl);
+
+    expect(url).toBe("https://blob.example/profile-hash.png");
+    expect(putMock.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ contentType: "image/png" }),
     );
   });
 });

--- a/apps/core/src/lib/blob.test.ts
+++ b/apps/core/src/lib/blob.test.ts
@@ -1,16 +1,29 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createUserFileUploadSession, listUserUploads } from "./blob";
+import {
+  createUserFileUploadSession,
+  listUserUploads,
+  uploadGeneratedChatImage,
+} from "./blob";
 
-const { listMock, generateClientTokenFromReadWriteTokenMock } = vi.hoisted(
-  () => ({
-    listMock: vi.fn(),
-    generateClientTokenFromReadWriteTokenMock: vi.fn(),
-  }),
-);
+const {
+  listMock,
+  putMock,
+  generateClientTokenFromReadWriteTokenMock,
+  getEnvMock,
+} = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  putMock: vi.fn(),
+  generateClientTokenFromReadWriteTokenMock: vi.fn(),
+  getEnvMock: vi.fn(() => ({})),
+}));
+
+vi.mock("@/config/env", () => ({
+  getEnv: getEnvMock,
+}));
 
 vi.mock("@vercel/blob", () => ({
-  put: vi.fn(),
+  put: putMock,
   list: listMock,
 }));
 
@@ -212,6 +225,35 @@ describe("listUserUploads", () => {
 
     await expect(listUserUploads("user_123", "token_123")).rejects.toThrow(
       "Blob list pagination is invalid: hasMore=true without cursor",
+    );
+  });
+});
+
+describe("uploadGeneratedChatImage", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("uses a .svg file extension for SVG data URLs (not .svg+xml)", async () => {
+    getEnvMock.mockReturnValue({ BLOB_READ_WRITE_TOKEN: "rw_token" });
+    putMock.mockResolvedValue({
+      url: "https://blob.example/generated.svg",
+    });
+
+    const dataUrl = `data:image/svg+xml;base64,${Buffer.from("<svg/>").toString("base64")}`;
+    const result = await uploadGeneratedChatImage({
+      dataUrl,
+      userId: "user_1",
+      conversationId: "conv_1",
+    });
+
+    expect(result?.mediaType).toBe("image/svg+xml");
+    expect(result?.filename).toMatch(/^generated-[a-f0-9]+\.svg$/);
+    const pathnameArg = putMock.mock.calls[0]?.[0];
+    expect(pathnameArg).toMatch(/\.svg$/);
+    expect(pathnameArg).not.toContain("svg+xml");
+    expect(putMock.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ contentType: "image/svg+xml" }),
     );
   });
 });

--- a/apps/core/src/lib/blob.test.ts
+++ b/apps/core/src/lib/blob.test.ts
@@ -234,6 +234,23 @@ describe("uploadGeneratedChatImage", () => {
     vi.resetAllMocks();
   });
 
+  it("accepts case-variant scheme, subtype, and base64 keyword in data URIs", async () => {
+    getEnvMock.mockReturnValue({ BLOB_READ_WRITE_TOKEN: "rw_token" });
+    putMock.mockResolvedValue({
+      url: "https://blob.example/generated.png",
+    });
+
+    const dataUrl = `Data:Image/PNG;Base64,${Buffer.from("hello").toString("base64")}`;
+    const result = await uploadGeneratedChatImage({
+      dataUrl,
+      userId: "user_1",
+      conversationId: "conv_1",
+    });
+
+    expect(result?.mediaType).toBe("image/png");
+    expect(result?.url).toBe("https://blob.example/generated.png");
+  });
+
   it("uses a .svg file extension for SVG data URLs (not .svg+xml)", async () => {
     getEnvMock.mockReturnValue({ BLOB_READ_WRITE_TOKEN: "rw_token" });
     putMock.mockResolvedValue({

--- a/apps/core/src/lib/blob.ts
+++ b/apps/core/src/lib/blob.ts
@@ -18,7 +18,12 @@ const USER_UPLOAD_ACCESS = "public" as const;
 const USER_UPLOAD_ADD_RANDOM_SUFFIX = true as const;
 const USER_UPLOAD_SESSION_TTL_MS = 15 * 60 * 1000;
 const IMAGE_DATA_URI_REGEX =
-  /^data:image\/(png|jpg|jpeg|gif|webp|bmp|svg\+xml);base64,/;
+  /^data:image\/(png|jpg|jpeg|gif|webp|bmp|svg\+xml);base64,/i;
+
+/** True when `value` is a supported generated-chat image data URI (case-insensitive scheme and subtype). */
+export function isGeneratedChatImageDataUri(value: string): boolean {
+  return IMAGE_DATA_URI_REGEX.test(value.trimStart());
+}
 
 function toBlobFile(data: {
   url: string;
@@ -193,7 +198,7 @@ export interface UploadedGeneratedChatImage {
 }
 
 function imageExtensionFromDataUriMatch(match: RegExpMatchArray): string {
-  const extension = match[1];
+  const extension = match[1]!.toLowerCase();
   if (extension === "jpeg") {
     return "jpg";
   }
@@ -213,7 +218,8 @@ export async function uploadGeneratedChatImage(params: {
   conversationId: string;
 }): Promise<UploadedGeneratedChatImage | null> {
   const env = getEnv();
-  const dataUriMatch = params.dataUrl.match(IMAGE_DATA_URI_REGEX);
+  const trimmedDataUrl = params.dataUrl.trimStart();
+  const dataUriMatch = trimmedDataUrl.match(IMAGE_DATA_URI_REGEX);
 
   if (!dataUriMatch) {
     return null;
@@ -227,7 +233,7 @@ export async function uploadGeneratedChatImage(params: {
   }
 
   const imageData = Buffer.from(
-    params.dataUrl.replace(IMAGE_DATA_URI_REGEX, "").replace(/\s/g, ""),
+    trimmedDataUrl.replace(IMAGE_DATA_URI_REGEX, "").replace(/\s/g, ""),
     "base64",
   );
   const imageHash = crypto
@@ -235,7 +241,7 @@ export async function uploadGeneratedChatImage(params: {
     .update(imageData)
     .digest("hex");
   const extension = imageExtensionFromDataUriMatch(dataUriMatch);
-  const mediaType = `image/${dataUriMatch[1]}`;
+  const mediaType = `image/${dataUriMatch[1]!.toLowerCase()}`;
   const filename = `generated-${imageHash}.${extension}`;
 
   try {

--- a/apps/core/src/lib/blob.ts
+++ b/apps/core/src/lib/blob.ts
@@ -17,6 +17,8 @@ type ListBlobItem = Awaited<ReturnType<typeof list>>["blobs"][number];
 const USER_UPLOAD_ACCESS = "public" as const;
 const USER_UPLOAD_ADD_RANDOM_SUFFIX = true as const;
 const USER_UPLOAD_SESSION_TTL_MS = 15 * 60 * 1000;
+const IMAGE_DATA_URI_REGEX =
+  /^data:image\/(png|jpg|jpeg|gif|webp|bmp|svg\+xml);base64,/;
 
 function toBlobFile(data: {
   url: string;
@@ -133,9 +135,7 @@ export async function uploadProfileImage(
 ): Promise<string | null> {
   const env = getEnv();
 
-  const dataUriRegex =
-    /^data:image\/(png|jpg|jpeg|gif|webp|bmp|svg\+xml);base64,/;
-  const dataUriMatch = base64Image.match(dataUriRegex);
+  const dataUriMatch = base64Image.match(IMAGE_DATA_URI_REGEX);
 
   if (!dataUriMatch) {
     return null;
@@ -150,7 +150,7 @@ export async function uploadProfileImage(
 
   // Extract the base64 encoded image data
   const imageData = Buffer.from(
-    base64Image.replace(dataUriRegex, ""),
+    base64Image.replace(IMAGE_DATA_URI_REGEX, ""),
     "base64",
   );
 
@@ -180,6 +180,80 @@ export async function uploadProfileImage(
     Sentry.captureException(error, {
       tags: {
         function: "uploadProfileImage",
+      },
+    });
+    return null;
+  }
+}
+
+export interface UploadedGeneratedChatImage {
+  url: string;
+  mediaType: string;
+  filename: string;
+}
+
+function imageExtensionFromDataUriMatch(match: RegExpMatchArray): string {
+  const extension = match[1];
+  return extension === "jpeg" ? "jpg" : extension;
+}
+
+/**
+ * Uploads a generated chat image data URL so persisted assistant messages can
+ * reference a small HTTPS file part instead of replaying base64 in text.
+ */
+export async function uploadGeneratedChatImage(params: {
+  dataUrl: string;
+  userId: string;
+  conversationId: string;
+}): Promise<UploadedGeneratedChatImage | null> {
+  const env = getEnv();
+  const dataUriMatch = params.dataUrl.match(IMAGE_DATA_URI_REGEX);
+
+  if (!dataUriMatch) {
+    return null;
+  }
+
+  if (!env.BLOB_READ_WRITE_TOKEN) {
+    console.warn(
+      "[Blob] BLOB_READ_WRITE_TOKEN not configured, skipping generated chat image upload",
+    );
+    return null;
+  }
+
+  const imageData = Buffer.from(
+    params.dataUrl.replace(IMAGE_DATA_URI_REGEX, "").replace(/\s/g, ""),
+    "base64",
+  );
+  const imageHash = crypto
+    .createHash(CRYPTO.IMAGE_HASH_ALGORITHM)
+    .update(imageData)
+    .digest("hex");
+  const extension = imageExtensionFromDataUriMatch(dataUriMatch);
+  const mediaType = `image/${dataUriMatch[1]}`;
+  const filename = `generated-${imageHash}.${extension}`;
+
+  try {
+    const blob = await put(
+      `${STORAGE.IMAGES_UPLOAD_DIR}/generated/${params.userId}/${params.conversationId}/${filename}`,
+      imageData,
+      {
+        access: "public",
+        contentType: mediaType,
+        token: env.BLOB_READ_WRITE_TOKEN,
+        allowOverwrite: true,
+        addRandomSuffix: false,
+      },
+    );
+
+    return {
+      url: blob.url,
+      mediaType,
+      filename,
+    };
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: {
+        function: "uploadGeneratedChatImage",
       },
     });
     return null;

--- a/apps/core/src/lib/blob.ts
+++ b/apps/core/src/lib/blob.ts
@@ -194,7 +194,13 @@ export interface UploadedGeneratedChatImage {
 
 function imageExtensionFromDataUriMatch(match: RegExpMatchArray): string {
   const extension = match[1];
-  return extension === "jpeg" ? "jpg" : extension;
+  if (extension === "jpeg") {
+    return "jpg";
+  }
+  if (extension === "svg+xml") {
+    return "svg";
+  }
+  return extension;
 }
 
 /**

--- a/apps/core/src/lib/blob.ts
+++ b/apps/core/src/lib/blob.ts
@@ -164,8 +164,8 @@ export async function uploadProfileImage(
     .update(imageData)
     .digest("hex");
 
-  // Extract MIME type from data URI (e.g., "image/jpeg")
-  const mimeType = `image/${dataUriMatch[1]}`;
+  // Extract MIME type from data URI (e.g., "image/jpeg"); subtype lowercased for /i regex.
+  const mimeType = `image/${dataUriMatch[1]!.toLowerCase()}`;
 
   // Upload new blob with hash as filename
   try {

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -28,6 +28,7 @@ const {
   setActiveUiStreamIdInMetadataMock,
   streamTextMock,
   toUIMessageStreamResponseMock,
+  uploadGeneratedChatImageMock,
   validateUIMessagesMock,
   waitUntilCapturedPromises,
 } = vi.hoisted(() => ({
@@ -50,6 +51,7 @@ const {
   setActiveUiStreamIdInMetadataMock: vi.fn(),
   streamTextMock: vi.fn(),
   toUIMessageStreamResponseMock: vi.fn(),
+  uploadGeneratedChatImageMock: vi.fn(),
   validateUIMessagesMock: vi.fn(),
   waitUntilCapturedPromises: [] as Promise<unknown>[],
 }));
@@ -116,6 +118,11 @@ vi.mock("@/lib/resumable-ui-stream-context", () => ({
   getResumableUiStreamContext: vi.fn(() => ({
     createNewResumableStream: createNewResumableStreamMock,
   })),
+}));
+
+vi.mock("@/lib/blob", () => ({
+  uploadGeneratedChatImage: (...args: unknown[]) =>
+    uploadGeneratedChatImageMock(...args),
 }));
 
 function createApp({
@@ -190,6 +197,11 @@ describe("POST /chat", () => {
     );
     setActiveUiStreamIdInMetadataMock.mockResolvedValue(undefined);
     clearActiveUiStreamIdInMetadataMock.mockResolvedValue(undefined);
+    uploadGeneratedChatImageMock.mockResolvedValue({
+      url: "https://blob.example.com/generated.png",
+      mediaType: "image/png",
+      filename: "generated.png",
+    });
     toUIMessageStreamResponseMock.mockReturnValue(
       new Response(null, {
         status: 200,
@@ -652,6 +664,214 @@ describe("POST /chat", () => {
     expect(uiArg).toHaveLength(2);
     expect(uiArg[0]?.parts?.[0]?.text).toBe("Earlier");
     expect(uiArg[1]?.parts?.[0]?.text).toBe("Next");
+  });
+
+  it("persists image generation intent on submitted user messages", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { model_id: "gpt-5-4" },
+    });
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      {
+        id: "message-1",
+        role: "user",
+        contentText: "Make an image",
+        metadata: {
+          image_generation: true,
+          ui_message_v1: {
+            parts: [{ type: "text", text: "Make an image" }],
+          },
+        },
+      },
+    ]);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        trigger: "submit-message",
+        imageGeneration: true,
+        message: {
+          role: "user",
+          parts: [{ type: "text", text: "Make an image" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(conversationMessageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            image_generation: true,
+          }),
+        }),
+      }),
+    );
+    const call = streamTextMock.mock.calls[0]![0] as {
+      providerOptions?: {
+        sokosumi?: { imageGenerationModel?: string | null };
+      };
+    };
+    expect(call.providerOptions?.sokosumi?.imageGenerationModel).toBe(
+      "openai/gpt-5.4-image-2",
+    );
+    infoSpy.mockRestore();
+  });
+
+  it("persists generated image markdown as structured file parts on finish", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+    conversationFindFirstMock
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: { model_id: "gpt-5-4" },
+      })
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: null,
+      });
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      {
+        id: "message-1",
+        role: "user",
+        contentText: "Make an image",
+        metadata: {
+          image_generation: true,
+          ui_message_v1: {
+            parts: [{ type: "text", text: "Make an image" }],
+          },
+        },
+      },
+    ]);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        trigger: "submit-message",
+        imageGeneration: true,
+        message: {
+          role: "user",
+          parts: [{ type: "text", text: "Make an image" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const streamCall = streamTextMock.mock.calls[0]![0] as {
+      onFinish: (finishEvent: {
+        text: string;
+        reasoning?: unknown[];
+      }) => Promise<void>;
+    };
+    await streamCall.onFinish({
+      text: `Here you go.\n\n![Generated image](${dataUrl})\n\n`,
+      reasoning: [],
+    });
+
+    expect(uploadGeneratedChatImageMock).toHaveBeenCalledWith({
+      dataUrl,
+      userId: "user_123",
+      conversationId: cid,
+    });
+    expect(conversationMessageCreateMock).toHaveBeenLastCalledWith({
+      data: expect.objectContaining({
+        role: "assistant",
+        contentText: "Here you go.",
+        metadata: {
+          ui_message_v1: {
+            parts: [
+              { type: "text", text: "Here you go." },
+              {
+                type: "file",
+                url: "https://blob.example.com/generated.png",
+                mediaType: "image/png",
+                filename: "generated.png",
+              },
+            ],
+          },
+        },
+      }),
+    });
+    infoSpy.mockRestore();
+  });
+
+  it("never persists data image markdown in assistant contentText when upload fails", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+    conversationFindFirstMock
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: { model_id: "gpt-5-4" },
+      })
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: null,
+      });
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      {
+        id: "message-1",
+        role: "user",
+        contentText: "Make an image",
+        metadata: {
+          image_generation: true,
+          ui_message_v1: {
+            parts: [{ type: "text", text: "Make an image" }],
+          },
+        },
+      },
+    ]);
+    uploadGeneratedChatImageMock.mockResolvedValueOnce(null);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        trigger: "submit-message",
+        imageGeneration: true,
+        message: {
+          role: "user",
+          parts: [{ type: "text", text: "Make an image" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const streamCall = streamTextMock.mock.calls[0]![0] as {
+      onFinish: (finishEvent: {
+        text: string;
+        reasoning?: unknown[];
+      }) => Promise<void>;
+    };
+    await streamCall.onFinish({
+      text: `Here you go.\n\n![Generated image](${dataUrl})\n\n`,
+      reasoning: [],
+    });
+
+    expect(conversationMessageCreateMock).toHaveBeenLastCalledWith({
+      data: expect.objectContaining({
+        role: "assistant",
+        contentText: "Here you go.",
+      }),
+    });
+    expect(
+      JSON.stringify(conversationMessageCreateMock.mock.calls.at(-1)),
+    ).not.toContain("data:image/png;base64");
+    infoSpy.mockRestore();
   });
 
   it("returns 403 when coworker chat is unavailable", async () => {

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -504,9 +504,12 @@ describe("POST /chat", () => {
     expect(response.status).toBe(200);
     expect(streamTextMock).toHaveBeenCalledOnce();
     const call = streamTextMock.mock.calls[0]![0] as {
-      providerOptions?: { sokosumi?: { mode?: string } };
+      providerOptions?: {
+        sokosumi?: { mode?: string; webSearchEnabled?: boolean };
+      };
     };
     expect(call.providerOptions?.sokosumi?.mode).toBe("openrouter");
+    expect(call.providerOptions?.sokosumi?.webSearchEnabled).toBe(true);
   });
 
   it("wires onInvalidProviderConversationId for coworker Conversations mode", async () => {
@@ -664,6 +667,69 @@ describe("POST /chat", () => {
     expect(uiArg).toHaveLength(2);
     expect(uiArg[0]?.parts?.[0]?.text).toBe("Earlier");
     expect(uiArg[1]?.parts?.[0]?.text).toBe("Next");
+  });
+
+  it("does not strip markdown images from assistant finish when image generation is off", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: { model_id: "claude-opus-4-6" },
+      })
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: null,
+      });
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      {
+        id: "message-1",
+        role: "user",
+        contentText: "Earlier",
+      },
+      {
+        id: "message-2",
+        role: "user",
+        contentText: "Show me a diagram link",
+      },
+    ]);
+
+    const app = createApp();
+    const finishText =
+      "See this chart.\n\n![diagram](https://example.com/chart.png)\n";
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        trigger: "submit-message",
+        message: {
+          role: "user",
+          parts: [{ type: "text", text: "Show me a diagram link" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const streamCall = streamTextMock.mock.calls[0]![0] as {
+      onFinish: (finishEvent: {
+        text: string;
+        reasoning?: unknown[];
+      }) => Promise<void>;
+    };
+    await streamCall.onFinish({
+      text: finishText,
+      reasoning: [],
+    });
+
+    expect(uploadGeneratedChatImageMock).not.toHaveBeenCalled();
+    expect(conversationMessageCreateMock).toHaveBeenLastCalledWith({
+      data: expect.objectContaining({
+        role: "assistant",
+        contentText: finishText,
+        metadata: undefined,
+      }),
+    });
   });
 
   it("persists image generation intent on submitted user messages", async () => {

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -120,10 +120,14 @@ vi.mock("@/lib/resumable-ui-stream-context", () => ({
   })),
 }));
 
-vi.mock("@/lib/blob", () => ({
-  uploadGeneratedChatImage: (...args: unknown[]) =>
-    uploadGeneratedChatImageMock(...args),
-}));
+vi.mock("@/lib/blob", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/blob")>();
+  return {
+    ...actual,
+    uploadGeneratedChatImage: (...args: unknown[]) =>
+      uploadGeneratedChatImageMock(...args),
+  };
+});
 
 function createApp({
   authContext = {
@@ -858,6 +862,94 @@ describe("POST /chat", () => {
           ui_message_v1: {
             parts: [
               { type: "text", text: "Here you go." },
+              {
+                type: "file",
+                url: "https://blob.example.com/generated.png",
+                mediaType: "image/png",
+                filename: "generated.png",
+              },
+            ],
+          },
+        },
+      }),
+    });
+    infoSpy.mockRestore();
+  });
+
+  it("uploads case-variant data image markdown when another remote image yields file parts", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    const dataUrl = "Data:Image/PNG;Base64,aGVsbG8=";
+    conversationFindFirstMock
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: { model_id: "gpt-5-4" },
+      })
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: null,
+      });
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      {
+        id: "message-1",
+        role: "user",
+        contentText: "Make images",
+        metadata: {
+          image_generation: true,
+          ui_message_v1: {
+            parts: [{ type: "text", text: "Make images" }],
+          },
+        },
+      },
+    ]);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        trigger: "submit-message",
+        imageGeneration: true,
+        message: {
+          role: "user",
+          parts: [{ type: "text", text: "Make images" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const streamCall = streamTextMock.mock.calls[0]![0] as {
+      onFinish: (finishEvent: {
+        text: string;
+        reasoning?: unknown[];
+      }) => Promise<void>;
+    };
+    await streamCall.onFinish({
+      text: `Here.\n\n![remote](https://example.com/chart.png)\n![gen](${dataUrl})\n`,
+      reasoning: [],
+    });
+
+    expect(uploadGeneratedChatImageMock).toHaveBeenCalledWith({
+      dataUrl,
+      userId: "user_123",
+      conversationId: cid,
+    });
+    expect(conversationMessageCreateMock).toHaveBeenLastCalledWith({
+      data: expect.objectContaining({
+        role: "assistant",
+        contentText: "Here.",
+        metadata: {
+          ui_message_v1: {
+            parts: [
+              { type: "text", text: "Here." },
+              {
+                type: "file",
+                url: "https://example.com/chart.png",
+                mediaType: "image/png",
+                filename: "chart.png",
+              },
               {
                 type: "file",
                 url: "https://blob.example.com/generated.png",

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -940,6 +940,75 @@ describe("POST /chat", () => {
     infoSpy.mockRestore();
   });
 
+  it("persists a fallback caption when upload fails and the assistant reply was image-only", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+    conversationFindFirstMock
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: { model_id: "gpt-5-4" },
+      })
+      .mockResolvedValueOnce({
+        id: cid,
+        metadata: null,
+      });
+    conversationMessageFindManyMock.mockResolvedValueOnce([
+      {
+        id: "message-1",
+        role: "user",
+        contentText: "Make an image",
+        metadata: {
+          image_generation: true,
+          ui_message_v1: {
+            parts: [{ type: "text", text: "Make an image" }],
+          },
+        },
+      },
+    ]);
+    uploadGeneratedChatImageMock.mockResolvedValueOnce(null);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        trigger: "submit-message",
+        imageGeneration: true,
+        message: {
+          role: "user",
+          parts: [{ type: "text", text: "Make an image" }],
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const streamCall = streamTextMock.mock.calls[0]![0] as {
+      onFinish: (finishEvent: {
+        text: string;
+        reasoning?: unknown[];
+      }) => Promise<void>;
+    };
+    await streamCall.onFinish({
+      text: `![Generated image](${dataUrl})\n`,
+      reasoning: [],
+    });
+
+    expect(conversationMessageCreateMock).toHaveBeenLastCalledWith({
+      data: expect.objectContaining({
+        role: "assistant",
+        contentText:
+          "The generated image could not be saved. Try generating again.",
+      }),
+    });
+    expect(
+      JSON.stringify(conversationMessageCreateMock.mock.calls.at(-1)),
+    ).not.toContain("data:image/png;base64");
+    infoSpy.mockRestore();
+  });
+
   it("returns 403 when coworker chat is unavailable", async () => {
     conversationFindFirstMock.mockResolvedValueOnce({
       id: "550e8400-e29b-41d4-a716-446655440000",

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -69,6 +69,10 @@ import { mapChatRequestToUiMessages } from "./map-chat-request-to-ui-messages.js
 const GENERATED_IMAGE_MARKDOWN_REGEX =
   /!\[[^\]\n]*\]\((data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[^)]+|https?:\/\/[^)\s]+)\)/gi;
 
+/** Shown when image markdown was stripped but blob upload failed and there is no caption left. */
+const ASSISTANT_GENERATED_IMAGE_UPLOAD_FAILED_FALLBACK =
+  "The generated image could not be saved. Try generating again.";
+
 const IMAGE_MEDIA_TYPE_BY_EXTENSION: Record<string, string> = {
   bmp: "image/bmp",
   gif: "image/gif",
@@ -205,20 +209,33 @@ async function prepareAssistantFinishForPersistence(params: {
     conversationId: params.conversationId,
   });
 
-  return {
-    text: strippedText,
-    uiParts:
-      fileParts.length > 0
-        ? [
-            ...(strippedText
-              ? ([
-                  { type: "text", text: strippedText },
-                ] satisfies PersistedChatUiPart[])
-              : []),
-            ...fileParts,
-          ]
-        : undefined,
-  };
+  if (fileParts.length > 0) {
+    return {
+      text: strippedText,
+      uiParts: [
+        ...(strippedText
+          ? ([
+              { type: "text", text: strippedText },
+            ] satisfies PersistedChatUiPart[])
+          : []),
+        ...fileParts,
+      ],
+    };
+  }
+
+  const hadDataImageUrl = imageUrls.some((url) =>
+    url.startsWith("data:image/"),
+  );
+
+  if (!hadDataImageUrl) {
+    return { text: params.text };
+  }
+
+  if (strippedText.trim().length === 0) {
+    return { text: ASSISTANT_GENERATED_IMAGE_UPLOAD_FAILED_FALLBACK };
+  }
+
+  return { text: strippedText };
 }
 
 async function persistUserOrSystemTurnForConversation(params: {

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -1,6 +1,9 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import type { SokosumiProviderCallOptions } from "@sokosumi/ai-provider";
-import { getChatModelImageGenerationOpenRouterId } from "@sokosumi/chat";
+import {
+  chatModelSupportsWebSearch,
+  getChatModelImageGenerationOpenRouterId,
+} from "@sokosumi/chat";
 import { waitUntil } from "@vercel/functions";
 import {
   convertToModelMessages,
@@ -182,7 +185,13 @@ async function prepareAssistantFinishForPersistence(params: {
   text: string;
   userId: string;
   conversationId: string;
+  /** When false, leave assistant text unchanged (normal chat may include `![](https://…)`). */
+  extractGeneratedImagesFromMarkdown: boolean;
 }): Promise<{ text: string; uiParts?: PersistedChatUiPart[] }> {
+  if (!params.extractGeneratedImagesFromMarkdown) {
+    return { text: params.text };
+  }
+
   const { strippedText, imageUrls } = extractGeneratedImageMarkdown(
     params.text,
   );
@@ -688,6 +697,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
         return null;
       })();
+      const webSearchEnabled =
+        !useCoworker && chatModelSupportsWebSearch(selectedModel);
 
       const sokosumiProviderOptions: SokosumiProviderCallOptions = {
         mode: useCoworker ? "coworker" : "openrouter",
@@ -700,6 +711,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           ? providerConversationId
           : null,
         imageGenerationModel,
+        webSearchEnabled,
         onResponseStarted: async (responseId: string) => {
           responsesApiResponseIdRef.current = responseId;
           if (!internalConversationId || !coworker) {
@@ -795,6 +807,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
                 text: finishEvent.text,
                 conversationId: internalConversationId,
                 userId: userContext.userId,
+                extractGeneratedImagesFromMarkdown: imageGeneration === true,
               });
             await persistAssistantFromAiSdk({
               conversationId: internalConversationId,

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -43,7 +43,10 @@ import {
   persistPendingResponseId,
 } from "@/helpers/persist-pending-response-id";
 import { normalizeSafeRemoteUrl } from "@/helpers/safe-url";
-import { uploadGeneratedChatImage } from "@/lib/blob";
+import {
+  isGeneratedChatImageDataUri,
+  uploadGeneratedChatImage,
+} from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
@@ -150,7 +153,7 @@ async function buildGeneratedImageFileParts(params: {
   const parts: PersistedChatUiFilePart[] = [];
 
   for (const imageUrl of params.imageUrls) {
-    if (imageUrl.startsWith("data:image/")) {
+    if (isGeneratedChatImageDataUri(imageUrl)) {
       const uploaded = await uploadGeneratedChatImage({
         dataUrl: imageUrl,
         userId: params.userId,
@@ -224,7 +227,7 @@ async function prepareAssistantFinishForPersistence(params: {
   }
 
   const hadDataImageUrl = imageUrls.some((url) =>
-    url.startsWith("data:image/"),
+    isGeneratedChatImageDataUri(url),
   );
 
   if (!hadDataImageUrl) {

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -540,7 +540,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             userId: userContext.userId,
             lastMessage: incomingLast,
             extractedText: lastUserMessageText ?? "",
-            imageGeneration: imageGeneration === true,
+            ...(imageGeneration === true ? { imageGeneration: true } : {}),
           });
         }
 
@@ -580,7 +580,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             userId: userContext.userId,
             lastMessage: incomingLast,
             extractedText: lastUserMessageText ?? "",
-            imageGeneration: imageGeneration === true,
+            ...(imageGeneration === true ? { imageGeneration: true } : {}),
           });
         }
       }

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -30,6 +30,8 @@ import {
   extractPersistableUiParts,
   extractReasoningPartsFromMessage,
   hasModelVisibleMessageContent,
+  type PersistedChatUiFilePart,
+  type PersistedChatUiPart,
 } from "@/helpers/message-content";
 import { jsonErrorResponse } from "@/helpers/openapi";
 import { persistAssistantFromAiSdk } from "@/helpers/persist-assistant-from-ai-sdk";
@@ -37,6 +39,8 @@ import {
   clearPendingAndSetPrevious,
   persistPendingResponseId,
 } from "@/helpers/persist-pending-response-id";
+import { normalizeSafeRemoteUrl } from "@/helpers/safe-url";
+import { uploadGeneratedChatImage } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
@@ -59,11 +63,161 @@ import { createCoworkerConversation } from "./coworker-conversation";
 
 import { mapChatRequestToUiMessages } from "./map-chat-request-to-ui-messages.js";
 
+const GENERATED_IMAGE_MARKDOWN_REGEX =
+  /!\[[^\]\n]*\]\((data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[^)]+|https?:\/\/[^)\s]+)\)/gi;
+
+const IMAGE_MEDIA_TYPE_BY_EXTENSION: Record<string, string> = {
+  bmp: "image/bmp",
+  gif: "image/gif",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+};
+
+function messageRequestedImageGeneration(
+  message: Record<string, unknown>,
+): boolean {
+  const metadata = message.metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+  return (metadata as Record<string, unknown>).imageGeneration === true;
+}
+
+function filenameFromImageUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const pathname = decodeURIComponent(parsed.pathname);
+    const filename = pathname.split("/").filter(Boolean).pop()?.trim();
+    return filename && filename.length > 0 ? filename : "generated-image";
+  } catch {
+    return "generated-image";
+  }
+}
+
+function inferImageMediaTypeFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const extension = parsed.pathname
+      .split(".")
+      .pop()
+      ?.toLowerCase()
+      .replace(/[^a-z0-9+]/g, "");
+    if (extension && IMAGE_MEDIA_TYPE_BY_EXTENSION[extension]) {
+      return IMAGE_MEDIA_TYPE_BY_EXTENSION[extension];
+    }
+  } catch {
+    return "image/png";
+  }
+
+  return "image/png";
+}
+
+function extractGeneratedImageMarkdown(text: string): {
+  strippedText: string;
+  imageUrls: string[];
+} {
+  const imageUrls: string[] = [];
+  const strippedText = text
+    .replace(GENERATED_IMAGE_MARKDOWN_REGEX, (_match, imageUrl: string) => {
+      imageUrls.push(imageUrl.trim());
+      return "";
+    })
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return {
+    strippedText,
+    imageUrls: [...new Set(imageUrls)],
+  };
+}
+
+async function buildGeneratedImageFileParts(params: {
+  imageUrls: string[];
+  userId: string;
+  conversationId: string;
+}): Promise<PersistedChatUiFilePart[]> {
+  const parts: PersistedChatUiFilePart[] = [];
+
+  for (const imageUrl of params.imageUrls) {
+    if (imageUrl.startsWith("data:image/")) {
+      const uploaded = await uploadGeneratedChatImage({
+        dataUrl: imageUrl,
+        userId: params.userId,
+        conversationId: params.conversationId,
+      });
+
+      if (uploaded) {
+        parts.push({
+          type: "file",
+          url: uploaded.url,
+          mediaType: uploaded.mediaType,
+          filename: uploaded.filename,
+        });
+      }
+      continue;
+    }
+
+    const normalizedUrl = normalizeSafeRemoteUrl(imageUrl);
+    if (!normalizedUrl) {
+      console.warn("Skipping unsafe generated image URL in chat finish text");
+      continue;
+    }
+
+    parts.push({
+      type: "file",
+      url: normalizedUrl,
+      mediaType: inferImageMediaTypeFromUrl(normalizedUrl),
+      filename: filenameFromImageUrl(normalizedUrl),
+    });
+  }
+
+  return parts;
+}
+
+async function prepareAssistantFinishForPersistence(params: {
+  text: string;
+  userId: string;
+  conversationId: string;
+}): Promise<{ text: string; uiParts?: PersistedChatUiPart[] }> {
+  const { strippedText, imageUrls } = extractGeneratedImageMarkdown(
+    params.text,
+  );
+  if (imageUrls.length === 0) {
+    return { text: params.text };
+  }
+
+  const fileParts = await buildGeneratedImageFileParts({
+    imageUrls,
+    userId: params.userId,
+    conversationId: params.conversationId,
+  });
+
+  return {
+    text: strippedText,
+    uiParts:
+      fileParts.length > 0
+        ? [
+            ...(strippedText
+              ? ([
+                  { type: "text", text: strippedText },
+                ] satisfies PersistedChatUiPart[])
+              : []),
+            ...fileParts,
+          ]
+        : undefined,
+  };
+}
+
 async function persistUserOrSystemTurnForConversation(params: {
   conversationId: string;
   userId: string;
   lastMessage: { role: string } & Record<string, unknown>;
   extractedText: string;
+  imageGeneration?: boolean;
 }): Promise<void> {
   const { conversationId, userId, lastMessage, extractedText } = params;
   if (lastMessage.role !== "user" && lastMessage.role !== "system") {
@@ -73,11 +227,16 @@ async function persistUserOrSystemTurnForConversation(params: {
   const reasoningParts = extractReasoningPartsFromMessage(lastMessage);
   const uiParts = extractPersistableUiParts(lastMessage);
   const titleSource = buildMessageTitleSource(lastMessage);
+  const isImageGeneration =
+    lastMessage.role === "user" &&
+    (params.imageGeneration === true ||
+      messageRequestedImageGeneration(lastMessage));
   const metadata =
-    reasoningParts.length > 0 || uiParts.length > 0
+    reasoningParts.length > 0 || uiParts.length > 0 || isImageGeneration
       ? {
           ...(reasoningParts.length > 0 ? { reasoning: reasoningParts } : {}),
           ...(uiParts.length > 0 ? { ui_message_v1: { parts: uiParts } } : {}),
+          ...(isImageGeneration ? { image_generation: true } : {}),
         }
       : undefined;
 
@@ -183,6 +342,10 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(withGlobalHeaderParameters(route), async (c) => {
+    let logImageGenerationRequest = false;
+    let logConversationId: string | null = null;
+    let logSelectedModel: string | null = null;
+    let logImageGenerationModel: string | null = null;
     try {
       const userContext = requireUserContext(c.var.authContext);
 
@@ -311,6 +474,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           throw badRequest("Selected model does not support image generation.");
         }
       }
+      logImageGenerationRequest = imageGeneration === true;
+      logConversationId = internalConversationId;
+      logSelectedModel = selectedModel;
+      logImageGenerationModel = imageGenerationModel;
 
       if (useCoworker) {
         if (!lastMessageHasCoworkerCompatibleContent) {
@@ -347,6 +514,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             userId: userContext.userId,
             lastMessage: incomingLast,
             extractedText: lastUserMessageText ?? "",
+            imageGeneration: imageGeneration === true,
           });
         }
 
@@ -386,6 +554,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             userId: userContext.userId,
             lastMessage: incomingLast,
             extractedText: lastUserMessageText ?? "",
+            imageGeneration: imageGeneration === true,
           });
         }
       }
@@ -456,6 +625,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             error,
           );
         }
+      }
+
+      if (imageGeneration === true) {
+        console.info("Starting OpenRouter image generation chat stream", {
+          conversationId: internalConversationId,
+          model: selectedModel,
+          imageGenerationModel,
+          messageCount: uiMessages.length,
+        });
       }
 
       const modelMessages = await convertToModelMessages(
@@ -612,13 +790,20 @@ export default function mount(app: OpenAPIHonoWithAuth) {
                     endedAtMs: thoughtPhaseMs.end ?? Date.now(),
                   }
                 : undefined;
+            const preparedAssistantMessage =
+              await prepareAssistantFinishForPersistence({
+                text: finishEvent.text,
+                conversationId: internalConversationId,
+                userId: userContext.userId,
+              });
             await persistAssistantFromAiSdk({
               conversationId: internalConversationId,
               userId: userContext.userId,
-              text: finishEvent.text,
+              text: preparedAssistantMessage.text,
               responsesApiResponseId: responsesApiResponseIdRef.current,
               reasoning: useCoworker ? finishEvent.reasoning : undefined,
               thoughtTiming,
+              uiParts: preparedAssistantMessage.uiParts,
             });
           } catch (error) {
             console.error(
@@ -700,6 +885,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           : {}),
       });
     } catch (error) {
+      if (logImageGenerationRequest) {
+        console.error("Failed to stream OpenRouter image generation chat", {
+          conversationId: logConversationId,
+          model: logSelectedModel,
+          imageGenerationModel: logImageGenerationModel,
+          error,
+        });
+      }
       if (
         error &&
         typeof error === "object" &&

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import type { SokosumiProviderCallOptions } from "@sokosumi/ai-provider";
+import { getChatModelImageGenerationOpenRouterId } from "@sokosumi/chat";
 import { waitUntil } from "@vercel/functions";
 import {
   convertToModelMessages,
@@ -190,6 +191,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         message: singleMessage,
         conversationId,
         model,
+        imageGeneration,
         trigger,
         previousResponseId: previousResponseIdFromRequest,
       } = c.req.valid("json");
@@ -294,6 +296,21 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       }
 
       const useCoworker = Boolean(internalConversationId) && Boolean(coworker);
+      let imageGenerationModel: string | null = null;
+
+      if (imageGeneration) {
+        if (useCoworker) {
+          throw badRequest(
+            "Image generation is only available for supported chat models.",
+          );
+        }
+
+        imageGenerationModel =
+          getChatModelImageGenerationOpenRouterId(selectedModel);
+        if (!imageGenerationModel) {
+          throw badRequest("Selected model does not support image generation.");
+        }
+      }
 
       if (useCoworker) {
         if (!lastMessageHasCoworkerCompatibleContent) {
@@ -504,6 +521,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         providerConversationId: coworkerConversationsMode
           ? providerConversationId
           : null,
+        imageGenerationModel,
         onResponseStarted: async (responseId: string) => {
           responsesApiResponseIdRef.current = responseId;
           if (!internalConversationId || !coworker) {

--- a/apps/core/src/routes/v1/conversations/[id]/messages/get.test.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/get.test.ts
@@ -1,0 +1,134 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import { defaultValidationHook } from "@/lib/hono";
+import type { AuthVariables } from "@/middleware/auth";
+
+import mountGetConversationMessages from "./get";
+
+const { prismaTransactionMock } = vi.hoisted(() => ({
+  prismaTransactionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: prismaTransactionMock,
+  },
+}));
+
+const CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const ASSISTANT_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+interface ConversationMessagesTestTransaction {
+  conversation: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+  conversationMessage: {
+    findMany: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createApp() {
+  const app = new OpenAPIHono<{
+    Variables: AuthVariables & { requestId: string };
+  }>({
+    defaultHook: defaultValidationHook,
+  });
+
+  app.use("*", async (c, next) => {
+    c.set("isAuthenticated", true);
+    c.set("authContext", {
+      actor: "user",
+      userId: "user_123",
+      organizationId: null,
+      role: "user",
+    });
+    c.set("requestId", "req_test");
+    return await next();
+  });
+
+  mountGetConversationMessages(app as unknown as OpenAPIHonoWithAuth);
+  return app;
+}
+
+describe("GET /conversations/{id}/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns assistant image file parts from persisted ui metadata", async () => {
+    prismaTransactionMock.mockImplementation(
+      (
+        callback: (tx: ConversationMessagesTestTransaction) => Promise<unknown>,
+      ) =>
+        callback({
+          conversation: {
+            findFirst: vi.fn().mockResolvedValue({
+              id: CONVERSATION_ID,
+              userId: "user_123",
+            }),
+          },
+          conversationMessage: {
+            findMany: vi.fn().mockResolvedValue([
+              {
+                id: ASSISTANT_MESSAGE_ID,
+                role: "assistant",
+                contentType: "output_text",
+                contentText: "Here's the generated image.",
+                createdAt: new Date("2026-05-01T17:00:00.000Z"),
+                metadata: {
+                  ui_message_v1: {
+                    parts: [
+                      {
+                        type: "output_text",
+                        text: "Here's the generated image.",
+                      },
+                      {
+                        type: "file",
+                        url: "https://blob.example.com/generated.png",
+                        mediaType: "image/png",
+                        filename: "generated.png",
+                      },
+                    ],
+                  },
+                },
+              },
+            ]),
+            count: vi.fn().mockResolvedValue(1),
+          },
+        }),
+    );
+
+    const app = createApp();
+    const response = await app.request(
+      `http://localhost/${CONVERSATION_ID}/messages`,
+    );
+    const body = (await response.json()) as {
+      data: Array<{
+        id: string;
+        role: string;
+        content: unknown;
+      }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([
+      {
+        id: ASSISTANT_MESSAGE_ID,
+        role: "assistant",
+        content: [
+          { type: "output_text", text: "Here's the generated image." },
+          {
+            type: "file",
+            url: "https://blob.example.com/generated.png",
+            mediaType: "image/png",
+            filename: "generated.png",
+          },
+        ],
+        createdAt: 1777654800,
+      },
+    ]);
+  });
+});

--- a/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 
 import {
   conversationMessageToApiContent,
+  imageGenerationFromMessageMetadata,
   thoughtTimingFromMessageMetadata,
 } from "@/helpers/conversation-message-api-content";
 import { internalServerError, notFound } from "@/helpers/error";
@@ -127,6 +128,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           metadata: item.metadata,
         });
         const thoughtTiming = thoughtTimingFromMessageMetadata(item.metadata);
+        const isImageGeneration =
+          item.role === "user" &&
+          imageGenerationFromMessageMetadata(item.metadata);
+        const metadata = isImageGeneration
+          ? { imageGeneration: true }
+          : undefined;
 
         return {
           id: item.id,
@@ -134,6 +141,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           content,
           createdAt: Math.floor(item.createdAt.getTime() / 1000),
           ...(thoughtTiming != null ? { thoughtTiming } : {}),
+          ...(metadata != null ? { metadata } : {}),
         };
       });
 

--- a/apps/core/src/schemas/chat-request.schema.ts
+++ b/apps/core/src/schemas/chat-request.schema.ts
@@ -28,6 +28,7 @@ export const aiSdkChatRequestSchema = z
     conversationId: z.string().uuid().optional(),
     previousResponseId: z.string().optional(),
     model: z.string().nullable().optional(),
+    imageGeneration: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     const useServerHistory =

--- a/apps/core/src/schemas/chat-request.schema.ts
+++ b/apps/core/src/schemas/chat-request.schema.ts
@@ -14,6 +14,12 @@ export const chatRequestMessageSchema = z.object({
   content: z
     .union([z.string(), z.array(chatRequestMessagePartSchema)])
     .optional(),
+  metadata: z
+    .object({
+      imageGeneration: z.boolean().optional(),
+    })
+    .passthrough()
+    .optional(),
   id: z.string().optional(),
 });
 

--- a/apps/core/src/schemas/chat-ui-message.schema.ts
+++ b/apps/core/src/schemas/chat-ui-message.schema.ts
@@ -86,6 +86,12 @@ export const chatUiThoughtTimingMetadataSchema = z.object({
   thoughtEndedAtMs: z.number(),
 });
 
+export const chatUiMessageMetadataSchema = chatUiThoughtTimingMetadataSchema
+  .partial()
+  .extend({
+    imageGeneration: z.boolean().optional(),
+  });
+
 /**
  * AI SDK `UIMessage`-compatible object returned by GET /v1/chat (`data.messages`).
  * Aligns with OpenAI-style roles and text-shaped content parts.
@@ -95,7 +101,7 @@ export const chatUiMessageSchema = z
     id: z.string(),
     role: z.enum(["user", "assistant", "system"]),
     parts: z.array(chatUiMessagePartSchema),
-    metadata: chatUiThoughtTimingMetadataSchema.optional(),
+    metadata: chatUiMessageMetadataSchema.optional(),
   })
   .openapi("ChatUiMessage");
 

--- a/apps/core/src/schemas/conversation-message.schema.ts
+++ b/apps/core/src/schemas/conversation-message.schema.ts
@@ -1,6 +1,9 @@
 import { z } from "@hono/zod-openapi";
 
-import { chatMessageContentPartSchema } from "@/schemas/chat-ui-message.schema";
+import {
+  chatMessageContentPartSchema,
+  chatUiMessageMetadataSchema,
+} from "@/schemas/chat-ui-message.schema";
 
 export const conversationMessageContentPartSchema =
   chatMessageContentPartSchema;
@@ -36,6 +39,10 @@ export const conversationMessageSchema = z
         description:
           "Wall-clock thought phase (ms since epoch), when persisted for coworker reasoning",
       }),
+    metadata: chatUiMessageMetadataSchema.optional().openapi({
+      description:
+        "UI message metadata, including whether a user turn requested image generation.",
+    }),
   })
   .openapi("ConversationMessage");
 

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Agentische Coworker",
         "models": "Modelle",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Kann Bilder erstellen",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "Demnächst verfügbar",
         "agenticCoworkers": "Agentische Coworker",
         "models": "Modelle",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Gespräche durchsuchen...",
           "clearSearch": "Suche zurücksetzen",
@@ -1230,6 +1240,7 @@
         "modelAlt": "Modell",
         "coworkerAlt": "Coworker",
         "userAvatarAlt": "Nutzer-Avatar",
+        "downloadGeneratedImage": "Generiertes Bild herunterladen",
         "expandPrompt": "Vollständige Nachricht anzeigen",
         "collapsePrompt": "Weniger anzeigen",
         "reasoning": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Agentic Coworkers",
         "models": "Models",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Can create images",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "Coming Soon",
         "agenticCoworkers": "Agentic Coworkers",
         "models": "Models",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Search conversations...",
           "clearSearch": "Clear search",
@@ -1233,6 +1243,7 @@
         "modelAlt": "Model",
         "coworkerAlt": "Coworker",
         "userAvatarAlt": "User avatar",
+        "downloadGeneratedImage": "Download generated image",
         "expandPrompt": "Show full message",
         "collapsePrompt": "Show less",
         "authorize": "Authorize",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Coworkers agénticos",
         "models": "Modelos",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Puede crear imágenes",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "Próximamente",
         "agenticCoworkers": "Coworkers agénticos",
         "models": "Modelos",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Buscar conversaciones...",
           "clearSearch": "Limpiar búsqueda",
@@ -1230,6 +1240,7 @@
         "modelAlt": "Modelo",
         "coworkerAlt": "Coworker",
         "userAvatarAlt": "Avatar del usuario",
+        "downloadGeneratedImage": "Descargar imagen generada",
         "expandPrompt": "Mostrar mensaje completo",
         "collapsePrompt": "Mostrar menos",
         "reasoning": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Collègues agentiques",
         "models": "Modèles",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Peut créer des images",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "Bientôt disponible",
         "agenticCoworkers": "Collègues agentiques",
         "models": "Modèles",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Rechercher des conversations...",
           "clearSearch": "Effacer la recherche",
@@ -1233,6 +1243,7 @@
         "modelAlt": "Modèle",
         "coworkerAlt": "Collègue",
         "userAvatarAlt": "Avatar de l’utilisateur",
+        "downloadGeneratedImage": "Télécharger l’image générée",
         "expandPrompt": "Afficher le message en entier",
         "collapsePrompt": "Afficher moins",
         "authorize": "Autoriser",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "In arrivo",
         "agenticCoworkers": "Coworker agentici",
         "models": "Modelli",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Cerca conversazioni...",
           "clearSearch": "Cancella ricerca",
@@ -1233,6 +1243,7 @@
         "modelAlt": "Modello",
         "coworkerAlt": "Coworker",
         "userAvatarAlt": "Avatar utente",
+        "downloadGeneratedImage": "Scarica immagine generata",
         "expandPrompt": "Mostra messaggio completo",
         "collapsePrompt": "Mostra meno",
         "authorize": "Autorizza",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Coworker agentici",
         "models": "Modelli",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Può creare immagini",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "近日公開",
         "agenticCoworkers": "エージェント型AI同僚",
         "models": "モデル",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "会話を検索...",
           "clearSearch": "検索をクリア",
@@ -1233,6 +1243,7 @@
         "modelAlt": "モデル",
         "coworkerAlt": "同僚",
         "userAvatarAlt": "ユーザーのアバター",
+        "downloadGeneratedImage": "生成画像をダウンロード",
         "expandPrompt": "メッセージ全文を表示",
         "collapsePrompt": "折りたたむ",
         "authorize": "承認",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "エージェント型AI同僚",
         "models": "モデル",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "画像を生成できます",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Coworkers agênticos",
         "models": "Modelos",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Pode criar imagens",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "Em breve",
         "agenticCoworkers": "Coworkers agênticos",
         "models": "Modelos",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Pesquisar conversas...",
           "clearSearch": "Limpar pesquisa",
@@ -1233,6 +1243,7 @@
         "modelAlt": "Modelo",
         "coworkerAlt": "Coworker",
         "userAvatarAlt": "Avatar do usuário",
+        "downloadGeneratedImage": "Baixar imagem gerada",
         "expandPrompt": "Mostrar mensagem completa",
         "collapsePrompt": "Mostrar menos",
         "authorize": "Autorizar",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "Em breve",
         "agenticCoworkers": "Colegas de trabalho baseados em agentes",
         "models": "Modelos",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "Pesquisar conversas...",
           "clearSearch": "Limpar pesquisa",
@@ -1233,6 +1243,7 @@
         "modelAlt": "Modelo",
         "coworkerAlt": "Colega de trabalho",
         "userAvatarAlt": "Avatar do utilizador",
+        "downloadGeneratedImage": "Transferir imagem gerada",
         "expandPrompt": "Mostrar mensagem completa",
         "collapsePrompt": "Mostrar menos",
         "authorize": "Autorizar",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "Colegas de trabalho baseados em agentes",
         "models": "Modelos",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "Pode criar imagens",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1214,6 +1214,7 @@
         "agenticCoworkers": "智能协作伙伴",
         "models": "模型",
         "supportsImageAttachments": "Supports image attachments",
+        "supportsImageGeneration": "可生成图片",
         "attachmentMenu": {
           "trigger": "Add",
           "uploadFile": "Upload file",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1213,6 +1213,16 @@
         "comingSoon": "即将推出",
         "agenticCoworkers": "智能协作伙伴",
         "models": "模型",
+        "supportsImageAttachments": "Supports image attachments",
+        "attachmentMenu": {
+          "trigger": "Add",
+          "uploadFile": "Upload file",
+          "createImage": "Create image"
+        },
+        "createImageChip": {
+          "label": "Create image",
+          "remove": "Remove create image"
+        },
         "ConversationsSidebar": {
           "searchPlaceholder": "搜索对话...",
           "clearSearch": "清除搜索",
@@ -1233,6 +1243,7 @@
         "modelAlt": "模型",
         "coworkerAlt": "协作伙伴",
         "userAvatarAlt": "用户头像",
+        "downloadGeneratedImage": "下载生成的图片",
         "expandPrompt": "显示完整消息",
         "collapsePrompt": "收起",
         "authorize": "授权",

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -150,6 +150,38 @@ function readPreviousResponseIdFromMetadata(
   return typeof p === "string" && p.trim().length > 0 ? p.trim() : undefined;
 }
 
+function readImageGenerationFromMessage(message: UIMessage): boolean {
+  const metadata = (message as { metadata?: unknown }).metadata;
+  return (
+    metadata != null &&
+    typeof metadata === "object" &&
+    (metadata as Record<string, unknown>).imageGeneration === true
+  );
+}
+
+function withImageGenerationMetadata(
+  message: ChatSendMessage,
+  imageGeneration: boolean,
+): ChatSendMessage {
+  if (!imageGeneration || typeof message !== "object" || message == null) {
+    return message;
+  }
+
+  const record = message as Record<string, unknown>;
+  const metadata =
+    record.metadata != null && typeof record.metadata === "object"
+      ? (record.metadata as Record<string, unknown>)
+      : {};
+
+  return {
+    ...record,
+    metadata: {
+      ...metadata,
+      imageGeneration: true,
+    },
+  } as ChatSendMessage;
+}
+
 interface ChatInterfaceProps {
   mobileKeyboardOptimized?: boolean;
   showGreetingAndSuggestions?: boolean;
@@ -1315,7 +1347,10 @@ export default function ChatInterface({
       }
 
       const messageText = getSendMessageText(message);
-      const sendPayload = toChatSendMessage(message);
+      const sendPayload = withImageGenerationMetadata(
+        toChatSendMessage(message),
+        options?.imageGeneration === true,
+      );
       const composeKind = options?.kind ?? "task";
       const sendOptions = options?.imageGeneration
         ? { body: { imageGeneration: true } }
@@ -1479,8 +1514,13 @@ export default function ChatInterface({
   const handleResendLastMessage = useCallback(
     async (message: UIMessage) => {
       if (!selectedChatId) return;
-      const sendPayload = buildResendMessage(message);
-      if (!sendPayload) return;
+      const isImageGeneration = readImageGenerationFromMessage(message);
+      const resendPayload = buildResendMessage(message);
+      if (!resendPayload) return;
+      const sendPayload = withImageGenerationMetadata(
+        resendPayload,
+        isImageGeneration,
+      );
       const list = await refreshConversations();
       const conv = list?.find((c) => c.id === selectedChatId);
       const pid = readPreviousResponseIdFromMetadata(
@@ -1489,7 +1529,11 @@ export default function ChatInterface({
       if (pid) {
         resendPreviousResponseIdOverrideRef.current.set(selectedChatId, pid);
       }
-      sendInConversation(selectedChatId, sendPayload);
+      sendInConversation(
+        selectedChatId,
+        sendPayload,
+        isImageGeneration ? { body: { imageGeneration: true } } : undefined,
+      );
     },
     [selectedChatId, sendInConversation, refreshConversations],
   );

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -1058,7 +1058,11 @@ export default function ChatInterface({
   ]);
 
   const sendInConversation = useCallback(
-    (conversationId: string, message: ChatSendMessage): boolean => {
+    (
+      conversationId: string,
+      message: ChatSendMessage,
+      sendOptions?: Parameters<UseChatHelpers<UIMessage>["sendMessage"]>[1],
+    ): boolean => {
       const payload = toChatSendMessage(message);
       let slot = conversationToSlot.get(conversationId);
       if (slot === undefined) {
@@ -1095,11 +1099,11 @@ export default function ChatInterface({
         );
         const slotToSend = slot;
         queueMicrotask(() => {
-          sendMessageSlots[slotToSend](payload);
+          sendMessageSlots[slotToSend](payload, sendOptions);
         });
         return true;
       }
-      sendMessageSlots[slot](payload);
+      sendMessageSlots[slot](payload, sendOptions);
       return true;
     },
     [
@@ -1313,6 +1317,9 @@ export default function ChatInterface({
       const messageText = getSendMessageText(message);
       const sendPayload = toChatSendMessage(message);
       const composeKind = options?.kind ?? "task";
+      const sendOptions = options?.imageGeneration
+        ? { body: { imageGeneration: true } }
+        : undefined;
 
       if (!selectedChatId) {
         if (composeKind === "task") {
@@ -1394,7 +1401,9 @@ export default function ChatInterface({
         }
 
         const cid = currentChatIdRef.current ?? conversationId;
-        const sent = cid ? sendInConversation(cid, sendPayload) : false;
+        const sent = cid
+          ? sendInConversation(cid, sendPayload, sendOptions)
+          : false;
         if (sent) setInput("");
         return sent;
       }
@@ -1414,7 +1423,7 @@ export default function ChatInterface({
         );
       }
 
-      const sent = sendInConversation(selectedChatId, sendPayload);
+      const sent = sendInConversation(selectedChatId, sendPayload, sendOptions);
       if (sent) setInput("");
       return sent;
     },

--- a/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
@@ -24,6 +24,7 @@ import type { Chat, Coworker } from "@/app/chat/utils/types";
 import {
   extractMessageContent,
   extractReasoningStepMessages,
+  getMessageFileParts,
   getThoughtTimingMsFromMessage,
   hasMessageTextOrFileParts,
 } from "@/app/chat-ui/utils/message-utils";
@@ -286,6 +287,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         (currentCreatedAt &&
           isDifferentDay(currentCreatedAt, previousCreatedAt));
       const content = extractMessageContent(message);
+      const fileParts = getMessageFileParts(message);
       const isLastMessage = index === messagesWithTimestamps.length - 1;
       const reasoningFromParts =
         role === "assistant" && isCoworker
@@ -369,6 +371,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
               <ChatMessage
                 role={role}
                 content={content}
+                fileParts={fileParts}
                 userImageUrl={userImageUrl}
                 userName={userName}
                 createdAt={createdAt}

--- a/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
@@ -142,7 +142,9 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         ? extractMessageContent(lastMessage)
         : "";
     const lastAssistantHasNoContent =
-      lastMessage?.role === "assistant" && !lastMessageContent.trim();
+      lastMessage?.role === "assistant" &&
+      !lastMessageContent.trim() &&
+      !hasMessageTextOrFileParts(lastMessage);
     const showStreamReasoningInLastAssistantRow =
       isCoworker &&
       isLoading &&

--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
@@ -115,6 +115,22 @@ describe("hasMessageTextOrFileParts", () => {
       }),
     ).toBe(true);
   });
+
+  it("returns true for file-only assistant image messages", () => {
+    expect(
+      hasMessageTextOrFileParts({
+        id: "a-file",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "file" as const,
+            url: "https://example.com/generated.png",
+            mediaType: "image/png",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("getMessageFileParts", () => {

--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
@@ -6,6 +6,7 @@ import {
   deduplicateMessagesById,
   extractMessageContent,
   extractReasoningStepMessages,
+  getMessageFileParts,
   getThoughtTimingMsFromMessage,
   hasMessageTextOrFileParts,
   mergeAssistantThoughtMetadataFromDb,
@@ -97,6 +98,50 @@ describe("hasMessageTextOrFileParts", () => {
         ],
       }),
     ).toBe(true);
+  });
+
+  it("returns true for file-only content arrays", () => {
+    expect(
+      hasMessageTextOrFileParts({
+        id: "u3",
+        role: "user" as const,
+        content: [
+          {
+            type: "file" as const,
+            url: "https://example.com/image.png",
+            mediaType: "image/png",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("getMessageFileParts", () => {
+  it("extracts file parts without mixing them into visible text", () => {
+    const message = {
+      id: "u4",
+      role: "user" as const,
+      parts: [
+        { type: "text" as const, text: "Look at this" },
+        {
+          type: "file" as const,
+          url: "https://example.com/blob.png",
+          mediaType: "image/png",
+          filename: "blob.png",
+        },
+      ],
+    };
+
+    expect(extractMessageContent(message)).toBe("Look at this");
+    expect(getMessageFileParts(message)).toEqual([
+      {
+        type: "file",
+        url: "https://example.com/blob.png",
+        mediaType: "image/png",
+        filename: "blob.png",
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
@@ -159,6 +159,25 @@ describe("getMessageFileParts", () => {
       },
     ]);
   });
+
+  it("dedupes the same file URL when it appears in both array content and parts", () => {
+    const url = "https://blob.example.com/generated.png";
+    const file = {
+      type: "file" as const,
+      url,
+      mediaType: "image/png" as const,
+      filename: "generated.png",
+    };
+    const message = {
+      id: "asst-dup",
+      role: "assistant" as const,
+      content: [{ type: "output_text" as const, text: "Caption." }, file],
+      parts: [{ type: "text" as const, text: "Caption." }, file],
+    };
+
+    expect(getMessageFileParts(message)).toEqual([file]);
+    expect(hasMessageTextOrFileParts(message)).toBe(true);
+  });
 });
 
 describe("extractReasoningStepMessages", () => {

--- a/apps/web/src/app/(app)/chat-ui/utils/message-utils.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/message-utils.ts
@@ -6,8 +6,21 @@ import { getReasoningStepDisplayText } from "./reasoning-generic-labels";
 
 export { convertItemsToMessages };
 
+export type MessageFilePart = Extract<
+  UIMessage["parts"][number],
+  { type: "file" }
+>;
+
+const VISIBLE_TEXT_PART_TYPES = new Set(["text", "input_text", "output_text"]);
+
+function readMessagePartArrays(message: Record<string, unknown>): unknown[] {
+  const contentParts = Array.isArray(message.content) ? message.content : [];
+  const uiParts = Array.isArray(message.parts) ? message.parts : [];
+  return [...contentParts, ...uiParts];
+}
+
 function appendVisibleTextFromPart(part: Record<string, unknown>): string {
-  if (part.type !== "text") {
+  if (!VISIBLE_TEXT_PART_TYPES.has(String(part.type))) {
     return "";
   }
   if ("text" in part && part.text !== null && part.text !== undefined) {
@@ -23,13 +36,37 @@ function appendVisibleTextFromPart(part: Record<string, unknown>): string {
   return "";
 }
 
+function normalizeFilePart(part: unknown): MessageFilePart | null {
+  if (!part || typeof part !== "object") {
+    return null;
+  }
+
+  const record = part as Record<string, unknown>;
+  if (
+    record.type !== "file" ||
+    typeof record.url !== "string" ||
+    typeof record.mediaType !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    type: "file",
+    url: record.url,
+    mediaType: record.mediaType,
+    ...(typeof record.filename === "string" && record.filename.trim()
+      ? { filename: record.filename }
+      : {}),
+  } satisfies MessageFilePart;
+}
+
 function hasMeaningfulUiPart(part: unknown): boolean {
   if (!part || typeof part !== "object") {
     return false;
   }
 
   const record = part as Record<string, unknown>;
-  if (record.type === "file") {
+  if (normalizeFilePart(record)) {
     return true;
   }
 
@@ -90,14 +127,18 @@ export function extractMessageContent(message: unknown): string {
   return content.trim();
 }
 
+export function getMessageFileParts(message: unknown): MessageFilePart[] {
+  const messageAny = message as Record<string, unknown>;
+  return readMessagePartArrays(messageAny)
+    .map((part) => normalizeFilePart(part))
+    .filter((part): part is MessageFilePart => part !== null);
+}
+
 export function hasMessageTextOrFileParts(message: unknown): boolean {
   const messageAny = message as Record<string, unknown>;
-  const parts = messageAny.parts;
-  if (!Array.isArray(parts)) {
-    return false;
-  }
-
-  return parts.some((part) => hasMeaningfulUiPart(part));
+  return readMessagePartArrays(messageAny).some((part) =>
+    hasMeaningfulUiPart(part),
+  );
 }
 
 /** Reasoning parts from a UIMessage (for ThoughtSummaryBar / loaders). */

--- a/apps/web/src/app/(app)/chat-ui/utils/message-utils.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/message-utils.ts
@@ -13,12 +13,6 @@ export type MessageFilePart = Extract<
 
 const VISIBLE_TEXT_PART_TYPES = new Set(["text", "input_text", "output_text"]);
 
-function readMessagePartArrays(message: Record<string, unknown>): unknown[] {
-  const contentParts = Array.isArray(message.content) ? message.content : [];
-  const uiParts = Array.isArray(message.parts) ? message.parts : [];
-  return [...contentParts, ...uiParts];
-}
-
 function appendVisibleTextFromPart(part: Record<string, unknown>): string {
   if (!VISIBLE_TEXT_PART_TYPES.has(String(part.type))) {
     return "";
@@ -58,6 +52,32 @@ function normalizeFilePart(part: unknown): MessageFilePart | null {
       ? { filename: record.filename }
       : {}),
   } satisfies MessageFilePart;
+}
+
+/**
+ * When both legacy array `content` and `parts` are present, the same file
+ * attachment can appear twice; keep first occurrence by URL.
+ */
+function dedupeFilePartsByUrlInMergedParts(parts: unknown[]): unknown[] {
+  const seenFileUrls = new Set<string>();
+  const out: unknown[] = [];
+  for (const part of parts) {
+    const file = normalizeFilePart(part);
+    if (file != null) {
+      if (seenFileUrls.has(file.url)) {
+        continue;
+      }
+      seenFileUrls.add(file.url);
+    }
+    out.push(part);
+  }
+  return out;
+}
+
+function readMessagePartArrays(message: Record<string, unknown>): unknown[] {
+  const contentParts = Array.isArray(message.content) ? message.content : [];
+  const uiParts = Array.isArray(message.parts) ? message.parts : [];
+  return dedupeFilePartsByUrlInMergedParts([...contentParts, ...uiParts]);
 }
 
 function hasMeaningfulUiPart(part: unknown): boolean {

--- a/apps/web/src/app/(app)/chat/components/chat-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-message.tsx
@@ -127,10 +127,13 @@ export default function ChatMessage({
   };
 
   const showStreamingDotsOnly = isAssistantStreaming && !hasDisplayContent;
-  /** Same source as `assistantContentSegments` so OAuth CTA matches visible markdown. */
+  /**
+   * OAuth URL must be read from full `content`, not `displayContent` (progressive
+   * reveal). Otherwise the authorize CTA only appears after the reveal catches up.
+   */
   const oauthAuthorizationUrl = isUser
     ? null
-    : extractOAuthAuthorizationUrl(displayContent);
+    : extractOAuthAuthorizationUrl(content);
   const assistantContentSegments = isUser
     ? []
     : parseMarkdownWithDataImageSegments(displayContent);

--- a/apps/web/src/app/(app)/chat/components/chat-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-message.tsx
@@ -7,8 +7,11 @@ import { useEffect, useRef, useState } from "react";
 import { useStreamingContent } from "@/app/chat/hooks/use-streaming-content";
 import { useStreamingPaused } from "@/app/chat/hooks/use-streaming-paused";
 import { getCoworkerImageUrl } from "@/app/chat/utils/coworker-utils";
+import { parseMarkdownWithDataImageSegments } from "@/app/chat/utils/generated-image-markdown";
 import { extractOAuthAuthorizationUrl } from "@/app/chat/utils/oauth-link";
+import { ChatGeneratedImageBubble } from "@/components/chat/chat-generated-image-bubble";
 import { ChatModelIcon } from "@/components/chat/chat-model-icon";
+import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import Markdown from "@/components/markdown";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -20,9 +23,17 @@ import { cn } from "@/lib/utils";
 
 import { ChatOAuthAuthenticateCta } from "./chat-oauth-authenticate-cta";
 
+interface MessageFilePart {
+  type: "file";
+  url: string;
+  mediaType: string;
+  filename?: string;
+}
+
 interface ChatMessageProps {
   role: "user" | "assistant" | "system";
   content: string;
+  fileParts?: MessageFilePart[];
   userImageUrl?: string;
   userName?: string;
   createdAt?: Date;
@@ -37,6 +48,7 @@ interface ChatMessageProps {
 export default function ChatMessage({
   role,
   content,
+  fileParts = [],
   userImageUrl,
   userName,
   createdAt,
@@ -53,6 +65,8 @@ export default function ChatMessage({
   const isAssistantStreaming = !isUser && isStreaming;
   const displayContent = useStreamingContent(content, isAssistantStreaming);
   const isPaused = useStreamingPaused(content, isAssistantStreaming);
+  const hasDisplayContent = displayContent.trim().length > 0;
+  const hasFileParts = fileParts.length > 0;
 
   const [isPromptExpanded, setIsPromptExpanded] = useState(false);
   const [showPromptToggle, setShowPromptToggle] = useState(false);
@@ -108,11 +122,13 @@ export default function ChatMessage({
     );
   };
 
-  const showStreamingDotsOnly =
-    isAssistantStreaming && !(displayContent && displayContent.trim());
+  const showStreamingDotsOnly = isAssistantStreaming && !hasDisplayContent;
   const oauthAuthorizationUrl = isUser
     ? null
     : extractOAuthAuthorizationUrl(content);
+  const assistantContentSegments = isUser
+    ? []
+    : parseMarkdownWithDataImageSegments(displayContent);
 
   return (
     <div
@@ -178,15 +194,30 @@ export default function ChatMessage({
                 )}
                 style={{ fontSize: "0.875rem" }}
               >
-                {displayContent && displayContent.trim() ? (
+                {hasDisplayContent || hasFileParts ? (
                   isUser ? (
                     <>
-                      <div
-                        ref={userContentRef}
-                        className={cn(!isPromptExpanded && "line-clamp-3")}
-                      >
-                        <Markdown>{displayContent}</Markdown>
-                      </div>
+                      {hasFileParts ? (
+                        <div className="mb-2 flex flex-wrap gap-2">
+                          {fileParts.map((part) => (
+                            <FileChipMiniPreviewWithMetadata
+                              key={part.url}
+                              url={part.url}
+                              fileName={part.filename}
+                              mediaType={part.mediaType}
+                              sizeClass="size-24"
+                            />
+                          ))}
+                        </div>
+                      ) : null}
+                      {hasDisplayContent ? (
+                        <div
+                          ref={userContentRef}
+                          className={cn(!isPromptExpanded && "line-clamp-3")}
+                        >
+                          <Markdown>{displayContent}</Markdown>
+                        </div>
+                      ) : null}
                       {(showPromptToggle || isPromptExpanded) && (
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -221,7 +252,42 @@ export default function ChatMessage({
                       )}
                     </>
                   ) : (
-                    <Markdown>{displayContent}</Markdown>
+                    <>
+                      {assistantContentSegments.map((segment, index) => {
+                        if (segment.type === "text") {
+                          if (segment.text.trim().length === 0) return null;
+                          return (
+                            <Markdown key={`text-${index}`}>
+                              {segment.text}
+                            </Markdown>
+                          );
+                        }
+
+                        return (
+                          <ChatGeneratedImageBubble
+                            key={`image-${index}`}
+                            alt={segment.alt}
+                            downloadLabel={t("downloadGeneratedImage")}
+                            src={
+                              segment.type === "image" ? segment.src : undefined
+                            }
+                          />
+                        );
+                      })}
+                      {hasFileParts ? (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {fileParts.map((part) => (
+                            <FileChipMiniPreviewWithMetadata
+                              key={part.url}
+                              url={part.url}
+                              fileName={part.filename}
+                              mediaType={part.mediaType}
+                              sizeClass="size-20"
+                            />
+                          ))}
+                        </div>
+                      ) : null}
+                    </>
                   )
                 ) : isAssistantStreaming ? (
                   <span className="reasoning-text-shine text-sm leading-5">

--- a/apps/web/src/app/(app)/chat/components/chat-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-message.tsx
@@ -45,6 +45,10 @@ interface ChatMessageProps {
   isStreaming?: boolean;
 }
 
+function isImageFilePart(part: MessageFilePart): boolean {
+  return part.mediaType.toLowerCase().startsWith("image/");
+}
+
 export default function ChatMessage({
   role,
   content,
@@ -129,6 +133,12 @@ export default function ChatMessage({
   const assistantContentSegments = isUser
     ? []
     : parseMarkdownWithDataImageSegments(displayContent);
+  const assistantImageFileParts = isUser
+    ? []
+    : fileParts.filter(isImageFilePart);
+  const assistantOtherFileParts = isUser
+    ? []
+    : fileParts.filter((part) => !isImageFilePart(part));
 
   return (
     <div
@@ -276,7 +286,15 @@ export default function ChatMessage({
                       })}
                       {hasFileParts ? (
                         <div className="mt-2 flex flex-wrap gap-2">
-                          {fileParts.map((part) => (
+                          {assistantImageFileParts.map((part) => (
+                            <ChatGeneratedImageBubble
+                              key={part.url}
+                              alt={part.filename ?? t("downloadGeneratedImage")}
+                              downloadLabel={t("downloadGeneratedImage")}
+                              src={part.url}
+                            />
+                          ))}
+                          {assistantOtherFileParts.map((part) => (
                             <FileChipMiniPreviewWithMetadata
                               key={part.url}
                               url={part.url}

--- a/apps/web/src/app/(app)/chat/components/chat-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-message.tsx
@@ -127,9 +127,10 @@ export default function ChatMessage({
   };
 
   const showStreamingDotsOnly = isAssistantStreaming && !hasDisplayContent;
+  /** Same source as `assistantContentSegments` so OAuth CTA matches visible markdown. */
   const oauthAuthorizationUrl = isUser
     ? null
-    : extractOAuthAuthorizationUrl(content);
+    : extractOAuthAuthorizationUrl(displayContent);
   const assistantContentSegments = isUser
     ? []
     : parseMarkdownWithDataImageSegments(displayContent);

--- a/apps/web/src/app/(app)/chat/components/message-list.tsx
+++ b/apps/web/src/app/(app)/chat/components/message-list.tsx
@@ -139,7 +139,9 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         ? extractMessageContent(lastMessage)
         : "";
     const lastAssistantHasNoContent =
-      lastMessage?.role === "assistant" && !lastMessageContent.trim();
+      lastMessage?.role === "assistant" &&
+      !lastMessageContent.trim() &&
+      !hasMessageTextOrFileParts(lastMessage);
     const showPendingErrorForEmptyAssistant =
       lastMessage?.role === "assistant" &&
       lastAssistantHasNoContent &&
@@ -195,10 +197,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       (lastUserMessage != null && hasMessageTextOrFileParts(lastUserMessage));
 
     const canResend = Boolean(
-      showPendingError &&
-        onResendLastMessage &&
-        lastUserMessageText &&
-        lastUserMessageHasContent,
+      showPendingError && onResendLastMessage && lastUserMessageHasContent,
     );
 
     const pendingErrorMessage = t("pendingResponseFailed");

--- a/apps/web/src/app/(app)/chat/components/message-list.tsx
+++ b/apps/web/src/app/(app)/chat/components/message-list.tsx
@@ -17,7 +17,11 @@ import {
   formatDaySeparator,
   isDifferentDay,
 } from "@/app/chat/utils/date-utils";
-import { extractMessageContent } from "@/app/chat/utils/message-utils";
+import {
+  extractMessageContent,
+  getMessageFileParts,
+  hasMessageTextOrFileParts,
+} from "@/app/chat/utils/message-utils";
 import type { Chat, Coworker } from "@/app/chat/utils/types";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -174,20 +178,27 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     const modelName = selectedChat?.model?.name;
     const modelId = selectedChat?.model?.id;
 
-    const lastUserMessageText = (() => {
+    const lastUserMessage = (() => {
       for (let i = messagesWithTimestamps.length - 1; i >= 0; i--) {
         const msg = messagesWithTimestamps[i];
         if ((msg.role as string) === "user") {
-          const text = extractMessageContent(msg).trim();
-          if (text) return text;
-          return "";
+          return msg;
         }
       }
-      return "";
+      return null;
     })();
+    const lastUserMessageText = lastUserMessage
+      ? extractMessageContent(lastUserMessage).trim()
+      : "";
+    const lastUserMessageHasContent =
+      lastUserMessageText.length > 0 ||
+      (lastUserMessage != null && hasMessageTextOrFileParts(lastUserMessage));
 
     const canResend = Boolean(
-      showPendingError && onResendLastMessage && lastUserMessageText,
+      showPendingError &&
+        onResendLastMessage &&
+        lastUserMessageText &&
+        lastUserMessageHasContent,
     );
 
     const pendingErrorMessage = t("pendingResponseFailed");
@@ -260,6 +271,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         (currentCreatedAt &&
           isDifferentDay(currentCreatedAt, previousCreatedAt));
       const content = extractMessageContent(message);
+      const fileParts = getMessageFileParts(message);
       let createdAt: Date | undefined;
       if ("createdAt" in message) {
         const createdAtValue = message.createdAt;
@@ -303,6 +315,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
               <ChatMessage
                 role={role}
                 content={content}
+                fileParts={fileParts}
                 userImageUrl={userImageUrl}
                 userName={userName}
                 createdAt={createdAt}
@@ -322,7 +335,7 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     return (
       <div
         ref={setWrapperRef}
-        className="absolute inset-x-0 top-0 bottom-[8rem] overflow-hidden"
+        className="absolute inset-x-0 top-0 bottom-32 overflow-hidden"
       >
         <div
           ref={scrollContainerRef}

--- a/apps/web/src/app/(app)/chat/hooks/use-streaming-content.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-streaming-content.ts
@@ -6,6 +6,7 @@ import {
   isDocumentHidden,
   useDocumentVisibilityState,
 } from "@/app/chat/hooks/document-visibility";
+import { clampRevealLengthForMarkdownDataImages } from "@/app/chat/utils/generated-image-markdown";
 
 const CHARS_PER_SECOND = 128;
 const CATCH_UP_THRESHOLD = 6;
@@ -153,5 +154,8 @@ export function useStreamingContent(
   ) {
     return content;
   }
-  return content.slice(0, revealedLength);
+  return content.slice(
+    0,
+    clampRevealLengthForMarkdownDataImages(content, revealedLength),
+  );
 }

--- a/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
@@ -41,6 +41,17 @@ describe("clampRevealLengthForMarkdownDataImages", () => {
       imageEnd,
     );
   });
+
+  it("does not treat a parenthesis inside alt text as the url closing paren", () => {
+    const image = "![caption with ) char](data:image/png;base64,AAA==)";
+    const content = `Before ${image} after`;
+    const desiredLength = content.indexOf("AAA") + 2;
+    const imageEnd = content.lastIndexOf(")") + 1;
+
+    expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
+      imageEnd,
+    );
+  });
 });
 
 describe("parseMarkdownWithDataImageSegments", () => {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
@@ -13,13 +13,25 @@ describe("clampRevealLengthForMarkdownDataImages", () => {
     expect(clampRevealLengthForMarkdownDataImages("Plain text", 5)).toBe(5);
   });
 
-  it("advances to the end of a complete image when the reveal lands inside it", () => {
+  it("holds at the start of a complete image when the reveal lands inside it", () => {
     const content = `Before ${pngImage} after`;
     const desiredLength = content.indexOf("abc123") + 2;
-    const imageEnd = content.indexOf(")") + 1;
+    const imageStart = content.indexOf("![");
 
     expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
+      imageStart,
+    );
+  });
+
+  it("returns the reveal length once it reaches past the closing paren", () => {
+    const content = `Before ${pngImage} after`;
+    const imageEnd = content.indexOf(")") + 1;
+
+    expect(clampRevealLengthForMarkdownDataImages(content, imageEnd)).toBe(
       imageEnd,
+    );
+    expect(clampRevealLengthForMarkdownDataImages(content, imageEnd + 5)).toBe(
+      imageEnd + 5,
     );
   });
 
@@ -35,10 +47,10 @@ describe("clampRevealLengthForMarkdownDataImages", () => {
   it("handles multiple images independently", () => {
     const content = `${pngImage}\n\nBetween\n\n${jpegImage}`;
     const desiredLength = content.lastIndexOf("def456") + 3;
-    const imageEnd = content.lastIndexOf(")") + 1;
+    const secondImageStart = content.indexOf(jpegImage);
 
     expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
-      imageEnd,
+      secondImageStart,
     );
   });
 
@@ -55,10 +67,10 @@ describe("clampRevealLengthForMarkdownDataImages", () => {
     const image = "![caption with ) char](data:image/png;base64,AAA==)";
     const content = `Before ${image} after`;
     const desiredLength = content.indexOf("AAA") + 2;
-    const imageEnd = content.lastIndexOf(")") + 1;
+    const imageStart = content.indexOf("![caption with ) char]");
 
     expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
-      imageEnd,
+      imageStart,
     );
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
@@ -42,6 +42,15 @@ describe("clampRevealLengthForMarkdownDataImages", () => {
     );
   });
 
+  it("returns desired length when reveal stops in text before a later image", () => {
+    const content = `${pngImage}\n\nBetween\n\n${jpegImage}`;
+    const desiredLength = content.indexOf("Between") + 3;
+
+    expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
+      desiredLength,
+    );
+  });
+
   it("does not treat a parenthesis inside alt text as the url closing paren", () => {
     const image = "![caption with ) char](data:image/png;base64,AAA==)";
     const content = `Before ${image} after`;

--- a/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
@@ -44,6 +44,15 @@ describe("clampRevealLengthForMarkdownDataImages", () => {
     ).toBe(imageStart);
   });
 
+  it("retreats before an incomplete case-variant data URI while streaming", () => {
+    const content = "Before ![Generated image](Data:Image/PNG;Base64,abc";
+    const imageStart = content.indexOf("![");
+
+    expect(
+      clampRevealLengthForMarkdownDataImages(content, content.length),
+    ).toBe(imageStart);
+  });
+
   it("handles multiple images independently", () => {
     const content = `${pngImage}\n\nBetween\n\n${jpegImage}`;
     const desiredLength = content.lastIndexOf("def456") + 3;
@@ -104,6 +113,30 @@ describe("parseMarkdownWithDataImageSegments", () => {
 
   it("turns a trailing incomplete data image into a pending image segment", () => {
     const content = "Before\n\n![Generated image](data:image/png;base64,abc";
+
+    expect(parseMarkdownWithDataImageSegments(content)).toEqual([
+      { type: "text", text: "Before\n\n" },
+      { type: "pending-image", alt: "Generated image" },
+    ]);
+  });
+
+  it("parses a complete case-variant data URI markdown image", () => {
+    const dataUrl = "Data:Image/PNG;Base64,abc123==";
+    expect(
+      parseMarkdownWithDataImageSegments(`Caption\n\n![x](${dataUrl})\n`),
+    ).toEqual([
+      { type: "text", text: "Caption\n\n" },
+      {
+        type: "image",
+        alt: "x",
+        src: dataUrl,
+      },
+      { type: "text", text: "\n" },
+    ]);
+  });
+
+  it("treats a trailing incomplete case-variant data uri as pending", () => {
+    const content = "Before\n\n![Generated image](Data:Image/PNG;Base64,abc";
 
     expect(parseMarkdownWithDataImageSegments(content)).toEqual([
       { type: "text", text: "Before\n\n" },

--- a/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampRevealLengthForMarkdownDataImages,
+  parseMarkdownWithDataImageSegments,
+} from "../generated-image-markdown";
+
+const pngImage = "![Generated image](data:image/png;base64,abc123==)";
+const jpegImage = "![Portrait](data:image/jpeg;base64,def456==)";
+
+describe("clampRevealLengthForMarkdownDataImages", () => {
+  it("returns the desired length when there are no markdown data images", () => {
+    expect(clampRevealLengthForMarkdownDataImages("Plain text", 5)).toBe(5);
+  });
+
+  it("advances to the end of a complete image when the reveal lands inside it", () => {
+    const content = `Before ${pngImage} after`;
+    const desiredLength = content.indexOf("abc123") + 2;
+    const imageEnd = content.indexOf(")") + 1;
+
+    expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
+      imageEnd,
+    );
+  });
+
+  it("retreats before an incomplete image while it is still streaming", () => {
+    const content = "Before ![Generated image](data:image/png;base64,abc";
+    const imageStart = content.indexOf("![");
+
+    expect(
+      clampRevealLengthForMarkdownDataImages(content, content.length),
+    ).toBe(imageStart);
+  });
+
+  it("handles multiple images independently", () => {
+    const content = `${pngImage}\n\nBetween\n\n${jpegImage}`;
+    const desiredLength = content.lastIndexOf("def456") + 3;
+    const imageEnd = content.lastIndexOf(")") + 1;
+
+    expect(clampRevealLengthForMarkdownDataImages(content, desiredLength)).toBe(
+      imageEnd,
+    );
+  });
+});
+
+describe("parseMarkdownWithDataImageSegments", () => {
+  it("splits complete data images from surrounding markdown text", () => {
+    expect(
+      parseMarkdownWithDataImageSegments(`Before\n\n${pngImage}\n\nAfter`),
+    ).toEqual([
+      { type: "text", text: "Before\n\n" },
+      {
+        type: "image",
+        alt: "Generated image",
+        src: "data:image/png;base64,abc123==",
+      },
+      { type: "text", text: "\n\nAfter" },
+    ]);
+  });
+
+  it("normalizes whitespace from streamed base64 image sources", () => {
+    const content = "![Generated image](data:image/png;base64,abc\n123==)";
+
+    expect(parseMarkdownWithDataImageSegments(content)).toEqual([
+      {
+        type: "image",
+        alt: "Generated image",
+        src: "data:image/png;base64,abc123==",
+      },
+    ]);
+  });
+
+  it("turns a trailing incomplete data image into a pending image segment", () => {
+    const content = "Before\n\n![Generated image](data:image/png;base64,abc";
+
+    expect(parseMarkdownWithDataImageSegments(content)).toEqual([
+      { type: "text", text: "Before\n\n" },
+      { type: "pending-image", alt: "Generated image" },
+    ]);
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
+++ b/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
@@ -1,0 +1,126 @@
+const DATA_IMAGE_MARKDOWN_START_REGEX =
+  /!\[[^\]\n]*\]\(data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,/g;
+
+const COMPLETE_DATA_IMAGE_MARKDOWN_REGEX =
+  /!\[([^\]\n]*)\]\((data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[A-Za-z0-9+/=\s]+)\)/g;
+
+const PENDING_DATA_IMAGE_MARKDOWN_REGEX =
+  /!\[([^\]\n]*)\]\(data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[A-Za-z0-9+/=\s]*$/;
+
+export interface GeneratedImageTextSegment {
+  type: "text";
+  text: string;
+}
+
+export interface GeneratedImageSegment {
+  type: "image";
+  alt: string;
+  src: string;
+}
+
+export interface PendingGeneratedImageSegment {
+  type: "pending-image";
+  alt: string;
+}
+
+export type GeneratedImageMarkdownSegment =
+  | GeneratedImageTextSegment
+  | GeneratedImageSegment
+  | PendingGeneratedImageSegment;
+
+function normalizeDataImageSrc(src: string): string {
+  return src.replace(/\s/g, "");
+}
+
+function findPendingDataImageTail(content: string) {
+  const match = PENDING_DATA_IMAGE_MARKDOWN_REGEX.exec(content);
+
+  if (!match || match.index === undefined) {
+    return null;
+  }
+
+  return {
+    start: match.index,
+    alt: match[1] ?? "",
+  };
+}
+
+export function clampRevealLengthForMarkdownDataImages(
+  fullContent: string,
+  desiredLength: number,
+): number {
+  const safeDesiredLength = Math.max(
+    0,
+    Math.min(desiredLength, fullContent.length),
+  );
+  const regex = new RegExp(DATA_IMAGE_MARKDOWN_START_REGEX);
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(fullContent)) !== null) {
+    const start = match.index;
+
+    if (safeDesiredLength <= start) {
+      continue;
+    }
+
+    const closingParenIndex = fullContent.indexOf(")", start);
+
+    if (closingParenIndex === -1) {
+      return start;
+    }
+
+    const end = closingParenIndex + 1;
+
+    if (safeDesiredLength < end) {
+      return end;
+    }
+  }
+
+  return safeDesiredLength;
+}
+
+export function parseMarkdownWithDataImageSegments(
+  content: string,
+): GeneratedImageMarkdownSegment[] {
+  const segments: GeneratedImageMarkdownSegment[] = [];
+  const pendingTail = findPendingDataImageTail(content);
+  const parseableContent = pendingTail
+    ? content.slice(0, pendingTail.start)
+    : content;
+  const regex = new RegExp(COMPLETE_DATA_IMAGE_MARKDOWN_REGEX);
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(parseableContent)) !== null) {
+    if (match.index > cursor) {
+      segments.push({
+        type: "text",
+        text: parseableContent.slice(cursor, match.index),
+      });
+    }
+
+    segments.push({
+      type: "image",
+      alt: match[1] ?? "",
+      src: normalizeDataImageSrc(match[2] ?? ""),
+    });
+
+    cursor = match.index + match[0].length;
+  }
+
+  if (cursor < parseableContent.length) {
+    segments.push({
+      type: "text",
+      text: parseableContent.slice(cursor),
+    });
+  }
+
+  if (pendingTail) {
+    segments.push({
+      type: "pending-image",
+      alt: pendingTail.alt,
+    });
+  }
+
+  return segments;
+}

--- a/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
+++ b/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
@@ -45,6 +45,29 @@ function findPendingDataImageTail(content: string) {
   };
 }
 
+/**
+ * Markdown image syntax is `![alt](url)`. Alt text cannot contain `]` in our
+ * matchers (`[^\]\n]*`), so the URL's closing `)` is the first `)` after
+ * `](`, not the first `)` after `![` (alt may contain `)`).
+ */
+function findMarkdownImageUrlClosingParenIndex(
+  fullContent: string,
+  imageBangIndex: number,
+): number {
+  const afterOpenBracket = imageBangIndex + 2;
+  if (afterOpenBracket > fullContent.length) {
+    return -1;
+  }
+  const altEnd = fullContent.indexOf("]", afterOpenBracket);
+  if (altEnd === -1) {
+    return -1;
+  }
+  if (fullContent.charCodeAt(altEnd + 1) !== 40 /* ( */) {
+    return -1;
+  }
+  return fullContent.indexOf(")", altEnd + 2);
+}
+
 export function clampRevealLengthForMarkdownDataImages(
   fullContent: string,
   desiredLength: number,
@@ -63,7 +86,10 @@ export function clampRevealLengthForMarkdownDataImages(
       continue;
     }
 
-    const closingParenIndex = fullContent.indexOf(")", start);
+    const closingParenIndex = findMarkdownImageUrlClosingParenIndex(
+      fullContent,
+      start,
+    );
 
     if (closingParenIndex === -1) {
       return start;

--- a/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
+++ b/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
@@ -82,8 +82,11 @@ export function clampRevealLengthForMarkdownDataImages(
   while ((match = regex.exec(fullContent)) !== null) {
     const start = match.index;
 
+    // `exec` yields non-overlapping matches in ascending index order. If the
+    // reveal end lies at or before this image's `![`, we're not inside any
+    // later image either, so the desired length is already safe.
     if (safeDesiredLength <= start) {
-      continue;
+      return safeDesiredLength;
     }
 
     const closingParenIndex = findMarkdownImageUrlClosingParenIndex(

--- a/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
+++ b/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
@@ -1,11 +1,11 @@
 const DATA_IMAGE_MARKDOWN_START_REGEX =
-  /!\[[^\]\n]*\]\(data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,/g;
+  /!\[[^\]\n]*\]\(data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,/gi;
 
 const COMPLETE_DATA_IMAGE_MARKDOWN_REGEX =
-  /!\[([^\]\n]*)\]\((data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[A-Za-z0-9+/=\s]+)\)/g;
+  /!\[([^\]\n]*)\]\((data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[A-Za-z0-9+/=\s]+)\)/gi;
 
 const PENDING_DATA_IMAGE_MARKDOWN_REGEX =
-  /!\[([^\]\n]*)\]\(data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[A-Za-z0-9+/=\s]*$/;
+  /!\[([^\]\n]*)\]\(data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,[A-Za-z0-9+/=\s]*$/i;
 
 export interface GeneratedImageTextSegment {
   type: "text";

--- a/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
+++ b/apps/web/src/app/(app)/chat/utils/generated-image-markdown.ts
@@ -101,7 +101,7 @@ export function clampRevealLengthForMarkdownDataImages(
     const end = closingParenIndex + 1;
 
     if (safeDesiredLength < end) {
-      return end;
+      return start;
     }
   }
 

--- a/apps/web/src/app/(app)/chat/utils/message-utils.ts
+++ b/apps/web/src/app/(app)/chat/utils/message-utils.ts
@@ -1,101 +1,12 @@
 import { convertItemsToMessages } from "@/lib/chat/conversation-api-to-ui-messages";
 
+export {
+  extractMessageContent,
+  getMessageFileParts,
+  hasMessageTextOrFileParts,
+  type MessageFilePart,
+} from "@/app/chat-ui/utils/message-utils";
 export { convertItemsToMessages };
-
-/**
- * Extract text content from a message in various formats (AI SDK v6, parts array, etc.)
- */
-export function extractMessageContent(message: unknown): string {
-  const messageAny = message as Record<string, unknown>;
-  let content = "";
-
-  // Try content property first
-  if (
-    "content" in messageAny &&
-    messageAny.content !== undefined &&
-    messageAny.content !== null
-  ) {
-    const msgContent = messageAny.content;
-    if (typeof msgContent === "string") {
-      content = msgContent;
-    } else if (Array.isArray(msgContent)) {
-      content = msgContent
-        .map((part: unknown) => {
-          if (typeof part === "string") return part;
-          if (part && typeof part === "object") {
-            const partObj = part as Record<string, unknown>;
-            if (
-              "text" in partObj &&
-              partObj.text !== null &&
-              partObj.text !== undefined
-            ) {
-              return String(partObj.text);
-            }
-            if (
-              "content" in partObj &&
-              partObj.content !== null &&
-              partObj.content !== undefined
-            ) {
-              return String(partObj.content);
-            }
-          }
-          return "";
-        })
-        .filter(Boolean)
-        .join("");
-    } else {
-      content = String(msgContent);
-    }
-  }
-
-  // Try "parts" property (AI SDK v6 format)
-  if (!content && "parts" in messageAny && Array.isArray(messageAny.parts)) {
-    content = (messageAny.parts as unknown[])
-      .map((part: unknown) => {
-        if (typeof part === "string") return part;
-        if (part && typeof part === "object") {
-          const partObj = part as Record<string, unknown>;
-          if (
-            "text" in partObj &&
-            partObj.text !== null &&
-            partObj.text !== undefined
-          ) {
-            return String(partObj.text);
-          }
-          if (
-            "content" in partObj &&
-            partObj.content !== null &&
-            partObj.content !== undefined
-          ) {
-            return String(partObj.content);
-          }
-          // Try direct stringification if it's a simple object
-          if (
-            "type" in partObj &&
-            partObj.type === "text" &&
-            "text" in partObj
-          ) {
-            return String(partObj.text);
-          }
-        }
-        return "";
-      })
-      .filter(Boolean)
-      .join("");
-  }
-
-  // Fallback: try "text" property directly
-  if (
-    !content &&
-    "text" in messageAny &&
-    messageAny.text !== undefined &&
-    messageAny.text !== null
-  ) {
-    content = String(messageAny.text);
-  }
-
-  return content.trim();
-}
 
 /**
  * Deduplicate messages by id (first occurrence wins). Prevents duplicate display

--- a/apps/web/src/app/(app)/chat/utils/message-utils.ts
+++ b/apps/web/src/app/(app)/chat/utils/message-utils.ts
@@ -1,31 +1,13 @@
 import { convertItemsToMessages } from "@/lib/chat/conversation-api-to-ui-messages";
 
 export {
+  deduplicateMessagesById,
   extractMessageContent,
   getMessageFileParts,
   hasMessageTextOrFileParts,
   type MessageFilePart,
 } from "@/app/chat-ui/utils/message-utils";
 export { convertItemsToMessages };
-
-/**
- * Deduplicate messages by id (first occurrence wins). Prevents duplicate display
- * when recovery or API returns the same item more than once.
- */
-export function deduplicateMessagesById<T extends { id?: string }>(
-  messages: T[],
-): T[] {
-  const seen = new Set<string>();
-  return messages.filter((m) => {
-    const id = m.id?.trim() ?? "";
-    if (!id) {
-      return true;
-    }
-    if (seen.has(id)) return false;
-    seen.add(id);
-    return true;
-  });
-}
 
 function readEpochMsFromUnknown(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {

--- a/apps/web/src/app/(app)/chat/utils/types.ts
+++ b/apps/web/src/app/(app)/chat/utils/types.ts
@@ -14,6 +14,7 @@ export type ChatComposeMessage = string | ChatSendMessage;
 export interface ChatComposeSubmitOptions {
   kind: ChatComposeKind;
   taskStatus?: TaskSubmitStatus;
+  imageGeneration?: boolean;
 }
 
 export interface Coworker {

--- a/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
@@ -50,4 +50,42 @@ describe("ChatGeneratedImageBubble", () => {
     expect(link).toHaveAttribute("href", "data:image/jpeg;base64,abc123==");
     expect(link).toHaveAttribute("download", "generated-image.jpg");
   });
+
+  it("uses the URL path extension for persisted HTTPS blob image src", () => {
+    render(
+      <ChatGeneratedImageBubble
+        alt="Generated image"
+        downloadLabel="Download generated image"
+        src="https://blob.example.com/uploads/generated-abc123.webp"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Generated image" });
+    fireEvent.load(image);
+
+    const link = screen.getByRole("link", {
+      name: "Download generated image",
+    });
+
+    expect(link).toHaveAttribute("download", "generated-image.webp");
+  });
+
+  it("uses svg extension for HTTPS URLs ending in .svg", () => {
+    render(
+      <ChatGeneratedImageBubble
+        alt="Generated image"
+        downloadLabel="Download generated image"
+        src="https://blob.example.com/path/generated-hash.svg"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Generated image" });
+    fireEvent.load(image);
+
+    const link = screen.getByRole("link", {
+      name: "Download generated image",
+    });
+
+    expect(link).toHaveAttribute("download", "generated-image.svg");
+  });
 });

--- a/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ChatGeneratedImageBubble } from "../chat-generated-image-bubble";
+
+describe("ChatGeneratedImageBubble", () => {
+  it("shows a loading skeleton while waiting for generated image data", () => {
+    const { container } = render(
+      <ChatGeneratedImageBubble
+        alt="Generated image"
+        downloadLabel="Download generated image"
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-slot="skeleton"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("fades in the image after it loads", () => {
+    render(
+      <ChatGeneratedImageBubble
+        alt="Generated image"
+        downloadLabel="Download generated image"
+        src="data:image/png;base64,abc123=="
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Generated image" });
+    expect(image).toHaveClass("opacity-0");
+
+    fireEvent.load(image);
+
+    expect(image).toHaveClass("opacity-100");
+  });
+
+  it("renders a download link for the generated image", () => {
+    render(
+      <ChatGeneratedImageBubble
+        alt="Generated image"
+        downloadLabel="Download generated image"
+        src="data:image/jpeg;base64,abc123=="
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "Download generated image",
+    });
+
+    expect(link).toHaveAttribute("href", "data:image/jpeg;base64,abc123==");
+    expect(link).toHaveAttribute("download", "generated-image.jpg");
+  });
+});

--- a/apps/web/src/components/chat/chat-generated-image-bubble.tsx
+++ b/apps/web/src/components/chat/chat-generated-image-bubble.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getExtensionFromUrl } from "@sokosumi/utils";
 import { Download, ImageOff } from "lucide-react";
 import { useState } from "react";
 
@@ -13,11 +14,37 @@ interface ChatGeneratedImageBubbleProps {
   src?: string;
 }
 
-function getGeneratedImageDownloadFilename(src: string): string {
-  const mediaType = src.match(/^data:image\/([^;]+);base64,/)?.[1];
-  const extension = mediaType === "jpeg" ? "jpg" : (mediaType ?? "png");
+const DOWNLOAD_IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "svg",
+]);
 
-  return `generated-image.${extension.replace("+xml", "")}`;
+function fileExtensionForGeneratedImageDownload(src: string): string {
+  const dataSubtype = src.match(/^data:image\/([^;]+);base64,/)?.[1];
+  if (dataSubtype) {
+    const ext =
+      dataSubtype === "jpeg" ? "jpg" : dataSubtype.replace("+xml", "");
+    return ext.length > 0 ? ext : "png";
+  }
+
+  const fromUrl = getExtensionFromUrl(src).toLowerCase();
+  if (fromUrl === "jpeg" || fromUrl === "jpg") {
+    return "jpg";
+  }
+  if (DOWNLOAD_IMAGE_EXTENSIONS.has(fromUrl)) {
+    return fromUrl;
+  }
+
+  return "png";
+}
+
+function getGeneratedImageDownloadFilename(src: string): string {
+  return `generated-image.${fileExtensionForGeneratedImageDownload(src)}`;
 }
 
 export function ChatGeneratedImageBubble({

--- a/apps/web/src/components/chat/chat-generated-image-bubble.tsx
+++ b/apps/web/src/components/chat/chat-generated-image-bubble.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Download, ImageOff } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface ChatGeneratedImageBubbleProps {
+  alt: string;
+  downloadLabel: string;
+  src?: string;
+}
+
+function getGeneratedImageDownloadFilename(src: string): string {
+  const mediaType = src.match(/^data:image\/([^;]+);base64,/)?.[1];
+  const extension = mediaType === "jpeg" ? "jpg" : (mediaType ?? "png");
+
+  return `generated-image.${extension.replace("+xml", "")}`;
+}
+
+export function ChatGeneratedImageBubble({
+  alt,
+  downloadLabel,
+  src,
+}: ChatGeneratedImageBubbleProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const showSkeleton = !src || (!isLoaded && !hasError);
+
+  return (
+    <figure className="not-prose my-3 w-full max-w-xl overflow-hidden rounded-xl border border-border bg-muted/20 shadow-sm">
+      <div className="relative aspect-square w-full overflow-hidden bg-muted/30">
+        {showSkeleton ? (
+          <div className="absolute inset-0">
+            <Skeleton className="size-full rounded-none" />
+            <div className="absolute inset-0 bg-linear-to-br from-transparent via-background/25 to-transparent" />
+            <div className="absolute inset-0 animate-pulse bg-linear-to-tr from-transparent via-background/30 to-transparent" />
+          </div>
+        ) : null}
+        {src ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            alt={alt}
+            className={cn(
+              "size-full object-cover transition-opacity duration-300",
+              isLoaded && !hasError ? "opacity-100" : "opacity-0",
+            )}
+            src={src}
+            onError={() => {
+              setHasError(true);
+            }}
+            onLoad={() => {
+              setIsLoaded(true);
+            }}
+          />
+        ) : null}
+        {hasError ? (
+          <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+            <ImageOff className="size-6" aria-hidden="true" />
+          </div>
+        ) : null}
+        {src && !hasError ? (
+          <Button
+            asChild
+            className="absolute top-2 right-2 z-10 size-8 rounded-full border border-border/70 bg-background/85 text-foreground shadow-sm backdrop-blur hover:bg-background"
+            size="icon"
+            variant="ghost"
+          >
+            <a
+              aria-label={downloadLabel}
+              download={getGeneratedImageDownloadFilename(src)}
+              href={src}
+            >
+              <Download className="size-4" aria-hidden="true" />
+            </a>
+          </Button>
+        ) : null}
+      </div>
+    </figure>
+  );
+}

--- a/apps/web/src/components/chat/coworker-model-selector.tsx
+++ b/apps/web/src/components/chat/coworker-model-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { CHAT_MODELS } from "@sokosumi/chat";
-import { ChevronDown } from "lucide-react";
+import { CHAT_MODELS, chatModelSupportsImageInput } from "@sokosumi/chat";
+import { ChevronDown, Image as ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -23,6 +23,7 @@ interface Model {
   id: string;
   name: string;
   icon?: React.ReactNode;
+  supportsImageInput?: boolean;
 }
 
 interface CoworkerModelSelectorProps {
@@ -73,6 +74,7 @@ export default function CoworkerModelSelector({
   const models: Model[] = CHAT_MODELS.map((model) => ({
     id: model.id,
     name: model.name,
+    supportsImageInput: chatModelSupportsImageInput(model.id),
   }));
 
   const getCoworkerAvatarUrl = (c: Coworker): string | null =>
@@ -224,6 +226,12 @@ export default function CoworkerModelSelector({
                   >
                     <ModelIcon modelId={model.id} modelName={model.name} />
                     <span className="flex-1 text-left">{model.name}</span>
+                    {model.supportsImageInput ? (
+                      <ImageIcon
+                        className="text-muted-foreground size-3.5 shrink-0"
+                        aria-label={t("supportsImageAttachments")}
+                      />
+                    ) : null}
                   </button>
                 ))}
               </div>

--- a/apps/web/src/components/chat/coworker-model-selector.tsx
+++ b/apps/web/src/components/chat/coworker-model-selector.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { CHAT_MODELS, chatModelSupportsImageInput } from "@sokosumi/chat";
-import { ChevronDown, Image as ImageIcon } from "lucide-react";
+import {
+  CHAT_MODELS,
+  chatModelSupportsImageGeneration,
+  chatModelSupportsImageInput,
+} from "@sokosumi/chat";
+import { ChevronDown, Image as ImageIcon, ImagePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -24,6 +28,7 @@ interface Model {
   name: string;
   icon?: React.ReactNode;
   supportsImageInput?: boolean;
+  supportsImageGeneration?: boolean;
 }
 
 interface CoworkerModelSelectorProps {
@@ -75,6 +80,7 @@ export default function CoworkerModelSelector({
     id: model.id,
     name: model.name,
     supportsImageInput: chatModelSupportsImageInput(model.id),
+    supportsImageGeneration: chatModelSupportsImageGeneration(model.id),
   }));
 
   const getCoworkerAvatarUrl = (c: Coworker): string | null =>
@@ -225,8 +231,15 @@ export default function CoworkerModelSelector({
                     )}
                   >
                     <ModelIcon modelId={model.id} modelName={model.name} />
-                    <span className="flex-1 text-left">{model.name}</span>
-                    {model.supportsImageInput ? (
+                    <span className="min-w-0 flex-1 text-left">
+                      {model.name}
+                    </span>
+                    {model.supportsImageGeneration ? (
+                      <ImagePlus
+                        className="text-muted-foreground size-3.5 shrink-0"
+                        aria-label={t("supportsImageGeneration")}
+                      />
+                    ) : model.supportsImageInput ? (
                       <ImageIcon
                         className="text-muted-foreground size-3.5 shrink-0"
                         aria-label={t("supportsImageAttachments")}

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import type { UseChatHelpers } from "@ai-sdk/react";
+import {
+  chatModelSupportsImageGeneration,
+  chatModelSupportsImageInput,
+} from "@sokosumi/chat";
+import { resolveUserUploadContentType } from "@sokosumi/utils";
 import type { UIMessage } from "ai";
+import { ImagePlus, Paperclip, Plus, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   type Dispatch,
@@ -33,6 +39,12 @@ import { CoworkerGalleryCard } from "@/components/agents/coworker-gallery-card";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   FileUpload,
   FileUploadDropzone,
   FileUploadTrigger,
@@ -52,7 +64,11 @@ import {
   sanitizeTaskAttachmentLabel,
 } from "@/lib/utils/task-attachments";
 import { uploadTaskAttachment } from "@/lib/utils/task-attachments.client";
-import { getUserFileUploadErrorMessage } from "@/lib/utils/user-file-upload.client";
+import {
+  getUserFileUploadErrorMessage,
+  type UserFileUploadProgress,
+  uploadUserFileDirect,
+} from "@/lib/utils/user-file-upload.client";
 import { ComposeKindSelector } from "./compose-kind-selector";
 import { CoworkerAvatarWithSkeleton } from "./coworker-avatar";
 import CoworkerModelSelector from "./coworker-model-selector";
@@ -104,6 +120,8 @@ interface MultimodalInputProps {
 const DEFAULT_COWORKER_SLUG = "elena";
 const TASK_MARKDOWN_EDITOR_ID = "chat-task-markdown-editor";
 
+type ChatFilePart = Extract<UIMessage["parts"][number], { type: "file" }>;
+
 function findDefaultCoworker(list: Coworker[] | undefined) {
   return (
     list?.find(
@@ -124,6 +142,19 @@ function matchesCoworker(a: Coworker | null, b: Coworker | null): boolean {
   return (
     a.id === b.id || a.slug === b.slug || a.id === b.slug || a.slug === b.id
   );
+}
+
+function buildChatMessagePayload(
+  text: string,
+  fileParts: ChatFilePart[],
+): ChatSendMessage {
+  const trimmedText = text.trim();
+  const parts: UIMessage["parts"] = [
+    ...(trimmedText ? [{ type: "text" as const, text: trimmedText }] : []),
+    ...fileParts,
+  ];
+
+  return { parts } as ChatSendMessage;
 }
 
 function PureMultimodalInput({
@@ -165,6 +196,8 @@ function PureMultimodalInput({
   const composeKind: ChatComposeKind = chatId ? "chat" : storedComposeKind;
   const [taskStatus, setTaskStatus] = useState<TaskSubmitStatus>("READY");
   const [pendingUploadFiles, setPendingUploadFiles] = useState<File[]>([]);
+  const [chatFileParts, setChatFileParts] = useState<ChatFilePart[]>([]);
+  const [imageGenerationEnabled, setImageGenerationEnabled] = useState(false);
   const [uploadingAttachmentsCount, setUploadingAttachmentsCount] = useState(0);
   const initialDefault = findDefaultCoworker(propCoworkers);
   const [preferredCoworker, setPreferredCoworker] = useState<Coworker | null>(
@@ -198,8 +231,25 @@ function PureMultimodalInput({
 
   const width = windowWidth;
   const isTaskComposer = !chatId && composeKind === "task";
+  const supportsChatImageInput = useMemo(
+    () => chatModelSupportsImageInput(selectedModel?.id ?? null),
+    [selectedModel?.id],
+  );
+  const supportsImageGeneration = useMemo(
+    () =>
+      selectedModel?.id
+        ? chatModelSupportsImageGeneration(selectedModel.id)
+        : false,
+    [selectedModel?.id],
+  );
+  const hasChatFileParts = !isTaskComposer && chatFileParts.length > 0;
   const isUploadingAttachments = uploadingAttachmentsCount > 0;
   const taskUploadFileLabel = tNewTask("uploadFile");
+  const attachmentMenuTriggerLabel = t("attachmentMenu.trigger");
+  const uploadFileMenuLabel = t("attachmentMenu.uploadFile");
+  const createImageMenuLabel = t("attachmentMenu.createImage");
+  const createImageChipLabel = t("createImageChip.label");
+  const removeCreateImageLabel = t("createImageChip.remove");
   const taskUploadFileErrorLabel = tNewTask("uploadFileError");
   const removeAttachmentLabel = tNewTask("removeAttachment");
   const taskUploadingFileLabel = getTaskAttachmentUploadLabelTemplate(
@@ -314,9 +364,27 @@ function PureMultimodalInput({
 
   useEffect(() => abortActiveUploads, [abortActiveUploads]);
 
+  useEffect(() => {
+    if (!supportsChatImageInput) {
+      setChatFileParts([]);
+    }
+  }, [supportsChatImageInput]);
+
+  useEffect(() => {
+    if (!supportsImageGeneration) {
+      setImageGenerationEnabled(false);
+    }
+  }, [supportsImageGeneration]);
+
   const handleAttachFiles = useCallback(
     async (files: File[]) => {
       if (files.length === 0) return;
+      if (
+        composeKind === "chat" &&
+        (!supportsChatImageInput || imageGenerationEnabled)
+      ) {
+        return;
+      }
 
       const uploadToast = createTaskAttachmentUploadToast({
         files,
@@ -332,12 +400,33 @@ function PureMultimodalInput({
 
       try {
         for (const [index, file] of files.entries()) {
-          const uploadedUrl = await uploadTaskAttachment(file, {
+          const uploadOptions = {
             abortSignal: controller.signal,
-            onUploadProgress: (progress) => {
+            onUploadProgress: (progress: UserFileUploadProgress) => {
               uploadToast.updateFileProgress(index, progress);
             },
-          });
+          };
+
+          if (composeKind === "chat") {
+            const mediaType = resolveUserUploadContentType(
+              file.name,
+              file.type,
+            );
+            const uploaded = await uploadUserFileDirect(file, uploadOptions);
+            uploadToast.markFileComplete(index);
+            setChatFileParts((parts) => [
+              ...parts,
+              {
+                type: "file",
+                url: uploaded.publicUrl,
+                mediaType: mediaType ?? file.type,
+                filename: sanitizeTaskAttachmentLabel(file.name, "file"),
+              },
+            ]);
+            continue;
+          }
+
+          const uploadedUrl = await uploadTaskAttachment(file, uploadOptions);
           uploadToast.markFileComplete(index);
 
           const safeName = sanitizeTaskAttachmentLabel(file.name, "file");
@@ -370,7 +459,10 @@ function PureMultimodalInput({
       }
     },
     [
+      composeKind,
+      imageGenerationEnabled,
       setInput,
+      supportsChatImageInput,
       taskUploadFileErrorLabel,
       taskUploadingFileLabel,
       taskUploadingFilesLabel,
@@ -401,12 +493,15 @@ function PureMultimodalInput({
     () => extractTaskAttachmentUrls(input),
     [input],
   );
+  const canSubmitContent = imageGenerationEnabled
+    ? input.trim().length > 0
+    : input.trim().length > 0 || hasChatFileParts;
   const canSubmit =
-    input.trim().length > 0 &&
+    canSubmitContent &&
     status === "ready" &&
     !submitBlocked &&
     (composeKind === "chat" || selectedCoworker != null) &&
-    (!isTaskComposer || !isUploadingAttachments);
+    !isUploadingAttachments;
   const placeholder = t(
     composeKind === "task"
       ? "welcomeScreen.taskPlaceholder"
@@ -433,7 +528,10 @@ function PureMultimodalInput({
       }
     }
 
-    const sendPayload = { text: input.trim() } as ChatSendMessage;
+    const sendPayload =
+      composeKind === "chat"
+        ? buildChatMessagePayload(input, chatFileParts)
+        : ({ text: input.trim() } as ChatSendMessage);
 
     // Use onSendMessage if provided (for welcome screen to create conversation)
     // Otherwise use sendMessage from useChat hook
@@ -445,18 +543,26 @@ function PureMultimodalInput({
         {
           kind: composeKind,
           taskStatus,
+          imageGeneration: imageGenerationEnabled,
         },
       );
       if (sendResult !== true) {
         return;
       }
     } else {
-      sendMessage(sendPayload);
+      sendMessage(
+        sendPayload,
+        imageGenerationEnabled
+          ? { body: { imageGeneration: true } }
+          : undefined,
+      );
     }
 
     setLocalStorageValue("chat-input", "");
     resetHeight();
     setInput("");
+    setChatFileParts([]);
+    setImageGenerationEnabled(false);
 
     if (width && width > 768) {
       if (isTaskComposer) {
@@ -467,8 +573,10 @@ function PureMultimodalInput({
     }
   }, [
     blurOnSendOnMobile,
+    chatFileParts,
     composeKind,
     focusTaskEditor,
+    imageGenerationEnabled,
     input,
     isTaskComposer,
     onSendMessage,
@@ -573,6 +681,21 @@ function PureMultimodalInput({
     },
     [setInput],
   );
+
+  const handleRemoveChatAttachment = useCallback((url: string) => {
+    setChatFileParts((parts) => parts.filter((part) => part.url !== url));
+  }, []);
+
+  const handleEnableImageGeneration = useCallback(() => {
+    if (!supportsImageGeneration || hasChatFileParts) {
+      return;
+    }
+    setImageGenerationEnabled(true);
+  }, [hasChatFileParts, supportsImageGeneration]);
+
+  const showAttachmentMenu =
+    composeKind === "chat" &&
+    (supportsChatImageInput || supportsImageGeneration);
 
   return (
     <div className={cn("relative flex w-full flex-col gap-4", className)}>
@@ -700,6 +823,44 @@ function PureMultimodalInput({
                 </FileUploadTrigger>
               </FileUploadDropzone>
             </FileUpload>
+          ) : supportsChatImageInput ? (
+            <FileUpload
+              value={pendingUploadFiles}
+              onValueChange={setPendingUploadFiles}
+              onAccept={(files) => {
+                void handleAttachFiles(files);
+              }}
+              multiple
+              disabled={isUploadingAttachments}
+              className="w-full"
+            >
+              <FileUploadDropzone className="data-dragging:bg-accent/20 w-full items-stretch justify-start border-0 p-0 hover:bg-transparent">
+                <PromptInputTextarea
+                  allowEnterToSubmitOnMobile={enterSubmitsOnMobile}
+                  className="placeholder:text-muted-foreground grow resize-none border-0! border-none! bg-transparent p-4 text-base ring-0 outline-none [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
+                  data-testid="multimodal-input"
+                  disableAutoResize={true}
+                  maxHeight={200}
+                  minHeight={44}
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={handleInput}
+                  placeholder={placeholder}
+                  ref={textareaRef}
+                  rows={1}
+                  value={input}
+                />
+                <FileUploadTrigger asChild>
+                  <button
+                    ref={attachmentTriggerRef}
+                    type="button"
+                    className="sr-only"
+                    aria-label={taskUploadFileLabel}
+                  >
+                    {taskUploadFileLabel}
+                  </button>
+                </FileUploadTrigger>
+              </FileUploadDropzone>
+            </FileUpload>
           ) : (
             <PromptInputTextarea
               allowEnterToSubmitOnMobile={enterSubmitsOnMobile}
@@ -708,6 +869,7 @@ function PureMultimodalInput({
               disableAutoResize={true}
               maxHeight={200}
               minHeight={44}
+              onClick={(event) => event.stopPropagation()}
               onChange={handleInput}
               placeholder={placeholder}
               ref={textareaRef}
@@ -735,8 +897,79 @@ function PureMultimodalInput({
             ))}
           </div>
         ) : null}
+        {!isTaskComposer &&
+        (chatFileParts.length > 0 || imageGenerationEnabled) ? (
+          <div className="flex flex-wrap gap-3 px-2 pb-1">
+            {chatFileParts.map((part) => (
+              <FileChipMiniPreviewWithMetadata
+                key={part.url}
+                url={part.url}
+                fileName={part.filename}
+                onRemove={() => handleRemoveChatAttachment(part.url)}
+                removeLabel={removeAttachmentLabel}
+              />
+            ))}
+            {imageGenerationEnabled ? (
+              <div className="bg-muted text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs">
+                <ImagePlus className="text-muted-foreground size-3.5" />
+                <span>{createImageChipLabel}</span>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground rounded-full p-0.5 transition-colors"
+                  aria-label={removeCreateImageLabel}
+                  onClick={() => setImageGenerationEnabled(false)}
+                >
+                  <X className="size-3" />
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
         <PromptInputToolbar className="border-top-0! border-t-0! p-3 dark:border-0 dark:border-transparent!">
           <PromptInputTools className="flex-wrap gap-1 sm:gap-1.5">
+            {showAttachmentMenu ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="size-8 rounded-full! p-0"
+                    disabled={isUploadingAttachments}
+                    title={attachmentMenuTriggerLabel}
+                    aria-label={attachmentMenuTriggerLabel}
+                  >
+                    <Plus className="size-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" side="top" sideOffset={8}>
+                  {supportsChatImageInput ? (
+                    <DropdownMenuItem
+                      disabled={
+                        isUploadingAttachments || imageGenerationEnabled
+                      }
+                      onSelect={() => attachmentTriggerRef.current?.click()}
+                    >
+                      <Paperclip className="size-4" />
+                      {uploadFileMenuLabel}
+                    </DropdownMenuItem>
+                  ) : null}
+                  {supportsImageGeneration ? (
+                    <DropdownMenuItem
+                      disabled={
+                        isUploadingAttachments ||
+                        hasChatFileParts ||
+                        imageGenerationEnabled
+                      }
+                      onSelect={handleEnableImageGeneration}
+                    >
+                      <ImagePlus className="size-4" />
+                      {createImageMenuLabel}
+                    </DropdownMenuItem>
+                  ) : null}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
             {!chatId ? (
               <ComposeKindSelector
                 value={composeKind}

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -379,10 +379,7 @@ function PureMultimodalInput({
   const handleAttachFiles = useCallback(
     async (files: File[]) => {
       if (files.length === 0) return;
-      if (
-        composeKind === "chat" &&
-        (!supportsChatImageInput || imageGenerationEnabled)
-      ) {
+      if (composeKind === "chat" && !supportsChatImageInput) {
         return;
       }
 
@@ -460,7 +457,6 @@ function PureMultimodalInput({
     },
     [
       composeKind,
-      imageGenerationEnabled,
       setInput,
       supportsChatImageInput,
       taskUploadFileErrorLabel,
@@ -493,9 +489,7 @@ function PureMultimodalInput({
     () => extractTaskAttachmentUrls(input),
     [input],
   );
-  const canSubmitContent = imageGenerationEnabled
-    ? input.trim().length > 0
-    : input.trim().length > 0 || hasChatFileParts;
+  const canSubmitContent = input.trim().length > 0 || hasChatFileParts;
   const canSubmit =
     canSubmitContent &&
     status === "ready" &&
@@ -687,11 +681,11 @@ function PureMultimodalInput({
   }, []);
 
   const handleEnableImageGeneration = useCallback(() => {
-    if (!supportsImageGeneration || hasChatFileParts) {
+    if (!supportsImageGeneration) {
       return;
     }
     setImageGenerationEnabled(true);
-  }, [hasChatFileParts, supportsImageGeneration]);
+  }, [supportsImageGeneration]);
 
   const showAttachmentMenu =
     composeKind === "chat" &&
@@ -945,9 +939,7 @@ function PureMultimodalInput({
                 <DropdownMenuContent align="start" side="top" sideOffset={8}>
                   {supportsChatImageInput ? (
                     <DropdownMenuItem
-                      disabled={
-                        isUploadingAttachments || imageGenerationEnabled
-                      }
+                      disabled={isUploadingAttachments}
                       onSelect={() => attachmentTriggerRef.current?.click()}
                     >
                       <Paperclip className="size-4" />
@@ -957,9 +949,7 @@ function PureMultimodalInput({
                   {supportsImageGeneration ? (
                     <DropdownMenuItem
                       disabled={
-                        isUploadingAttachments ||
-                        hasChatFileParts ||
-                        imageGenerationEnabled
+                        isUploadingAttachments || imageGenerationEnabled
                       }
                       onSelect={handleEnableImageGeneration}
                     >

--- a/apps/web/src/components/jobs/job-details/file-chip-with-metadata.tsx
+++ b/apps/web/src/components/jobs/job-details/file-chip-with-metadata.tsx
@@ -98,6 +98,7 @@ export function FileChipWithMetadata({
 export function FileChipMiniPreviewWithMetadata({
   url,
   fileName,
+  mediaType,
   ...props
 }: Omit<FileChipMiniPreviewProps, "fileName"> & { fileName?: string | null }) {
   const metadata = useFileHeadMetadata(url);
@@ -106,6 +107,7 @@ export function FileChipMiniPreviewWithMetadata({
     <FileChipMiniPreview
       url={url}
       fileName={fileName ?? metadata?.fileName}
+      mediaType={mediaType ?? metadata?.contentType}
       size={metadata?.size}
       {...props}
     />

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -43,7 +43,7 @@ export function FileChipMiniPreview({
   const prettySize = formatBytes(size);
 
   return (
-    <div className={cn("relative inline-flex", className)}>
+    <div className={cn("not-prose relative inline-flex", className)}>
       <Tooltip>
         <TooltipTrigger asChild>
           <a
@@ -51,18 +51,20 @@ export function FileChipMiniPreview({
             target="_blank"
             rel="noreferrer noopener"
             className={cn(
-              "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative inline-flex overflow-hidden rounded-xl border outline-none transition",
+              "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 overflow-hidden rounded-xl border outline-none transition",
               sizeClass,
             )}
           >
             {isImage ? (
-              <Image
-                src={url}
-                alt={resolvedFileName}
-                fill
-                sizes="80px"
-                className="object-cover"
-              />
+              <div className="relative size-full overflow-hidden">
+                  <Image
+                    src={url}
+                    alt={resolvedFileName}
+                    fill
+                    sizes="96px"
+                    className="object-cover object-center"
+                  />
+              </div>
             ) : (
               <div className="text-muted-foreground flex size-full items-center justify-center">
                 <div className="flex size-8 items-center justify-center rounded-md">

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -16,6 +16,7 @@ import { getExtensionFromUrl, isImageUrl } from "@sokosumi/utils";
 export interface FileChipMiniPreviewProps {
   url: string;
   fileName?: string | null;
+  mediaType?: string | null;
   size?: number | bigint | null;
   className?: string;
   sizeClass?: string;
@@ -26,6 +27,7 @@ export interface FileChipMiniPreviewProps {
 export function FileChipMiniPreview({
   url,
   fileName,
+  mediaType,
   size,
   className,
   sizeClass = "size-20",
@@ -33,8 +35,11 @@ export function FileChipMiniPreview({
   removeLabel = "Remove file",
 }: FileChipMiniPreviewProps) {
   const resolvedFileName = fileName ?? url.split("/").pop() ?? url;
-  const isImage = isImageUrl(url);
-  const extension = getExtensionFromUrl(url);
+  const isImage =
+    mediaType?.toLowerCase().startsWith("image/") ||
+    isImageUrl(url) ||
+    (fileName ? isImageUrl(fileName) : false);
+  const extension = getExtensionFromUrl(fileName ?? url);
   const prettySize = formatBytes(size);
 
   return (

--- a/apps/web/src/lib/chat/__tests__/conversation-api-to-ui-messages.test.ts
+++ b/apps/web/src/lib/chat/__tests__/conversation-api-to-ui-messages.test.ts
@@ -67,6 +67,52 @@ describe("convertItemsToMessages", () => {
     ]);
   });
 
+  it("maps assistant generated image file parts from API content arrays", () => {
+    const messages = convertItemsToMessages([
+      {
+        id: "a3",
+        role: "assistant",
+        createdAt: 1700000001,
+        content: [
+          { type: "output_text", text: "Here's the generated image." },
+          {
+            type: "file",
+            url: "https://blob.example.com/generated.png",
+            mediaType: "image/png",
+            filename: "generated.png",
+          },
+        ],
+      },
+    ]);
+
+    expect(messages[0]?.parts).toEqual([
+      { type: "text", text: "Here's the generated image." },
+      {
+        type: "file",
+        url: "https://blob.example.com/generated.png",
+        mediaType: "image/png",
+        filename: "generated.png",
+      },
+    ]);
+    expect((messages[0] as { content?: string } | undefined)?.content).toBe(
+      "Here's the generated image.",
+    );
+  });
+
+  it("maps image generation metadata onto user messages", () => {
+    const messages = convertItemsToMessages([
+      {
+        id: "u3",
+        role: "user",
+        createdAt: 1700000001,
+        content: [{ type: "text", text: "Make an image" }],
+        metadata: { imageGeneration: true },
+      },
+    ]);
+
+    expect(messages[0]?.metadata).toEqual({ imageGeneration: true });
+  });
+
   it("keeps file-only API content as renderable parts after hydration", () => {
     const messages = convertItemsToMessages([
       {

--- a/apps/web/src/lib/chat/__tests__/conversation-api-to-ui-messages.test.ts
+++ b/apps/web/src/lib/chat/__tests__/conversation-api-to-ui-messages.test.ts
@@ -67,6 +67,34 @@ describe("convertItemsToMessages", () => {
     ]);
   });
 
+  it("keeps file-only API content as renderable parts after hydration", () => {
+    const messages = convertItemsToMessages([
+      {
+        id: "u2",
+        role: "user",
+        createdAt: 1700000001,
+        content: [
+          {
+            type: "file",
+            url: "https://example.com/image.png",
+            mediaType: "image/png",
+            filename: "image.png",
+          },
+        ],
+      },
+    ]);
+
+    expect((messages[0] as { content?: string } | undefined)?.content).toBe("");
+    expect(messages[0]?.parts).toEqual([
+      {
+        type: "file",
+        url: "https://example.com/image.png",
+        mediaType: "image/png",
+        filename: "image.png",
+      },
+    ]);
+  });
+
   it("attaches thought timing metadata when the API item includes thoughtTiming", () => {
     const messages = convertItemsToMessages([
       {

--- a/apps/web/src/lib/chat/conversation-api-to-ui-messages.ts
+++ b/apps/web/src/lib/chat/conversation-api-to-ui-messages.ts
@@ -23,6 +23,9 @@ export interface ConvertibleConversationApiMessage {
   role: string;
   content: ConversationApiMessageContent;
   createdAt: number;
+  metadata?: {
+    imageGeneration?: boolean;
+  };
   thoughtTiming?: {
     startedAtMs: number | null;
     endedAtMs: number | null;
@@ -118,8 +121,22 @@ export function convertItemsToMessages(
         : "user";
 
     const timing = message.thoughtTiming;
+    const isImageGeneration =
+      validRole === "user" && message.metadata?.imageGeneration === true;
     const hasCompleteThoughtTiming =
       timing != null && timing.startedAtMs != null && timing.endedAtMs != null;
+    const metadata =
+      hasCompleteThoughtTiming || isImageGeneration
+        ? {
+            ...(hasCompleteThoughtTiming
+              ? {
+                  thoughtStartedAtMs: timing.startedAtMs,
+                  thoughtEndedAtMs: timing.endedAtMs,
+                }
+              : {}),
+            ...(isImageGeneration ? { imageGeneration: true } : {}),
+          }
+        : undefined;
 
     return {
       id: message.id,
@@ -127,14 +144,7 @@ export function convertItemsToMessages(
       parts,
       content: visibleText,
       createdAt: new Date(message.createdAt * 1000),
-      ...(hasCompleteThoughtTiming
-        ? {
-            metadata: {
-              thoughtStartedAtMs: timing.startedAtMs,
-              thoughtEndedAtMs: timing.endedAtMs,
-            },
-          }
-        : {}),
+      ...(metadata != null ? { metadata } : {}),
     };
   });
 }

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -1288,12 +1288,11 @@ export const ChatUiMessageSchema = {
                 },
                 thoughtEndedAtMs: {
                     type: 'number'
+                },
+                imageGeneration: {
+                    type: 'boolean'
                 }
-            },
-            required: [
-                'thoughtStartedAtMs',
-                'thoughtEndedAtMs'
-            ]
+            }
         }
     },
     required: [
@@ -1584,6 +1583,21 @@ export const ConversationMessageSchema = {
                 'endedAtMs'
             ],
             description: 'Wall-clock thought phase (ms since epoch), when persisted for coworker reasoning'
+        },
+        metadata: {
+            type: 'object',
+            properties: {
+                thoughtStartedAtMs: {
+                    type: 'number'
+                },
+                thoughtEndedAtMs: {
+                    type: 'number'
+                },
+                imageGeneration: {
+                    type: 'boolean'
+                }
+            },
+            description: 'UI message metadata, including whether a user turn requested image generation.'
         }
     },
     required: [

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -325,8 +325,9 @@ export type ChatUiMessage = {
         text: string;
     }>;
     metadata?: {
-        thoughtStartedAtMs: number;
-        thoughtEndedAtMs: number;
+        thoughtStartedAtMs?: number;
+        thoughtEndedAtMs?: number;
+        imageGeneration?: boolean;
     };
 };
 
@@ -438,6 +439,14 @@ export type ConversationMessage = {
     thoughtTiming?: {
         startedAtMs: number | null;
         endedAtMs: number | null;
+    };
+    /**
+     * UI message metadata, including whether a user turn requested image generation.
+     */
+    metadata?: {
+        thoughtStartedAtMs?: number;
+        thoughtEndedAtMs?: number;
+        imageGeneration?: boolean;
     };
 };
 
@@ -3729,6 +3738,10 @@ export type PostChatData = {
                 type: string;
                 text: string;
             }>;
+            metadata?: {
+                imageGeneration?: boolean;
+                [key: string]: unknown;
+            };
             id?: string;
         }>;
         message?: {
@@ -3769,6 +3782,10 @@ export type PostChatData = {
                 type: string;
                 text: string;
             }>;
+            metadata?: {
+                imageGeneration?: boolean;
+                [key: string]: unknown;
+            };
             id?: string;
         };
         id?: string;
@@ -3777,6 +3794,7 @@ export type PostChatData = {
         conversationId?: string;
         previousResponseId?: string;
         model?: string | null;
+        imageGeneration?: boolean;
     };
     headers?: {
         /**

--- a/packages/ai-provider/src/parse-provider-options.ts
+++ b/packages/ai-provider/src/parse-provider-options.ts
@@ -38,6 +38,10 @@ export function parseSokosumiProviderOptions(
   const previousResponseId = pickString(raw.previousResponseId) ?? null;
   const providerConversationId = pickString(raw.providerConversationId) ?? null;
   const imageGenerationModel = pickString(raw.imageGenerationModel) ?? null;
+  const webSearchEnabled = raw.webSearchEnabled === true;
+  const webSearchParameters = isRecord(raw.webSearchParameters)
+    ? raw.webSearchParameters
+    : null;
 
   const onResponseStarted =
     typeof raw.onResponseStarted === "function"
@@ -102,6 +106,8 @@ export function parseSokosumiProviderOptions(
     imageGenerationModel: imageGenerationModel?.trim().length
       ? imageGenerationModel.trim()
       : null,
+    webSearchEnabled,
+    webSearchParameters,
     onResponseStarted,
     onResponseCompleted,
     onInvalidPreviousResponseId,

--- a/packages/ai-provider/src/parse-provider-options.ts
+++ b/packages/ai-provider/src/parse-provider-options.ts
@@ -37,6 +37,7 @@ export function parseSokosumiProviderOptions(
   const sokosumiOrganizationId = pickString(raw.sokosumiOrganizationId) ?? null;
   const previousResponseId = pickString(raw.previousResponseId) ?? null;
   const providerConversationId = pickString(raw.providerConversationId) ?? null;
+  const imageGenerationModel = pickString(raw.imageGenerationModel) ?? null;
 
   const onResponseStarted =
     typeof raw.onResponseStarted === "function"
@@ -97,6 +98,9 @@ export function parseSokosumiProviderOptions(
       : null,
     providerConversationId: providerConversationId?.trim().length
       ? providerConversationId.trim()
+      : null,
+    imageGenerationModel: imageGenerationModel?.trim().length
+      ? imageGenerationModel.trim()
       : null,
     onResponseStarted,
     onResponseCompleted,

--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -102,7 +102,7 @@ describe("promptToResponsesInput", () => {
           },
           {
             type: "input_file",
-            file_data: "JVBERi0xLjcK",
+            file_data: "data:application/pdf;base64,JVBERi0xLjcK",
             filename: "brief.pdf",
           },
         ],
@@ -138,12 +138,12 @@ describe("promptToResponsesInput", () => {
         content: [
           {
             type: "input_file",
-            file_data: "SGVsbG8=",
+            file_data: "data:;base64,SGVsbG8=",
             filename: "blob.bin",
           },
           {
             type: "input_file",
-            file_data: "JVBERi0xLjcK",
+            file_data: "data:;base64,JVBERi0xLjcK",
             filename: "from-url.pdf",
           },
         ],

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -210,7 +210,7 @@ function filePartToResponsesContent(
 
   return {
     type: "input_file",
-    file_data: toFileData(part),
+    file_data: toResponsesInputFileData(part),
     filename: part.filename,
   };
 }
@@ -231,15 +231,22 @@ function toImageUrl(part: LanguageModelV3FilePart): string {
   return toDataUrl(part);
 }
 
-function toFileData(part: LanguageModelV3FilePart): string {
+/**
+ * Inline `file_data` for OpenRouter/OpenAI Responses `input_file`.
+ * Providers (e.g. Azure) expect PDFs and similar blobs as full data URLs
+ * (`data:application/pdf;base64,...`), not raw base64 — see OpenRouter PDF docs
+ * and OpenAI file-input guides.
+ */
+function toResponsesInputFileData(part: LanguageModelV3FilePart): string {
   if (part.data instanceof Uint8Array) {
-    return Buffer.from(part.data).toString("base64");
+    return `data:${part.mediaType};base64,${Buffer.from(part.data).toString("base64")}`;
   }
 
   if (part.data instanceof URL) {
     const url = part.data.toString();
     if (url.startsWith("data:")) {
-      return extractBase64DataFromDataUrl(url, part);
+      extractBase64DataFromDataUrl(url, part);
+      return url;
     }
     throw invalidFilePartError(
       part,
@@ -255,9 +262,10 @@ function toFileData(part: LanguageModelV3FilePart): string {
       );
     }
     if (part.data.startsWith("data:")) {
-      return extractBase64DataFromDataUrl(part.data, part);
+      extractBase64DataFromDataUrl(part.data, part);
+      return part.data;
     }
-    return part.data;
+    return `data:${part.mediaType};base64,${part.data}`;
   }
 
   throw invalidFilePartError(

--- a/packages/ai-provider/src/sokosumi-language-model.openrouter-image-generation.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.openrouter-image-generation.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSokosumiLanguageModel } from "./sokosumi-language-model.js";
+
+describe("SokosumiLanguageModel OpenRouter image generation", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("forwards the image generation server tool when a model is configured", async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return okStreamResponse();
+    }) as typeof fetch;
+
+    const model = createSokosumiLanguageModel("openai/gpt-5.4", {
+      openRouterApiKey: "sk-or-test",
+    });
+
+    await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "A cat" }] }],
+      providerOptions: {
+        sokosumi: {
+          mode: "openrouter",
+          imageGenerationModel: "openai/gpt-5.4-image-2",
+        },
+      },
+    });
+
+    expect(requestBody).toMatchObject({
+      model: "openai/gpt-5.4",
+      tools: [
+        {
+          type: "openrouter:image_generation",
+          parameters: {
+            model: "openai/gpt-5.4-image-2",
+            quality: "high",
+          },
+        },
+      ],
+    });
+  });
+
+  it("omits the image generation server tool when no model is configured", async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return okStreamResponse();
+    }) as typeof fetch;
+
+    const model = createSokosumiLanguageModel("openai/gpt-5.4", {
+      openRouterApiKey: "sk-or-test",
+    });
+
+    await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "A cat" }] }],
+      providerOptions: {
+        sokosumi: {
+          mode: "openrouter",
+        },
+      },
+    });
+
+    expect(requestBody?.tools).toBeUndefined();
+  });
+});
+
+function okStreamResponse(): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    },
+  );
+}

--- a/packages/ai-provider/src/sokosumi-language-model.openrouter-image-generation.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.openrouter-image-generation.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSokosumiLanguageModel } from "./sokosumi-language-model.js";
 
-describe("SokosumiLanguageModel OpenRouter image generation", () => {
+describe("SokosumiLanguageModel OpenRouter server tools", () => {
   const originalFetch = globalThis.fetch;
 
   afterEach(() => {
@@ -45,7 +45,82 @@ describe("SokosumiLanguageModel OpenRouter image generation", () => {
     });
   });
 
-  it("omits the image generation server tool when no model is configured", async () => {
+  it("forwards the web search server tool when enabled", async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return okStreamResponse();
+    }) as typeof fetch;
+
+    const model = createSokosumiLanguageModel("openai/gpt-5.4", {
+      openRouterApiKey: "sk-or-test",
+    });
+
+    await model.doStream({
+      prompt: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "What happened today?" }],
+        },
+      ],
+      providerOptions: {
+        sokosumi: {
+          mode: "openrouter",
+          webSearchEnabled: true,
+        },
+      },
+    });
+
+    expect(requestBody).toMatchObject({
+      model: "openai/gpt-5.4",
+      tools: [
+        {
+          type: "openrouter:web_search",
+        },
+      ],
+    });
+  });
+
+  it("forwards web search before image generation when both are enabled", async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      requestBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return okStreamResponse();
+    }) as typeof fetch;
+
+    const model = createSokosumiLanguageModel("openai/gpt-5.4", {
+      openRouterApiKey: "sk-or-test",
+    });
+
+    await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "A cat" }] }],
+      providerOptions: {
+        sokosumi: {
+          mode: "openrouter",
+          imageGenerationModel: "openai/gpt-5.4-image-2",
+          webSearchEnabled: true,
+        },
+      },
+    });
+
+    expect(requestBody).toMatchObject({
+      model: "openai/gpt-5.4",
+      tools: [
+        {
+          type: "openrouter:web_search",
+        },
+        {
+          type: "openrouter:image_generation",
+          parameters: {
+            model: "openai/gpt-5.4-image-2",
+            quality: "high",
+          },
+        },
+      ],
+    });
+  });
+
+  it("omits server tools when none are enabled", async () => {
     let requestBody: Record<string, unknown> | null = null;
     globalThis.fetch = vi.fn(async (_url, init) => {
       requestBody = init?.body ? JSON.parse(String(init.body)) : null;

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -136,17 +136,29 @@ export function createSokosumiLanguageModel(
       );
     }
 
-    const coworkerWarnings = sokosumiOpts.imageGenerationModel
-      ? [
-          ...promptWarnings,
-          {
-            type: "compatibility" as const,
-            feature: "openrouter:image_generation",
-            details:
-              "Image generation server tools are only forwarded in OpenRouter mode.",
-          },
-        ]
-      : promptWarnings;
+    const coworkerWarnings = [
+      ...promptWarnings,
+      ...(sokosumiOpts.imageGenerationModel
+        ? [
+            {
+              type: "compatibility" as const,
+              feature: "openrouter:image_generation",
+              details:
+                "Image generation server tools are only forwarded in OpenRouter mode.",
+            },
+          ]
+        : []),
+      ...(sokosumiOpts.webSearchEnabled
+        ? [
+            {
+              type: "compatibility" as const,
+              feature: "openrouter:web_search",
+              details:
+                "Web search server tools are only forwarded in OpenRouter mode.",
+            },
+          ]
+        : []),
+    ];
 
     return streamCoworker(coworkerWarnings, sokosumiOpts, options);
   }
@@ -179,24 +191,31 @@ async function streamOpenRouter(
   }
 
   const modelIdentifier = getModelIdentifier(modelId);
+  const tools: Array<Record<string, unknown>> = [];
+  if (sokosumiOpts.webSearchEnabled) {
+    tools.push({
+      type: "openrouter:web_search",
+      ...(sokosumiOpts.webSearchParameters
+        ? { parameters: sokosumiOpts.webSearchParameters }
+        : {}),
+    });
+  }
+  if (sokosumiOpts.imageGenerationModel) {
+    tools.push({
+      type: "openrouter:image_generation",
+      parameters: {
+        model: sokosumiOpts.imageGenerationModel,
+        quality: "high",
+      },
+    });
+  }
+
   const requestBody = {
     model: modelIdentifier,
     input: responsesInput,
     stream: true,
     max_output_tokens: config.openRouterMaxOutputTokens ?? 4096,
-    ...(sokosumiOpts.imageGenerationModel
-      ? {
-          tools: [
-            {
-              type: "openrouter:image_generation",
-              parameters: {
-                model: sokosumiOpts.imageGenerationModel,
-                quality: "high",
-              },
-            },
-          ],
-        }
-      : {}),
+    ...(tools.length > 0 ? { tools } : {}),
   };
 
   const response = await fetch(OPENROUTER_RESPONSES_URL, {

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -136,7 +136,19 @@ export function createSokosumiLanguageModel(
       );
     }
 
-    return streamCoworker(promptWarnings, sokosumiOpts, options);
+    const coworkerWarnings = sokosumiOpts.imageGenerationModel
+      ? [
+          ...promptWarnings,
+          {
+            type: "compatibility" as const,
+            feature: "openrouter:image_generation",
+            details:
+              "Image generation server tools are only forwarded in OpenRouter mode.",
+          },
+        ]
+      : promptWarnings;
+
+    return streamCoworker(coworkerWarnings, sokosumiOpts, options);
   }
 
   return {
@@ -172,6 +184,19 @@ async function streamOpenRouter(
     input: responsesInput,
     stream: true,
     max_output_tokens: config.openRouterMaxOutputTokens ?? 4096,
+    ...(sokosumiOpts.imageGenerationModel
+      ? {
+          tools: [
+            {
+              type: "openrouter:image_generation",
+              parameters: {
+                model: sokosumiOpts.imageGenerationModel,
+                quality: "high",
+              },
+            },
+          ],
+        }
+      : {}),
   };
 
   const response = await fetch(OPENROUTER_RESPONSES_URL, {

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
@@ -261,7 +261,7 @@ describe("createResponsesSseToV3Stream", () => {
     expect(completedIds).toEqual(["resp_tail_id"]);
   });
 
-  it("emits image generation tool results as markdown image text", async () => {
+  it("emits image generation tool results as transient markdown image text", async () => {
     const body = encodeSse([
       "event: response.created",
       'data: {"type":"response.created","response":{"id":"resp_image"}}',
@@ -294,6 +294,66 @@ describe("createResponsesSseToV3Stream", () => {
     );
   });
 
+  it("emits data image tool results for live preview", async () => {
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_data_image"}}',
+      `data: {"type":"response.output_item.done","item":{"type":"function_call_output","output":{"status":"ok","imageUrl":"${dataUrl}"}}}`,
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_data_image"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(text).toContain(`![Generated image](${dataUrl})`);
+  });
+
+  it("does not emit non-previewable image URL strings", async () => {
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_invalid_image"}}',
+      'data: {"type":"response.output_item.done","item":{"type":"function_call_output","output":{"status":"ok","imageUrl":"not-a-url"}}}',
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_invalid_image"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(text).not.toContain("![Generated image]");
+    expect(text).not.toContain("not-a-url");
+  });
+
   it("emits image generation tool results when output is a JSON string", async () => {
     const body = encodeSse([
       "event: response.created",
@@ -323,5 +383,37 @@ describe("createResponsesSseToV3Stream", () => {
     expect(text).toContain(
       "![Generated image](https://example.com/generated-string.png)",
     );
+  });
+
+  it("emits the same image URL again for distinct output items", async () => {
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_reused_image"}}',
+      'data: {"type":"response.output_item.done","item":{"id":"item_1","type":"function_call_output","output":{"imageUrl":"https://example.com/reused.png"}}}',
+      'data: {"type":"response.output_item.done","item":{"id":"item_2","type":"function_call_output","output":{"imageUrl":"https://example.com/reused.png"}}}',
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_reused_image","output":[{"imageUrl":"https://example.com/reused.png"}]}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(
+      text.match(/!\[Generated image\]\(https:\/\/example\.com\/reused\.png\)/g)
+        ?.length,
+    ).toBe(2);
   });
 });

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
@@ -354,6 +354,79 @@ describe("createResponsesSseToV3Stream", () => {
     expect(text).not.toContain("not-a-url");
   });
 
+  it("does not inject image markdown when assistant streams JSON text containing imageUrl", async () => {
+    const jsonLine =
+      '{"imageUrl":"https://example.com/structured-reply.json","answer":42}';
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_json_assistant"}}',
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: jsonLine,
+      })}`,
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_json_assistant"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(text).toContain(jsonLine);
+    expect(text).not.toContain("![Generated image]");
+  });
+
+  it("does not inject image markdown for message output_item.done with JSON in output_text", async () => {
+    const jsonLine =
+      '{"imageUrl":"https://example.com/not-a-generated-preview.png"}';
+    const item = {
+      type: "message",
+      id: "msg_json",
+      role: "assistant",
+      content: [{ type: "output_text", text: jsonLine }],
+    };
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_msg_item"}}',
+      `data: {"type":"response.output_item.done","item":${JSON.stringify(item)}}`,
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_msg_item"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(text).not.toContain("![Generated image]");
+    expect(text).not.toContain("not-a-generated-preview.png");
+  });
+
   it("emits image generation tool results when output is a JSON string", async () => {
     const body = encodeSse([
       "event: response.created",

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
@@ -260,4 +260,68 @@ describe("createResponsesSseToV3Stream", () => {
 
     expect(completedIds).toEqual(["resp_tail_id"]);
   });
+
+  it("emits image generation tool results as markdown image text", async () => {
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_image"}}',
+      'data: {"type":"response.output_text.delta","delta":"Here is the image:"}',
+      'data: {"type":"response.output_item.done","item":{"type":"function_call_output","output":{"status":"ok","imageUrl":"https://example.com/generated.png"}}}',
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_image"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(text).toContain("Here is the image:");
+    expect(text).toContain(
+      "![Generated image](https://example.com/generated.png)",
+    );
+  });
+
+  it("emits image generation tool results when output is a JSON string", async () => {
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_image_string"}}',
+      'data: {"type":"response.output_item.done","item":{"type":"function_call_output","output":"{\\"status\\":\\"ok\\",\\"imageUrl\\":\\"https://example.com/generated-string.png\\"}"}}',
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_image_string"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const reader = stream.getReader();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (
+        value &&
+        typeof value === "object" &&
+        "type" in value &&
+        (value as { type: string }).type === "text-delta"
+      ) {
+        text += (value as { delta?: string }).delta ?? "";
+      }
+    }
+
+    expect(text).toContain(
+      "![Generated image](https://example.com/generated-string.png)",
+    );
+  });
 });

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
@@ -68,13 +68,18 @@ function isPreviewableImageUrl(imageUrl: string): boolean {
   }
 }
 
-function collectImageUrls(value: unknown, seen = new Set<unknown>()): string[] {
-  if (typeof value === "string" && value.trim()) {
-    try {
-      return collectImageUrls(JSON.parse(value), seen);
-    } catch {
-      return [];
-    }
+/**
+ * Walks objects/arrays for image tool payload shapes (`imageUrl`, nested
+ * `image_url.url`). Does **not** JSON.parse string values: assistant text may
+ * be valid JSON (e.g. `{"imageUrl":"…"}`) and must not become synthetic image
+ * markdown.
+ */
+function collectImageUrlsFromObjectGraph(
+  value: unknown,
+  seen = new Set<unknown>(),
+): string[] {
+  if (typeof value === "string") {
+    return [];
   }
 
   if (!value || typeof value !== "object" || seen.has(value)) {
@@ -83,7 +88,7 @@ function collectImageUrls(value: unknown, seen = new Set<unknown>()): string[] {
   seen.add(value);
 
   if (Array.isArray(value)) {
-    return value.flatMap((item) => collectImageUrls(item, seen));
+    return value.flatMap((item) => collectImageUrlsFromObjectGraph(item, seen));
   }
 
   const record = value as Record<string, unknown>;
@@ -100,10 +105,41 @@ function collectImageUrls(value: unknown, seen = new Set<unknown>()): string[] {
   }
 
   for (const nested of Object.values(record)) {
-    urls.push(...collectImageUrls(nested, seen));
+    urls.push(...collectImageUrlsFromObjectGraph(nested, seen));
   }
 
   return urls;
+}
+
+function tryParseJsonObjectOrArrayString(raw: string): unknown | undefined {
+  const t = raw.trim();
+  if (
+    !(t.startsWith("{") && t.endsWith("}")) &&
+    !(t.startsWith("[") && t.endsWith("]"))
+  ) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/** `function_call_output.output` may be a JSON string; parse at most once here. */
+function collectImageUrlsFromFunctionCallOutput(
+  output: unknown,
+  seen = new Set<unknown>(),
+): string[] {
+  let root: unknown = output;
+  if (typeof output === "string" && output.trim()) {
+    const parsed = tryParseJsonObjectOrArrayString(output);
+    root = parsed !== undefined ? parsed : output;
+  }
+  if (typeof root === "string") {
+    return [];
+  }
+  return collectImageUrlsFromObjectGraph(root, seen);
 }
 
 export function createResponsesSseToV3Stream(
@@ -172,12 +208,12 @@ export function createResponsesSseToV3Stream(
         });
       }
 
-      function emitImageUrls(
-        value: unknown,
+      function emitCollectedImageUrls(
+        imageUrls: string[],
         scopeKey: string,
         source: "item" | "aggregate",
       ) {
-        for (const imageUrl of collectImageUrls(value)) {
+        for (const imageUrl of imageUrls) {
           if (!isPreviewableImageUrl(imageUrl)) {
             continue;
           }
@@ -281,7 +317,18 @@ export function createResponsesSseToV3Stream(
         } else if (chunk.type === "response.output_item.done") {
           const itemId =
             typeof chunk.item?.id === "string" ? chunk.item.id : undefined;
-          emitImageUrls(chunk.item, itemId ?? "item", "item");
+          const item = chunk.item;
+          if (item?.type === "function_call_output") {
+            const output =
+              item && "output" in item
+                ? (item as Record<string, unknown>).output
+                : undefined;
+            emitCollectedImageUrls(
+              collectImageUrlsFromFunctionCallOutput(output),
+              itemId ?? "item",
+              "item",
+            );
+          }
           if (itemId && chunk.item?.type === "reasoning") {
             delete reasoningAccumulator[itemId];
             if (reasoningStarted.has(itemId)) {
@@ -322,8 +369,16 @@ export function createResponsesSseToV3Stream(
         }
 
         const aggregateScope = responseId ?? lastKnownResponseId ?? "response";
-        emitImageUrls(chunk.output, aggregateScope, "aggregate");
-        emitImageUrls(chunk.response, aggregateScope, "aggregate");
+        emitCollectedImageUrls(
+          collectImageUrlsFromObjectGraph(chunk.output),
+          aggregateScope,
+          "aggregate",
+        );
+        emitCollectedImageUrls(
+          collectImageUrlsFromObjectGraph(chunk.response),
+          aggregateScope,
+          "aggregate",
+        );
 
         const isCompletionSignal =
           chunk.type === "response.completed" ||
@@ -395,7 +450,11 @@ export function createResponsesSseToV3Stream(
                 emitTextDelta(text);
               }
               const aggregateScope = parsed.id ?? lastKnownResponseId ?? "tail";
-              emitImageUrls(parsed.output, aggregateScope, "aggregate");
+              emitCollectedImageUrls(
+                collectImageUrlsFromObjectGraph(parsed.output),
+                aggregateScope,
+                "aggregate",
+              );
               const tailCompletionId =
                 typeof parsed.id === "string" ? parsed.id : lastKnownResponseId;
               if (

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
@@ -10,6 +10,8 @@ import { extractTextFromCompletedOutput } from "../completed-output-text.js";
 const SSE_DATA_PREFIX = "data: ";
 const SSE_DONE_MARKER = "[DONE]";
 const TEXT_BLOCK_ID = "sokosumi-output-text";
+const DATA_IMAGE_URL_REGEX =
+  /^data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,/i;
 
 export function emptyUsage(): LanguageModelV3Usage {
   return {
@@ -51,6 +53,19 @@ type SseChunk = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPreviewableImageUrl(imageUrl: string): boolean {
+  if (DATA_IMAGE_URL_REGEX.test(imageUrl)) {
+    return true;
+  }
+
+  try {
+    const protocol = new URL(imageUrl).protocol;
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
 }
 
 function collectImageUrls(value: unknown, seen = new Set<unknown>()): string[] {
@@ -113,7 +128,8 @@ export function createResponsesSseToV3Stream(
       let onResponseCompletedEmitted = false;
       const reasoningAccumulator: Record<string, string> = {};
       const reasoningStarted = new Set<string>();
-      const emittedImageUrls = new Set<string>();
+      const emittedImageKeys = new Set<string>();
+      const emittedImageUrlsFromItems = new Set<string>();
       let needNewlineBeforeNextDelta = false;
 
       function closeWithFinish() {
@@ -156,12 +172,31 @@ export function createResponsesSseToV3Stream(
         });
       }
 
-      function emitImageUrls(value: unknown) {
+      function emitImageUrls(
+        value: unknown,
+        scopeKey: string,
+        source: "item" | "aggregate",
+      ) {
         for (const imageUrl of collectImageUrls(value)) {
-          if (emittedImageUrls.has(imageUrl)) {
+          if (!isPreviewableImageUrl(imageUrl)) {
             continue;
           }
-          emittedImageUrls.add(imageUrl);
+          if (
+            source === "aggregate" &&
+            emittedImageUrlsFromItems.has(imageUrl)
+          ) {
+            continue;
+          }
+          const key = `${scopeKey}:${imageUrl}`;
+          if (emittedImageKeys.has(key)) {
+            continue;
+          }
+          emittedImageKeys.add(key);
+          if (source === "item") {
+            emittedImageUrlsFromItems.add(imageUrl);
+          }
+          // Transient live preview only. Core persists these image URLs as
+          // structured file parts and strips the markdown from contentText.
           emitTextDelta(`\n\n![Generated image](${imageUrl})\n\n`);
         }
       }
@@ -244,9 +279,9 @@ export function createResponsesSseToV3Stream(
             emitReasoningDelta(itemId, next);
           }
         } else if (chunk.type === "response.output_item.done") {
-          emitImageUrls(chunk.item);
           const itemId =
             typeof chunk.item?.id === "string" ? chunk.item.id : undefined;
+          emitImageUrls(chunk.item, itemId ?? "item", "item");
           if (itemId && chunk.item?.type === "reasoning") {
             delete reasoningAccumulator[itemId];
             if (reasoningStarted.has(itemId)) {
@@ -286,8 +321,9 @@ export function createResponsesSseToV3Stream(
           return false;
         }
 
-        emitImageUrls(chunk.output);
-        emitImageUrls(chunk.response);
+        const aggregateScope = responseId ?? lastKnownResponseId ?? "response";
+        emitImageUrls(chunk.output, aggregateScope, "aggregate");
+        emitImageUrls(chunk.response, aggregateScope, "aggregate");
 
         const isCompletionSignal =
           chunk.type === "response.completed" ||
@@ -358,7 +394,8 @@ export function createResponsesSseToV3Stream(
                 ensureTextStart();
                 emitTextDelta(text);
               }
-              emitImageUrls(parsed.output);
+              const aggregateScope = parsed.id ?? lastKnownResponseId ?? "tail";
+              emitImageUrls(parsed.output, aggregateScope, "aggregate");
               const tailCompletionId =
                 typeof parsed.id === "string" ? parsed.id : lastKnownResponseId;
               if (

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
@@ -44,10 +44,52 @@ type SseChunk = {
   id?: string;
   item_id?: string;
   status?: string;
-  item?: { type?: string; id?: string };
-  response?: { id?: string };
+  item?: { type?: string; id?: string } & Record<string, unknown>;
+  response?: { id?: string } & Record<string, unknown>;
   output?: unknown;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectImageUrls(value: unknown, seen = new Set<unknown>()): string[] {
+  if (typeof value === "string" && value.trim()) {
+    try {
+      return collectImageUrls(JSON.parse(value), seen);
+    } catch {
+      return [];
+    }
+  }
+
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectImageUrls(item, seen));
+  }
+
+  const record = value as Record<string, unknown>;
+  const urls: string[] = [];
+  if (typeof record.imageUrl === "string" && record.imageUrl.trim()) {
+    urls.push(record.imageUrl.trim());
+  }
+
+  if (isRecord(record.image_url)) {
+    const nestedUrl = record.image_url.url;
+    if (typeof nestedUrl === "string" && nestedUrl.trim()) {
+      urls.push(nestedUrl.trim());
+    }
+  }
+
+  for (const nested of Object.values(record)) {
+    urls.push(...collectImageUrls(nested, seen));
+  }
+
+  return urls;
+}
 
 export function createResponsesSseToV3Stream(
   body: ReadableStream<Uint8Array>,
@@ -71,6 +113,7 @@ export function createResponsesSseToV3Stream(
       let onResponseCompletedEmitted = false;
       const reasoningAccumulator: Record<string, string> = {};
       const reasoningStarted = new Set<string>();
+      const emittedImageUrls = new Set<string>();
       let needNewlineBeforeNextDelta = false;
 
       function closeWithFinish() {
@@ -111,6 +154,16 @@ export function createResponsesSseToV3Stream(
           id: TEXT_BLOCK_ID,
           delta,
         });
+      }
+
+      function emitImageUrls(value: unknown) {
+        for (const imageUrl of collectImageUrls(value)) {
+          if (emittedImageUrls.has(imageUrl)) {
+            continue;
+          }
+          emittedImageUrls.add(imageUrl);
+          emitTextDelta(`\n\n![Generated image](${imageUrl})\n\n`);
+        }
       }
 
       function ensureReasoningStart(id: string) {
@@ -191,6 +244,7 @@ export function createResponsesSseToV3Stream(
             emitReasoningDelta(itemId, next);
           }
         } else if (chunk.type === "response.output_item.done") {
+          emitImageUrls(chunk.item);
           const itemId =
             typeof chunk.item?.id === "string" ? chunk.item.id : undefined;
           if (itemId && chunk.item?.type === "reasoning") {
@@ -231,6 +285,9 @@ export function createResponsesSseToV3Stream(
           emitTextDelta(toSend);
           return false;
         }
+
+        emitImageUrls(chunk.output);
+        emitImageUrls(chunk.response);
 
         const isCompletionSignal =
           chunk.type === "response.completed" ||
@@ -301,6 +358,7 @@ export function createResponsesSseToV3Stream(
                 ensureTextStart();
                 emitTextDelta(text);
               }
+              emitImageUrls(parsed.output);
               const tailCompletionId =
                 typeof parsed.id === "string" ? parsed.id : lastKnownResponseId;
               if (

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -6,6 +6,7 @@ export interface SokosumiProviderCallOptions {
   sokosumiOrganizationId?: string | null;
   previousResponseId?: string | null;
   providerConversationId?: string | null;
+  imageGenerationModel?: string | null;
   onResponseStarted?: (responseId: string) => void | Promise<void>;
   onResponseCompleted?: (responseId: string) => void | Promise<void>;
   onInvalidPreviousResponseId?: () => void | Promise<void>;

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -1,3 +1,5 @@
+export type OpenRouterWebSearchParameters = Record<string, unknown>;
+
 export interface SokosumiProviderCallOptions {
   mode: "openrouter" | "coworker";
   coworkerBaseUrl?: string | null;
@@ -7,6 +9,8 @@ export interface SokosumiProviderCallOptions {
   previousResponseId?: string | null;
   providerConversationId?: string | null;
   imageGenerationModel?: string | null;
+  webSearchEnabled?: boolean;
+  webSearchParameters?: OpenRouterWebSearchParameters | null;
   onResponseStarted?: (responseId: string) => void | Promise<void>;
   onResponseCompleted?: (responseId: string) => void | Promise<void>;
   onInvalidPreviousResponseId?: () => void | Promise<void>;

--- a/packages/chat/src/models/chat-models.test.ts
+++ b/packages/chat/src/models/chat-models.test.ts
@@ -4,6 +4,7 @@ import {
   CHAT_MODELS,
   chatModelSupportsImageGeneration,
   chatModelSupportsImageInput,
+  chatModelSupportsWebSearch,
   getChatModelImageGenerationOpenRouterId,
   getModelIdentifier,
 } from "./chat-models.js";
@@ -17,6 +18,7 @@ describe("chat models", () => {
           name: "MiMo V2.5 Pro",
           openRouterId: "xiaomi/mimo-v2.5-pro",
           inputModalities: ["text"],
+          webSearch: true,
         }),
         expect.objectContaining({
           id: "kimi-k2-6",
@@ -35,6 +37,7 @@ describe("chat models", () => {
           name: "GPT-5.4",
           openRouterId: "openai/gpt-5.4",
           inputModalities: ["text", "image"],
+          webSearch: true,
           imageGenerationOpenRouterId: "openai/gpt-5.4-image-2",
         }),
       ]),
@@ -101,5 +104,19 @@ describe("chat models", () => {
     expect(chatModelSupportsImageInput("gpt-4o")).toBe(true);
     expect(chatModelSupportsImageInput("gpt-4")).toBe(false);
     expect(chatModelSupportsImageInput("mixtral-8x22b")).toBe(false);
+  });
+
+  it("reports web search support per catalog and legacy ids", () => {
+    expect(chatModelSupportsWebSearch("mimo-v2-5-pro")).toBe(true);
+    expect(chatModelSupportsWebSearch("deepseek-v4-pro")).toBe(true);
+    expect(chatModelSupportsWebSearch("kimi-k2-6")).toBe(true);
+    expect(chatModelSupportsWebSearch("gpt-5-4")).toBe(true);
+    expect(chatModelSupportsWebSearch(null)).toBe(true);
+    expect(chatModelSupportsWebSearch("kimi-k2-5")).toBe(true);
+    expect(chatModelSupportsWebSearch("deepseek-v3-2")).toBe(true);
+    expect(chatModelSupportsWebSearch("gpt-4o")).toBe(true);
+    expect(chatModelSupportsWebSearch("gpt-4")).toBe(true);
+    expect(chatModelSupportsWebSearch("mixtral-8x22b")).toBe(true);
+    expect(chatModelSupportsWebSearch("unknown-model")).toBe(true);
   });
 });

--- a/packages/chat/src/models/chat-models.test.ts
+++ b/packages/chat/src/models/chat-models.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { CHAT_MODELS, getModelIdentifier } from "./chat-models.js";
+import {
+  CHAT_MODELS,
+  chatModelSupportsImageGeneration,
+  chatModelSupportsImageInput,
+  getChatModelImageGenerationOpenRouterId,
+  getModelIdentifier,
+} from "./chat-models.js";
 
 describe("chat models", () => {
   it("registers upgraded OpenRouter model slugs", () => {
@@ -10,24 +16,52 @@ describe("chat models", () => {
           id: "mimo-v2-5-pro",
           name: "MiMo V2.5 Pro",
           openRouterId: "xiaomi/mimo-v2.5-pro",
+          inputModalities: ["text"],
         }),
         expect.objectContaining({
           id: "kimi-k2-6",
           name: "Kimi K2.6",
           openRouterId: "moonshotai/kimi-k2.6",
+          inputModalities: ["text", "image"],
         }),
         expect.objectContaining({
           id: "deepseek-v4-pro",
           name: "DeepSeek V4 Pro",
           openRouterId: "deepseek/deepseek-v4-pro",
+          inputModalities: ["text"],
         }),
         expect.objectContaining({
           id: "gpt-5-4",
           name: "GPT-5.4",
           openRouterId: "openai/gpt-5.4",
+          inputModalities: ["text", "image"],
+          imageGenerationOpenRouterId: "openai/gpt-5.4-image-2",
         }),
       ]),
     );
+  });
+
+  it("registers image generation pair slugs for supported models", () => {
+    expect(getChatModelImageGenerationOpenRouterId("gpt-5-4")).toBe(
+      "openai/gpt-5.4-image-2",
+    );
+    expect(
+      getChatModelImageGenerationOpenRouterId("gemini-3-flash-preview"),
+    ).toBe("google/gemini-3.1-flash-image-preview");
+    expect(getChatModelImageGenerationOpenRouterId("gpt-5-2")).toBe(
+      "openai/gpt-5.4-image-2",
+    );
+    expect(getChatModelImageGenerationOpenRouterId(null)).toBe(
+      "openai/gpt-5.4-image-2",
+    );
+    expect(getChatModelImageGenerationOpenRouterId("grok-4-1-fast")).toBeNull();
+    expect(getChatModelImageGenerationOpenRouterId("unknown-model")).toBeNull();
+
+    expect(chatModelSupportsImageGeneration("gpt-5-4")).toBe(true);
+    expect(chatModelSupportsImageGeneration("gemini-3-flash-preview")).toBe(
+      true,
+    );
+    expect(chatModelSupportsImageGeneration("grok-4-1-fast")).toBe(false);
   });
 
   it("registers Claude Opus 4.7 with the OpenRouter slug", () => {
@@ -54,5 +88,18 @@ describe("chat models", () => {
       "deepseek/deepseek-v4-pro",
     );
     expect(getModelIdentifier("gpt-5-2")).toBe("openai/gpt-5.4");
+  });
+
+  it("reports image input support per catalog and legacy ids", () => {
+    expect(chatModelSupportsImageInput("mimo-v2-5-pro")).toBe(false);
+    expect(chatModelSupportsImageInput("deepseek-v4-pro")).toBe(false);
+    expect(chatModelSupportsImageInput("kimi-k2-6")).toBe(true);
+    expect(chatModelSupportsImageInput("gpt-5-4")).toBe(true);
+    expect(chatModelSupportsImageInput(null)).toBe(true);
+    expect(chatModelSupportsImageInput("kimi-k2-5")).toBe(true);
+    expect(chatModelSupportsImageInput("deepseek-v3-2")).toBe(false);
+    expect(chatModelSupportsImageInput("gpt-4o")).toBe(true);
+    expect(chatModelSupportsImageInput("gpt-4")).toBe(false);
+    expect(chatModelSupportsImageInput("mixtral-8x22b")).toBe(false);
   });
 });

--- a/packages/chat/src/models/chat-models.ts
+++ b/packages/chat/src/models/chat-models.ts
@@ -1,8 +1,14 @@
+/** Input kinds the model accepts on OpenRouter (chat). */
+export type ChatInputModality = "text" | "image";
+
 export interface ChatModel {
   id: string;
   name: string;
   iconProvider: string;
   openRouterId: string;
+  inputModalities: readonly ChatInputModality[];
+  /** OpenRouter slug used by the openrouter:image_generation server tool. */
+  imageGenerationOpenRouterId?: string;
 }
 
 export const CHAT_MODELS = [
@@ -11,42 +17,51 @@ export const CHAT_MODELS = [
     name: "MiMo V2.5 Pro",
     iconProvider: "xiaomi",
     openRouterId: "xiaomi/mimo-v2.5-pro",
+    inputModalities: ["text"] as const,
   },
   {
     id: "kimi-k2-6",
     name: "Kimi K2.6",
     iconProvider: "moonshot",
     openRouterId: "moonshotai/kimi-k2.6",
+    inputModalities: ["text", "image"] as const,
   },
   {
     id: "gemini-3-flash-preview",
     name: "Gemini 3 Flash Preview",
     iconProvider: "google",
     openRouterId: "google/gemini-3-flash-preview",
+    inputModalities: ["text", "image"] as const,
+    imageGenerationOpenRouterId: "google/gemini-3.1-flash-image-preview",
   },
   {
     id: "deepseek-v4-pro",
     name: "DeepSeek V4 Pro",
     iconProvider: "deepseek",
     openRouterId: "deepseek/deepseek-v4-pro",
+    inputModalities: ["text"] as const,
   },
   {
     id: "claude-opus-4-7",
     name: "Claude Opus 4.7",
     iconProvider: "anthropic",
     openRouterId: "anthropic/claude-opus-4.7",
+    inputModalities: ["text", "image"] as const,
   },
   {
     id: "grok-4-1-fast",
     name: "Grok 4.1 Fast",
     iconProvider: "xai",
     openRouterId: "x-ai/grok-4.1-fast",
+    inputModalities: ["text", "image"] as const,
   },
   {
     id: "gpt-5-4",
     name: "GPT-5.4",
     iconProvider: "openai",
     openRouterId: "openai/gpt-5.4",
+    inputModalities: ["text", "image"] as const,
+    imageGenerationOpenRouterId: "openai/gpt-5.4-image-2",
   },
 ] as const satisfies ReadonlyArray<ChatModel>;
 
@@ -71,6 +86,78 @@ const CHAT_MODEL_MAP = new Map<string, string>([
   ["mixtral-8x22b", "mistralai/mixtral-8x22b-instruct"],
   ["mixtral-8x7b", "mistralai/mixtral-8x7b-instruct"],
 ]);
+
+function modalitiesIncludeImage(
+  modalities: readonly ChatInputModality[],
+): boolean {
+  for (const modality of modalities) {
+    if (modality === "image") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Legacy OpenRouter slugs not listed in {@link CHAT_MODELS}. */
+const LEGACY_OPENROUTER_IMAGE_INPUT = new Map<string, boolean>([
+  ["openai/gpt-4o", true],
+  ["openai/gpt-4o-mini", true],
+  ["openai/gpt-4", false],
+  ["google/gemini-2.0-flash-001", true],
+  ["google/gemini-2.5-pro", true],
+  ["mistralai/mixtral-8x22b-instruct", false],
+  ["mistralai/mixtral-8x7b-instruct", false],
+]);
+
+export function chatModelSupportsImageInput(modelId: string | null): boolean {
+  const effectiveId = modelId ?? DEFAULT_CHAT_MODEL_ID;
+  const fromCatalog = CHAT_MODELS.find((m) => m.id === effectiveId);
+  if (fromCatalog) {
+    return modalitiesIncludeImage(fromCatalog.inputModalities);
+  }
+
+  const openRouterSlug = CHAT_MODEL_MAP.get(effectiveId);
+  if (!openRouterSlug) {
+    return chatModelSupportsImageInput(null);
+  }
+
+  const upgraded = CHAT_MODELS.find((m) => m.openRouterId === openRouterSlug);
+  if (upgraded) {
+    return modalitiesIncludeImage(upgraded.inputModalities);
+  }
+
+  return LEGACY_OPENROUTER_IMAGE_INPUT.get(openRouterSlug) ?? false;
+}
+
+function findCurrentCatalogModel(modelId: string | null): ChatModel | null {
+  const effectiveId = modelId ?? DEFAULT_CHAT_MODEL_ID;
+  const fromCatalog = CHAT_MODELS.find((model) => model.id === effectiveId);
+  if (fromCatalog) {
+    return fromCatalog;
+  }
+
+  const openRouterSlug = CHAT_MODEL_MAP.get(effectiveId);
+  if (!openRouterSlug) {
+    return null;
+  }
+
+  return (
+    CHAT_MODELS.find((model) => model.openRouterId === openRouterSlug) ?? null
+  );
+}
+
+export function getChatModelImageGenerationOpenRouterId(
+  modelId: string | null,
+): string | null {
+  return findCurrentCatalogModel(modelId)?.imageGenerationOpenRouterId ?? null;
+}
+
+export function chatModelSupportsImageGeneration(
+  modelId: string | null,
+): boolean {
+  return getChatModelImageGenerationOpenRouterId(modelId) !== null;
+}
 
 function getDefaultOpenRouterModelId(): string {
   const defaultModel = CHAT_MODELS.find(

--- a/packages/chat/src/models/chat-models.ts
+++ b/packages/chat/src/models/chat-models.ts
@@ -7,6 +7,7 @@ export interface ChatModel {
   iconProvider: string;
   openRouterId: string;
   inputModalities: readonly ChatInputModality[];
+  webSearch: boolean;
   /** OpenRouter slug used by the openrouter:image_generation server tool. */
   imageGenerationOpenRouterId?: string;
 }
@@ -18,6 +19,7 @@ export const CHAT_MODELS = [
     iconProvider: "xiaomi",
     openRouterId: "xiaomi/mimo-v2.5-pro",
     inputModalities: ["text"] as const,
+    webSearch: true,
   },
   {
     id: "kimi-k2-6",
@@ -25,6 +27,7 @@ export const CHAT_MODELS = [
     iconProvider: "moonshot",
     openRouterId: "moonshotai/kimi-k2.6",
     inputModalities: ["text", "image"] as const,
+    webSearch: true,
   },
   {
     id: "gemini-3-flash-preview",
@@ -32,6 +35,7 @@ export const CHAT_MODELS = [
     iconProvider: "google",
     openRouterId: "google/gemini-3-flash-preview",
     inputModalities: ["text", "image"] as const,
+    webSearch: true,
     imageGenerationOpenRouterId: "google/gemini-3.1-flash-image-preview",
   },
   {
@@ -40,6 +44,7 @@ export const CHAT_MODELS = [
     iconProvider: "deepseek",
     openRouterId: "deepseek/deepseek-v4-pro",
     inputModalities: ["text"] as const,
+    webSearch: true,
   },
   {
     id: "claude-opus-4-7",
@@ -47,6 +52,7 @@ export const CHAT_MODELS = [
     iconProvider: "anthropic",
     openRouterId: "anthropic/claude-opus-4.7",
     inputModalities: ["text", "image"] as const,
+    webSearch: true,
   },
   {
     id: "grok-4-1-fast",
@@ -54,6 +60,7 @@ export const CHAT_MODELS = [
     iconProvider: "xai",
     openRouterId: "x-ai/grok-4.1-fast",
     inputModalities: ["text", "image"] as const,
+    webSearch: true,
   },
   {
     id: "gpt-5-4",
@@ -61,6 +68,7 @@ export const CHAT_MODELS = [
     iconProvider: "openai",
     openRouterId: "openai/gpt-5.4",
     inputModalities: ["text", "image"] as const,
+    webSearch: true,
     imageGenerationOpenRouterId: "openai/gpt-5.4-image-2",
   },
 ] as const satisfies ReadonlyArray<ChatModel>;
@@ -110,6 +118,17 @@ const LEGACY_OPENROUTER_IMAGE_INPUT = new Map<string, boolean>([
   ["mistralai/mixtral-8x7b-instruct", false],
 ]);
 
+/** Legacy OpenRouter slugs not listed in {@link CHAT_MODELS}. */
+const LEGACY_OPENROUTER_WEB_SEARCH = new Map<string, boolean>([
+  ["openai/gpt-4o", true],
+  ["openai/gpt-4o-mini", true],
+  ["openai/gpt-4", true],
+  ["google/gemini-2.0-flash-001", true],
+  ["google/gemini-2.5-pro", true],
+  ["mistralai/mixtral-8x22b-instruct", true],
+  ["mistralai/mixtral-8x7b-instruct", true],
+]);
+
 export function chatModelSupportsImageInput(modelId: string | null): boolean {
   const effectiveId = modelId ?? DEFAULT_CHAT_MODEL_ID;
   const fromCatalog = CHAT_MODELS.find((m) => m.id === effectiveId);
@@ -157,6 +176,21 @@ export function chatModelSupportsImageGeneration(
   modelId: string | null,
 ): boolean {
   return getChatModelImageGenerationOpenRouterId(modelId) !== null;
+}
+
+export function chatModelSupportsWebSearch(modelId: string | null): boolean {
+  const effectiveId = modelId ?? DEFAULT_CHAT_MODEL_ID;
+  const currentModel = findCurrentCatalogModel(effectiveId);
+  if (currentModel) {
+    return currentModel.webSearch;
+  }
+
+  const openRouterSlug = CHAT_MODEL_MAP.get(effectiveId);
+  if (!openRouterSlug) {
+    return chatModelSupportsWebSearch(null);
+  }
+
+  return LEGACY_OPENROUTER_WEB_SEARCH.get(openRouterSlug) ?? false;
 }
 
 function getDefaultOpenRouterModelId(): string {


### PR DESCRIPTION
## Summary

Adds an optional **image generation** path for supported chat models (OpenRouter), improves **multimodal** compose (attachments + “create image” mode), and renders **file parts** and **inline generated images** in the chat transcript. The API rejects image generation when a coworker session is active or the selected model does not support it.

## Key changes

- **apps/core**: `imageGeneration` boolean on the chat request schema; resolves the OpenRouter image model via `@sokosumi/chat` and passes `imageGenerationModel` into the provider flow; returns `400` for unsupported combinations.
- **packages/chat**: Model metadata helpers (e.g. image input / image generation OpenRouter IDs) and tests.
- **packages/ai-provider**: Responses input mapping, SSE streaming, and `SokosumiLanguageModel` updates for image-generation behavior, with focused tests.
- **apps/web**: Multimodal input dropdown (upload file vs. create image), compose options plumbed through `ChatInterface` / `sendMessage` body, model selector hint for image-capable models, `ChatMessage` + message list handling for `file` parts and markdown `data:` image segments (including streaming clamp so partial base64 does not break the UI), shared `message-utils` re-export from chat-ui, i18n keys, and new components/tests (`chat-generated-image-bubble`, `generated-image-markdown`).

## Technical notes

- User-visible text extraction treats `input_text` / `output_text` parts like text; file parts are listed separately from markdown body.
- Coworker + image generation is explicitly disallowed at the API layer.

## Testing

- `pnpm --filter @sokosumi/chat test`
- `pnpm --filter @sokosumi/ai-provider test`
- `pnpm --filter core test`
- `pnpm exec vitest run` (from `apps/web`) on:
  - `src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts`
  - `src/app/(app)/chat/utils/__tests__/generated-image-markdown.test.ts`
  - `src/components/chat/__tests__/chat-generated-image-bubble.test.tsx`
  - `src/lib/chat/__tests__/conversation-api-to-ui-messages.test.ts`

## Risk / follow-ups

- Non-English locale files include some **English placeholders** for new attachment-menu strings; consider follow-up translations.
- Verify end-to-end image generation against real OpenRouter credentials in staging if not already covered.
