### PR TITLE
fix(auth): configure sentinel client identify URL from env

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -64,6 +64,7 @@ BETTER_AUTH_SECRET=<better-auth-secret>
 BETTER_AUTH_API_KEY=<better-auth-api-key>
 BETTER_AUTH_ORG_INVITATION_LIMIT=<organization-invitation-limit>
 BETTER_AUTH_ORG_LIMIT=<organization-limit>
+NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL=https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L
 
 # Postmark
 POSTMARK_FROM_EMAIL=<your-postmark-from-email>

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -64,7 +64,7 @@ BETTER_AUTH_SECRET=<better-auth-secret>
 BETTER_AUTH_API_KEY=<better-auth-api-key>
 BETTER_AUTH_ORG_INVITATION_LIMIT=<organization-invitation-limit>
 BETTER_AUTH_ORG_LIMIT=<organization-limit>
-NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL=https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L
+NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL=https://kv.better-auth.com/projects/<your-project-id>
 
 # Postmark
 POSTMARK_FROM_EMAIL=<your-postmark-from-email>

--- a/apps/web/src/config/env.public.ts
+++ b/apps/web/src/config/env.public.ts
@@ -34,6 +34,7 @@ const envPublicConfigSchema = z.object({
     .min(0)
     .default(100),
   NEXT_PUBLIC_SHOW_EMERGENCY_DIALOG: z.coerce.boolean().default(false),
+  NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL: z.url().optional(),
 });
 
 let envPublicConfig: z.infer<typeof envPublicConfigSchema>;
@@ -64,6 +65,8 @@ function validateEnv() {
       process.env.NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD,
     NEXT_PUBLIC_SHOW_EMERGENCY_DIALOG:
       process.env.NEXT_PUBLIC_SHOW_EMERGENCY_DIALOG,
+    NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL:
+      process.env.NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL,
   };
 
   const parsedConfig = envPublicConfigSchema.safeParse(rawEnv);

--- a/apps/web/src/lib/auth/__tests__/auth.client.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.client.test.ts
@@ -71,7 +71,7 @@ describe("auth client", () => {
       NEXT_PUBLIC_VERCEL_ENV: undefined,
       NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: undefined,
       NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL:
-        "https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L",
+        "https://kv.better-auth.com/projects/example-project-id",
     });
   });
 
@@ -112,8 +112,7 @@ describe("auth client", () => {
     await import("../auth.client");
 
     expect(sentinelClientMock).toHaveBeenCalledWith({
-      identifyUrl:
-        "https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L",
+      identifyUrl: "https://kv.better-auth.com/projects/example-project-id",
     });
   });
 
@@ -123,7 +122,7 @@ describe("auth client", () => {
       NEXT_PUBLIC_VERCEL_ENV: "preview",
       NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: "feature/123",
       NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL:
-        "https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L",
+        "https://kv.better-auth.com/projects/example-project-id",
     });
 
     await import("../auth.client");

--- a/apps/web/src/lib/auth/__tests__/auth.client.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.client.test.ts
@@ -70,6 +70,8 @@ describe("auth client", () => {
       NEXT_PUBLIC_NETWORK: "Preprod",
       NEXT_PUBLIC_VERCEL_ENV: undefined,
       NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: undefined,
+      NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL:
+        "https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L",
     });
   });
 
@@ -106,11 +108,22 @@ describe("auth client", () => {
     });
   });
 
+  it("configures sentinelClient with the project identify url", async () => {
+    await import("../auth.client");
+
+    expect(sentinelClientMock).toHaveBeenCalledWith({
+      identifyUrl:
+        "https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L",
+    });
+  });
+
   it("uses the preview branch prefix when the public Vercel env is preview", async () => {
     getEnvPublicConfigMock.mockReturnValue({
       NEXT_PUBLIC_NETWORK: "Mainnet",
       NEXT_PUBLIC_VERCEL_ENV: "preview",
       NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: "feature/123",
+      NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL:
+        "https://kv.better-auth.com/projects/cxQKnhdfEtjquuAjSN6GcqNv9YoOPS5L",
     });
 
     await import("../auth.client");

--- a/apps/web/src/lib/auth/auth.client.ts
+++ b/apps/web/src/lib/auth/auth.client.ts
@@ -18,6 +18,10 @@ import { getEnvPublicConfig } from "@/config/env.public";
 
 import type { auth } from "./auth";
 
+function getSentinelIdentifyUrl(): string | undefined {
+  return getEnvPublicConfig().NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL;
+}
+
 function getLastUsedLoginMethodCookieName(): string {
   const env = getEnvPublicConfig();
 
@@ -49,7 +53,9 @@ export const authClient = createAuthClient({
       subscription: true,
     }),
     dashClient(),
-    sentinelClient(),
+    sentinelClient({
+      identifyUrl: getSentinelIdentifyUrl(),
+    }),
   ],
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Configures the Better Auth Sentinel client to use the project-scoped identify ingestion URL from environment variables, which removes the default global ingestion warning in the browser.

## Changes

- Added `NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL` to public env config (validated as URL)
- Passed the value to `sentinelClient({ identifyUrl })` in `auth.client.ts`
- Documented the variable in `apps/web/.env.example` with a placeholder URL
- Added a unit test asserting Sentinel client configuration

## Deployment

Set the identify URL from your Better Auth project settings in each environment (Vercel, local `.env`, etc.):

```bash
NEXT_PUBLIC_BETTER_AUTH_SENTINEL_IDENTIFY_URL=https://kv.better-auth.com/projects/<your-project-id>
```

## Verification

- `pnpm --filter web test src/lib/auth/__tests__/auth.client.test.ts`
- `pnpm --filter web check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec43cb93-165e-402c-94a2-f9c8522fc1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec43cb93-165e-402c-94a2-f9c8522fc1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

