### PR TITLE
perf(agents): cache the global agent catalog across requests

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -173,6 +173,30 @@ import { JobsList } from "src/app/(app)/agents/[agentId]/jobs/components/jobs-li
 - Never access Prisma directly from components
 - Use server actions for mutations
 
+### Core API reads & caching (performance)
+
+We are migrating web data access from direct DB reads to the Core API
+(`coreClient` in `src/lib/clients/core.client.ts`). Two performance rules:
+
+- **Never blindly cache Core responses across requests.** Every `coreClient`
+  call attaches the caller's cookies (`buildAuthHeaders`) and defaults to
+  `cache: "no-store"`, because most responses are **user/workspace-scoped** —
+  caching them in Next's shared fetch cache would leak one user's data to
+  another. Keep `no-store` for anything user-specific.
+- **Do cross-request cache _global_ catalog reads.** The agent catalog
+  (`GET /v1/agents`) is global — it carries no per-user fields and is not
+  user-scoped — so it is safe to share. `getAllCoreAgents`
+  (`src/lib/agents/core-loaders.ts`) loads every page of the catalog; without
+  caching, **every page that needs agents re-paginates the whole catalog over
+  HTTP on every request** (React `cache()` only dedupes within one request).
+  It opts into fetch-level revalidation via `coreClient.getAgents(query,
+  { revalidate, tags: [AGENTS_CACHE_TAG] })`, so the catalog is fetched at most
+  once per TTL across all users. Invalidate on demand with
+  `revalidateTag(AGENTS_CACHE_TAG)`. The proper long-term fix is a Core
+  endpoint that returns the filtered catalog in one call (see the
+  `TODO(core-api)` in `core-loaders.ts`); until then, do not add new
+  per-request all-pages loops.
+
 ### Better Auth ID generation
 
 - `src/lib/auth/auth.ts` sets `advanced.database.generateId: "uuid"` so Better Auth–managed rows get UUID-shaped primary keys, consistent with `@sokosumi/database` Prisma models. Do not remove this without aligning the shared schema and any database migrations.

--- a/apps/web/src/lib/agents/core-loaders.ts
+++ b/apps/web/src/lib/agents/core-loaders.ts
@@ -10,6 +10,15 @@ import type {
 
 const AGENTS_PAGE_SIZE = 100;
 
+// The agent catalog is global and changes infrequently. Without cross-request
+// caching, every page that needs agents re-paginates the whole catalog over
+// HTTP (React `cache()` only dedupes within a single request). Cache the
+// underlying fetches with a short TTL + tag so the catalog is fetched at most
+// once per window across all requests; call `revalidateTag(AGENTS_CACHE_TAG)`
+// to invalidate on demand (e.g. after an agent sync).
+const AGENTS_CACHE_REVALIDATE_SECONDS = 60;
+export const AGENTS_CACHE_TAG = "core-agents-catalog";
+
 export const getCoreAgentById = cache(
   async (agentId: string): Promise<CoreAgentDetail | null> => {
     try {
@@ -32,10 +41,16 @@ export const getAllCoreAgents = cache(async (): Promise<CoreAgent[]> => {
   // TODO(core-api): replace all-page loading after Core supports gallery search
   // and a pagination strategy that preserves the current filter UX.
   do {
-    const response = await coreClient.getAgents({
-      cursor,
-      limit: AGENTS_PAGE_SIZE,
-    });
+    const response = await coreClient.getAgents(
+      {
+        cursor,
+        limit: AGENTS_PAGE_SIZE,
+      },
+      {
+        revalidate: AGENTS_CACHE_REVALIDATE_SECONDS,
+        tags: [AGENTS_CACHE_TAG],
+      },
+    );
 
     agents.push(...response.data);
     cursor = response.meta?.pagination?.nextCursor ?? undefined;

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -689,14 +689,25 @@ export function createCoreClient(getClient: GetClient) {
     );
   }
 
-  async function getAgents(query?: GetAgentsData["query"]) {
+  async function getAgents(
+    query?: GetAgentsData["query"],
+    cacheOptions?: { revalidate: number; tags?: string[] },
+  ) {
     return executeOperation(
       getClient,
       (client) =>
         coreGetAgents({
           client,
           query,
-          cache: "no-store",
+          // The agent catalog (GET /v1/agents) is global — it carries no
+          // per-user fields and is not user/workspace-scoped — so callers may
+          // opt into cross-request revalidation caching. Next keys the fetch
+          // cache by URL (not auth headers), so the cached payload is safely
+          // shared across users. Without `cacheOptions` this stays `no-store`,
+          // which every other (user-scoped) Core call must keep.
+          ...(cacheOptions
+            ? { next: cacheOptions }
+            : { cache: "no-store" as const }),
         }),
       "Failed to fetch agents",
     );


### PR DESCRIPTION
## Problem

`getAllCoreAgents` (`src/lib/agents/core-loaders.ts`) paginates the **entire** agent catalog over HTTP, and React `cache()` only dedupes within a single request. So **every** server render that needs agents — the catalog page, the task agent-picker (every task create/edit page + action), the billing "random agent" cards — re-fetched all catalog pages from Core on every request, each page `cache: "no-store"`. On Core, each `GET /v1/agents` page also recomputes per-agent rating aggregates + average execution times. This is a real, repeated cost on hot paths.

## Fix

The catalog (`GET /v1/agents`) is **global**: it carries no per-user fields and is not user/workspace-scoped (verified — the query uses `buildAvailableAgentWhereClause`, and the response is aggregate metrics/author/legal/categories only). Its payload is identical for every user, so it's safe to share across requests.

- Added an optional `cacheOptions` arg to the `getAgents` wrapper (`core.shared.ts`). When provided it switches that fetch from `cache: "no-store"` to `next: { revalidate, tags }`; **every other (user-scoped) Core call is untouched and stays `no-store`**.
- `getAllCoreAgents` opts in with a **60s TTL** + tag `core-agents-catalog`.

Next keys the fetch cache by **URL, not auth headers**, so the cached catalog is shared across users (correct here — global data; this is exactly why we must *not* do it for user-scoped endpoints). Net: the catalog is fetched at most once per TTL across all requests instead of on every render.

## Safety

- Only the catalog path opts in; user-scoped reads keep `no-store` (no cross-user leakage).
- Confirmed the catalog response has no per-user fields and no user/workspace filter.

## Tradeoff (needs a 👍 on the value)

Catalog changes — a newly onlined agent, a price change — become visible **up to the TTL (60s) late**, where today they're always fresh. 60s is conservative and tunable; the cache tag allows explicit invalidation via `revalidateTag(AGENTS_CACHE_TAG)` (e.g. after an agent sync) if you'd prefer event-based invalidation over / in addition to the TTL.

## Notes

- Documented the rule in `apps/web/AGENTS.md` → **Core API reads & caching**: never cross-request-cache user-scoped Core responses; do cache the global catalog; avoid new per-request all-pages loops.
- The proper long-term fix is a Core endpoint that returns the filtered catalog in one call (existing `TODO(core-api)` in `core-loaders.ts`); this is the safe interim win.
- Independent of the agents-domain migration (PR #3058); composes with it (its new task/billing callers get the same caching for free).

## Verification
- `pnpm --filter web test src/lib/clients src/lib/agents "src/app/(app)/agents"` — 71 pass
- `pnpm check` (biome) — clean
- `pnpm web:build` (tsc) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)