### PR TITLE
feat(web): add Cmd+K shortcut to start new chat

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
@@ -2,8 +2,9 @@
 
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useEffect, useMemo } from "react";
 
 import { SheetClose } from "@/components/ui/sheet";
 import {
@@ -18,18 +19,67 @@ import { cn } from "@/lib/utils";
 export default function NewChatTaskActions() {
   const tChat = useTranslations("App.Chat.Chat");
   const pathname = usePathname();
+  const router = useRouter();
   const isChatActive = pathname === "/chat" || pathname.startsWith("/chat/");
+  const sidebarNewLabel = tChat("sidebarNew");
+  const shortcutLabel = useMemo(() => {
+    if (typeof navigator === "undefined") return "Ctrl+K";
+    const navUaPlatform = (
+      navigator as unknown as { userAgentData?: { platform?: string } }
+    ).userAgentData?.platform;
+    const platform = navUaPlatform ?? navigator.platform ?? "";
+    return /Mac|iPhone|iPad|iPod/i.test(platform) ? "⌘K" : "Ctrl+K";
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() !== "k" ||
+        !(event.metaKey || event.ctrlKey)
+      ) {
+        return;
+      }
+
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
+          return;
+        }
+      }
+
+      event.preventDefault();
+      router.push("/chat");
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [router]);
 
   return (
     <SidebarGroup className="w-full">
       <SidebarGroupContent>
         <SidebarMenu className="gap-0 pt-2">
           <SidebarMenuItem>
-            <SidebarMenuButton asChild isActive={isChatActive}>
+            <SidebarMenuButton
+              asChild
+              isActive={isChatActive}
+              tooltip={{
+                children: (
+                  <span className="flex items-center gap-2">
+                    <span>{sidebarNewLabel}</span>
+                    <span className="text-muted-foreground text-xs tracking-widest">
+                      {shortcutLabel}
+                    </span>
+                  </span>
+                ),
+              }}
+            >
               <SheetClose asChild>
                 <Link
                   href="/chat"
                   aria-current={isChatActive ? "page" : undefined}
+                  aria-keyshortcuts="Meta+K Control+K"
                   className={cn(
                     "flex min-h-auto w-full items-center gap-2 px-3",
                     isChatActive
@@ -38,7 +88,16 @@ export default function NewChatTaskActions() {
                   )}
                 >
                   <Plus className="size-4" aria-hidden />
-                  <span className="flex-1 truncate">{tChat("sidebarNew")}</span>
+                  <span className="flex-1 truncate">{sidebarNewLabel}</span>
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "text-muted-foreground ml-auto hidden shrink-0 text-xs tracking-widest opacity-0 transition-opacity group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 group-data-[collapsible=icon]:hidden md:inline",
+                      isChatActive && "text-primary-foreground/80",
+                    )}
+                  >
+                    {shortcutLabel}
+                  </span>
                 </Link>
               </SheetClose>
             </SidebarMenuButton>

--- a/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
@@ -4,7 +4,7 @@ import { Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 
 import { SheetClose } from "@/components/ui/sheet";
 import {
@@ -14,6 +14,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import useIsApplePlatform from "@/hooks/use-is-apple-platform";
 import { cn } from "@/lib/utils";
 
 export default function NewChatTaskActions() {
@@ -22,14 +23,8 @@ export default function NewChatTaskActions() {
   const router = useRouter();
   const isChatActive = pathname === "/chat" || pathname.startsWith("/chat/");
   const sidebarNewLabel = tChat("sidebarNew");
-  const shortcutLabel = useMemo(() => {
-    if (typeof navigator === "undefined") return "Ctrl+K";
-    const navUaPlatform = (
-      navigator as unknown as { userAgentData?: { platform?: string } }
-    ).userAgentData?.platform;
-    const platform = navUaPlatform ?? navigator.platform ?? "";
-    return /Mac|iPhone|iPad|iPod/i.test(platform) ? "⌘K" : "Ctrl+K";
-  }, []);
+  const isApplePlatform = useIsApplePlatform();
+  const shortcutLabel = isApplePlatform ? "⌘K" : "Ctrl+K";
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/apps/web/src/components/jobs/job-details/download-button.tsx
+++ b/apps/web/src/components/jobs/job-details/download-button.tsx
@@ -2,7 +2,7 @@
 
 import { Download } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import useIsApplePlatform from "@/hooks/use-is-apple-platform";
 import { cn } from "@/lib/utils";
 import { sanitizeMarkdown } from "@/lib/utils/sanitizeMarkdown";
 
@@ -40,19 +41,8 @@ export default function DownloadButton({
 }: DownloadButtonProps) {
   const t = useTranslations("Components.Jobs.JobDetails.Output");
 
-  const isMac = useMemo(() => {
-    if (typeof navigator === "undefined") return false;
-    const navUaPlatform = (
-      navigator as unknown as { userAgentData?: { platform?: string } }
-    ).userAgentData?.platform;
-    const platform = navUaPlatform ?? navigator.platform ?? "";
-    return /Mac|iPhone|iPad|iPod/i.test(platform);
-  }, []);
-
-  const shortcutLabel = useMemo(
-    () => (isMac ? "⇧⌘E" : "Shift+Ctrl+E"),
-    [isMac],
-  );
+  const isApplePlatform = useIsApplePlatform();
+  const shortcutLabel = isApplePlatform ? "⇧⌘E" : "Shift+Ctrl+E";
 
   async function markdownToHtml(markdownContent: string) {
     const [{ marked }] = await Promise.all([
@@ -189,7 +179,7 @@ export default function DownloadButton({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isHostKey = isMac ? e.metaKey : e.ctrlKey;
+      const isHostKey = isApplePlatform ? e.metaKey : e.ctrlKey;
       if (isHostKey && e.shiftKey && e.key.toLowerCase() === "e") {
         e.preventDefault();
         handleDownloadMarkdown();
@@ -197,7 +187,7 @@ export default function DownloadButton({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isMac, handleDownloadMarkdown]);
+  }, [isApplePlatform, handleDownloadMarkdown]);
 
   return (
     <DropdownMenu>

--- a/apps/web/src/hooks/use-is-apple-platform.ts
+++ b/apps/web/src/hooks/use-is-apple-platform.ts
@@ -2,20 +2,10 @@
 
 import { useSyncExternalStore } from "react";
 
-function getIsApplePlatform(): boolean {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
-
-  const navUaPlatform = (
-    navigator as unknown as { userAgentData?: { platform?: string } }
-  ).userAgentData?.platform;
-  const platform = navUaPlatform ?? navigator.platform ?? "";
-  return /Mac|iPhone|iPad|iPod/i.test(platform);
-}
+import { isApplePlatform } from "@/lib/utils/user-agent";
 
 const subscribe = () => () => {};
 
 export default function useIsApplePlatform() {
-  return useSyncExternalStore(subscribe, getIsApplePlatform, () => false);
+  return useSyncExternalStore(subscribe, isApplePlatform, () => false);
 }

--- a/apps/web/src/hooks/use-is-apple-platform.ts
+++ b/apps/web/src/hooks/use-is-apple-platform.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+function getIsApplePlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const navUaPlatform = (
+    navigator as unknown as { userAgentData?: { platform?: string } }
+  ).userAgentData?.platform;
+  const platform = navUaPlatform ?? navigator.platform ?? "";
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+const subscribe = () => () => {};
+
+export default function useIsApplePlatform() {
+  return useSyncExternalStore(subscribe, getIsApplePlatform, () => false);
+}

--- a/apps/web/src/lib/utils/__tests__/user-agent.test.ts
+++ b/apps/web/src/lib/utils/__tests__/user-agent.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it } from "vitest";
-import { getOSFromUserAgent } from "@/lib/utils";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getOSFromUserAgent, isApplePlatform } from "@/lib/utils";
+
+function mockNavigator(userAgent: string) {
+  Object.defineProperty(global, "navigator", {
+    value: { userAgent },
+    configurable: true,
+  });
+}
 
 describe("getOSFromUserAgent", () => {
-  it("returns default values when navigator is undefined", () => {
-    const originalNavigator = global.navigator;
+  const originalNavigator = global.navigator;
 
+  afterEach(() => {
+    Object.defineProperty(global, "navigator", {
+      value: originalNavigator,
+      configurable: true,
+    });
+  });
+
+  it("returns default values when navigator is undefined", () => {
     Object.defineProperty(global, "navigator", {
       value: undefined,
       configurable: true,
@@ -14,10 +29,71 @@ describe("getOSFromUserAgent", () => {
       os: "Unknown",
       isMobile: false,
     });
+  });
 
+  it("detects MacOS from user agent", () => {
+    mockNavigator(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    );
+
+    expect(getOSFromUserAgent()).toEqual({
+      os: "MacOS",
+      isMobile: false,
+    });
+  });
+
+  it("detects iOS from user agent", () => {
+    mockNavigator(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+    );
+
+    expect(getOSFromUserAgent()).toEqual({
+      os: "iOS",
+      isMobile: true,
+    });
+  });
+});
+
+describe("isApplePlatform", () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
     Object.defineProperty(global, "navigator", {
       value: originalNavigator,
       configurable: true,
     });
+  });
+
+  it("returns false when navigator is undefined", () => {
+    Object.defineProperty(global, "navigator", {
+      value: undefined,
+      configurable: true,
+    });
+
+    expect(isApplePlatform()).toBe(false);
+  });
+
+  it("returns true for MacOS", () => {
+    mockNavigator(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    );
+
+    expect(isApplePlatform()).toBe(true);
+  });
+
+  it("returns true for iOS", () => {
+    mockNavigator(
+      "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+    );
+
+    expect(isApplePlatform()).toBe(true);
+  });
+
+  it("returns false for Windows", () => {
+    mockNavigator(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    );
+
+    expect(isApplePlatform()).toBe(false);
   });
 });

--- a/apps/web/src/lib/utils/user-agent.ts
+++ b/apps/web/src/lib/utils/user-agent.ts
@@ -51,3 +51,12 @@ export function getOSFromUserAgent(): { os: OS; isMobile: boolean } {
     isMobile: false,
   };
 }
+
+export function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const { os } = getOSFromUserAgent();
+  return os === "MacOS" || os === "iOS";
+}


### PR DESCRIPTION
## Summary

Adds a global keyboard shortcut to open a new chat from anywhere in the app, with platform-aware shortcut hints in the sidebar.

## Key changes

- Register a global `Cmd+K` / `Ctrl+K` listener that navigates to `/chat`
- Skip the shortcut when focus is in an input, textarea, or contenteditable field
- Show platform-specific shortcut labels (`⌘K` on macOS/iOS, `Ctrl+K` elsewhere) in the sidebar tooltip and on hover/focus
- Add `aria-keyshortcuts` on the New Chat link for accessibility

## Technical details

- Implemented in `new-chat-task-actions.tsx` using `useRouter`, `useEffect`, and `useMemo`
- Platform detection uses `navigator.userAgentData.platform` with a fallback to `navigator.platform`
- Shortcut hint is hidden in collapsed icon sidebar mode and on small screens until hover/focus

## Test plan

- [ ] Press `Cmd+K` (macOS) or `Ctrl+K` (Windows/Linux) from a non-input area and confirm navigation to `/chat`
- [ ] Verify the shortcut does not fire while typing in chat input, search fields, or textareas
- [ ] Hover/focus the sidebar New Chat item and confirm the shortcut label appears on desktop
- [ ] Confirm tooltip shows the shortcut when sidebar is expanded
- [ ] Verify shortcut hint is hidden when sidebar is collapsed to icon mode


Made with [Cursor](https://cursor.com)