### PR TITLE
feat(auth): enable Stripe customer_update on subscription checkout

### DIFF
--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -358,7 +358,7 @@ describe("web auth config", () => {
     });
   });
 
-  it("requires a billing address for subscription checkout", async () => {
+  it("configures subscription checkout for billing, tax IDs, and customer updates", async () => {
     await import("../auth");
 
     const [[config]] = stripePluginMock.mock.calls as Array<
@@ -368,6 +368,10 @@ describe("web auth config", () => {
             getCheckoutSessionParams: () => Promise<{
               params?: {
                 billing_address_collection?: string;
+                customer_update?: {
+                  address?: string;
+                  name?: string;
+                };
                 tax_id_collection?: {
                   enabled: boolean;
                 };
@@ -383,6 +387,10 @@ describe("web auth config", () => {
     expect(sessionParams).toEqual({
       params: {
         billing_address_collection: "required",
+        customer_update: {
+          address: "auto",
+          name: "auto",
+        },
         tax_id_collection: {
           enabled: true,
         },

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -694,6 +694,10 @@ export const auth = betterAuth({
         getCheckoutSessionParams: async () => ({
           params: {
             billing_address_collection: "required",
+            customer_update: {
+              address: "auto",
+              name: "auto",
+            },
             tax_id_collection: {
               enabled: true,
             },


### PR DESCRIPTION
## Summary

Subscription Checkout sessions created via the Better Auth Stripe plugin now pass Stripe’s `customer_update` options so the linked Stripe Customer’s **name** and **address** are updated automatically from Checkout when the payer completes the session. This complements existing `billing_address_collection: "required"` and `tax_id_collection.enabled: true` settings.

## Key changes

- **`getCheckoutSessionParams`** (`apps/web/src/lib/auth/auth.ts`): add `customer_update: { address: "auto", name: "auto" }` to Checkout `params`.
- **Tests** (`apps/web/src/lib/auth/__tests__/auth.test.ts`): extend expectations and typings for the mocked plugin config; rename the example test to reflect billing, tax IDs, and customer updates.

## Technical notes

- Uses [Stripe Checkout `customer_update`](https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-customer_update) so collected billing details propagate to the Customer object without extra server-side sync for those fields.

## Testing

- `pnpm --filter web test src/lib/auth/__tests__/auth.test.ts` (26 tests passed).
