### PR TITLE
feat(web): hide Hermes from coworker UI listings

### DIFF
--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -11,6 +11,7 @@ import {
 import { getAllCoreAgents } from "@/lib/agents/core-loaders";
 import { coreClient } from "@/lib/clients/core.client";
 import { agentService } from "@/lib/services";
+import { coworkerService } from "@/lib/services/coworker.service";
 
 import FilterSection from "./components/filter-section";
 import FilteredAgents from "./components/filtered-agents";
@@ -25,15 +26,13 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function GalleryPage() {
-  const [coreAgents, categoriesResponse, favoriteAgents, coworkersResponse] =
+  const [coreAgents, categoriesResponse, favoriteAgents, coworkers] =
     await Promise.all([
       getAllCoreAgents(),
       coreClient.getCategories(),
       // TODO(core-api): replace with a Core favorites API when available.
       agentService.getFavoriteAgents(),
-      coreClient.getCoworkers({
-        scope: "whitelisted",
-      }),
+      coworkerService.listCoworkers(),
     ]);
   const agentsWithPrice = mapCoreAgentsToAgentWithCreditsPrice(coreAgents);
 
@@ -49,7 +48,7 @@ export default async function GalleryPage() {
       <div className="space-y-12 px-2">
         <FilterSection categories={categories} />
 
-        <CoworkerGallerySection coworkers={coworkersResponse.data} />
+        <CoworkerGallerySection coworkers={coworkers} />
 
         <div className="space-y-6">
           <FilteredAgents

--- a/apps/web/src/app/(app)/tasks/utils/coworker-options.ts
+++ b/apps/web/src/app/(app)/tasks/utils/coworker-options.ts
@@ -1,4 +1,5 @@
 import type { Coworker } from "@/lib/clients/generated/core";
+import { normalizeCoworkerSlug } from "@/lib/coworkers/ui-restricted-slugs";
 import type { CoworkerOption } from "@/lib/types/coworker";
 
 import { COWORKER_FALLBACK_IMAGES } from "./coworker-fallback-images";
@@ -21,10 +22,10 @@ export function findCoworkerIdBySlug(
   options: CoworkerOption[],
   slug: string,
 ): string | null {
-  const normalized = slug.trim().toLowerCase();
+  const normalized = normalizeCoworkerSlug(slug);
   if (!normalized) return null;
   const match = options.find(
-    (option) => option.slug.toLowerCase() === normalized,
+    (option) => normalizeCoworkerSlug(option.slug) === normalized,
   );
   return match?.id ?? null;
 }

--- a/apps/web/src/lib/coworkers/__tests__/ui-restricted-slugs.test.ts
+++ b/apps/web/src/lib/coworkers/__tests__/ui-restricted-slugs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterCoworkersForUiListing,
+  isUiRestrictedCoworkerSlug,
+  normalizeCoworkerSlug,
+} from "@/lib/coworkers/ui-restricted-slugs";
+
+describe("ui-restricted coworker slugs", () => {
+  it("normalizes coworker slugs for comparisons", () => {
+    expect(normalizeCoworkerSlug(" Hermes ")).toBe("hermes");
+  });
+
+  it("matches restricted slugs case-insensitively", () => {
+    expect(isUiRestrictedCoworkerSlug("hermes")).toBe(true);
+    expect(isUiRestrictedCoworkerSlug("Hermes")).toBe(true);
+  });
+
+  it("does not restrict other or missing slugs", () => {
+    expect(isUiRestrictedCoworkerSlug("hannah")).toBe(false);
+    expect(isUiRestrictedCoworkerSlug("")).toBe(false);
+    expect(isUiRestrictedCoworkerSlug(null)).toBe(false);
+    expect(isUiRestrictedCoworkerSlug(undefined)).toBe(false);
+  });
+
+  it("filters restricted coworkers from UI listings", () => {
+    const coworkers = [
+      { id: "cow-1", slug: "hannah" },
+      { id: "cow-2", slug: "HERMES" },
+      { id: "cow-3", slug: null },
+    ];
+
+    expect(filterCoworkersForUiListing(coworkers)).toEqual([
+      { id: "cow-1", slug: "hannah" },
+      { id: "cow-3", slug: null },
+    ]);
+  });
+});

--- a/apps/web/src/lib/coworkers/ui-restricted-slugs.ts
+++ b/apps/web/src/lib/coworkers/ui-restricted-slugs.ts
@@ -1,0 +1,24 @@
+export const UI_RESTRICTED_COWORKER_SLUGS = ["hermes"] as const;
+
+const UI_RESTRICTED_COWORKER_SLUG_SET = new Set<string>(
+  UI_RESTRICTED_COWORKER_SLUGS.map(normalizeCoworkerSlug),
+);
+
+export function normalizeCoworkerSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+export function isUiRestrictedCoworkerSlug(
+  slug: string | null | undefined,
+): boolean {
+  if (!slug) return false;
+  return UI_RESTRICTED_COWORKER_SLUG_SET.has(normalizeCoworkerSlug(slug));
+}
+
+export function filterCoworkersForUiListing<T extends { slug?: string | null }>(
+  coworkers: readonly T[],
+): T[] {
+  return coworkers.filter(
+    (coworker) => !isUiRestrictedCoworkerSlug(coworker.slug),
+  );
+}

--- a/apps/web/src/lib/services/__tests__/coworker.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/coworker.service.test.ts
@@ -53,6 +53,34 @@ describe("coworker.service", () => {
     expect(result).toEqual([]);
   });
 
+  it("excludes UI-restricted coworkers", async () => {
+    coreClientMock.getCoworkers.mockResolvedValue({
+      data: [
+        {
+          id: "cow-1",
+          slug: "hannah",
+          name: "Hannah",
+        },
+        {
+          id: "cow-2",
+          slug: "Hermes",
+          name: "Hermes",
+        },
+      ],
+    });
+
+    const { coworkerService } = await import("../coworker.service");
+    const result = await coworkerService.listCoworkers();
+
+    expect(result).toEqual([
+      {
+        id: "cow-1",
+        slug: "hannah",
+        name: "Hannah",
+      },
+    ]);
+  });
+
   it("forwards the capability filter when provided", async () => {
     coreClientMock.getCoworkers.mockResolvedValue({
       data: [],

--- a/apps/web/src/lib/services/coworker.service.ts
+++ b/apps/web/src/lib/services/coworker.service.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { coreClient } from "@/lib/clients/core.client";
 import type { Coworker, GetCoworkersData } from "@/lib/clients/generated/core";
+import { filterCoworkersForUiListing } from "@/lib/coworkers/ui-restricted-slugs";
 
 export type CoworkerCapability = NonNullable<
   NonNullable<GetCoworkersData["query"]>["capability"]
@@ -17,7 +18,7 @@ export const coworkerService = (() => {
         capability: [capability],
       }),
     });
-    return response.data ?? [];
+    return filterCoworkersForUiListing(response.data ?? []);
   }
 
   return {


### PR DESCRIPTION
## Summary

- Hide the Hermes coworker from user-facing coworker lists (agents gallery and anywhere that uses `coworkerService.listCoworkers()`).
- Add a small `ui-restricted-slugs` helper so slug normalization and filtering stay consistent across the web app.

## Key changes

- **`apps/web/src/lib/coworkers/ui-restricted-slugs.ts`**: Defines `UI_RESTRICTED_COWORKER_SLUGS` (currently `hermes`), `normalizeCoworkerSlug`, `isUiRestrictedCoworkerSlug`, and `filterCoworkersForUiListing`.
- **`coworker.service`**: Applies `filterCoworkersForUiListing` to all `listCoworkers()` results so restricted coworkers never surface in UI-driven fetches.
- **Agents gallery** (`agents/page.tsx`): Loads coworkers via `coworkerService.listCoworkers()` instead of calling `coreClient.getCoworkers` directly.
- **Task coworker options**: Uses shared `normalizeCoworkerSlug` for slug lookups (case-insensitive, trimmed).

## Technical notes

- Restriction is **UI-only** at the web service layer; the Core API can still return Hermes. This keeps Hermes available for backend/orchestration flows without exposing it in gallery and list UIs.
- Adding another restricted slug is a one-line change to `UI_RESTRICTED_COWORKER_SLUGS`.

## Test plan

- [x] `pnpm --filter web test src/lib/coworkers/__tests__/ui-restricted-slugs.test.ts src/lib/services/__tests__/coworker.service.test.ts`
- [ ] Open `/agents` and confirm Hermes does not appear in the coworker gallery section
- [ ] Confirm other coworkers (e.g. Hannah) still appear
- [ ] Smoke-test task flows that pick coworkers by slug still resolve non-restricted slugs correctly


Made with [Cursor](https://cursor.com)