### PR TITLE
fix(chat): refine coworker highlight and rename Gemini 3 Flash

### DIFF
--- a/apps/web/src/components/chat/coworker-model-selector.tsx
+++ b/apps/web/src/components/chat/coworker-model-selector.tsx
@@ -192,7 +192,9 @@ export default function CoworkerModelSelector({
                 onClick={() => handleCoworkerSelect(coworker)}
                 className={cn(
                   "hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2 rounded-sm px-2 py-2 text-sm transition-colors",
-                  selectedCoworker?.id === coworker.id && "bg-accent",
+                  !selectedModel &&
+                    selectedCoworker?.id === coworker.id &&
+                    "bg-accent",
                 )}
               >
                 <CoworkerAvatarWithSkeleton

--- a/packages/chat/src/models/chat-models.ts
+++ b/packages/chat/src/models/chat-models.ts
@@ -31,7 +31,7 @@ export const CHAT_MODELS = [
   },
   {
     id: "gemini-3-flash-preview",
-    name: "Gemini 3 Flash Preview",
+    name: "Gemini 3 Flash",
     iconProvider: "google",
     openRouterId: "google/gemini-3-flash-preview",
     inputModalities: ["text", "image"] as const,


### PR DESCRIPTION
## Summary

Two small chat UX cleanups in the coworker/model selector:

- Stop highlighting the active coworker row when a chat model is also selected, so only one selection is visually emphasized at a time.
- Rename the `gemini-3-flash-preview` display label from "Gemini 3 Flash Preview" to "Gemini 3 Flash".

## Key Changes

- `apps/web/src/components/chat/coworker-model-selector.tsx`: gate the `bg-accent` highlight on `!selectedModel` so coworker selection no longer competes with the selected model state.
- `packages/chat/src/models/chat-models.ts`: update the display name for the `gemini-3-flash-preview` entry.

## Technical Details

- Behavior is purely presentational; no API, schema, or routing changes.
- The model `id` and `openRouterId` remain unchanged, so persisted selections and OpenRouter routing are unaffected.

## Testing

- Manual: open the coworker/model selector, choose a model, then hover/select a coworker — only the model row stays highlighted.
- Manual: confirm the model dropdown lists "Gemini 3 Flash" instead of "Gemini 3 Flash Preview".

Made with [Cursor](https://cursor.com)