### PR TITLE
chore: enable TypeScript LSP plugin in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` to enable the TypeScript LSP plugin (`typescript-lsp@claude-plugins-official`)
- Turns on the TypeScript language server integration for Claude Code tooling in this repo

## Test plan

- [x] Verify Claude Code sessions in this repo have TypeScript LSP support active

🤖 Generated with [Claude Code](https://claude.com/claude-code)