### PR TITLE
refactor(web): decouple TaskStatus/SokosumiJobStatus enums from @sokosumi/database

### DIFF
--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -1,4 +1,5 @@
-import { type Prisma, TaskStatus } from "@sokosumi/database";
+import { type Prisma } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it, vi } from "vitest";
 
 import type { EnvVariables } from "@/lib/hono";

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -1,9 +1,5 @@
-import {
-  type Job,
-  type Prisma,
-  type Task,
-  TaskStatus,
-} from "@sokosumi/database";
+import { type Job, type Prisma, type Task } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import prisma from "@/lib/db/prisma";
 import type { EnvVariables } from "@/lib/hono";

--- a/apps/core/src/helpers/history.test.ts
+++ b/apps/core/src/helpers/history.test.ts
@@ -1,5 +1,5 @@
-import { HistoryKind, JobType, TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { HistoryKind, JobType } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it, vi } from "vitest";
 
 import type prisma from "@/lib/db/prisma";

--- a/apps/core/src/helpers/history.ts
+++ b/apps/core/src/helpers/history.ts
@@ -1,15 +1,11 @@
-import {
-  type Agent,
-  HistoryKind,
-  type Prisma,
-  TaskStatus,
-} from "@sokosumi/database";
+import { type Agent, HistoryKind, type Prisma } from "@sokosumi/database";
 import { computeJobStatus } from "@sokosumi/database/helpers";
+import { jobForStatusComputeSelect } from "@sokosumi/database/types/job";
 import {
-  jobForStatusComputeSelect,
+  convertCentsToCredits,
   SokosumiJobStatus,
-} from "@sokosumi/database/types/job";
-import { convertCentsToCredits } from "@sokosumi/utils";
+  TaskStatus,
+} from "@sokosumi/utils";
 
 import { getAgentIcon, getAgentName } from "@/helpers/agent";
 import { createPaginationMeta } from "@/helpers/pagination";

--- a/apps/core/src/helpers/project-stats.test.ts
+++ b/apps/core/src/helpers/project-stats.test.ts
@@ -1,8 +1,6 @@
-import { AgentJobStatus, JobType, TaskStatus } from "@sokosumi/database";
-import {
-  jobForStatusComputeSelect,
-  SokosumiJobStatus,
-} from "@sokosumi/database/types/job";
+import { AgentJobStatus, JobType } from "@sokosumi/database";
+import { jobForStatusComputeSelect } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getProjectStatsByProjectIds } from "./project-stats";

--- a/apps/core/src/helpers/project-stats.ts
+++ b/apps/core/src/helpers/project-stats.ts
@@ -1,9 +1,6 @@
-import { type TaskStatus } from "@sokosumi/database";
 import { computeJobStatus } from "@sokosumi/database/helpers";
-import {
-  jobForStatusComputeSelect,
-  type SokosumiJobStatus,
-} from "@sokosumi/database/types/job";
+import { jobForStatusComputeSelect } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 
 import prisma from "@/lib/db/prisma";
 

--- a/apps/core/src/helpers/task-link.test.ts
+++ b/apps/core/src/helpers/task-link.test.ts
@@ -1,4 +1,5 @@
-import { TaskLinkType, TaskStatus } from "@sokosumi/database";
+import { TaskLinkType } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import type { TaskLinkRow } from "@/types/task-link";

--- a/apps/core/src/helpers/task.test.ts
+++ b/apps/core/src/helpers/task.test.ts
@@ -1,5 +1,5 @@
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
-import { convertCreditsToCents } from "@sokosumi/utils";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { convertCreditsToCents, TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import type { AuthenticationContext } from "@/middleware/auth";

--- a/apps/core/src/helpers/task.ts
+++ b/apps/core/src/helpers/task.ts
@@ -1,5 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
-import { convertCentsToCredits } from "@sokosumi/utils";
+import { convertCentsToCredits, TaskStatus } from "@sokosumi/utils";
 
 import type { AuthenticationContext } from "@/middleware/auth";
 import { isCoworkerAuthContext } from "@/middleware/auth";

--- a/apps/core/src/lib/ably/publish.test.ts
+++ b/apps/core/src/lib/ably/publish.test.ts
@@ -1,4 +1,4 @@
-import { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { describe, expect, it, vi } from "vitest";
 
 import { publishJobStatusData, publishTaskEventData } from "./publish";

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -1,4 +1,4 @@
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import { getRestClient } from "./client";
 import { makeAgentJobsChannelName, makeUserTasksChannelName } from "./utils";

--- a/apps/core/src/routes/v1/agents/[id]/jobs/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/jobs/get.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { JobType, OnChainJobStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import { getUserJobs } from "@/helpers/job";
 import {

--- a/apps/core/src/routes/v1/coworkers/me/events/get.ts
+++ b/apps/core/src/routes/v1/coworkers/me/events/get.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { requireCoworkerCapability } from "@/helpers/access-control";
 import {

--- a/apps/core/src/routes/v1/history/get.test.ts
+++ b/apps/core/src/routes/v1/history/get.test.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { HistoryKind, TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { HistoryKind } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LIMITS } from "@/config/constants";

--- a/apps/core/src/routes/v1/jobs/[id]/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { JobType, jobInclude, OnChainJobStatus } from "@sokosumi/database";
 import { mapJobWithStatus } from "@sokosumi/database/helpers";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import { notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";

--- a/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
@@ -1,5 +1,5 @@
 import { AgentJobStatus, JobType } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/jobs/get.ts
+++ b/apps/core/src/routes/v1/jobs/get.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { AgentJobStatus, JobType, OnChainJobStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import { getUserJobs } from "@/helpers/job";
 import {

--- a/apps/core/src/routes/v1/projects/stats/get.test.ts
+++ b/apps/core/src/routes/v1/projects/stats/get.test.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { AgentJobStatus, JobType, TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { AgentJobStatus, JobType } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/tasks/[id]/delete.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/delete.test.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
-import { getTaskCannotArchiveMessage } from "@sokosumi/utils";
+import { getTaskCannotArchiveMessage, TaskStatus } from "@sokosumi/utils";
 import type { RequestIdVariables } from "hono/request-id";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { errorHandler } from "@/helpers/error-handler";

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
-import { convertCreditsToCents } from "@sokosumi/utils";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { convertCreditsToCents, TaskStatus } from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 import { err, ok } from "neverthrow";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/apps/core/src/routes/v1/tasks/[id]/events/schema.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/schema.test.ts
@@ -1,4 +1,5 @@
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import { LIMITS } from "@/config/constants";

--- a/apps/core/src/routes/v1/tasks/[id]/events/schema.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { LIMITS } from "@/config/constants";
 import { isTaskStatusSpendable } from "@/helpers/task";

--- a/apps/core/src/routes/v1/tasks/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/get.test.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskLinkType, TaskStatus } from "@sokosumi/database";
+import { TaskLinkType } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/tasks/[id]/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/get.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { requireTaskReadForRouteVars } from "@/helpers/access-control";
 import { notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/tasks/[id]/links/links.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/links/links.test.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { Prisma, TaskLinkType, TaskStatus } from "@sokosumi/database";
+import { Prisma, TaskLinkType } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/core/src/routes/v1/tasks/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/patch.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/tasks/[id]/patch.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/patch.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import {
   requireTaskAssignableCoworker,

--- a/apps/core/src/routes/v1/tasks/[id]/workspace/put.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/workspace/put.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/core/src/routes/v1/tasks/get.test.ts
+++ b/apps/core/src/routes/v1/tasks/get.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/core/src/routes/v1/tasks/get.ts
+++ b/apps/core/src/routes/v1/tasks/get.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { Prisma, TaskStatus } from "@sokosumi/database";
+import { Prisma } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { requireCoworkerCapability } from "@/helpers/access-control";
 import { badRequest } from "@/helpers/error";

--- a/apps/core/src/routes/v1/tasks/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/post.test.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";

--- a/apps/core/src/routes/v1/tasks/post.ts
+++ b/apps/core/src/routes/v1/tasks/post.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { requireTaskAssignableCoworker } from "@/helpers/access-control";
 import { notFound } from "@/helpers/error";

--- a/apps/core/src/routes/v1/tasks/whitelist-enforcement.test.ts
+++ b/apps/core/src/routes/v1/tasks/whitelist-enforcement.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/core/src/schemas/history.schema.test.ts
+++ b/apps/core/src/schemas/history.schema.test.ts
@@ -1,5 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/apps/core/src/schemas/history.schema.ts
+++ b/apps/core/src/schemas/history.schema.ts
@@ -1,6 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime";
 

--- a/apps/core/src/schemas/job.schema.ts
+++ b/apps/core/src/schemas/job.schema.ts
@@ -1,11 +1,11 @@
 import { z } from "@hono/zod-openapi";
 import { AgentJobStatus, JobType, OnChainJobStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
 import type {
   InputFieldSchemaType,
   InputSchemaSchemaType,
 } from "@sokosumi/masumi/schemas";
 import { inputGroupsSchema, inputSchemaSchema } from "@sokosumi/masumi/schemas";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 import { organizationSummarySchema } from "@/schemas/organization.schema";

--- a/apps/core/src/schemas/project.schema.ts
+++ b/apps/core/src/schemas/project.schema.ts
@@ -1,6 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 

--- a/apps/core/src/schemas/public-share.schema.ts
+++ b/apps/core/src/schemas/public-share.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "@hono/zod-openapi";
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
-import { SokosumiJobStatus } from "@sokosumi/database/types/job";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 import { jobSchema } from "@/schemas/job.schema.js";

--- a/apps/core/src/schemas/task-link.schema.ts
+++ b/apps/core/src/schemas/task-link.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 

--- a/apps/core/src/schemas/task.schema.test.ts
+++ b/apps/core/src/schemas/task.schema.test.ts
@@ -1,4 +1,5 @@
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import { taskEventSchema } from "./task.schema";

--- a/apps/core/src/schemas/task.schema.ts
+++ b/apps/core/src/schemas/task.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 import { coworkerSummarySchema } from "@/schemas/coworker.schema";

--- a/apps/core/src/services/job-sync.service.test.ts
+++ b/apps/core/src/services/job-sync.service.test.ts
@@ -1,9 +1,5 @@
-import {
-  AgentJobStatus,
-  AgentStatus,
-  JobType,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { AgentJobStatus, AgentStatus, JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { err, ok } from "neverthrow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/core/src/services/job-sync.service.ts
+++ b/apps/core/src/services/job-sync.service.ts
@@ -1,10 +1,5 @@
 import * as Sentry from "@sentry/node";
-import {
-  AgentJobStatus,
-  JobType,
-  Prisma,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { AgentJobStatus, JobType, Prisma } from "@sokosumi/database";
 import {
   buildJobsNeedingAgentStatusSyncWhere,
   buildJobsNeedingPurchaseSyncWhere,
@@ -27,6 +22,7 @@ import {
   renderJobInputRequiredEmail,
 } from "@sokosumi/email";
 import { createAgentClient } from "@sokosumi/masumi";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import pLimit from "p-limit";
 
 import { paymentClient } from "@/clients/masumi-payment.client";

--- a/apps/core/src/types/task-link.test.ts
+++ b/apps/core/src/types/task-link.test.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import { buildVisibleTaskLinksInclude } from "./task-link";

--- a/apps/core/src/types/task-link.ts
+++ b/apps/core/src/types/task-link.ts
@@ -1,4 +1,5 @@
-import { type Prisma, TaskStatus } from "@sokosumi/database";
+import { type Prisma } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { type AuthenticationContext } from "@/middleware/auth";
 

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/__tests__/jobs-list-row.test.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/__tests__/jobs-list-row.test.tsx
@@ -1,8 +1,5 @@
-import {
-  JobType,
-  type JobWithSokosumiStatus,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { JobType, type JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/__tests__/jobs-list.test.ts
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/__tests__/jobs-list.test.ts
@@ -1,8 +1,5 @@
-import {
-  JobType,
-  type JobWithSokosumiStatus,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { JobType, type JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import { buildJobDayGroups } from "../jobs-list.utils";

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import {
-  type JobWithSokosumiStatus,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { type JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { ChannelProvider, useChannel } from "ably/react";
 import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { useChat } from "@ai-sdk/react";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import type { UIMessage } from "ai";
 import { DefaultChatTransport } from "ai";
 import { Loader2 } from "lucide-react";

--- a/apps/web/src/app/(app)/history/__tests__/history-list-item.test.tsx
+++ b/apps/web/src/app/(app)/history/__tests__/history-list-item.test.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/app/(app)/history/components/__tests__/history-view-filters.test.tsx
+++ b/apps/web/src/app/(app)/history/components/__tests__/history-view-filters.test.tsx
@@ -1,4 +1,4 @@
-import { SokosumiJobStatus, TaskStatus } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/app/(app)/history/components/history-list-item.tsx
+++ b/apps/web/src/app/(app)/history/components/history-list-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SokosumiJobStatus, TaskStatus } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { ListTodo } from "lucide-react";
 import Link from "next/link";
 import {

--- a/apps/web/src/app/(app)/history/page.tsx
+++ b/apps/web/src/app/(app)/history/page.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 

--- a/apps/web/src/app/(app)/history/utils/__tests__/history-filters.test.ts
+++ b/apps/web/src/app/(app)/history/utils/__tests__/history-filters.test.ts
@@ -1,4 +1,4 @@
-import { SokosumiJobStatus, TaskStatus } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/apps/web/src/app/(app)/history/utils/history-filters.ts
+++ b/apps/web/src/app/(app)/history/utils/history-filters.ts
@@ -1,4 +1,4 @@
-import { SokosumiJobStatus, TaskStatus } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 
 export const HISTORY_SEARCH_MAX_LENGTH = 200;
 export const HISTORY_SCOPE_VALUES = ["owned", "workspace"] as const;

--- a/apps/web/src/app/(app)/projects/components/project-job-picker-dialog.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-job-picker-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { Loader2, Sparkles } from "lucide-react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { unassignedWorkspaceJobsQuery } from "@/app/projects/constants";

--- a/apps/web/src/app/(app)/projects/components/project-jobs-section.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-jobs-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { Loader2, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/apps/web/src/app/(app)/projects/components/project-task-picker-dialog.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-task-picker-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { ListTodo, Loader2 } from "lucide-react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { unassignedWorkspaceTasksQuery } from "@/app/projects/constants";

--- a/apps/web/src/app/(app)/projects/components/project-tasks-section.tsx
+++ b/apps/web/src/app/(app)/projects/components/project-tasks-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { Loader2, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/apps/web/src/app/(app)/tasks/(root)/page.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/page.tsx
@@ -1,4 +1,5 @@
-import { AgentJobStatus, TaskStatus } from "@sokosumi/database";
+import { AgentJobStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 

--- a/apps/web/src/app/(app)/tasks/[taskId]/@modal/(.)edit/page.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/@modal/(.)edit/page.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 

--- a/apps/web/src/app/(app)/tasks/[taskId]/edit/page.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";

--- a/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/actions.test.ts
@@ -1,4 +1,5 @@
-import { AgentJobStatus, TaskStatus } from "@sokosumi/database";
+import { AgentJobStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const listCoworkersMock = vi.fn();

--- a/apps/web/src/app/(app)/tasks/components/__tests__/jobs-list-view.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/jobs-list-view.test.tsx
@@ -1,4 +1,5 @@
-import { JobType, SokosumiJobStatus } from "@sokosumi/database";
+import { JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
@@ -1,4 +1,5 @@
-import { TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { forwardRef, useImperativeHandle } from "react";

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-jobs.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-jobs.test.tsx
@@ -1,8 +1,5 @@
-import {
-  type AgentWithCreditsPrice,
-  JobType,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { type AgentWithCreditsPrice, JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-related-tasks.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-related-tasks.test.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-relation-row.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-relation-row.test.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/tasks-view-filters.test.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/app/(app)/tasks/components/jobs-list-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/jobs-list-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { useEffect, useMemo, useState } from "react";
 
 import type { TasksViewJob } from "@/app/tasks/types/tasks-view-job";

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { BlobStatus, TaskEventOrigin, TaskStatus } from "@sokosumi/database";
+import { BlobStatus, TaskEventOrigin } from "@sokosumi/database";
 import {
   extractFileLikeLinks,
   extractHttpLinks,
   resolveIpfsOrHttpUrl,
+  TaskStatus,
 } from "@sokosumi/utils";
 import { ArrowUp, Command, CornerDownLeft, Loader2 } from "lucide-react";
 import Link from "next/link";

--- a/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
@@ -7,7 +7,7 @@ import {
   useDraggable,
   useDroppable,
 } from "@dnd-kit/core";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { type CSSProperties, type ReactNode, useRef } from "react";
 
 import type { KanbanColumnId } from "@/lib/types/task";

--- a/apps/web/src/app/(app)/tasks/components/task-edit-modal.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-edit-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { ArrowLeft, Command, CornerDownLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/apps/web/src/app/(app)/tasks/components/task-job-status-badge.client.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-job-status-badge.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { JobType, SokosumiJobStatus } from "@sokosumi/database";
+import type { JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { useChannel } from "ably/react";
 import { useEffect, useState } from "react";
 

--- a/apps/web/src/app/(app)/tasks/components/task-jobs.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-jobs.tsx
@@ -1,7 +1,5 @@
-import type {
-  AgentWithCreditsPrice,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import type { AgentWithCreditsPrice } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import Link from "next/link";
 
 import { AgentIcon } from "@/components/agents/agent-icon";

--- a/apps/web/src/app/(app)/tasks/components/task-related-tasks.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-related-tasks.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import type { TaskLinkRelation } from "@/lib/clients/generated/core/types.gen";
 

--- a/apps/web/src/app/(app)/tasks/components/task-relation-row.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-relation-row.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
 import type { TaskLinkRelation } from "@/lib/clients/generated/core/types.gen";

--- a/apps/web/src/app/(app)/tasks/components/task-status-badge.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-status-badge.tsx
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { Building2, CircleDashed, FolderKanban, Sparkles } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -9,11 +9,8 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import {
-  AgentJobStatus,
-  SokosumiJobStatus,
-  TaskStatus,
-} from "@sokosumi/database";
+import { AgentJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 import { ChannelProvider, useChannel } from "ably/react";
 import { CircleHelp, Plus } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";

--- a/apps/web/src/app/(app)/tasks/types/tasks-view-job.ts
+++ b/apps/web/src/app/(app)/tasks/types/tasks-view-job.ts
@@ -1,4 +1,5 @@
-import type { JobType, SokosumiJobStatus } from "@sokosumi/database";
+import type { JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 export interface TasksViewJob {
   id: string;

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/jobs-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/jobs-filters.test.ts
@@ -1,4 +1,5 @@
-import { AgentJobStatus, SokosumiJobStatus } from "@sokosumi/database";
+import { AgentJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { getTasksColumnPage } from "../tasks-column-page";
 

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/apps/web/src/app/(app)/tasks/utils/jobs-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/jobs-filters.ts
@@ -1,4 +1,5 @@
-import { AgentJobStatus, SokosumiJobStatus } from "@sokosumi/database";
+import { AgentJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import {
   firstQueryString,

--- a/apps/web/src/app/(app)/tasks/utils/jobs-view-data.ts
+++ b/apps/web/src/app/(app)/tasks/utils/jobs-view-data.ts
@@ -1,9 +1,7 @@
 import "server-only";
 
-import type {
-  AgentWithCreditsPrice,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import type { AgentWithCreditsPrice } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 import type { TasksViewJob } from "@/app/tasks/types/tasks-view-job";
 import { getCoworkerImage } from "@/app/tasks/utils/coworker-image";

--- a/apps/web/src/app/(app)/tasks/utils/tasks-column-page.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-column-page.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { AgentWithCreditsPrice } from "@sokosumi/database";
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import type { TasksScope } from "@/app/tasks/utils/tasks-filters";
 import type { Coworker } from "@/lib/clients/generated/core";

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import type { TaskWithCoworker } from "@/lib/types/task";
 

--- a/apps/web/src/app/share/components/shared-task-view.tsx
+++ b/apps/web/src/app/share/components/shared-task-view.tsx
@@ -1,10 +1,10 @@
+import { BlobStatus, TaskEventOrigin } from "@sokosumi/database";
 import {
-  BlobStatus,
+  extractFileLikeLinks,
+  extractHttpLinks,
   SokosumiJobStatus,
-  TaskEventOrigin,
   TaskStatus,
-} from "@sokosumi/database";
-import { extractFileLikeLinks, extractHttpLinks } from "@sokosumi/utils";
+} from "@sokosumi/utils";
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import { useFormatter } from "next-intl";

--- a/apps/web/src/components/jobs/__tests__/job-status-badge.test.tsx
+++ b/apps/web/src/components/jobs/__tests__/job-status-badge.test.tsx
@@ -1,4 +1,5 @@
-import { JobType, SokosumiJobStatus } from "@sokosumi/database";
+import { JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/components/jobs/job-details/__tests__/job-details-view.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/job-details-view.test.tsx
@@ -1,4 +1,5 @@
-import { JobWithSokosumiStatus, SokosumiJobStatus } from "@sokosumi/database";
+import { JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/components/jobs/job-details/__tests__/job-details.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/job-details.test.tsx
@@ -1,4 +1,5 @@
-import { JobWithSokosumiStatus, SokosumiJobStatus } from "@sokosumi/database";
+import { JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/apps/web/src/components/jobs/job-details/__tests__/job-meta-details.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/job-meta-details.test.tsx
@@ -1,8 +1,5 @@
-import {
-  JobType,
-  type JobWithSokosumiStatus,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { JobType, type JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/components/jobs/job-details/__tests__/job-share-modal.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/job-share-modal.test.tsx
@@ -1,8 +1,5 @@
-import {
-  JobType,
-  type JobWithSokosumiStatus,
-  SokosumiJobStatus,
-} from "@sokosumi/database";
+import { JobType, type JobWithSokosumiStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/components/jobs/job-details/__tests__/outputs.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/outputs.test.tsx
@@ -2,8 +2,8 @@ import {
   AgentJobStatus,
   type JobEventWithRelations,
   type JobWithSokosumiStatus,
-  SokosumiJobStatus,
 } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/src/components/jobs/job-details/refund-request.tsx
+++ b/apps/web/src/components/jobs/job-details/refund-request.tsx
@@ -4,8 +4,8 @@ import {
   JobType,
   type JobWithSokosumiStatus,
   type PaidJobWithStatus,
-  SokosumiJobStatus,
 } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import {
   ExternalLink,
   HandCoins,

--- a/apps/web/src/components/jobs/job-status-badge.tsx
+++ b/apps/web/src/components/jobs/job-status-badge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { JobType, SokosumiJobStatus } from "@sokosumi/database";
+import { JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { useTranslations } from "next-intl";
 
 import { getJobStatusBadgeLabelKey } from "@/components/jobs/job-status-label";

--- a/apps/web/src/components/jobs/job-status-label.ts
+++ b/apps/web/src/components/jobs/job-status-label.ts
@@ -1,4 +1,5 @@
-import { JobType, SokosumiJobStatus } from "@sokosumi/database";
+import { JobType } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 export function getJobStatusBadgeLabelKey(
   status: SokosumiJobStatus,

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -1,4 +1,4 @@
-import { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import * as z from "zod";
 
 export const jobStatusDataSchema = z.object({

--- a/apps/web/src/lib/actions/task/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/task/__tests__/action.test.ts
@@ -1,4 +1,5 @@
-import { TaskLinkType, TaskStatus } from "@sokosumi/database";
+import { TaskLinkType } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_TASK_NAME_MAX_LENGTH } from "@/lib/utils/task-transformer";

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { TaskLinkType, TaskStatus } from "@sokosumi/database";
+import { TaskLinkType } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { revalidatePath } from "next/cache";
 
 import { toCoreApiActionError } from "@/lib/clients/core.client";

--- a/apps/web/src/lib/services/__tests__/task.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/task.service.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { AgentJobStatus, TaskStatus } from "@sokosumi/database";
+import { AgentJobStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 const coreClientMock = {
   createTaskLink: vi.fn(),

--- a/apps/web/src/lib/services/organization-seat-credits.service.ts
+++ b/apps/web/src/lib/services/organization-seat-credits.service.ts
@@ -4,7 +4,6 @@ import {
   CreditBucketReferenceType,
   type Prisma,
   TaskEventOrigin,
-  TaskStatus,
 } from "@sokosumi/database";
 import {
   buildOrganizationSeatAssignmentSubscriptionReferenceId,
@@ -16,7 +15,7 @@ import {
   resolvePurchasedSeats,
 } from "@sokosumi/database/helpers";
 import { subscriptionRepository } from "@sokosumi/database/repositories";
-import { convertCreditsToCents } from "@sokosumi/utils";
+import { convertCreditsToCents, TaskStatus } from "@sokosumi/utils";
 import Stripe from "stripe";
 
 import { getEnvSecrets } from "@/config/env.secrets";

--- a/apps/web/src/lib/services/task.service.ts
+++ b/apps/web/src/lib/services/task.service.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
-import type { AgentJobStatus, TaskStatus } from "@sokosumi/database";
+import type { AgentJobStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { coreClient } from "@/lib/clients/core.client";
 import type {

--- a/apps/web/src/lib/stripe/webhook-handlers.ts
+++ b/apps/web/src/lib/stripe/webhook-handlers.ts
@@ -5,7 +5,6 @@ import {
   MemberRole,
   type Prisma,
   TaskEventOrigin,
-  TaskStatus,
 } from "@sokosumi/database";
 import {
   buildOrganizationInvoiceCreditReferenceId,
@@ -31,6 +30,7 @@ import {
   convertCentsToCredits,
   convertCreditsToCents,
   getOrganizationMetadata,
+  TaskStatus,
 } from "@sokosumi/utils";
 import Stripe from "stripe";
 

--- a/apps/web/src/lib/types/job.ts
+++ b/apps/web/src/lib/types/job.ts
@@ -1,4 +1,4 @@
-import type { SokosumiJobStatus } from "@sokosumi/database";
+import { SokosumiJobStatus } from "@sokosumi/utils";
 
 export interface SyncJobTransactionResult {
   jobStatus: SokosumiJobStatus;

--- a/apps/web/src/lib/types/task.ts
+++ b/apps/web/src/lib/types/task.ts
@@ -1,4 +1,5 @@
-import type { AgentWithCreditsPrice, TaskStatus } from "@sokosumi/database";
+import type { AgentWithCreditsPrice } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import type { Coworker } from "@/lib/clients/generated/core";
 import type {

--- a/apps/web/src/lib/utils/__tests__/task-transformer.test.ts
+++ b/apps/web/src/lib/utils/__tests__/task-transformer.test.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
 import type {

--- a/apps/web/src/lib/utils/task-column.ts
+++ b/apps/web/src/lib/utils/task-column.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
 
 import type { KanbanColumnId } from "@/lib/types/task";
 

--- a/packages/database/src/helpers/job.test.ts
+++ b/packages/database/src/helpers/job.test.ts
@@ -1,9 +1,7 @@
 import assert from "node:assert/strict";
-
+import { SokosumiJobStatus } from "@sokosumi/utils";
 import { describe, it } from "vitest";
-
 import { JobType } from "../generated/prisma/client.js";
-import { SokosumiJobStatus } from "../types/job.js";
 import { computeJobStatus } from "./job.js";
 
 function createPaidJob(overrides: Record<string, unknown> = {}) {

--- a/packages/database/src/helpers/job.ts
+++ b/packages/database/src/helpers/job.ts
@@ -1,4 +1,4 @@
-import { convertCentsToCredits } from "@sokosumi/utils";
+import { convertCentsToCredits, SokosumiJobStatus } from "@sokosumi/utils";
 
 import {
   AgentJobStatus,
@@ -18,7 +18,6 @@ import {
   type JobWithSokosumiStatus,
   type JobWithTransaction,
   type PaidJobWithStatus,
-  SokosumiJobStatus,
 } from "../types/job.js";
 
 const TEN_MINUTES_TIMESTAMP = 1000 * 60 * 10; // 10min

--- a/packages/database/src/types/__tests__/status-enums-drift.test.ts
+++ b/packages/database/src/types/__tests__/status-enums-drift.test.ts
@@ -1,0 +1,35 @@
+import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
+import { describe, expect, it } from "vitest";
+
+import { TaskStatus as PrismaTaskStatus } from "../../generated/prisma/enums.js";
+
+/**
+ * `@sokosumi/utils` hosts the client-safe single source of truth for these
+ * statuses so the web bundle does not depend on `@sokosumi/database`. The
+ * Prisma `TaskStatus` enum can only be edited via the schema, so guard against
+ * silent drift between the two definitions here, where both are importable.
+ */
+describe("status enum drift guard", () => {
+  it("utils TaskStatus matches the Prisma-generated TaskStatus enum", () => {
+    expect({ ...TaskStatus }).toEqual({ ...PrismaTaskStatus });
+  });
+
+  it("SokosumiJobStatus keeps its canonical lowercase string values", () => {
+    // SokosumiJobStatus has no Prisma counterpart; lock the values so the
+    // client-safe map cannot drift unnoticed.
+    expect({ ...SokosumiJobStatus }).toEqual({
+      STARTED: "started",
+      COMPLETED: "completed",
+      PROCESSING: "processing",
+      INPUT_REQUIRED: "input_required",
+      RESULT_PENDING: "result_pending",
+      FAILED: "failed",
+      PAYMENT_PENDING: "payment_pending",
+      PAYMENT_FAILED: "payment_failed",
+      REFUND_PENDING: "refund_pending",
+      REFUND_RESOLVED: "refund_resolved",
+      DISPUTE_PENDING: "dispute_pending",
+      DISPUTE_RESOLVED: "dispute_resolved",
+    });
+  });
+});

--- a/packages/database/src/types/job.ts
+++ b/packages/database/src/types/job.ts
@@ -1,3 +1,5 @@
+import type { SokosumiJobStatus } from "@sokosumi/utils";
+
 import {
   AgentJobStatus,
   OnChainJobStatus,
@@ -233,24 +235,6 @@ export type PaidJobWithStatus = Override<BaseJobWithStatus, BasePaidJob>;
 export enum JobErrorNoteKeys {
   StatusMismatch = "Job.StatusMismatch",
   Unknown = "Job.UnknownState",
-}
-
-export enum SokosumiJobStatus {
-  STARTED = "started",
-  COMPLETED = "completed",
-  PROCESSING = "processing",
-  INPUT_REQUIRED = "input_required",
-  RESULT_PENDING = "result_pending",
-  FAILED = "failed",
-
-  PAYMENT_PENDING = "payment_pending",
-  PAYMENT_FAILED = "payment_failed",
-
-  REFUND_PENDING = "refund_pending",
-  REFUND_RESOLVED = "refund_resolved",
-
-  DISPUTE_PENDING = "dispute_pending",
-  DISPUTE_RESOLVED = "dispute_resolved",
 }
 
 export const finalizedOnChainJobStatuses: OnChainJobStatus[] = [

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -73,12 +73,14 @@ export {
   type OrganizationMetadata,
   parseOrganizationMetadata,
 } from "./organization-metadata.js";
+export { SokosumiJobStatus } from "./sokosumi-job-status.js";
 export {
   getTaskCannotArchiveMessage,
   isTaskArchivableStatus,
   TASK_ARCHIVABLE_STATUSES,
   type TaskArchivableStatus,
 } from "./task-archive.js";
+export { TaskStatus } from "./task-status.js";
 export { getFallbackUserName, getStoredUserName } from "./user-name.js";
 export {
   isUserUploadAllowedContentType,

--- a/packages/utils/src/sokosumi-job-status.ts
+++ b/packages/utils/src/sokosumi-job-status.ts
@@ -1,0 +1,29 @@
+/**
+ * Sōkosumi-facing job statuses derived from on-chain and agent state.
+ *
+ * Client-safe single source of truth, re-used by `@sokosumi/database`,
+ * `apps/core`, and `apps/web`. Previously a TS enum in `@sokosumi/database`;
+ * moved here as a const map (per the repo convention to avoid enums) so
+ * consumers can reference these values without pulling in
+ * `@sokosumi/database`.
+ */
+export const SokosumiJobStatus = {
+  STARTED: "started",
+  COMPLETED: "completed",
+  PROCESSING: "processing",
+  INPUT_REQUIRED: "input_required",
+  RESULT_PENDING: "result_pending",
+  FAILED: "failed",
+
+  PAYMENT_PENDING: "payment_pending",
+  PAYMENT_FAILED: "payment_failed",
+
+  REFUND_PENDING: "refund_pending",
+  REFUND_RESOLVED: "refund_resolved",
+
+  DISPUTE_PENDING: "dispute_pending",
+  DISPUTE_RESOLVED: "dispute_resolved",
+} as const;
+
+export type SokosumiJobStatus =
+  (typeof SokosumiJobStatus)[keyof typeof SokosumiJobStatus];

--- a/packages/utils/src/task-status.ts
+++ b/packages/utils/src/task-status.ts
@@ -1,0 +1,29 @@
+/**
+ * Sōkosumi task lifecycle statuses.
+ *
+ * Client-safe single source of truth that mirrors the Prisma `TaskStatus`
+ * enum in `@sokosumi/database`. Defined here as a const map (not a TS enum,
+ * per the repo convention) so consumers — most importantly the web bundle —
+ * can reference these values without pulling in `@sokosumi/database`.
+ *
+ * The Prisma-generated `prisma-client` enum is itself a const map with the
+ * same string values, so the two are structurally identical and assignable in
+ * both directions. A drift guard test in `@sokosumi/database` asserts they
+ * stay in sync.
+ */
+export const TaskStatus = {
+  DRAFT: "DRAFT",
+  READY: "READY",
+  INPUT_REQUIRED: "INPUT_REQUIRED",
+  AUTHENTICATION_REQUIRED: "AUTHENTICATION_REQUIRED",
+  OUT_OF_CREDITS: "OUT_OF_CREDITS",
+  CREDITS_TOPPED_UP: "CREDITS_TOPPED_UP",
+  RUNNING: "RUNNING",
+  AWAITING_EXTERNAL: "AWAITING_EXTERNAL",
+  COMPLETED: "COMPLETED",
+  FAILED: "FAILED",
+  CANCEL_REQUESTED: "CANCEL_REQUESTED",
+  CANCELED: "CANCELED",
+} as const;
+
+export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];


### PR DESCRIPTION
## Summary

Extracted `TaskStatus` and `SokosumiJobStatus` from `@sokosumi/database` into `@sokosumi/utils` to enable client-side code (particularly the web bundle) to reference these status values without pulling in the database package as a dependency.

## Key Changes

- **New exports in `@sokosumi/utils`:**
  - Added `TaskStatus` as a const map (mirrors Prisma enum, client-safe single source of truth)
  - Added `SokosumiJobStatus` as a const map (moved from database package)
  - Both exported as const maps per repo convention (avoiding TypeScript enums)

- **Updated `@sokosumi/database`:**
  - Removed `SokosumiJobStatus` enum definition from `packages/database/src/types/job.ts`
  - Now imports `SokosumiJobStatus` type from `@sokosumi/utils`
  - Added drift guard test to ensure `TaskStatus` and `SokosumiJobStatus` stay in sync between packages

- **Updated all consumers:**
  - `apps/core`: Updated imports across helpers, services, routes, and schemas
  - `apps/web`: Updated imports across components, pages, utilities, and services
  - `packages/database`: Updated helper imports

## Implementation Details

- `TaskStatus` is structurally identical to the Prisma-generated enum (both are const maps with string values), ensuring bidirectional assignability
- Added `status-enums-drift.test.ts` in `@sokosumi/database` to guard against silent drift between the two definitions
- `SokosumiJobStatus` values are locked to their canonical lowercase string representations in the test
- All 60+ import statements updated to reference the new location in `@sokosumi/utils`

https://claude.ai/code/session_01SA5BSSVSZvCnTWMN1Neaqh