### PR TITLE
feat(credits): pre-create local free periods with credit bucket activatesAt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,29 @@ jobs:
       - name: Run Biome checks
         run: pnpm check
 
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run TypeScript typecheck
+        run: pnpm typecheck
+
   biome-annotations:
     name: Biome PR annotations
     runs-on: ubuntu-latest

--- a/apps/core/src/helpers/organization.test.ts
+++ b/apps/core/src/helpers/organization.test.ts
@@ -32,6 +32,7 @@ function createMember(overrides: Record<string, unknown> = {}) {
     id: "member_1",
     role: MemberRole.MEMBER,
     createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    seatAssignedAt: null,
     userId: "user_123",
     organizationId: "org_123",
     ...overrides,

--- a/apps/core/src/helpers/subscription.test.ts
+++ b/apps/core/src/helpers/subscription.test.ts
@@ -13,11 +13,11 @@ import {
 const getCreditsMock = vi.fn();
 
 const {
-  getLatestActiveSubscriptionByReferenceIdMock,
+  resolveActiveSubscriptionByReferenceIdMock,
   getLatestSubscriptionByReferenceIdMock,
   listAvailableBucketsWithBalancesMock,
 } = vi.hoisted(() => ({
-  getLatestActiveSubscriptionByReferenceIdMock: vi.fn(),
+  resolveActiveSubscriptionByReferenceIdMock: vi.fn(),
   getLatestSubscriptionByReferenceIdMock: vi.fn(),
   listAvailableBucketsWithBalancesMock: vi.fn(),
 }));
@@ -28,8 +28,8 @@ vi.mock("@/helpers/user", () => ({
 
 vi.mock("@sokosumi/database/repositories", () => ({
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
     getLatestSubscriptionByReferenceId: (...args: unknown[]) =>
       getLatestSubscriptionByReferenceIdMock(...args),
   },
@@ -283,7 +283,7 @@ describe("getCurrentSubscriptionCredits", () => {
       remaining: 7,
     });
 
-    const bucketWhere = {
+    const bucketScope = {
       referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
       userId: "user_1",
       organizationId: null,
@@ -294,6 +294,12 @@ describe("getCurrentSubscriptionCredits", () => {
       createdAt: {
         lt: now,
       },
+    };
+    const bucketWhere = {
+      AND: [
+        { OR: [{ activatesAt: null }, { activatesAt: { lte: now } }] },
+        bucketScope,
+      ],
     };
 
     expect(aggregateBuckets).toHaveBeenCalledWith({
@@ -342,7 +348,7 @@ describe("getCurrentSubscriptionCredits", () => {
       remaining: 9,
     });
 
-    const bucketWhere = {
+    const bucketScope = {
       referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
       organizationId: "org_1",
       userId: "user_1",
@@ -359,6 +365,12 @@ describe("getCurrentSubscriptionCredits", () => {
       createdAt: {
         lt: now,
       },
+    };
+    const bucketWhere = {
+      AND: [
+        { OR: [{ activatesAt: null }, { activatesAt: { lte: now } }] },
+        bucketScope,
+      ],
     };
 
     expect(aggregateBuckets).toHaveBeenCalledWith({
@@ -448,18 +460,23 @@ describe("getCurrentSubscriptionCredits", () => {
       _sum: {
         amount: true,
       },
-      where: expect.objectContaining({
-        createdAt: {
-          lt: now,
-        },
-      }),
+      where: {
+        AND: [
+          { OR: [{ activatesAt: null }, { activatesAt: { lte: now } }] },
+          expect.objectContaining({
+            createdAt: {
+              lt: now,
+            },
+          }),
+        ],
+      },
     });
   });
 });
 
 describe("buildCreditsPayload", () => {
   beforeEach(() => {
-    getLatestActiveSubscriptionByReferenceIdMock.mockReset();
+    resolveActiveSubscriptionByReferenceIdMock.mockReset();
     getLatestSubscriptionByReferenceIdMock.mockReset();
     listAvailableBucketsWithBalancesMock.mockReset();
     listAvailableBucketsWithBalancesMock.mockResolvedValue([]);
@@ -477,7 +494,7 @@ describe("buildCreditsPayload", () => {
         periodEnd,
         periodStart,
       });
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue(
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(
         activeSubscription,
       );
 
@@ -553,7 +570,7 @@ describe("buildCreditsPayload", () => {
         tx,
       );
 
-      expect(getLatestActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
+      expect(resolveActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
         "user_1",
         tx,
       );
@@ -573,7 +590,7 @@ describe("buildCreditsPayload", () => {
       getCreditsMock.mockResolvedValue(25);
       const periodStart = new Date("2025-01-01T00:00:00.000Z");
       const periodEnd = new Date("2025-02-01T00:00:00.000Z");
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
       getLatestSubscriptionByReferenceIdMock.mockResolvedValue(
         createSubscriptionRecord({
           periodEnd,
@@ -654,7 +671,7 @@ describe("buildCreditsPayload", () => {
         tx,
       );
 
-      expect(getLatestActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
+      expect(resolveActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
         "user_1",
         tx,
       );
@@ -675,7 +692,7 @@ describe("buildCreditsPayload", () => {
       vi.setSystemTime(new Date("2025-01-15T12:00:00.000Z"));
 
       getCreditsMock.mockResolvedValue(10);
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
       getLatestSubscriptionByReferenceIdMock.mockResolvedValue(null);
 
       const expiresAt = new Date("2026-03-01T00:00:00.000Z");

--- a/apps/core/src/helpers/subscription.ts
+++ b/apps/core/src/helpers/subscription.ts
@@ -1,5 +1,8 @@
 import { CreditBucketReferenceType, type Prisma } from "@sokosumi/database";
-import { getOrganizationMemberSubscriptionReferencePrefixForStartsWith } from "@sokosumi/database/helpers";
+import {
+  creditBucketActivatesAtOrBefore,
+  getOrganizationMemberSubscriptionReferencePrefixForStartsWith,
+} from "@sokosumi/database/helpers";
 import {
   creditBucketRepository,
   subscriptionRepository,
@@ -88,7 +91,7 @@ export async function getCurrentSubscriptionCredits(params: {
     return null;
   }
 
-  const currentPeriodBucketWhere = params.organizationId
+  const currentPeriodBucketScope = params.organizationId
     ? {
         referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
         organizationId: params.organizationId,
@@ -119,6 +122,10 @@ export async function getCurrentSubscriptionCredits(params: {
           lt: now,
         },
       };
+
+  const currentPeriodBucketWhere = {
+    AND: [creditBucketActivatesAtOrBefore(now), currentPeriodBucketScope],
+  };
 
   const totalAggregateResult = await params.tx.creditBucket.aggregate({
     _sum: {
@@ -228,7 +235,7 @@ export async function buildCreditsPayload(params: {
     params.tx,
   );
   const latestSubscription =
-    (await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    (await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
       params.referenceId,
       params.tx,
     )) ??

--- a/apps/core/src/routes/sync/free-subscriptions-renewal/get.ts
+++ b/apps/core/src/routes/sync/free-subscriptions-renewal/get.ts
@@ -26,6 +26,7 @@ export default function mount(app: Hono) {
 
         console.info("[sync/free-subscriptions-renewal] Completed sync", {
           durationMs: Date.now() - startedAt,
+          preCreated: result.preCreated,
           renewalErrors: result.renewalErrors,
           renewed: result.renewed,
           stoppedEarly: result.stoppedEarly,

--- a/apps/core/src/services/free-subscription-sync.service.test.ts
+++ b/apps/core/src/services/free-subscription-sync.service.test.ts
@@ -71,8 +71,15 @@ function isPreCreateQuery(where: {
   return Boolean(where.periodEnd?.gt && where.periodEnd?.lte);
 }
 
-function isOverdueQuery(where: { periodEnd?: { lte?: Date } }): boolean {
+function isOverdueQuery(where: {
+  periodEnd?: { gt?: Date; lte?: Date };
+}): boolean {
   return Boolean(where.periodEnd?.lte && !where.periodEnd?.gt);
+}
+
+interface SubscriptionRenewalFindManyWhere {
+  OR?: Array<{ referenceId: string }> | unknown[];
+  periodEnd?: { gt?: Date; lte?: Date };
 }
 
 describe("freeSubscriptionSyncService", () => {
@@ -93,7 +100,7 @@ describe("freeSubscriptionSyncService", () => {
 
   it("pre-creates upcoming local free subscriptions within the lookahead window", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({ where }: { where: { OR?: unknown[]; periodEnd?: unknown } }) => {
+      ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {
         if (where.OR) {
           return Promise.resolve([]);
         }
@@ -147,7 +154,7 @@ describe("freeSubscriptionSyncService", () => {
 
   it("renews due local free subscriptions exactly once per overdue period", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({ where }: { where: { OR?: unknown[]; periodEnd?: unknown } }) => {
+      ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {
         if (where.OR) {
           return Promise.resolve([]);
         }
@@ -203,11 +210,7 @@ describe("freeSubscriptionSyncService", () => {
 
   it("closes overdue subscription when the next local free successor already exists", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({
-        where,
-      }: {
-        where: { OR?: Array<{ referenceId: string }>; periodEnd?: unknown };
-      }) => {
+      ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {
         if (where.OR) {
           return Promise.resolve([
             {
@@ -258,7 +261,7 @@ describe("freeSubscriptionSyncService", () => {
 
   it("catches up multiple overdue local free subscriptions in one run", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({ where }: { where: { OR?: unknown[]; periodEnd?: unknown } }) => {
+      ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {
         if (where.OR) {
           return Promise.resolve([]);
         }

--- a/apps/core/src/services/free-subscription-sync.service.test.ts
+++ b/apps/core/src/services/free-subscription-sync.service.test.ts
@@ -364,10 +364,12 @@ describe("freeSubscriptionSyncService", () => {
       "./free-subscription-sync.service"
     );
 
-    await freeSubscriptionSyncService.renewLocalFreeSubscriptions(
-      createSyncExecutionOptions(),
-    );
+    const result =
+      await freeSubscriptionSyncService.renewLocalFreeSubscriptions(
+        createSyncExecutionOptions(),
+      );
 
+    expect(result.renewed).toBe(0);
     expect(closeOverdueLocalFreeSubscriptionMock).toHaveBeenCalledTimes(1);
     expect(
       transitionToNextLocalFreeSubscriptionPeriodMock,

--- a/apps/core/src/services/free-subscription-sync.service.test.ts
+++ b/apps/core/src/services/free-subscription-sync.service.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  closeOverdueLocalFreeSubscriptionMock,
+  ensureNextLocalFreeSubscriptionPeriodMock,
   subscriptionFindManyMock,
   transitionToNextLocalFreeSubscriptionPeriodMock,
 } = vi.hoisted(() => ({
+  closeOverdueLocalFreeSubscriptionMock: vi.fn(),
+  ensureNextLocalFreeSubscriptionPeriodMock: vi.fn(),
   subscriptionFindManyMock: vi.fn(),
   transitionToNextLocalFreeSubscriptionPeriodMock: vi.fn(),
 }));
@@ -11,6 +15,7 @@ const {
 vi.mock("@sokosumi/database/helpers", () => ({
   ACTIVE_SUBSCRIPTION_STATUSES: ["active", "trialing", "past_due", "unpaid"],
   FREE_SUBSCRIPTION_PLAN: "free",
+  FREE_SUBSCRIPTION_PRECREATE_LOOKAHEAD_MS: 15 * 60 * 1000,
   getNextMonthlyPeriodEnd: (periodStart: Date, anchorDate: Date) => {
     const targetMonthIndex = periodStart.getUTCMonth() + 1;
     const targetYear =
@@ -32,6 +37,10 @@ vi.mock("@sokosumi/database/helpers", () => ({
       ),
     );
   },
+  ensureNextLocalFreeSubscriptionPeriod: (...args: unknown[]) =>
+    ensureNextLocalFreeSubscriptionPeriodMock(...args),
+  closeOverdueLocalFreeSubscription: (...args: unknown[]) =>
+    closeOverdueLocalFreeSubscriptionMock(...args),
   transitionToNextLocalFreeSubscriptionPeriod: (...args: unknown[]) =>
     transitionToNextLocalFreeSubscriptionPeriodMock(...args),
 }));
@@ -56,11 +65,23 @@ function createSyncExecutionOptions() {
   };
 }
 
+function isPreCreateQuery(where: {
+  periodEnd?: { gt?: Date; lte?: Date };
+}): boolean {
+  return Boolean(where.periodEnd?.gt && where.periodEnd?.lte);
+}
+
+function isOverdueQuery(where: { periodEnd?: { lte?: Date } }): boolean {
+  return Boolean(where.periodEnd?.lte && !where.periodEnd?.gt);
+}
+
 describe("freeSubscriptionSyncService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-15T00:00:00.000Z"));
     vi.resetAllMocks();
+    ensureNextLocalFreeSubscriptionPeriodMock.mockResolvedValue(true);
+    closeOverdueLocalFreeSubscriptionMock.mockResolvedValue(undefined);
     transitionToNextLocalFreeSubscriptionPeriodMock.mockResolvedValue(
       undefined,
     );
@@ -70,25 +91,88 @@ describe("freeSubscriptionSyncService", () => {
     vi.useRealTimers();
   });
 
-  it("renews due local free subscriptions exactly once per overdue period", async () => {
+  it("pre-creates upcoming local free subscriptions within the lookahead window", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({ where }: { where: { OR?: unknown[] } }) => {
+      ({ where }: { where: { OR?: unknown[]; periodEnd?: unknown } }) => {
         if (where.OR) {
           return Promise.resolve([]);
         }
 
-        return Promise.resolve([
-          {
-            canceledAt: null,
-            createdAt: new Date("2026-03-15T00:00:00.000Z"),
-            endedAt: null,
-            id: "sub-local-1",
-            periodEnd: new Date("2026-04-15T00:00:00.000Z"),
-            referenceId: "org-1",
-            stripeCustomerId: "cus_1",
-            stripeSubscriptionId: null,
-          },
-        ]);
+        if (isPreCreateQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              endedAt: null,
+              id: "sub-upcoming",
+              periodEnd: new Date("2026-04-15T00:10:00.000Z"),
+              referenceId: "user-1",
+              seats: null,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        if (isOverdueQuery(where)) {
+          return Promise.resolve([]);
+        }
+
+        return Promise.resolve([]);
+      },
+    );
+
+    const { freeSubscriptionSyncService } = await import(
+      "./free-subscription-sync.service"
+    );
+
+    const result =
+      await freeSubscriptionSyncService.renewLocalFreeSubscriptions(
+        createSyncExecutionOptions(),
+      );
+
+    expect(result.preCreated).toBe(1);
+    expect(result.renewed).toBe(0);
+    expect(ensureNextLocalFreeSubscriptionPeriodMock).toHaveBeenCalledWith(
+      {
+        activatesAt: new Date("2026-04-15T00:10:00.000Z"),
+        subscription: expect.objectContaining({ id: "sub-upcoming" }),
+      },
+      expect.anything(),
+    );
+    expect(
+      transitionToNextLocalFreeSubscriptionPeriodMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("renews due local free subscriptions exactly once per overdue period", async () => {
+    subscriptionFindManyMock.mockImplementation(
+      ({ where }: { where: { OR?: unknown[]; periodEnd?: unknown } }) => {
+        if (where.OR) {
+          return Promise.resolve([]);
+        }
+
+        if (isPreCreateQuery(where)) {
+          return Promise.resolve([]);
+        }
+
+        if (isOverdueQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              endedAt: null,
+              id: "sub-local-1",
+              periodEnd: new Date("2026-04-15T00:00:00.000Z"),
+              referenceId: "org-1",
+              seats: null,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        return Promise.resolve([]);
       },
     );
 
@@ -108,24 +192,22 @@ describe("freeSubscriptionSyncService", () => {
     ).toHaveBeenCalledWith(
       {
         setCanceledAt: false,
-        subscription: {
-          canceledAt: null,
-          createdAt: new Date("2026-03-15T00:00:00.000Z"),
-          endedAt: null,
+        subscription: expect.objectContaining({
           id: "sub-local-1",
-          periodEnd: new Date("2026-04-15T00:00:00.000Z"),
           referenceId: "org-1",
-          stripeCustomerId: "cus_1",
-          stripeSubscriptionId: null,
-        },
+        }),
       },
       expect.anything(),
     );
   });
 
-  it("skips renewal when the next local free successor already exists", async () => {
+  it("closes overdue subscription when the next local free successor already exists", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({ where }: { where: { OR?: Array<{ referenceId: string }> } }) => {
+      ({
+        where,
+      }: {
+        where: { OR?: Array<{ referenceId: string }>; periodEnd?: unknown };
+      }) => {
         if (where.OR) {
           return Promise.resolve([
             {
@@ -136,18 +218,27 @@ describe("freeSubscriptionSyncService", () => {
           ]);
         }
 
-        return Promise.resolve([
-          {
-            canceledAt: null,
-            createdAt: new Date("2026-03-15T00:00:00.000Z"),
-            endedAt: null,
-            id: "sub-local-1",
-            periodEnd: new Date("2026-04-15T00:00:00.000Z"),
-            referenceId: "user-1",
-            stripeCustomerId: "cus_1",
-            stripeSubscriptionId: null,
-          },
-        ]);
+        if (isPreCreateQuery(where)) {
+          return Promise.resolve([]);
+        }
+
+        if (isOverdueQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              endedAt: null,
+              id: "sub-local-1",
+              periodEnd: new Date("2026-04-15T00:00:00.000Z"),
+              referenceId: "user-1",
+              seats: null,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        return Promise.resolve([]);
       },
     );
 
@@ -159,6 +250,7 @@ describe("freeSubscriptionSyncService", () => {
       createSyncExecutionOptions(),
     );
 
+    expect(closeOverdueLocalFreeSubscriptionMock).toHaveBeenCalledTimes(1);
     expect(
       transitionToNextLocalFreeSubscriptionPeriodMock,
     ).not.toHaveBeenCalled();
@@ -166,33 +258,41 @@ describe("freeSubscriptionSyncService", () => {
 
   it("catches up multiple overdue local free subscriptions in one run", async () => {
     subscriptionFindManyMock.mockImplementation(
-      ({ where }: { where: { OR?: unknown[] } }) => {
+      ({ where }: { where: { OR?: unknown[]; periodEnd?: unknown } }) => {
         if (where.OR) {
           return Promise.resolve([]);
         }
 
-        return Promise.resolve([
-          {
-            canceledAt: null,
-            createdAt: new Date("2026-01-31T10:00:00.000Z"),
-            endedAt: null,
-            id: "sub-local-1",
-            periodEnd: new Date("2026-02-28T10:00:00.000Z"),
-            referenceId: "user-1",
-            stripeCustomerId: "cus_1",
-            stripeSubscriptionId: null,
-          },
-          {
-            canceledAt: null,
-            createdAt: new Date("2026-02-28T10:00:00.000Z"),
-            endedAt: null,
-            id: "sub-local-2",
-            periodEnd: new Date("2026-03-31T10:00:00.000Z"),
-            referenceId: "user-2",
-            stripeCustomerId: "cus_2",
-            stripeSubscriptionId: null,
-          },
-        ]);
+        if (isPreCreateQuery(where)) {
+          return Promise.resolve([]);
+        }
+
+        if (isOverdueQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-01-31T10:00:00.000Z"),
+              endedAt: null,
+              id: "sub-local-1",
+              periodEnd: new Date("2026-02-28T10:00:00.000Z"),
+              referenceId: "user-1",
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-02-28T10:00:00.000Z"),
+              endedAt: null,
+              id: "sub-local-2",
+              periodEnd: new Date("2026-03-31T10:00:00.000Z"),
+              referenceId: "user-2",
+              stripeCustomerId: "cus_2",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        return Promise.resolve([]);
       },
     );
 

--- a/apps/core/src/services/free-subscription-sync.service.test.ts
+++ b/apps/core/src/services/free-subscription-sync.service.test.ts
@@ -152,6 +152,121 @@ describe("freeSubscriptionSyncService", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("does not increment preCreated when ensureNextLocalFreeSubscriptionPeriod returns false", async () => {
+    ensureNextLocalFreeSubscriptionPeriodMock.mockResolvedValue(false);
+    subscriptionFindManyMock.mockImplementation(
+      ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {
+        if (where.OR) {
+          return Promise.resolve([]);
+        }
+
+        if (isPreCreateQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              endedAt: null,
+              id: "sub-orphan",
+              periodEnd: new Date("2026-04-15T00:10:00.000Z"),
+              referenceId: "missing-user",
+              seats: null,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        if (isOverdueQuery(where)) {
+          return Promise.resolve([]);
+        }
+
+        return Promise.resolve([]);
+      },
+    );
+
+    const { freeSubscriptionSyncService } = await import(
+      "./free-subscription-sync.service"
+    );
+
+    const result =
+      await freeSubscriptionSyncService.renewLocalFreeSubscriptions(
+        createSyncExecutionOptions(),
+      );
+
+    expect(result.preCreated).toBe(0);
+    expect(ensureNextLocalFreeSubscriptionPeriodMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the overdue phase handle subscriptions when pre-create could not ensure a successor", async () => {
+    ensureNextLocalFreeSubscriptionPeriodMock.mockResolvedValue(false);
+    subscriptionFindManyMock.mockImplementation(
+      ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {
+        if (where.OR) {
+          return Promise.resolve([]);
+        }
+
+        if (isPreCreateQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              endedAt: null,
+              id: "sub-orphan",
+              periodEnd: new Date("2026-04-15T00:10:00.000Z"),
+              referenceId: "missing-user",
+              seats: null,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        if (isOverdueQuery(where)) {
+          return Promise.resolve([
+            {
+              canceledAt: null,
+              createdAt: new Date("2026-03-15T00:00:00.000Z"),
+              endedAt: null,
+              id: "sub-orphan",
+              periodEnd: new Date("2026-04-15T00:00:00.000Z"),
+              referenceId: "missing-user",
+              seats: null,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: null,
+            },
+          ]);
+        }
+
+        return Promise.resolve([]);
+      },
+    );
+
+    const { freeSubscriptionSyncService } = await import(
+      "./free-subscription-sync.service"
+    );
+
+    const result =
+      await freeSubscriptionSyncService.renewLocalFreeSubscriptions(
+        createSyncExecutionOptions(),
+      );
+
+    expect(result.preCreated).toBe(0);
+    expect(result.renewed).toBe(1);
+    expect(ensureNextLocalFreeSubscriptionPeriodMock).toHaveBeenCalledTimes(1);
+    expect(
+      transitionToNextLocalFreeSubscriptionPeriodMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      transitionToNextLocalFreeSubscriptionPeriodMock,
+    ).toHaveBeenCalledWith(
+      {
+        setCanceledAt: false,
+        subscription: expect.objectContaining({ id: "sub-orphan" }),
+      },
+      expect.anything(),
+    );
+  });
+
   it("renews due local free subscriptions exactly once per overdue period", async () => {
     subscriptionFindManyMock.mockImplementation(
       ({ where }: { where: SubscriptionRenewalFindManyWhere }) => {

--- a/apps/core/src/services/free-subscription-sync.service.ts
+++ b/apps/core/src/services/free-subscription-sync.service.ts
@@ -247,6 +247,7 @@ async function preCreateUpcomingLocalFreeSubscriptions(
   const lookaheadEnd = new Date(
     now.getTime() + FREE_SUBSCRIPTION_PRECREATE_LOOKAHEAD_MS,
   );
+  const preCreateVisitedSubscriptionIds = new Set<string>();
 
   while (true) {
     if (
@@ -278,7 +279,9 @@ async function preCreateUpcomingLocalFreeSubscriptions(
     const subscriptionsNeedingPreCreate =
       await filterSubscriptionsMissingNextLocalSuccessor(
         upcomingLocalFreeSubscriptions.filter(
-          (subscription) => !attemptedSubscriptionIds.has(subscription.id),
+          (subscription) =>
+            !attemptedSubscriptionIds.has(subscription.id) &&
+            !preCreateVisitedSubscriptionIds.has(subscription.id),
         ),
       );
 
@@ -297,7 +300,7 @@ async function preCreateUpcomingLocalFreeSubscriptions(
         return { preCreated, stoppedEarly };
       }
 
-      attemptedSubscriptionIds.add(subscription.id);
+      preCreateVisitedSubscriptionIds.add(subscription.id);
 
       const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
       if (!nextPeriod) {
@@ -305,8 +308,8 @@ async function preCreateUpcomingLocalFreeSubscriptions(
       }
 
       try {
-        await prisma.$transaction(async (tx) => {
-          await ensureNextLocalFreeSubscriptionPeriod(
+        const ensured = await prisma.$transaction(async (tx) => {
+          return ensureNextLocalFreeSubscriptionPeriod(
             {
               activatesAt: nextPeriod.periodStart,
               subscription,
@@ -314,8 +317,13 @@ async function preCreateUpcomingLocalFreeSubscriptions(
             tx,
           );
         });
-        preCreated += 1;
+
+        if (ensured) {
+          preCreated += 1;
+          attemptedSubscriptionIds.add(subscription.id);
+        }
       } catch (error) {
+        attemptedSubscriptionIds.add(subscription.id);
         console.error(
           `${LOG_PREFIX} Failed to pre-create local free subscription ${subscription.id}:`,
           error,

--- a/apps/core/src/services/free-subscription-sync.service.ts
+++ b/apps/core/src/services/free-subscription-sync.service.ts
@@ -1,6 +1,9 @@
 import {
   ACTIVE_SUBSCRIPTION_STATUSES,
+  closeOverdueLocalFreeSubscription,
+  ensureNextLocalFreeSubscriptionPeriod,
   FREE_SUBSCRIPTION_PLAN,
+  FREE_SUBSCRIPTION_PRECREATE_LOOKAHEAD_MS,
   getNextMonthlyPeriodEnd,
   transitionToNextLocalFreeSubscriptionPeriod,
 } from "@sokosumi/database/helpers";
@@ -16,6 +19,7 @@ interface SyncExecutionOptions {
 }
 
 export interface FreeSubscriptionRenewalSyncResult {
+  preCreated: number;
   renewalErrors: number;
   renewed: number;
   stoppedEarly: boolean;
@@ -150,24 +154,185 @@ async function filterSubscriptionsMissingNextLocalSuccessor(
   });
 }
 
-async function renewLocalFreeSubscriptionPeriod(
+function subscriptionHasNextLocalSuccessor(
   subscription: LocalFreeSubscriptionRecord,
-): Promise<void> {
-  await prisma.$transaction(async (tx) => {
-    await transitionToNextLocalFreeSubscriptionPeriod(
-      {
-        setCanceledAt: false,
-        subscription,
-      },
-      tx,
-    );
-  });
+  existingSuccessorKeys: Set<string>,
+): boolean {
+  const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
+
+  if (!nextPeriod) {
+    return false;
+  }
+
+  return existingSuccessorKeys.has(
+    buildLocalFreeSubscriptionPeriodKey(nextPeriod),
+  );
 }
 
-async function renewLocalFreeSubscriptions(
+async function loadExistingSuccessorKeys(
+  subscriptions: LocalFreeSubscriptionRecord[],
+): Promise<Set<string>> {
+  const successorPeriods = new Map<string, LocalFreeSubscriptionPeriodRecord>();
+
+  for (const subscription of subscriptions) {
+    const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
+
+    if (!nextPeriod) {
+      continue;
+    }
+
+    successorPeriods.set(
+      buildLocalFreeSubscriptionPeriodKey(nextPeriod),
+      nextPeriod,
+    );
+  }
+
+  if (successorPeriods.size === 0) {
+    return new Set();
+  }
+
+  const existingLocalSuccessors = await prisma.subscription.findMany({
+    where: {
+      OR: Array.from(successorPeriods.values()).map((successorPeriod) => ({
+        periodEnd: successorPeriod.periodEnd,
+        periodStart: successorPeriod.periodStart,
+        plan: FREE_SUBSCRIPTION_PLAN,
+        referenceId: successorPeriod.referenceId,
+        stripeSubscriptionId: null,
+      })),
+    },
+    select: {
+      periodEnd: true,
+      periodStart: true,
+      referenceId: true,
+    },
+  });
+
+  return new Set(
+    existingLocalSuccessors.flatMap((successor) => {
+      if (!successor.periodStart || !successor.periodEnd) {
+        return [];
+      }
+
+      return [
+        buildLocalFreeSubscriptionPeriodKey({
+          periodEnd: successor.periodEnd,
+          periodStart: successor.periodStart,
+          referenceId: successor.referenceId,
+        }),
+      ];
+    }),
+  );
+}
+
+const localFreeSubscriptionSelect = {
+  canceledAt: true,
+  createdAt: true,
+  endedAt: true,
+  id: true,
+  periodEnd: true,
+  referenceId: true,
+  seats: true,
+  stripeCustomerId: true,
+  stripeSubscriptionId: true,
+} as const;
+
+async function preCreateUpcomingLocalFreeSubscriptions(
   options: SyncExecutionOptions,
-): Promise<FreeSubscriptionRenewalSyncResult> {
-  const attemptedSubscriptionIds = new Set<string>();
+  attemptedSubscriptionIds: Set<string>,
+): Promise<{ preCreated: number; stoppedEarly: boolean }> {
+  let preCreated = 0;
+  let stoppedEarly = false;
+  const now = new Date();
+  const lookaheadEnd = new Date(
+    now.getTime() + FREE_SUBSCRIPTION_PRECREATE_LOOKAHEAD_MS,
+  );
+
+  while (true) {
+    if (
+      shouldStopSync(
+        options,
+        "Stopping before querying more local free subscriptions for pre-create",
+      )
+    ) {
+      stoppedEarly = true;
+      return { preCreated, stoppedEarly };
+    }
+
+    const upcomingLocalFreeSubscriptions = (await prisma.subscription.findMany({
+      where: {
+        plan: FREE_SUBSCRIPTION_PLAN,
+        periodEnd: {
+          gt: now,
+          lte: lookaheadEnd,
+        },
+        status: {
+          in: [...ACTIVE_SUBSCRIPTION_STATUSES],
+        },
+        stripeSubscriptionId: null,
+      },
+      orderBy: [{ periodEnd: "asc" }, { updatedAt: "asc" }],
+      select: localFreeSubscriptionSelect,
+    })) as LocalFreeSubscriptionRecord[];
+
+    const subscriptionsNeedingPreCreate =
+      await filterSubscriptionsMissingNextLocalSuccessor(
+        upcomingLocalFreeSubscriptions.filter(
+          (subscription) => !attemptedSubscriptionIds.has(subscription.id),
+        ),
+      );
+
+    if (subscriptionsNeedingPreCreate.length === 0) {
+      return { preCreated, stoppedEarly };
+    }
+
+    for (const subscription of subscriptionsNeedingPreCreate) {
+      if (
+        shouldStopSync(
+          options,
+          "Stopping before pre-creating more local free subscriptions",
+        )
+      ) {
+        stoppedEarly = true;
+        return { preCreated, stoppedEarly };
+      }
+
+      attemptedSubscriptionIds.add(subscription.id);
+
+      const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
+      if (!nextPeriod) {
+        continue;
+      }
+
+      try {
+        await prisma.$transaction(async (tx) => {
+          await ensureNextLocalFreeSubscriptionPeriod(
+            {
+              activatesAt: nextPeriod.periodStart,
+              subscription,
+            },
+            tx,
+          );
+        });
+        preCreated += 1;
+      } catch (error) {
+        console.error(
+          `${LOG_PREFIX} Failed to pre-create local free subscription ${subscription.id}:`,
+          error,
+        );
+      }
+    }
+  }
+}
+
+async function closeOverdueLocalFreeSubscriptions(
+  options: SyncExecutionOptions,
+  attemptedSubscriptionIds: Set<string>,
+): Promise<{
+  renewalErrors: number;
+  renewed: number;
+  stoppedEarly: boolean;
+}> {
   let renewalErrors = 0;
   let renewed = 0;
   let stoppedEarly = false;
@@ -195,31 +360,21 @@ async function renewLocalFreeSubscriptions(
         stripeSubscriptionId: null,
       },
       orderBy: [{ periodEnd: "asc" }, { updatedAt: "asc" }],
-      select: {
-        canceledAt: true,
-        createdAt: true,
-        endedAt: true,
-        id: true,
-        periodEnd: true,
-        referenceId: true,
-        seats: true,
-        stripeCustomerId: true,
-        stripeSubscriptionId: true,
-      },
+      select: localFreeSubscriptionSelect,
     })) as LocalFreeSubscriptionRecord[];
 
-    const subscriptionsNeedingRenewal =
-      await filterSubscriptionsMissingNextLocalSuccessor(
-        dueLocalFreeSubscriptions.filter(
-          (subscription) => !attemptedSubscriptionIds.has(subscription.id),
-        ),
-      );
+    const pendingOverdue = dueLocalFreeSubscriptions.filter(
+      (subscription) => !attemptedSubscriptionIds.has(subscription.id),
+    );
 
-    if (subscriptionsNeedingRenewal.length === 0) {
+    if (pendingOverdue.length === 0) {
       return { renewalErrors, renewed, stoppedEarly };
     }
 
-    for (const subscription of subscriptionsNeedingRenewal) {
+    const existingSuccessorKeys =
+      await loadExistingSuccessorKeys(pendingOverdue);
+
+    for (const subscription of pendingOverdue) {
       if (
         shouldStopSync(
           options,
@@ -233,7 +388,30 @@ async function renewLocalFreeSubscriptions(
       attemptedSubscriptionIds.add(subscription.id);
 
       try {
-        await renewLocalFreeSubscriptionPeriod(subscription);
+        await prisma.$transaction(async (tx) => {
+          if (
+            subscriptionHasNextLocalSuccessor(
+              subscription,
+              existingSuccessorKeys,
+            )
+          ) {
+            await closeOverdueLocalFreeSubscription(
+              {
+                setCanceledAt: false,
+                subscription,
+              },
+              tx,
+            );
+          } else {
+            await transitionToNextLocalFreeSubscriptionPeriod(
+              {
+                setCanceledAt: false,
+                subscription,
+              },
+              tx,
+            );
+          }
+        });
         renewed += 1;
       } catch (error) {
         renewalErrors += 1;
@@ -244,6 +422,38 @@ async function renewLocalFreeSubscriptions(
       }
     }
   }
+}
+
+async function renewLocalFreeSubscriptions(
+  options: SyncExecutionOptions,
+): Promise<FreeSubscriptionRenewalSyncResult> {
+  const attemptedSubscriptionIds = new Set<string>();
+
+  const preCreateResult = await preCreateUpcomingLocalFreeSubscriptions(
+    options,
+    attemptedSubscriptionIds,
+  );
+
+  if (preCreateResult.stoppedEarly) {
+    return {
+      preCreated: preCreateResult.preCreated,
+      renewalErrors: 0,
+      renewed: 0,
+      stoppedEarly: true,
+    };
+  }
+
+  const overdueResult = await closeOverdueLocalFreeSubscriptions(
+    options,
+    attemptedSubscriptionIds,
+  );
+
+  return {
+    preCreated: preCreateResult.preCreated,
+    renewalErrors: overdueResult.renewalErrors,
+    renewed: overdueResult.renewed,
+    stoppedEarly: overdueResult.stoppedEarly,
+  };
 }
 
 export const freeSubscriptionSyncService = {

--- a/apps/core/src/services/free-subscription-sync.service.ts
+++ b/apps/core/src/services/free-subscription-sync.service.ts
@@ -86,89 +86,6 @@ function getNextLocalFreeSubscriptionPeriod(
   };
 }
 
-async function filterSubscriptionsMissingNextLocalSuccessor(
-  subscriptions: LocalFreeSubscriptionRecord[],
-): Promise<LocalFreeSubscriptionRecord[]> {
-  const successorPeriods = new Map<string, LocalFreeSubscriptionPeriodRecord>();
-
-  for (const subscription of subscriptions) {
-    const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
-
-    if (!nextPeriod) {
-      continue;
-    }
-
-    successorPeriods.set(
-      buildLocalFreeSubscriptionPeriodKey(nextPeriod),
-      nextPeriod,
-    );
-  }
-
-  if (successorPeriods.size === 0) {
-    return subscriptions.filter((subscription) => subscription.periodEnd);
-  }
-
-  const existingLocalSuccessors = await prisma.subscription.findMany({
-    where: {
-      OR: Array.from(successorPeriods.values()).map((successorPeriod) => ({
-        periodEnd: successorPeriod.periodEnd,
-        periodStart: successorPeriod.periodStart,
-        plan: FREE_SUBSCRIPTION_PLAN,
-        referenceId: successorPeriod.referenceId,
-        stripeSubscriptionId: null,
-      })),
-    },
-    select: {
-      periodEnd: true,
-      periodStart: true,
-      referenceId: true,
-    },
-  });
-
-  const existingSuccessorKeys = new Set(
-    existingLocalSuccessors.flatMap((successor) => {
-      if (!successor.periodStart || !successor.periodEnd) {
-        return [];
-      }
-
-      return [
-        buildLocalFreeSubscriptionPeriodKey({
-          periodEnd: successor.periodEnd,
-          periodStart: successor.periodStart,
-          referenceId: successor.referenceId,
-        }),
-      ];
-    }),
-  );
-
-  return subscriptions.filter((subscription) => {
-    const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
-
-    if (!nextPeriod) {
-      return false;
-    }
-
-    return !existingSuccessorKeys.has(
-      buildLocalFreeSubscriptionPeriodKey(nextPeriod),
-    );
-  });
-}
-
-function subscriptionHasNextLocalSuccessor(
-  subscription: LocalFreeSubscriptionRecord,
-  existingSuccessorKeys: Set<string>,
-): boolean {
-  const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
-
-  if (!nextPeriod) {
-    return false;
-  }
-
-  return existingSuccessorKeys.has(
-    buildLocalFreeSubscriptionPeriodKey(nextPeriod),
-  );
-}
-
 async function loadExistingSuccessorKeys(
   subscriptions: LocalFreeSubscriptionRecord[],
 ): Promise<Set<string>> {
@@ -223,6 +140,37 @@ async function loadExistingSuccessorKeys(
       ];
     }),
   );
+}
+
+function subscriptionHasNextLocalSuccessor(
+  subscription: LocalFreeSubscriptionRecord,
+  existingSuccessorKeys: Set<string>,
+): boolean {
+  const nextPeriod = getNextLocalFreeSubscriptionPeriod(subscription);
+
+  if (!nextPeriod) {
+    return false;
+  }
+
+  return existingSuccessorKeys.has(
+    buildLocalFreeSubscriptionPeriodKey(nextPeriod),
+  );
+}
+
+async function filterSubscriptionsMissingNextLocalSuccessor(
+  subscriptions: LocalFreeSubscriptionRecord[],
+): Promise<LocalFreeSubscriptionRecord[]> {
+  const existingSuccessorKeys = await loadExistingSuccessorKeys(subscriptions);
+
+  return subscriptions.filter((subscription) => {
+    if (
+      subscriptionHasNextLocalSuccessor(subscription, existingSuccessorKeys)
+    ) {
+      return false;
+    }
+
+    return getNextLocalFreeSubscriptionPeriod(subscription) !== null;
+  });
 }
 
 const localFreeSubscriptionSelect = {

--- a/apps/core/src/services/free-subscription-sync.service.ts
+++ b/apps/core/src/services/free-subscription-sync.service.ts
@@ -343,14 +343,14 @@ async function closeOverdueLocalFreeSubscriptions(
 
       attemptedSubscriptionIds.add(subscription.id);
 
+      const hasExistingSuccessor = subscriptionHasNextLocalSuccessor(
+        subscription,
+        existingSuccessorKeys,
+      );
+
       try {
         await prisma.$transaction(async (tx) => {
-          if (
-            subscriptionHasNextLocalSuccessor(
-              subscription,
-              existingSuccessorKeys,
-            )
-          ) {
+          if (hasExistingSuccessor) {
             await closeOverdueLocalFreeSubscription(
               {
                 setCanceledAt: false,
@@ -368,7 +368,10 @@ async function closeOverdueLocalFreeSubscriptions(
             );
           }
         });
-        renewed += 1;
+
+        if (!hasExistingSuccessor) {
+          renewed += 1;
+        }
       } catch (error) {
         renewalErrors += 1;
         console.error(

--- a/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
@@ -9,7 +9,7 @@ const getSessionMock = vi.fn();
 const getActiveOrganizationMock = vi.fn();
 const getMyMemberInOrganizationMock = vi.fn();
 const getBalanceMock = vi.fn();
-const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const getSubscriptionCatalogMock = vi.fn();
 const getUserByIdMock = vi.fn();
 const getSeatSummaryMock = vi.fn();
@@ -83,8 +83,8 @@ vi.mock("@sokosumi/database/repositories", () => ({
     getBalance: (...args: unknown[]) => getBalanceMock(...args),
   },
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
   },
   userRepository: {
     getUserById: (...args: unknown[]) => getUserByIdMock(...args),
@@ -169,7 +169,7 @@ describe("BillingPage", () => {
       },
     });
     getBalanceMock.mockResolvedValue(BigInt(0));
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: "2026-03-01T00:00:00.000Z",
       plan: "pro",
       seats: 2,
@@ -191,7 +191,7 @@ describe("BillingPage", () => {
   it("passes the zero-margin override to personal billing credits when the flag is enabled", async () => {
     getActiveOrganizationMock.mockResolvedValue(null);
     zeroMarginTopUpEnabledMock.mockResolvedValue(true);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: "2026-03-01T00:00:00.000Z",
       plan: "free",
       seats: 1,
@@ -227,7 +227,7 @@ describe("BillingPage", () => {
       role: MemberRole.OWNER,
     });
     zeroMarginTopUpEnabledMock.mockResolvedValue(true);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: "2026-03-01T00:00:00.000Z",
       plan: "free",
       seats: 2,
@@ -281,7 +281,7 @@ describe("BillingPage", () => {
   it("shows the personal credits tab even on the free plan", async () => {
     getActiveOrganizationMock.mockResolvedValue(null);
     zeroMarginTopUpEnabledMock.mockResolvedValue(false);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: "2026-03-01T00:00:00.000Z",
       plan: "free",
       seats: 1,
@@ -330,7 +330,7 @@ describe("BillingPage", () => {
       role: MemberRole.OWNER,
     });
     zeroMarginTopUpEnabledMock.mockResolvedValue(false);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: "2026-03-01T00:00:00.000Z",
       plan: "free",
       seats: 5,
@@ -378,7 +378,7 @@ describe("BillingPage", () => {
       role: MemberRole.OWNER,
     });
     zeroMarginTopUpEnabledMock.mockResolvedValue(false);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: "2026-03-01T00:00:00.000Z",
       plan: "pro",
       seats: 10,

--- a/apps/web/src/app/(app)/billing/page.tsx
+++ b/apps/web/src/app/(app)/billing/page.tsx
@@ -116,7 +116,7 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
     }
 
     const latestSubscription =
-      await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
         activeOrganization.id,
         prisma,
       );
@@ -241,7 +241,7 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
     user,
   ] = await Promise.all([
     creditBucketRepository.getBalance(userId, null, prisma),
-    subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    subscriptionRepository.resolveActiveSubscriptionByReferenceId(
       userId,
       prisma,
     ),

--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getMyMemberInOrganizationMock = vi.fn();
-const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const getSeatSummaryMock = vi.fn();
 const listActiveSubscriptionsMock = vi.fn();
 const getSubscriptionCatalogMock = vi.fn();
@@ -58,8 +58,8 @@ vi.mock("@/lib/stripe/subscription-catalog", () => ({
 
 vi.mock("@sokosumi/database/repositories", () => ({
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
   },
 }));
 
@@ -89,7 +89,7 @@ describe("OnboardingDialogLoader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSubscriptionCatalogMock.mockResolvedValue(createSubscriptionCatalog());
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       plan: "starter",
       seats: 3,
     });
@@ -178,7 +178,7 @@ describe("OnboardingDialogLoader", () => {
     expect(onboardingDialogMock).not.toHaveBeenCalled();
     expect(getMyMemberInOrganizationMock).toHaveBeenCalledOnce();
     expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
-    expect(getLatestActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
+    expect(resolveActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
     expect(listActiveSubscriptionsMock).not.toHaveBeenCalled();
   });
 
@@ -211,7 +211,7 @@ describe("OnboardingDialogLoader", () => {
     expect(queryByTestId("onboarding-dialog")).toBeNull();
     expect(onboardingDialogMock).not.toHaveBeenCalled();
     expect(getMyMemberInOrganizationMock).toHaveBeenCalledOnce();
-    expect(getLatestActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
+    expect(resolveActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
     expect(listActiveSubscriptionsMock).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to load subscription catalog for onboarding",

--- a/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
@@ -93,7 +93,7 @@ export async function OnboardingDialogLoader({
         ? userService.getMyMemberInOrganization(activeOrganization.id)
         : Promise.resolve(null);
   const latestOrganizationSubscriptionPromise = activeOrganization
-    ? subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    ? subscriptionRepository.resolveActiveSubscriptionByReferenceId(
         activeOrganization.id,
         prisma,
       )

--- a/apps/web/src/app/(app)/projects/__tests__/constants.test.ts
+++ b/apps/web/src/app/(app)/projects/__tests__/constants.test.ts
@@ -33,9 +33,9 @@ describe("unassignedWorkspaceJobsQuery", () => {
 
   it("differs from omitting projectId, which lists all workspace jobs", () => {
     const unassignedQuery = unassignedWorkspaceJobsQuery();
-    const allJobsQuery = {
+    const allJobsQuery: NonNullable<GetJobsData["query"]> = {
       scope: "workspace",
-    } satisfies NonNullable<GetJobsData["query"]>;
+    };
 
     expect(unassignedQuery.projectId).toBe("null");
     expect(allJobsQuery.projectId).toBeUndefined();
@@ -59,9 +59,9 @@ describe("unassignedWorkspaceTasksQuery", () => {
 
   it("differs from omitting projectId, which lists all workspace tasks", () => {
     const unassignedQuery = unassignedWorkspaceTasksQuery();
-    const allTasksQuery = {
+    const allTasksQuery: NonNullable<GetTasksData["query"]> = {
       scope: "workspace",
-    } satisfies NonNullable<GetTasksData["query"]>;
+    };
 
     expect(unassignedQuery.projectId).toBe("null");
     expect(allTasksQuery.projectId).toBeUndefined();

--- a/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
@@ -425,7 +425,7 @@ async function getCurrentPlan(
   }
 
   const latestSubscription =
-    await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
       organizationId ?? session.user.id,
       prisma,
     );

--- a/apps/web/src/lib/services/__tests__/organization-seat-credits.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/organization-seat-credits.service.test.ts
@@ -5,7 +5,7 @@ vi.mock("server-only", () => ({}));
 
 const countOrganizationSubscriptionPeriodSeatGrantsMock = vi.fn();
 const hasOrganizationMemberSubscriptionPeriodGrantMock = vi.fn();
-const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const getSubscriptionCatalogMock = vi.fn();
 const subscriptionsRetrieveMock = vi.fn();
 
@@ -24,8 +24,8 @@ vi.mock("@sokosumi/database/helpers", async (importOriginal) => {
 
 vi.mock("@sokosumi/database/repositories", () => ({
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
   },
 }));
 
@@ -70,7 +70,7 @@ describe("grantUnusedSeatSubscriptionCreditsIfEligible", () => {
     getSubscriptionCatalogMock.mockResolvedValue({
       starter: { credits: 100 },
     });
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       plan: "starter",
       periodEnd,
       seats: 5,
@@ -156,7 +156,7 @@ describe("grantUnusedSeatSubscriptionCreditsIfEligible", () => {
   });
 
   it("skips grant for local free subscriptions", async () => {
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       plan: "free",
       periodEnd,
       seats: 5,

--- a/apps/web/src/lib/services/__tests__/organization-seat.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/organization-seat.service.test.ts
@@ -17,7 +17,7 @@ const getMemberByUserIdAndOrganizationIdMock = vi.fn();
 const getAssignedMemberCountMock = vi.fn();
 const assignSeatMock = vi.fn();
 const unassignSeatMock = vi.fn();
-const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const memberCountMock = vi.fn();
 const grantUnusedSeatSubscriptionCreditsIfEligibleMock = vi.fn();
 const grantFreeOrganizationMemberSubscriptionCreditsMock = vi.fn();
@@ -54,8 +54,8 @@ vi.mock("@sokosumi/database/repositories", () => ({
     unassignSeat: (...args: unknown[]) => unassignSeatMock(...args),
   },
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
   },
 }));
 
@@ -91,7 +91,7 @@ describe("organizationSeatService", () => {
   it("returns zero purchased seats for free organizations", async () => {
     getAssignedMemberCountMock.mockResolvedValue(2);
     memberCountMock.mockResolvedValue(5);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       plan: "free",
       seats: null,
       status: "active",
@@ -115,7 +115,7 @@ describe("organizationSeatService", () => {
   it("returns paid seat counts for active paid subscriptions", async () => {
     getAssignedMemberCountMock.mockResolvedValue(2);
     memberCountMock.mockResolvedValue(5);
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       plan: "starter",
       seats: 4,
       status: "active",
@@ -138,7 +138,7 @@ describe("organizationSeatService", () => {
 
   it("assigns a seat when caller is owner and capacity remains", async () => {
     getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({ role: "owner" });
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       seats: 3,
     });
     assignSeatMock.mockResolvedValue({
@@ -172,12 +172,10 @@ describe("organizationSeatService", () => {
   it("reads purchased seats inside the transaction before assigning", async () => {
     const callOrder: string[] = [];
     getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({ role: "owner" });
-    getLatestActiveSubscriptionByReferenceIdMock.mockImplementation(
-      async () => {
-        callOrder.push("getSubscription");
-        return { seats: 3 };
-      },
-    );
+    resolveActiveSubscriptionByReferenceIdMock.mockImplementation(async () => {
+      callOrder.push("getSubscription");
+      return { seats: 3 };
+    });
     assignSeatMock.mockImplementation(async () => {
       callOrder.push("assignSeat");
       return {
@@ -218,7 +216,7 @@ describe("organizationSeatService", () => {
       id: "member-1",
       userId: "user-2",
     });
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       periodEnd: new Date("2026-06-01T00:00:00.000Z"),
       plan: "starter",
       status: "active",
@@ -255,7 +253,7 @@ describe("organizationSeatService", () => {
       id: "member-1",
       userId: "user-2",
     });
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       periodEnd: new Date("2026-06-01T00:00:00.000Z"),
       periodStart: new Date("2026-05-01T00:00:00.000Z"),
@@ -291,7 +289,7 @@ describe("organizationSeatService", () => {
 
   it("syncs local-free credits for all members when assigning in a free organization", async () => {
     getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({ role: "owner" });
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       periodEnd: new Date("2026-06-01T00:00:00.000Z"),
       periodStart: new Date("2026-05-01T00:00:00.000Z"),
@@ -328,7 +326,7 @@ describe("organizationSeatService", () => {
 
   it("does not sync local-free credits when assigning in a paid organization", async () => {
     getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({ role: "owner" });
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       seats: 3,
       status: "active",
       stripeSubscriptionId: "sub_123",

--- a/apps/web/src/lib/services/__tests__/organization-subscription.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/organization-subscription.service.test.ts
@@ -17,7 +17,7 @@ const getOrganizationMemberUserIdsMock = vi.fn();
 const getUnassignedMemberUserIdsMock = vi.fn();
 const ensureLocalFreeSubscriptionPeriodMock = vi.fn();
 const grantFreeOrganizationMemberSubscriptionCreditsMock = vi.fn();
-const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const prismaTransactionMock = vi.fn();
 const updateSubscriptionRecordMock = vi.fn();
 const retrieveStripeSubscriptionMock = vi.fn();
@@ -35,8 +35,8 @@ vi.mock("@sokosumi/database/repositories", () => ({
       getMemberByUserIdAndOrganizationIdMock(...args),
   },
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
   },
 }));
 
@@ -117,7 +117,7 @@ describe("organizationSubscriptionService", () => {
     });
 
     it("does not load subscription data or update seats when creating invitations", async () => {
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "starter",
         seats: 2,
@@ -130,9 +130,7 @@ describe("organizationSubscriptionService", () => {
 
       await organizationSubscriptionService.ensureCanCreateInvitation("org-1");
 
-      expect(
-        getLatestActiveSubscriptionByReferenceIdMock,
-      ).not.toHaveBeenCalled();
+      expect(resolveActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
       expect(getAssignedMemberCountMock).not.toHaveBeenCalled();
       expect(retrieveStripeSubscriptionMock).not.toHaveBeenCalled();
       expect(updateStripeSubscriptionMock).not.toHaveBeenCalled();
@@ -142,7 +140,7 @@ describe("organizationSubscriptionService", () => {
 
   describe("ensureCanAcceptInvitation", () => {
     it("throws when no active organization subscription exists", async () => {
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
 
       const { organizationSubscriptionService } = await import(
         "../organization-subscription.service"
@@ -161,7 +159,7 @@ describe("organizationSubscriptionService", () => {
     });
 
     it("does not pre-allocate seats for a local free subscription", async () => {
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "free",
         seats: 2,
@@ -174,7 +172,7 @@ describe("organizationSubscriptionService", () => {
 
       await organizationSubscriptionService.ensureCanAcceptInvitation("org-1");
 
-      expect(getLatestActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
+      expect(resolveActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
         "org-1",
         expect.any(Object),
       );
@@ -185,7 +183,7 @@ describe("organizationSubscriptionService", () => {
     });
 
     it("does not auto-increase Stripe seats when accepting an invitation", async () => {
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "starter",
         seats: 2,
@@ -230,7 +228,7 @@ describe("organizationSubscriptionService", () => {
       getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
         role: "owner",
       });
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
 
       const { organizationSubscriptionService } = await import(
         "../organization-subscription.service"
@@ -251,7 +249,7 @@ describe("organizationSubscriptionService", () => {
       getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
         role: "owner",
       });
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "starter",
         seats: 4,
@@ -282,7 +280,7 @@ describe("organizationSubscriptionService", () => {
         role: "owner",
       });
       getAssignedMemberCountMock.mockResolvedValue(4);
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "starter",
         seats: 6,
@@ -309,7 +307,7 @@ describe("organizationSubscriptionService", () => {
         role: "admin",
       });
       getAssignedMemberCountMock.mockResolvedValue(2);
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "starter",
         seats: 2,
@@ -356,7 +354,7 @@ describe("organizationSubscriptionService", () => {
         role: "owner",
       });
       getAssignedMemberCountMock.mockResolvedValue(4);
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "free",
         seats: 6,
@@ -386,7 +384,7 @@ describe("organizationSubscriptionService", () => {
       });
       const periodStart = new Date("2026-04-08T00:00:00.000Z");
       const periodEnd = new Date("2026-05-08T00:00:00.000Z");
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         createdAt: periodStart,
         id: "sub-row-1",
         plan: "free",
@@ -422,7 +420,7 @@ describe("organizationSubscriptionService", () => {
     it("syncs local free credits for all organization members", async () => {
       const periodStart = new Date("2026-04-08T00:00:00.000Z");
       const periodEnd = new Date("2026-05-08T00:00:00.000Z");
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         createdAt: periodStart,
         id: "sub-row-1",
         plan: "free",
@@ -470,7 +468,7 @@ describe("organizationSubscriptionService", () => {
 
     it("grants free monthly credits to unassigned members in a paid organization without a local-free subscription row", async () => {
       const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-      getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
         id: "sub-row-1",
         plan: "starter",
         seats: 5,

--- a/apps/web/src/lib/services/organization-seat-credits.service.ts
+++ b/apps/web/src/lib/services/organization-seat-credits.service.ts
@@ -104,7 +104,7 @@ export async function grantUnusedSeatSubscriptionCreditsIfEligible(
   tx: Prisma.TransactionClient,
 ): Promise<GrantUnusedSeatSubscriptionCreditsResult> {
   const subscription =
-    await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
       organizationId,
       tx,
     );

--- a/apps/web/src/lib/services/organization-seat.service.ts
+++ b/apps/web/src/lib/services/organization-seat.service.ts
@@ -140,7 +140,7 @@ export const organizationSeatService = (() => {
             organizationId,
           },
         }),
-        subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+        subscriptionRepository.resolveActiveSubscriptionByReferenceId(
           organizationId,
           prisma,
         ),
@@ -171,7 +171,7 @@ export const organizationSeatService = (() => {
       try {
         return await prisma.$transaction(async (tx) => {
           const subscription =
-            await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+            await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
               organizationId,
               tx,
             );
@@ -237,7 +237,7 @@ export const organizationSeatService = (() => {
           );
 
           const subscription =
-            await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+            await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
               organizationId,
               tx,
             );

--- a/apps/web/src/lib/services/organization-subscription.service.ts
+++ b/apps/web/src/lib/services/organization-subscription.service.ts
@@ -32,11 +32,11 @@ function isOwnerOrAdmin(role: string): boolean {
   return role === MemberRole.OWNER || role === MemberRole.ADMIN;
 }
 
-async function getLatestActiveOrganizationSubscription(
+async function resolveActiveOrganizationSubscription(
   organizationId: string,
 ): Promise<ActiveOrganizationSubscription | null> {
   const subscription =
-    await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
       organizationId,
       prisma,
     );
@@ -137,7 +137,7 @@ async function ensureActiveOrganizationSubscription(
   missingSubscriptionMessage: string,
 ): Promise<ActiveOrganizationSubscription> {
   const activeSubscription =
-    await getLatestActiveOrganizationSubscription(organizationId);
+    await resolveActiveOrganizationSubscription(organizationId);
   if (!activeSubscription) {
     throw new APIError("BAD_REQUEST", {
       message: missingSubscriptionMessage,
@@ -269,7 +269,7 @@ async function syncLocalFreeSeatsAndCreditsForCurrentMembersInternal(
 ): Promise<number> {
   const currentActiveSubscription =
     activeSubscription ??
-    (await getLatestActiveOrganizationSubscription(organizationId));
+    (await resolveActiveOrganizationSubscription(organizationId));
 
   if (!currentActiveSubscription) {
     return resolvePurchasedSeats(undefined);

--- a/apps/web/src/lib/stripe/__tests__/webhook-handlers.test.ts
+++ b/apps/web/src/lib/stripe/__tests__/webhook-handlers.test.ts
@@ -26,7 +26,7 @@ const claimWelcomeCouponMock = vi.fn();
 const ensureInitialLocalFreeSubscriptionPeriodMock = vi.fn();
 const transitionToNextLocalFreeSubscriptionPeriodMock = vi.fn();
 const getSubscriptionByStripeSubscriptionIdMock = vi.fn();
-const getLatestActiveSubscriptionByReferenceIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const subscriptionUpdateManyMock = vi.fn();
 const prismaOrganizationUpdateMock = vi.fn();
 const prismaUserUpdateMock = vi.fn();
@@ -89,8 +89,8 @@ vi.mock("@sokosumi/database/repositories", () => ({
     updateOrganizationInvoiceEmail: vi.fn(),
   },
   subscriptionRepository: {
-    getLatestActiveSubscriptionByReferenceId: (...args: unknown[]) =>
-      getLatestActiveSubscriptionByReferenceIdMock(...args),
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
     getSubscriptionByStripeSubscriptionId: (...args: unknown[]) =>
       getSubscriptionByStripeSubscriptionIdMock(...args),
   },
@@ -1646,7 +1646,7 @@ describe("handleSubscriptionDeletedEvent", () => {
     transitionToNextLocalFreeSubscriptionPeriodMock.mockResolvedValue(
       undefined,
     );
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
     getSubscriptionByStripeSubscriptionIdMock.mockResolvedValue({
       canceledAt: new Date("2026-04-09T07:39:30.188Z"),
       createdAt: new Date("2026-03-09T07:39:30.188Z"),
@@ -1673,7 +1673,7 @@ describe("handleSubscriptionDeletedEvent", () => {
       "sub_123",
       expect.anything(),
     );
-    expect(getLatestActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
+    expect(resolveActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
       "user-1",
       expect.anything(),
     );
@@ -1739,7 +1739,7 @@ describe("handleSubscriptionDeletedEvent", () => {
   });
 
   it("skips the free fallback when another paid subscription is still active", async () => {
-    getLatestActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
       id: "sub_active_paid_2",
       plan: "pro",
     });

--- a/apps/web/src/lib/stripe/webhook-handlers.ts
+++ b/apps/web/src/lib/stripe/webhook-handlers.ts
@@ -1031,7 +1031,7 @@ export async function handleSubscriptionDeletedEvent(
 
   await prisma.$transaction(async (tx) => {
     const latestActiveSubscription =
-      await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
         localSubscription.referenceId,
         tx,
       );

--- a/apps/web/src/lib/utils/__tests__/task-transformer.test.ts
+++ b/apps/web/src/lib/utils/__tests__/task-transformer.test.ts
@@ -21,6 +21,7 @@ function buildTask(
     updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     userId: "user-1",
     organizationId: null,
+    projectId: null,
     user: { id: "user-1", name: "Test User", image: null },
     organization: null,
     coworkerId: null,

--- a/packages/database/prisma/migrations/20260602120000_add_credit_bucket_activates_at/migration.sql
+++ b/packages/database/prisma/migrations/20260602120000_add_credit_bucket_activates_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "credit_bucket" ADD COLUMN "activatesAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "credit_bucket_activatesAt_idx" ON "credit_bucket"("activatesAt");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -621,8 +621,9 @@ model CreditBucket {
   updatedAt DateTime @updatedAt
 
   // Amount of credits in this bucket (in cents, always positive)
-  amount    BigInt
-  expiresAt DateTime? // (null = non-expiring)
+  amount      BigInt
+  expiresAt   DateTime? // (null = non-expiring)
+  activatesAt DateTime? // (null = active immediately)
 
   referenceId   String?
   referenceType CreditBucketReferenceType?
@@ -644,6 +645,7 @@ model CreditBucket {
   @@unique([referenceId, referenceType])
   @@index([userId, organizationId, expiresAt])
   @@index([expiresAt])
+  @@index([activatesAt])
   @@map("credit_bucket")
 }
 

--- a/packages/database/src/helpers/__tests__/organization-seat-credits.test.ts
+++ b/packages/database/src/helpers/__tests__/organization-seat-credits.test.ts
@@ -50,19 +50,26 @@ describe("organization-seat-credits helpers", () => {
 
     expect(countMock).toHaveBeenCalledWith({
       where: {
-        organizationId: "org-1",
-        expiresAt: {
-          gt: now,
-        },
-        referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
-        referenceId: {
-          startsWith: "member:",
-        },
-        NOT: {
-          referenceId: {
-            contains: ":local-free:",
+        AND: [
+          {
+            OR: [{ activatesAt: null }, { activatesAt: { lte: now } }],
           },
-        },
+          {
+            organizationId: "org-1",
+            expiresAt: {
+              gt: now,
+            },
+            referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
+            referenceId: {
+              startsWith: "member:",
+            },
+            NOT: {
+              referenceId: {
+                contains: ":local-free:",
+              },
+            },
+          },
+        ],
       },
     });
   });
@@ -81,20 +88,27 @@ describe("organization-seat-credits helpers", () => {
 
     expect(findFirstMock).toHaveBeenCalledWith({
       where: {
-        organizationId: "org-1",
-        expiresAt: {
-          gt: now,
-        },
-        userId: "user-1",
-        referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
-        referenceId: {
-          startsWith: "member:user-1:",
-        },
-        NOT: {
-          referenceId: {
-            contains: ":local-free:",
+        AND: [
+          {
+            OR: [{ activatesAt: null }, { activatesAt: { lte: now } }],
           },
-        },
+          {
+            organizationId: "org-1",
+            expiresAt: {
+              gt: now,
+            },
+            userId: "user-1",
+            referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
+            referenceId: {
+              startsWith: "member:user-1:",
+            },
+            NOT: {
+              referenceId: {
+                contains: ":local-free:",
+              },
+            },
+          },
+        ],
       },
       select: {
         id: true,
@@ -112,7 +126,10 @@ describe("organization-seat-credits helpers", () => {
       },
     } as never);
 
-    expect(countMock.mock.calls[0]?.[0].where.NOT).toEqual({
+    const scopeWhere = countMock.mock.calls[0]?.[0].where.AND[1] as {
+      NOT: { referenceId: { contains: string } };
+    };
+    expect(scopeWhere.NOT).toEqual({
       referenceId: {
         contains: ":local-free:",
       },
@@ -131,7 +148,10 @@ describe("organization-seat-credits helpers", () => {
       } as never),
     ).resolves.toBe(false);
 
-    expect(findFirstMock.mock.calls[0]?.[0].where.NOT).toEqual({
+    const scopeWhere = findFirstMock.mock.calls[0]?.[0].where.AND[1] as {
+      NOT: { referenceId: { contains: string } };
+    };
+    expect(scopeWhere.NOT).toEqual({
       referenceId: {
         contains: ":local-free:",
       },

--- a/packages/database/src/helpers/credit.test.ts
+++ b/packages/database/src/helpers/credit.test.ts
@@ -5,9 +5,33 @@ import { describe, it } from "vitest";
 import {
   buildOrganizationInvoiceCreditReferenceId,
   buildUserInvoiceCreditReferenceId,
+  creditBucketActivatesAtOrBefore,
+  creditBucketActivatesAtOrBeforeSql,
   getCreditExpiryDate,
   splitAmountEvenlyWithRemainderRotation,
 } from "./credit.js";
+
+describe("creditBucketActivatesAtOrBefore", () => {
+  it("returns Prisma filter for immediate or started buckets", () => {
+    const now = new Date("2026-04-10T12:00:00.000Z");
+
+    assert.deepEqual(creditBucketActivatesAtOrBefore(now), {
+      OR: [{ activatesAt: null }, { activatesAt: { lte: now } }],
+    });
+  });
+});
+
+describe("creditBucketActivatesAtOrBeforeSql", () => {
+  it("returns SQL fragment matching spendable activation predicate", () => {
+    const now = new Date("2026-04-10T12:00:00.000Z");
+    const fragment = creditBucketActivatesAtOrBeforeSql(now);
+    const sqlText = JSON.stringify(fragment);
+
+    assert.ok(sqlText.includes("activatesAt"));
+    assert.ok(sqlText.includes("IS NULL"));
+    assert.ok(sqlText.includes(now.toISOString()));
+  });
+});
 
 describe("splitAmountEvenlyWithRemainderRotation", () => {
   it("returns empty allocations for non-positive amounts or empty members", () => {

--- a/packages/database/src/helpers/credit.ts
+++ b/packages/database/src/helpers/credit.ts
@@ -1,4 +1,25 @@
+import { Prisma } from "../generated/prisma/client.js";
+
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Prisma filter: bucket is spendable at `now` (null activatesAt = immediate).
+ */
+export function creditBucketActivatesAtOrBefore(
+  now: Date,
+): Prisma.CreditBucketWhereInput {
+  return {
+    OR: [{ activatesAt: null }, { activatesAt: { lte: now } }],
+  };
+}
+
+/**
+ * Raw SQL fragment for spendable buckets at `now`.
+ */
+export function creditBucketActivatesAtOrBeforeSql(now: Date): Prisma.Sql {
+  return Prisma.sql`(cb."activatesAt" IS NULL OR cb."activatesAt" <= ${now})`;
+}
+
 export const ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX = "member:";
 export const USER_CREDIT_REFERENCE_PREFIX = "user:";
 export const ORGANIZATION_CREDIT_REFERENCE_PREFIX = "org:";

--- a/packages/database/src/helpers/organization-seat-credits.ts
+++ b/packages/database/src/helpers/organization-seat-credits.ts
@@ -4,6 +4,7 @@ import {
 } from "../generated/prisma/client.js";
 import {
   buildOrganizationMemberSubscriptionReferenceId,
+  creditBucketActivatesAtOrBefore,
   ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX,
 } from "./credit.js";
 import { resolvePurchasedSeats } from "./organization-seats.js";
@@ -27,19 +28,24 @@ export async function countOrganizationSubscriptionPeriodSeatGrants(
 ): Promise<number> {
   return await tx.creditBucket.count({
     where: {
-      organizationId,
-      expiresAt: {
-        gt: now,
-      },
-      referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
-      referenceId: {
-        startsWith: ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX,
-      },
-      NOT: {
-        referenceId: {
-          contains: LOCAL_FREE_SUBSCRIPTION_REFERENCE_CONTAINS,
+      AND: [
+        creditBucketActivatesAtOrBefore(now),
+        {
+          organizationId,
+          expiresAt: {
+            gt: now,
+          },
+          referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
+          referenceId: {
+            startsWith: ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX,
+          },
+          NOT: {
+            referenceId: {
+              contains: LOCAL_FREE_SUBSCRIPTION_REFERENCE_CONTAINS,
+            },
+          },
         },
-      },
+      ],
     },
   });
 }
@@ -52,20 +58,25 @@ export async function hasOrganizationMemberSubscriptionPeriodGrant(
 ): Promise<boolean> {
   const existingBucket = await tx.creditBucket.findFirst({
     where: {
-      organizationId,
-      expiresAt: {
-        gt: now,
-      },
-      userId,
-      referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
-      referenceId: {
-        startsWith: `${ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX}${userId}:`,
-      },
-      NOT: {
-        referenceId: {
-          contains: LOCAL_FREE_SUBSCRIPTION_REFERENCE_CONTAINS,
+      AND: [
+        creditBucketActivatesAtOrBefore(now),
+        {
+          organizationId,
+          expiresAt: {
+            gt: now,
+          },
+          userId,
+          referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
+          referenceId: {
+            startsWith: `${ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX}${userId}:`,
+          },
+          NOT: {
+            referenceId: {
+              contains: LOCAL_FREE_SUBSCRIPTION_REFERENCE_CONTAINS,
+            },
+          },
         },
-      },
+      ],
     },
     select: {
       id: true,

--- a/packages/database/src/helpers/organization-subscription-credit-routing.test.ts
+++ b/packages/database/src/helpers/organization-subscription-credit-routing.test.ts
@@ -57,27 +57,36 @@ function createLocalFreePeriodClient() {
 }
 
 function createPaidOrgFreeGrantClient(params?: {
-  existingFreeBucketUserIds?: string[];
+  existingFreeBucketReferenceIds?: string[];
 }) {
-  const findFirstBucketMock = vi
-    .fn()
-    .mockImplementation(({ where }: { where: { userId: string } }) =>
-      Promise.resolve(
-        params?.existingFreeBucketUserIds?.includes(where.userId)
+  const findUniqueBucketMock = vi.fn().mockImplementation(
+    ({
+      where,
+    }: {
+      where: {
+        referenceId_referenceType: {
+          referenceId: string;
+        };
+      };
+    }) => {
+      const referenceId = where.referenceId_referenceType.referenceId;
+      return Promise.resolve(
+        params?.existingFreeBucketReferenceIds?.includes(referenceId)
           ? { id: "existing-free-bucket" }
           : null,
-      ),
-    );
+      );
+    },
+  );
   const createTransactionMock = vi.fn().mockResolvedValue({
     id: "tx_free",
   });
 
   return {
     createTransactionMock,
-    findFirstBucketMock,
+    findUniqueBucketMock,
     tx: {
       creditBucket: {
-        findFirst: findFirstBucketMock,
+        findUnique: findUniqueBucketMock,
       },
       transaction: {
         create: createTransactionMock,

--- a/packages/database/src/helpers/subscription.test.ts
+++ b/packages/database/src/helpers/subscription.test.ts
@@ -7,33 +7,43 @@ import {
   buildLocalFreeUserSubscriptionReferenceId,
   ensureInitialLocalFreeSubscriptionPeriod,
   ensureLocalFreeSubscriptionPeriod,
+  ensureNextLocalFreeSubscriptionPeriod,
   getNextMonthlyPeriodEnd,
   grantFreeOrganizationMemberSubscriptionCredits,
   transitionToNextLocalFreeSubscriptionPeriod,
 } from "./subscription.js";
 
 function createFreeGrantClient(params?: {
-  existingFreeBucketUserIds?: string[];
+  existingFreeBucketReferenceIds?: string[];
 }) {
-  const findFirstBucketMock = vi
-    .fn()
-    .mockImplementation(({ where }: { where: { userId: string } }) =>
-      Promise.resolve(
-        params?.existingFreeBucketUserIds?.includes(where.userId)
+  const findUniqueBucketMock = vi.fn().mockImplementation(
+    ({
+      where,
+    }: {
+      where: {
+        referenceId_referenceType: {
+          referenceId: string;
+        };
+      };
+    }) => {
+      const referenceId = where.referenceId_referenceType.referenceId;
+      return Promise.resolve(
+        params?.existingFreeBucketReferenceIds?.includes(referenceId)
           ? { id: "existing-free-bucket" }
           : null,
-      ),
-    );
+      );
+    },
+  );
   const createTransactionMock = vi.fn().mockResolvedValue({
     id: "tx_free",
   });
 
   return {
     createTransactionMock,
-    findFirstBucketMock,
+    findUniqueBucketMock,
     tx: {
       creditBucket: {
-        findFirst: findFirstBucketMock,
+        findUnique: findUniqueBucketMock,
       },
       transaction: {
         create: createTransactionMock,
@@ -251,6 +261,35 @@ describe("ensureLocalFreeSubscriptionPeriod", () => {
     assert.equal(createSubscriptionMock.mock.calls[0]?.[0].data.seats, 1);
     assert.equal(findUniqueBucketMock.mock.calls.length, 1);
     assert.equal(createTransactionMock.mock.calls.length, 1);
+    assert.equal(
+      createTransactionMock.mock.calls[0]?.[0].data.sourceCreditBucket.create
+        .activatesAt,
+      null,
+    );
+  });
+
+  it("stores activatesAt on new buckets when provided", async () => {
+    const activatesAt = new Date("2026-05-01T00:00:00.000Z");
+    const { createTransactionMock, tx } = createTransactionClient();
+
+    await ensureLocalFreeSubscriptionPeriod(
+      {
+        activatesAt,
+        billingAnchorDate: new Date("2026-04-01T00:00:00.000Z"),
+        organizationId: null,
+        userId: "user-1",
+        periodEnd: new Date("2026-06-01T00:00:00.000Z"),
+        periodStart: new Date("2026-05-01T00:00:00.000Z"),
+        referenceId: "user-1",
+      },
+      tx,
+    );
+
+    assert.equal(
+      createTransactionMock.mock.calls[0]?.[0].data.sourceCreditBucket.create
+        .activatesAt,
+      activatesAt,
+    );
   });
 
   it("creates an organization subscription row and grants one bucket per member seat", async () => {
@@ -374,6 +413,71 @@ describe("ensureLocalFreeSubscriptionPeriod", () => {
     });
     assert.equal(createSubscriptionMock.mock.calls.length, 0);
     assert.equal(createTransactionMock.mock.calls.length, 0);
+  });
+});
+
+describe("ensureNextLocalFreeSubscriptionPeriod", () => {
+  it("defaults activatesAt to the next period start when omitted", async () => {
+    vi.useFakeTimers();
+    const { createTransactionMock, tx } = createTransitionClient({
+      organization: null,
+      user: { id: "user-1" },
+    });
+
+    await ensureNextLocalFreeSubscriptionPeriod(
+      {
+        subscription: {
+          canceledAt: null,
+          createdAt: new Date("2026-01-30T10:00:00.000Z"),
+          endedAt: null,
+          id: "subscription-source",
+          periodEnd: new Date("2026-02-28T10:00:00.000Z"),
+          referenceId: "user-1",
+          seats: null,
+          stripeCustomerId: "cus_1",
+          stripeSubscriptionId: null,
+        },
+      },
+      tx,
+    );
+
+    assert.equal(
+      createTransactionMock.mock.calls[0]?.[0].data.sourceCreditBucket.create.activatesAt?.toISOString(),
+      "2026-02-28T10:00:00.000Z",
+    );
+    vi.useRealTimers();
+  });
+
+  it("forwards explicit activatesAt to ensureLocalFreeSubscriptionPeriod", async () => {
+    const activatesAt = new Date("2026-06-01T00:00:00.000Z");
+    const { createTransactionMock, tx } = createTransitionClient({
+      organization: null,
+      user: { id: "user-1" },
+    });
+
+    await ensureNextLocalFreeSubscriptionPeriod(
+      {
+        activatesAt,
+        subscription: {
+          canceledAt: null,
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          endedAt: null,
+          id: "subscription-source",
+          periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+          referenceId: "user-1",
+          seats: null,
+          stripeCustomerId: "cus_1",
+          stripeSubscriptionId: null,
+        },
+      },
+      tx,
+    );
+
+    assert.equal(
+      createTransactionMock.mock.calls[0]?.[0].data.sourceCreditBucket.create
+        .activatesAt,
+      activatesAt,
+    );
   });
 });
 
@@ -524,21 +628,32 @@ describe("ensureInitialLocalFreeSubscriptionPeriod", () => {
 
 describe("grantFreeOrganizationMemberSubscriptionCredits", () => {
   it("grants one free-tier bucket per unique member for a future period", async () => {
-    const { createTransactionMock, findFirstBucketMock, tx } =
+    const { createTransactionMock, findUniqueBucketMock, tx } =
       createFreeGrantClient();
+    const periodEnd = new Date("2026-05-01T00:00:00.000Z");
 
     const grantsCreated = await grantFreeOrganizationMemberSubscriptionCredits(
       {
         memberUserIds: ["member-1", "member-1", "owner-1"],
         now: new Date("2026-04-01T00:00:00.000Z"),
         organizationId: "org-1",
-        periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+        periodEnd,
       },
       tx,
     );
 
     assert.equal(grantsCreated, 2);
-    assert.equal(findFirstBucketMock.mock.calls.length, 2);
+    assert.equal(findUniqueBucketMock.mock.calls.length, 2);
+    assert.deepEqual(findUniqueBucketMock.mock.calls[0]?.[0].where, {
+      referenceId_referenceType: {
+        referenceId: buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+          "member-1",
+          "org-1",
+          periodEnd,
+        ),
+        referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
+      },
+    });
     assert.equal(createTransactionMock.mock.calls.length, 2);
 
     const createdReferenceIds = createTransactionMock.mock.calls.map(
@@ -571,9 +686,43 @@ describe("grantFreeOrganizationMemberSubscriptionCredits", () => {
     );
   });
 
-  it("skips members that already hold a current free-tier bucket", async () => {
+  it("skips when a period bucket already exists even if not yet spendable", async () => {
+    const periodEnd = new Date("2026-05-01T00:00:00.000Z");
+    const referenceId = buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+      "member-1",
+      "org-1",
+      periodEnd,
+    );
+    const { createTransactionMock, findUniqueBucketMock, tx } =
+      createFreeGrantClient({
+        existingFreeBucketReferenceIds: [referenceId],
+      });
+
+    const grantsCreated = await grantFreeOrganizationMemberSubscriptionCredits(
+      {
+        memberUserIds: ["member-1"],
+        now: new Date("2026-04-01T00:00:00.000Z"),
+        organizationId: "org-1",
+        periodEnd,
+      },
+      tx,
+    );
+
+    assert.equal(grantsCreated, 0);
+    assert.equal(findUniqueBucketMock.mock.calls.length, 1);
+    assert.equal(createTransactionMock.mock.calls.length, 0);
+  });
+
+  it("skips members that already hold a bucket for the period", async () => {
+    const periodEnd = new Date("2026-05-01T00:00:00.000Z");
     const { createTransactionMock, tx } = createFreeGrantClient({
-      existingFreeBucketUserIds: ["member-1"],
+      existingFreeBucketReferenceIds: [
+        buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+          "member-1",
+          "org-1",
+          periodEnd,
+        ),
+      ],
     });
 
     const grantsCreated = await grantFreeOrganizationMemberSubscriptionCredits(
@@ -581,7 +730,7 @@ describe("grantFreeOrganizationMemberSubscriptionCredits", () => {
         memberUserIds: ["member-1", "owner-1"],
         now: new Date("2026-04-01T00:00:00.000Z"),
         organizationId: "org-1",
-        periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+        periodEnd,
       },
       tx,
     );
@@ -667,6 +816,11 @@ describe("transitionToNextLocalFreeSubscriptionPeriod", () => {
       "2026-03-30T10:00:00.000Z",
     );
     assert.equal(createTransactionMock.mock.calls.length, 1);
+    assert.equal(
+      createTransactionMock.mock.calls[0]?.[0].data.sourceCreditBucket.create
+        .activatesAt,
+      null,
+    );
     assert.deepEqual(updateSubscriptionMock.mock.calls[0][0], {
       where: {
         id: "subscription-source",
@@ -677,6 +831,39 @@ describe("transitionToNextLocalFreeSubscriptionPeriod", () => {
         status: "canceled",
       },
     });
+    vi.useRealTimers();
+  });
+
+  it("sets future activatesAt when the next period has not started yet", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"));
+    const { createTransactionMock, tx } = createTransitionClient({
+      organization: null,
+      user: { id: "user-1" },
+    });
+
+    await transitionToNextLocalFreeSubscriptionPeriod(
+      {
+        setCanceledAt: true,
+        subscription: {
+          canceledAt: null,
+          createdAt: new Date("2026-03-01T00:00:00.000Z"),
+          endedAt: null,
+          id: "subscription-source",
+          periodEnd: new Date("2026-04-15T00:00:00.000Z"),
+          referenceId: "user-1",
+          seats: null,
+          stripeCustomerId: "cus_1",
+          stripeSubscriptionId: null,
+        },
+      },
+      tx,
+    );
+
+    assert.equal(
+      createTransactionMock.mock.calls[0]?.[0].data.sourceCreditBucket.create.activatesAt?.toISOString(),
+      "2026-04-15T00:00:00.000Z",
+    );
     vi.useRealTimers();
   });
 

--- a/packages/database/src/helpers/subscription.ts
+++ b/packages/database/src/helpers/subscription.ts
@@ -5,7 +5,6 @@ import {
 } from "../generated/prisma/client.js";
 import {
   buildOrganizationMemberSubscriptionReferenceId,
-  getOrganizationMemberSubscriptionReferencePrefixForStartsWith,
   USER_CREDIT_REFERENCE_PREFIX,
 } from "./credit.js";
 import {
@@ -24,6 +23,9 @@ export const ACTIVE_SUBSCRIPTION_STATUSES = [
 export const FREE_SUBSCRIPTION_MONTHLY_CREDITS = 250;
 export const FREE_SUBSCRIPTION_PLAN = "free";
 export const MONTHLY_BILLING_INTERVAL = "month";
+
+/** Pre-create next local-free period this far before current periodEnd (5m cron × 3+ ticks). */
+export const FREE_SUBSCRIPTION_PRECREATE_LOOKAHEAD_MS = 15 * 60 * 1000;
 
 /**
  * Reference suffix segment that marks a member subscription-period credit
@@ -49,6 +51,7 @@ interface LocalFreeSubscriptionGrant {
 }
 
 interface EnsureLocalFreeSubscriptionPeriodBaseParams {
+  activatesAt?: Date | null;
   billingAnchorDate: Date;
   periodEnd: Date;
   periodStart: Date;
@@ -232,20 +235,19 @@ export async function grantFreeOrganizationMemberSubscriptionCredits(
   let grantsCreated = 0;
 
   for (const userId of userIds) {
-    const existingForPeriod = await tx.creditBucket.findFirst({
+    const referenceId = buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+      userId,
+      params.organizationId,
+      params.periodEnd,
+    );
+
+    // Idempotency: any bucket for this period (including future `activatesAt` from
+    // pre-create). Spendability is enforced separately via creditBucketActivatesAtOrBefore.
+    const existingForPeriod = await tx.creditBucket.findUnique({
       where: {
-        organizationId: params.organizationId,
-        userId,
-        referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
-        referenceId: {
-          startsWith:
-            getOrganizationMemberSubscriptionReferencePrefixForStartsWith(
-              userId,
-            ),
-          contains: LOCAL_FREE_SUBSCRIPTION_REFERENCE_CONTAINS,
-        },
-        expiresAt: {
-          gt: now,
+        referenceId_referenceType: {
+          referenceId,
+          referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
         },
       },
       select: {
@@ -256,12 +258,6 @@ export async function grantFreeOrganizationMemberSubscriptionCredits(
     if (existingForPeriod) {
       continue;
     }
-
-    const referenceId = buildLocalFreeOrganizationMemberSubscriptionReferenceId(
-      userId,
-      params.organizationId,
-      params.periodEnd,
-    );
 
     await tx.transaction.create({
       data: {
@@ -375,29 +371,28 @@ async function closeOutSourceSubscription(params: {
   });
 }
 
-export async function transitionToNextLocalFreeSubscriptionPeriod(
-  params: TransitionToNextLocalFreeSubscriptionParams,
+export interface EnsureNextLocalFreeSubscriptionPeriodParams {
+  activatesAt?: Date | null;
+  subscription: TransitionToNextLocalFreeSubscriptionParams["subscription"];
+}
+
+export async function ensureNextLocalFreeSubscriptionPeriod(
+  params: EnsureNextLocalFreeSubscriptionPeriodParams,
   tx: Prisma.TransactionClient,
-): Promise<void> {
+): Promise<boolean> {
   const { subscription } = params;
-  const settledAt = new Date();
 
   if (!subscription.periodEnd) {
-    await closeOutSourceSubscription({
-      endedAtFallback: settledAt,
-      id: subscription.id,
-      setCanceledAt: params.setCanceledAt,
-      settledAt,
-      subscription,
-      tx,
-    });
-    return;
+    return false;
   }
 
   const { periodEnd, periodStart } = buildNextLocalFreePeriod({
     createdAt: subscription.createdAt,
     periodEnd: subscription.periodEnd,
   });
+  const activatesAt =
+    params.activatesAt === undefined ? periodStart : params.activatesAt;
+
   const organization = await tx.organization.findUnique({
     where: {
       id: subscription.referenceId,
@@ -415,6 +410,7 @@ export async function transitionToNextLocalFreeSubscriptionPeriod(
 
     await ensureLocalFreeSubscriptionPeriod(
       {
+        activatesAt,
         billingAnchorDate: subscription.createdAt,
         memberUserIds,
         organizationId: organization.id,
@@ -426,50 +422,94 @@ export async function transitionToNextLocalFreeSubscriptionPeriod(
       },
       tx,
     );
-  } else {
-    const user = await tx.user.findUnique({
-      where: {
-        id: subscription.referenceId,
-      },
-      select: {
-        id: true,
-      },
-    });
-
-    if (!user) {
-      await closeOutSourceSubscription({
-        endedAtFallback: periodStart,
-        id: subscription.id,
-        setCanceledAt: true,
-        settledAt,
-        subscription,
-        tx,
-      });
-      return;
-    }
-
-    await ensureLocalFreeSubscriptionPeriod(
-      {
-        billingAnchorDate: subscription.createdAt,
-        organizationId: null,
-        periodEnd,
-        periodStart,
-        referenceId: user.id,
-        stripeCustomerId: subscription.stripeCustomerId,
-        userId: user.id,
-      },
-      tx,
-    );
+    return true;
   }
 
+  const user = await tx.user.findUnique({
+    where: {
+      id: subscription.referenceId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!user) {
+    return false;
+  }
+
+  await ensureLocalFreeSubscriptionPeriod(
+    {
+      activatesAt,
+      billingAnchorDate: subscription.createdAt,
+      organizationId: null,
+      periodEnd,
+      periodStart,
+      referenceId: user.id,
+      stripeCustomerId: subscription.stripeCustomerId,
+      userId: user.id,
+    },
+    tx,
+  );
+  return true;
+}
+
+export async function closeOverdueLocalFreeSubscription(
+  params: TransitionToNextLocalFreeSubscriptionParams,
+  tx: Prisma.TransactionClient,
+): Promise<void> {
+  const { subscription } = params;
+  const settledAt = new Date();
+  const endedAtFallback = subscription.periodEnd ?? settledAt;
+
   await closeOutSourceSubscription({
-    endedAtFallback: periodStart,
+    endedAtFallback,
     id: subscription.id,
     setCanceledAt: params.setCanceledAt,
     settledAt,
     subscription,
     tx,
   });
+}
+
+export async function transitionToNextLocalFreeSubscriptionPeriod(
+  params: TransitionToNextLocalFreeSubscriptionParams,
+  tx: Prisma.TransactionClient,
+): Promise<void> {
+  const { subscription } = params;
+  const settledAt = new Date();
+
+  if (!subscription.periodEnd) {
+    await closeOverdueLocalFreeSubscription(params, tx);
+    return;
+  }
+
+  const { periodStart } = buildNextLocalFreePeriod({
+    createdAt: subscription.createdAt,
+    periodEnd: subscription.periodEnd,
+  });
+
+  const ensured = await ensureNextLocalFreeSubscriptionPeriod(
+    {
+      activatesAt: periodStart <= settledAt ? null : periodStart,
+      subscription,
+    },
+    tx,
+  );
+
+  if (!ensured) {
+    await closeOutSourceSubscription({
+      endedAtFallback: periodStart,
+      id: subscription.id,
+      setCanceledAt: true,
+      settledAt,
+      subscription,
+      tx,
+    });
+    return;
+  }
+
+  await closeOverdueLocalFreeSubscription(params, tx);
 }
 
 export async function ensureLocalFreeSubscriptionPeriod(
@@ -546,6 +586,7 @@ export async function ensureLocalFreeSubscriptionPeriod(
           : {}),
         sourceCreditBucket: {
           create: {
+            activatesAt: params.activatesAt ?? null,
             amount,
             expiresAt: params.periodEnd,
             organizationId,

--- a/packages/database/src/repositories/__tests__/credit-bucket.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/credit-bucket.repository.test.ts
@@ -184,6 +184,8 @@ describe("creditBucketRepository.getBalance (organization)", () => {
     assert.ok(
       values.includes(CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD),
     );
+    const sqlText = JSON.stringify(queryArgs);
+    assert.ok(sqlText.includes("activatesAt"));
   });
 
   it("escapes LIKE wildcards in organization member reference scope", async () => {
@@ -301,6 +303,8 @@ describe("creditBucketRepository.getUnexpiredBuckets (organization)", () => {
         },
       },
     ]);
+    const activationWhere = andClause[1] as { OR?: unknown[] };
+    assert.ok(Array.isArray(activationWhere.OR));
   });
 
   it("uses escaped prefix for startsWith when userId contains LIKE wildcards", async () => {

--- a/packages/database/src/repositories/__tests__/subscription.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/subscription.repository.test.ts
@@ -33,8 +33,96 @@ describe("subscriptionRepository", () => {
     });
   });
 
-  it("orders latest active subscriptions with null period ends last", async () => {
+  it("getCurrentInPeriodActiveSubscriptionByReferenceId filters by period window", async () => {
+    const inPeriodRow = { id: "current-period" };
     let findFirstCall: unknown;
+    const now = new Date("2026-04-10T00:00:00.000Z");
+    const tx = {
+      subscription: {
+        findFirst: async (args: unknown) => {
+          findFirstCall = args;
+          return inPeriodRow;
+        },
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const result =
+      await subscriptionRepository.getCurrentInPeriodActiveSubscriptionByReferenceId(
+        "reference-1",
+        tx,
+        now,
+      );
+
+    assert.equal(result, inPeriodRow);
+    const call = findFirstCall as {
+      where: {
+        periodEnd: { gt: Date };
+        periodStart: { lte: Date };
+        referenceId: string;
+      };
+    };
+    assert.equal(call.where.referenceId, "reference-1");
+    assert.equal(call.where.periodStart.lte, now);
+    assert.equal(call.where.periodEnd.gt, now);
+  });
+
+  it("getLatestActiveSubscriptionByReferenceId orders by periodEnd only", async () => {
+    const fallbackRow = { id: "fallback" };
+    let findFirstCall: unknown;
+    const tx = {
+      subscription: {
+        findFirst: async (args: unknown) => {
+          findFirstCall = args;
+          return fallbackRow;
+        },
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const result =
+      await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+        "reference-1",
+        tx,
+      );
+
+    assert.equal(result, fallbackRow);
+    assert.deepEqual((findFirstCall as { orderBy: unknown }).orderBy, [
+      { periodEnd: { sort: "desc", nulls: "last" } },
+      { updatedAt: "desc" },
+    ]);
+    assert.equal(
+      (findFirstCall as { where: { periodStart?: unknown } }).where.periodStart,
+      undefined,
+    );
+  });
+
+  it("resolveActiveSubscriptionByReferenceId prefers in-period over latest by periodEnd", async () => {
+    const inPeriodRow = { id: "current-period" };
+    const calls: unknown[] = [];
+    const tx = {
+      subscription: {
+        findFirst: async (args: unknown) => {
+          calls.push(args);
+          if (calls.length === 1) {
+            return inPeriodRow;
+          }
+          return { id: "should-not-be-used" };
+        },
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const result =
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
+        "reference-1",
+        tx,
+      );
+
+    assert.equal(result, inPeriodRow);
+    assert.equal(calls.length, 1);
+  });
+
+  it("getLatestStartedActiveSubscriptionByReferenceId excludes future periodStart", async () => {
+    let findFirstCall: unknown;
+    const now = new Date("2026-04-14T12:00:00.000Z");
     const tx = {
       subscription: {
         findFirst: async (args: unknown) => {
@@ -44,22 +132,72 @@ describe("subscriptionRepository", () => {
       },
     } as unknown as Prisma.TransactionClient;
 
-    await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
+    await subscriptionRepository.getLatestStartedActiveSubscriptionByReferenceId(
       "reference-1",
       tx,
+      now,
     );
 
-    assert.deepEqual(findFirstCall, {
+    const call = findFirstCall as {
       where: {
-        referenceId: "reference-1",
-        status: {
-          in: ["active", "trialing", "past_due", "unpaid"],
+        OR: Array<{ periodStart: null | { lte: Date } }>;
+      };
+    };
+    assert.deepEqual(call.where.OR, [
+      { periodStart: null },
+      { periodStart: { lte: now } },
+    ]);
+  });
+
+  it("resolveActiveSubscriptionByReferenceId falls back to latest started active when not in period", async () => {
+    const fallbackRow = { id: "fallback" };
+    const calls: unknown[] = [];
+    const now = new Date("2026-04-14T12:00:00.000Z");
+    const tx = {
+      subscription: {
+        findFirst: async (args: unknown) => {
+          calls.push(args);
+          if (calls.length === 1) {
+            return null;
+          }
+          return fallbackRow;
         },
       },
-      orderBy: [
-        { periodEnd: { sort: "desc", nulls: "last" } },
-        { updatedAt: "desc" },
-      ],
-    });
+    } as unknown as Prisma.TransactionClient;
+
+    const result =
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
+        "reference-1",
+        tx,
+        now,
+      );
+
+    assert.equal(result, fallbackRow);
+    assert.equal(calls.length, 2);
+    assert.ok(
+      (calls[0] as { where: { periodEnd?: { gt: Date } } }).where.periodEnd,
+    );
+    assert.deepEqual((calls[1] as { where: { OR: unknown } }).where.OR, [
+      { periodStart: null },
+      { periodStart: { lte: now } },
+    ]);
+  });
+
+  it("resolveActiveSubscriptionByReferenceId returns null when only a future period is active", async () => {
+    const now = new Date("2026-04-14T12:00:00.000Z");
+    const tx = {
+      subscription: {
+        findFirst: async () => null,
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const result =
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
+        "reference-1",
+        tx,
+        now,
+      );
+
+    assert.equal(result, null);
   });
 });

--- a/packages/database/src/repositories/credit-bucket.repository.ts
+++ b/packages/database/src/repositories/credit-bucket.repository.ts
@@ -4,6 +4,8 @@ import {
   Prisma,
 } from "../generated/prisma/client.js";
 import {
+  creditBucketActivatesAtOrBefore,
+  creditBucketActivatesAtOrBeforeSql,
   escapeStringForLike,
   getOrganizationMemberSubscriptionReferencePrefix,
   getOrganizationMemberSubscriptionReferencePrefixForStartsWith,
@@ -50,6 +52,7 @@ export const creditBucketRepository = {
       where: {
         AND: [
           scopeWhere,
+          creditBucketActivatesAtOrBefore(now),
           { OR: [{ expiresAt: null }, { expiresAt: { gt: now } }] },
         ],
       },
@@ -87,6 +90,7 @@ export const creditBucketRepository = {
         LEFT JOIN credit_consumption cc ON cc."bucketId" = cb.id
         WHERE ${where}
           AND (cb."expiresAt" IS NULL OR cb."expiresAt" > ${now})
+          AND ${creditBucketActivatesAtOrBeforeSql(now)}
         GROUP BY cb.id, cb.amount
       )
       SELECT COALESCE(SUM(available), 0)::bigint AS balance
@@ -130,6 +134,7 @@ export const creditBucketRepository = {
         LEFT JOIN credit_consumption cc ON cc."bucketId" = cb.id
         WHERE ${where}
           AND (cb."expiresAt" IS NULL OR cb."expiresAt" > ${now})
+          AND ${creditBucketActivatesAtOrBeforeSql(now)}
           AND cb."referenceType" IS DISTINCT FROM ${CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD}
         GROUP BY cb.id, cb.amount, cb."expiresAt", cb."createdAt"
         HAVING (cb.amount - COALESCE(SUM(cc.amount), 0)) > 0
@@ -224,6 +229,7 @@ async function getFifoBucketsToCoverSpend(
       LEFT JOIN credit_consumption cc ON cc."bucketId" = cb.id
       WHERE ${where}
         AND (cb."expiresAt" IS NULL OR cb."expiresAt" > ${now})
+        AND ${creditBucketActivatesAtOrBeforeSql(now)}
       GROUP BY cb.id, cb.amount, cb."expiresAt", cb."createdAt"
       HAVING (cb.amount - COALESCE(SUM(cc.amount), 0)) > 0
     ),

--- a/packages/database/src/repositories/subscription.repository.ts
+++ b/packages/database/src/repositories/subscription.repository.ts
@@ -1,6 +1,23 @@
 import type { Prisma, Subscription } from "../generated/prisma/client.js";
 import { ACTIVE_SUBSCRIPTION_STATUSES } from "../helpers/subscription.js";
 
+function activeSubscriptionStatusWhere(): Prisma.SubscriptionWhereInput {
+  return {
+    status: {
+      in: [...ACTIVE_SUBSCRIPTION_STATUSES],
+    },
+  };
+}
+
+/** `periodStart` unset or on/before `now` (excludes pre-created future periods). */
+function subscriptionPeriodStartedAtOrBefore(
+  now: Date,
+): Prisma.SubscriptionWhereInput {
+  return {
+    OR: [{ periodStart: null }, { periodStart: { lte: now } }],
+  };
+}
+
 export const subscriptionRepository = {
   async getSubscriptionByStripeSubscriptionId(
     stripeSubscriptionId: string,
@@ -29,6 +46,35 @@ export const subscriptionRepository = {
     });
   },
 
+  /**
+   * Active subscription whose billing period contains `now`
+   * (`periodStart <= now < periodEnd`). Use when credits/UI must reflect the
+   * period the customer is in, not a pre-created successor row.
+   */
+  async getCurrentInPeriodActiveSubscriptionByReferenceId(
+    referenceId: string,
+    tx: Prisma.TransactionClient,
+    now: Date = new Date(),
+  ): Promise<Subscription | null> {
+    return await tx.subscription.findFirst({
+      where: {
+        referenceId,
+        ...activeSubscriptionStatusWhere(),
+        periodStart: {
+          lte: now,
+        },
+        periodEnd: {
+          gt: now,
+        },
+      },
+      orderBy: [{ updatedAt: "desc" }],
+    });
+  },
+
+  /**
+   * Active subscription with the latest `periodEnd` (any status window).
+   * Ignores whether `now` falls inside that period.
+   */
   async getLatestActiveSubscriptionByReferenceId(
     referenceId: string,
     tx: Prisma.TransactionClient,
@@ -36,14 +82,58 @@ export const subscriptionRepository = {
     return await tx.subscription.findFirst({
       where: {
         referenceId,
-        status: {
-          in: [...ACTIVE_SUBSCRIPTION_STATUSES],
-        },
+        ...activeSubscriptionStatusWhere(),
       },
       orderBy: [
         { periodEnd: { sort: "desc", nulls: "last" } },
         { updatedAt: "desc" },
       ],
     });
+  },
+
+  /**
+   * Active subscription with the latest `periodEnd` among rows whose period has
+   * started (`periodStart` null or `<= now`). Excludes pre-created successors
+   * whose `periodStart` is still in the future.
+   */
+  async getLatestStartedActiveSubscriptionByReferenceId(
+    referenceId: string,
+    tx: Prisma.TransactionClient,
+    now: Date = new Date(),
+  ): Promise<Subscription | null> {
+    return await tx.subscription.findFirst({
+      where: {
+        referenceId,
+        ...activeSubscriptionStatusWhere(),
+        ...subscriptionPeriodStartedAtOrBefore(now),
+      },
+      orderBy: [
+        { periodEnd: { sort: "desc", nulls: "last" } },
+        { updatedAt: "desc" },
+      ],
+    });
+  },
+
+  /**
+   * Billing/credits resolution: current in-period row when one exists, otherwise
+   * the latest started active row by `periodEnd` (ended periods, missing dates).
+   */
+  async resolveActiveSubscriptionByReferenceId(
+    referenceId: string,
+    tx: Prisma.TransactionClient,
+    now: Date = new Date(),
+  ): Promise<Subscription | null> {
+    return (
+      (await subscriptionRepository.getCurrentInPeriodActiveSubscriptionByReferenceId(
+        referenceId,
+        tx,
+        now,
+      )) ??
+      (await subscriptionRepository.getLatestStartedActiveSubscriptionByReferenceId(
+        referenceId,
+        tx,
+        now,
+      ))
+    );
   },
 };


### PR DESCRIPTION
## Summary

- Add optional `activatesAt` on `credit_bucket` so pre-created renewal buckets are not spendable until their period starts.
- Refactor local free subscription renewal in core: pre-create the next period up to 15 minutes before `periodEnd`, then close overdue rows when a successor exists.
- Split subscription lookup in `@sokosumi/database`: in-period resolution, started-period fallback (excludes future pre-created rows), and `resolveActiveSubscriptionByReferenceId` for billing/credits/seats.
- Wire web and core callers to `resolveActiveSubscriptionByReferenceId`; grant idempotency uses per-period `referenceId` on `findUnique`.

## Database

- Migration: `20260602120000_add_credit_bucket_activates_at`
- Helpers: `creditBucketActivatesAtOrBefore` (Prisma + raw SQL) applied in credit-bucket repo and seat-credit queries
- Subscription repository: `getCurrentInPeriodActiveSubscriptionByReferenceId`, `getLatestStartedActiveSubscriptionByReferenceId`, `resolveActiveSubscriptionByReferenceId`

## Core

- `free-subscription-sync.service`: Phase A pre-create (15m lookahead), Phase B overdue close/transition
- `getCurrentSubscriptionCredits` respects `activatesAt` on subscription-period buckets

## Web

- Billing, seats, webhooks, onboarding, and tasks use `resolveActiveSubscriptionByReferenceId`
- Rename internal helper to `resolveActiveOrganizationSubscription` for clarity

## Test plan

- [x] `pnpm --filter @sokosumi/database test`
- [x] `pnpm core:test` (including free-subscription-sync and subscription helpers)
- [x] `pnpm --filter web test` (billing, seats, webhooks, organization-subscription)
- [ ] `pnpm prisma:migrate:deploy` in each environment (note: ensure broken migration dir `20260602070355_enterprise_contracts` does not block deploy if present locally)

## Notes

- Paid Stripe flows omit `activatesAt` (immediate spend). Pre-create + delayed activation is local free cron only.
- Billing may briefly show no `currentPeriodEnd` if `resolve` returns null during a short gap; accepted for now (no billing snapshot UI in this PR).


Made with [Cursor](https://cursor.com)