### PR TITLE
fix(web): ignore third-party analytics fetch errors in Sentry

### DIFF
--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -1,5 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
 
+import {
+  beforeSendClientEvent,
+  thirdPartyAnalyticsDenyUrls,
+} from "@/lib/sentry/third-party-fetch-errors";
+
 Sentry.init({
   // eslint-disable-next-line no-restricted-properties
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -9,6 +14,9 @@ Sentry.init({
   // sendDefaultPii: true,
   // TODO: Uncomment this when Sentry team fixed open issue
   // https://github.com/getsentry/sentry-javascript/issues/16542
+
+  denyUrls: thirdPartyAnalyticsDenyUrls,
+  beforeSend: beforeSendClientEvent,
 
   integrations: [Sentry.replayIntegration({})],
 

--- a/apps/web/src/lib/sentry/__tests__/third-party-fetch-errors.test.ts
+++ b/apps/web/src/lib/sentry/__tests__/third-party-fetch-errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  beforeSendClientEvent,
+  isThirdPartyAnalyticsFetchFailure,
+} from "@/lib/sentry/third-party-fetch-errors";
+
+describe("isThirdPartyAnalyticsFetchFailure", () => {
+  it("returns true for Plausible fetch failures", () => {
+    expect(
+      isThirdPartyAnalyticsFetchFailure(
+        "TypeError: Failed to fetch (plausible.io)",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for LinkedIn pixel fetch failures", () => {
+    expect(
+      isThirdPartyAnalyticsFetchFailure(
+        "TypeError: Failed to fetch (px.ads.linkedin.com)",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for generic fetch failures without a host", () => {
+    expect(
+      isThirdPartyAnalyticsFetchFailure("TypeError: Failed to fetch"),
+    ).toBe(false);
+  });
+
+  it("returns false for first-party API fetch failures", () => {
+    expect(
+      isThirdPartyAnalyticsFetchFailure(
+        "TypeError: Failed to fetch (app.sokosumi.com)",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("beforeSendClientEvent", () => {
+  it("drops third-party analytics fetch error events", () => {
+    const result = beforeSendClientEvent(
+      {
+        exception: {
+          values: [
+            {
+              value: "TypeError: Failed to fetch (plausible.io)",
+            },
+          ],
+        },
+      },
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps application fetch error events", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            value: "TypeError: Failed to fetch (app.sokosumi.com)",
+          },
+        ],
+      },
+    };
+
+    expect(beforeSendClientEvent(event, {})).toBe(event);
+  });
+});

--- a/apps/web/src/lib/sentry/third-party-fetch-errors.ts
+++ b/apps/web/src/lib/sentry/third-party-fetch-errors.ts
@@ -1,0 +1,67 @@
+import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+
+/** Hostnames for marketing/analytics scripts loaded via GTM or similar. */
+const THIRD_PARTY_ANALYTICS_HOSTS = [
+  "plausible.io",
+  "px.ads.linkedin.com",
+  "www.google-analytics.com",
+  "google-analytics.com",
+  "googletagmanager.com",
+  "doubleclick.net",
+] as const;
+
+/** Script URL substrings used by common third-party trackers (denyUrls). */
+export const thirdPartyAnalyticsDenyUrls: RegExp[] = [
+  /plausible\.io/i,
+  /px\.ads\.linkedin\.com/i,
+  /googletagmanager\.com/i,
+  /google-analytics\.com/i,
+  /doubleclick\.net/i,
+];
+
+const thirdPartyFetchFailurePattern =
+  /^TypeError: Failed to fetch \(([^)]+)\)$/;
+
+function getEventErrorMessage(event: ErrorEvent): string {
+  const exceptionValue = event.exception?.values?.[0]?.value;
+  if (typeof exceptionValue === "string" && exceptionValue.length > 0) {
+    return exceptionValue;
+  }
+
+  if (typeof event.message === "string") {
+    return event.message;
+  }
+
+  return "";
+}
+
+function isKnownThirdPartyHost(host: string): boolean {
+  const normalizedHost = host.toLowerCase();
+
+  return THIRD_PARTY_ANALYTICS_HOSTS.some((knownHost) => {
+    return (
+      normalizedHost === knownHost || normalizedHost.endsWith(`.${knownHost}`)
+    );
+  });
+}
+
+/** Chrome reports blocked third-party network calls as `Failed to fetch (hostname)`. */
+export function isThirdPartyAnalyticsFetchFailure(message: string): boolean {
+  const match = message.match(thirdPartyFetchFailurePattern);
+  if (!match) {
+    return false;
+  }
+
+  return isKnownThirdPartyHost(match[1]);
+}
+
+export function beforeSendClientEvent(
+  event: ErrorEvent,
+  _hint: EventHint,
+): ErrorEvent | null {
+  if (isThirdPartyAnalyticsFetchFailure(getEventErrorMessage(event))) {
+    return null;
+  }
+
+  return event;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves noisy Sentry issue [SOKOSUMI-NQ](https://masumi.sentry.io/issues/SOKOSUMI-NQ): `TypeError: Failed to fetch (plausible.io)` on `/tasks/:taskId`.

These events come from the Plausible analytics script loaded via Google Tag Manager. They are typically caused by ad blockers, privacy extensions, or network restrictions—not application bugs. Sentry was capturing them as unhandled promise rejections.

## Changes

- Add client-side Sentry filters (`denyUrls` + `beforeSend`) for known third-party analytics hosts (Plausible, LinkedIn pixel, Google Analytics/GTM, etc.)
- Keep reporting first-party `Failed to fetch` errors (e.g. `app.sokosumi.com`)
- Add unit tests for the filter logic

## Verification

- `pnpm --filter web test src/lib/sentry/__tests__/third-party-fetch-errors.test.ts`
- `pnpm --filter web check`

Fixes SOKOSUMI-NQ
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79ac13a3-7897-4598-bd3a-bede7e7664b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ac13a3-7897-4598-bd3a-bede7e7664b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

