### PR TITLE
fix(core): authorize coworker delegation on job routes (per-resource)

### DIFF
--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -13,8 +13,10 @@ import {
   requireCoworkerCapability,
   requireCoworkerChatCapability,
   requireCoworkerTaskCollaboration,
+  requireJobCollaboration,
   requireJobOwnership,
   requireJobRead,
+  requireJobReadForRouteVars,
   requireTaskAssignableCoworker,
   requireTaskCollaboration,
   requireTaskOwnership,
@@ -591,5 +593,271 @@ describe("requireJobOwnership", () => {
     await expect(
       requireJobOwnership(sessionUserContext, "job_123", tx),
     ).rejects.toThrow("You can only access your own jobs");
+  });
+});
+
+const delegatedCoworkerContext: CoworkerAuthenticationContext = {
+  actor: "coworker",
+  coworkerId: "cow_123",
+  delegation: {
+    userId: "user_delegate",
+    organizationId: "org_123",
+  },
+};
+
+describe("requireJobReadForRouteVars", () => {
+  it("delegates to workspace read for users", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: userAuthContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await requireJobReadForRouteVars(vars, "job_123", tx);
+
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_123", workspaceId },
+    });
+    expect(tx.coworker.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns not found for a user when the job is not in the workspace", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce(null);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: userAuthContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await expect(
+      requireJobReadForRouteVars(vars, "job_123", tx),
+    ).rejects.toThrow("Job not found");
+  });
+
+  it("allows a delegated coworker to read a job assigned to it", async () => {
+    const tx = createTransactionClient();
+
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    } as never);
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      taskId: "tsk_123",
+    } as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      coworkerId: "cow_123",
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: delegatedCoworkerContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await requireJobReadForRouteVars(vars, "job_123", tx);
+
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_123", workspaceId },
+    });
+    expect(tx.task.findFirst).toHaveBeenCalledWith({
+      where: { id: "tsk_123" },
+      select: { coworkerId: true },
+    });
+  });
+
+  it("rejects a delegated coworker reading a job assigned to another coworker", async () => {
+    const tx = createTransactionClient();
+
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    } as never);
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      taskId: "tsk_123",
+    } as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      coworkerId: "cow_other",
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: delegatedCoworkerContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await expect(
+      requireJobReadForRouteVars(vars, "job_123", tx),
+    ).rejects.toThrow("You can only access jobs assigned to your coworker");
+  });
+
+  it("rejects a delegated coworker reading a job with no task", async () => {
+    const tx = createTransactionClient();
+
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    } as never);
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      taskId: null,
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: delegatedCoworkerContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await expect(
+      requireJobReadForRouteVars(vars, "job_123", tx),
+    ).rejects.toThrow("You can only access jobs assigned to your coworker");
+
+    expect(tx.task.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects a delegated coworker without tasks capability before loading the job", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce(null);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: delegatedCoworkerContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await expect(
+      requireJobReadForRouteVars(vars, "job_123", tx),
+    ).rejects.toThrow("Coworker is not allowed to use tasks");
+
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects a bare coworker without delegation", async () => {
+    const tx = createTransactionClient();
+    const bareCoworkerContext: CoworkerAuthenticationContext = {
+      actor: "coworker",
+      coworkerId: "cow_123",
+    };
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: bareCoworkerContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await expect(
+      requireJobReadForRouteVars(vars, "job_123", tx),
+    ).rejects.toThrow("Delegation headers");
+
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireJobCollaboration", () => {
+  it("uses ownership for users", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+    } as never);
+
+    await requireJobCollaboration(userAuthContext, "job_123", tx);
+
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_123", userId: "user_123" },
+    });
+  });
+
+  it("rejects users that do not own the job", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce(null);
+
+    await expect(
+      requireJobCollaboration(userAuthContext, "job_123", tx),
+    ).rejects.toThrow("You can only access your own jobs");
+  });
+
+  it("allows a delegated coworker to act on a job assigned to it", async () => {
+    const tx = createTransactionClient();
+
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    } as never);
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      taskId: "tsk_123",
+    } as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      coworkerId: "cow_123",
+    } as never);
+
+    await requireJobCollaboration(delegatedCoworkerContext, "job_123", tx);
+
+    expect(tx.job.findFirst).toHaveBeenCalledWith({
+      where: { id: "job_123", userId: "user_delegate" },
+    });
+    expect(tx.task.findFirst).toHaveBeenCalledWith({
+      where: { id: "tsk_123" },
+      select: { coworkerId: true },
+    });
+  });
+
+  it("rejects a delegated coworker acting on a job assigned to another coworker", async () => {
+    const tx = createTransactionClient();
+
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    } as never);
+    vi.mocked(tx.job.findFirst).mockResolvedValueOnce({
+      id: "job_123",
+      taskId: "tsk_123",
+    } as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      coworkerId: "cow_other",
+    } as never);
+
+    await expect(
+      requireJobCollaboration(delegatedCoworkerContext, "job_123", tx),
+    ).rejects.toThrow("You can only access jobs assigned to your coworker");
+  });
+
+  it("rejects a delegated coworker without tasks capability before loading the job", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce(null);
+
+    await expect(
+      requireJobCollaboration(delegatedCoworkerContext, "job_123", tx),
+    ).rejects.toThrow("Coworker is not allowed to use tasks");
+
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects a bare coworker without delegation", async () => {
+    const tx = createTransactionClient();
+    const bareCoworkerContext: CoworkerAuthenticationContext = {
+      actor: "coworker",
+      coworkerId: "cow_123",
+    };
+
+    await expect(
+      requireJobCollaboration(bareCoworkerContext, "job_123", tx),
+    ).rejects.toThrow("Delegation headers");
+
+    expect(tx.job.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -338,3 +338,125 @@ export async function requireJobRead(
 
   return job;
 }
+
+// -----------------------------------------------------------------------------
+// Job collaboration (delegated coworker must be assigned to the job's task)
+// -----------------------------------------------------------------------------
+
+/**
+ * A delegated coworker may only act on a job whose task is assigned to that
+ * coworker. Jobs have no direct coworker; the relationship is
+ * `Job.taskId -> Task.coworkerId`. Jobs without a task, or whose task is
+ * assigned to a different coworker, are denied.
+ *
+ * @throws {forbidden} If the job is not attached to a task assigned to the coworker
+ */
+async function assertJobAssignedToCoworker(
+  job: Job,
+  coworkerId: string,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<void> {
+  if (job.taskId === null) {
+    throw forbidden("You can only access jobs assigned to your coworker");
+  }
+
+  const task = await tx.task.findFirst({
+    where: { id: job.taskId },
+    select: { coworkerId: true },
+  });
+
+  if (task?.coworkerId !== coworkerId) {
+    throw forbidden("You can only access jobs assigned to your coworker");
+  }
+}
+
+/**
+ * Job read for a workspace-scoped user or an assigned coworker with the tasks
+ * capability. Pass the route `Variables` object (e.g. `c.var` from
+ * `OpenAPIHonoWithAuth`). Mirrors `requireTaskReadForRouteVars` for jobs.
+ *
+ * @throws {forbidden} If a bare coworker (no delegation) is used, or a delegated
+ *   coworker is not assigned to the job's task
+ * @throws {notFound} If the job is not in the active workspace
+ */
+export async function requireJobReadForRouteVars(
+  vars: EnvVariables["Variables"],
+  jobId: string,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<Job> {
+  const { authContext, workspaceContext } = vars;
+
+  if (isUserAuthContext(authContext)) {
+    return await requireJobRead(
+      requireWorkspaceContext(workspaceContext),
+      jobId,
+      tx,
+    );
+  }
+
+  const coworker = requireCoworkerAuthContext(authContext);
+  if (coworker.delegation) {
+    await requireCoworkerCapability(coworker.coworkerId, "tasks", tx);
+
+    const job = await requireJobRead(
+      requireWorkspaceContext(workspaceContext),
+      jobId,
+      tx,
+    );
+
+    await assertJobAssignedToCoworker(job, coworker.coworkerId, tx);
+
+    return job;
+  }
+
+  // Bare coworkers (no delegation) have no user/workspace context for jobs.
+  throw forbidden(
+    "Delegation headers (X-Delegation-User-Id) are required for this resource",
+  );
+}
+
+/**
+ * Collaboration (write) access for a job: the authenticated user must own the
+ * job, or the delegated coworker must have the tasks capability and be assigned
+ * to the job's task. Mirrors `requireTaskCollaboration` for jobs.
+ *
+ * @throws {forbidden} If the user does not own the job, a bare coworker is used,
+ *   or a delegated coworker is not assigned to the job's task
+ */
+export async function requireJobCollaboration(
+  authContext: AuthenticationContext,
+  jobId: string,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<Job> {
+  if (isUserAuthContext(authContext)) {
+    return await requireJobOwnership(
+      { source: "session", ...authContext },
+      jobId,
+      tx,
+    );
+  }
+
+  const coworker = requireCoworkerAuthContext(authContext);
+  if (coworker.delegation) {
+    await requireCoworkerCapability(coworker.coworkerId, "tasks", tx);
+
+    const job = await requireJobOwnership(
+      {
+        source: "delegation",
+        userId: coworker.delegation.userId,
+        organizationId: coworker.delegation.organizationId,
+      },
+      jobId,
+      tx,
+    );
+
+    await assertJobAssignedToCoworker(job, coworker.coworkerId, tx);
+
+    return job;
+  }
+
+  // Bare coworkers (no delegation) have no user/workspace context for jobs.
+  throw forbidden(
+    "Delegation headers (X-Delegation-User-Id) are required for this resource",
+  );
+}

--- a/apps/core/src/helpers/job.test.ts
+++ b/apps/core/src/helpers/job.test.ts
@@ -199,4 +199,70 @@ describe("getUserJobs", () => {
       }),
     );
   });
+
+  it("restricts a delegated coworker to jobs assigned to its tasks", async () => {
+    const tx = {
+      coworker: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "cow_123",
+          slug: "ops-agent",
+          baseURL: null,
+        }),
+      },
+      job: {
+        findMany: vi.fn().mockResolvedValue([]),
+        count: vi.fn().mockResolvedValue(0),
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await getUserJobs(orgJobContext, {
+      take: 20,
+      tx,
+      coworkerId: "cow_123",
+    });
+
+    expect(tx.coworker.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "cow_123",
+          capabilities: { has: "tasks" },
+        }),
+      }),
+    );
+    expect(tx.job.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              userId: "user_123",
+              workspaceId: orgWorkspaceContext.workspaceId,
+            },
+            { task: { coworkerId: "cow_123" } },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("rejects a delegated coworker without the tasks capability", async () => {
+    const tx = {
+      coworker: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      job: {
+        findMany: vi.fn().mockResolvedValue([]),
+        count: vi.fn().mockResolvedValue(0),
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await expect(
+      getUserJobs(orgJobContext, {
+        take: 20,
+        tx,
+        coworkerId: "cow_123",
+      }),
+    ).rejects.toThrow("Coworker is not allowed to use tasks");
+
+    expect(tx.job.findMany).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/helpers/job.ts
+++ b/apps/core/src/helpers/job.ts
@@ -26,6 +26,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { paymentClient } from "@/clients/masumi-payment.client";
 import { openrouterClient } from "@/clients/openrouter.client";
+import { requireCoworkerCapability } from "@/helpers/access-control";
 import {
   buildAvailableAgentWhereClause,
   getAgentCost,
@@ -559,6 +560,7 @@ export async function getUserJobs(
     projectId?: string | null;
     status?: AgentJobStatus;
     scope?: "workspace" | "owned";
+    coworkerId?: string;
     cursor?: string;
     take: number;
     skip?: number;
@@ -574,12 +576,18 @@ export async function getUserJobs(
     projectId,
     status,
     scope = "owned",
+    coworkerId,
     cursor,
     take,
     skip,
     tx = prisma,
   } = options;
   const { userContext, workspaceContext } = context;
+
+  // A delegated coworker may only list jobs whose task is assigned to it.
+  if (coworkerId) {
+    await requireCoworkerCapability(coworkerId, "tasks", tx);
+  }
 
   const where: Prisma.JobWhereInput = {
     AND: [
@@ -590,6 +598,9 @@ export async function getUserJobs(
       ...(agentId ? [{ agentId }] : []),
       ...(projectId !== undefined ? [{ projectId }] : []),
       ...(status ? [{ events: { some: { status: { equals: status } } } }] : []),
+      // `task` is an optional to-one relation, so this filter requires the job
+      // to HAVE a task assigned to this coworker — null-task jobs are excluded.
+      ...(coworkerId ? [{ task: { coworkerId } }] : []),
     ],
   };
 

--- a/apps/core/src/routes/v1/agents/[id]/jobs/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/jobs/get.test.ts
@@ -186,6 +186,7 @@ describe("GET /agents/{id}/jobs", () => {
       {
         agentId: "agent_123",
         scope: "owned",
+        coworkerId: "cow_123",
         cursor: undefined,
         take: 20,
         skip: undefined,

--- a/apps/core/src/routes/v1/agents/[id]/jobs/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/jobs/get.ts
@@ -16,7 +16,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
+import { isCoworkerAuthContext, requireUserContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
 import { jobSummariesSchema } from "@/schemas/job.schema.js";
 import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
@@ -123,6 +123,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { scope } = queryParams;
     const { cursor, take, skip } = parseCursorPagination(queryParams);
 
+    // Delegated coworkers only see jobs whose task is assigned to them.
+    const coworkerId = isCoworkerAuthContext(c.var.authContext)
+      ? c.var.authContext.coworkerId
+      : undefined;
+
     const { jobs, count, hasMore } = await getUserJobs(
       {
         userContext,
@@ -131,6 +136,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       {
         agentId: id,
         scope,
+        coworkerId,
         cursor,
         take,
         skip,

--- a/apps/core/src/routes/v1/jobs/[id]/events/get.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/events/get.test.ts
@@ -211,12 +211,13 @@ describe("GET /jobs/{id}/events", () => {
     const response = await app.request("http://localhost/job_123/events");
 
     expect(response.status).toBe(404);
+    // The authorization read (requireJobReadForRouteVars) short-circuits before
+    // the include-heavy fetch, so the only query is the workspace-scoped check.
     expect(jobFindFirstMock).toHaveBeenCalledWith({
       where: {
         id: "job_123",
         workspaceId: "11111111-1111-7111-8111-111111111111",
       },
-      include: expect.any(Object),
     });
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/events/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/events/get.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { jobWithEvents } from "@sokosumi/database/types/job";
 
+import { requireJobReadForRouteVars } from "@/helpers/access-control.js";
 import { notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -9,7 +10,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
 import { jobEventsSchema } from "@/schemas/job.schema.js";
 
@@ -75,11 +75,11 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    requireUserContext(c.var.authContext);
     const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
     const events = await prisma.$transaction(async (tx) => {
+      await requireJobReadForRouteVars(c.var, id, tx);
       const job = await tx.job.findFirst({
         where: {
           id,

--- a/apps/core/src/routes/v1/jobs/[id]/files/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/files/get.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { BlobStatus } from "@sokosumi/database";
 
-import { requireJobRead } from "@/helpers/access-control.js";
+import { requireJobReadForRouteVars } from "@/helpers/access-control.js";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -9,8 +9,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
-import { requireWorkspaceContext } from "@/middleware/workspace";
 import { filesSchema } from "@/schemas/file.schema";
 
 const params = z.object({
@@ -60,12 +58,10 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    requireUserContext(c.var.authContext);
-    const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
     const blobs = await prisma.$transaction(async (tx) => {
-      await requireJobRead(workspaceContext, id, tx);
+      await requireJobReadForRouteVars(c.var, id, tx);
       const blobs = await tx.blob.findMany({
         where: {
           event: { jobId: id },

--- a/apps/core/src/routes/v1/jobs/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.test.ts
@@ -13,12 +13,19 @@ const { authContextState, prismaTransactionMock, jobFindFirstMock } =
         userId: "user_123",
         organizationId: "org_123",
         role: "user",
-      } as {
-        actor: "user";
-        userId: string;
-        organizationId: string | null;
-        role: string;
-      } | null,
+      } as
+        | {
+            actor: "user";
+            userId: string;
+            organizationId: string | null;
+            role: string;
+          }
+        | {
+            actor: "coworker";
+            coworkerId: string;
+            delegation?: { userId: string; organizationId: string | null };
+          }
+        | null,
     },
     prismaTransactionMock: vi.fn(),
     jobFindFirstMock: vi.fn(),
@@ -83,6 +90,12 @@ vi.mock("@/middleware/auth", () => ({
     authContext.actor === "user",
   isCoworkerAuthContext: (authContext: { actor: string }) =>
     authContext.actor === "coworker",
+  requireCoworkerAuthContext: (authContext: { actor: string }) => {
+    if (authContext.actor !== "coworker") {
+      throw new Error("mock requireCoworkerAuthContext: not a coworker");
+    }
+    return authContext;
+  },
 }));
 
 vi.mock("@/middleware/workspace", async (importOriginal) => {
@@ -327,5 +340,69 @@ describe("GET /jobs/{id}", () => {
     const response = await app.request("http://localhost/job_123");
 
     expect(response.status).toBe(404);
+  });
+
+  it("allows a delegated coworker to read a job assigned to its task", async () => {
+    authContextState.current = {
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: { userId: "user_123", organizationId: "org_123" },
+    };
+    const coworkerFindFirstMock = vi.fn().mockResolvedValue({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    });
+    const taskFindFirstMock = vi
+      .fn()
+      .mockResolvedValue({ coworkerId: "cow_123" });
+    jobFindFirstMock.mockResolvedValue({ ...createJob(), taskId: "tsk_123" });
+    prismaTransactionMock.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) =>
+        await callback({
+          coworker: { findFirst: coworkerFindFirstMock },
+          job: { findFirst: jobFindFirstMock },
+          task: { findFirst: taskFindFirstMock },
+        }),
+    );
+
+    const app = createApp();
+    const response = await app.request("http://localhost/job_123");
+
+    expect(response.status).toBe(200);
+    expect(taskFindFirstMock).toHaveBeenCalledWith({
+      where: { id: "tsk_123" },
+      select: { coworkerId: true },
+    });
+  });
+
+  it("rejects a delegated coworker reading a job assigned to another coworker", async () => {
+    authContextState.current = {
+      actor: "coworker",
+      coworkerId: "cow_123",
+      delegation: { userId: "user_123", organizationId: "org_123" },
+    };
+    const coworkerFindFirstMock = vi.fn().mockResolvedValue({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    });
+    const taskFindFirstMock = vi
+      .fn()
+      .mockResolvedValue({ coworkerId: "cow_other" });
+    jobFindFirstMock.mockResolvedValue({ ...createJob(), taskId: "tsk_123" });
+    prismaTransactionMock.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) =>
+        await callback({
+          coworker: { findFirst: coworkerFindFirstMock },
+          job: { findFirst: jobFindFirstMock },
+          task: { findFirst: taskFindFirstMock },
+        }),
+    );
+
+    const app = createApp();
+    const response = await app.request("http://localhost/job_123");
+
+    expect(response.status).toBe(403);
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.ts
@@ -3,6 +3,7 @@ import { JobType, jobInclude, OnChainJobStatus } from "@sokosumi/database";
 import { mapJobWithStatus } from "@sokosumi/database/helpers";
 import { SokosumiJobStatus } from "@sokosumi/utils";
 
+import { requireJobReadForRouteVars } from "@/helpers/access-control.js";
 import { notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -11,7 +12,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
 import { jobSchema } from "@/schemas/job.schema.js";
 import { serializeJobDetails } from "@/types/job";
@@ -100,12 +100,13 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    requireUserContext(c.var.authContext);
     const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
     const job = await prisma.$transaction(async (tx) => {
-      // Workspace collaborators may read full job details here.
+      // Authorize the read (workspace scope for users; assigned-task scope for
+      // delegated coworkers) before loading full details.
+      await requireJobReadForRouteVars(c.var, id, tx);
       const job = await tx.job.findFirst({
         where: {
           id,

--- a/apps/core/src/routes/v1/jobs/[id]/input-request/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/input-request/get.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { AgentJobStatus } from "@sokosumi/database";
 
-import { requireJobRead } from "@/helpers/access-control.js";
+import { requireJobReadForRouteVars } from "@/helpers/access-control.js";
 import { notFound, unprocessableEntity } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -10,8 +10,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
-import { requireWorkspaceContext } from "@/middleware/workspace";
 
 const params = z.object({
   id: z.string().openapi({
@@ -64,12 +62,10 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    requireUserContext(c.var.authContext);
-    const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
     const jobEvent = await prisma.$transaction(async (tx) => {
-      await requireJobRead(workspaceContext, id, tx);
+      await requireJobReadForRouteVars(c.var, id, tx);
       const jobEvent = await tx.jobEvent.findFirst({
         where: {
           jobId: id,

--- a/apps/core/src/routes/v1/jobs/[id]/inputs/post.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/inputs/post.ts
@@ -2,7 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { AgentJobStatus } from "@sokosumi/database";
 import { createAgentClient } from "@sokosumi/masumi";
 
-import { requireJobOwnership } from "@/helpers/access-control.js";
+import { requireJobCollaboration } from "@/helpers/access-control.js";
 import {
   badRequest,
   conflict,
@@ -16,7 +16,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { jobInputSchema } from "@/schemas/job.schema";
 
 const params = z.object({
@@ -94,7 +93,6 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const authContext = requireUserContext(c.var.authContext);
     const { id: jobId } = c.req.valid("param");
     const { eventId, inputData } = c.req.valid("json");
 
@@ -103,7 +101,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     }
 
     const jobEvent = await prisma.$transaction(async (tx) => {
-      await requireJobOwnership(authContext, jobId, tx);
+      await requireJobCollaboration(c.var.authContext, jobId, tx);
       const jobEvent = await tx.jobEvent.findFirst({
         where: {
           id: eventId,

--- a/apps/core/src/routes/v1/jobs/[id]/links/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/links/get.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { requireJobRead } from "@/helpers/access-control";
+import { requireJobReadForRouteVars } from "@/helpers/access-control";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -8,8 +8,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
-import { requireWorkspaceContext } from "@/middleware/workspace";
 import { linksSchema } from "@/schemas/link.schema";
 import { flattenLinkJobId, linkWithJobIdInclude } from "@/types/link";
 
@@ -64,12 +62,10 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    requireUserContext(c.var.authContext);
-    const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const { id } = c.req.valid("param");
 
     const links = await prisma.$transaction(async (tx) => {
-      await requireJobRead(workspaceContext, id, tx);
+      await requireJobReadForRouteVars(c.var, id, tx);
       const links = await tx.link.findMany({
         where: { event: { jobId: id } },
         include: linkWithJobIdInclude,

--- a/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
@@ -2,6 +2,7 @@ import { AgentJobStatus, JobType } from "@sokosumi/database";
 import { SokosumiJobStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { forbidden } from "@/helpers/error";
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { patchJobRequestSchema } from "@/schemas/job.schema";
 
@@ -10,10 +11,10 @@ import mountPatchJobById from "./patch";
 const {
   authContextState,
   prismaTransactionMock,
-  jobFindUniqueMock,
   jobUpdateMock,
   mapJobWithStatusMock,
   serializeJobDetailsMock,
+  requireJobCollaborationMock,
 } = vi.hoisted(() => ({
   authContextState: {
     current: {
@@ -29,10 +30,14 @@ const {
     } | null,
   },
   prismaTransactionMock: vi.fn(),
-  jobFindUniqueMock: vi.fn(),
   jobUpdateMock: vi.fn(),
   mapJobWithStatusMock: vi.fn(),
   serializeJobDetailsMock: vi.fn(),
+  requireJobCollaborationMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/access-control.js", () => ({
+  requireJobCollaboration: requireJobCollaborationMock,
 }));
 
 vi.mock("@/middleware/auth", () => ({
@@ -232,14 +237,14 @@ describe("PATCH /jobs/{id}", () => {
       async (callback: (tx: unknown) => Promise<unknown>) =>
         await callback({
           job: {
-            findUnique: jobFindUniqueMock,
             update: jobUpdateMock,
           },
         }),
     );
-    jobFindUniqueMock.mockResolvedValueOnce({
+    requireJobCollaborationMock.mockResolvedValue({
       id: "job_123",
       userId: "user_123",
+      taskId: null,
     });
     jobUpdateMock.mockResolvedValue({ id: "job_123" });
     mapJobWithStatusMock.mockReturnValue({});
@@ -289,11 +294,10 @@ describe("PATCH /jobs/{id}", () => {
   });
 
   it("returns 403 when the job is owned by another user", async () => {
-    jobFindUniqueMock.mockReset();
-    jobFindUniqueMock.mockResolvedValueOnce({
-      id: "job_123",
-      userId: "other_user",
-    });
+    requireJobCollaborationMock.mockReset();
+    requireJobCollaborationMock.mockRejectedValueOnce(
+      forbidden("You can only access your own jobs"),
+    );
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123", {
@@ -308,9 +312,11 @@ describe("PATCH /jobs/{id}", () => {
     expect(jobUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when the job does not exist", async () => {
-    jobFindUniqueMock.mockReset();
-    jobFindUniqueMock.mockResolvedValueOnce(null);
+  it("returns 403 when the job does not exist (no existence leak)", async () => {
+    requireJobCollaborationMock.mockReset();
+    requireJobCollaborationMock.mockRejectedValueOnce(
+      forbidden("You can only access your own jobs"),
+    );
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123", {
@@ -321,7 +327,7 @@ describe("PATCH /jobs/{id}", () => {
       body: JSON.stringify({ name: "Renamed job" }),
     });
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(403);
     expect(jobUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/patch.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.ts
@@ -2,7 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { jobInclude } from "@sokosumi/database";
 import { mapJobWithStatus } from "@sokosumi/database/helpers";
 
-import { forbidden, notFound } from "@/helpers/error.js";
+import { requireJobCollaboration } from "@/helpers/access-control.js";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -10,7 +10,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { jobSchema, patchJobRequestSchema } from "@/schemas/job.schema.js";
 import { serializeJobDetails } from "@/types/job";
 
@@ -51,26 +50,11 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const { name } = c.req.valid("json");
 
     const job = await prisma.$transaction(async (tx) => {
-      const existing = await tx.job.findUnique({
-        where: { id },
-        select: {
-          id: true,
-          userId: true,
-        },
-      });
-
-      if (!existing) {
-        throw notFound("Job not found");
-      }
-
-      if (existing.userId !== userContext.userId) {
-        throw forbidden("You can only update your own jobs");
-      }
+      await requireJobCollaboration(c.var.authContext, id, tx);
 
       const job = await tx.job.update({
         where: { id },

--- a/apps/core/src/routes/v1/jobs/[id]/refund/post.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/refund/post.test.ts
@@ -12,9 +12,9 @@ const {
   prismaTransactionMock,
   jobFindUniqueMock,
   updateJobPurchaseByExternalIdMock,
-  requireJobOwnershipMock,
+  requireJobCollaborationMock,
 } = vi.hoisted(() => ({
-  requireJobOwnershipMock: vi.fn(async () => undefined),
+  requireJobCollaborationMock: vi.fn(async () => undefined),
   authContextState: {
     current: {
       actor: "user",
@@ -107,7 +107,7 @@ vi.mock("@/middleware/auth", () => ({
 }));
 
 vi.mock("@/helpers/access-control.js", () => ({
-  requireJobOwnership: requireJobOwnershipMock,
+  requireJobCollaboration: requireJobCollaborationMock,
 }));
 
 const requestRefundMock = vi.fn();
@@ -220,8 +220,8 @@ describe("POST /jobs/{id}/refund", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     jobFindUniqueMock.mockReset();
-    requireJobOwnershipMock.mockReset();
-    requireJobOwnershipMock.mockResolvedValue(undefined);
+    requireJobCollaborationMock.mockReset();
+    requireJobCollaborationMock.mockResolvedValue(undefined);
     authContextState.current = {
       actor: "user",
       userId: "user_123",
@@ -280,7 +280,7 @@ describe("POST /jobs/{id}/refund", () => {
   });
 
   it("returns 403 when the job belongs to another user", async () => {
-    requireJobOwnershipMock.mockRejectedValueOnce(
+    requireJobCollaborationMock.mockRejectedValueOnce(
       forbidden("You can only access your own jobs"),
     );
 

--- a/apps/core/src/routes/v1/jobs/[id]/refund/post.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/refund/post.ts
@@ -4,7 +4,7 @@ import { mapJobWithStatus } from "@sokosumi/database/helpers";
 import { jobPurchaseRepository } from "@sokosumi/database/repositories";
 
 import { paymentClient } from "@/clients/masumi-payment.client.js";
-import { requireJobOwnership } from "@/helpers/access-control.js";
+import { requireJobCollaboration } from "@/helpers/access-control.js";
 import { notFound, unprocessableEntity } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -13,7 +13,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import { jobSchema } from "@/schemas/job.schema.js";
 import { serializeJobDetails } from "@/types/job";
 
@@ -102,12 +101,11 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const { blockchainIdentifier, externalId } = await prisma.$transaction(
       async (tx) => {
-        await requireJobOwnership(userContext, id, tx);
+        await requireJobCollaboration(c.var.authContext, id, tx);
 
         const job = await tx.job.findUnique({
           where: { id },

--- a/apps/core/src/routes/v1/jobs/[id]/share/delete.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/delete.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { forbidden } from "@/helpers/error";
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
 import mountDeleteJobShareById from "./delete";
@@ -7,8 +8,8 @@ import mountDeleteJobShareById from "./delete";
 const {
   authContextState,
   prismaTransactionMock,
-  jobFindUniqueMock,
   deleteByJobIdMock,
+  requireJobCollaborationMock,
 } = vi.hoisted(() => ({
   authContextState: {
     current: {
@@ -24,8 +25,12 @@ const {
     } | null,
   },
   prismaTransactionMock: vi.fn(),
-  jobFindUniqueMock: vi.fn(),
   deleteByJobIdMock: vi.fn(),
+  requireJobCollaborationMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/access-control.js", () => ({
+  requireJobCollaboration: requireJobCollaborationMock,
 }));
 
 vi.mock("@/middleware/auth", () => ({
@@ -117,16 +122,12 @@ describe("DELETE /jobs/{id}/share", () => {
       role: "user",
     };
     prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          job: {
-            findUnique: jobFindUniqueMock,
-          },
-        }),
+      async (callback: (tx: unknown) => Promise<unknown>) => await callback({}),
     );
-    jobFindUniqueMock.mockResolvedValue({
+    requireJobCollaborationMock.mockResolvedValue({
       id: "job_123",
       userId: "user_123",
+      taskId: null,
     });
     deleteByJobIdMock.mockResolvedValue({ count: 1 });
   });
@@ -160,10 +161,9 @@ describe("DELETE /jobs/{id}/share", () => {
   });
 
   it("returns 403 when the job is owned by another user", async () => {
-    jobFindUniqueMock.mockResolvedValue({
-      id: "job_123",
-      userId: "other_user",
-    });
+    requireJobCollaborationMock.mockRejectedValueOnce(
+      forbidden("You can only access your own jobs"),
+    );
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123/share", {
@@ -174,15 +174,17 @@ describe("DELETE /jobs/{id}/share", () => {
     expect(deleteByJobIdMock).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when the job does not exist", async () => {
-    jobFindUniqueMock.mockResolvedValue(null);
+  it("returns 403 when the job does not exist (no existence leak)", async () => {
+    requireJobCollaborationMock.mockRejectedValueOnce(
+      forbidden("You can only access your own jobs"),
+    );
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123/share", {
       method: "DELETE",
     });
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(403);
     expect(deleteByJobIdMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/share/delete.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/delete.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { publicShareRepository } from "@sokosumi/database/repositories";
 
-import { forbidden, notFound } from "@/helpers/error.js";
+import { requireJobCollaboration } from "@/helpers/access-control.js";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -9,7 +9,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 
 const paramsSchema = z.object({
   id: z.string().openapi({
@@ -43,25 +42,10 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     await prisma.$transaction(async (tx) => {
-      const job = await tx.job.findUnique({
-        where: { id },
-        select: {
-          id: true,
-          userId: true,
-        },
-      });
-
-      if (!job) {
-        throw notFound("Job not found");
-      }
-
-      if (job.userId !== userContext.userId) {
-        throw forbidden("You can only manage sharing for your own jobs");
-      }
+      await requireJobCollaboration(c.var.authContext, id, tx);
 
       await publicShareRepository.deleteByJobId(id, tx);
     });

--- a/apps/core/src/routes/v1/jobs/[id]/share/put.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/put.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { forbidden } from "@/helpers/error";
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 
 import mountPutJobShareById from "./put";
@@ -7,8 +8,8 @@ import mountPutJobShareById from "./put";
 const {
   authContextState,
   prismaTransactionMock,
-  jobFindUniqueMock,
   upsertForJobMock,
+  requireJobCollaborationMock,
 } = vi.hoisted(() => ({
   authContextState: {
     current: {
@@ -24,8 +25,12 @@ const {
     } | null,
   },
   prismaTransactionMock: vi.fn(),
-  jobFindUniqueMock: vi.fn(),
   upsertForJobMock: vi.fn(),
+  requireJobCollaborationMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/access-control.js", () => ({
+  requireJobCollaboration: requireJobCollaborationMock,
 }));
 
 vi.mock("@/middleware/auth", () => ({
@@ -117,16 +122,12 @@ describe("PUT /jobs/{id}/share", () => {
       role: "user",
     };
     prismaTransactionMock.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) =>
-        await callback({
-          job: {
-            findUnique: jobFindUniqueMock,
-          },
-        }),
+      async (callback: (tx: unknown) => Promise<unknown>) => await callback({}),
     );
-    jobFindUniqueMock.mockResolvedValue({
+    requireJobCollaborationMock.mockResolvedValue({
       id: "job_123",
       userId: "user_123",
+      taskId: null,
     });
     upsertForJobMock.mockResolvedValue({
       id: "share_123",
@@ -185,10 +186,9 @@ describe("PUT /jobs/{id}/share", () => {
   });
 
   it("returns 403 when the job is owned by another user", async () => {
-    jobFindUniqueMock.mockResolvedValue({
-      id: "job_123",
-      userId: "other_user",
-    });
+    requireJobCollaborationMock.mockRejectedValueOnce(
+      forbidden("You can only access your own jobs"),
+    );
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123/share", {
@@ -205,8 +205,10 @@ describe("PUT /jobs/{id}/share", () => {
     expect(upsertForJobMock).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when the job does not exist", async () => {
-    jobFindUniqueMock.mockResolvedValue(null);
+  it("returns 403 when the job does not exist (no existence leak)", async () => {
+    requireJobCollaborationMock.mockRejectedValueOnce(
+      forbidden("You can only access your own jobs"),
+    );
     const app = createApp();
 
     const response = await app.request("http://localhost/job_123/share", {
@@ -219,7 +221,7 @@ describe("PUT /jobs/{id}/share", () => {
       }),
     });
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(403);
     expect(upsertForJobMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/jobs/[id]/share/put.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/put.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { publicShareRepository } from "@sokosumi/database/repositories";
 
-import { forbidden, notFound } from "@/helpers/error.js";
+import { requireJobCollaboration } from "@/helpers/access-control.js";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -9,7 +9,6 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
 import {
   jobShareSchema,
   putJobShareRequestSchema,
@@ -49,26 +48,11 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const { allowSearchIndexing } = c.req.valid("json");
 
     const share = await prisma.$transaction(async (tx) => {
-      const job = await tx.job.findUnique({
-        where: { id },
-        select: {
-          id: true,
-          userId: true,
-        },
-      });
-
-      if (!job) {
-        throw notFound("Job not found");
-      }
-
-      if (job.userId !== userContext.userId) {
-        throw forbidden("You can only manage sharing for your own jobs");
-      }
+      await requireJobCollaboration(c.var.authContext, id, tx);
 
       return await publicShareRepository.upsertForJob(
         id,

--- a/apps/core/src/routes/v1/jobs/[id]/workspace/put.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/workspace/put.ts
@@ -3,6 +3,7 @@ import { jobInclude, Prisma } from "@sokosumi/database";
 import { mapJobWithStatus } from "@sokosumi/database/helpers";
 import { workspaceRepository } from "@sokosumi/database/repositories";
 
+import { requireJobCollaboration } from "@/helpers/access-control";
 import { conflict, forbidden, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { resolveMemberOrganizationById } from "@/helpers/organization";
@@ -62,6 +63,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const job = await prisma.$transaction(
       async (tx) => {
+        // A delegated coworker may only move a job whose task is assigned to it.
+        await requireJobCollaboration(c.var.authContext, id, tx);
+
         const currentJob = await tx.job.findFirst({
           where: {
             id,

--- a/apps/core/src/routes/v1/jobs/get.test.ts
+++ b/apps/core/src/routes/v1/jobs/get.test.ts
@@ -192,6 +192,7 @@ describe("GET /jobs", () => {
         projectId: undefined,
         status: undefined,
         scope: "owned",
+        coworkerId: "cow_123",
         cursor: undefined,
         take: 20,
         skip: undefined,

--- a/apps/core/src/routes/v1/jobs/get.ts
+++ b/apps/core/src/routes/v1/jobs/get.ts
@@ -16,7 +16,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
+import { isCoworkerAuthContext, requireUserContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
 import { jobSummariesSchema } from "@/schemas/job.schema.js";
 import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
@@ -141,6 +141,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { agentId, projectId, scope, status } = queryParams;
     const { cursor, take, skip } = parseCursorPagination(queryParams);
 
+    // Delegated coworkers only see jobs whose task is assigned to them.
+    const coworkerId = isCoworkerAuthContext(c.var.authContext)
+      ? c.var.authContext.coworkerId
+      : undefined;
+
     const { jobs, count, hasMore } = await getUserJobs(
       {
         userContext,
@@ -151,6 +156,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         projectId: projectId === "null" ? null : projectId,
         scope,
         status,
+        coworkerId,
         cursor,
         take,
         skip,


### PR DESCRIPTION
## What & why

Closes [SOK-556](https://linear.app/masumi/issue/SOK-556). Follow-up to SOK-554 (PR #3080).

SOK-554 added a broad coworker-delegation layer: a coworker API key sending `X-Delegation-User-Id` acts as that user, but the middleware does **not** verify the coworker may act for that user. SOK-554 closed this for **task** routes (`task.coworkerId === coworker.coworkerId`). **Jobs were left unprotected** — a delegated coworker could read *and* write any job of the delegated user.

A `Job` has no direct `coworkerId`; the only coworker link is `Job.taskId → Task.coworkerId`. Per-job predicate:

> A delegated coworker may touch a job iff `job.taskId !== null` **and** the related task's `coworkerId === coworker.coworkerId`.

Jobs with no task, or a task assigned to another coworker, are denied (fail-closed).

## Changes

- **`helpers/access-control.ts`** — new `requireJobReadForRouteVars` (reads) and `requireJobCollaboration` (writes), sharing a private `assertJobAssignedToCoworker`. Mirrors the existing `requireTaskReadForRouteVars` / `requireTaskCollaboration`.
- **Read routes** (`jobs/[id]/get`, `events`, `files`, `links`, `input-request`) authorize via `requireJobReadForRouteVars`.
- **List routes** (`jobs/get`, `agents/[id]/jobs/get`) pass `coworkerId` into `getUserJobs`, which checks the `tasks` capability and adds a `{ task: { coworkerId } }` filter (Prisma optional-to-one relation → excludes null-task jobs).
- **Write routes** (`inputs`, `refund`, `patch`, `share/put`, `share/delete`, `workspace/put`) go through `requireJobCollaboration`.

### User-facing impact
- Delegated-coworker requests now only see/act on jobs whose task is assigned to that coworker. Regular user sessions are unchanged.
- **Behaviour change:** missing-job writes on `patch` / `share` / `workspace` normalize **404 → 403** (no existence leak), matching `inputs` / `refund`.

No schema change.

## Verification
- `pnpm --filter @sokosumi/core test` → 149 files, **1112 passed**
- `pnpm core:check` (biome) → clean
- `pnpm core:build` (tsc + tsup) → clean
- Code-reviewed (subagent): merge-ready, zero Critical/Important; both Minor nits applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)