### PR TITLE
feat(history): show resolved icons for jobs and conversations

### DIFF
--- a/apps/web/src/app/(app)/history/__tests__/history-list-item.test.tsx
+++ b/apps/web/src/app/(app)/history/__tests__/history-list-item.test.tsx
@@ -1,6 +1,6 @@
 import { TaskStatus } from "@sokosumi/database";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getHistoryItemHref,
@@ -14,17 +14,36 @@ import {
 } from "@/app/history/utils/history-row-subtitle";
 import type { HistoryItem } from "@/lib/services/history.service";
 
+const iconMocks = vi.hoisted(() => ({
+  agentIcon: vi.fn(),
+  chatModelIcon: vi.fn(),
+}));
+
 vi.mock("next-intl", () => ({
   useLocale: () => "en",
   useTranslations: () => (key: string) => key,
 }));
 
 vi.mock("@/components/agents/agent-icon", () => ({
-  AgentIcon: () => <span data-testid="agent-icon" />,
+  AgentIcon: (props: {
+    agent: { name: string; icon: string | null };
+    className?: string;
+  }) => {
+    iconMocks.agentIcon(props);
+    return <span data-testid="agent-icon" />;
+  },
 }));
 
 vi.mock("@/components/chat/chat-model-icon", () => ({
-  ChatModelIcon: () => <span data-testid="chat-model-icon" />,
+  ChatModelIcon: (props: {
+    modelId: string;
+    modelName?: string;
+    className?: string;
+    size?: number;
+  }) => {
+    iconMocks.chatModelIcon(props);
+    return <span data-testid="chat-model-icon" />;
+  },
 }));
 
 const labels: HistoryListItemLabels = {
@@ -59,15 +78,35 @@ const labels: HistoryListItemLabels = {
 };
 
 const subtitleLookups: HistorySubtitleLookups = {
-  agentNameById: {
-    "agent-1": "Research Agent",
+  agentPreviewById: {
+    "agent-1": {
+      name: "Research Agent",
+      icon: "https://example.com/research.svg",
+    },
   },
   bucketDisplayNameBySlug: {
     hannah: "Hannah",
+    "gpt-5-4": "GPT-5.4",
+  },
+  bucketIconBySlug: {
+    hannah: {
+      kind: "coworker",
+      name: "Hannah",
+      imageUrl: "/images/coworkers/hannah.webp",
+    },
+    "gpt-5-4": {
+      kind: "model",
+      modelId: "gpt-5-4",
+      modelName: "GPT-5.4",
+    },
   },
 };
 
 describe("HistoryListItem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders localized task status labels instead of TaskStatusBadge defaults", () => {
     const item: HistoryItem = {
       kind: "task",
@@ -231,6 +270,14 @@ describe("HistoryListItem", () => {
     );
 
     expect(screen.getByText("Research Agent")).toBeInTheDocument();
+    expect(iconMocks.agentIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: {
+          name: "Research Agent",
+          icon: "https://example.com/research.svg",
+        },
+      }),
+    );
   });
 
   it("uses the bucket display name as the conversation fallback subtitle", () => {
@@ -254,6 +301,35 @@ describe("HistoryListItem", () => {
     );
 
     expect(screen.getByText("Hannah")).toBeInTheDocument();
+    expect(screen.getByText("H")).toBeInTheDocument();
+  });
+
+  it("passes resolved model data to the chat model icon", () => {
+    const item: HistoryItem = {
+      kind: "conversation",
+      id: "conversation-1",
+      title: "Planning chat",
+      description: null,
+      status: "active",
+      updatedAt: new Date("2026-02-19T10:00:00.000Z"),
+      credits: null,
+      bucketSlug: "gpt-5-4",
+    };
+
+    render(
+      <HistoryListItem
+        item={item}
+        subtitleLookups={subtitleLookups}
+        labels={labels}
+      />,
+    );
+
+    expect(iconMocks.chatModelIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: "gpt-5-4",
+        modelName: "GPT-5.4",
+      }),
+    );
   });
 
   it("does not repeat the title when the fallback subtitle matches it", () => {

--- a/apps/web/src/app/(app)/history/components/history-list-item.tsx
+++ b/apps/web/src/app/(app)/history/components/history-list-item.tsx
@@ -15,6 +15,7 @@ import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
 import { AgentIcon } from "@/components/agents/agent-icon";
 import { ChatModelIcon } from "@/components/chat/chat-model-icon";
 import { JobStatusBadge } from "@/components/jobs/job-status-badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { HistoryItem } from "@/lib/services/history.service";
 import { cn } from "@/lib/utils";
 import { formatCreditsForDisplay } from "@/lib/utils/credits";
@@ -117,37 +118,102 @@ function HistoryTypeColumn({
   labels: HistoryListItemLabels;
   subtitleLookups: HistorySubtitleLookups;
 }) {
-  const jobAgentName =
-    item.kind === "job" && item.agentId
-      ? subtitleLookups.agentNameById[item.agentId]
-      : undefined;
-
   return (
     <div className="flex w-9 shrink-0 items-center gap-1.5 sm:w-30">
       <span
         className="text-muted-foreground flex size-9 items-center justify-center rounded-full"
         aria-hidden
       >
-        {item.kind === "task" ? (
-          <ListTodo className="size-4" />
-        ) : item.kind === "job" ? (
-          <AgentIcon
-            agent={{ name: jobAgentName ?? item.title, icon: null }}
-            className="size-4"
-          />
-        ) : (
-          <ChatModelIcon
-            modelId=""
-            modelName={labels.kind.conversation}
-            className="size-4"
-            size={16}
-          />
-        )}
+        <HistoryTypeIcon
+          item={item}
+          labels={labels}
+          subtitleLookups={subtitleLookups}
+        />
       </span>
       <span className="text-muted-foreground w-full rounded-full px-1.5 py-0.5 text-[10px] font-medium tracking-wider uppercase hidden sm:block">
         {labels.kind[item.kind]}
       </span>
     </div>
+  );
+}
+
+function HistoryTypeIcon({
+  item,
+  labels,
+  subtitleLookups,
+}: {
+  item: HistoryItem;
+  labels: HistoryListItemLabels;
+  subtitleLookups: HistorySubtitleLookups;
+}) {
+  if (item.kind === "task") {
+    return <ListTodo className="size-4" />;
+  }
+
+  if (item.kind === "job") {
+    const agentPreview = subtitleLookups.agentPreviewById[item.agentId];
+
+    return (
+      <AgentIcon
+        agent={{
+          name: agentPreview?.name ?? item.title,
+          icon: agentPreview?.icon ?? null,
+        }}
+        className="size-4"
+      />
+    );
+  }
+
+  const bucketIcon = item.bucketSlug
+    ? subtitleLookups.bucketIconBySlug[item.bucketSlug]
+    : undefined;
+
+  return (
+    <HistoryConversationIcon
+      bucketIcon={bucketIcon}
+      fallbackLabel={labels.kind.conversation}
+    />
+  );
+}
+
+function HistoryConversationIcon({
+  bucketIcon,
+  fallbackLabel,
+}: {
+  bucketIcon: HistorySubtitleLookups["bucketIconBySlug"][string] | undefined;
+  fallbackLabel: string;
+}) {
+  if (bucketIcon?.kind === "model") {
+    return (
+      <ChatModelIcon
+        modelId={bucketIcon.modelId}
+        modelName={bucketIcon.modelName}
+        className="size-4"
+        size={16}
+      />
+    );
+  }
+
+  if (bucketIcon?.kind === "coworker") {
+    return (
+      <Avatar className="size-4">
+        {bucketIcon.imageUrl ? (
+          <AvatarImage src={bucketIcon.imageUrl} alt={bucketIcon.name} />
+        ) : null}
+        <AvatarFallback className="bg-primary text-primary-foreground text-[8px]">
+          {bucketIcon.name.charAt(0).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+    );
+  }
+
+  return (
+    <ChatModelIcon
+      modelId=""
+      modelName={fallbackLabel}
+      className="size-4"
+      size={16}
+    />
   );
 }
 

--- a/apps/web/src/app/(app)/history/utils/__tests__/history-row-subtitle.server.test.ts
+++ b/apps/web/src/app/(app)/history/utils/__tests__/history-row-subtitle.server.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HistoryItem } from "@/lib/services/history.service";
+
+const prismaMock = vi.hoisted(() => ({
+  agent: {
+    findMany: vi.fn(),
+  },
+}));
+
+const coworkerServiceMock = vi.hoisted(() => ({
+  listCoworkers: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: prismaMock,
+}));
+
+vi.mock("@/lib/services/coworker.service", () => ({
+  coworkerService: coworkerServiceMock,
+}));
+
+describe("buildHistorySubtitleLookups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves agent icons, coworker bucket icons, and model bucket icons", async () => {
+    prismaMock.agent.findMany.mockResolvedValue([
+      {
+        id: "agent-1",
+        name: "Research Agent",
+        overrideName: null,
+        icon: "https://example.com/research.svg",
+      },
+    ]);
+    coworkerServiceMock.listCoworkers.mockResolvedValue([
+      {
+        id: "coworker-1",
+        slug: "hannah",
+        name: "Hannah",
+        image: "https://example.com/hannah.webp",
+      },
+    ]);
+
+    const { buildHistorySubtitleLookups } = await import(
+      "@/app/history/utils/history-row-subtitle.server"
+    );
+    const result = await buildHistorySubtitleLookups([
+      {
+        kind: "job",
+        id: "job-1",
+        title: "Analyze data",
+        description: null,
+        status: "completed",
+        updatedAt: new Date("2026-02-19T10:00:00.000Z"),
+        credits: 2,
+        projectId: null,
+        agentId: "agent-1",
+      },
+      {
+        kind: "conversation",
+        id: "conversation-1",
+        title: "Chat with Hannah",
+        description: null,
+        status: "active",
+        updatedAt: new Date("2026-02-19T10:00:00.000Z"),
+        credits: null,
+        bucketSlug: "hannah",
+      },
+      {
+        kind: "conversation",
+        id: "conversation-2",
+        title: "Chat with GPT-5.4",
+        description: null,
+        status: "active",
+        updatedAt: new Date("2026-02-19T10:00:00.000Z"),
+        credits: null,
+        bucketSlug: "gpt-5-4",
+      },
+    ] satisfies HistoryItem[]);
+
+    expect(result.agentPreviewById).toEqual({
+      "agent-1": {
+        name: "Research Agent",
+        icon: "https://example.com/research.svg",
+      },
+    });
+    expect(result.bucketIconBySlug.hannah).toEqual({
+      kind: "coworker",
+      name: "Hannah",
+      imageUrl: "https://example.com/hannah.webp",
+    });
+    expect(result.bucketIconBySlug["gpt-5-4"]).toEqual({
+      kind: "model",
+      modelId: "gpt-5-4",
+      modelName: "GPT-5.4",
+    });
+  });
+});

--- a/apps/web/src/app/(app)/history/utils/history-row-subtitle.server.ts
+++ b/apps/web/src/app/(app)/history/utils/history-row-subtitle.server.ts
@@ -1,14 +1,23 @@
 import "server-only";
 
+import { CHAT_MODELS } from "@sokosumi/chat";
+
 import { slugify } from "@/app/chat/utils/bucket-slug";
 import {
   createEmptyHistorySubtitleLookups,
+  type HistoryBucketIconPreview,
   type HistorySubtitleLookups,
 } from "@/app/history/utils/history-row-subtitle";
+import { getCoworkerImage } from "@/app/tasks/utils/coworker-image";
 import prisma from "@/lib/db/prisma";
-import { getAgentName } from "@/lib/helpers/agent";
+import { getAgentName, getAgentResolvedIcon } from "@/lib/helpers/agent";
 import { coworkerService } from "@/lib/services/coworker.service";
 import type { HistoryItem } from "@/lib/services/history.service";
+
+interface BucketLookup {
+  bucketDisplayNameBySlug: Record<string, string>;
+  bucketIconBySlug: Record<string, HistoryBucketIconPreview>;
+}
 
 export async function buildHistorySubtitleLookups(
   history: HistoryItem[],
@@ -20,14 +29,14 @@ export async function buildHistorySubtitleLookups(
     return createEmptyHistorySubtitleLookups();
   }
 
-  const [agentNameById, bucketDisplayNameBySlug] = await Promise.all([
-    buildAgentNameLookup(agentIds),
-    buildBucketDisplayNameLookup(bucketSlugs),
+  const [agentPreviewById, bucketLookup] = await Promise.all([
+    buildAgentPreviewLookup(agentIds),
+    buildBucketLookup(bucketSlugs),
   ]);
 
   return {
-    agentNameById,
-    bucketDisplayNameBySlug,
+    agentPreviewById,
+    ...bucketLookup,
   };
 }
 
@@ -51,9 +60,9 @@ function getUniqueBucketSlugs(history: HistoryItem[]): string[] {
   ];
 }
 
-async function buildAgentNameLookup(
+async function buildAgentPreviewLookup(
   agentIds: string[],
-): Promise<Record<string, string>> {
+): Promise<HistorySubtitleLookups["agentPreviewById"]> {
   if (agentIds.length === 0) return {};
 
   const agents = await prisma.agent
@@ -67,37 +76,92 @@ async function buildAgentNameLookup(
         id: true,
         name: true,
         overrideName: true,
+        icon: true,
       },
     })
     .catch(() => []);
 
   return Object.fromEntries(
-    agents.map((agent) => [
-      agent.id,
-      getAgentName(agent as Parameters<typeof getAgentName>[0]),
-    ]),
+    agents.map((agent) => {
+      const name = getAgentName(agent as Parameters<typeof getAgentName>[0]);
+      return [
+        agent.id,
+        {
+          name,
+          icon: getAgentResolvedIcon(
+            agent as Parameters<typeof getAgentResolvedIcon>[0],
+          ),
+        },
+      ];
+    }),
   );
 }
 
-async function buildBucketDisplayNameLookup(
-  bucketSlugs: string[],
-): Promise<Record<string, string>> {
-  if (bucketSlugs.length === 0) return {};
-
-  const coworkers = await coworkerService.listCoworkers().catch(() => []);
-  const coworkerNameBySlug = new Map<string, string>();
-
-  for (const coworker of coworkers) {
-    coworkerNameBySlug.set(slugify(coworker.slug), coworker.name);
-    coworkerNameBySlug.set(slugify(coworker.name), coworker.name);
+async function buildBucketLookup(bucketSlugs: string[]): Promise<BucketLookup> {
+  if (bucketSlugs.length === 0) {
+    return {
+      bucketDisplayNameBySlug: {},
+      bucketIconBySlug: {},
+    };
   }
 
-  return Object.fromEntries(
-    bucketSlugs.map((bucketSlug) => [
-      bucketSlug,
-      coworkerNameBySlug.get(slugify(bucketSlug)) ?? humanizeSlug(bucketSlug),
+  const coworkers = await coworkerService.listCoworkers().catch(() => []);
+  const coworkerBySlug = new Map<
+    string,
+    { name: string; imageUrl: string | null }
+  >();
+
+  for (const coworker of coworkers) {
+    const preview = {
+      name: coworker.name,
+      imageUrl: getCoworkerImage(coworker),
+    };
+    coworkerBySlug.set(slugify(coworker.slug), preview);
+    coworkerBySlug.set(slugify(coworker.name), preview);
+  }
+
+  const modelBySlug = new Map(
+    CHAT_MODELS.flatMap((model) => [
+      [slugify(model.name), model],
+      [slugify(model.id), model],
     ]),
   );
+
+  const bucketDisplayNameBySlug: Record<string, string> = {};
+  const bucketIconBySlug: Record<string, HistoryBucketIconPreview> = {};
+
+  for (const bucketSlug of bucketSlugs) {
+    const normalizedSlug = slugify(bucketSlug);
+    const coworker = coworkerBySlug.get(normalizedSlug);
+
+    if (coworker) {
+      bucketDisplayNameBySlug[bucketSlug] = coworker.name;
+      bucketIconBySlug[bucketSlug] = {
+        kind: "coworker",
+        name: coworker.name,
+        imageUrl: coworker.imageUrl,
+      };
+      continue;
+    }
+
+    const model = modelBySlug.get(normalizedSlug);
+    if (model) {
+      bucketDisplayNameBySlug[bucketSlug] = model.name;
+      bucketIconBySlug[bucketSlug] = {
+        kind: "model",
+        modelId: model.id,
+        modelName: model.name,
+      };
+      continue;
+    }
+
+    bucketDisplayNameBySlug[bucketSlug] = humanizeSlug(bucketSlug);
+  }
+
+  return {
+    bucketDisplayNameBySlug,
+    bucketIconBySlug,
+  };
 }
 
 function humanizeSlug(slug: string): string {

--- a/apps/web/src/app/(app)/history/utils/history-row-subtitle.ts
+++ b/apps/web/src/app/(app)/history/utils/history-row-subtitle.ts
@@ -1,8 +1,13 @@
 import type { HistoryItem } from "@/lib/services/history.service";
 
+export type HistoryBucketIconPreview =
+  | { kind: "model"; modelId: string; modelName: string }
+  | { kind: "coworker"; name: string; imageUrl: string | null };
+
 export interface HistorySubtitleLookups {
-  agentNameById: Record<string, string>;
+  agentPreviewById: Record<string, { name: string; icon: string | null }>;
   bucketDisplayNameBySlug: Record<string, string>;
+  bucketIconBySlug: Record<string, HistoryBucketIconPreview>;
 }
 
 export interface HistorySubtitleLabels {
@@ -11,8 +16,9 @@ export interface HistorySubtitleLabels {
 
 export function createEmptyHistorySubtitleLookups(): HistorySubtitleLookups {
   return {
-    agentNameById: {},
+    agentPreviewById: {},
     bucketDisplayNameBySlug: {},
+    bucketIconBySlug: {},
   };
 }
 
@@ -21,13 +27,17 @@ export function mergeHistorySubtitleLookups(
   next: HistorySubtitleLookups,
 ): HistorySubtitleLookups {
   return {
-    agentNameById: {
-      ...current.agentNameById,
-      ...next.agentNameById,
+    agentPreviewById: {
+      ...current.agentPreviewById,
+      ...next.agentPreviewById,
     },
     bucketDisplayNameBySlug: {
       ...current.bucketDisplayNameBySlug,
       ...next.bucketDisplayNameBySlug,
+    },
+    bucketIconBySlug: {
+      ...current.bucketIconBySlug,
+      ...next.bucketIconBySlug,
     },
   };
 }
@@ -52,7 +62,7 @@ function getHistoryRowSubtitleFallback(
 ): string | null {
   switch (item.kind) {
     case "job":
-      return lookups.agentNameById[item.agentId]?.trim() || null;
+      return lookups.agentPreviewById[item.agentId]?.name.trim() || null;
     case "conversation":
       return item.bucketSlug
         ? lookups.bucketDisplayNameBySlug[item.bucketSlug]?.trim() || null


### PR DESCRIPTION
## Summary

History list items now show the correct icon for each row type: agent icons for jobs, coworker avatars for coworker conversations, and chat model icons for model-backed conversations. Subtitle lookups were extended to resolve this metadata server-side in a single pass.

## Key changes

- Extended `HistorySubtitleLookups` with `agentPreviewById` (name + icon) and `bucketIconBySlug` (coworker avatar or chat model preview)
- Updated `buildHistorySubtitleLookups` to fetch agent icons, coworker images, and chat model metadata from `CHAT_MODELS`
- Refactored `HistoryListItem` type column into dedicated icon components (`HistoryTypeIcon`, `HistoryConversationIcon`)
- Added/updated unit tests for list item rendering and server-side lookup building

## Technical details

- Coworker buckets resolve via `coworkerService` + `getCoworkerImage`
- Model buckets resolve via slugified model id/name against `CHAT_MODELS`
- Jobs use `getAgentResolvedIcon` for the agent icon preview
- Fallback remains a generic conversation icon when bucket metadata is unavailable

## Test plan

- [x] `pnpm --filter web test src/app/(app)/history/__tests__/history-list-item.test.tsx`
- [x] `pnpm --filter web test src/app/(app)/history/utils/__tests__/history-row-subtitle.server.test.ts`
- [ ] Verify history page shows agent icons on job rows
- [ ] Verify coworker conversation rows show coworker avatar/initial
- [ ] Verify model conversation rows show the correct model icon


Made with [Cursor](https://cursor.com)