### PR TITLE
fix(core): treat delegated coworkers as the user for task writes

### DIFF
--- a/apps/core/src/helpers/task.test.ts
+++ b/apps/core/src/helpers/task.test.ts
@@ -599,6 +599,37 @@ describe("validateStatusTransition", () => {
       ).toThrow();
     });
   });
+
+  describe("delegated coworker acts as the user", () => {
+    const delegatedCoworkerContext: AuthenticationContext = {
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: {
+        userId: "user_123",
+        organizationId: null,
+      },
+    };
+
+    it("allows a user-side transition (DRAFT → READY)", () => {
+      expect(() =>
+        validateStatusTransition(
+          delegatedCoworkerContext,
+          TaskStatus.DRAFT,
+          TaskStatus.READY,
+        ),
+      ).not.toThrow();
+    });
+
+    it("rejects an agent-only transition (READY → RUNNING)", () => {
+      expect(() =>
+        validateStatusTransition(
+          delegatedCoworkerContext,
+          TaskStatus.READY,
+          TaskStatus.RUNNING,
+        ),
+      ).toThrow("Invalid status transition from READY to RUNNING");
+    });
+  });
 });
 
 describe("validateTaskCoworkerAssignment", () => {

--- a/apps/core/src/helpers/task.ts
+++ b/apps/core/src/helpers/task.ts
@@ -1,7 +1,7 @@
 import { convertCentsToCredits, TaskStatus } from "@sokosumi/utils";
 
 import type { AuthenticationContext } from "@/middleware/auth";
-import { isCoworkerAuthContext } from "@/middleware/auth";
+import { isCoworkerAgentContext } from "@/middleware/auth";
 import { flattenJob } from "@/types/job";
 import {
   type TaskListItemWithIncludes,
@@ -47,7 +47,9 @@ interface ValidateTaskCoworkerAssignmentParams {
 function getAllowedTransitions(
   authContext: AuthenticationContext,
 ): Record<TaskStatus, TaskStatus[]> {
-  if (isCoworkerAuthContext(authContext)) {
+  // A coworker acting as itself (the agent) uses the agent transition table.
+  // A delegated coworker acts as the user, so it falls through to the user table.
+  if (isCoworkerAgentContext(authContext)) {
     return {
       [TaskStatus.DRAFT]: [],
       [TaskStatus.READY]: [

--- a/apps/core/src/middleware/auth.ts
+++ b/apps/core/src/middleware/auth.ts
@@ -91,6 +91,20 @@ export function isCoworkerAuthContext(
 }
 
 /**
+ * True only for a coworker acting as itself — the agent, with no delegation headers.
+ * A coworker that supplies delegation acts as the delegated user, so this returns
+ * false for it (use {@link requireUserContext} / the user code paths in that case).
+ *
+ * Use to gate agent-only semantics (coworker status transitions, agent task
+ * payments) that must NOT apply when a coworker is impersonating a user.
+ */
+export function isCoworkerAgentContext(
+  authContext: AuthenticationContext,
+): authContext is CoworkerAuthenticationContext {
+  return isCoworkerAuthContext(authContext) && !authContext.delegation;
+}
+
+/**
  * Effective user context for a handler: either a Better Auth session (`source: "session"`)
  * or a coworker API key with delegation headers (`source: "delegation"`). Use
  * {@link requireUserAuthContext} when the operation must not run under coworker

--- a/apps/core/src/middleware/auth.ts
+++ b/apps/core/src/middleware/auth.ts
@@ -97,10 +97,14 @@ export function isCoworkerAuthContext(
  *
  * Use to gate agent-only semantics (coworker status transitions, agent task
  * payments) that must NOT apply when a coworker is impersonating a user.
+ *
+ * Returns a plain boolean, not a type predicate: a `false` result is not
+ * necessarily a user — it may be a delegated coworker — so narrowing the
+ * negative branch to `UserAuthenticationContext` would be unsound.
  */
 export function isCoworkerAgentContext(
   authContext: AuthenticationContext,
-): authContext is CoworkerAuthenticationContext {
+): boolean {
   return isCoworkerAuthContext(authContext) && !authContext.delegation;
 }
 

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -766,4 +766,84 @@ describe("POST /{id}/events", () => {
       }),
     );
   });
+
+  it("rejects credits from a user session canceling a task", async () => {
+    requireTaskCollaborationMock.mockResolvedValue(
+      createTask({ status: TaskStatus.READY, coworkerId: null }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn(),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "user",
+      userId: USER_ID,
+      organizationId: null,
+      role: "user",
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+        credits: 5,
+      }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+    expect(tx.task.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects masumiPayment from a delegated coworker", async () => {
+    requireTaskCollaborationMock.mockResolvedValue(
+      createTask({ status: TaskStatus.READY, coworkerId: null }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn(),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+      delegation: {
+        userId: USER_ID,
+        organizationId: null,
+      },
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+        masumiPayment: validMasumiPaymentBody,
+      }),
+    });
+
+    // masumiPayment is schema-restricted to COMPLETED, which a delegated
+    // coworker can never reach; the request is rejected before any charge.
+    expect(response.status).not.toBe(201);
+    expect(createPurchaseFromMasumiTaskPaymentMock).not.toHaveBeenCalled();
+    expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -589,7 +589,7 @@ describe("POST /{id}/events", () => {
     expect(createPurchaseFromMasumiTaskPaymentMock).not.toHaveBeenCalled();
   });
 
-  it("attributes a delegated coworker's comment to the delegated user", async () => {
+  it("attributes a delegated coworker's comment to the user and the acting coworker", async () => {
     const tx: TransactionMock = {
       taskEvent: {
         create: vi.fn().mockResolvedValue(
@@ -597,7 +597,7 @@ describe("POST /{id}/events", () => {
             status: null,
             comment: "On behalf of the user",
             userId: USER_ID,
-            coworkerId: null,
+            coworkerId: COWORKER_ID,
           }),
         ),
       },
@@ -626,12 +626,14 @@ describe("POST /{id}/events", () => {
     });
 
     expect(response.status).toBe(201);
+    // Recorded against the delegated user, but the acting coworker is retained
+    // so the audit trail is not a forged user-only record.
     expect(tx.taskEvent.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           comment: "On behalf of the user",
           userId: USER_ID,
-          coworkerId: null,
+          coworkerId: COWORKER_ID,
         }),
       }),
     );
@@ -726,7 +728,7 @@ describe("POST /{id}/events", () => {
           createTaskEvent({
             status: TaskStatus.CANCELED,
             userId: USER_ID,
-            coworkerId: null,
+            coworkerId: COWORKER_ID,
           }),
         ),
       },
@@ -761,7 +763,7 @@ describe("POST /{id}/events", () => {
         data: expect.objectContaining({
           status: TaskStatus.CANCELED,
           userId: USER_ID,
-          coworkerId: null,
+          coworkerId: COWORKER_ID,
         }),
       }),
     );

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -588,4 +588,182 @@ describe("POST /{id}/events", () => {
     expect(tx.taskEvent.create).not.toHaveBeenCalled();
     expect(createPurchaseFromMasumiTaskPaymentMock).not.toHaveBeenCalled();
   });
+
+  it("attributes a delegated coworker's comment to the delegated user", async () => {
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn().mockResolvedValue(
+          createTaskEvent({
+            status: null,
+            comment: "On behalf of the user",
+            userId: USER_ID,
+            coworkerId: null,
+          }),
+        ),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+      delegation: {
+        userId: USER_ID,
+        organizationId: null,
+      },
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        comment: "On behalf of the user",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          comment: "On behalf of the user",
+          userId: USER_ID,
+          coworkerId: null,
+        }),
+      }),
+    );
+  });
+
+  it("rejects an agent-only transition for a delegated coworker", async () => {
+    requireTaskCollaborationMock.mockResolvedValue(
+      createTask({ status: TaskStatus.READY }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn(),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+      delegation: {
+        userId: USER_ID,
+        organizationId: null,
+      },
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.RUNNING,
+      }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+    expect(tx.task.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects credits from a delegated coworker canceling a task", async () => {
+    requireTaskCollaborationMock.mockResolvedValue(
+      createTask({ status: TaskStatus.READY, coworkerId: null }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn(),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+      delegation: {
+        userId: USER_ID,
+        organizationId: null,
+      },
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+        credits: 5,
+      }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+    expect(tx.task.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("lets a delegated coworker cancel a task without charging", async () => {
+    requireTaskCollaborationMock.mockResolvedValue(
+      createTask({ status: TaskStatus.READY, coworkerId: null }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn().mockResolvedValue(
+          createTaskEvent({
+            status: TaskStatus.CANCELED,
+            userId: USER_ID,
+            coworkerId: null,
+          }),
+        ),
+      },
+      task: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+      delegation: {
+        userId: USER_ID,
+        organizationId: null,
+      },
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: TaskStatus.CANCELED,
+          userId: USER_ID,
+          coworkerId: null,
+        }),
+      }),
+    );
+  });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -28,7 +28,8 @@ import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import {
   type AuthenticationContext,
-  isCoworkerAuthContext,
+  isCoworkerAgentContext,
+  isUserAuthContext,
 } from "@/middleware/auth";
 import { taskEventSchema } from "@/schemas/task.schema";
 
@@ -42,17 +43,25 @@ const paramsSchema = z.object({
 });
 
 function getActorData(authContext: AuthenticationContext) {
-  if (isCoworkerAuthContext(authContext)) {
-    return {
-      userId: null,
-      coworkerId: authContext.coworkerId,
-    };
-  } else {
+  if (isUserAuthContext(authContext)) {
     return {
       userId: authContext.userId,
       coworkerId: null,
     };
   }
+
+  // A delegated coworker acts as the user, so the event is attributed to that user.
+  if (authContext.delegation) {
+    return {
+      userId: authContext.delegation.userId,
+      coworkerId: null,
+    };
+  }
+
+  return {
+    userId: null,
+    coworkerId: authContext.coworkerId,
+  };
 }
 
 async function mapCreatedTaskEventForResponse(
@@ -125,11 +134,24 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             coworkerId: task.coworkerId,
           });
 
+          // Billing is settled only by the assigned coworker agent. User and
+          // delegated-coworker callers use the user transition table, and the
+          // charge branch below is gated on isCoworkerAgentContext — so credits
+          // or masumiPayment from them would be silently dropped. Reject it.
+          if (
+            !isCoworkerAgentContext(authContext) &&
+            (credits != null || masumiPayment !== undefined)
+          ) {
+            throw unprocessableEntity(
+              "Only the assigned coworker can set credits or masumiPayment when changing task status",
+            );
+          }
+
           let cents: bigint | undefined;
           let transactionId: string | null = null;
 
           if (
-            isCoworkerAuthContext(authContext) &&
+            isCoworkerAgentContext(authContext) &&
             isTaskStatusSpendable(status)
           ) {
             if (masumiPayment) {
@@ -197,7 +219,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
           const payment =
             masumiPayment !== undefined &&
-            isCoworkerAuthContext(authContext) &&
+            isCoworkerAgentContext(authContext) &&
             isTaskStatusSpendable(status)
               ? masumiPayment
               : null;

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -137,13 +137,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           // Billing is settled only by the assigned coworker agent. User and
           // delegated-coworker callers use the user transition table, and the
           // charge branch below is gated on isCoworkerAgentContext — so credits
-          // or masumiPayment from them would be silently dropped. Reject it.
-          if (
-            !isCoworkerAgentContext(authContext) &&
-            (credits != null || masumiPayment !== undefined)
-          ) {
+          // from them would be silently dropped. Reject it.
+          //
+          // masumiPayment needs no check here: the schema only allows it with
+          // status COMPLETED, which the user transition table can never reach,
+          // so a non-agent caller is already rejected upstream (400/422).
+          if (!isCoworkerAgentContext(authContext) && credits != null) {
             throw unprocessableEntity(
-              "Only the assigned coworker can set credits or masumiPayment when changing task status",
+              "Only the assigned coworker can set credits when changing task status",
             );
           }
 

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -50,11 +50,14 @@ function getActorData(authContext: AuthenticationContext) {
     };
   }
 
-  // A delegated coworker acts as the user, so the event is attributed to that user.
+  // A delegated coworker acts on behalf of the user: attribute the event to the
+  // delegated user, but keep the coworker that actually performed it so the
+  // audit trail shows "coworker X on behalf of user Y", not a forged
+  // user-only record. (See SOK-554: delegation is currently broad.)
   if (authContext.delegation) {
     return {
       userId: authContext.delegation.userId,
-      coworkerId: null,
+      coworkerId: authContext.coworkerId,
     };
   }
 

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -134,15 +134,18 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             coworkerId: task.coworkerId,
           });
 
-          // Billing is settled only by the assigned coworker agent. User and
-          // delegated-coworker callers use the user transition table, and the
-          // charge branch below is gated on isCoworkerAgentContext — so credits
-          // from them would be silently dropped. Reject it.
+          // Only the assigned coworker agent settles billing.
+          const isAgent = isCoworkerAgentContext(authContext);
+          const isAgentSpend = isAgent && isTaskStatusSpendable(status);
+
+          // User and delegated-coworker callers use the user transition table,
+          // and the charge branch below is gated on isAgent — so credits from
+          // them would be silently dropped. Reject it.
           //
           // masumiPayment needs no check here: the schema only allows it with
           // status COMPLETED, which the user transition table can never reach,
           // so a non-agent caller is already rejected upstream (400/422).
-          if (!isCoworkerAgentContext(authContext) && credits != null) {
+          if (!isAgent && credits != null) {
             throw unprocessableEntity(
               "Only the assigned coworker can set credits when changing task status",
             );
@@ -151,10 +154,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           let cents: bigint | undefined;
           let transactionId: string | null = null;
 
-          if (
-            isCoworkerAgentContext(authContext) &&
-            isTaskStatusSpendable(status)
-          ) {
+          if (isAgentSpend) {
             if (masumiPayment) {
               console.info("[tasks] masumi task payment: using masumiPayment", {
                 masumiPayment,
@@ -219,11 +219,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           }
 
           const payment =
-            masumiPayment !== undefined &&
-            isCoworkerAgentContext(authContext) &&
-            isTaskStatusSpendable(status)
-              ? masumiPayment
-              : null;
+            masumiPayment !== undefined && isAgentSpend ? masumiPayment : null;
 
           return {
             event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
@@ -15,7 +15,7 @@ const { createAgentJobForUserMock, flattenJobMock, requireTaskAccessMock } =
   }));
 
 vi.mock("@/helpers/access-control", () => ({
-  requireTaskCollaboration: requireTaskAccessMock,
+  requireCoworkerTaskCollaboration: requireTaskAccessMock,
 }));
 
 vi.mock("@/helpers/job", () => ({
@@ -141,7 +141,7 @@ describe("POST /tasks/{id}/jobs", () => {
     );
   });
 
-  it("forwards the delegation context to task collaboration access", async () => {
+  it("uses assigned-agent collaboration, not delegation, to resolve the task", async () => {
     const app = createApp({
       actor: "coworker",
       coworkerId: "cow_123",
@@ -159,56 +159,15 @@ describe("POST /tasks/{id}/jobs", () => {
       body: requestBody,
     });
 
+    // The endpoint is coworker-scoped and routes through the coworker-only
+    // helper, which ignores delegation (assignment is enforced internally).
     expect(response.status).toBe(201);
     expect(requireTaskAccessMock).toHaveBeenCalledWith(
       expect.objectContaining({
         actor: "coworker",
         coworkerId: "cow_123",
-        delegation: {
-          userId: "user_123",
-          organizationId: "org_123",
-        },
       }),
       "tsk_123",
     );
-    expect(createAgentJobForUserMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: {
-          userId: "user_123",
-          organizationId: "org_123",
-          workspaceId: "11111111-1111-7111-8111-111111111111",
-        },
-      }),
-    );
-  });
-
-  it("rejects adding a job to a draft task", async () => {
-    requireTaskAccessMock.mockResolvedValue({
-      id: "tsk_123",
-      userId: "user_123",
-      organizationId: "org_123",
-      workspaceId: "11111111-1111-7111-8111-111111111111",
-      status: TaskStatus.DRAFT,
-    });
-
-    const app = createApp({
-      actor: "coworker",
-      coworkerId: "cow_123",
-      delegation: {
-        userId: "user_123",
-        organizationId: "org_123",
-      },
-    });
-
-    const response = await app.request("http://localhost/tsk_123/jobs", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: requestBody,
-    });
-
-    expect(response.status).toBe(422);
-    expect(createAgentJobForUserMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
@@ -181,4 +181,34 @@ describe("POST /tasks/{id}/jobs", () => {
       }),
     );
   });
+
+  it("rejects adding a job to a draft task", async () => {
+    requireTaskAccessMock.mockResolvedValue({
+      id: "tsk_123",
+      userId: "user_123",
+      organizationId: "org_123",
+      workspaceId: "11111111-1111-7111-8111-111111111111",
+      status: TaskStatus.DRAFT,
+    });
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: {
+        userId: "user_123",
+        organizationId: "org_123",
+      },
+    });
+
+    const response = await app.request("http://localhost/tsk_123/jobs", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: requestBody,
+    });
+
+    expect(response.status).toBe(422);
+    expect(createAgentJobForUserMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.test.ts
@@ -15,7 +15,7 @@ const { createAgentJobForUserMock, flattenJobMock, requireTaskAccessMock } =
   }));
 
 vi.mock("@/helpers/access-control", () => ({
-  requireCoworkerTaskCollaboration: requireTaskAccessMock,
+  requireTaskCollaboration: requireTaskAccessMock,
 }));
 
 vi.mock("@/helpers/job", () => ({
@@ -27,17 +27,14 @@ vi.mock("@/types/job", () => ({
 }));
 
 describe("POST /tasks/{id}/jobs", () => {
-  function createApp() {
+  function createApp(authContext: AuthVariables["authContext"]) {
     const app = new OpenAPIHono<{
       Variables: AuthVariables;
     }>();
 
     app.use("*", async (c, next) => {
       c.set("isAuthenticated", true);
-      c.set("authContext", {
-        actor: "coworker",
-        coworkerId: "cow_123",
-      });
+      c.set("authContext", authContext);
 
       return await next();
     });
@@ -98,30 +95,35 @@ describe("POST /tasks/{id}/jobs", () => {
     });
   });
 
+  const requestBody = JSON.stringify({
+    agentId: "agent_123",
+    inputSchema: {
+      input_data: [
+        {
+          id: "prompt",
+          type: "string",
+          name: "Prompt",
+        },
+      ],
+    },
+    inputData: {
+      prompt: "hello",
+    },
+    maxCredits: 5,
+  });
+
   it("inherits workspace placement from the parent task", async () => {
-    const app = createApp();
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+    });
 
     const response = await app.request("http://localhost/tsk_123/jobs", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        agentId: "agent_123",
-        inputSchema: {
-          input_data: [
-            {
-              id: "prompt",
-              type: "string",
-              name: "Prompt",
-            },
-          ],
-        },
-        inputData: {
-          prompt: "hello",
-        },
-        maxCredits: 5,
-      }),
+      body: requestBody,
     });
 
     expect(response.status).toBe(201);
@@ -134,6 +136,47 @@ describe("POST /tasks/{id}/jobs", () => {
         },
         taskContext: {
           taskId: "tsk_123",
+        },
+      }),
+    );
+  });
+
+  it("forwards the delegation context to task collaboration access", async () => {
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: {
+        userId: "user_123",
+        organizationId: "org_123",
+      },
+    });
+
+    const response = await app.request("http://localhost/tsk_123/jobs", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: requestBody,
+    });
+
+    expect(response.status).toBe(201);
+    expect(requireTaskAccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: "coworker",
+        coworkerId: "cow_123",
+        delegation: {
+          userId: "user_123",
+          organizationId: "org_123",
+        },
+      }),
+      "tsk_123",
+    );
+    expect(createAgentJobForUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: {
+          userId: "user_123",
+          organizationId: "org_123",
+          workspaceId: "11111111-1111-7111-8111-111111111111",
         },
       }),
     );

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { requireCoworkerTaskCollaboration } from "@/helpers/access-control";
+import { requireTaskCollaboration } from "@/helpers/access-control";
 import { createAgentJobForUser } from "@/helpers/job";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { created } from "@/helpers/response";
@@ -48,7 +48,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const authContext = requireCoworkerAuthContext(c.var.authContext);
 
     const { id: taskId } = c.req.valid("param");
-    const task = await requireCoworkerTaskCollaboration(authContext, taskId);
+    const task = await requireTaskCollaboration(authContext, taskId);
 
     const { agentId, inputData, inputSchema, maxCredits, name } =
       c.req.valid("json");

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
@@ -52,9 +52,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id: taskId } = c.req.valid("param");
     const task = await requireTaskCollaboration(authContext, taskId);
 
-    // The non-delegated coworker path already excludes DRAFT tasks; the
-    // delegated path resolves via task ownership, which does not. Jobs cannot
-    // be added to a task that is not ready, so reject DRAFT here too.
+    // The non-delegated coworker path already excludes DRAFT inside
+    // requireCoworkerTaskCollaboration, which returns 404 to avoid leaking task
+    // existence to an unassigned agent. The delegated/owner path resolves via
+    // task ownership, which does not exclude DRAFT; since that caller already
+    // knows the task exists, reject DRAFT with an explanatory 422 rather than a
+    // 404. The differing status codes are intentional, not an oversight.
     if (task.status === TaskStatus.DRAFT) {
       throw unprocessableEntity("Cannot add a job to a draft task");
     }

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
@@ -1,6 +1,8 @@
 import { createRoute, z } from "@hono/zod-openapi";
+import { TaskStatus } from "@sokosumi/utils";
 
 import { requireTaskCollaboration } from "@/helpers/access-control";
+import { unprocessableEntity } from "@/helpers/error";
 import { createAgentJobForUser } from "@/helpers/job";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { created } from "@/helpers/response";
@@ -49,6 +51,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const { id: taskId } = c.req.valid("param");
     const task = await requireTaskCollaboration(authContext, taskId);
+
+    // The non-delegated coworker path already excludes DRAFT tasks; the
+    // delegated path resolves via task ownership, which does not. Jobs cannot
+    // be added to a task that is not ready, so reject DRAFT here too.
+    if (task.status === TaskStatus.DRAFT) {
+      throw unprocessableEntity("Cannot add a job to a draft task");
+    }
 
     const { agentId, inputData, inputSchema, maxCredits, name } =
       c.req.valid("json");

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
@@ -1,8 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { TaskStatus } from "@sokosumi/utils";
 
-import { requireTaskCollaboration } from "@/helpers/access-control";
-import { unprocessableEntity } from "@/helpers/error";
+import { requireCoworkerTaskCollaboration } from "@/helpers/access-control";
 import { createAgentJobForUser } from "@/helpers/job";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { created } from "@/helpers/response";
@@ -50,17 +48,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const authContext = requireCoworkerAuthContext(c.var.authContext);
 
     const { id: taskId } = c.req.valid("param");
-    const task = await requireTaskCollaboration(authContext, taskId);
-
-    // The non-delegated coworker path already excludes DRAFT inside
-    // requireCoworkerTaskCollaboration, which returns 404 to avoid leaking task
-    // existence to an unassigned agent. The delegated/owner path resolves via
-    // task ownership, which does not exclude DRAFT; since that caller already
-    // knows the task exists, reject DRAFT with an explanatory 422 rather than a
-    // 404. The differing status codes are intentional, not an oversight.
-    if (task.status === TaskStatus.DRAFT) {
-      throw unprocessableEntity("Cannot add a job to a draft task");
-    }
+    // Assigned-agent-only collaboration: this endpoint is coworker-scoped and
+    // intentionally does NOT honor delegation. Delegated/user job creation goes
+    // through the user-context routes (agents/{id}/jobs, projects/{id}/jobs).
+    // See SOK-554: per-coworker delegation authz before broadening this.
+    const task = await requireCoworkerTaskCollaboration(authContext, taskId);
 
     const { agentId, inputData, inputSchema, maxCredits, name } =
       c.req.valid("json");


### PR DESCRIPTION
## Summary

Makes coworker **delegation** behave consistently on task **events**: a coworker that supplies `X-Delegation-User-Id` acts **as the delegated user**, not as the agent. Also hardens billing-field handling.

> **Scope note:** an earlier revision also made `POST /tasks/{id}/jobs` delegation-aware. That was reverted (see below) after a security review — that endpoint stays assigned-agent-only.

## Changes

**1. Task events — treat delegated coworkers as the user** (`events/post.ts`, `helpers/task.ts`, `middleware/auth.ts`)
Added `isCoworkerAgentContext` (coworker *without* delegation) and used it to gate agent-only semantics:
- `getAllowedTransitions`: a delegated coworker now uses the **user** transition table — may do user-side transitions (e.g. `DRAFT → READY`, cancel a not-yet-run task) but not agent-only ones (e.g. `READY → RUNNING`).
- `getActorData`: delegated events are attributed to the **delegated user**.
- The masumi/credit charge branch is gated on `isCoworkerAgentContext`, so a delegated coworker never drives agent billing. (Net effect: this PR *removes* a delegated-payment vector that previously existed on this route.)

**2. Reject silently-dropped billing fields** (`events/post.ts`)
The charge branch is agent-only, so a non-agent caller (user session *or* delegated coworker) sending `credits` on a spendable status (e.g. `CANCELED`) used to get a `201` with **no transaction recorded**. Now returns `422`. Closes a pre-existing silent-drop for user sessions too. (`masumiPayment` needs no guard — the schema restricts it to `COMPLETED`, which the user transition table can never reach.)

**3. `isCoworkerAgentContext` returns a plain boolean**
Not a type predicate: a `false` result may be a delegated coworker, so narrowing the negative branch to `UserAuthenticationContext` would be unsound.

## Reverted: delegation on `POST /tasks/{id}/jobs`

A security review (Cursor, HIGH) flagged that routing this endpoint through `requireTaskCollaboration` lets a delegated coworker create jobs (a spend) on a user's task, given the broad delegation-authz model. After investigation it was reverted to `requireCoworkerTaskCollaboration` (assigned-agent-only):
- It's a coworker-scoped collaboration endpoint; delegated/user job creation already has proper homes on the user-context routes (`agents/{id}/jobs`, `projects/{id}/jobs`), so delegation here was redundant.
- Reverting alone is **not** a security fix — the broad-authz gap is systemic and still reachable via those user-context routes.

The real remediation — a per-coworker delegation permission model in `coworkerDelegationMiddleware` (the single chokepoint) — is tracked in **[SOK-554](https://linear.app/masumi/issue/SOK-554)**.

## Behavior (task events)

| caller | task transitions | event attribution | agent billing |
| --- | --- | --- | --- |
| user session | user table | user | no |
| coworker + delegation | **user table** | **delegated user** | no |
| coworker (assigned agent) | coworker table | coworker | yes |

## Verification

- `pnpm --filter @sokosumi/core test` — full suite green
- `pnpm exec biome check` — clean on changed files
- `tsc --noEmit` — clean

New tests cover: delegated transition rules (user table), delegated event attribution, billing fields rejected for non-agent callers (user + delegated), delegated cancel allowed without charge, and `jobs/post` resolving via coworker collaboration (not delegation).

## Follow-up

- **[SOK-554](https://linear.app/masumi/issue/SOK-554)** — per-coworker delegation authorization in `coworkerDelegationMiddleware` (systemic fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
