### PR TITLE
refactor(web): remove leftover My Feed test reference

### DIFF
--- a/apps/web/src/app/(app)/chat-ui/utils/__tests__/chat-route-base.test.ts
+++ b/apps/web/src/app/(app)/chat-ui/utils/__tests__/chat-route-base.test.ts
@@ -33,7 +33,6 @@ describe("chat-route-base", () => {
     expect(isChatShellPathname("/chat/foo")).toBe(true);
     expect(isChatShellPathname("/new-chat")).toBe(false);
     expect(isChatShellPathname("/new-chat/foo")).toBe(false);
-    expect(isChatShellPathname("/feed")).toBe(false);
   });
 
   it("getPendingConversationStorageKey is stable", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the last leftover from the My Feed feature removal in `c6c9bb4`.

- Deletes the `/feed` assertion from `chat-route-base` tests, which referenced the removed route

## Context

After searching the codebase for feed-related leftovers (routes, services, translations, assets, navigation), this was the only remaining reference tied to the removed My Feed feature.

## Test plan

- [x] `pnpm --filter web test -- src/app/(app)/chat-ui/utils/__tests__/chat-route-base.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aefd8c5d-3862-40fb-a0d4-4ceec1b842b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aefd8c5d-3862-40fb-a0d4-4ceec1b842b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

