### PR TITLE
fix(core): recover from resumable UI stream Redis ack timeout

### DIFF
--- a/apps/core/src/routes/v1/chat/stream-get.test.ts
+++ b/apps/core/src/routes/v1/chat/stream-get.test.ts
@@ -120,6 +120,25 @@ describe("GET /chat/stream/:conversationId", () => {
     expect(resumeExistingStreamMock).not.toHaveBeenCalled();
   });
 
+  it("returns 204 and clears stale id when resume throws ack timeout", async () => {
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { active_ui_stream_id: "stream_slow" },
+    });
+    resumeExistingStreamMock.mockRejectedValueOnce(
+      new Error("Timeout waiting for ack"),
+    );
+
+    const app = createApp();
+    const response = await app.request(`http://localhost/stream/${cid}`);
+
+    expect(response.status).toBe(204);
+    expect(clearActiveUiStreamIdInMetadataMock).toHaveBeenCalledWith({
+      conversationId: cid,
+      userId: "user_123",
+    });
+  });
+
   it("returns 204 and clears stale id when resume returns null", async () => {
     conversationFindFirstMock.mockResolvedValueOnce({
       id: cid,

--- a/apps/core/src/routes/v1/chat/stream-get.ts
+++ b/apps/core/src/routes/v1/chat/stream-get.ts
@@ -18,6 +18,11 @@ import {
 } from "@/lib/resumable-ui-stream-context";
 import { requireUserContext } from "@/middleware/auth";
 
+/** `resumable-stream` rejects with this after a fixed ~1s Redis pub/sub handshake timeout. */
+function isResumableStreamAckTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.message === "Timeout waiting for ack";
+}
+
 const route = createRoute({
   method: "get",
   path: "/stream/{conversationId}",
@@ -82,7 +87,29 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     }
 
     const ctx = getResumableUiStreamContext();
-    const resumed = await ctx.resumeExistingStream(activeStreamId);
+    let resumed;
+    try {
+      resumed = await ctx.resumeExistingStream(activeStreamId);
+    } catch (error) {
+      if (!isResumableStreamAckTimeoutError(error)) {
+        throw error;
+      }
+      console.warn(
+        "Resumable UI stream resume timed out waiting for Redis ack (likely slow Redis or cross-instance latency)",
+        { conversationId, activeStreamId },
+      );
+      void clearActiveUiStreamIdInMetadata({
+        conversationId,
+        userId: userContext.userId,
+      }).catch((clearError) => {
+        console.error(
+          "Failed to clear active UI stream id after resume ack timeout:",
+          clearError,
+        );
+      });
+      return new Response(null, { status: 204 });
+    }
+
     if (resumed == null) {
       void clearActiveUiStreamIdInMetadata({
         conversationId,


### PR DESCRIPTION
## Summary

Handles the Redis pub/sub handshake timeout from `resumable-stream` when resuming an active UI chat stream. If `resumeExistingStream` rejects with `"Timeout waiting for ack"`, the handler now logs a warning, clears the stale `active_ui_stream_id` in conversation metadata (same path as when resume returns `null`), and returns **204 No Content** so the client can recover instead of surfacing a hard error.

## Key changes

- **`apps/core/src/routes/v1/chat/stream-get.ts`**: Wrap `resumeExistingStream` in try/catch; detect ack-timeout errors via message match; `clearActiveUiStreamIdInMetadata` + 204 on timeout; rethrow other errors.
- **`apps/core/src/routes/v1/chat/stream-get.test.ts`**: New test asserting 204 + metadata clear when resume rejects with the timeout error.

## Technical notes

The `resumable-stream` library rejects with `Error` and message `Timeout waiting for ack` after a short (~1s) wait for subscription ack on Redis; slow Redis or cross-instance latency can trigger this even when the stored stream id is no longer usable. Clearing metadata aligns behavior with the existing “resume returned null” stale-id path.

## Testing

- `pnpm --filter core test apps/core/src/routes/v1/chat/stream-get.test.ts`

## Risk

Low. Scope is limited to this route; non-timeout errors still propagate unchanged.
