### PR TITLE
fix(chat-ui): resume multi-slot useChat only when active UI stream exists

### DIFF
--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/app/chat-ui/utils/chat-route-base";
 import {
   hasImageGenerationUiMessage,
+  readActiveUiStreamIdFromMetadata,
   readConversationImageGenerationFromMetadata,
 } from "@/app/chat-ui/utils/conversation-metadata";
 import {
@@ -719,6 +720,35 @@ export default function ChatInterface({
   const slot1BoundId = slotToConversation.get(1) ?? null;
   const slot2BoundId = slotToConversation.get(2) ?? null;
 
+  const { resumeSlot0, resumeSlot1, resumeSlot2 } = useMemo(() => {
+    function slotResumeFor(boundId: string | null): boolean {
+      if (!boundId) return false;
+      const meta =
+        selectedConversation?.id === boundId
+          ? (selectedConversation.metadata as
+              | Record<string, unknown>
+              | null
+              | undefined)
+          : (conversations.find((c) => c.id === boundId)?.metadata as
+              | Record<string, unknown>
+              | null
+              | undefined);
+      return readActiveUiStreamIdFromMetadata(meta) != null;
+    }
+    return {
+      resumeSlot0: slotResumeFor(slot0BoundId),
+      resumeSlot1: slotResumeFor(slot1BoundId),
+      resumeSlot2: slotResumeFor(slot2BoundId),
+    };
+  }, [
+    slot0BoundId,
+    slot1BoundId,
+    slot2BoundId,
+    conversations,
+    selectedConversation?.id,
+    selectedConversation?.metadata,
+  ]);
+
   const transport0 = useMemo(
     () => makeSlotTransport(0, CHAT_API_PATH),
     [CHAT_API_PATH],
@@ -821,7 +851,7 @@ export default function ChatInterface({
   const chat0 = useChat({
     id: SLOT_PLACEHOLDER_CHAT_IDS[0],
     messages: slot0InitialMessages,
-    resume: Boolean(slot0BoundId),
+    resume: resumeSlot0,
     transport: transport0,
     onData: onDataForSlot(0),
     onError: onErrorForSlot(0),
@@ -830,7 +860,7 @@ export default function ChatInterface({
   const chat1 = useChat({
     id: SLOT_PLACEHOLDER_CHAT_IDS[1],
     messages: slot1InitialMessages,
-    resume: Boolean(slot1BoundId),
+    resume: resumeSlot1,
     transport: transport1,
     onData: onDataForSlot(1),
     onError: onErrorForSlot(1),
@@ -839,7 +869,7 @@ export default function ChatInterface({
   const chat2 = useChat({
     id: SLOT_PLACEHOLDER_CHAT_IDS[2],
     messages: slot2InitialMessages,
-    resume: Boolean(slot2BoundId),
+    resume: resumeSlot2,
     transport: transport2,
     onData: onDataForSlot(2),
     onError: onErrorForSlot(2),

--- a/apps/web/src/app/(app)/chat-ui/utils/conversation-metadata.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/conversation-metadata.ts
@@ -1,5 +1,13 @@
 import type { UIMessage } from "ai";
 
+/** Matches `ACTIVE_UI_STREAM_ID_METADATA_KEY` in core (`active_ui_stream_id`). */
+export function readActiveUiStreamIdFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): string | null {
+  const v = metadata?.active_ui_stream_id;
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+}
+
 export function readPendingResponsesApiResponseIdFromMetadata(
   metadata: Record<string, unknown> | null | undefined,
 ): string | undefined {


### PR DESCRIPTION
## Summary

Multi-slot `useChat` instances previously set `resume: true` whenever a conversation was bound to a slot. That could trigger stream resume logic even when no server-side active UI stream existed. This change gates `resume` on presence of `active_ui_stream_id` in conversation metadata (same key as core).

## Key changes

- Add `readActiveUiStreamIdFromMetadata()` in `conversation-metadata.ts` to read and validate `active_ui_stream_id`.
- In `ChatInterface`, derive `resumeSlot0` / `resumeSlot1` / `resumeSlot2` from bound conversation metadata (selected conversation or list lookup) instead of `Boolean(slotBoundId)`.

## Technical notes

- Metadata is read as `Record<string, unknown>` consistent with existing helpers in the same module.
- `useMemo` dependencies include bound slot IDs, `conversations`, and selected conversation id/metadata so resume flags stay accurate when switching selection or when metadata updates.

## Testing

- Not run in this environment; recommend `pnpm --filter web test` and a quick manual check: open a chat with an in-flight stream vs idle bound conversation and confirm reconnect behavior matches expectations.
