### PR TITLE
ci: split tests into a dedicated workflow separate from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -63,14 +62,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install Dependencies
         run: pnpm install
-
-      - name: Run Tests
-        run: pnpm test:ci
 
       - name: Run Prisma Migrate
         run: pnpm prisma:migrate:dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Tests
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+env:
+  # Tests mock their dependencies and inject their own env defaults, so a
+  # placeholder is enough for any config that reads DATABASE_URL at import time.
+  DATABASE_URL: "postgresql://user:password@localhost:5432/sokosumi"
+
+jobs:
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Web Tests
+        run: pnpm web:test:ci
+
+  core:
+    name: Core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Core Tests
+        run: pnpm core:test:ci
+
+  packages:
+    name: Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Package Tests
+        run: pnpm --filter "./packages/*" test:ci


### PR DESCRIPTION
## Summary
This PR introduces a dedicated CI test workflow and updates the project's Node.js version requirement from 22 to 24.

## Key Changes
- **Added `.github/workflows/test.yml`**: New CI workflow that runs tests across three separate jobs:
  - Web tests (`pnpm web:test:ci`)
  - Core tests (`pnpm core:test:ci`)
  - Package tests (`pnpm --filter "./packages/*" test:ci`)
  - Runs on pull requests and manual workflow dispatch
  - Sets up Node.js 24 with pnpm caching

- **Updated `.github/workflows/build.yml`**:
  - Removed `pull-requests: write` permission (no longer needed)
  - Updated Node.js version from 22 to 24
  - Removed test execution from build workflow (now handled by dedicated test workflow)
  - Kept Prisma migration step in build workflow

## Implementation Details
- Tests are now run in parallel across three independent jobs for better CI performance
- DATABASE_URL environment variable is set as a placeholder since tests mock their dependencies
- Build workflow is now focused solely on building, with testing delegated to the separate test workflow

https://claude.ai/code/session_01Js8DTputKox6tXLzpWTNNH