### PR TITLE
fix(sync): reduce per-user Sentry noise for transient Hermes orchestrator errors

### DIFF
--- a/apps/core/src/services/__tests__/hermes-inbox-sync.service.test.ts
+++ b/apps/core/src/services/__tests__/hermes-inbox-sync.service.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { HermesOrchestratorError } from "@/clients/hermes-orchestrator.client";
+import { isTransientOrchestratorError } from "@/services/hermes-inbox-sync.service";
+
+describe("isTransientOrchestratorError", () => {
+  it("treats HermesOrchestratorError with 5xx status as transient", () => {
+    expect(
+      isTransientOrchestratorError(new HermesOrchestratorError(500, {})),
+    ).toBe(true);
+    expect(
+      isTransientOrchestratorError(
+        new HermesOrchestratorError(502, { code: "BAD_GATEWAY" }),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientOrchestratorError(new HermesOrchestratorError(503, {})),
+    ).toBe(true);
+  });
+
+  it("treats HermesOrchestratorError with 4xx status as non-transient", () => {
+    expect(
+      isTransientOrchestratorError(new HermesOrchestratorError(400, {})),
+    ).toBe(false);
+    expect(
+      isTransientOrchestratorError(new HermesOrchestratorError(404, {})),
+    ).toBe(false);
+    expect(
+      isTransientOrchestratorError(new HermesOrchestratorError(429, {})),
+    ).toBe(false);
+  });
+
+  it("treats TypeError('fetch failed') with a cause as transient (connect timeout, reset, etc.)", () => {
+    const err = Object.assign(new TypeError("fetch failed"), {
+      cause: new Error("connect timeout"),
+    });
+    expect(isTransientOrchestratorError(err)).toBe(true);
+  });
+
+  it("does not treat TypeError('fetch failed') without a cause as transient", () => {
+    expect(isTransientOrchestratorError(new TypeError("fetch failed"))).toBe(
+      false,
+    );
+  });
+
+  it("does not treat unrelated TypeErrors as transient", () => {
+    expect(
+      isTransientOrchestratorError(
+        new TypeError("Cannot read properties of undefined"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat generic Errors as transient", () => {
+    expect(
+      isTransientOrchestratorError(new Error("some unexpected error")),
+    ).toBe(false);
+  });
+
+  it("does not treat non-Error values as transient", () => {
+    expect(isTransientOrchestratorError(null)).toBe(false);
+    expect(isTransientOrchestratorError("string error")).toBe(false);
+    expect(isTransientOrchestratorError(42)).toBe(false);
+  });
+});

--- a/apps/core/src/services/hermes-inbox-sync.service.ts
+++ b/apps/core/src/services/hermes-inbox-sync.service.ts
@@ -6,6 +6,7 @@ import {
   ackInstanceInbox,
   getInstanceInbox,
   type HermesInboxMessage,
+  HermesOrchestratorError,
 } from "@/clients/hermes-orchestrator.client";
 import { getEnv } from "@/config/env";
 import prisma from "@/lib/db/prisma";
@@ -20,6 +21,29 @@ const INBOX_FETCH_LIMIT = 50;
 const INBOX_SINCE_OVERLAP_MS = 5 * 60_000;
 const HERMES_INBOX_MESSAGE_UUID_NAMESPACE =
   "3ed84820-2c89-4546-9a58-96b20f8b4980";
+
+/**
+ * Returns true for errors that represent transient external-service failures
+ * (Hermes orchestrator 5xx responses, network connect timeouts, etc.) that are
+ * expected to self-resolve on the next poll cycle. These should NOT be reported
+ * to Sentry per-user — doing so creates one event per affected user per minute
+ * when the orchestrator is down, which drowns out actionable signal.
+ */
+export function isTransientOrchestratorError(error: unknown): boolean {
+  if (error instanceof HermesOrchestratorError && error.httpStatus >= 500) {
+    return true;
+  }
+  // Node's undici raises TypeError("fetch failed") wrapping a ConnectTimeoutError,
+  // ResetConnectionError, etc. when the upstream host is unreachable.
+  if (
+    error instanceof TypeError &&
+    error.message === "fetch failed" &&
+    error.cause instanceof Error
+  ) {
+    return true;
+  }
+  return false;
+}
 
 interface SyncOptions {
   abortSignal: AbortSignal;
@@ -38,6 +62,8 @@ interface PollOutcome {
     | "error";
   count?: number;
   status?: string;
+  /** Set when outcome is "error" due to a transient external-service failure (5xx, network timeout). */
+  transientError?: unknown;
 }
 
 export interface HermesInboxSyncSummary {
@@ -204,14 +230,23 @@ async function pollOne(
       signal: options.abortSignal,
     });
   } catch (error) {
-    Sentry.captureException(error, {
-      tags: { context: "hermes_inbox_poll" },
-      extra: { userId: instance.userId },
-    });
+    const transient = isTransientOrchestratorError(error);
+    // Transient external-service failures (5xx, network timeout) are reported
+    // once per batch by pollInboxes rather than once per affected user.
+    if (!transient) {
+      Sentry.captureException(error, {
+        tags: { context: "hermes_inbox_poll" },
+        extra: { userId: instance.userId },
+      });
+    }
     await markPolled({ userId: instance.userId, incrementErrors: true }).catch(
       () => undefined,
     );
-    return { userId: instance.userId, outcome: "error" };
+    return {
+      userId: instance.userId,
+      outcome: "error",
+      ...(transient && { transientError: error }),
+    };
   }
 
   if (result.kind === "not_implemented") {
@@ -352,6 +387,8 @@ async function pollInboxes(
 
   let totalMessages = 0;
   let polled = 0;
+  let firstTransientError: unknown = null;
+  let transientErrorCount = 0;
 
   for (const instance of due) {
     if (!shouldContinueSync(options)) {
@@ -365,6 +402,10 @@ async function pollInboxes(
       if (outcome.outcome === "messages") {
         totalMessages += outcome.count ?? 0;
       }
+      if (outcome.transientError !== undefined) {
+        transientErrorCount++;
+        if (!firstTransientError) firstTransientError = outcome.transientError;
+      }
     } catch (error) {
       polled += 1;
       breakdown.error += 1;
@@ -373,6 +414,15 @@ async function pollInboxes(
         extra: { userId: instance.userId },
       });
     }
+  }
+
+  // Report one aggregate event for all transient orchestrator errors so the
+  // team sees one Sentry alert per outage window, not one per affected user.
+  if (transientErrorCount > 0) {
+    Sentry.captureException(firstTransientError, {
+      tags: { context: "hermes_inbox_poll_batch" },
+      extra: { transientErrorCount, polled },
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary

**Sentry issues addressed**
- [SOKOSUMI-CORE-1M](https://masumi.sentry.io/issues/SOKOSUMI-CORE-1M) — `Error: Hermes orchestrator error (502)` — **78 events / 56 users** (ongoing since May 20)
- [SOKOSUMI-CORE-1J](https://masumi.sentry.io/issues/SOKOSUMI-CORE-1J) — `TypeError: fetch failed` (ConnectTimeout to orchestrator) — **18 events / 11 users** (ongoing since May 14)

**Root cause**

Both issues fire from `pollOne()` inside `hermesInboxSyncService.pollInboxes()`, which is invoked by the `GET /sync/hermes/poll-inboxes` Vercel cron (every minute). When the Hermes orchestrator service at `orchestrator-production-35d4.up.railway.app` returns HTTP 502 or is unreachable, the existing code called `Sentry.captureException()` once per affected user. With 56+ users in the batch, a single orchestrator outage window produced hundreds of near-identical Sentry events rather than one actionable alert.

Both failure modes are **expected transient external-service blips**: the error counter (`HermesInstance.consecutivePollErrors`) is already incremented correctly and the next poll cycle recovers automatically. No user data is lost.

**Fix**

- Added `isTransientOrchestratorError(error)` — returns `true` for `HermesOrchestratorError` with HTTP status ≥ 500 and for undici network failures (`TypeError("fetch failed")` with a cause), which are the two patterns observed in production.
- `pollOne()` no longer calls `Sentry.captureException` per user for transient errors; it instead sets `PollOutcome.transientError` on the returned outcome.
- `pollInboxes()` accumulates these and emits **one** `Sentry.captureException` (tagged `hermes_inbox_poll_batch`) per cron invocation when any transient errors occurred — preserving actionable signal without the per-user flood.
- Non-transient errors (4xx orchestrator responses, message-persist failures, ack failures) continue to fire per-user events as before.

**Not addressed (separate follow-up needed)**

- [SOKOSUMI-CORE-1X](https://masumi.sentry.io/issues/SOKOSUMI-CORE-1X) — `Error: Connection terminated unexpectedly` in Prisma `$transaction` on `GET /sync/jobs` (3 events / 1 user). Root cause is stale serverless connection pool; requires infrastructure-level mitigation (pgBouncer / Prisma Accelerate). Low priority given frequency.

## Test plan

- [x] `pnpm --filter core test src/services/__tests__/hermes-inbox-sync.service.test.ts` — 7/7 pass
- [x] `pnpm check` — no Biome errors
- [ ] Confirm Sentry issue SOKOSUMI-CORE-1M stops generating new per-user events after deploy; one `hermes_inbox_poll_batch` event per outage window is expected instead

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrMLuvakHPZhBBJ5MGokLz)_