### PR TITLE
chore(database): drop unused coworker supportsConversationsApi column

### DIFF
--- a/packages/database/prisma/migrations/20260526120000_drop_coworker_supports_conversations_api/migration.sql
+++ b/packages/database/prisma/migrations/20260526120000_drop_coworker_supports_conversations_api/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "coworker" DROP COLUMN "supportsConversationsApi";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1156,8 +1156,6 @@ model Coworker {
   image       String?
   metadata    Json?
 
-  supportsConversationsApi Boolean @default(true)
-
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## Summary

- Removes the unused `supportsConversationsApi` column from the `coworker` table.
- Coworker chat access is already enforced via `capabilities` (including `"chat"`) and `baseURL`; nothing in web or core referenced this flag.

## Test plan

- [x] Run `pnpm prisma:migrate:dev` locally and confirm migration applies cleanly.
- [x] Run `pnpm prisma:generate` (or full CI) to verify the Prisma client builds.
- [ ] Deploy migration to staging/production with `pnpm prisma:migrate:deploy` when merging.


Made with [Cursor](https://cursor.com)