### PR TITLE
fix(web): make relative time hydration-safe in members table and ratings

### DIFF
--- a/apps/web/src/components/__tests__/time-ago.test.tsx
+++ b/apps/web/src/components/__tests__/time-ago.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TimeAgo } from "@/components/time-ago";
+
+describe("TimeAgo", () => {
+  it("renders a stable, UTC-pinned absolute date on the server (no effects)", () => {
+    // The server render (and the matching first client render) must emit a
+    // deterministic absolute date rather than a clock-dependent relative
+    // string, otherwise SSR and hydration diverge (Sentry SOKOSUMI-A).
+    const date = new Date("2026-04-15T10:00:00.000Z");
+
+    const markup = renderToStaticMarkup(<TimeAgo date={date} strict />);
+
+    expect(markup).toContain("Apr 15, 10:00");
+    expect(markup).not.toMatch(/ago/);
+    expect(markup).toContain(date.toISOString());
+  });
+
+  it("swaps to the live relative string after mount on the client", () => {
+    const date = new Date(Date.now() - 60_000);
+
+    // Testing Library flushes effects, so the post-mount relative label applies.
+    render(<TimeAgo date={date} strict />);
+
+    expect(screen.getByText(/ago$/)).toBeInTheDocument();
+  });
+
+  it("renders an em dash for an invalid date", () => {
+    render(<TimeAgo date="not-a-date" />);
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/agents/rating-list-item.tsx
+++ b/apps/web/src/components/agents/rating-list-item.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import type { UserAgentRatingWithUser } from "@sokosumi/database";
-import { formatDistanceToNow } from "date-fns";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { StarRating } from "@/components/agents/star-rating";
+import { TimeAgo } from "@/components/time-ago";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 
@@ -45,9 +45,10 @@ export function RatingListItem({ rating }: RatingListItemProps) {
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
             <span className="text-sm font-medium">{rating.user.name}</span>
-            <span className="text-muted-foreground/40 text-xs whitespace-nowrap">
-              {formatDistanceToNow(rating.createdAt, { addSuffix: true })}
-            </span>
+            <TimeAgo
+              date={rating.createdAt}
+              className="text-muted-foreground/40 text-xs whitespace-nowrap"
+            />
           </div>
           <div className="mt-1">
             <StarRating averageRating={rating.rating} size="sm" />

--- a/apps/web/src/components/members-table/members-table-columns.tsx
+++ b/apps/web/src/components/members-table/members-table-columns.tsx
@@ -2,10 +2,10 @@
 
 import type { Member } from "@sokosumi/database";
 import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { formatDistanceToNowStrict } from "date-fns";
 import { useTranslations } from "next-intl";
 import { DataTableColumnHeader } from "@/components/data-table";
 import { OrganizationRoleBadge } from "@/components/organizations";
+import { TimeAgo } from "@/components/time-ago";
 import InvitationActionsDropdown from "./invitation-actions-dropdown";
 import MemberActionsDropdown from "./member-actions-dropdown";
 import { useSeatManagementContext } from "./seat-management-context";
@@ -76,7 +76,7 @@ export function getMembersTableColumns(
         }
         return (
           <div className="p-2 whitespace-nowrap">
-            {formatDistanceToNowStrict(lastSeenAt, { addSuffix: true })}
+            <TimeAgo date={lastSeenAt} strict />
           </div>
         );
       },

--- a/apps/web/src/components/time-ago.tsx
+++ b/apps/web/src/components/time-ago.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { formatDistanceToNow, formatDistanceToNowStrict } from "date-fns";
+import { useEffect, useState } from "react";
+
+import { formatShortDateTime } from "@/lib/utils/datetime";
+
+interface TimeAgoProps {
+  /** The timestamp to render relative to the current time. */
+  date: string | Date;
+  /** Append an "ago"/"in" suffix. Defaults to true. */
+  addSuffix?: boolean;
+  /**
+   * Use date-fns `formatDistanceToNowStrict` (a single, exact unit) instead
+   * of `formatDistanceToNow` (which adds "about", "almost", etc.). Defaults
+   * to false.
+   */
+  strict?: boolean;
+  /** Locale used for the SSR-stable absolute-date fallback. */
+  locale?: string;
+  className?: string;
+}
+
+/**
+ * Renders a relative "time ago" string that is safe to server-render.
+ *
+ * Relative time is derived from the current clock, which advances between the
+ * server render and the client hydration. Computing it during SSR and again
+ * during hydration therefore yields different text and triggers a hydration
+ * mismatch (Sentry SOKOSUMI-A). To stay deterministic, we render a stable,
+ * UTC-pinned absolute date during SSR and the first client render, then swap
+ * to the live relative string after mount — a client-only update that cannot
+ * mismatch the server output.
+ */
+export function TimeAgo({
+  date,
+  addSuffix = true,
+  strict = false,
+  locale = "en",
+  className,
+}: TimeAgoProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(dateObj.getTime())) {
+    return <span className={className}>—</span>;
+  }
+
+  const absolute = formatShortDateTime(dateObj, locale);
+  const label = mounted
+    ? strict
+      ? formatDistanceToNowStrict(dateObj, { addSuffix })
+      : formatDistanceToNow(dateObj, { addSuffix })
+    : absolute;
+
+  return (
+    <time
+      dateTime={dateObj.toISOString()}
+      title={absolute}
+      className={className}
+    >
+      {label}
+    </time>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the React hydration error reported in Sentry **SOKOSUMI-A** on `/organizations/[organizationSlug]` (1,961 occurrences across Chrome/Firefox/Safari).

### Root cause

The "Last seen" column of the members table rendered relative time with `formatDistanceToNowStrict(lastSeenAt, { addSuffix: true })`. Although the component is `"use client"`, Next.js still server-renders it for the initial HTML. The relative string ("5 seconds ago") is computed against `Date.now()` at **SSR time** and recomputed at **hydration time** on the client. Because real time elapses between those two moments (network + JS load), the strings differ for recently-seen rows → text-content hydration mismatch. The same latent pattern existed in the agent `rating-list-item.tsx`.

### Fix

- Add a reusable client-mounted **`TimeAgo`** component that renders a deterministic, UTC-pinned absolute date (via the existing `formatShortDateTime` / `HYDRATION_STABLE_TIME_ZONE` convention) during SSR and the first client render, then swaps to the live relative string after mount — a client-only update that cannot mismatch the server output. Guards invalid dates and emits a semantic `<time dateTime title>` element.
- Use it in the members table last-seen column (the SOKOSUMI-A culprit) and the rating list item (shared latent bug).

## User-facing impact

No visible change in steady state. Briefly, a stable absolute date is shown on first paint before it swaps to the relative "time ago" string after mount — eliminating the hydration error and the resulting console noise/replay error.

## Verification

- `pnpm --filter web exec biome check` — clean on all changed files
- `tsc --noEmit` — clean
- New `time-ago.test.tsx` — 3/3 pass (SSR-stable output, post-mount relative swap, invalid-date handling)
- Existing members-table + agents tests — 24 passed / 1 skipped, no regressions

Fixes SOKOSUMI-A

https://claude.ai/code/session_01DzmswBf5sGjtmowch9LpPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzmswBf5sGjtmowch9LpPa)_