### PR TITLE
fix(chat): filter coworkers by compose capability

### DIFF
--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -312,10 +312,6 @@ export default function ChatInterface({
   ]);
 
   const { coworkers } = useCoworkersContext();
-  const chatCapableCoworkers = useMemo(
-    () => filterCoworkersForComposeKind(coworkers, "chat"),
-    [coworkers],
-  );
 
   const welcomeCoworkerSlug = searchParams?.get("coworker") ?? null;
   const initialWelcomeCoworker = useMemo(() => {
@@ -1794,7 +1790,7 @@ export default function ChatInterface({
         open={showSelectCoworkerModal}
         onOpenChange={setShowSelectCoworkerModal}
         onSelect={handleCoworkerSelected}
-        coworkers={chatCapableCoworkers}
+        coworkers={coworkers}
       />
     </div>
   );

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -29,6 +29,7 @@ import { useChatMessages } from "@/app/chat/hooks/use-chat-messages";
 import { useChatPreview } from "@/app/chat/hooks/use-chat-preview";
 import { useChatSync } from "@/app/chat/hooks/use-chat-sync";
 import { useCoworkerPostRefreshAssistantPoll } from "@/app/chat/hooks/use-coworker-post-refresh-assistant-poll";
+import { coworkerHasCapability } from "@/app/chat/utils/coworker-utils";
 import type {
   Chat,
   ChatComposeKind,
@@ -1450,7 +1451,7 @@ export default function ChatInterface({
           const selectedTaskCoworker =
             coworker ??
             coworkers.find((candidate) =>
-              candidate.capabilities?.includes("tasks"),
+              coworkerHasCapability(candidate, "tasks"),
             ) ??
             null;
 

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -29,7 +29,12 @@ import { useChatMessages } from "@/app/chat/hooks/use-chat-messages";
 import { useChatPreview } from "@/app/chat/hooks/use-chat-preview";
 import { useChatSync } from "@/app/chat/hooks/use-chat-sync";
 import { useCoworkerPostRefreshAssistantPoll } from "@/app/chat/hooks/use-coworker-post-refresh-assistant-poll";
-import { coworkerHasCapability } from "@/app/chat/utils/coworker-utils";
+import {
+  coworkerHasCapability,
+  filterCoworkersForComposeKind,
+  findCoworkerBySlugOrId,
+  findDefaultCoworker,
+} from "@/app/chat/utils/coworker-utils";
 import type {
   Chat,
   ChatComposeKind,
@@ -307,25 +312,18 @@ export default function ChatInterface({
   ]);
 
   const { coworkers } = useCoworkersContext();
+  const chatCapableCoworkers = useMemo(
+    () => filterCoworkersForComposeKind(coworkers, "chat"),
+    [coworkers],
+  );
 
   const welcomeCoworkerSlug = searchParams?.get("coworker") ?? null;
-  const defaultWelcomeSlug = "elena";
   const initialWelcomeCoworker = useMemo(() => {
     if (welcomeCoworkerSlug) {
-      const slug = welcomeCoworkerSlug.toLowerCase();
-      return (
-        coworkers.find((c) => c.slug?.toLowerCase() === slug) ??
-        coworkers.find((c) => c.id.toLowerCase() === slug)
-      );
+      return findCoworkerBySlugOrId(coworkers, welcomeCoworkerSlug);
     }
-    return (
-      coworkers.find(
-        (c) =>
-          c.slug?.toLowerCase() === defaultWelcomeSlug ||
-          c.id?.toLowerCase() === defaultWelcomeSlug,
-      ) ??
-      coworkers[0] ??
-      null
+    return findDefaultCoworker(
+      filterCoworkersForComposeKind(coworkers, "task"),
     );
   }, [coworkers, welcomeCoworkerSlug]);
 
@@ -335,15 +333,29 @@ export default function ChatInterface({
     id: string;
     name: string;
   } | null>(null);
-  const effectiveWelcomeCoworker =
-    welcomeSelectedModel != null
-      ? null
-      : welcomeCoworkerSlug != null
-        ? initialWelcomeCoworker
-        : (welcomeSelectedCoworker ?? initialWelcomeCoworker);
-
   const [welcomeComposeKind, setWelcomeComposeKind] =
     useState<ChatComposeKind>("task");
+  const effectiveWelcomeCoworker = useMemo(() => {
+    if (welcomeSelectedModel != null) {
+      return null;
+    }
+    const candidate =
+      welcomeCoworkerSlug != null
+        ? initialWelcomeCoworker
+        : (welcomeSelectedCoworker ?? initialWelcomeCoworker);
+    if (!candidate) {
+      return null;
+    }
+    const capability = welcomeComposeKind === "task" ? "tasks" : "chat";
+    return coworkerHasCapability(candidate, capability) ? candidate : null;
+  }, [
+    initialWelcomeCoworker,
+    welcomeComposeKind,
+    welcomeCoworkerSlug,
+    welcomeSelectedCoworker,
+    welcomeSelectedModel,
+  ]);
+
   const [isWelcomeTaskSubmitting, setIsWelcomeTaskSubmitting] = useState(false);
   const welcomeTaskCreationInFlightRef = useRef(false);
 
@@ -387,7 +399,7 @@ export default function ChatInterface({
   );
 
   const handleWelcomeCoworkerChange = useCallback(
-    (coworker: Coworker) => {
+    (coworker: Coworker | null) => {
       setWelcomeSelectedCoworker(coworker);
       setWelcomeSelectedModel(null);
       welcomeSelectedCoworkerRef.current = coworker;
@@ -1497,7 +1509,17 @@ export default function ChatInterface({
           }
         } else {
           const selectedCoworker =
-            coworker ?? effectiveWelcomeCoworker ?? coworkers[0] ?? null;
+            (coworker && coworkerHasCapability(coworker, "chat")
+              ? coworker
+              : null) ??
+            (effectiveWelcomeCoworker &&
+            coworkerHasCapability(effectiveWelcomeCoworker, "chat")
+              ? effectiveWelcomeCoworker
+              : null) ??
+            coworkers.find((candidate) =>
+              coworkerHasCapability(candidate, "chat"),
+            ) ??
+            null;
           if (!selectedCoworker) {
             toast.error(t("noCoworkersAvailable"));
             setIsWelcomeTransitioning(false);
@@ -1772,7 +1794,7 @@ export default function ChatInterface({
         open={showSelectCoworkerModal}
         onOpenChange={setShowSelectCoworkerModal}
         onSelect={handleCoworkerSelected}
-        coworkers={coworkers}
+        coworkers={chatCapableCoworkers}
       />
     </div>
   );

--- a/apps/web/src/app/(app)/chat/components/select-coworker-modal.tsx
+++ b/apps/web/src/app/(app)/chat/components/select-coworker-modal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { filterCoworkersForComposeKind } from "@/app/chat/utils/coworker-utils";
 import type { Coworker } from "@/app/chat/utils/types";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -42,7 +43,10 @@ export default function SelectCoworkerModal({
   const t = useTranslations("App.Chat.Chat");
   const [selectedCoworkerId, setSelectedCoworkerId] = useState<string>("");
 
-  const coworkers = propCoworkers ?? [];
+  const coworkers = useMemo(
+    () => filterCoworkersForComposeKind(propCoworkers ?? [], "chat"),
+    [propCoworkers],
+  );
 
   const selectedCoworker = coworkers.find((c) => c.id === selectedCoworkerId);
 

--- a/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
+++ b/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
@@ -3,8 +3,12 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { useTranslations } from "next-intl";
-import type { Dispatch, SetStateAction } from "react";
-import { getCoworkerImageUrl } from "@/app/chat/utils/coworker-utils";
+import { type Dispatch, type SetStateAction, useMemo } from "react";
+import {
+  filterCoworkersForComposeKind,
+  findDefaultCoworker,
+  getCoworkerImageUrl,
+} from "@/app/chat/utils/coworker-utils";
 import type {
   ChatComposeKind,
   ChatComposeMessage,
@@ -41,7 +45,7 @@ interface WelcomeScreenProps {
   coworkers?: Coworker[];
   coworkersLoading?: boolean;
   initialCoworker?: Coworker;
-  onCoworkerChange?: (coworker: Coworker) => void;
+  onCoworkerChange?: (coworker: Coworker | null) => void;
   selectedModel?: { id: string; name: string } | null;
   onSelectModel?: (model: { id: string; name: string } | null) => void;
 }
@@ -94,7 +98,12 @@ export default function WelcomeScreen({
   }
 
   const isTaskWelcomeHeader = welcomeComposeKind === "task";
-  const visualCoworker = initialCoworker ?? coworkers?.[0];
+  const composeKindCoworkers = useMemo(
+    () => filterCoworkersForComposeKind(coworkers ?? [], welcomeComposeKind),
+    [coworkers, welcomeComposeKind],
+  );
+  const visualCoworker =
+    initialCoworker ?? findDefaultCoworker(composeKindCoworkers) ?? undefined;
   const visualCoworkerName = visualCoworker?.name ?? "";
   const visualCoworkerAvatarUrl = visualCoworker
     ? (getCoworkerImageUrl(

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   coworkerHasCapability,
   filterCoworkersForComposeKind,
+  findCoworkerBySlugOrId,
+  findDefaultCoworker,
   mapDbCoworkerToChatCoworker,
 } from "../coworker-utils";
 import type { Coworker } from "../types";
@@ -47,6 +49,39 @@ describe("mapDbCoworkerToChatCoworker", () => {
       useCase: "",
       metadata: null,
     });
+  });
+});
+
+describe("findCoworkerBySlugOrId", () => {
+  const coworkers = [
+    baseCoworker({ id: "id-1", slug: "elena", name: "Elena" }),
+    baseCoworker({ id: "tasky", slug: "tasky", name: "Tasky" }),
+  ];
+
+  it("matches slug case-insensitively", () => {
+    expect(findCoworkerBySlugOrId(coworkers, "ELENA")).toEqual(coworkers[0]);
+  });
+
+  it("falls back to id when slug does not match", () => {
+    expect(findCoworkerBySlugOrId(coworkers, "tasky")).toEqual(coworkers[1]);
+  });
+});
+
+describe("findDefaultCoworker", () => {
+  it("prefers elena when present in the list", () => {
+    const coworkers = [
+      baseCoworker({ id: "1", slug: "tasky", name: "Tasky" }),
+      baseCoworker({ id: "2", slug: "elena", name: "Elena" }),
+    ];
+    expect(findDefaultCoworker(coworkers)).toEqual(coworkers[1]);
+  });
+
+  it("falls back to first list entry when elena is absent", () => {
+    const coworkers = [
+      baseCoworker({ id: "1", slug: "tasky", name: "Tasky" }),
+      baseCoworker({ id: "2", slug: "alex", name: "Alex" }),
+    ];
+    expect(findDefaultCoworker(coworkers)).toEqual(coworkers[0]);
   });
 });
 

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { mapDbCoworkerToChatCoworker } from "../coworker-utils";
+import {
+  coworkerHasCapability,
+  filterCoworkersForComposeKind,
+  mapDbCoworkerToChatCoworker,
+} from "../coworker-utils";
+import type { Coworker } from "../types";
+
+function baseCoworker(
+  overrides: Partial<Coworker> & Pick<Coworker, "id" | "slug" | "name">,
+): Coworker {
+  return {
+    description: "",
+    useCase: "",
+    capabilities: [],
+    ...overrides,
+  };
+}
 
 describe("mapDbCoworkerToChatCoworker", () => {
   it("keeps the coworker slug on the chat shape", () => {
@@ -31,5 +47,54 @@ describe("mapDbCoworkerToChatCoworker", () => {
       useCase: "",
       metadata: null,
     });
+  });
+});
+
+describe("filterCoworkersForComposeKind", () => {
+  const coworkers = [
+    baseCoworker({
+      id: "1",
+      slug: "both",
+      name: "Both",
+      capabilities: ["chat", "tasks"],
+    }),
+    baseCoworker({
+      id: "2",
+      slug: "chat-only",
+      name: "Chat only",
+      capabilities: ["chat"],
+    }),
+    baseCoworker({
+      id: "3",
+      slug: "task-only",
+      name: "Task only",
+      capabilities: ["tasks"],
+    }),
+  ];
+
+  it("returns task-capable coworkers for task compose kind", () => {
+    expect(filterCoworkersForComposeKind(coworkers, "task")).toEqual([
+      coworkers[0],
+      coworkers[2],
+    ]);
+  });
+
+  it("returns chat-capable coworkers for chat compose kind", () => {
+    expect(filterCoworkersForComposeKind(coworkers, "chat")).toEqual([
+      coworkers[0],
+      coworkers[1],
+    ]);
+  });
+
+  it("excludes coworkers with missing or empty capabilities", () => {
+    const noCapabilities = baseCoworker({
+      id: "4",
+      slug: "none",
+      name: "None",
+      capabilities: [],
+    });
+    expect(coworkerHasCapability(noCapabilities, "chat")).toBe(false);
+    expect(filterCoworkersForComposeKind([noCapabilities], "chat")).toEqual([]);
+    expect(filterCoworkersForComposeKind([noCapabilities], "task")).toEqual([]);
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
@@ -252,4 +252,19 @@ describe("resolveHydratedWelcomeSelection", () => {
     expect(r.composeKind).toBe("task");
     expect(r.coworker).toBeNull();
   });
+
+  it("for chat compose, picks a chat-capable fallback when stored coworker cannot chat", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "chat" as const,
+      modelId: null,
+      coworkerSlugOrId: "tasky",
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("chat");
+    expect(r.coworker?.capabilities?.includes("chat")).toBe(true);
+    expect(r.coworker?.slug).toBe("alex");
+  });
 });

--- a/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
@@ -267,4 +267,51 @@ describe("resolveHydratedWelcomeSelection", () => {
     expect(r.coworker?.capabilities?.includes("chat")).toBe(true);
     expect(r.coworker?.slug).toBe("alex");
   });
+
+  it("for chat compose with null coworkerSlugOrId, picks first chat-capable coworker", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "chat" as const,
+      modelId: null,
+      coworkerSlugOrId: null,
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("chat");
+    expect(r.coworker?.capabilities?.includes("chat")).toBe(true);
+    expect(r.coworker?.slug).toBe("alex");
+  });
+
+  it("for chat compose when stored coworker id/slug is unknown, picks first chat-capable coworker", () => {
+    const stored = {
+      v: 1 as const,
+      composeKind: "chat" as const,
+      modelId: null,
+      coworkerSlugOrId: "missing-coworker",
+    };
+    const r = resolveHydratedWelcomeSelection(coworkers, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("chat");
+    expect(r.coworker?.capabilities?.includes("chat")).toBe(true);
+    expect(r.coworker?.slug).toBe("alex");
+  });
+
+  it("for chat compose with no chat-capable coworkers, returns null coworker", () => {
+    const taskOnly = [
+      baseCoworker({ id: "c", slug: "tasky", capabilities: ["tasks"] }),
+    ];
+    const stored = {
+      v: 1 as const,
+      composeKind: "chat" as const,
+      modelId: null,
+      coworkerSlugOrId: null,
+    };
+    const r = resolveHydratedWelcomeSelection(taskOnly, stored, {
+      urlCoworkerSlug: false,
+    });
+    expect(r.composeKind).toBe("chat");
+    expect(r.coworker).toBeNull();
+  });
 });

--- a/apps/web/src/app/(app)/chat/utils/coworker-utils.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-utils.ts
@@ -3,10 +3,28 @@
  */
 
 import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
-
-import type { Coworker } from "@/app/chat/utils/types";
-/** DB coworker shape as returned by GET /api/coworkers (and Core GET /v1/coworkers) */
+import type { ChatComposeKind, Coworker } from "@/app/chat/utils/types";
 import type { Coworker as CoreCoworker } from "@/lib/clients/generated/core";
+
+export type CoworkerCapability = "chat" | "tasks";
+
+export function coworkerHasCapability(
+  coworker: Coworker,
+  capability: CoworkerCapability,
+): boolean {
+  return coworker.capabilities?.includes(capability) ?? false;
+}
+
+export function filterCoworkersForComposeKind(
+  coworkers: Coworker[],
+  composeKind: ChatComposeKind,
+): Coworker[] {
+  const capability: CoworkerCapability =
+    composeKind === "task" ? "tasks" : "chat";
+  return coworkers.filter((coworker) =>
+    coworkerHasCapability(coworker, capability),
+  );
+}
 
 const DEFAULT_COWORKER_AVATARS: Record<string, string> = {
   alex: "/images/coworkers/alex.webp",

--- a/apps/web/src/app/(app)/chat/utils/coworker-utils.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-utils.ts
@@ -26,6 +26,34 @@ export function filterCoworkersForComposeKind(
   );
 }
 
+export const DEFAULT_COWORKER_SLUG = "elena";
+
+export function findCoworkerBySlugOrId(
+  coworkers: Coworker[],
+  slugOrId: string,
+): Coworker | null {
+  const normalized = slugOrId.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return (
+    coworkers.find((coworker) => coworker.slug?.toLowerCase() === normalized) ??
+    coworkers.find((coworker) => coworker.id.toLowerCase() === normalized) ??
+    null
+  );
+}
+
+export function findDefaultCoworker(
+  coworkers: Coworker[],
+  preferredSlug: string = DEFAULT_COWORKER_SLUG,
+): Coworker | null {
+  const preferred = findCoworkerBySlugOrId(coworkers, preferredSlug);
+  if (preferred) {
+    return preferred;
+  }
+  return coworkers[0] ?? null;
+}
+
 const DEFAULT_COWORKER_AVATARS: Record<string, string> = {
   alex: "/images/coworkers/alex.webp",
   elena: "/images/coworkers/elena.webp",

--- a/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
+++ b/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
@@ -1,5 +1,9 @@
 import { CHAT_MODELS } from "@sokosumi/chat";
 
+import {
+  type CoworkerCapability,
+  coworkerHasCapability,
+} from "./coworker-utils";
 import type { ChatComposeKind, Coworker } from "./types";
 
 export const WELCOME_COMPOSE_PREFERENCES_STORAGE_KEY =
@@ -16,10 +20,11 @@ function isChatComposeKind(v: unknown): v is ChatComposeKind {
   return v === "chat" || v === "task";
 }
 
-function firstCoworkerWithTasksCapability(
+function firstCoworkerWithCapability(
   coworkers: Coworker[],
+  capability: CoworkerCapability,
 ): Coworker | null {
-  return coworkers.find((x) => x.capabilities?.includes("tasks")) ?? null;
+  return coworkers.find((x) => coworkerHasCapability(x, capability)) ?? null;
 }
 
 export function readWelcomeComposePreferences(): WelcomeComposeStoredV1 | null {
@@ -99,7 +104,7 @@ export function resolveHydratedWelcomeSelection(
       composeKind: defaultCompose,
       coworker:
         defaultCompose === "task"
-          ? firstCoworkerWithTasksCapability(coworkers)
+          ? firstCoworkerWithCapability(coworkers, "tasks")
           : null,
       model: null,
     };
@@ -134,23 +139,30 @@ export function resolveHydratedWelcomeSelection(
     );
     if (c) {
       if (composeKind === "task") {
-        if (c.capabilities?.includes("tasks")) {
+        if (coworkerHasCapability(c, "tasks")) {
           return { composeKind: "task", coworker: c, model: null };
         }
         return {
           composeKind: "task",
-          coworker: firstCoworkerWithTasksCapability(coworkers),
+          coworker: firstCoworkerWithCapability(coworkers, "tasks"),
           model: null,
         };
       }
-      return { composeKind: "chat", coworker: c, model: null };
+      if (coworkerHasCapability(c, "chat")) {
+        return { composeKind: "chat", coworker: c, model: null };
+      }
+      return {
+        composeKind: "chat",
+        coworker: firstCoworkerWithCapability(coworkers, "chat"),
+        model: null,
+      };
     }
   }
 
   if (composeKind === "task") {
     return {
       composeKind: "task",
-      coworker: firstCoworkerWithTasksCapability(coworkers),
+      coworker: firstCoworkerWithCapability(coworkers, "tasks"),
       model: null,
     };
   }

--- a/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
+++ b/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
@@ -167,5 +167,9 @@ export function resolveHydratedWelcomeSelection(
     };
   }
 
-  return { composeKind, coworker: null, model: null };
+  return {
+    composeKind: "chat",
+    coworker: firstCoworkerWithCapability(coworkers, "chat"),
+    model: null,
+  };
 }

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -73,7 +73,7 @@ export default async function AppLayout({ children }: AppLayoutProps) {
     getPendingNoticesAction(),
     userService.getActiveOrganization(),
     coreClient.getMyCredits().catch(() => null),
-    coworkerService.listCoworkers("chat").catch(() => []),
+    coworkerService.listCoworkers().catch(() => []),
     hermesBetaEnabled(),
   ]);
   const creditsResult = creditsResultRaw as GetUsersByIdCreditsResponse | null;

--- a/apps/web/src/app/api/coworkers/route.ts
+++ b/apps/web/src/app/api/coworkers/route.ts
@@ -1,11 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server";
 
+import type { CoworkerCapability } from "@/app/chat/utils/coworker-utils";
 import { getSession } from "@/lib/auth/utils";
 import { CoworkerSchema } from "@/lib/clients/generated/core/schemas.gen";
-import {
-  type CoworkerCapability,
-  coworkerService,
-} from "@/lib/services/coworker.service";
+import { coworkerService } from "@/lib/services/coworker.service";
 
 /**
  * GET /api/coworkers

--- a/apps/web/src/components/chat/__tests__/multimodal-input.test.tsx
+++ b/apps/web/src/components/chat/__tests__/multimodal-input.test.tsx
@@ -4,8 +4,10 @@ import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type {
+  ChatComposeKind,
   ChatComposeMessage,
   ChatComposeSubmitOptions,
+  Coworker,
 } from "@/app/chat/utils/types";
 
 import { MultimodalInput } from "../multimodal-input";
@@ -21,6 +23,109 @@ vi.mock("@/components/agents/coworker-gallery-card", () => ({
 vi.mock("../coworker-model-selector", () => ({
   default: () => null,
 }));
+
+const taskOnlyCoworker: Coworker = {
+  id: "task-1",
+  slug: "tasky",
+  name: "Tasky",
+  description: "",
+  useCase: "",
+  capabilities: ["tasks"],
+};
+
+const elenaCoworker: Coworker = {
+  id: "elena",
+  slug: "elena",
+  name: "Elena",
+  description: "",
+  useCase: "",
+  capabilities: ["chat", "tasks"],
+};
+
+const customCoworker: Coworker = {
+  id: "custom",
+  slug: "custom",
+  name: "Custom",
+  description: "",
+  useCase: "",
+  capabilities: ["chat", "tasks"],
+};
+
+const bothCapableCoworkers = [customCoworker, elenaCoworker];
+
+function WelcomeMultimodalInput({
+  onCoworkerChange,
+  onSendMessage,
+  initialComposeKind = "task",
+}: {
+  onCoworkerChange?: (coworker: Coworker | null) => void;
+  onSendMessage?: (
+    message: ChatComposeMessage,
+    coworker?: Coworker,
+    model?: { id: string; name: string },
+    options?: ChatComposeSubmitOptions,
+  ) => boolean | Promise<boolean>;
+  initialComposeKind?: ChatComposeKind;
+}) {
+  const [input, setInput] = useState("");
+  const [composeKind, setComposeKind] =
+    useState<ChatComposeKind>(initialComposeKind);
+
+  return (
+    <MultimodalInput
+      input={input}
+      setInput={setInput}
+      status="ready"
+      stop={() => {}}
+      messages={[]}
+      setMessages={() => {}}
+      sendMessage={() => Promise.resolve()}
+      onSendMessage={onSendMessage}
+      controlledComposeKind={composeKind}
+      onComposeKindChange={setComposeKind}
+      coworkers={[taskOnlyCoworker]}
+      coworker={taskOnlyCoworker}
+      onCoworkerChange={onCoworkerChange}
+    />
+  );
+}
+
+function UncontrolledComposeKindInput({
+  onSendMessage,
+}: {
+  onSendMessage: (
+    message: ChatComposeMessage,
+    coworker?: Coworker,
+  ) => boolean | Promise<boolean>;
+}) {
+  const [input, setInput] = useState("");
+  const [composeKind, setComposeKind] = useState<ChatComposeKind>("task");
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="fill-task-input"
+        onClick={() => setInput("Task message")}
+      >
+        Fill task input
+      </button>
+      <MultimodalInput
+        input={input}
+        setInput={setInput}
+        status="ready"
+        stop={() => {}}
+        messages={[]}
+        setMessages={() => {}}
+        sendMessage={() => Promise.resolve()}
+        onSendMessage={onSendMessage}
+        controlledComposeKind={composeKind}
+        onComposeKindChange={setComposeKind}
+        coworkers={bothCapableCoworkers}
+      />
+    </>
+  );
+}
 
 function TestMultimodalInput({
   persistentImageGeneration = false,
@@ -54,6 +159,68 @@ function TestMultimodalInput({
 }
 
 describe("MultimodalInput", () => {
+  it("notifies parent with null when switching to chat without chat-capable coworkers", () => {
+    const onCoworkerChange = vi.fn();
+
+    render(
+      <WelcomeMultimodalInput
+        initialComposeKind="task"
+        onCoworkerChange={onCoworkerChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "composeChat" }));
+
+    expect(onCoworkerChange).toHaveBeenCalledWith(null);
+  });
+
+  it("preserves manual coworker selection across compose-kind toggles without prop coworker", async () => {
+    const onSendMessage = vi.fn().mockResolvedValue(true);
+
+    render(<UncontrolledComposeKindInput onSendMessage={onSendMessage} />);
+
+    const avatarButtons = screen
+      .getAllByRole("button")
+      .filter((button) => button.className.includes("cursor-pointer"));
+    fireEvent.click(avatarButtons[0]!);
+
+    fireEvent.click(screen.getByRole("radio", { name: "composeChat" }));
+    fireEvent.click(screen.getByRole("radio", { name: "composeTask" }));
+
+    fireEvent.click(screen.getByTestId("fill-task-input"));
+    fireEvent.click(screen.getByTestId("send-button"));
+
+    await waitFor(() => {
+      expect(onSendMessage).toHaveBeenCalled();
+    });
+
+    expect(onSendMessage.mock.calls[0]?.[1]).toMatchObject({
+      id: "custom",
+      slug: "custom",
+    });
+  });
+
+  it("blocks chat send when no chat coworker or model is selected", () => {
+    const onSendMessage = vi.fn().mockResolvedValue(true);
+
+    render(
+      <WelcomeMultimodalInput
+        initialComposeKind="chat"
+        onSendMessage={onSendMessage}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Hello" },
+    });
+
+    expect(screen.getByTestId("send-button")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("send-button"));
+
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
   it("keeps persistent image generation enabled and sends it with the message", async () => {
     const onSendMessage = vi.fn().mockResolvedValue(true);
     render(

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -20,7 +20,10 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
-import { getCoworkerImageUrl } from "@/app/chat/utils/coworker-utils";
+import {
+  filterCoworkersForComposeKind,
+  getCoworkerImageUrl,
+} from "@/app/chat/utils/coworker-utils";
 import type {
   ChatComposeKind,
   ChatComposeMessage,
@@ -201,9 +204,21 @@ function PureMultimodalInput({
   const [chatFileParts, setChatFileParts] = useState<ChatFilePart[]>([]);
   const [imageGenerationEnabled, setImageGenerationEnabled] = useState(false);
   const [uploadingAttachmentsCount, setUploadingAttachmentsCount] = useState(0);
-  const initialDefault = findDefaultCoworker(propCoworkers);
   const [preferredCoworker, setPreferredCoworker] = useState<Coworker | null>(
-    propCoworker ?? (propSelectedModel ? null : initialDefault),
+    () => {
+      if (propCoworker) {
+        return propCoworker;
+      }
+      if (propSelectedModel) {
+        return null;
+      }
+      const initialComposeKind: ChatComposeKind = chatId
+        ? "chat"
+        : (controlledComposeKind ?? "task");
+      return findDefaultCoworker(
+        filterCoworkersForComposeKind(propCoworkers ?? [], initialComposeKind),
+      );
+    },
   );
   const [selectedModel, setSelectedModel] = useState<{
     id: string;
@@ -212,11 +227,20 @@ function PureMultimodalInput({
 
   // Sync selected agent from props when switching conversations (model vs coworker).
   useEffect(() => {
-    const defaultCoworker = findDefaultCoworker(propCoworkers);
+    if (propCoworker) {
+      setPreferredCoworker(propCoworker);
+      return;
+    }
+    if (propSelectedModel) {
+      setPreferredCoworker(null);
+      return;
+    }
     setPreferredCoworker(
-      propCoworker ?? (propSelectedModel ? null : defaultCoworker),
+      findDefaultCoworker(
+        filterCoworkersForComposeKind(propCoworkers ?? [], composeKind),
+      ),
     );
-  }, [propCoworker, propSelectedModel, propCoworkers]);
+  }, [composeKind, propCoworker, propSelectedModel, propCoworkers]);
 
   useEffect(() => {
     setSelectedModel(propSelectedModel ?? null);
@@ -471,12 +495,7 @@ function PureMultimodalInput({
 
   const coworkers = propCoworkers ?? [];
   const availableCoworkers = useMemo(
-    () =>
-      composeKind === "task"
-        ? coworkers.filter((coworker) =>
-            coworker.capabilities?.includes("tasks"),
-          )
-        : coworkers,
+    () => filterCoworkersForComposeKind(coworkers, composeKind),
     [composeKind, coworkers],
   );
   const selectedCoworker = useMemo(() => {
@@ -637,9 +656,7 @@ function PureMultimodalInput({
       if (nextKind === "task") {
         setSelectedModel(null);
         onSelectModel?.(null);
-        const taskCoworkers = coworkers.filter((coworker) =>
-          coworker.capabilities?.includes("tasks"),
-        );
+        const taskCoworkers = filterCoworkersForComposeKind(coworkers, "task");
         const hasCurrentTaskCoworker = taskCoworkers.some((coworker) =>
           matchesCoworker(coworker, preferredCoworker),
         );
@@ -653,11 +670,15 @@ function PureMultimodalInput({
         return;
       }
 
-      if (!preferredCoworker) {
-        const defaultCoworker = findDefaultCoworker(coworkers);
-        setPreferredCoworker(defaultCoworker);
-        if (defaultCoworker) {
-          onCoworkerChange?.(defaultCoworker);
+      const chatCoworkers = filterCoworkersForComposeKind(coworkers, "chat");
+      const hasCurrentChatCoworker = chatCoworkers.some((coworker) =>
+        matchesCoworker(coworker, preferredCoworker),
+      );
+      if (!hasCurrentChatCoworker) {
+        const defaultChatCoworker = findDefaultCoworker(chatCoworkers);
+        setPreferredCoworker(defaultChatCoworker);
+        if (defaultChatCoworker) {
+          onCoworkerChange?.(defaultChatCoworker);
         }
       }
     },

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -22,6 +22,7 @@ import {
 import { toast } from "sonner";
 import {
   filterCoworkersForComposeKind,
+  findDefaultCoworker,
   getCoworkerImageUrl,
 } from "@/app/chat/utils/coworker-utils";
 import type {
@@ -115,28 +116,15 @@ interface MultimodalInputProps {
   coworker?: Coworker;
   coworkers?: Coworker[];
   coworkersLoading?: boolean;
-  onCoworkerChange?: (coworker: Coworker) => void;
+  onCoworkerChange?: (coworker: Coworker | null) => void;
   enterSubmitsOnMobile?: boolean;
   blurOnSendOnMobile?: boolean;
   persistentImageGeneration?: boolean;
 }
 
-const DEFAULT_COWORKER_SLUG = "elena";
 const TASK_MARKDOWN_EDITOR_ID = "chat-task-markdown-editor";
 
 type ChatFilePart = Extract<UIMessage["parts"][number], { type: "file" }>;
-
-function findDefaultCoworker(list: Coworker[] | undefined) {
-  return (
-    list?.find(
-      (coworker) =>
-        coworker.slug?.toLowerCase() === DEFAULT_COWORKER_SLUG ||
-        coworker.id?.toLowerCase() === DEFAULT_COWORKER_SLUG,
-    ) ??
-    list?.[0] ??
-    null
-  );
-}
 
 function matchesCoworker(a: Coworker | null, b: Coworker | null): boolean {
   if (!a || !b) {
@@ -215,8 +203,13 @@ function PureMultimodalInput({
       const initialComposeKind: ChatComposeKind = chatId
         ? "chat"
         : (controlledComposeKind ?? "task");
-      return findDefaultCoworker(
-        filterCoworkersForComposeKind(propCoworkers ?? [], initialComposeKind),
+      return (
+        findDefaultCoworker(
+          filterCoworkersForComposeKind(
+            propCoworkers ?? [],
+            initialComposeKind,
+          ),
+        ) ?? null
       );
     },
   );
@@ -225,22 +218,37 @@ function PureMultimodalInput({
     name: string;
   } | null>(propSelectedModel ?? null);
 
-  // Sync selected agent from props when switching conversations (model vs coworker).
+  // Sync from props when the conversation or parent-driven agent changes.
+  // Compose-kind toggles are handled in handleComposeKindChange — do not reset here.
   useEffect(() => {
-    if (propCoworker) {
-      setPreferredCoworker(propCoworker);
-      return;
-    }
     if (propSelectedModel) {
       setPreferredCoworker(null);
+      return;
+    }
+    if (propCoworker) {
+      const filteredCoworkers = filterCoworkersForComposeKind(
+        [propCoworker],
+        composeKind,
+      );
+      if (filteredCoworkers.length > 0) {
+        setPreferredCoworker(filteredCoworkers[0] ?? null);
+      } else {
+        setPreferredCoworker(null);
+      }
+    }
+  }, [composeKind, propCoworker, propSelectedModel]);
+
+  // Seed default coworker when the coworkers list loads (uncontrolled selection only).
+  useEffect(() => {
+    if (propCoworker || propSelectedModel) {
       return;
     }
     setPreferredCoworker(
       findDefaultCoworker(
         filterCoworkersForComposeKind(propCoworkers ?? [], composeKind),
-      ),
+      ) ?? null,
     );
-  }, [composeKind, propCoworker, propSelectedModel, propCoworkers]);
+  }, [propCoworkers]);
 
   useEffect(() => {
     setSelectedModel(propSelectedModel ?? null);
@@ -517,7 +525,9 @@ function PureMultimodalInput({
     canSubmitContent &&
     status === "ready" &&
     !submitBlocked &&
-    (composeKind === "chat" || selectedCoworker != null) &&
+    (composeKind === "chat"
+      ? selectedCoworker != null || selectedModel != null
+      : selectedCoworker != null) &&
     !isUploadingAttachments;
   const placeholder = t(
     composeKind === "task"
@@ -663,9 +673,7 @@ function PureMultimodalInput({
         if (!hasCurrentTaskCoworker) {
           const defaultTaskCoworker = findDefaultCoworker(taskCoworkers);
           setPreferredCoworker(defaultTaskCoworker);
-          if (defaultTaskCoworker) {
-            onCoworkerChange?.(defaultTaskCoworker);
-          }
+          onCoworkerChange?.(defaultTaskCoworker);
         }
         return;
       }
@@ -677,9 +685,7 @@ function PureMultimodalInput({
       if (!hasCurrentChatCoworker) {
         const defaultChatCoworker = findDefaultCoworker(chatCoworkers);
         setPreferredCoworker(defaultChatCoworker);
-        if (defaultChatCoworker) {
-          onCoworkerChange?.(defaultChatCoworker);
-        }
+        onCoworkerChange?.(defaultChatCoworker);
       }
     },
     [

--- a/apps/web/src/lib/services/coworker.service.ts
+++ b/apps/web/src/lib/services/coworker.service.ts
@@ -1,12 +1,9 @@
 import "server-only";
 
+import type { CoworkerCapability } from "@/app/chat/utils/coworker-utils";
 import { coreClient } from "@/lib/clients/core.client";
-import type { Coworker, GetCoworkersData } from "@/lib/clients/generated/core";
+import type { Coworker } from "@/lib/clients/generated/core";
 import { filterCoworkersForUiListing } from "@/lib/coworkers/ui-restricted-slugs";
-
-export type CoworkerCapability = NonNullable<
-  NonNullable<GetCoworkersData["query"]>["capability"]
->[number];
 
 export const coworkerService = (() => {
   async function listCoworkers(


### PR DESCRIPTION
## Summary

Chat compose previously showed all coworkers (including task-only agents) because filtering applied only to task mode. This change centralizes capability checks and filters the coworker picker, defaults, and welcome preferences by compose kind (`chat` vs `task`).

## Key changes

- Add `coworkerHasCapability` and `filterCoworkersForComposeKind` in `coworker-utils.ts` as the single source of truth for capability filtering.
- **Multimodal input**: filter available coworkers by compose kind; pick defaults from the filtered list; when switching to chat, re-select a chat-capable coworker if the current one is task-only.
- **Welcome compose preferences**: if a stored coworker lacks `chat` capability, fall back to the first chat-capable coworker (mirrors existing task fallback).
- **App layout**: load all coworkers server-side (`listCoworkers()` without `"chat"` filter) so the client can filter per compose mode.
- **CoworkerCapability type**: moved to chat utils; service and API route import the shared type.

## Technical details

| Area | Before | After |
|------|--------|-------|
| Chat compose picker | All coworkers | Only `chat`-capable |
| Task compose picker | `tasks`-capable only | Unchanged (shared helper) |
| Stored prefs (chat + task-only coworker) | Kept invalid coworker | Falls back to chat-capable default |
| Layout coworker fetch | `listCoworkers("chat")` | `listCoworkers()` (full list, client filters) |

## Test plan

- [x] `pnpm test` — `coworker-utils.test.ts` and `welcome-compose-preferences.test.ts` (19 tests)
- [ ] Welcome screen: switch to **Chat**, confirm picker lists only chat-capable coworkers
- [ ] Welcome screen: switch to **Task**, confirm picker lists only task-capable coworkers
- [ ] Switch Chat → Task with a chat-only coworker selected; verify selection updates to a task-capable default
- [ ] Switch Task → Chat with a task-only coworker selected; verify selection updates to a chat-capable default
- [ ] Reload with stored preference pointing at a task-only coworker in chat mode; verify fallback to a chat-capable coworker


Made with [Cursor](https://cursor.com)