### PR TITLE
fix(web): move Serviceplan AI Coworker link to Legal menu

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/profile-switch.client.tsx
@@ -80,7 +80,7 @@ function getWorkspaceKey(workspace: WorkspaceItem): string {
 
 interface HelpLinkItem {
   url: string;
-  translationKey: "documentation" | "serviceplanAiCoworker" | "support";
+  translationKey: "documentation" | "support";
   icon?: ComponentType<{ "aria-hidden"?: boolean; className?: string }>;
 }
 
@@ -90,7 +90,8 @@ interface LegalLinkItem {
     | "termsOfService"
     | "privacyPolicy"
     | "imprint"
-    | "acceptableUse";
+    | "acceptableUse"
+    | "serviceplanAiCoworker";
   icon?: ComponentType<{ "aria-hidden"?: boolean; className?: string }>;
 }
 
@@ -101,11 +102,6 @@ const HELP_LINKS: HelpLinkItem[] = [
     icon: BookOpen,
   },
   {
-    url: "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
-    translationKey: "serviceplanAiCoworker",
-    icon: Bot,
-  },
-  {
     url: "mailto:info@sokosumi.com",
     translationKey: "support",
     icon: CircleHelp,
@@ -113,6 +109,11 @@ const HELP_LINKS: HelpLinkItem[] = [
 ];
 
 const LEGAL_LINKS: LegalLinkItem[] = [
+  {
+    url: "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
+    translationKey: "serviceplanAiCoworker",
+    icon: Bot,
+  },
   {
     url: "https://www.sokosumi.com/terms-of-service",
     translationKey: "termsOfService",

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
@@ -213,18 +213,6 @@ export default function UserAvatarClient({
                 className="cursor-pointer"
                 onClick={() => {
                   closeMenu();
-                  handleOpenExternalLink(
-                    "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
-                  );
-                }}
-              >
-                <Bot className="text-muted-foreground size-4" />
-                {t("serviceplanAiCoworker")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onClick={() => {
-                  closeMenu();
                   handleOpenExternalLink("mailto:info@sokosumi.com");
                 }}
               >
@@ -239,6 +227,18 @@ export default function UserAvatarClient({
               {t("legal")}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  closeMenu();
+                  handleOpenExternalLink(
+                    "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
+                  );
+                }}
+              >
+                <Bot className="text-muted-foreground size-4" />
+                {t("serviceplanAiCoworker")}
+              </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
                 onClick={() => {


### PR DESCRIPTION
## Summary
- Moves the Serviceplan AI Coworker external link from the Help submenu to the Legal submenu in both profile menus (sidebar profile switch and user avatar dropdown).
- Lists it as the first item under Legal.

## Test plan
- [ ] Open profile menu in sidebar and expand Legal — Serviceplan AI Coworker is first and opens the correct URL.
- [ ] Open user avatar dropdown and expand Legal — same link appears first.
- [ ] Confirm Help submenu no longer includes Serviceplan AI Coworker (Documentation and Support only).


Made with [Cursor](https://cursor.com)