### PR TITLE
fix(web): move legal links to profile menu with legal submenu

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
@@ -16,6 +16,7 @@ import {
   PanelLeft,
   Plus,
   ReceiptText,
+  Scale,
   User as UserIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -75,15 +76,17 @@ function getWorkspaceKey(workspace: WorkspaceItem): string {
 
 interface HelpLinkItem {
   url: string;
+  translationKey: "documentation" | "serviceplanAiCoworker" | "support";
+  icon?: ComponentType<{ "aria-hidden"?: boolean; className?: string }>;
+}
+
+interface LegalLinkItem {
+  url: string;
   translationKey:
-    | "documentation"
-    | "serviceplanAiCoworker"
-    | "support"
     | "termsOfService"
     | "privacyPolicy"
     | "imprint"
     | "acceptableUse";
-  icon?: ComponentType<{ "aria-hidden"?: boolean; className?: string }>;
 }
 
 const HELP_LINKS: HelpLinkItem[] = [
@@ -104,7 +107,7 @@ const HELP_LINKS: HelpLinkItem[] = [
   },
 ];
 
-const LEGAL_LINKS: HelpLinkItem[] = [
+const LEGAL_LINKS: LegalLinkItem[] = [
   {
     url: "https://www.sokosumi.com/terms-of-service",
     translationKey: "termsOfService",
@@ -156,19 +159,14 @@ function HelpLinks({
 function LegalLinks({
   handleOpenExternalLink,
   itemClassName,
-  labelClassName,
   tUserAvatar,
 }: {
   handleOpenExternalLink: (url: string) => void;
   itemClassName: string;
-  labelClassName: string;
-  tUserAvatar: (key: HelpLinkItem["translationKey"] | "legal") => string;
+  tUserAvatar: (key: LegalLinkItem["translationKey"]) => string;
 }) {
   return (
     <>
-      <DropdownMenuLabel className={labelClassName}>
-        {tUserAvatar("legal")}
-      </DropdownMenuLabel>
       {LEGAL_LINKS.map((item) => (
         <DropdownMenuItem
           key={item.translationKey}
@@ -253,6 +251,7 @@ export default function ProfileSwitchClient({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isWorkspaceSectionOpen, setIsWorkspaceSectionOpen] = useState(false);
   const [isHelpSectionOpen, setIsHelpSectionOpen] = useState(false);
+  const [isLegalSectionOpen, setIsLegalSectionOpen] = useState(false);
   const { isMobile, state, toggleSidebar } = useSidebar();
   const isCollapsedDesktop = !isMobile && state === "collapsed";
   const canOpenMenu = isMobile || state !== "collapsed";
@@ -266,6 +265,7 @@ export default function ProfileSwitchClient({
     if (!open) {
       setIsWorkspaceSectionOpen(false);
       setIsHelpSectionOpen(false);
+      setIsLegalSectionOpen(false);
     }
   };
 
@@ -276,6 +276,7 @@ export default function ProfileSwitchClient({
         setIsDropdownOpen(false);
         setIsWorkspaceSectionOpen(false);
         setIsHelpSectionOpen(false);
+        setIsLegalSectionOpen(false);
       }, 100);
       return () => clearTimeout(timer);
     }
@@ -318,6 +319,7 @@ export default function ProfileSwitchClient({
     setIsDropdownOpen(false);
     setIsWorkspaceSectionOpen(false);
     setIsHelpSectionOpen(false);
+    setIsLegalSectionOpen(false);
   };
 
   const handleWorkspaceSelect = (workspaceId: string | null) => {
@@ -575,12 +577,29 @@ export default function ProfileSwitchClient({
                           tUserAvatar={tUserAvatar}
                         />
                       ) : null}
-                      <LegalLinks
-                        handleOpenExternalLink={handleOpenExternalLink}
-                        itemClassName="cursor-pointer"
-                        labelClassName="text-muted-foreground text-xs"
-                        tUserAvatar={tUserAvatar}
-                      />
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        onSelect={(event) => {
+                          event.preventDefault();
+                          setIsLegalSectionOpen((previous) => !previous);
+                        }}
+                      >
+                        <Scale className="text-muted-foreground size-4" />
+                        <span>{tUserAvatar("legal")}</span>
+                        <ChevronDown
+                          className={cn(
+                            "text-muted-foreground ml-auto size-4 transition-transform",
+                            isLegalSectionOpen ? "rotate-180" : "",
+                          )}
+                        />
+                      </DropdownMenuItem>
+                      {isLegalSectionOpen ? (
+                        <LegalLinks
+                          handleOpenExternalLink={handleOpenExternalLink}
+                          itemClassName="cursor-pointer pl-8"
+                          tUserAvatar={tUserAvatar}
+                        />
+                      ) : null}
                     </>
                   ) : (
                     <>
@@ -597,12 +616,19 @@ export default function ProfileSwitchClient({
                           />
                         </DropdownMenuSubContent>
                       </DropdownMenuSub>
-                      <LegalLinks
-                        handleOpenExternalLink={handleOpenExternalLink}
-                        itemClassName="cursor-pointer"
-                        labelClassName="text-muted-foreground text-xs"
-                        tUserAvatar={tUserAvatar}
-                      />
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2">
+                          <Scale className="text-muted-foreground size-4" />
+                          <span>{tUserAvatar("legal")}</span>
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="w-64">
+                          <LegalLinks
+                            handleOpenExternalLink={handleOpenExternalLink}
+                            itemClassName="cursor-pointer"
+                            tUserAvatar={tUserAvatar}
+                          />
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
                     </>
                   )}
                 </DropdownMenuGroup>

--- a/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
@@ -116,16 +116,14 @@ const LEGAL_LINKS: HelpLinkItem[] = [
   },
 ];
 
-function HelpAndLegalLinks({
+function HelpLinks({
   handleOpenExternalLink,
   itemClassName,
-  labelClassName,
   tUserAvatar,
 }: {
   handleOpenExternalLink: (url: string) => void;
   itemClassName: string;
-  labelClassName: string;
-  tUserAvatar: (key: HelpLinkItem["translationKey"] | "legal") => string;
+  tUserAvatar: (key: HelpLinkItem["translationKey"]) => string;
 }) {
   return (
     <>
@@ -144,7 +142,23 @@ function HelpAndLegalLinks({
           </DropdownMenuItem>
         );
       })}
-      <DropdownMenuSeparator />
+    </>
+  );
+}
+
+function LegalLinks({
+  handleOpenExternalLink,
+  itemClassName,
+  labelClassName,
+  tUserAvatar,
+}: {
+  handleOpenExternalLink: (url: string) => void;
+  itemClassName: string;
+  labelClassName: string;
+  tUserAvatar: (key: HelpLinkItem["translationKey"] | "legal") => string;
+}) {
+  return (
+    <>
       <DropdownMenuLabel className={labelClassName}>
         {tUserAvatar("legal")}
       </DropdownMenuLabel>
@@ -548,29 +562,41 @@ export default function ProfileSwitchClient({
                         />
                       </DropdownMenuItem>
                       {isHelpSectionOpen ? (
-                        <HelpAndLegalLinks
+                        <HelpLinks
                           handleOpenExternalLink={handleOpenExternalLink}
                           itemClassName="cursor-pointer pl-8"
-                          labelClassName="text-muted-foreground pl-8 text-xs"
                           tUserAvatar={tUserAvatar}
                         />
                       ) : null}
+                      <LegalLinks
+                        handleOpenExternalLink={handleOpenExternalLink}
+                        itemClassName="cursor-pointer"
+                        labelClassName="text-muted-foreground text-xs"
+                        tUserAvatar={tUserAvatar}
+                      />
                     </>
                   ) : (
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger className="gap-2">
-                        <LifeBuoy className="text-muted-foreground size-4" />
-                        <span>{tUserAvatar("help")}</span>
-                      </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent className="w-64">
-                        <HelpAndLegalLinks
-                          handleOpenExternalLink={handleOpenExternalLink}
-                          itemClassName="cursor-pointer"
-                          labelClassName="text-muted-foreground text-xs"
-                          tUserAvatar={tUserAvatar}
-                        />
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
+                    <>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2">
+                          <LifeBuoy className="text-muted-foreground size-4" />
+                          <span>{tUserAvatar("help")}</span>
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="w-64">
+                          <HelpLinks
+                            handleOpenExternalLink={handleOpenExternalLink}
+                            itemClassName="cursor-pointer"
+                            tUserAvatar={tUserAvatar}
+                          />
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                      <LegalLinks
+                        handleOpenExternalLink={handleOpenExternalLink}
+                        itemClassName="cursor-pointer"
+                        labelClassName="text-muted-foreground text-xs"
+                        tUserAvatar={tUserAvatar}
+                      />
+                    </>
                   )}
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />

--- a/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
@@ -11,12 +11,16 @@ import {
   Check,
   ChevronDown,
   CircleHelp,
+  Landmark,
   LifeBuoy,
+  ListChecks,
   LogOut,
   PanelLeft,
   Plus,
   ReceiptText,
   Scale,
+  ScrollText,
+  Shield,
   User as UserIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -87,6 +91,7 @@ interface LegalLinkItem {
     | "privacyPolicy"
     | "imprint"
     | "acceptableUse";
+  icon?: ComponentType<{ "aria-hidden"?: boolean; className?: string }>;
 }
 
 const HELP_LINKS: HelpLinkItem[] = [
@@ -111,18 +116,22 @@ const LEGAL_LINKS: LegalLinkItem[] = [
   {
     url: "https://www.sokosumi.com/terms-of-service",
     translationKey: "termsOfService",
+    icon: ScrollText,
   },
   {
     url: "https://www.sokosumi.com/privacy-policy",
     translationKey: "privacyPolicy",
+    icon: Shield,
   },
   {
     url: "https://www.sokosumi.com/imprint",
     translationKey: "imprint",
+    icon: Landmark,
   },
   {
     url: "https://www.sokosumi.com/acceptable-use",
     translationKey: "acceptableUse",
+    icon: ListChecks,
   },
 ];
 
@@ -167,15 +176,21 @@ function LegalLinks({
 }) {
   return (
     <>
-      {LEGAL_LINKS.map((item) => (
-        <DropdownMenuItem
-          key={item.translationKey}
-          className={itemClassName}
-          onClick={() => handleOpenExternalLink(item.url)}
-        >
-          <span>{tUserAvatar(item.translationKey)}</span>
-        </DropdownMenuItem>
-      ))}
+      {LEGAL_LINKS.map((item) => {
+        const Icon = item.icon;
+        return (
+          <DropdownMenuItem
+            key={item.translationKey}
+            className={itemClassName}
+            onClick={() => handleOpenExternalLink(item.url)}
+          >
+            {Icon ? (
+              <Icon className="text-muted-foreground size-4" aria-hidden />
+            ) : null}
+            <span>{tUserAvatar(item.translationKey)}</span>
+          </DropdownMenuItem>
+        );
+      })}
     </>
   );
 }

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
@@ -214,54 +214,49 @@ export default function UserAvatarClient({
                 <CircleHelp className="text-muted-foreground size-4" />
                 {t("support")}
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-muted-foreground text-xs">
-                {t("legal")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => {
-                  closeMenu();
-                  handleOpenExternalLink(
-                    "https://www.sokosumi.com/terms-of-service",
-                  );
-                }}
-              >
-                {t("termsOfService")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => {
-                  closeMenu();
-                  handleOpenExternalLink(
-                    "https://www.sokosumi.com/privacy-policy",
-                  );
-                }}
-              >
-                {t("privacyPolicy")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => {
-                  closeMenu();
-                  handleOpenExternalLink("https://www.sokosumi.com/imprint");
-                }}
-              >
-                {t("imprint")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => {
-                  closeMenu();
-                  handleOpenExternalLink(
-                    "https://www.sokosumi.com/acceptable-use",
-                  );
-                }}
-              >
-                {t("acceptableUse")}
-              </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+          <DropdownMenuLabel className="text-muted-foreground text-xs">
+            {t("legal")}
+          </DropdownMenuLabel>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => {
+              closeMenu();
+              handleOpenExternalLink(
+                "https://www.sokosumi.com/terms-of-service",
+              );
+            }}
+          >
+            {t("termsOfService")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => {
+              closeMenu();
+              handleOpenExternalLink("https://www.sokosumi.com/privacy-policy");
+            }}
+          >
+            {t("privacyPolicy")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => {
+              closeMenu();
+              handleOpenExternalLink("https://www.sokosumi.com/imprint");
+            }}
+          >
+            {t("imprint")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => {
+              closeMenu();
+              handleOpenExternalLink("https://www.sokosumi.com/acceptable-use");
+            }}
+          >
+            {t("acceptableUse")}
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="flex cursor-pointer items-center gap-2"

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
@@ -8,11 +8,15 @@ import {
   Cable,
   ChevronDown,
   CircleHelp,
+  Landmark,
   LifeBuoy,
+  ListChecks,
   LogOut,
   ReceiptText,
   Scale,
+  ScrollText,
   Settings as SettingsIcon,
+  Shield,
   User as UserIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -244,6 +248,7 @@ export default function UserAvatarClient({
                   );
                 }}
               >
+                <ScrollText className="text-muted-foreground size-4" />
                 {t("termsOfService")}
               </DropdownMenuItem>
               <DropdownMenuItem
@@ -255,6 +260,7 @@ export default function UserAvatarClient({
                   );
                 }}
               >
+                <Shield className="text-muted-foreground size-4" />
                 {t("privacyPolicy")}
               </DropdownMenuItem>
               <DropdownMenuItem
@@ -264,6 +270,7 @@ export default function UserAvatarClient({
                   handleOpenExternalLink("https://www.sokosumi.com/imprint");
                 }}
               >
+                <Landmark className="text-muted-foreground size-4" />
                 {t("imprint")}
               </DropdownMenuItem>
               <DropdownMenuItem
@@ -275,6 +282,7 @@ export default function UserAvatarClient({
                   );
                 }}
               >
+                <ListChecks className="text-muted-foreground size-4" />
                 {t("acceptableUse")}
               </DropdownMenuItem>
             </DropdownMenuSubContent>

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
@@ -11,6 +11,7 @@ import {
   LifeBuoy,
   LogOut,
   ReceiptText,
+  Scale,
   Settings as SettingsIcon,
   User as UserIcon,
 } from "lucide-react";
@@ -228,47 +229,56 @@ export default function UserAvatarClient({
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          <DropdownMenuLabel className="text-muted-foreground text-xs">
-            {t("legal")}
-          </DropdownMenuLabel>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={() => {
-              closeMenu();
-              handleOpenExternalLink(
-                "https://www.sokosumi.com/terms-of-service",
-              );
-            }}
-          >
-            {t("termsOfService")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={() => {
-              closeMenu();
-              handleOpenExternalLink("https://www.sokosumi.com/privacy-policy");
-            }}
-          >
-            {t("privacyPolicy")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={() => {
-              closeMenu();
-              handleOpenExternalLink("https://www.sokosumi.com/imprint");
-            }}
-          >
-            {t("imprint")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={() => {
-              closeMenu();
-              handleOpenExternalLink("https://www.sokosumi.com/acceptable-use");
-            }}
-          >
-            {t("acceptableUse")}
-          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
+              <Scale className="text-muted-foreground size-4" />
+              {t("legal")}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  closeMenu();
+                  handleOpenExternalLink(
+                    "https://www.sokosumi.com/terms-of-service",
+                  );
+                }}
+              >
+                {t("termsOfService")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  closeMenu();
+                  handleOpenExternalLink(
+                    "https://www.sokosumi.com/privacy-policy",
+                  );
+                }}
+              >
+                {t("privacyPolicy")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  closeMenu();
+                  handleOpenExternalLink("https://www.sokosumi.com/imprint");
+                }}
+              >
+                {t("imprint")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  closeMenu();
+                  handleOpenExternalLink(
+                    "https://www.sokosumi.com/acceptable-use",
+                  );
+                }}
+              >
+                {t("acceptableUse")}
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="flex cursor-pointer items-center gap-2"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves legal links out of the Help submenu into a dedicated **Legal** menu item with its own submenu, matching the Help pattern. Legal submenu items include lucide icons for visual consistency with Help.

## Changes

- **Help submenu** (unchanged): Documentation, Serviceplan AI Coworker, Support
- **Legal submenu** (new): Terms of Service, Privacy Policy, Imprint, Acceptable Use
- **Legal icons**: `ScrollText`, `Shield`, `Landmark`, `ListChecks` (parent trigger uses `Scale`)
- Updated both profile dropdown implementations:
  - `profile-switch.client.tsx` (sidebar profile menu — desktop submenus + mobile expandable sections)
  - `user-avatar.client.tsx` (legacy settings dropdown)

## Menu structure

```
Account
Organizations
Billing (when permitted)
Connections
Help → Documentation | Serviceplan AI Coworker | Support
Legal → Terms of Service | Privacy Policy | Imprint | Acceptable Use
Logout
```

## Commits

- `fix(web): move legal links to main profile menu under Help`
- `fix(web): show legal links in legal submenu`
- `fix(web): add icons to legal submenu items`

## Verification

- [x] `pnpm --filter web check`
- [ ] Manual check in profile dropdown (desktop + mobile)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbd92683-0748-4901-bbe1-b380e1eec15e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbd92683-0748-4901-bbe1-b380e1eec15e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>