### PR TITLE
fix(sync): only alert on Hermes orchestrator outages, not isolated 502s

### DIFF
--- a/apps/core/src/services/hermes-inbox-sync.service.test.ts
+++ b/apps/core/src/services/hermes-inbox-sync.service.test.ts
@@ -25,6 +25,7 @@ const HERMES_INBOX_MESSAGE_UUID_NAMESPACE =
 
 vi.mock("@sentry/node", () => ({
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
 }));
 
 vi.mock("@/config/env", () => ({
@@ -307,5 +308,80 @@ describe("hermesInboxSyncService", () => {
         extra: { userId: "user-unhandled" },
       }),
     );
+  });
+
+  it("escalates a single aggregate outage event when transient failures dominate the batch", async () => {
+    const instances = Array.from({ length: 6 }, (_, i) => ({
+      userId: `user-outage-${i}`,
+      lastInboxMessageAt: null,
+      lastPolledAt: null,
+    }));
+    hermesInstanceFindManyMock.mockResolvedValue(instances);
+
+    const transientError = Object.assign(new TypeError("fetch failed"), {
+      cause: new Error("connect timeout"),
+    });
+    getInstanceInboxMock.mockRejectedValue(transientError);
+
+    const summary = await hermesInboxSyncService.pollInboxes({
+      abortSignal: new AbortController().signal,
+      deadlineMs: Date.now() + 60_000,
+      shouldContinue: () => true,
+    });
+
+    expect(summary.breakdown.error).toBe(6);
+    // Per-user transient failures stay muted — they're aggregated, not paged
+    // once per affected user.
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    // One aggregate outage event, on its own fingerprint so it never re-groups
+    // under the raw HermesOrchestratorError (SOKOSUMI-CORE-1M).
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "hermes_inbox_orchestrator_outage",
+      expect.objectContaining({
+        level: "error",
+        fingerprint: ["hermes-inbox-orchestrator-outage"],
+        tags: { context: "hermes_inbox_poll_batch" },
+        extra: expect.objectContaining({
+          transientErrorCount: 6,
+          polled: 6,
+          sampleError: "fetch failed",
+        }),
+      }),
+    );
+  });
+
+  it("does not alert when a transient failure is isolated among healthy polls", async () => {
+    const instances = Array.from({ length: 6 }, (_, i) => ({
+      userId: `user-blip-${i}`,
+      lastInboxMessageAt: null,
+      lastPolledAt: null,
+    }));
+    hermesInstanceFindManyMock.mockResolvedValue(instances);
+
+    const transientError = Object.assign(new TypeError("fetch failed"), {
+      cause: new Error("connect timeout"),
+    });
+    let call = 0;
+    getInstanceInboxMock.mockImplementation(async () => {
+      call += 1;
+      if (call === 1) throw transientError;
+      return {
+        kind: "messages" as const,
+        data: { messages: [], hasMore: false },
+      };
+    });
+
+    const summary = await hermesInboxSyncService.pollInboxes({
+      abortSignal: new AbortController().signal,
+      deadlineMs: Date.now() + 60_000,
+      shouldContinue: () => true,
+    });
+
+    expect(summary.breakdown.error).toBe(1);
+    expect(summary.breakdown.no_messages).toBe(5);
+    // A lone self-healing 502/timeout must not page anyone.
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/services/hermes-inbox-sync.service.ts
+++ b/apps/core/src/services/hermes-inbox-sync.service.ts
@@ -23,6 +23,15 @@ const HERMES_INBOX_MESSAGE_UUID_NAMESPACE =
   "3ed84820-2c89-4546-9a58-96b20f8b4980";
 
 /**
+ * Outage-alert thresholds for the batch poll. We only escalate transient
+ * orchestrator failures to Sentry when they dominate a non-trivial batch —
+ * the signature of an actual orchestrator outage. A single 502 among
+ * otherwise-healthy polls self-heals on the next cycle and must not alert.
+ */
+const OUTAGE_MIN_POLLED_FOR_ALERT = 5;
+const OUTAGE_TRANSIENT_RATIO = 0.5;
+
+/**
  * Returns true for errors that represent transient external-service failures
  * (Hermes orchestrator 5xx responses, network connect timeouts, etc.) that are
  * expected to self-resolve on the next poll cycle. These should NOT be reported
@@ -416,12 +425,33 @@ async function pollInboxes(
     }
   }
 
-  // Report one aggregate event for all transient orchestrator errors so the
-  // team sees one Sentry alert per outage window, not one per affected user.
-  if (transientErrorCount > 0) {
-    Sentry.captureException(firstTransientError, {
+  // Escalate to Sentry only when transient orchestrator failures dominate a
+  // non-trivial batch — the signature of an actual orchestrator outage rather
+  // than the occasional self-healing 502. Reporting every batch that had a
+  // single failed poll kept SOKOSUMI-CORE-1M perpetually "regressed" (the cron
+  // runs each minute and one 502 among healthy polls recovers next cycle).
+  //
+  // Use captureMessage with a dedicated fingerprint so this forms its own
+  // outage issue instead of re-grouping under the raw HermesOrchestratorError —
+  // re-capturing that exception would revive the per-request 502 issue we are
+  // deliberately muting. The representative error rides along in `extra`.
+  const isLikelyOutage =
+    polled >= OUTAGE_MIN_POLLED_FOR_ALERT &&
+    transientErrorCount >= Math.ceil(polled * OUTAGE_TRANSIENT_RATIO);
+
+  if (isLikelyOutage) {
+    Sentry.captureMessage("hermes_inbox_orchestrator_outage", {
+      level: "error",
+      fingerprint: ["hermes-inbox-orchestrator-outage"],
       tags: { context: "hermes_inbox_poll_batch" },
-      extra: { transientErrorCount, polled },
+      extra: {
+        transientErrorCount,
+        polled,
+        sampleError:
+          firstTransientError instanceof Error
+            ? firstTransientError.message
+            : String(firstTransientError),
+      },
     });
   }
 


### PR DESCRIPTION
## What

Fixes the noise behind Sentry issue **SOKOSUMI-CORE-1M** (`Error: Hermes orchestrator error (502)`, surfacing via the per-minute cron `GET /sync/hermes/poll-inboxes`).

## Why

The previous fix (#3061) collapsed per-user reports into one aggregate event per batch, but the batch poller still called `Sentry.captureException(firstTransientError, …)` for **any** batch with ≥1 transient error, passing the raw `HermesOrchestratorError`. Because the cron runs every minute and Sentry groups by exception type + stack, a single self-healing 502 among healthy polls (the latest event showed `transientErrorCount: 1, polled: 9`) kept re-landing in the SOKOSUMI-CORE-1M group and held the issue perpetually **regressed**.

## Change

In `apps/core/src/services/hermes-inbox-sync.service.ts`:

- Added thresholds `OUTAGE_MIN_POLLED_FOR_ALERT = 5` and `OUTAGE_TRANSIENT_RATIO = 0.5`.
- Escalate to Sentry **only** when transient failures dominate a non-trivial batch (≥5 polled **and** ≥50% transient) — the signature of an actual orchestrator outage. Isolated blips are absorbed silently (they recover next cycle and already bump the per-instance `consecutivePollErrors` counter).
- Switched from `captureException(rawError)` to `captureMessage("hermes_inbox_orchestrator_outage", …)` with a dedicated `fingerprint`, so outages form their own clean issue instead of reviving the per-request 502 group. The representative error message rides along in `extra.sampleError`.

## User-facing impact

No behavior change for end users. Operationally: Sentry stops firing on isolated, self-healing orchestrator 502s and only pages on genuine outage windows under a distinct, clearly-named issue.

## Verification

- `pnpm --filter @sokosumi/core test` for the two inbox-sync suites — **15 passed** (added coverage: escalates when transient failures dominate; stays silent on an isolated failure).
- `tsc --noEmit` clean.
- Biome check clean.

## Follow-up

The existing SOKOSUMI-CORE-1M issue will likely need to be **manually marked resolved** in Sentry once this deploys — the new code intentionally no longer reports into that group, so no `Fixes SOKOSUMI-CORE-1M` trailer was used (that would mis-link an unrelated commit reference).

https://claude.ai/code/session_019jhBHtFHaMuHAqCAf79kVY

---
_Generated by [Claude Code](https://claude.ai/code/session_019jhBHtFHaMuHAqCAf79kVY)_