### PR TITLE
feat(web): bulk org invites and hide billing portal for enterprise

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Mitglieder gesammelt einladen",
+        "description": "Füge E-Mail-Adressen ein, um mehrere Mitglieder gleichzeitig einzuladen.",
+        "label": "E-Mail-Adressen",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Trenne E-Mail-Adressen mit Kommas, Semikolons oder Zeilenumbrüchen.",
+        "submit": "Einladungen senden",
+        "close": "Schließen",
+        "error": "Einladungen konnten nicht gesendet werden",
+        "summary": "Gesendet: {sent}. Fehlgeschlagen: {failed}.",
+        "Status": {
+          "sent": "Gesendet",
+          "failed": "Fehlgeschlagen"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "Möchtest du die Organisation wirklich verlassen?",
         "description": "Organisation \"{organization}\" verlassen.",
@@ -2316,6 +2331,7 @@
         "edit": "Bearbeiten",
         "delete": "Löschen",
         "invite": "Mitglied einladen",
+        "bulkInvite": "Mehrere einladen",
         "InvoiceEmail": {
           "title": "Rechnungs-E-Mail",
           "description": "E-Mail-Adresse für den Empfang von Rechnungen und Billing-Benachrichtigungen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Bulk invite members",
+        "description": "Paste email addresses to invite multiple members at once.",
+        "label": "Email addresses",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Separate emails with commas, semicolons, or new lines.",
+        "submit": "Send invites",
+        "close": "Close",
+        "error": "Failed to send invites",
+        "summary": "Sent: {sent}. Failed: {failed}.",
+        "Status": {
+          "sent": "Sent",
+          "failed": "Failed"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "Do you really want to leave the organization?",
         "description": "Leave the organization \"{organization}\".",
@@ -2378,6 +2393,7 @@
         "edit": "Edit",
         "delete": "Delete",
         "invite": "Invite Member",
+        "bulkInvite": "Bulk invite",
         "InvoiceEmail": {
           "title": "Invoice Email",
           "description": "Email address for receiving invoices and billing notifications",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Invitar miembros en bloque",
+        "description": "Pega direcciones de email para invitar a varios miembros a la vez.",
+        "label": "Direcciones de email",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Separa los emails con comas, punto y coma o saltos de línea.",
+        "submit": "Enviar invitaciones",
+        "close": "Cerrar",
+        "error": "No se pudieron enviar las invitaciones",
+        "summary": "Enviadas: {sent}. Fallidas: {failed}.",
+        "Status": {
+          "sent": "Enviada",
+          "failed": "Fallida"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "¿Seguro que quieres salir de la organización?",
         "description": "Salir de la organización \"{organization}\".",
@@ -2316,6 +2331,7 @@
         "edit": "Editar",
         "delete": "Eliminar",
         "invite": "Invitar miembro",
+        "bulkInvite": "Invitar en bloque",
         "InvoiceEmail": {
           "title": "Email de facturación",
           "description": "Dirección de email para recibir facturas y notificaciones de Billing",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Inviter des membres en masse",
+        "description": "Collez des adresses e-mail pour inviter plusieurs membres à la fois.",
+        "label": "Adresses e-mail",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Séparez les e-mails par des virgules, des points-virgules ou des sauts de ligne.",
+        "submit": "Envoyer les invitations",
+        "close": "Fermer",
+        "error": "Impossible d’envoyer les invitations",
+        "summary": "Envoyées : {sent}. Échouées : {failed}.",
+        "Status": {
+          "sent": "Envoyée",
+          "failed": "Échouée"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "Voulez-vous vraiment quitter l’organisation ?",
         "description": "Quitter l’organisation « {organization} ».",
@@ -2378,6 +2393,7 @@
         "edit": "Modifier",
         "delete": "Supprimer",
         "invite": "Inviter un membre",
+        "bulkInvite": "Invitation groupée",
         "InvoiceEmail": {
           "title": "E-mail de facturation",
           "description": "Adresse e-mail pour recevoir les factures et les notifications de facturation",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Invita membri in blocco",
+        "description": "Incolla gli indirizzi email per invitare più membri alla volta.",
+        "label": "Indirizzi email",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Separa le email con virgole, punti e virgola o nuove righe.",
+        "submit": "Invia inviti",
+        "close": "Chiudi",
+        "error": "Impossibile inviare gli inviti",
+        "summary": "Inviati: {sent}. Non riusciti: {failed}.",
+        "Status": {
+          "sent": "Inviato",
+          "failed": "Non riuscito"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "Vuoi davvero uscire dall’organizzazione?",
         "description": "Esci dall’organizzazione \"{organization}\".",
@@ -2378,6 +2393,7 @@
         "edit": "Modifica",
         "delete": "Elimina",
         "invite": "Invita un membro",
+        "bulkInvite": "Invita in blocco",
         "InvoiceEmail": {
           "title": "Email per le fatture",
           "description": "Indirizzo email per ricevere fatture e notifiche di fatturazione",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "メンバーを一括招待",
+        "description": "メールアドレスを貼り付けて、複数のメンバーを一度に招待します。",
+        "label": "メールアドレス",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "メールアドレスはカンマ、セミコロン、または改行で区切ってください。",
+        "submit": "招待を送信",
+        "close": "閉じる",
+        "error": "招待を送信できませんでした",
+        "summary": "送信済み: {sent}。失敗: {failed}。",
+        "Status": {
+          "sent": "送信済み",
+          "failed": "失敗"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "本当に組織から退出しますか？",
         "description": "組織「{organization}」から退出します。",
@@ -2378,6 +2393,7 @@
         "edit": "編集",
         "delete": "削除",
         "invite": "メンバーを招待",
+        "bulkInvite": "一括招待",
         "InvoiceEmail": {
           "title": "請求書送付先メール",
           "description": "請求書および請求関連の通知を受け取るメールアドレス",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Convidar membros em massa",
+        "description": "Cole endereços de e-mail para convidar vários membros de uma vez.",
+        "label": "Endereços de e-mail",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Separe os e-mails com vírgulas, ponto e vírgula ou quebras de linha.",
+        "submit": "Enviar convites",
+        "close": "Fechar",
+        "error": "Não foi possível enviar os convites",
+        "summary": "Enviados: {sent}. Falharam: {failed}.",
+        "Status": {
+          "sent": "Enviado",
+          "failed": "Falhou"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "Você realmente quer sair da organização?",
         "description": "Sair da organização \"{organization}\".",
@@ -2378,6 +2393,7 @@
         "edit": "Editar",
         "delete": "Excluir",
         "invite": "Convidar membro",
+        "bulkInvite": "Convidar em massa",
         "InvoiceEmail": {
           "title": "E-mail para faturas",
           "description": "Endereço de e-mail para receber faturas e notificações de cobrança",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "Convidar membros em massa",
+        "description": "Cole endereços de e-mail para convidar vários membros de uma só vez.",
+        "label": "Endereços de e-mail",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "Separe os e-mails com vírgulas, ponto e vírgula ou quebras de linha.",
+        "submit": "Enviar convites",
+        "close": "Fechar",
+        "error": "Não foi possível enviar os convites",
+        "summary": "Enviados: {sent}. Falhados: {failed}.",
+        "Status": {
+          "sent": "Enviado",
+          "failed": "Falhado"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "Tem a certeza de que pretende sair da organização?",
         "description": "Sair da organização \"{organization}\".",
@@ -2378,6 +2393,7 @@
         "edit": "Editar",
         "delete": "Eliminar",
         "invite": "Convidar membro",
+        "bulkInvite": "Convidar em massa",
         "InvoiceEmail": {
           "title": "E-mail de faturação",
           "description": "Endereço de e-mail para receber faturas e notificações de faturação",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -595,6 +595,21 @@
           }
         }
       },
+      "BulkInviteModal": {
+        "title": "批量邀请成员",
+        "description": "粘贴电子邮件地址，一次邀请多位成员。",
+        "label": "电子邮件地址",
+        "placeholder": "alex@example.com, sam@example.com",
+        "hint": "请使用逗号、分号或换行分隔电子邮件地址。",
+        "submit": "发送邀请",
+        "close": "关闭",
+        "error": "发送邀请失败",
+        "summary": "已发送：{sent}。失败：{failed}。",
+        "Status": {
+          "sent": "已发送",
+          "failed": "失败"
+        }
+      },
       "LeaveOrganizationModal": {
         "title": "您确定要退出该组织吗？",
         "description": "退出组织 \"{organization}\"。",
@@ -2378,6 +2393,7 @@
         "edit": "编辑",
         "delete": "删除",
         "invite": "邀请成员",
+        "bulkInvite": "批量邀请",
         "InvoiceEmail": {
           "title": "发票邮箱",
           "description": "用于接收发票和计费通知的邮箱地址",

--- a/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
@@ -347,4 +347,35 @@ describe("BillingPage", () => {
     expect(balanceBillingPortalLinkMock).not.toHaveBeenCalled();
     expect(view.queryByTestId("balance-billing-portal-link")).toBeNull();
   });
+
+  it("hides the billing portal for organization enterprise plans even with a Stripe customer", async () => {
+    getActiveOrganizationMock.mockResolvedValue({
+      _count: { members: 2 },
+      id: "org-1",
+      name: "Org One",
+      stripeCustomerId: "cus_org_1",
+    });
+    getMyMemberInOrganizationMock.mockResolvedValue({
+      role: MemberRole.OWNER,
+    });
+    zeroMarginTopUpEnabledMock.mockResolvedValue(false);
+    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      periodEnd: "2026-03-01T00:00:00.000Z",
+      plan: "enterprise",
+      seats: 10,
+    });
+
+    const { default: BillingPage } = await import("../page");
+
+    const view = render(
+      await BillingPage({
+        searchParams: Promise.resolve({
+          tab: "subscription",
+        }),
+      }),
+    );
+
+    expect(balanceBillingPortalLinkMock).not.toHaveBeenCalled();
+    expect(view.queryByTestId("balance-billing-portal-link")).toBeNull();
+  });
 });

--- a/apps/web/src/app/(app)/billing/page.tsx
+++ b/apps/web/src/app/(app)/billing/page.tsx
@@ -175,7 +175,8 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             stripeCustomerId={activeOrganization.stripeCustomerId}
             stripeCustomerLabel={t("stripeCustomerIdLabel")}
             billingPortal={
-              activeOrganization.stripeCustomerId ? (
+              activeOrganization.stripeCustomerId &&
+              currentPlan !== "enterprise" ? (
                 <BalanceBillingPortalLink
                   baseReturnPath="/billing"
                   description={t("billingPortalDescription")}
@@ -299,7 +300,7 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
           stripeCustomerId={user?.stripeCustomerId ?? null}
           stripeCustomerLabel={t("stripeCustomerIdLabel")}
           billingPortal={
-            user?.stripeCustomerId ? (
+            user?.stripeCustomerId && currentPlan !== "enterprise" ? (
               <BalanceBillingPortalLink
                 baseReturnPath="/billing"
                 description={t("billingPortalDescription")}

--- a/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-invite-button.tsx
+++ b/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-invite-button.tsx
@@ -2,7 +2,10 @@
 
 import { useTranslations } from "next-intl";
 
-import { OrganizationMemberInviteModal } from "@/components/organizations";
+import {
+  OrganizationBulkInviteModal,
+  OrganizationMemberInviteModal,
+} from "@/components/organizations";
 import { Button } from "@/components/ui/button";
 import useModal from "@/hooks/use-modal";
 
@@ -31,20 +34,43 @@ function OrganizationMemberInviteModalHost({
   );
 }
 
+function OrganizationBulkInviteModalHost({
+  open,
+  onOpenChange,
+  organizationId,
+}: OrganizationMemberInviteModalHostProps) {
+  return (
+    <OrganizationBulkInviteModal
+      open={open}
+      onOpenChange={onOpenChange}
+      organizationId={organizationId}
+    />
+  );
+}
+
 export default function OrganizationInviteButton({
   organizationId,
   className,
 }: OrganizationInviteButtonProps) {
   const t = useTranslations("App.Organizations.OrganizationDetail");
-  const { Component, showModal } = useModal(OrganizationMemberInviteModalHost, {
-    organizationId,
-  });
+  const { Component: InviteMemberModal, showModal: showInviteMemberModal } =
+    useModal(OrganizationMemberInviteModalHost, { organizationId });
+  const { Component: BulkInviteModal, showModal: showBulkInviteModal } =
+    useModal(OrganizationBulkInviteModalHost, { organizationId });
 
   return (
     <>
-      {Component}
-      <Button onClick={showModal} className={className}>
+      {InviteMemberModal}
+      {BulkInviteModal}
+      <Button onClick={showInviteMemberModal} className={className}>
         {t("invite")}
+      </Button>
+      <Button
+        onClick={showBulkInviteModal}
+        variant="outline"
+        className={className}
+      >
+        {t("bulkInvite")}
       </Button>
     </>
   );

--- a/apps/web/src/components/organizations/index.ts
+++ b/apps/web/src/components/organizations/index.ts
@@ -1,4 +1,5 @@
 export * from "./leave-organization-modal";
+export * from "./organization-bulk-invite";
 export * from "./organization-information";
 export * from "./organization-logo";
 export * from "./organization-member-invite";

--- a/apps/web/src/components/organizations/organization-bulk-invite/index.ts
+++ b/apps/web/src/components/organizations/organization-bulk-invite/index.ts
@@ -1,0 +1,1 @@
+export { default as OrganizationBulkInviteModal } from "./modal";

--- a/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
+++ b/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
@@ -87,7 +87,17 @@ export default function OrganizationBulkInviteModal({
       router.refresh();
     }
 
-    toast.success(t("summary", { sent: sentCount, failed: failedCount }));
+    const summaryMessage = t("summary", {
+      sent: sentCount,
+      failed: failedCount,
+    });
+    if (sentCount === 0) {
+      toast.error(summaryMessage);
+    } else if (failedCount > 0) {
+      toast.warning(summaryMessage);
+    } else {
+      toast.success(summaryMessage);
+    }
     setIsSubmitting(false);
   };
 

--- a/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
+++ b/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
@@ -65,40 +65,46 @@ export default function OrganizationBulkInviteModal({
     setIsSubmitting(true);
     setResults([]);
 
-    const result = await inviteOrganizationMembersBulk({
-      organizationId,
-      rawEmails,
-    });
+    try {
+      const result = await inviteOrganizationMembersBulk({
+        organizationId,
+        rawEmails,
+      });
 
-    if (!result.ok) {
-      toast.error(result.error.message ?? t("error"));
+      if (!result.ok) {
+        toast.error(result.error.message ?? t("error"));
+        return;
+      }
+
+      const nextResults = result.data.results;
+      const sentCount = nextResults.filter(
+        (row) => row.status === "sent",
+      ).length;
+      const failedCount = nextResults.length - sentCount;
+
+      setResults(nextResults);
+      setRawEmails("");
+
+      if (sentCount > 0) {
+        router.refresh();
+      }
+
+      const summaryMessage = t("summary", {
+        sent: sentCount,
+        failed: failedCount,
+      });
+      if (sentCount === 0) {
+        toast.error(summaryMessage);
+      } else if (failedCount > 0) {
+        toast.warning(summaryMessage);
+      } else {
+        toast.success(summaryMessage);
+      }
+    } catch (_error) {
+      toast.error(t("error"));
+    } finally {
       setIsSubmitting(false);
-      return;
     }
-
-    const nextResults = result.data.results;
-    const sentCount = nextResults.filter((row) => row.status === "sent").length;
-    const failedCount = nextResults.length - sentCount;
-
-    setResults(nextResults);
-    setRawEmails("");
-
-    if (sentCount > 0) {
-      router.refresh();
-    }
-
-    const summaryMessage = t("summary", {
-      sent: sentCount,
-      failed: failedCount,
-    });
-    if (sentCount === 0) {
-      toast.error(summaryMessage);
-    } else if (failedCount > 0) {
-      toast.warning(summaryMessage);
-    } else {
-      toast.success(summaryMessage);
-    }
-    setIsSubmitting(false);
   };
 
   return (

--- a/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
+++ b/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import {
+  type Dispatch,
+  type FormEvent,
+  type SetStateAction,
+  useState,
+} from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { inviteOrganizationMembersBulk } from "@/lib/actions/organization";
+
+interface OrganizationBulkInviteModalProps {
+  open: boolean;
+  onOpenChange: Dispatch<SetStateAction<boolean>>;
+  organizationId: string;
+}
+
+type BulkInviteResultRow = {
+  email: string;
+  status: "sent" | "failed";
+};
+
+export default function OrganizationBulkInviteModal({
+  open,
+  onOpenChange,
+  organizationId,
+}: OrganizationBulkInviteModalProps) {
+  const t = useTranslations("Components.Organizations.BulkInviteModal");
+  const router = useRouter();
+  const [rawEmails, setRawEmails] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [results, setResults] = useState<BulkInviteResultRow[]>([]);
+  const hasResults = results.length > 0;
+
+  const handleClose = () => {
+    setRawEmails("");
+    setResults([]);
+    onOpenChange(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isSubmitting) return;
+    if (!nextOpen) {
+      handleClose();
+      return;
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setResults([]);
+
+    const result = await inviteOrganizationMembersBulk({
+      organizationId,
+      rawEmails,
+    });
+
+    if (!result.ok) {
+      toast.error(result.error.message ?? t("error"));
+      setIsSubmitting(false);
+      return;
+    }
+
+    const nextResults = result.data.results;
+    const sentCount = nextResults.filter((row) => row.status === "sent").length;
+    const failedCount = nextResults.length - sentCount;
+
+    setResults(nextResults);
+    setRawEmails("");
+
+    if (sentCount > 0) {
+      router.refresh();
+    }
+
+    toast.success(t("summary", { sent: sentCount, failed: failedCount }));
+    setIsSubmitting(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[80svh] w-[calc(100vw-2rem)] max-w-lg! overflow-hidden">
+        <DialogTitle className="text-center">{t("title")}</DialogTitle>
+        <DialogDescription className="text-center">
+          {t("description")}
+        </DialogDescription>
+        {!hasResults ? (
+          <form onSubmit={handleSubmit} className="min-w-0 space-y-4">
+            <div className="min-w-0 space-y-2">
+              <Label htmlFor="bulk-invite-emails">{t("label")}</Label>
+              <Textarea
+                id="bulk-invite-emails"
+                value={rawEmails}
+                onChange={(event) => setRawEmails(event.target.value)}
+                placeholder={t("placeholder")}
+                disabled={isSubmitting}
+                className="max-h-36 min-h-36 max-w-full resize-none overflow-y-auto"
+              />
+              <p className="text-muted-foreground text-sm">{t("hint")}</p>
+            </div>
+            <Button type="submit" disabled={isSubmitting} className="w-full">
+              {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {t("submit")}
+            </Button>
+          </form>
+        ) : null}
+        {hasResults ? (
+          <div className="max-h-56 overflow-y-auto rounded-md border">
+            <ul className="divide-y">
+              {results.map((row) => (
+                <li
+                  key={`${row.email}-${row.status}`}
+                  className="flex items-center justify-between gap-3 px-3 py-2"
+                >
+                  <span className="truncate text-sm">{row.email}</span>
+                  <Badge
+                    variant={row.status === "sent" ? "secondary" : "outline"}
+                  >
+                    {row.status === "sent"
+                      ? t("Status.sent")
+                      : t("Status.failed")}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {hasResults ? (
+          <Button type="button" onClick={handleClose} className="w-full">
+            {t("close")}
+          </Button>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/actions/organization/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/organization/__tests__/action.test.ts
@@ -1,0 +1,228 @@
+import { MemberRole } from "@sokosumi/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+export {};
+
+const createInvitationMock = vi.fn();
+const getEnvSecretsMock = vi.fn();
+const getMemberByUserIdAndOrganizationIdMock = vi.fn();
+const headersMock = vi.fn();
+
+vi.mock("@/middleware/auth-middleware", () => ({
+  withSession:
+    (handler: (params: unknown) => Promise<unknown>) =>
+    async (params: unknown) =>
+      await handler(params),
+}));
+
+vi.mock("@/config/env.secrets", () => ({
+  getEnvSecrets: () => getEnvSecretsMock(),
+}));
+
+vi.mock("@/lib/auth/auth", () => ({
+  auth: {
+    api: {
+      createInvitation: (...args: unknown[]) => createInvitationMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/utils", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {},
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  invitationRepository: {},
+  memberRepository: {
+    getMemberByUserIdAndOrganizationId: (...args: unknown[]) =>
+      getMemberByUserIdAndOrganizationIdMock(...args),
+  },
+  organizationRepository: {},
+}));
+
+vi.mock("next/headers", () => ({
+  headers: () => headersMock(),
+}));
+
+vi.mock("@/lib/services/preferred-organization.service", () => ({
+  preferredOrganizationService: {},
+}));
+
+vi.mock("@/lib/services/stripe.service", () => ({
+  stripeService: {},
+}));
+
+const session = {
+  user: {
+    id: "user-1",
+  },
+} as never;
+
+describe("organization actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createInvitationMock.mockResolvedValue({});
+    getEnvSecretsMock.mockReturnValue({
+      BETTER_AUTH_ORG_INVITATION_LIMIT: 100,
+    });
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
+      role: MemberRole.ADMIN,
+    });
+    headersMock.mockResolvedValue(new Headers());
+  });
+
+  it("bulk invites parsed emails and preserves first-seen dedupe order", async () => {
+    const { inviteOrganizationMembersBulk } = await import("../action");
+
+    const result = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails:
+        "first@example.com, second@example.com\nFIRST@example.com; third@example.com",
+      session,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        results: [
+          { email: "first@example.com", status: "sent" },
+          { email: "second@example.com", status: "sent" },
+          { email: "third@example.com", status: "sent" },
+        ],
+      },
+    });
+    expect(createInvitationMock).toHaveBeenCalledTimes(3);
+    expect(createInvitationMock).toHaveBeenNthCalledWith(1, {
+      body: {
+        email: "first@example.com",
+        organizationId: "org-1",
+        resend: true,
+        role: MemberRole.MEMBER,
+      },
+      headers: expect.any(Headers),
+    });
+  });
+
+  it("returns sent and failed statuses for a partial batch", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    createInvitationMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("invite failed"));
+    const { inviteOrganizationMembersBulk } = await import("../action");
+
+    const result = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails: "ok@example.com, fail@example.com",
+      session,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        results: [
+          { email: "ok@example.com", status: "sent" },
+          { email: "fail@example.com", status: "failed" },
+        ],
+      },
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("rejects users who are not members of the organization", async () => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue(null);
+    const { inviteOrganizationMembersBulk } = await import("../action");
+
+    const result = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails: "member@example.com",
+      session,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "You are not a member of this organization",
+      },
+    });
+    expect(createInvitationMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects members without owner or admin permissions", async () => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
+      role: MemberRole.MEMBER,
+    });
+    const { inviteOrganizationMembersBulk } = await import("../action");
+
+    const result = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails: "member@example.com",
+      session,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Only organization owners and admins can invite members",
+      },
+    });
+    expect(createInvitationMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty or invalid email input", async () => {
+    const { inviteOrganizationMembersBulk } = await import("../action");
+
+    const emptyResult = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails: "",
+      session,
+    });
+    const invalidResult = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails: "not-an-email",
+      session,
+    });
+
+    expect(emptyResult.ok).toBe(false);
+    expect(invalidResult).toEqual({
+      ok: false,
+      error: {
+        code: "BAD_INPUT",
+        message: "Enter at least one valid email address",
+      },
+    });
+    expect(createInvitationMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects batches over the invitation limit", async () => {
+    getEnvSecretsMock.mockReturnValue({
+      BETTER_AUTH_ORG_INVITATION_LIMIT: 1,
+    });
+    const { inviteOrganizationMembersBulk } = await import("../action");
+
+    const result = await inviteOrganizationMembersBulk({
+      organizationId: "org-1",
+      rawEmails: "first@example.com, second@example.com",
+      session,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "BAD_INPUT",
+        message: "You can invite up to 1 members at a time",
+      },
+    });
+    expect(createInvitationMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/actions/organization/action.ts
+++ b/apps/web/src/lib/actions/organization/action.ts
@@ -8,17 +8,19 @@ import {
 import { getOrganizationMetadata } from "@sokosumi/utils";
 import * as z from "zod";
 
-import { type ActionError, CommonErrorCode } from "@/lib/actions";
+import { getEnvSecrets } from "@/config/env.secrets";
+import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import prisma from "@/lib/db/prisma";
 import {
   type OrganizationInformationFormSchemaType,
   organizationInformationFormSchema,
 } from "@/lib/schemas";
 import {
+  type BulkInviteResultRow,
   organizationService,
-  preferredOrganizationService,
-  stripeService,
-} from "@/lib/services";
+} from "@/lib/services/organization.service";
+import { preferredOrganizationService } from "@/lib/services/preferred-organization.service";
+import { stripeService } from "@/lib/services/stripe.service";
 import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
@@ -52,6 +54,11 @@ export async function generateOrganizationSlug(
 const updateInvoiceEmailSchema = z.object({
   organizationId: z.string(),
   invoiceEmail: z.email().nullable(),
+});
+
+const bulkInviteEmailsSchema = z.object({
+  organizationId: z.string().min(1),
+  rawEmails: z.string().min(1),
 });
 
 interface UpdateOrganizationInvoiceEmailParameters
@@ -120,6 +127,99 @@ export const updateOrganizationInvoiceEmail = withSession<
     invoiceEmail: getOrganizationMetadata(updatedOrganization.metadata)
       .invoiceEmail,
   });
+});
+
+interface InviteOrganizationMembersBulkParameters extends AuthenticatedRequest {
+  organizationId: string;
+  rawEmails: string;
+}
+
+function parseBulkInviteEmails(rawEmails: string): string[] | null {
+  const emailsByKey = new Map<string, string>();
+  const emailSchema = z.email();
+
+  for (const rawEmail of rawEmails.split(/[\n,;]+/)) {
+    const email = rawEmail.trim();
+    if (!email) continue;
+
+    if (!emailSchema.safeParse(email).success) {
+      return null;
+    }
+
+    const emailKey = email.toLowerCase();
+    if (!emailsByKey.has(emailKey)) {
+      emailsByKey.set(emailKey, email);
+    }
+  }
+
+  return Array.from(emailsByKey.values());
+}
+
+export const inviteOrganizationMembersBulk = withSession<
+  InviteOrganizationMembersBulkParameters,
+  Result<{ results: BulkInviteResultRow[] }, ActionError>
+>(async ({ organizationId, rawEmails, session }) => {
+  const parsedResult = bulkInviteEmailsSchema.safeParse({
+    organizationId,
+    rawEmails,
+  });
+  if (!parsedResult.success) {
+    return Err({
+      code: CommonErrorCode.BAD_INPUT,
+      message: parsedResult.error.issues[0]?.message,
+    });
+  }
+
+  const emails = parseBulkInviteEmails(parsedResult.data.rawEmails);
+  if (!emails || emails.length === 0) {
+    return Err({
+      code: CommonErrorCode.BAD_INPUT,
+      message: "Enter at least one valid email address",
+    });
+  }
+
+  const invitationLimit = getEnvSecrets().BETTER_AUTH_ORG_INVITATION_LIMIT;
+  if (emails.length > invitationLimit) {
+    return Err({
+      code: CommonErrorCode.BAD_INPUT,
+      message: `You can invite up to ${invitationLimit} members at a time`,
+    });
+  }
+
+  const member = await memberRepository.getMemberByUserIdAndOrganizationId(
+    session.user.id,
+    parsedResult.data.organizationId,
+    prisma,
+  );
+
+  if (!member) {
+    return Err({
+      code: CommonErrorCode.UNAUTHORIZED,
+      message: "You are not a member of this organization",
+    });
+  }
+
+  if (member.role !== MemberRole.OWNER && member.role !== MemberRole.ADMIN) {
+    return Err({
+      code: CommonErrorCode.UNAUTHORIZED,
+      message: "Only organization owners and admins can invite members",
+    });
+  }
+
+  try {
+    return Ok(
+      await organizationService.inviteMultipleMembers(
+        parsedResult.data.organizationId,
+        emails,
+        MemberRole.MEMBER,
+      ),
+    );
+  } catch (error) {
+    console.error("Failed to bulk invite organization members", error);
+    return Err({
+      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+    });
+  }
 });
 
 const updatePreferredOrganizationSchema = z.object({

--- a/apps/web/src/lib/services/organization.service.ts
+++ b/apps/web/src/lib/services/organization.service.ts
@@ -18,6 +18,11 @@ import { auth } from "@/lib/auth/auth";
 import { getSession } from "@/lib/auth/utils";
 import prisma from "@/lib/db/prisma";
 
+export type BulkInviteResultRow = {
+  email: string;
+  status: "sent" | "failed";
+};
+
 /**
  * Service for organization and invitations related operations.
  * Provides methods to get members and pending invitations for the current user.
@@ -171,30 +176,44 @@ export const organizationService = (() => {
 
   /**
    * Invites multiple members to an organization in batch.
+   * Callers must verify the current user can invite members before calling.
    *
    * @param organizationId - The ID of the organization.
    * @param emails - Array of email addresses to invite.
    * @param role - The role to assign to invited members.
-   * @returns Promise that resolves when all invitations are sent.
+   * @returns Promise that resolves with one status row per email.
    */
   async function inviteMultipleMembers(
     organizationId: string,
     emails: string[],
     role: MemberRole,
-  ): Promise<void> {
+  ): Promise<{ results: BulkInviteResultRow[] }> {
     const headersList = await headers();
+    const results: BulkInviteResultRow[] = [];
 
     for (const email of emails) {
-      await auth.api.createInvitation({
-        body: {
+      try {
+        await auth.api.createInvitation({
+          body: {
+            email,
+            role,
+            organizationId,
+            resend: true,
+          },
+          headers: headersList,
+        });
+        results.push({ email, status: "sent" });
+      } catch (error) {
+        console.error("Failed to invite organization member", {
           email,
-          role,
           organizationId,
-          resend: true,
-        },
-        headers: headersList,
-      });
+          error,
+        });
+        results.push({ email, status: "failed" });
+      }
     }
+
+    return { results };
   }
 
   return {


### PR DESCRIPTION
## Summary

- Adds bulk organization member invites: paste multiple emails (comma, semicolon, or newline separated), server-side parsing and deduplication, per-email success/failure results, and localized UI strings across supported locales.
- Hides the Stripe balance billing portal link on the billing page when the active plan is enterprise (for both organization and personal contexts), with a regression test.

## Key changes

- New `OrganizationBulkInviteModal` and outline **Bulk invite** button next to single **Invite member** on the organization detail invite control.
- New `inviteOrganizationMembersBulk` server action: validates input, enforces `BETTER_AUTH_ORG_INVITATION_LIMIT`, checks owner/admin membership, calls `organizationService.inviteMultipleMembers`.
- `inviteMultipleMembers` now wraps each Better Auth `createInvitation` in try/catch and returns `{ results: { email, status }[] }` instead of failing the whole batch on one error.
- Billing: `BalanceBillingPortalLink` is only rendered when there is a Stripe customer **and** `currentPlan !== "enterprise"`.

## Test plan

- [x] `pnpm --filter web test src/lib/actions/organization/__tests__/action.test.ts src/app/(app)/billing/__tests__/page.test.tsx`
- [ ] Manual: organization page — bulk invite with valid/invalid mix; confirm summary and toasts.
- [ ] Manual: billing subscription tab as enterprise — confirm billing portal link is hidden despite `stripeCustomerId`.

## Risks / notes

- Enterprise customers with self-serve Stripe expectations will no longer see the portal link in-app; confirm product intent for that segment.
