### PR TITLE
refactor(billing): embed Stripe billing portal in balance section

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1750,10 +1750,9 @@
         "credits": "Credits",
         "coupon": "Gutschein"
       },
-      "billingPortalTitle": "Billing-Portal",
-      "billingPortalDescription": "Öffne das Stripe-Billing-Portal, um deine Abonnements, Zahlungsdetails und Rechnungen zu verwalten.",
+      "billingPortalDescription": "Lade deine Rechnungen herunter, ändere deine Rechnungsadressen und verwalte weitere Rechnungsinformationen.",
+      "manageYourBilling": "Billing verwalten",
       "openingBillingPortal": "Wird geöffnet...",
-      "billingPortalCta": "Billing-Portal öffnen",
       "orgAccessRestrictedTitle": "Billing-Zugang eingeschränkt",
       "orgAccessRestrictedDescription": "Nur Eigentümer und Admins der Organisation können Billing-Details einsehen.",
       "orgAccessRestrictedHint": "Wechsle zu deinem persönlichen Account oder kontaktiere einen Organisations-Admin, wenn du Zugang benötigst.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1812,10 +1812,9 @@
         "credits": "Credits",
         "coupon": "Coupon"
       },
-      "billingPortalTitle": "Billing Portal",
-      "billingPortalDescription": "Open Stripe Billing Portal to manage your subscriptions, billing details, and invoices.",
+      "billingPortalDescription": "Download your invoices, change your billing addresses and manage other billing information.",
+      "manageYourBilling": "Manage your billing",
       "openingBillingPortal": "Opening...",
-      "billingPortalCta": "Open billing portal",
       "orgAccessRestrictedTitle": "Billing access restricted",
       "orgAccessRestrictedDescription": "Only organization owners and admins can view billing details for this organization.",
       "orgAccessRestrictedHint": "Switch to a personal context or contact an organization owner/admin if you need access.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1750,10 +1750,9 @@
         "credits": "Credits",
         "coupon": "Cupón"
       },
-      "billingPortalTitle": "Portal de Billing",
-      "billingPortalDescription": "Abre el portal de Billing de Stripe para gestionar tus suscripciones, datos de pago y facturas.",
+      "billingPortalDescription": "Descarga tus facturas, cambia tus direcciones de facturación y gestiona otra información de facturación.",
+      "manageYourBilling": "Gestionar facturación",
       "openingBillingPortal": "Abriendo...",
-      "billingPortalCta": "Abrir portal de Billing",
       "orgAccessRestrictedTitle": "Acceso a Billing restringido",
       "orgAccessRestrictedDescription": "Solo los propietarios y admins de la organización pueden ver los detalles de Billing.",
       "orgAccessRestrictedHint": "Cambia a tu cuenta personal o contacta a un admin de la organización si necesitas acceso.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1812,10 +1812,9 @@
         "credits": "Crédits",
         "coupon": "Code promo"
       },
-      "billingPortalTitle": "Portail de facturation",
-      "billingPortalDescription": "Ouvrez le portail de facturation Stripe pour gérer vos abonnements, vos informations de facturation et vos factures.",
+      "billingPortalDescription": "Téléchargez vos factures, modifiez vos adresses de facturation et gérez d’autres informations de facturation.",
+      "manageYourBilling": "Gérer votre facturation",
       "openingBillingPortal": "Ouverture...",
-      "billingPortalCta": "Ouvrir le portail de facturation",
       "orgAccessRestrictedTitle": "Accès à la facturation restreint",
       "orgAccessRestrictedDescription": "Seuls les propriétaires et administrateurs de l’organisation peuvent consulter les informations de facturation de cette organisation.",
       "orgAccessRestrictedHint": "Basculez vers un contexte personnel ou contactez un propriétaire/administrateur de l’organisation si vous avez besoin d’un accès.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1812,10 +1812,9 @@
         "credits": "Crediti",
         "coupon": "Coupon"
       },
-      "billingPortalTitle": "Portale di fatturazione",
-      "billingPortalDescription": "Apri il Portale di fatturazione Stripe per gestire i tuoi abbonamenti, i dettagli di fatturazione e le fatture.",
+      "billingPortalDescription": "Scarica le fatture, modifica gli indirizzi di fatturazione e gestisci altre informazioni di fatturazione.",
+      "manageYourBilling": "Gestisci la fatturazione",
       "openingBillingPortal": "Apertura in corso...",
-      "billingPortalCta": "Apri il portale di fatturazione",
       "orgAccessRestrictedTitle": "Accesso alla fatturazione limitato",
       "orgAccessRestrictedDescription": "Solo i proprietari e gli amministratori dell’organizzazione possono visualizzare i dettagli di fatturazione per questa organizzazione.",
       "orgAccessRestrictedHint": "Passa al contesto personale o contatta un proprietario/amministratore dell’organizzazione se ti serve l’accesso.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1812,10 +1812,9 @@
         "credits": "クレジット",
         "coupon": "クーポン"
       },
-      "billingPortalTitle": "請求ポータル",
-      "billingPortalDescription": "Stripe の請求ポータルを開いて、サブスクリプション、請求情報、請求書を管理します。",
+      "billingPortalDescription": "請求書をダウンロードし、請求先住所を変更し、その他の請求情報を管理できます。",
+      "manageYourBilling": "請求を管理",
       "openingBillingPortal": "開いています...",
-      "billingPortalCta": "請求ポータルを開く",
       "orgAccessRestrictedTitle": "請求へのアクセスが制限されています",
       "orgAccessRestrictedDescription": "この組織の請求情報を閲覧できるのは、組織のオーナーと管理者のみです。",
       "orgAccessRestrictedHint": "個人コンテキストに切り替えるか、アクセスが必要な場合は組織のオーナー／管理者にお問い合わせください。",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1812,10 +1812,9 @@
         "credits": "Créditos",
         "coupon": "Cupom"
       },
-      "billingPortalTitle": "Portal de cobrança",
-      "billingPortalDescription": "Abra o Portal de Cobrança da Stripe para gerenciar suas assinaturas, dados de cobrança e faturas.",
+      "billingPortalDescription": "Baixe suas faturas, altere seus endereços de cobrança e gerencie outras informações de cobrança.",
+      "manageYourBilling": "Gerenciar cobrança",
       "openingBillingPortal": "Abrindo...",
-      "billingPortalCta": "Abrir portal de cobrança",
       "orgAccessRestrictedTitle": "Acesso à cobrança restrito",
       "orgAccessRestrictedDescription": "Apenas proprietários e admins da organização podem ver os detalhes de cobrança desta organização.",
       "orgAccessRestrictedHint": "Mude para o contexto pessoal ou fale com um proprietário/admin da organização se precisar de acesso.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1812,10 +1812,9 @@
         "credits": "Créditos",
         "coupon": "Cupão"
       },
-      "billingPortalTitle": "Portal de faturação",
-      "billingPortalDescription": "Abra o Portal de faturação da Stripe para gerir as suas subscrições, os seus detalhes de faturação e as faturas.",
+      "billingPortalDescription": "Transfira as suas faturas, altere as suas moradas de faturação e gira outras informações de faturação.",
+      "manageYourBilling": "Gerir faturação",
       "openingBillingPortal": "A abrir...",
-      "billingPortalCta": "Abrir portal de faturação",
       "orgAccessRestrictedTitle": "Acesso à faturação restrito",
       "orgAccessRestrictedDescription": "Apenas os proprietários e administradores da organização podem ver os detalhes de faturação desta organização.",
       "orgAccessRestrictedHint": "Mude para um contexto pessoal ou contacte um proprietário/administrador da organização se precisar de acesso.",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1812,10 +1812,9 @@
         "credits": "积分",
         "coupon": "优惠券"
       },
-      "billingPortalTitle": "计费门户",
-      "billingPortalDescription": "打开 Stripe 计费门户以管理您的订阅、账单信息和发票。",
+      "billingPortalDescription": "下载您的发票，更改账单地址并管理其他账单信息。",
+      "manageYourBilling": "管理账单",
       "openingBillingPortal": "正在打开...",
-      "billingPortalCta": "打开计费门户",
       "orgAccessRestrictedTitle": "计费访问受限",
       "orgAccessRestrictedDescription": "只有组织所有者和管理员可以查看该组织的计费详情。",
       "orgAccessRestrictedHint": "如需访问，请切换到个人上下文，或联系组织所有者/管理员。",

--- a/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
@@ -13,7 +13,7 @@ const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
 const getSubscriptionCatalogMock = vi.fn();
 const getUserByIdMock = vi.fn();
 const zeroMarginTopUpEnabledMock = vi.fn();
-const billingPortalCardMock = vi.fn();
+const balanceBillingPortalLinkMock = vi.fn();
 const creditsSectionMock = vi.fn();
 const billingTabsMock = vi.fn();
 const organizationSubscriptionSectionMock = vi.fn();
@@ -88,13 +88,15 @@ vi.mock("@sokosumi/database/repositories", () => ({
 }));
 
 vi.mock("@/components/billing/balance-section", () => ({
-  BalanceSection: () => <div data-testid="balance-section" />,
+  BalanceSection: (props: { billingPortal?: React.ReactNode }) => (
+    <div data-testid="balance-section">{props.billingPortal}</div>
+  ),
 }));
 
-vi.mock("@/components/billing/billing-portal-card", () => ({
-  BillingPortalCard: (props: unknown) => {
-    billingPortalCardMock(props);
-    return <div data-testid="billing-portal-card" />;
+vi.mock("@/components/billing/balance-billing-portal-link", () => ({
+  BalanceBillingPortalLink: (props: unknown) => {
+    balanceBillingPortalLinkMock(props);
+    return <div data-testid="balance-billing-portal-link" />;
   },
 }));
 
@@ -342,7 +344,7 @@ describe("BillingPage", () => {
         memberCount: 2,
       }),
     );
-    expect(billingPortalCardMock).not.toHaveBeenCalled();
-    expect(view.queryByTestId("billing-portal-card")).toBeNull();
+    expect(balanceBillingPortalLinkMock).not.toHaveBeenCalled();
+    expect(view.queryByTestId("balance-billing-portal-link")).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/billing/page.tsx
+++ b/apps/web/src/app/(app)/billing/page.tsx
@@ -8,8 +8,8 @@ import { convertCentsToCredits } from "@sokosumi/utils";
 import { getTranslations } from "next-intl/server";
 import Stripe from "stripe";
 
+import { BalanceBillingPortalLink } from "@/components/billing/balance-billing-portal-link";
 import { BalanceSection } from "@/components/billing/balance-section";
-import { BillingPortalCard } from "@/components/billing/billing-portal-card";
 import { BillingTabs } from "@/components/billing/billing-tabs";
 import CouponSection from "@/components/billing/coupon-section";
 import CreditsSection from "@/components/billing/credits-section";
@@ -170,6 +170,22 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             })}
             stripeCustomerId={activeOrganization.stripeCustomerId}
             stripeCustomerLabel={t("stripeCustomerIdLabel")}
+            billingPortal={
+              activeOrganization.stripeCustomerId ? (
+                <BalanceBillingPortalLink
+                  baseReturnPath="/billing"
+                  description={t("billingPortalDescription")}
+                  generalErrorMessage={t("Errors.general")}
+                  label={t("manageYourBilling")}
+                  openingLabel={t("openingBillingPortal")}
+                  organizationId={activeOrganization.id}
+                  returnPath="/billing"
+                  unauthenticatedActionLabel={t("Errors.unauthenticatedAction")}
+                  unauthenticatedErrorMessage={t("Errors.unauthenticated")}
+                  unauthorizedErrorMessage={t("Errors.unauthorized")}
+                />
+              ) : null
+            }
           />
 
           <BillingTabs
@@ -210,22 +226,6 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
               />
             }
           />
-
-          {activeOrganization.stripeCustomerId ? (
-            <BillingPortalCard
-              baseReturnPath="/billing"
-              ctaLabel={t("billingPortalCta")}
-              description={t("billingPortalDescription")}
-              generalErrorMessage={t("Errors.general")}
-              openingLabel={t("openingBillingPortal")}
-              organizationId={activeOrganization.id}
-              returnPath="/billing"
-              title={t("billingPortalTitle")}
-              unauthenticatedActionLabel={t("Errors.unauthenticatedAction")}
-              unauthenticatedErrorMessage={t("Errors.unauthenticated")}
-              unauthorizedErrorMessage={t("Errors.unauthorized")}
-            />
-          ) : null}
         </div>
       </div>
     );
@@ -280,6 +280,20 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
           })}
           stripeCustomerId={user?.stripeCustomerId ?? null}
           stripeCustomerLabel={t("stripeCustomerIdLabel")}
+          billingPortal={
+            user?.stripeCustomerId ? (
+              <BalanceBillingPortalLink
+                baseReturnPath="/billing"
+                description={t("billingPortalDescription")}
+                generalErrorMessage={t("Errors.general")}
+                label={t("manageYourBilling")}
+                openingLabel={t("openingBillingPortal")}
+                returnPath="/billing"
+                unauthenticatedActionLabel={t("Errors.unauthenticatedAction")}
+                unauthenticatedErrorMessage={t("Errors.unauthenticated")}
+              />
+            ) : null
+          }
         />
 
         <BillingTabs
@@ -317,20 +331,6 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             />
           }
         />
-
-        {user?.stripeCustomerId ? (
-          <BillingPortalCard
-            baseReturnPath="/billing"
-            ctaLabel={t("billingPortalCta")}
-            description={t("billingPortalDescription")}
-            generalErrorMessage={t("Errors.general")}
-            openingLabel={t("openingBillingPortal")}
-            returnPath="/billing"
-            title={t("billingPortalTitle")}
-            unauthenticatedActionLabel={t("Errors.unauthenticatedAction")}
-            unauthenticatedErrorMessage={t("Errors.unauthenticated")}
-          />
-        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/billing/balance-billing-portal-link.tsx
+++ b/apps/web/src/components/billing/balance-billing-portal-link.tsx
@@ -1,63 +1,51 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { ChevronRight, Loader2, ReceiptText } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { CommonErrorCode } from "@/lib/actions";
 import {
   openOrganizationBillingPortal,
   openPersonalBillingPortal,
 } from "@/lib/actions/subscription";
 
-interface BillingPortalCardProps {
+interface BalanceBillingPortalLinkProps {
   baseReturnPath?: string;
-  ctaLabel: string;
   description: string;
   generalErrorMessage: string;
+  label: string;
   openingLabel: string;
   organizationId?: string | null;
   returnPath: string;
-  title: string;
   unauthenticatedActionLabel: string;
   unauthenticatedErrorMessage: string;
   unauthorizedErrorMessage?: string;
 }
 
-export function BillingPortalCard({
+export function BalanceBillingPortalLink({
   baseReturnPath,
-  ctaLabel,
   description,
   generalErrorMessage,
+  label,
   openingLabel,
   organizationId = null,
   returnPath,
-  title,
   unauthenticatedActionLabel,
   unauthenticatedErrorMessage,
   unauthorizedErrorMessage,
-}: BillingPortalCardProps) {
+}: BalanceBillingPortalLinkProps) {
   const router = useRouter();
   const [isPending, setIsPending] = useState(false);
 
   function resolveReturnPath(): string {
-    if (!baseReturnPath) {
-      return returnPath;
-    }
+    if (!baseReturnPath) return returnPath;
 
     const searchParams = new URLSearchParams(window.location.search);
     const tab = searchParams.get("tab");
-    if (!tab) {
-      return baseReturnPath;
-    }
+    if (!tab) return baseReturnPath;
 
     const encodedTab = encodeURIComponent(tab);
     return `${baseReturnPath}?tab=${encodedTab}`;
@@ -102,30 +90,32 @@ export function BillingPortalCard({
   }
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div className="space-y-1.5">
-          <CardTitle>{title}</CardTitle>
-          <CardDescription>{description}</CardDescription>
-        </div>
-        <Button
-          variant="outline"
-          className="self-start md:self-center"
-          disabled={isPending}
-          onClick={() => {
-            void handleOpenBillingPortal();
-          }}
-        >
-          {isPending ? (
-            <>
-              <Loader2 className="mr-2 size-4 animate-spin" />
-              {openingLabel}
-            </>
-          ) : (
-            ctaLabel
-          )}
-        </Button>
-      </CardHeader>
-    </Card>
+    <Button
+      type="button"
+      variant="ghost"
+      className="group h-auto w-full justify-start gap-3 rounded-lg p-3 text-left hover:bg-accent/60 has-[>svg]:px-3"
+      disabled={isPending}
+      aria-busy={isPending}
+      onClick={() => {
+        void handleOpenBillingPortal();
+      }}
+    >
+      <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        {isPending ? (
+          <Loader2 className="size-5 animate-spin" />
+        ) : (
+          <ReceiptText className="size-5" />
+        )}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="font-semibold text-primary">
+          {isPending ? openingLabel : label}
+        </span>
+        <span className="text-muted-foreground text-sm leading-snug whitespace-normal">
+          {description}
+        </span>
+      </span>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </Button>
   );
 }

--- a/apps/web/src/components/billing/balance-section.tsx
+++ b/apps/web/src/components/billing/balance-section.tsx
@@ -36,12 +36,7 @@ export function BalanceSection({
   return (
     <Card>
       <CardHeader className="grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-y-1.5">
-        <div
-          className={cn(
-            "col-start-1 row-span-1 flex min-w-0 flex-col gap-1",
-            billingPortal ? "sm:row-span-3" : "sm:row-span-2",
-          )}
-        >
+        <div className="col-start-1 row-span-1 flex min-w-0 flex-col gap-1 sm:row-span-2">
           <CardTitle>{title}</CardTitle>
           <CardDescription>{description}</CardDescription>
         </div>

--- a/apps/web/src/components/billing/balance-section.tsx
+++ b/apps/web/src/components/billing/balance-section.tsx
@@ -1,13 +1,18 @@
+import type { ReactNode } from "react";
+
 import { BalanceStripeCustomerRow } from "@/components/billing/balance-stripe-customer-row";
 import {
   Card,
+  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
 interface BalanceSectionProps {
+  billingPortal?: ReactNode;
   creditsLabel: string;
   description: string;
   stripeCustomerId?: null | string;
@@ -16,6 +21,7 @@ interface BalanceSectionProps {
 }
 
 export function BalanceSection({
+  billingPortal,
   creditsLabel,
   description,
   stripeCustomerId,
@@ -29,23 +35,28 @@ export function BalanceSection({
 
   return (
     <Card>
-      <CardHeader className="grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-1.5">
-        <div className="col-start-1 row-span-2 flex min-w-0 flex-col gap-1">
+      <CardHeader className="grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-y-1.5">
+        <div
+          className={cn(
+            "col-start-1 row-span-1 flex min-w-0 flex-col gap-1",
+            billingPortal ? "sm:row-span-3" : "sm:row-span-2",
+          )}
+        >
           <CardTitle>{title}</CardTitle>
           <CardDescription>{description}</CardDescription>
         </div>
         <p
           className={cn(
-            "col-start-2 justify-self-end text-right text-3xl font-semibold tracking-tight tabular-nums",
+            "col-start-1 justify-self-start text-left text-2xl font-semibold tracking-tight tabular-nums sm:col-start-2 sm:justify-self-end sm:text-right sm:text-3xl",
             stripeRow
-              ? "row-start-1 self-start"
-              : "row-span-2 row-start-1 self-start",
+              ? "self-start sm:row-start-1"
+              : "self-start sm:row-span-2 sm:row-start-1",
           )}
         >
           {creditsLabel}
         </p>
         {stripeRow ? (
-          <div className="col-start-2 row-start-2 justify-self-end self-start">
+          <div className="col-start-1 max-w-full justify-self-start self-start sm:col-start-2 sm:row-start-2 sm:justify-self-end">
             <BalanceStripeCustomerRow
               key={stripeRow.id}
               ariaLabel={stripeRow.ariaLabel}
@@ -54,6 +65,12 @@ export function BalanceSection({
           </div>
         ) : null}
       </CardHeader>
+      {billingPortal ? (
+        <CardContent>
+          <Separator />
+          <div className="pt-2">{billingPortal}</div>
+        </CardContent>
+      ) : null}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

Consolidates the Stripe Billing Portal entry point into the existing balance card instead of rendering a separate card below it. The portal is exposed as an optional `billingPortal` slot on `BalanceSection`, keeping the billing page layout calmer and reducing duplicate chrome.

## Key changes

- **Removed** `BillingPortalCard` as a standalone surface.
- **Added** `BalanceBillingPortalLink`, a small client component that preserves the previous portal-opening behavior (return path with `tab` query preservation, loading state, toast handling for auth errors).
- **Extended** `BalanceSection` with optional `billingPortal` content rendered under a separator in `CardContent`, with responsive grid tweaks so the balance amount and Stripe customer row stack cleanly on small screens.
- **Updated** `billing/page.tsx` to pass the link for both organization and personal contexts when a Stripe customer id exists.
- **i18n**: Dropped `billingPortalTitle` and `billingPortalCta`; refreshed `billingPortalDescription` copy and added `manageYourBilling` across all locale catalogs.

## Technical notes

- Server Components still own layout and translations; only the link/button interaction stays client-side (`"use client"` on `BalanceBillingPortalLink`).
- Organization flow continues to pass `organizationId` and `unauthorizedErrorMessage`; personal flow omits them as before.

## Testing

- Not run in this environment. Recommended: `pnpm --filter web test apps/web/src/app/(app)/billing/__tests__/page.test.tsx` and a quick manual check of `/billing` with and without `stripeCustomerId`, plus org vs personal context.

## Risk / follow-up

- Low functional risk: same server actions (`openOrganizationBillingPortal` / `openPersonalBillingPortal`) and return-path logic as the deleted card.
- Visual regression: verify spacing and the new inline link affordance on mobile and desktop.
