### PR TITLE
refactor(web): replace third-party error UI with native React implementations

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -95,7 +95,6 @@
     "react": "19.2.7",
     "react-day-picker": "10.0.1",
     "react-dom": "19.2.7",
-    "react-error-boundary": "6.1.2",
     "react-file-icon": "1.6.0",
     "react-hook-form": "7.77.0",
     "react-icons": "5.6.0",

--- a/apps/web/src/app/(app)/tasks/components/task-detail-link.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-link.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import type { ComponentProps } from "react";
+import type {
+  ComponentProps,
+  FocusEvent,
+  MouseEvent,
+  PointerEvent,
+  TouchEvent,
+} from "react";
 
 import {
   isTasksRootPath,
@@ -16,6 +22,7 @@ interface TaskDetailLinkProps
 
 export function TaskDetailLink({
   href,
+  onClick,
   onPointerEnter,
   onFocus,
   onTouchStart,
@@ -27,42 +34,50 @@ export function TaskDetailLink({
     router.prefetch(href);
   };
 
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    onClick?.(event);
+    if (event.defaultPrevented || typeof window === "undefined") {
+      return;
+    }
+
+    if (isTasksRootPath(window.location.pathname)) {
+      window.sessionStorage.setItem(
+        TASKS_RETURN_PATH_SESSION_KEY,
+        `${window.location.pathname}${window.location.search}`,
+      );
+    }
+  }
+
+  function handlePointerEnter(event: PointerEvent<HTMLAnchorElement>) {
+    onPointerEnter?.(event);
+    if (!event.defaultPrevented) {
+      prefetchTaskDetail();
+    }
+  }
+
+  function handleFocus(event: FocusEvent<HTMLAnchorElement>) {
+    onFocus?.(event);
+    if (!event.defaultPrevented) {
+      prefetchTaskDetail();
+    }
+  }
+
+  function handleTouchStart(event: TouchEvent<HTMLAnchorElement>) {
+    onTouchStart?.(event);
+    if (!event.defaultPrevented) {
+      prefetchTaskDetail();
+    }
+  }
+
   return (
     <Link
       {...props}
       href={href}
       prefetch={false}
-      onClick={(event) => {
-        props.onClick?.(event);
-        if (event.defaultPrevented || typeof window === "undefined") {
-          return;
-        }
-
-        if (isTasksRootPath(window.location.pathname)) {
-          window.sessionStorage.setItem(
-            TASKS_RETURN_PATH_SESSION_KEY,
-            `${window.location.pathname}${window.location.search}`,
-          );
-        }
-      }}
-      onPointerEnter={(event) => {
-        onPointerEnter?.(event);
-        if (!event.defaultPrevented) {
-          prefetchTaskDetail();
-        }
-      }}
-      onFocus={(event) => {
-        onFocus?.(event);
-        if (!event.defaultPrevented) {
-          prefetchTaskDetail();
-        }
-      }}
-      onTouchStart={(event) => {
-        onTouchStart?.(event);
-        if (!event.defaultPrevented) {
-          prefetchTaskDetail();
-        }
-      }}
+      onClick={handleClick}
+      onPointerEnter={handlePointerEnter}
+      onFocus={handleFocus}
+      onTouchStart={handleTouchStart}
     />
   );
 }

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import NextError from "next/error";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 
 import {
   hasDeploymentRefreshGuard,
@@ -10,12 +9,58 @@ import {
   performDeploymentRefresh,
 } from "@/lib/utils/deployment-refresh";
 
+const nextErrorLayoutStyles = {
+  error: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: "100vh",
+    textAlign: "center" as const,
+    display: "flex",
+    flexDirection: "column" as const,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  desc: {
+    lineHeight: "48px",
+  },
+  h2: {
+    fontSize: 14,
+    fontWeight: 400,
+    lineHeight: "28px",
+    margin: 0,
+  },
+  wrap: {
+    display: "inline-block",
+  },
+};
+
+const nextErrorBodyStyles = `body{color:#000;background:#fff;margin:0}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}}`;
+
+function applyStoredThemeToBody() {
+  try {
+    const theme = localStorage.getItem("theme");
+    const isDark =
+      theme === "dark" ||
+      (theme !== "light" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+    document.body.style.background = isDark ? "#000" : "#fff";
+    document.body.style.color = isDark ? "#fff" : "#000";
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
 export default function GlobalError({
   error,
 }: {
   error: Error & { digest?: string };
 }) {
   const [shouldReload, setShouldReload] = useState(false);
+
+  useLayoutEffect(() => {
+    applyStoredThemeToBody();
+  }, []);
 
   useEffect(() => {
     const message = error?.message ?? "";
@@ -35,13 +80,19 @@ export default function GlobalError({
   }
 
   return (
-    <html>
+    <html lang="en">
       <body>
-        {/* `NextError` is the default Next.js error page component. Its type
-        definition requires a `statusCode` prop. However, since the App Router
-        does not expose status codes for errors, we simply pass 0 to render a
-        generic error message. */}
-        <NextError statusCode={0} />
+        <style dangerouslySetInnerHTML={{ __html: nextErrorBodyStyles }} />
+        <div style={nextErrorLayoutStyles.error}>
+          <div style={nextErrorLayoutStyles.desc}>
+            <div style={nextErrorLayoutStyles.wrap}>
+              <h2 style={nextErrorLayoutStyles.h2}>
+                Application error: a client-side exception has occurred (see the
+                browser console for more information).
+              </h2>
+            </div>
+          </div>
+        </div>
       </body>
     </html>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import * as Sentry from "@sentry/nextjs";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
@@ -55,7 +56,7 @@ export default async function RootLayout({
       <head>
         {ucDataSettingsId && (
           <>
-            <script
+            <Script
               id="_before-gtm"
               dangerouslySetInnerHTML={{
                 __html: `(function(w,l){
@@ -63,13 +64,15 @@ export default async function RootLayout({
                   w[l].push('consent','default',{'ad_personalization':'denied','ad_storage':'denied','ad_user_data':'denied','analytics_storage':'denied','wait_for_update':2000});
                 })(window,'dataLayer');`,
               }}
+              strategy="beforeInteractive"
             />
-            <script
+            <Script
               id="usercentrics-cmp"
               src="https://web.cmp.usercentrics.eu/ui/loader.js"
               {...(draftUserCentrics && { "data-draft": "true" })}
               data-settings-id={ucDataSettingsId}
               async
+              strategy="afterInteractive"
             />
           </>
         )}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import * as Sentry from "@sentry/nextjs";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
@@ -56,24 +55,21 @@ export default async function RootLayout({
       <head>
         {ucDataSettingsId && (
           <>
-            <Script
+            <script
               id="_before-gtm"
               dangerouslySetInnerHTML={{
-                __html: `
-                (function(w,l){
+                __html: `(function(w,l){
                   w[l]=w[l]||[];
                   w[l].push('consent','default',{'ad_personalization':'denied','ad_storage':'denied','ad_user_data':'denied','analytics_storage':'denied','wait_for_update':2000});
                 })(window,'dataLayer');`,
               }}
-              strategy="beforeInteractive"
             />
-            <Script
+            <script
               id="usercentrics-cmp"
               src="https://web.cmp.usercentrics.eu/ui/loader.js"
               {...(draftUserCentrics && { "data-draft": "true" })}
               data-settings-id={ucDataSettingsId}
               async
-              strategy="afterInteractive"
             />
           </>
         )}

--- a/apps/web/src/components/agents/agent-verified-badge.tsx
+++ b/apps/web/src/components/agents/agent-verified-badge.tsx
@@ -3,6 +3,7 @@
 import { ShieldCheck } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import type { MouseEvent } from "react";
 
 import {
   Tooltip,
@@ -41,7 +42,9 @@ function AgentVerifiedBadge({ className }: AgentVerifiedBadgeProps) {
             target="_blank"
             rel="noreferrer noopener"
             className="underline"
-            onClick={(e) => e.stopPropagation()}
+            onClick={(event: MouseEvent<HTMLAnchorElement>) =>
+              event.stopPropagation()
+            }
           >
             {t("learnMore")}
           </Link>{" "}

--- a/apps/web/src/components/default-error-boundary.tsx
+++ b/apps/web/src/components/default-error-boundary.tsx
@@ -1,23 +1,39 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { ErrorBoundary } from "react-error-boundary";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface DefaultErrorBoundaryProps {
-  children: React.ReactNode;
-  fallback?: React.ReactNode;
+  children: ReactNode;
+  fallback?: ReactNode;
 }
 
-export default function DefaultErrorBoundary({
-  children,
-  fallback,
-}: DefaultErrorBoundaryProps) {
-  return (
-    <ErrorBoundary fallback={fallback ?? <DefaultErrorBoundaryError />}>
-      {children}
-    </ErrorBoundary>
-  );
+interface DefaultErrorBoundaryState {
+  hasError: boolean;
 }
+
+class DefaultErrorBoundary extends Component<
+  DefaultErrorBoundaryProps,
+  DefaultErrorBoundaryState
+> {
+  state: DefaultErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): DefaultErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(_error: Error, _errorInfo: ErrorInfo) {}
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <DefaultErrorBoundaryError />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default DefaultErrorBoundary;
 
 function DefaultErrorBoundaryError() {
   const t = useTranslations("Components.DefaultErrorBoundary");

--- a/apps/web/src/contexts/theme-context.tsx
+++ b/apps/web/src/contexts/theme-context.tsx
@@ -2,10 +2,18 @@ import {
   ThemeProvider as NextThemesProvider,
   type ThemeProviderProps,
 } from "next-themes";
+import type { ComponentType, ReactNode } from "react";
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+interface AppThemeProviderProps extends ThemeProviderProps {
+  children: ReactNode;
+}
+
+const ThemeProviderComponent =
+  NextThemesProvider as ComponentType<AppThemeProviderProps>;
+
+export function ThemeProvider({ children, ...props }: AppThemeProviderProps) {
   return (
-    <NextThemesProvider
+    <ThemeProviderComponent
       attribute="class"
       defaultTheme="system"
       enableSystem
@@ -13,6 +21,6 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       {...props}
     >
       {children}
-    </NextThemesProvider>
+    </ThemeProviderComponent>
   );
 }

--- a/apps/web/src/types/next-script.d.ts
+++ b/apps/web/src/types/next-script.d.ts
@@ -1,0 +1,17 @@
+import "next/script";
+
+/**
+ * Next.js `ScriptProps` extends `ScriptHTMLAttributes` as a named import from
+ * `"react"`, but `@types/react` 19 exposes that type on the `React` namespace
+ * only (`export = React`). TypeScript then omits standard script attributes
+ * (`src`, `async`, `dangerouslySetInnerHTML`, etc.) from `ScriptProps`.
+ *
+ * Merge the missing DOM script attributes here until Next.js fixes the import.
+ */
+declare module "next/script" {
+  export interface ScriptProps {
+    async?: boolean;
+    dangerouslySetInnerHTML?: { __html: string };
+    src?: string;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,9 +346,6 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
-      react-error-boundary:
-        specifier: 6.1.2
-        version: 6.1.2(react@19.2.7)
       react-file-icon:
         specifier: 1.6.0
         version: 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5860,8 +5857,8 @@ packages:
     resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.22.2:
-    resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
+  enhanced-resolve@5.23.0:
+    resolution: {integrity: sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -14855,7 +14852,7 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
-  enhanced-resolve@5.22.2:
+  enhanced-resolve@5.23.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -18818,7 +18815,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.22.2
+      enhanced-resolve: 5.23.0
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0


### PR DESCRIPTION
## Summary

- Remove the `react-error-boundary` dependency and replace it with a lightweight class-based `DefaultErrorBoundary` using native React error boundary APIs.
- Replace `next/error` in `global-error.tsx` with inline error markup that respects the user's stored theme preference.
- Swap Next.js `Script` components for native `<script>` tags for Usercentrics consent and GTM dataLayer initialization.

## Key changes

### Error handling
- **`default-error-boundary.tsx`**: Reimplements error boundary as a React class component with `getDerivedStateFromError`, preserving the existing translated fallback UI.
- **`global-error.tsx`**: Inlines the standard Next.js client error message layout, applies stored theme to the body via `useLayoutEffect`, and keeps existing stale-deployment auto-reload behavior.

### Dependencies & scripts
- **`package.json` / lockfile**: Drops `react-error-boundary`.
- **`layout.tsx`**: Uses native `<script>` tags instead of `next/script` for consent and GTM bootstrap scripts.

### TypeScript fixes
- **`theme-context.tsx`**: Casts `NextThemesProvider` to `ComponentType` for React 19 compatibility.
- **`task-detail-link.tsx`**: Extracts event handlers with explicit React event types.
- **`agent-verified-badge.tsx`**: Adds explicit `MouseEvent<HTMLAnchorElement>` typing on link click handler.

## Architecture benefits

- Fewer runtime dependencies for error handling paths that only need basic catch-and-fallback behavior.
- Global error page no longer depends on Pages Router `next/error`, which is a better fit for App Router.
- Consent scripts load via standard HTML script tags without Next.js Script scheduling overhead.

## Testing

- [ ] Trigger a component error inside a `DefaultErrorBoundary` wrapper and confirm the translated fallback renders.
- [ ] Force a global client error and verify the inline error message appears with correct light/dark body colors based on stored theme.
- [ ] Confirm Usercentrics consent banner and GTM dataLayer still initialize on page load.
- [ ] Navigate task detail links and verify prefetch-on-hover/focus/touch still works.
- [ ] Run `pnpm web:check` and `pnpm web:build`.


Made with [Cursor](https://cursor.com)