### PR TITLE
feat(chat): image-gen conversations and reasoning streaming improvements

### DIFF
--- a/apps/web/src/app/(app)/chat-ui/components/__tests__/message-list.test.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/__tests__/message-list.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@/components/chat/chat-model-icon", () => ({
 }));
 
 describe("MessageList", () => {
-  it("shows live reasoning for model chats", () => {
+  it("shows streaming thought summary on the assistant row for model chats when live reasoning arrives before assistant content", () => {
     const messages = [
       {
         id: "user-1",
@@ -72,7 +72,7 @@ describe("MessageList", () => {
       />,
     );
 
-    expect(screen.getByText("reasoning.thinking")).toBeInTheDocument();
+    expect(screen.getByText("reasoning.expandSteps")).toBeInTheDocument();
     expect(screen.queryByText("reasoning.processing")).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/chat-ui/components/__tests__/message-list.test.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/__tests__/message-list.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import type { UIMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Chat } from "@/app/chat/utils/types";
+
+import MessageList from "../message-list";
+
+vi.mock("next-intl", () => ({
+  useFormatter: () => ({
+    dateTime: () => "10:00",
+  }),
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/app/chat/hooks/use-scroll-to-bottom", () => ({
+  useScrollToBottom: () => ({
+    containerRef: { current: null },
+    endRef: { current: null },
+    scrollToMax: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/chat/components/chat-message", () => ({
+  default: ({ content }: { content: string }) => (
+    <div data-testid="chat-message">{content}</div>
+  ),
+}));
+
+vi.mock("@/components/chat/chat-model-icon", () => ({
+  ChatModelIcon: ({ modelName }: { modelName: string }) => (
+    <span>{modelName}</span>
+  ),
+}));
+
+describe("MessageList", () => {
+  it("shows live reasoning for model chats", () => {
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Create an image" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [],
+      },
+    ] satisfies UIMessage[];
+    const chats = [
+      {
+        id: "conversation-1",
+        title: "GPT-5.4",
+        createdAt: new Date("2026-05-05T09:00:00.000Z"),
+        updatedAt: new Date("2026-05-05T09:00:00.000Z"),
+        status: "active",
+        model: { id: "gpt-5-4", name: "GPT-5.4" },
+      },
+    ] satisfies Chat[];
+
+    render(
+      <MessageList
+        chats={chats}
+        isCoworker={false}
+        isLoading={true}
+        messages={messages}
+        reasoningMessages={[
+          { id: "reasoning-1", message: "Planning image generation" },
+        ]}
+        selectedChatId="conversation-1"
+        userImageUrl=""
+      />,
+    );
+
+    expect(screen.getByText("reasoning.thinking")).toBeInTheDocument();
+    expect(screen.queryByText("reasoning.processing")).toBeNull();
+  });
+});

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -1319,13 +1319,14 @@ export default function ChatInterface({
   const handleModelSelected = useCallback(
     async (
       model: { id: string; name: string } | null,
+      options?: { imageGeneration?: boolean },
     ): Promise<string | null> => {
       if (!model) {
         setSelectedModel(null);
         selectedModelRef.current = null;
         return null;
       }
-      const conversation = await createModelChat(model);
+      const conversation = await createModelChat(model, options);
       return conversation?.id || null;
     },
     [createModelChat, setSelectedModel],
@@ -1439,7 +1440,9 @@ export default function ChatInterface({
         if (model || selectedModel) {
           const modelToUse = model || selectedModel;
           if (modelToUse) {
-            conversationId = await handleModelSelected(modelToUse);
+            conversationId = await handleModelSelected(modelToUse, {
+              imageGeneration: imageGenerationForSend,
+            });
           }
         } else {
           const selectedCoworker =

--- a/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/message-list.tsx
@@ -145,13 +145,13 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       lastMessage?.role === "assistant" &&
       !lastMessageContent.trim() &&
       !hasMessageTextOrFileParts(lastMessage);
+    const hasLiveReasoning = reasoningMessages.length > 0;
     const showStreamReasoningInLastAssistantRow =
-      isCoworker &&
       isLoading &&
       lastAssistantHasNoContent &&
       lastMessage != null &&
       extractReasoningStepMessages(lastMessage).length === 0 &&
-      reasoningMessages.length > 0;
+      hasLiveReasoning;
     const showPendingErrorForEmptyAssistant =
       lastMessage?.role === "assistant" &&
       lastAssistantHasNoContent &&
@@ -162,9 +162,8 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         lastMessage.role !== "assistant" ||
         lastAssistantHasNoContent);
     const showReasoningLoaders =
-      isCoworker &&
       showLoadingArea &&
-      reasoningMessages.length > 0 &&
+      hasLiveReasoning &&
       !showStreamReasoningInLastAssistantRow;
     const showPendingError = showPendingErrorForEmptyAssistant;
     const showLoadingIndicator =
@@ -292,15 +291,12 @@ const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       const fileParts = getMessageFileParts(message);
       const isLastMessage = index === messagesWithTimestamps.length - 1;
       const reasoningFromParts =
-        role === "assistant" && isCoworker
-          ? extractReasoningStepMessages(message)
-          : [];
+        role === "assistant" ? extractReasoningStepMessages(message) : [];
       const showStreamOnlyThoughtBar =
         role === "assistant" &&
-        isCoworker &&
         isLastMessage &&
         reasoningFromParts.length === 0 &&
-        reasoningMessages.length > 0 &&
+        hasLiveReasoning &&
         (isLoading || content.trim().length > 0);
       const storedThoughtTiming =
         role === "assistant" && isCoworker

--- a/apps/web/src/app/(app)/chat-ui/hooks/use-chat-creation.ts
+++ b/apps/web/src/app/(app)/chat-ui/hooks/use-chat-creation.ts
@@ -67,12 +67,18 @@ export function useChatCreation({
     useState(true);
 
   const createModelChat = useCallback(
-    async (model: { id: string; name: string }) => {
+    async (
+      model: { id: string; name: string },
+      options?: { imageGeneration?: boolean },
+    ) => {
       const conversation = await createNewConversation(
         {
           model_id: model.id,
           model_name: model.name,
           type: "model",
+          ...(options?.imageGeneration === true
+            ? { image_generation: true }
+            : {}),
         },
         model.name,
       );

--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts
@@ -243,6 +243,29 @@ describe("extractReasoningStepMessages", () => {
       },
     ]);
   });
+
+  it("extracts only thought from JSON reasoning parts", () => {
+    const message = {
+      id: "json-thought",
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "reasoning" as const,
+          text: JSON.stringify({
+            action: "dalle.text2im",
+            action_input: JSON.stringify({ prompt: "Cyberpunk city" }),
+            thought: "I will generate the requested cyberpunk city image.",
+          }),
+        },
+      ],
+    };
+    expect(extractReasoningStepMessages(message)).toEqual([
+      {
+        id: "json-thought-reasoning-0",
+        message: "I will generate the requested cyberpunk city image.",
+      },
+    ]);
+  });
 });
 
 describe("getThoughtTimingMsFromMessage", () => {

--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/reasoning-generic-labels.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/reasoning-generic-labels.test.ts
@@ -22,4 +22,29 @@ describe("getReasoningStepDisplayText", () => {
       "_thought\nBody",
     );
   });
+
+  it("extracts thought from ReAct JSON reasoning objects", () => {
+    const raw = JSON.stringify({
+      action: "dalle.text2im",
+      action_input: JSON.stringify({ prompt: "Cyberpunk city" }),
+      thought:
+        "I will generate a high-detail cyberpunk city landscape with neon lights.",
+    });
+
+    expect(getReasoningStepDisplayText(raw)).toBe(
+      "I will generate a high-detail cyberpunk city landscape with neon lights.",
+    );
+  });
+
+  it("extracts thought from numeric-prefixed JSON reasoning objects", () => {
+    const raw = `0${JSON.stringify({
+      action: "dalle.text2im",
+      action_input: JSON.stringify({ prompt: "Cyberpunk city" }),
+      thought: "I will generate the requested image.",
+    })}`;
+
+    expect(getReasoningStepDisplayText(raw)).toBe(
+      "I will generate the requested image.",
+    );
+  });
 });

--- a/apps/web/src/app/(app)/chat-ui/utils/reasoning-generic-labels.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/reasoning-generic-labels.ts
@@ -1,9 +1,39 @@
+import { findJsonObjectEnd } from "@sokosumi/utils";
+
 const REASONING_GENERIC_LABELS = new Set([
   "Processing...",
   "Thinking...",
   "Searching files...",
   "Calling tools...",
 ]);
+
+function extractThoughtFromJsonObject(raw: string): string | null {
+  const candidate = raw
+    .trim()
+    .replace(/^\d+(?=\s*\{)/, "")
+    .trimStart();
+  if (!candidate.startsWith("{")) {
+    return null;
+  }
+
+  const jsonEnd = findJsonObjectEnd(candidate, 0);
+  if (jsonEnd === -1 || candidate.slice(jsonEnd).trim() !== "") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(candidate) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const thought = (parsed as Record<string, unknown>).thought;
+    return typeof thought === "string" && thought.trim()
+      ? thought.trim()
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 export function isReasoningGenericLabel(message: string): boolean {
   return REASONING_GENERIC_LABELS.has(message) || message.trim() === "";
@@ -13,6 +43,10 @@ export function getReasoningStepDisplayText(raw: string): string | null {
   const s = raw.trim();
   if (isReasoningGenericLabel(s)) {
     return null;
+  }
+  const thought = extractThoughtFromJsonObject(s);
+  if (thought) {
+    return thought;
   }
   return s;
 }

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.test.ts
@@ -671,6 +671,47 @@ describe("createResponsesSseToV3Stream", () => {
     expect(reasoning["react-thought"]).toBeUndefined();
   });
 
+  it("flushes oversized ambiguous ReAct candidates while preserving reasoning", async () => {
+    const ambiguousText = `{${"x".repeat(17_000)}`;
+    const body = encodeSse([
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_ambiguous_react"}}',
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: ambiguousText,
+      })}`,
+      'data: {"type":"response.output_item.added","item":{"type":"reasoning","id":"rs_ambiguous"}}',
+      'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_ambiguous","delta":"I can keep reasoning while text is ambiguous."}',
+      'data: {"type":"response.output_text.delta","delta":" still visible"}',
+      'data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"rs_ambiguous"}}',
+      "event: response.completed",
+      'data: {"type":"response.completed","status":"completed","response":{"id":"resp_ambiguous_react"}}',
+      "data: [DONE]",
+    ]);
+
+    const stream = createImageGenerationStream(body);
+    const reader = stream.getReader();
+    const textDeltas: string[] = [];
+    const reasoning: Record<string, string> = {};
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || typeof value !== "object" || !("type" in value)) continue;
+      if (value.type === "text-delta") {
+        textDeltas.push(value.delta);
+      }
+      if (value.type === "reasoning-delta") {
+        reasoning[value.id] = `${reasoning[value.id] ?? ""}${value.delta}`;
+      }
+    }
+
+    expect(textDeltas).toEqual([ambiguousText, " still visible"]);
+    expect(reasoning.rs_ambiguous).toBe(
+      "I can keep reasoning while text is ambiguous.",
+    );
+  });
+
   it("suppresses ReAct JSON while preserving function_call_output image previews", async () => {
     const envelope = {
       action: "openrouter_image_generation",

--- a/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v3-stream.ts
@@ -16,6 +16,7 @@ const SSE_DATA_PREFIX = "data: ";
 const SSE_DONE_MARKER = "[DONE]";
 const TEXT_BLOCK_ID = "sokosumi-output-text";
 const REACT_THOUGHT_ID = "react-thought";
+const MAX_REACT_ENVELOPE_BUFFER_CHARS = 16_384;
 const DATA_IMAGE_URL_REGEX =
   /^data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,/i;
 
@@ -299,6 +300,11 @@ export function createResponsesSseToV3Stream(
 
         const parsed = parseReactEnvelopeBuffer(pendingReactEnvelopeText);
         if (parsed.status === "incomplete") {
+          if (
+            pendingReactEnvelopeText.length > MAX_REACT_ENVELOPE_BUFFER_CHARS
+          ) {
+            flushPendingReactEnvelopeText();
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary

This improves model chats that use image generation: new conversations persist the image-generation flag, the message list surfaces streaming reasoning for model chats (not only coworkers), reasoning labels extract readable `thought` text from ReAct-style JSON payloads, and the Responses SSE adapter avoids unbounded buffering when ReAct envelope parsing stays ambiguous.

## Key changes

- **Web — conversation creation**: `useChatCreation` accepts optional `{ imageGeneration }` and sends `image_generation: true` when creating a model conversation; `ChatInterface` passes this when sending with image generation enabled.
- **Web — reasoning UI**: `MessageList` no longer gates live reasoning loaders and stream-only thought bars on `isCoworker`; assistant messages extract reasoning steps for model chats where applicable.
- **Web — reasoning display**: `getReasoningStepDisplayText` parses whole-object JSON (including numeric prefixes) via `findJsonObjectEnd` from `@sokosumi/utils` and returns the `thought` field when present; aligned coverage in `extractReasoningStepMessages` tests.
- **ai-provider**: Pending ReAct envelope text is flushed when it exceeds 16,384 characters while still incomplete, so oversized ambiguous prefixes cannot stall reasoning deltas indefinitely.

## Testing

- `pnpm --filter web test src/app/(app)/chat-ui/utils/__tests__/message-utils.test.ts src/app/(app)/chat-ui/utils/__tests__/reasoning-generic-labels.test.ts src/app/(app)/chat-ui/components/__tests__/message-list.test.tsx`
- `pnpm --filter @sokosumi/ai-provider test src/stream/responses-sse-to-v3-stream.test.ts`

## Risk notes

- Broader reasoning UI for non-coworker chats may surface steps in more model contexts; confirm this matches product intent.
- Flushing oversized ambiguous ReAct buffers may change edge-case output for pathological streams; tradeoff favors bounded memory and continued reasoning delivery.
