### PR TITLE
fix(ai-provider): align coworker Responses with conversation and chaining

### DIFF
--- a/apps/core/.agents/skills/openai-agent-chat/references/api-reference.md
+++ b/apps/core/.agents/skills/openai-agent-chat/references/api-reference.md
@@ -27,7 +27,7 @@ const response = await openai.responses.create({
   ],
 
   // Conversation linking (pick one state strategy)
-  conversation_id: "conv_...",        // Conversations API strategy
+  conversation: "conv_...",           // Conversations API strategy
   previous_response_id: "resp_...",   // chaining strategy
   // (omit both for stateless input-array strategy)
 
@@ -276,7 +276,7 @@ Complete list of streaming event types from `responses.create({ stream: true })`
 |---|---|---|---|
 | **History ownership** | Client | OpenAI (30-day TTL) | OpenAI (no TTL) |
 | **Storage cost** | Your infra | None extra | None extra |
-| **History on reconnect** | Client must send full history | Pass only latest message | Just pass conversation_id |
+| **History on reconnect** | Client must send full history | Pass only latest message | Just pass conversation |
 | **Item management** | Manual array | None | Full CRUD |
 | **ZDR compatible** | Yes (store=false) | No | No (items persist) |
 | **Compaction** | Manual (standalone endpoint) | Auto or server-side | Auto or server-side |

--- a/packages/ai-provider/src/parse-provider-options.ts
+++ b/packages/ai-provider/src/parse-provider-options.ts
@@ -82,11 +82,11 @@ export function parseSokosumiProviderOptions(
           'providerOptions.sokosumi.sokosumiUserId is required when mode is "coworker".',
       });
     }
-    if (!providerConversationId?.trim()) {
+    if (!providerConversationId?.trim() && !previousResponseId?.trim()) {
       throw new InvalidPromptError({
         prompt: raw,
         message:
-          'providerOptions.sokosumi.providerConversationId is required when mode is "coworker".',
+          'providerOptions.sokosumi.providerConversationId or providerOptions.sokosumi.previousResponseId is required when mode is "coworker".',
       });
     }
   }

--- a/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
@@ -163,6 +163,36 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
     expect(call).toBe(1);
   });
 
+  it("preserves error body on previous_response_id-only failures (no double response.text)", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response("previous_response_not_found", { status: 400 });
+    }) as typeof fetch;
+
+    const model = createSokosumiLanguageModel("anthropic/claude-3.5-sonnet", {
+      openRouterApiKey: "sk-or-test",
+    });
+
+    await expect(
+      model.doStream({
+        prompt: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Hello" }],
+          },
+        ],
+        providerOptions: {
+          sokosumi: {
+            mode: "coworker",
+            coworkerBaseUrl: "https://cow.example/api",
+            coworkerSlug: "agent",
+            sokosumiUserId: "user-1",
+            previousResponseId: "resp_stale",
+          },
+        },
+      }),
+    ).rejects.toThrowError(/previous_response_not_found/);
+  });
+
   it("retries without conversation when the API rejects the conversation", async () => {
     const onInvalidProviderConversationId = vi.fn();
     let call = 0;

--- a/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
@@ -14,7 +14,7 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("rejects coworker mode without providerConversationId", async () => {
+  it("rejects coworker mode without providerConversationId or previousResponseId", async () => {
     const model = createSokosumiLanguageModel("anthropic/claude-3.5-sonnet", {
       openRouterApiKey: "sk-or-test",
     });
@@ -34,13 +34,13 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
     ).rejects.toBeInstanceOf(InvalidPromptError);
   });
 
-  it("sends conversation_id and omits previous_response_id when providerConversationId is set", async () => {
+  it("sends conversation only and omits previous_response_id when both are set", async () => {
     let call = 0;
     globalThis.fetch = vi.fn(async (_url, init) => {
       call++;
       const body = init?.body ? JSON.parse(String(init.body)) : {};
       const headers = (init?.headers ?? {}) as Record<string, string>;
-      expect(body.conversation_id).toBe("conv_abc");
+      expect(body.conversation).toBe("conv_abc");
       expect(body.previous_response_id).toBeUndefined();
       expect(body.input).toEqual([
         {
@@ -100,7 +100,70 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
     expect(call).toBe(1);
   });
 
-  it("retries without conversation_id when the API rejects the conversation", async () => {
+  it("sends previous_response_id without conversation when only previousResponseId is set", async () => {
+    let call = 0;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      call++;
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(body.conversation).toBeUndefined();
+      expect(body.previous_response_id).toBe("resp_only");
+      expect(body.input).toEqual([
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Only last" }],
+        },
+      ]);
+      expect(headers["X-Coworker-Slug"]).toBe("agent");
+      expect(headers["X-Sokosumi-User-Id"]).toBe("user-1");
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        },
+      );
+    }) as typeof fetch;
+
+    const model = createSokosumiLanguageModel("anthropic/claude-3.5-sonnet", {
+      openRouterApiKey: "sk-or-test",
+    });
+
+    await model.doStream({
+      prompt: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Earlier" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Old reply" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Only last" }],
+        },
+      ],
+      providerOptions: {
+        sokosumi: {
+          mode: "coworker",
+          coworkerBaseUrl: "https://cow.example/api",
+          coworkerSlug: "agent",
+          sokosumiUserId: "user-1",
+          previousResponseId: "resp_only",
+        },
+      },
+    });
+
+    expect(call).toBe(1);
+  });
+
+  it("retries without conversation when the API rejects the conversation", async () => {
     const onInvalidProviderConversationId = vi.fn();
     let call = 0;
     globalThis.fetch = vi.fn(async (_url, init) => {
@@ -111,11 +174,26 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
       expect(headers["X-Sokosumi-User-Id"]).toBe("user-1");
       expect(headers["X-Sokosumi-Organization-Id"]).toBeUndefined();
       if (call === 1) {
-        expect(body.conversation_id).toBe("conv_bad");
+        expect(body.conversation).toBe("conv_bad");
+        expect(body.previous_response_id).toBeUndefined();
+        expect(body.input).toEqual([
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Hello" }],
+          },
+        ]);
         return new Response("invalid_conversation_id", { status: 400 });
       }
-      expect(body.conversation_id).toBeUndefined();
+      expect(body.conversation).toBeUndefined();
       expect(body.previous_response_id).toBeUndefined();
+      expect(body.input).toEqual([
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Hello" }],
+        },
+      ]);
       return new Response(
         new ReadableStream({
           start(controller) {
@@ -146,6 +224,7 @@ describe("SokosumiLanguageModel coworker Conversations mode", () => {
           coworkerBaseUrl: "https://cow.example/api",
           coworkerSlug: "agent",
           sokosumiUserId: "user-1",
+          previousResponseId: "resp_old",
           providerConversationId: "conv_bad",
           onInvalidProviderConversationId,
         },

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -278,7 +278,8 @@ async function streamCoworker(
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
   options: LanguageModelV3CallOptions,
 ): Promise<LanguageModelV3StreamResult> {
-  const providerConvId = sokosumiOpts.providerConversationId!.trim();
+  const providerConvId = sokosumiOpts.providerConversationId?.trim() ?? null;
+  const previousResponseId = sokosumiOpts.previousResponseId?.trim() ?? null;
 
   const fullResponsesInput = promptToResponsesInput(options.prompt);
   const responsesInput = lastTurnToResponsesInput(options.prompt);
@@ -299,24 +300,28 @@ async function streamCoworker(
   type CoworkerResponsesBody = {
     input: typeof fullResponsesInput;
     stream: boolean;
-    conversation_id?: string;
+    conversation?: string;
+    previous_response_id?: string;
   };
 
   function buildCoworkerResponsesBody(
     input: typeof fullResponsesInput,
-    includeConversationId: boolean,
   ): CoworkerResponsesBody {
     const body: CoworkerResponsesBody = {
       input,
       stream: true,
     };
-    if (includeConversationId) {
-      body.conversation_id = providerConvId;
+    if (providerConvId) {
+      body.conversation = providerConvId;
+      return body;
+    }
+    if (previousResponseId) {
+      body.previous_response_id = previousResponseId;
     }
     return body;
   }
 
-  let body = buildCoworkerResponsesBody(responsesInput, true);
+  let body = buildCoworkerResponsesBody(responsesInput);
 
   let requestBodyForError: CoworkerResponsesBody = body;
 
@@ -347,7 +352,7 @@ async function streamCoworker(
   if (!response.ok) {
     const errorText = await response.text().catch(() => "Unknown error");
     const isInvalidConversationId =
-      Boolean(body.conversation_id) &&
+      Boolean(body.conversation) &&
       (errorText.includes("invalid_conversation") ||
         errorText.includes("conversation not found") ||
         errorText.includes("invalid_conversation_id") ||
@@ -360,7 +365,10 @@ async function streamCoworker(
           await Promise.resolve(notify());
         } catch (_error) {}
       }
-      const retryBody = buildCoworkerResponsesBody(fullResponsesInput, false);
+      const retryBody: CoworkerResponsesBody = {
+        input: fullResponsesInput,
+        stream: true,
+      };
       body = retryBody;
       requestBodyForError = retryBody;
       response = await fetch(url, {

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -321,6 +321,21 @@ async function streamCoworker(
     return body;
   }
 
+  function throwCoworkerResponsesApiError(
+    res: Response,
+    errorText: string,
+    bodyForError: CoworkerResponsesBody,
+  ): never {
+    throw new APICallError({
+      message: `Coworker Responses API error: ${res.status} ${errorText}`,
+      url,
+      requestBodyValues: bodyForError,
+      statusCode: res.status,
+      responseBody: errorText,
+      isRetryable: res.status >= 500,
+    });
+  }
+
   let body = buildCoworkerResponsesBody(responsesInput);
 
   let requestBodyForError: CoworkerResponsesBody = body;
@@ -377,19 +392,14 @@ async function streamCoworker(
         body: JSON.stringify(retryBody),
         signal: options.abortSignal,
       });
+    } else {
+      throwCoworkerResponsesApiError(response, errorText, requestBodyForError);
     }
   }
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "Unknown error");
-    throw new APICallError({
-      message: `Coworker Responses API error: ${response.status} ${errorText}`,
-      url,
-      requestBodyValues: requestBodyForError,
-      statusCode: response.status,
-      responseBody: errorText,
-      isRetryable: response.status >= 500,
-    });
+    throwCoworkerResponsesApiError(response, errorText, requestBodyForError);
   }
 
   if (!response.body) {


### PR DESCRIPTION
## Summary

Aligns Sokosumi coworker streaming with the OpenAI Responses API shape for conversation state, and allows **Responses chaining** via `previousResponseId` when no Conversations id is present.

## Key changes

- **Request body**: coworker `doStream` now sends `conversation` (not `conversation_id`) and may send `previous_response_id` when only chaining is used.
- **Validation**: `parseSokosumiProviderOptions` accepts coworker mode when either `providerConversationId` or `previousResponseId` is set (still requires `sokosumiUserId` and other coworker fields).
- **Precedence**: if both conversation id and `previousResponseId` are set, the request uses **conversation only** and omits `previous_response_id`.
- **Retry**: on invalid conversation errors, the retry request sends **full** Responses `input` with **no** `conversation` or `previous_response_id` (stateless recovery path).
- **Docs**: OpenAI agent chat skill API reference updated (`conversation_id` → `conversation`).
- **Tests**: coworker retry tests updated and extended for `previousResponseId`-only requests and retry body expectations.

## Technical notes

- Coworker `CoworkerResponsesBody` type reflects `conversation?: string` and `previous_response_id?: string`.
- Invalid-conversation detection still keys off presence of `conversation` in the failed request body.

## Testing

- `pnpm --filter @sokosumi/ai-provider test src/sokosumi-language-model.coworker-retry.test.ts` (4 tests passed locally)

## Risk / follow-ups

- Callers that still send only `conversation_id`-shaped expectations on the wire should verify the upstream coworker proxy accepts `conversation` as documented.
