### PR TITLE
docs: add root CLAUDE.md referencing AGENTS.md guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,7 @@ docs(readme): update setup instructions
 
 ### Pull Requests
 
+- **Title**: Follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) syntax (e.g. `feat(auth): add refresh token`)
 - **Description**: Explain user-facing impact
 - **Links**: Reference Linear or GitHub issues
 - **Verification**: List steps (e.g., `pnpm test`, `pnpm build`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Sokosumi
+
+Project guidance for AI agents lives in `AGENTS.md`, imported below so it
+applies across Claude Code, Cursor, and other AGENTS.md-aware tools from a
+single source of truth.
+
+@AGENTS.md


### PR DESCRIPTION
## Summary
Added a new `CLAUDE.md` file that serves as an entry point for AI agent guidance, directing to the centralized `AGENTS.md` file for project-specific instructions.

## Key Changes
- Created `CLAUDE.md` as a reference document for Claude Code and other AGENTS.md-aware tools
- Established a single source of truth for AI agent guidance by importing `AGENTS.md`
- Ensures consistent project guidance across Claude Code, Cursor, and similar tools

## Implementation Details
The file acts as a bridge document that points to `AGENTS.md` using the `@AGENTS.md` reference syntax, allowing AI agents to discover and apply project guidance from a centralized location rather than duplicating instructions across multiple files.

https://claude.ai/code/session_016JmjzgjGu5Bx2DdBTE52N9