### PR TITLE
feat(web): add Serviceplan AI Coworker link to Help menu

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -133,6 +133,7 @@
       "help": "Hilfe",
       "legal": "Rechtliches",
       "documentation": "Dokumentation",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Nutzungsbedingungen",
       "privacyPolicy": "Datenschutzrichtlinie",
       "imprint": "Impressum",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -129,6 +129,7 @@
       "legal": "Legal",
       "support": "Support",
       "documentation": "Documentation",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Terms of Service",
       "privacyPolicy": "Privacy Policy",
       "imprint": "Imprint",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -133,6 +133,7 @@
       "help": "Ayuda",
       "legal": "Legal",
       "documentation": "Documentación",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Términos de servicio",
       "privacyPolicy": "Política de privacidad",
       "imprint": "Aviso legal",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -129,6 +129,7 @@
       "legal": "Mentions légales",
       "support": "Support",
       "documentation": "Documentation",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Conditions d’utilisation",
       "privacyPolicy": "Politique de confidentialité",
       "imprint": "Mentions légales",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -129,6 +129,7 @@
       "legal": "Note legali",
       "support": "Supporto",
       "documentation": "Documentazione",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Termini di servizio",
       "privacyPolicy": "Informativa sulla privacy",
       "imprint": "Note legali",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -129,6 +129,7 @@
       "legal": "法務",
       "support": "サポート",
       "documentation": "ドキュメント",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "利用規約",
       "privacyPolicy": "プライバシーポリシー",
       "imprint": "会社情報",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -129,6 +129,7 @@
       "legal": "Jurídico",
       "support": "Suporte",
       "documentation": "Documentação",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Termos de serviço",
       "privacyPolicy": "Política de privacidade",
       "imprint": "Informações legais",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -129,6 +129,7 @@
       "legal": "Legal",
       "support": "Suporte",
       "documentation": "Documentação",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "Termos de serviço",
       "privacyPolicy": "Política de privacidade",
       "imprint": "Aviso legal",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -129,6 +129,7 @@
       "legal": "法律",
       "support": "支持",
       "documentation": "文档",
+      "serviceplanAiCoworker": "Serviceplan AI Coworker",
       "termsOfService": "服务条款",
       "privacyPolicy": "隐私政策",
       "imprint": "法律声明",

--- a/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
@@ -5,6 +5,7 @@ import gravatarUrl from "gravatar-url";
 import {
   ArrowLeftRight,
   BookOpen,
+  Bot,
   Building2,
   Cable,
   Check,
@@ -76,6 +77,7 @@ interface HelpLinkItem {
   url: string;
   translationKey:
     | "documentation"
+    | "serviceplanAiCoworker"
     | "support"
     | "termsOfService"
     | "privacyPolicy"
@@ -89,6 +91,11 @@ const HELP_LINKS: HelpLinkItem[] = [
     url: "https://docs.sokosumi.com/documentation",
     translationKey: "documentation",
     icon: BookOpen,
+  },
+  {
+    url: "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
+    translationKey: "serviceplanAiCoworker",
+    icon: Bot,
   },
   {
     url: "mailto:info@sokosumi.com",

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
@@ -3,6 +3,7 @@
 import { MemberRole, type MemberWithOrganization } from "@sokosumi/database";
 import {
   BookOpen,
+  Bot,
   Building2,
   Cable,
   ChevronDown,
@@ -203,7 +204,18 @@ export default function UserAvatarClient({
                 <BookOpen className="text-muted-foreground size-4" />
                 {t("documentation")}
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  closeMenu();
+                  handleOpenExternalLink(
+                    "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
+                  );
+                }}
+              >
+                <Bot className="text-muted-foreground size-4" />
+                {t("serviceplanAiCoworker")}
+              </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
                 onClick={() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new **Serviceplan AI Coworker** entry under **Help** in the user profile menu, positioned between **Documentation** and **Support**. The link opens the Serviceplan legal AI coworkers landing page in a new tab.

## Changes

- Updated `profile-switch.client.tsx` (sidebar profile menu) and `user-avatar.client.tsx` (header profile menu) with the new external link
- Added `Components.UserAvatar.serviceplanAiCoworker` translation key across all locale files

## Verification

- `pnpm web:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b4645b4-b05e-49eb-b760-b2035a91045e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b4645b4-b05e-49eb-b760-b2035a91045e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

