### PR TITLE
feat(web): allowlist House of Communication Hermes beta emails

### DIFF
--- a/apps/web/src/lib/flags/__tests__/hermes-beta.test.ts
+++ b/apps/web/src/lib/flags/__tests__/hermes-beta.test.ts
@@ -35,9 +35,9 @@ describe("hermesBetaEnabled", () => {
   it.each([
     "user@nmkr.io",
     "USER@NMKR.IO",
-    "user@house-of-communication.com",
-    "USER@HOUSE-OF-COMMUNICATION.COM",
-  ])("returns true for beta domain %s", async (email) => {
+    "k.platz@house-of-communication.com",
+    "K.PLATZ@HOUSE-OF-COMMUNICATION.COM",
+  ])("returns true for beta access email %s", async (email) => {
     getSessionMock.mockResolvedValue({ user: { email } });
 
     const { hermesBetaEnabled } = await import("../hermes-beta");

--- a/apps/web/src/lib/hermes/__tests__/beta-access.test.ts
+++ b/apps/web/src/lib/hermes/__tests__/beta-access.test.ts
@@ -5,9 +5,24 @@ import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 describe("isHermesBetaAccessEmail", () => {
   it("matches allowed beta domains only", () => {
     expect(isHermesBetaAccessEmail("a@nmkr.io")).toBe(true);
-    expect(isHermesBetaAccessEmail("a@house-of-communication.com")).toBe(true);
     expect(isHermesBetaAccessEmail("a@sub.nmkr.io")).toBe(false);
     expect(isHermesBetaAccessEmail(null)).toBe(false);
     expect(isHermesBetaAccessEmail("not-an-email")).toBe(false);
+  });
+
+  it.each([
+    "k.platz@house-of-communication.com",
+    "y.bollinger@house-of-communication.com",
+    "s.kuepers@house-of-communication.com",
+    "m.starkova@house-of-communication.com",
+    "K.PLATZ@HOUSE-OF-COMMUNICATION.COM",
+  ])("allows House of Communication pilot email %s", (email) => {
+    expect(isHermesBetaAccessEmail(email)).toBe(true);
+  });
+
+  it("denies other House of Communication emails", () => {
+    expect(isHermesBetaAccessEmail("someone@house-of-communication.com")).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/src/lib/hermes/beta-access.ts
+++ b/apps/web/src/lib/hermes/beta-access.ts
@@ -1,16 +1,32 @@
 import { getEmailDomain } from "@/lib/utils";
 
 /** Email domains allowed to use Hermes beta (sidebar, page, APIs). */
-export const HERMES_BETA_EMAIL_DOMAINS = [
-  "nmkr.io",
-  "house-of-communication.com",
+export const HERMES_BETA_EMAIL_DOMAINS = ["nmkr.io"] as const;
+
+/** Individual House of Communication emails allowed to use Hermes beta. */
+export const HERMES_BETA_ALLOWED_EMAILS = [
+  "k.platz@house-of-communication.com",
+  "y.bollinger@house-of-communication.com",
+  "s.kuepers@house-of-communication.com",
+  "m.starkova@house-of-communication.com",
 ] as const;
 
 const HERMES_BETA_EMAIL_DOMAIN_SET = new Set<string>(HERMES_BETA_EMAIL_DOMAINS);
+const HERMES_BETA_ALLOWED_EMAIL_SET = new Set<string>(
+  HERMES_BETA_ALLOWED_EMAILS.map((allowedEmail) => allowedEmail.toLowerCase()),
+);
 
 export function isHermesBetaAccessEmail(
   email: string | null | undefined,
 ): boolean {
-  const domain = email ? getEmailDomain(email) : null;
+  if (!email) {
+    return false;
+  }
+
+  if (HERMES_BETA_ALLOWED_EMAIL_SET.has(email.toLowerCase())) {
+    return true;
+  }
+
+  const domain = getEmailDomain(email);
   return domain !== null && HERMES_BETA_EMAIL_DOMAIN_SET.has(domain);
 }


### PR DESCRIPTION
## Summary

Hermes beta access for House of Communication is no longer granted to the entire `@house-of-communication.com` domain. Access is limited to four named pilot accounts, while `@nmkr.io` domain access is unchanged.

## Key changes

- Remove `house-of-communication.com` from `HERMES_BETA_EMAIL_DOMAINS`.
- Add `HERMES_BETA_ALLOWED_EMAILS` with four pilot addresses (case-insensitive match).
- Update `isHermesBetaAccessEmail` to check the allowlist before domain rules.
- Extend unit tests for allowed pilots, denied generic HoC addresses, and flag integration.

## Technical details

- Allowlist emails are normalized to lowercase in a `Set` for O(1) lookup.
- `HERMES_BETA_EMAIL_DOMAINS` is now `as const` with only `nmkr.io`.

**Allowed HoC pilot emails:**
- `k.platz@house-of-communication.com`
- `y.bollinger@house-of-communication.com`
- `s.kuepers@house-of-communication.com`
- `m.starkova@house-of-communication.com`

## Test plan

- [ ] `pnpm --filter web test apps/web/src/lib/hermes/__tests__/beta-access.test.ts`
- [ ] `pnpm --filter web test apps/web/src/lib/flags/__tests__/hermes-beta.test.ts`
- [ ] Confirm a listed HoC pilot can reach Hermes beta UI/API when signed in
- [ ] Confirm another `@house-of-communication.com` address does not get beta access
- [ ] Confirm `@nmkr.io` users still have beta access


Made with [Cursor](https://cursor.com)