### PR TITLE
fix(database): avoid flattening missing event on link upsert

### DIFF
--- a/apps/core/src/types/link.ts
+++ b/apps/core/src/types/link.ts
@@ -18,8 +18,14 @@ export type LinkWithJobId = Omit<LinkWithJobIdRaw, "event"> & {
 
 export function flattenLinkJobId(link: LinkWithJobIdRaw): LinkWithJobId {
   const { event, ...rest } = link;
+  const jobId = event?.jobId;
+  if (!jobId) {
+    throw new Error(
+      `Link ${rest.id} is missing job event (eventId=${rest.eventId})`,
+    );
+  }
   return {
     ...rest,
-    jobId: event.jobId,
+    jobId,
   };
 }

--- a/packages/database/src/repositories/__tests__/link.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/link.repository.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+import { describe, it } from "vitest";
+
+import type { Prisma } from "../../generated/prisma/client.js";
+import { linkRepository } from "../link.repository.js";
+
+describe("linkRepository.upsertLink", () => {
+  it("returns the upserted link without loading the event relation", async () => {
+    let upsertCall: unknown;
+    const tx = {
+      link: {
+        upsert: async (args: unknown) => {
+          upsertCall = args;
+          return {
+            id: "link-1",
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+            eventId: "event-1",
+            url: "https://example.com/page",
+            title: null,
+          };
+        },
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const link = await linkRepository.upsertLink(
+      {
+        eventId: "event-1",
+        url: "https://example.com/page",
+      },
+      tx,
+    );
+
+    assert.equal(link.id, "link-1");
+    assert.equal(link.eventId, "event-1");
+    assert.equal((upsertCall as { include?: unknown }).include, undefined);
+  });
+});

--- a/packages/database/src/repositories/link.repository.ts
+++ b/packages/database/src/repositories/link.repository.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "../generated/prisma/client.js";
+import type { Link, Prisma } from "../generated/prisma/client.js";
 import {
   flattenLinkJobId,
   type LinkWithJobId,
@@ -13,8 +13,8 @@ export const linkRepository = {
       title?: string;
     },
     tx: Prisma.TransactionClient,
-  ): Promise<LinkWithJobId> {
-    const link = await tx.link.upsert({
+  ): Promise<Link> {
+    return tx.link.upsert({
       where: {
         eventId_url: { eventId: data.eventId, url: data.url },
       },
@@ -26,9 +26,7 @@ export const linkRepository = {
         url: data.url,
         title: data.title,
       },
-      include: linkInclude,
     });
-    return flattenLinkJobId(link);
   },
 
   async getLinksByEventId(

--- a/packages/database/src/types/__tests__/link.test.ts
+++ b/packages/database/src/types/__tests__/link.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+import { describe, it } from "vitest";
+
+import { flattenLinkJobId } from "../link.js";
+
+describe("flattenLinkJobId", () => {
+  it("flattens event.jobId onto the link", () => {
+    const flattened = flattenLinkJobId({
+      id: "link-1",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      eventId: "event-1",
+      url: "https://example.com",
+      title: null,
+      event: { jobId: "job-1" },
+    });
+
+    assert.equal(flattened.jobId, "job-1");
+    assert.equal(flattened.id, "link-1");
+    assert.equal("event" in flattened, false);
+  });
+
+  it("throws when the event relation is missing", () => {
+    assert.throws(
+      () =>
+        flattenLinkJobId({
+          id: "link-1",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          eventId: "event-1",
+          url: "https://example.com",
+          title: null,
+          event: undefined as unknown as { jobId: string },
+        }),
+      /missing job event/,
+    );
+  });
+});

--- a/packages/database/src/types/link.ts
+++ b/packages/database/src/types/link.ts
@@ -18,8 +18,14 @@ export type LinkWithJobId = Omit<LinkWithJobIdRaw, "event"> & {
 
 export function flattenLinkJobId(link: LinkWithJobIdRaw): LinkWithJobId {
   const { event, ...rest } = link;
+  const jobId = event?.jobId;
+  if (!jobId) {
+    throw new Error(
+      `Link ${rest.id} is missing job event (eventId=${rest.eventId})`,
+    );
+  }
   return {
     ...rest,
-    jobId: event.jobId,
+    jobId,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOKOSUMI-CORE-R](https://masumi.sentry.io/issues/SOKOSUMI-CORE-R): `TypeError: Cannot read properties of undefined (reading 'jobId')` during job sync source import.

## Root cause

`linkRepository.upsertLink` loaded the related `event` via Prisma `include` and immediately called `flattenLinkJobId`, which assumed `event` was always present. In production (via `GET /sync/jobs` → `enqueueFromMarkdown`), the upsert could succeed while the included `event` was missing, causing a crash on `event.jobId`.

## Fix

- Return the plain `Link` from `upsertLink`, matching `upsertOutputBlob` (callers do not use `jobId` from the return value).
- Harden `flattenLinkJobId` in `@sokosumi/database` and core with an explicit error when `event.jobId` is absent (read paths).

## Verification

- `pnpm --filter @sokosumi/database test src/repositories/__tests__/link.repository.test.ts src/types/__tests__/link.test.ts`
- `pnpm --filter core test src/services/source-import.service.test.ts`
- `pnpm --filter @sokosumi/database build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95130628-ec4b-4812-ad0a-f7bc1b3fb58b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95130628-ec4b-4812-ad0a-f7bc1b3fb58b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

