### PR TITLE
fix(web): allowlist Core chat proxy headers to prevent Undici failures

### DIFF
--- a/apps/web/src/app/api/chat/[conversationId]/stream/route.ts
+++ b/apps/web/src/app/api/chat/[conversationId]/stream/route.ts
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import type { NextRequest } from "next/server";
 
 import { getSession } from "@/lib/auth/utils";
+import { buildCoreChatProxyHeaders } from "@/lib/clients/utils/build-core-chat-proxy-headers";
 import { getCoreApiBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 
 const CORE_CHAT_PATH = "chat" as const;
@@ -22,8 +23,9 @@ export async function GET(
   }
 
   try {
-    const requestHeaders = new Headers(await headers());
-    requestHeaders.delete("Content-Length");
+    const requestHeaders = buildCoreChatProxyHeaders(
+      new Headers(await headers()),
+    );
 
     const coreUrl = `${getCoreApiBaseUrl()}/${CORE_CHAT_PATH}/stream/${encodeURIComponent(conversationId)}`;
 

--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -82,6 +82,7 @@ describe("chat route", () => {
       headersMock.mockResolvedValue(
         createReadonlyHeaders({
           cookie: "session=abc",
+          "transfer-encoding": "chunked",
           "x-organization-slug": "my-org",
         }),
       );
@@ -124,6 +125,7 @@ describe("chat route", () => {
       expect(init.method).toBe("GET");
       expect(forwardedHeaders.get("cookie")).toBe("session=abc");
       expect(forwardedHeaders.has("content-length")).toBe(false);
+      expect(forwardedHeaders.has("transfer-encoding")).toBe(false);
     });
   });
 
@@ -151,6 +153,7 @@ describe("chat route", () => {
         createReadonlyHeaders({
           cookie: "session=abc",
           "content-length": "999",
+          "transfer-encoding": "chunked",
           "x-organization-slug": "my-org",
         }),
       );
@@ -182,6 +185,7 @@ describe("chat route", () => {
       expect(forwardedHeaders.get("x-organization-slug")).toBe("my-org");
       expect(forwardedHeaders.get("content-type")).toBe("application/json");
       expect(forwardedHeaders.has("content-length")).toBe(false);
+      expect(forwardedHeaders.has("transfer-encoding")).toBe(false);
     });
   });
 });

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { getSession } from "@/lib/auth/utils";
+import { buildCoreChatProxyHeaders } from "@/lib/clients/utils/build-core-chat-proxy-headers";
 import { getCoreApiBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 
 const CORE_CHAT_PATH = "chat" as const;
@@ -26,8 +27,9 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const requestHeaders = new Headers(await headers());
-    requestHeaders.delete("Content-Length");
+    const requestHeaders = buildCoreChatProxyHeaders(
+      new Headers(await headers()),
+    );
 
     const incoming = new URL(req.url);
     const coreSearch = new URLSearchParams(incoming.search);
@@ -71,9 +73,10 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
 
-    const requestHeaders = new Headers(await headers());
+    const requestHeaders = buildCoreChatProxyHeaders(
+      new Headers(await headers()),
+    );
     requestHeaders.set("Content-Type", "application/json");
-    requestHeaders.delete("Content-Length");
 
     const response = await fetch(`${getCoreApiBaseUrl()}/${CORE_CHAT_PATH}`, {
       method: "POST",

--- a/apps/web/src/lib/clients/utils/__tests__/build-core-chat-proxy-headers.test.ts
+++ b/apps/web/src/lib/clients/utils/__tests__/build-core-chat-proxy-headers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCoreChatProxyHeaders } from "../build-core-chat-proxy-headers";
+
+describe("buildCoreChatProxyHeaders", () => {
+  it("copies cookie, authorization, and x-organization-slug only", () => {
+    const incoming = new Headers({
+      cookie: "session=abc",
+      authorization: "Bearer token",
+      "x-organization-slug": "acme",
+      host: "app.example.com",
+      "transfer-encoding": "chunked",
+      "content-length": "42",
+    });
+
+    const out = buildCoreChatProxyHeaders(incoming);
+
+    expect(out.get("cookie")).toBe("session=abc");
+    expect(out.get("authorization")).toBe("Bearer token");
+    expect(out.get("x-organization-slug")).toBe("acme");
+    expect(out.has("host")).toBe(false);
+    expect(out.has("transfer-encoding")).toBe(false);
+    expect(out.has("content-length")).toBe(false);
+  });
+
+  it("returns empty headers when no allowlisted values are present", () => {
+    const incoming = new Headers({
+      "x-forwarded-for": "1.2.3.4",
+      "transfer-encoding": "chunked",
+    });
+
+    const out = buildCoreChatProxyHeaders(incoming);
+
+    expect([...out.keys()]).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/clients/utils/build-core-chat-proxy-headers.ts
+++ b/apps/web/src/lib/clients/utils/build-core-chat-proxy-headers.ts
@@ -1,0 +1,24 @@
+/**
+ * Builds headers for server-side `fetch()` from the Next.js app to Core.
+ *
+ * Do not pass `headers()` directly into `fetch()`: on Vercel the incoming request
+ * can include hop-by-hop headers (e.g. `transfer-encoding`). Undici rejects those
+ * on outbound requests with `InvalidArgumentError: invalid transfer-encoding header`,
+ * which surfaces as `TypeError: fetch failed` and a 500 from `/api/chat`.
+ */
+export function buildCoreChatProxyHeaders(headerSource: Headers): Headers {
+  const out = new Headers();
+  const cookie = headerSource.get("cookie");
+  if (cookie) {
+    out.set("cookie", cookie);
+  }
+  const authorization = headerSource.get("authorization");
+  if (authorization) {
+    out.set("authorization", authorization);
+  }
+  const organizationSlug = headerSource.get("x-organization-slug");
+  if (organizationSlug) {
+    out.set("x-organization-slug", organizationSlug);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Server-side chat routes forward the browser request to Core with `fetch()`. Copying all incoming `headers()` values can include hop-by-hop fields such as `transfer-encoding`, which Undici rejects on outbound requests and surfaces as `TypeError: fetch failed` and a 500 from `/api/chat`. This change builds an explicit allowlist for Core proxy requests instead of forwarding the full header bag.

## Key changes

- Add `buildCoreChatProxyHeaders()` to copy only `cookie`, `authorization`, and `x-organization-slug` from the incoming request.
- Use it in `GET`/`POST` `/api/chat` and the conversation stream route in place of mutating a cloned `Headers` instance.
- Extend route tests to assert `transfer-encoding` is not forwarded; add unit tests for the helper.

## Testing

- `pnpm --filter web test apps/web/src/lib/clients/utils/__tests__/build-core-chat-proxy-headers.test.ts`
- `pnpm --filter web test apps/web/src/app/api/chat/__tests__/route.test.ts`

## Risk / notes

- Any header required for Core that is not in the allowlist will no longer be forwarded. Current contract assumes session cookie, optional bearer auth, and organization slug only.
