### PR TITLE
fix(core): map coworker OpenAI billing errors to 403, not 503

### DIFF
--- a/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createCoworkerConversation } from "./coworker-conversation";
+import {
+  COWORKER_CHAT_BILLING_MESSAGE,
+  CoworkerConversationError,
+  createCoworkerConversation,
+  throwCoworkerRemoteConversationHttpError,
+} from "./coworker-conversation";
 
 const fetchMock = vi.fn();
 
@@ -104,5 +109,66 @@ describe("coworker-conversation", () => {
         sokosumi_conversation_id: "conv-local-1",
       },
     });
+  });
+
+  it("throws CoworkerConversationError with billing_required on OpenAI 403", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: async () =>
+        JSON.stringify({
+          error: {
+            message: "Account setup or billing required",
+            type: "invalid_request_error",
+            code: "billing_required",
+          },
+        }),
+    });
+
+    await expect(
+      createCoworkerConversation({
+        responsesApiBaseUrl: DEFAULT_BASE_URL,
+        sokosumiUserId: "user_1",
+        sokosumiOrganizationId: null,
+        coworkerSlug: "ops-agent",
+        sokosumiConversationId: "conv-local-1",
+      }),
+    ).rejects.toMatchObject({
+      name: "CoworkerConversationError",
+      upstreamStatus: 403,
+      upstreamCode: "billing_required",
+    });
+  });
+});
+
+describe("throwCoworkerRemoteConversationHttpError", () => {
+  it("maps billing_required to 403 with a user-facing message", () => {
+    expect(() =>
+      throwCoworkerRemoteConversationHttpError(
+        new CoworkerConversationError(
+          "Conversations API request failed",
+          403,
+          "billing_required",
+        ),
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        status: 403,
+        message: COWORKER_CHAT_BILLING_MESSAGE,
+      }),
+    );
+  });
+
+  it("maps unexpected upstream 5xx to 503 without reporting to Sentry", () => {
+    expect(() =>
+      throwCoworkerRemoteConversationHttpError(
+        new CoworkerConversationError("Conversations API request failed", 502),
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        status: 503,
+        cause: expect.objectContaining({ reportToSentry: false }),
+      }),
+    );
   });
 });

--- a/apps/core/src/routes/v1/chat/coworker-conversation.ts
+++ b/apps/core/src/routes/v1/chat/coworker-conversation.ts
@@ -1,4 +1,23 @@
+import {
+  forbidden,
+  serviceUnavailable,
+  tooManyRequests,
+} from "@/helpers/error";
+
 const CREATE_CONVERSATION_TIMEOUT_MS = 25_000;
+
+const COWORKER_PROVIDER_CONFIG_ERROR_CODES = new Set([
+  "billing_required",
+  "insufficient_quota",
+  "invalid_api_key",
+  "account_deactivated",
+]);
+
+export const COWORKER_CHAT_UNAVAILABLE_MESSAGE =
+  "This AI coworker is temporarily unavailable. Please try again later or choose another coworker.";
+
+export const COWORKER_CHAT_BILLING_MESSAGE =
+  "This AI coworker cannot accept messages right now because its provider account needs billing setup.";
 
 export interface CreateCoworkerConversationOptions {
   responsesApiBaseUrl: string;
@@ -6,6 +25,103 @@ export interface CreateCoworkerConversationOptions {
   sokosumiOrganizationId: string | null;
   coworkerSlug: string;
   sokosumiConversationId: string;
+}
+
+export class CoworkerConversationError extends Error {
+  readonly upstreamStatus: number;
+  readonly upstreamCode?: string;
+
+  constructor(message: string, upstreamStatus: number, upstreamCode?: string) {
+    super(message);
+    this.name = "CoworkerConversationError";
+    this.upstreamStatus = upstreamStatus;
+    this.upstreamCode = upstreamCode;
+  }
+}
+
+function parseOpenAiErrorBody(errorText: string): {
+  code?: string;
+  message?: string;
+} {
+  try {
+    const parsed = JSON.parse(errorText) as Record<string, unknown>;
+    const errorObj = parsed.error;
+    if (errorObj && typeof errorObj === "object") {
+      const nested = errorObj as Record<string, unknown>;
+      return {
+        code: typeof nested.code === "string" ? nested.code : undefined,
+        message:
+          typeof nested.message === "string" ? nested.message : undefined,
+      };
+    }
+  } catch {
+    // Non-JSON error bodies are handled below.
+  }
+
+  if (errorText.includes("billing_required")) {
+    return { code: "billing_required" };
+  }
+
+  return {};
+}
+
+function isCoworkerProviderConfigError(
+  code: string | undefined,
+  upstreamStatus: number,
+): boolean {
+  if (code && COWORKER_PROVIDER_CONFIG_ERROR_CODES.has(code)) {
+    return true;
+  }
+
+  return upstreamStatus === 401 || upstreamStatus === 403;
+}
+
+function userMessageForCoworkerProviderError(code?: string): string {
+  if (code === "billing_required" || code === "insufficient_quota") {
+    return COWORKER_CHAT_BILLING_MESSAGE;
+  }
+
+  return COWORKER_CHAT_UNAVAILABLE_MESSAGE;
+}
+
+export function throwCoworkerRemoteConversationHttpError(
+  error: unknown,
+): never {
+  if (error instanceof CoworkerConversationError) {
+    const { upstreamStatus, upstreamCode } = error;
+
+    if (isCoworkerProviderConfigError(upstreamCode, upstreamStatus)) {
+      throw forbidden(userMessageForCoworkerProviderError(upstreamCode));
+    }
+
+    if (upstreamStatus === 429) {
+      throw tooManyRequests(
+        "This AI coworker is receiving too many requests. Please try again shortly.",
+      );
+    }
+
+    if (upstreamStatus >= 500) {
+      throw serviceUnavailable(
+        "Coworker chat is temporarily unavailable. Please try again shortly.",
+        {
+          kind: "coworker-upstream-unavailable",
+          reportToSentry: false,
+        },
+      );
+    }
+
+    throw forbidden(COWORKER_CHAT_UNAVAILABLE_MESSAGE);
+  }
+
+  if (error instanceof Error && error.name === "TimeoutError") {
+    throw serviceUnavailable(
+      "Coworker chat timed out while starting a conversation. Please try again shortly.",
+    );
+  }
+
+  throw serviceUnavailable(
+    "Coworker chat could not create or resolve a remote conversation. Please try again shortly.",
+  );
 }
 
 export async function createCoworkerConversation(
@@ -40,24 +156,41 @@ export async function createCoworkerConversation(
     metadata.sokosumi_organization_id = options.sokosumiOrganizationId;
   }
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: requestHeaders,
-    body: JSON.stringify({ metadata }),
-    signal: AbortSignal.timeout(CREATE_CONVERSATION_TIMEOUT_MS),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: requestHeaders,
+      body: JSON.stringify({ metadata }),
+      signal: AbortSignal.timeout(CREATE_CONVERSATION_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw error;
+    }
+    throw new CoworkerConversationError(
+      "Conversations API request failed",
+      503,
+    );
+  }
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "Unknown error");
-    throw new Error(`Conversations API error: ${response.status} ${errorText}`);
+    const { code } = parseOpenAiErrorBody(errorText);
+    throw new CoworkerConversationError(
+      "Conversations API request failed",
+      response.status,
+      code,
+    );
   }
 
   let body: unknown;
   try {
     body = await response.json();
-  } catch (parseErr) {
-    throw new Error(
-      `Conversations API invalid JSON: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+  } catch {
+    throw new CoworkerConversationError(
+      "Conversations API returned invalid JSON",
+      502,
     );
   }
 
@@ -72,7 +205,10 @@ export async function createCoworkerConversation(
         : null;
 
   if (!id) {
-    throw new Error("Conversations API returned no conversation id");
+    throw new CoworkerConversationError(
+      "Conversations API returned no conversation id",
+      502,
+    );
   }
 
   return { id };

--- a/apps/core/src/routes/v1/chat/post.test.ts
+++ b/apps/core/src/routes/v1/chat/post.test.ts
@@ -6,6 +6,7 @@ import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { defaultValidationHook } from "@/lib/hono";
 import type { AuthVariables } from "@/middleware/auth";
 
+import { CoworkerConversationError } from "./coworker-conversation";
 import mountPostChat from "./post";
 
 const {
@@ -72,10 +73,15 @@ vi.mock("@/helpers/access-control", () => ({
   requireCoworkerChatCapability: requireCoworkerChatCapabilityMock,
 }));
 
-vi.mock("./coworker-conversation", () => ({
-  createCoworkerConversation: (...args: unknown[]) =>
-    createCoworkerConversationMock(...args),
-}));
+vi.mock("./coworker-conversation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./coworker-conversation")>();
+  return {
+    ...actual,
+    createCoworkerConversation: (...args: unknown[]) =>
+      createCoworkerConversationMock(...args),
+  };
+});
 
 vi.mock("@/clients/openrouter.client", () => ({
   openrouterClient: {
@@ -1706,7 +1712,7 @@ describe("POST /chat", () => {
     expect(streamTextMock).not.toHaveBeenCalled();
   });
 
-  it("returns 503 when creating the remote coworker conversation fails", async () => {
+  it("returns 503 when creating the remote coworker conversation fails unexpectedly", async () => {
     const cid = "550e8400-e29b-41d4-a716-446655440000";
     conversationFindFirstMock.mockResolvedValueOnce({
       id: cid,
@@ -1730,6 +1736,38 @@ describe("POST /chat", () => {
     });
 
     expect(response.status).toBe(503);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when coworker provider billing is required", async () => {
+    const cid = "550e8400-e29b-41d4-a716-446655440000";
+    conversationFindFirstMock.mockResolvedValueOnce({
+      id: cid,
+      metadata: { coworker_slug: "ops-agent" },
+      providerConversationId: null,
+    });
+    coworkerFindFirstMock.mockResolvedValueOnce({ id: "cow_123" });
+    createCoworkerConversationMock.mockRejectedValueOnce(
+      new CoworkerConversationError(
+        "Conversations API request failed",
+        403,
+        "billing_required",
+      ),
+    );
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: cid,
+        conversationId: cid,
+        messages: [{ role: "user", parts: [{ type: "text", text: "Hi" }] }],
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain("billing setup");
     expect(streamTextMock).not.toHaveBeenCalled();
   });
 

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -66,7 +66,10 @@ import {
   AI_SDK_CHAT_MESSAGES_REQUIREMENT,
   aiSdkChatRequestSchema,
 } from "@/schemas/chat-request.schema.js";
-import { createCoworkerConversation } from "./coworker-conversation";
+import {
+  createCoworkerConversation,
+  throwCoworkerRemoteConversationHttpError,
+} from "./coworker-conversation";
 
 import { mapChatRequestToUiMessages } from "./map-chat-request-to-ui-messages.js";
 
@@ -679,9 +682,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             sokosumiConversationId: internalConversationId,
           });
         } catch (error) {
-          throw serviceUnavailable(
-            `Coworker chat could not create a remote conversation: ${error instanceof Error ? error.message : String(error)}`,
-          );
+          throwCoworkerRemoteConversationHttpError(error);
         }
         const updated = await prisma.conversation.updateMany({
           where: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOKOSUMI-CORE-1A](https://masumi.sentry.io/issues/SOKOSUMI-CORE-1A): coworker chat was surfacing OpenAI `billing_required` (403) as a generic **503 Service Unavailable**, which also caused noisy Sentry alerts on `POST /v1/chat`.

## What changed

- Parse upstream Conversations API failures into a structured `CoworkerConversationError` (HTTP status + OpenAI error code when present).
- Map provider configuration problems (`billing_required`, `insufficient_quota`, `invalid_api_key`, other 401/403) to **403** with user-facing messages (no Sentry report).
- Keep true transient/unexpected failures as **503**, but mark known upstream 5xx as `reportToSentry: false` to avoid alert spam for provider outages.

## Operational note

This does **not** fix missing OpenAI billing on the coworker provider account—that still requires ops (valid API key / billing on the coworker Responses endpoint). Users now get a clear message instead of a misleading “try again shortly” 503.

## Verification

- `pnpm --filter core test src/routes/v1/chat/coworker-conversation.test.ts src/routes/v1/chat/post.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acededb5-28a2-4c3b-8032-7943315824c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acededb5-28a2-4c3b-8032-7943315824c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

