### PR TITLE
fix(core): avoid transaction timeout in source import enqueue

### DIFF
--- a/apps/core/src/services/source-import.service.test.ts
+++ b/apps/core/src/services/source-import.service.test.ts
@@ -2,17 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { sourceImportService } from "./source-import.service";
 
-const {
-  captureExceptionMock,
-  prismaTransactionMock,
-  upsertLinkMock,
-  upsertOutputBlobMock,
-} = vi.hoisted(() => ({
-  captureExceptionMock: vi.fn(),
-  prismaTransactionMock: vi.fn(),
-  upsertLinkMock: vi.fn(),
-  upsertOutputBlobMock: vi.fn(),
-}));
+const { captureExceptionMock, upsertLinkMock, upsertOutputBlobMock } =
+  vi.hoisted(() => ({
+    captureExceptionMock: vi.fn(),
+    upsertLinkMock: vi.fn(),
+    upsertOutputBlobMock: vi.fn(),
+  }));
 
 vi.mock("@sentry/node", () => ({
   captureException: captureExceptionMock,
@@ -28,17 +23,12 @@ vi.mock("@sokosumi/database/repositories", () => ({
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
-  default: {
-    $transaction: prismaTransactionMock,
-  },
+  default: {},
 }));
 
 describe("sourceImportService.enqueueFromMarkdown", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      return await callback({});
-    });
   });
 
   it("upserts unique file blobs and http links from markdown", async () => {
@@ -53,7 +43,6 @@ describe("sourceImportService.enqueueFromMarkdown", () => {
       ].join("\n"),
     );
 
-    expect(prismaTransactionMock).toHaveBeenCalledTimes(1);
     expect(upsertOutputBlobMock).toHaveBeenCalledTimes(1);
     expect(upsertOutputBlobMock).toHaveBeenCalledWith(
       {
@@ -61,7 +50,7 @@ describe("sourceImportService.enqueueFromMarkdown", () => {
         sourceUrl: "https://example.com/result.pdf",
         name: "result.pdf",
       },
-      {},
+      expect.anything(),
     );
     expect(upsertLinkMock).toHaveBeenCalledTimes(1);
     expect(upsertLinkMock).toHaveBeenCalledWith(
@@ -70,7 +59,7 @@ describe("sourceImportService.enqueueFromMarkdown", () => {
         url: "https://example.com/page",
         title: undefined,
       },
-      {},
+      expect.anything(),
     );
   });
 
@@ -91,10 +80,9 @@ describe("sourceImportService.enqueueFromMarkdown", () => {
     expect(upsertLinkMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips transaction work when markdown contains no importable links", async () => {
+  it("skips upserts when markdown contains no importable links", async () => {
     await sourceImportService.enqueueFromMarkdown("event_1", "No links here");
 
-    expect(prismaTransactionMock).not.toHaveBeenCalled();
     expect(upsertOutputBlobMock).not.toHaveBeenCalled();
     expect(upsertLinkMock).not.toHaveBeenCalled();
   });

--- a/apps/core/src/services/source-import.service.ts
+++ b/apps/core/src/services/source-import.service.ts
@@ -24,44 +24,42 @@ export const sourceImportService = {
       return;
     }
 
-    await prisma.$transaction(async (tx) => {
-      for (const url of fileLinks) {
-        if (!isHttpUrl(url)) {
-          continue;
-        }
-
-        try {
-          await blobRepository.upsertOutputBlob(
-            {
-              eventId: jobEventId,
-              sourceUrl: url,
-              name: getUrlBasename(url) ?? undefined,
-            },
-            tx,
-          );
-        } catch (error) {
-          Sentry.captureException(error);
-        }
+    for (const url of fileLinks) {
+      if (!isHttpUrl(url)) {
+        continue;
       }
 
-      for (const url of httpLinks) {
-        if (!isHttpUrl(url)) {
-          continue;
-        }
-
-        try {
-          await linkRepository.upsertLink(
-            {
-              eventId: jobEventId,
-              url,
-              title: undefined,
-            },
-            tx,
-          );
-        } catch (error) {
-          Sentry.captureException(error);
-        }
+      try {
+        await blobRepository.upsertOutputBlob(
+          {
+            eventId: jobEventId,
+            sourceUrl: url,
+            name: getUrlBasename(url) ?? undefined,
+          },
+          prisma,
+        );
+      } catch (error) {
+        Sentry.captureException(error);
       }
-    });
+    }
+
+    for (const url of httpLinks) {
+      if (!isHttpUrl(url)) {
+        continue;
+      }
+
+      try {
+        await linkRepository.upsertLink(
+          {
+            eventId: jobEventId,
+            url,
+            title: undefined,
+          },
+          prisma,
+        );
+      } catch (error) {
+        Sentry.captureException(error);
+      }
+    }
   },
 };

--- a/apps/web/src/lib/services/source-import.service.ts
+++ b/apps/web/src/lib/services/source-import.service.ts
@@ -22,7 +22,7 @@ export const sourceImportService = (() => {
    * - For each file-like link that is a valid HTTP URL, creates a pending result blob in the database,
    *   guessing the file name from the URL if possible.
    * - For each HTTP link that is a valid HTTP URL, upserts a link record in the database.
-   * - All operations are performed within a single database transaction for consistency.
+   * - Each upsert is independent; failures on one URL do not block the rest.
    *
    * @param jobEventId - The ID of the job event associated with the result (and blobs).
    * @param markdown - The markdown content to scan for links.
@@ -35,39 +35,38 @@ export const sourceImportService = (() => {
     const fileLinks = extractFileLikeLinks(markdown);
     const httpLinks = extractHttpLinks(markdown);
     if (fileLinks.length === 0 && httpLinks.length === 0) return;
-    await prisma.$transaction(async (tx) => {
-      for (const url of fileLinks) {
-        if (!isHttpUrl(url)) continue;
-        const guessedName = getUrlBasename(url) ?? undefined;
-        try {
-          await blobRepository.upsertOutputBlob(
-            {
-              eventId: jobEventId,
-              sourceUrl: url,
-              name: guessedName,
-            },
-            tx,
-          );
-        } catch (error) {
-          Sentry.captureException(error);
-        }
+
+    for (const url of fileLinks) {
+      if (!isHttpUrl(url)) continue;
+      const guessedName = getUrlBasename(url) ?? undefined;
+      try {
+        await blobRepository.upsertOutputBlob(
+          {
+            eventId: jobEventId,
+            sourceUrl: url,
+            name: guessedName,
+          },
+          prisma,
+        );
+      } catch (error) {
+        Sentry.captureException(error);
       }
-      for (const url of httpLinks) {
-        if (!isHttpUrl(url)) continue;
-        try {
-          await linkRepository.upsertLink(
-            {
-              eventId: jobEventId,
-              url,
-              title: undefined,
-            },
-            tx,
-          );
-        } catch (error) {
-          Sentry.captureException(error);
-        }
+    }
+    for (const url of httpLinks) {
+      if (!isHttpUrl(url)) continue;
+      try {
+        await linkRepository.upsertLink(
+          {
+            eventId: jobEventId,
+            url,
+            title: undefined,
+          },
+          prisma,
+        );
+      } catch (error) {
+        Sentry.captureException(error);
       }
-    });
+    }
   }
 
   return { enqueueFromMarkdown };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOKOSUMI-CORE-N](https://masumi.sentry.io/issues/SOKOSUMI-CORE-N): Prisma interactive transaction timeouts in `enqueueFromMarkdown` during `GET /sync/jobs`.

## Root cause

`sourceImportService.enqueueFromMarkdown` wrapped every blob/link upsert from job result markdown in one `prisma.$transaction` call. Prisma’s default interactive transaction timeout is 5 seconds. Large agent outputs with many links could take ~6–14+ seconds of sequential upserts, so the transaction expired before commit.

## Fix

Run each idempotent upsert with the default Prisma client instead of holding a single long transaction. Per-URL failures were already caught and reported to Sentry individually, so all-or-nothing semantics were not required.

## Changes

- `apps/core/src/services/source-import.service.ts` — remove wrapping transaction
- `apps/web/src/lib/services/source-import.service.ts` — same pattern for parity
- `apps/core/src/services/source-import.service.test.ts` — update expectations

## Verification

- `pnpm --filter core test src/services/source-import.service.test.ts`
- `pnpm --filter core build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42223ddb-2618-4a07-8556-27067afa7a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42223ddb-2618-4a07-8556-27067afa7a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

