### PR TITLE
feat(web): add last seen column to members table

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -181,8 +181,12 @@
         "name": "Name",
         "email": "E-Mail",
         "role": "Rolle",
+        "lastSeen": "Zuletzt gesehen",
         "actions": "Aktionen",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "Nie"
       },
       "Seat": {
         "assigned": "Zugewiesen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -181,8 +181,12 @@
         "name": "Name",
         "email": "Email",
         "role": "Role",
+        "lastSeen": "Last seen",
         "seat": "Seat",
         "actions": "Actions"
+      },
+      "LastSeen": {
+        "never": "Never"
       },
       "Seat": {
         "assigned": "Assigned",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -181,8 +181,12 @@
         "name": "Nombre",
         "email": "Email",
         "role": "Rol",
+        "lastSeen": "Última conexión",
         "actions": "Acciones",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "Nunca"
       },
       "Seat": {
         "assigned": "Asignado",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -181,8 +181,12 @@
         "name": "Nom",
         "email": "E-mail",
         "role": "Rôle",
+        "lastSeen": "Dernière connexion",
         "actions": "Actions",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "Jamais"
       },
       "Seat": {
         "assigned": "Attribué",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -181,8 +181,12 @@
         "name": "Nome",
         "email": "Email",
         "role": "Ruolo",
+        "lastSeen": "Ultimo accesso",
         "actions": "Azioni",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "Mai"
       },
       "Seat": {
         "assigned": "Assegnato",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -181,8 +181,12 @@
         "name": "名前",
         "email": "メール",
         "role": "役割",
+        "lastSeen": "最終ログイン",
         "actions": "操作",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "未ログイン"
       },
       "Seat": {
         "assigned": "割り当て済み",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -181,8 +181,12 @@
         "name": "Nome",
         "email": "E-mail",
         "role": "Função",
+        "lastSeen": "Última atividade",
         "actions": "Ações",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "Nunca"
       },
       "Seat": {
         "assigned": "Atribuído",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -181,8 +181,12 @@
         "name": "Nome",
         "email": "E-mail",
         "role": "Função",
+        "lastSeen": "Última atividade",
         "actions": "Ações",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "Nunca"
       },
       "Seat": {
         "assigned": "Atribuído",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -181,8 +181,12 @@
         "name": "名称",
         "email": "邮箱",
         "role": "角色",
+        "lastSeen": "最近活跃",
         "actions": "操作",
         "seat": "Seat"
+      },
+      "LastSeen": {
+        "never": "从未"
       },
       "Seat": {
         "assigned": "已分配",

--- a/apps/web/src/app/(app)/organizations/[organizationSlug]/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[organizationSlug]/page.tsx
@@ -88,6 +88,10 @@ export default async function OrganizationPage({
   const members = await organizationService.getOrganizationMembersWithUser(
     organization.id,
   );
+  const memberLastSeenAtByUserId =
+    await organizationService.getMemberLastSeenAtByUserIds(
+      members.map((member) => member.userId),
+    );
   const seatSummary = isOwnerOrAdmin
     ? await organizationSeatService.getSeatSummary(organization.id)
     : null;
@@ -117,6 +121,7 @@ export default async function OrganizationPage({
             me={member}
             members={members}
             pendingInvitations={pendingInvitations}
+            memberLastSeenAtByUserId={memberLastSeenAtByUserId}
             showSeatManagement={isOwnerOrAdmin && seatSummary?.paidPlan != null}
             unusedSeats={seatSummary?.unusedSeats ?? 0}
           />

--- a/apps/web/src/components/members-table/members-table-columns.tsx
+++ b/apps/web/src/components/members-table/members-table-columns.tsx
@@ -2,7 +2,7 @@
 
 import type { Member } from "@sokosumi/database";
 import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { useTranslations } from "next-intl";
+import { useFormatter, useNow, useTranslations } from "next-intl";
 import { DataTableColumnHeader } from "@/components/data-table";
 import { OrganizationRoleBadge } from "@/components/organizations";
 import InvitationActionsDropdown from "./invitation-actions-dropdown";
@@ -54,6 +54,35 @@ export function getMembersTableColumns(
       enableHiding: false,
     }) as ColumnDef<MemberRowData>,
 
+    lastSeenColumn: columnHelper.accessor(
+      (row) => row.lastSeenAt?.getTime() ?? null,
+      {
+        id: "lastSeen",
+        minSize: 140,
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title={t("Header.lastSeen")} />
+        ),
+        cell: ({ row }) => (
+          <LastSeenCell lastSeenAt={row.original.lastSeenAt} />
+        ),
+        enableSorting: true,
+        sortingFn: (rowA, rowB) => {
+          const a = rowA.original.lastSeenAt?.getTime() ?? 0;
+          const b = rowB.original.lastSeenAt?.getTime() ?? 0;
+          if (a === 0 && b === 0) {
+            return 0;
+          }
+          if (a === 0) {
+            return 1;
+          }
+          if (b === 0) {
+            return -1;
+          }
+          return a - b;
+        },
+      },
+    ) as ColumnDef<MemberRowData>,
+
     seatColumn: columnHelper.display({
       id: "seat",
       minSize: 120,
@@ -79,6 +108,26 @@ export function getMembersTableColumns(
       },
     }) as ColumnDef<MemberRowData>,
   };
+}
+
+function LastSeenCell({
+  lastSeenAt,
+}: {
+  lastSeenAt: MemberRowData["lastSeenAt"];
+}) {
+  const t = useTranslations("Components.MembersTable.LastSeen");
+  const formatter = useFormatter();
+  const now = useNow({ updateInterval: 60_000 });
+
+  if (lastSeenAt === undefined) {
+    return <div className="p-2" />;
+  }
+
+  if (lastSeenAt === null) {
+    return <div className="text-muted-foreground p-2">{t("never")}</div>;
+  }
+
+  return <div className="p-2">{formatter.relativeTime(lastSeenAt, now)}</div>;
 }
 
 function SeatStatusCell({ member }: { member: MemberRowData["member"] }) {

--- a/apps/web/src/components/members-table/members-table.tsx
+++ b/apps/web/src/components/members-table/members-table.tsx
@@ -24,6 +24,7 @@ interface MembersTableProps {
   me: Member;
   members: MemberWithUser[];
   pendingInvitations: Invitation[];
+  memberLastSeenAtByUserId?: Record<string, string | Date>;
   showSeatManagement?: boolean;
   unusedSeats?: number;
 }
@@ -32,6 +33,7 @@ export default function MembersTable({
   me,
   members,
   pendingInvitations,
+  memberLastSeenAtByUserId = {},
   showSeatManagement = false,
   unusedSeats = 0,
 }: MembersTableProps) {
@@ -49,6 +51,7 @@ export default function MembersTable({
             data={combineMembersAndPendingInvitations(
               members,
               pendingInvitations,
+              memberLastSeenAtByUserId,
             )}
             rowClassName={() =>
               "text-foreground active:bg-muted hover:bg-muted"
@@ -72,12 +75,18 @@ function getColumns(
   me: Member,
   showSeatManagement: boolean,
 ) {
-  const { nameColumn, emailColumn, roleColumn, seatColumn, actionColumn } =
-    getMembersTableColumns(t, me);
+  const {
+    nameColumn,
+    emailColumn,
+    roleColumn,
+    lastSeenColumn,
+    seatColumn,
+    actionColumn,
+  } = getMembersTableColumns(t, me);
   const isOwnerOrAdmin =
     me.role === MemberRole.OWNER || me.role === MemberRole.ADMIN;
 
-  return [nameColumn, emailColumn, roleColumn]
+  return [nameColumn, emailColumn, roleColumn, lastSeenColumn]
     .concat(showSeatManagement ? [seatColumn] : [])
     .concat(isOwnerOrAdmin ? [actionColumn] : []);
 }
@@ -85,6 +94,7 @@ function getColumns(
 function combineMembersAndPendingInvitations(
   members: MemberWithUser[],
   pendingInvitations: Invitation[],
+  memberLastSeenAtByUserId: Record<string, string | Date>,
 ): MemberRowData[] {
   // Sort members by role score, then by name
   const sortedMembers = [...members].sort((a, b) => {
@@ -105,7 +115,12 @@ function combineMembersAndPendingInvitations(
   );
 
   // Convert members to row data
-  const memberRows = sortedMembers.map(convertMemberWithUserToMemberRowData);
+  const memberRows = sortedMembers.map((member) =>
+    convertMemberWithUserToMemberRowData(
+      member,
+      memberLastSeenAtByUserId[member.userId],
+    ),
+  );
 
   // Convert filtered invitations to row data
   const invitationRows = filteredInvitations.map(
@@ -117,11 +132,13 @@ function combineMembersAndPendingInvitations(
 
 function convertMemberWithUserToMemberRowData(
   member: MemberWithUser,
+  lastSeenAt?: string | Date,
 ): MemberRowData {
   return {
     email: member.user.email,
     name: member.user.name,
     role: member.role,
+    lastSeenAt: lastSeenAt ? new Date(lastSeenAt) : null,
     member,
   };
 }

--- a/apps/web/src/components/members-table/types.ts
+++ b/apps/web/src/components/members-table/types.ts
@@ -4,6 +4,7 @@ export interface MemberRowData {
   name?: string | undefined;
   email: string;
   role: string;
+  lastSeenAt?: Date | null | undefined;
   member?: MemberWithUser | undefined;
   invitation?: Invitation | undefined;
 }

--- a/apps/web/src/lib/services/organization.service.ts
+++ b/apps/web/src/lib/services/organization.service.ts
@@ -9,6 +9,7 @@ import type {
 import {
   invitationRepository,
   memberRepository,
+  sessionRepository,
 } from "@sokosumi/database/repositories";
 import { nanoid } from "nanoid";
 import { headers } from "next/headers";
@@ -135,6 +136,20 @@ export const organizationService = (() => {
     return members;
   }
 
+  /**
+   * Returns the latest session activity timestamp per user id.
+   */
+  async function getMemberLastSeenAtByUserIds(
+    userIds: string[],
+  ): Promise<Record<string, Date>> {
+    const lastSeenAtByUserId = await sessionRepository.getLastSeenAtByUserIds(
+      userIds,
+      prisma,
+    );
+
+    return Object.fromEntries(lastSeenAtByUserId);
+  }
+
   async function getPendingInvitations(
     organizationId: string,
   ): Promise<Invitation[]> {
@@ -221,6 +236,7 @@ export const organizationService = (() => {
     getPendingInvitation,
     getPendingInvitations,
     getOrganizationMembersWithUser,
+    getMemberLastSeenAtByUserIds,
     createOrganizationWithOwner,
     inviteMultipleMembers,
   };

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -43,6 +43,7 @@ export * from "./lock.repository.js";
 export * from "./member.repository.js";
 export * from "./organization.repository.js";
 export * from "./public-share.repository.js";
+export * from "./session.repository.js";
 export * from "./subscription.repository.js";
 export * from "./sync-metadata.repository.js";
 export * from "./tag.repository.js";

--- a/packages/database/src/repositories/session.repository.ts
+++ b/packages/database/src/repositories/session.repository.ts
@@ -1,0 +1,45 @@
+import type { Prisma } from "../generated/prisma/client.js";
+
+/**
+ * Repository for Better Auth session records.
+ */
+export const sessionRepository = (() => {
+  /**
+   * Returns the most recent session activity timestamp per user,
+   * derived from the latest `updatedAt` across all sessions.
+   */
+  async function getLastSeenAtByUserIds(
+    userIds: string[],
+    tx: Prisma.TransactionClient,
+  ): Promise<Map<string, Date>> {
+    if (userIds.length === 0) {
+      return new Map();
+    }
+
+    const results = await tx.session.groupBy({
+      by: ["userId"],
+      where: {
+        userId: {
+          in: userIds,
+        },
+      },
+      _max: {
+        updatedAt: true,
+      },
+    });
+
+    const lastSeenAtByUserId = new Map<string, Date>();
+    for (const result of results) {
+      const lastSeenAt = result._max.updatedAt;
+      if (lastSeenAt) {
+        lastSeenAtByUserId.set(result.userId, lastSeenAt);
+      }
+    }
+
+    return lastSeenAtByUserId;
+  }
+
+  return {
+    getLastSeenAtByUserIds,
+  };
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Organization admins can see how recently each member was active via a new **Last seen** column on the members table.

## Changes

- **Database**: Added `sessionRepository.getLastSeenAtByUserIds()` — groups sessions by user and returns max `updatedAt` (no schema migration).
- **Service**: Added `organizationService.getMemberLastSeenAtByUserIds()` and wired it on the organization detail page.
- **UI**: Sortable **Last seen** column with locale-safe relative timestamps (`useFormatter` + `useNow`).
  - Members with no session activity → **Never**
  - Pending invitations → empty cell
- **i18n**: Added `Components.MembersTable.Header.lastSeen` and `Components.MembersTable.LastSeen.never` across all 9 locale files.

## Verification

- `pnpm database:build`
- `pnpm web:check`
- `pnpm web:test` (215 files, 1267 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4752fb1b-253f-4cb7-a46b-77576f152a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4752fb1b-253f-4cb7-a46b-77576f152a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

