### PR TITLE
fix(sidebar): move chat lists below admin menu

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -55,7 +55,7 @@ export default function Sidebar({
               <AdminMenu />
             </>
           ) : null}
-          <SidebarSeparator className="mx-0 mt-2" />
+          <SidebarSeparator className="mx-0" />
           <ChatListsClient />
         </div>
       </SidebarContent>

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -49,14 +49,14 @@ export default function Sidebar({
           <NewChatTaskActions />
           <SidebarSeparator className="mx-0 mt-2" />
           <MenuItems hermesMenuEnabled={hermesMenuEnabled} />
-          <SidebarSeparator className="mx-0 mt-2" />
-          <ChatListsClient />
           {adminMenuEnabled ? (
             <>
               <SidebarSeparator className="mx-0" />
               <AdminMenu />
             </>
           ) : null}
+          <SidebarSeparator className="mx-0 mt-2" />
+          <ChatListsClient />
         </div>
       </SidebarContent>
       <SidebarFooter className="shrink-0 px-0">


### PR DESCRIPTION
## Summary

- Reorders sidebar sections so the admin menu appears before chat history lists
- Keeps navigation items grouped above scrollable chat list content

## Key changes

- Moved `ChatListsClient` below the conditional `AdminMenu` block in `apps/web/src/app/(app)/components/sidebar/index.tsx`
- Preserved existing separators; chat lists still get a top separator before the list section

**Before:** New chat/actions → menu items → chat lists → admin menu (if enabled)

**After:** New chat/actions → menu items → admin menu (if enabled) → chat lists

## Technical details

Single layout reorder in the sidebar content stack. No prop, API, or translation changes.

## Test plan

- [ ] Open the app sidebar as a regular user and confirm chat lists still render below menu items
- [ ] Open the sidebar as an admin user and confirm the admin menu appears above chat lists
- [ ] Verify separators and spacing look correct in both light and dark mode
- [ ] Collapse the sidebar to icon mode and confirm layout still works


Made with [Cursor](https://cursor.com)