### PR TITLE
fix(web): guard against undefined event.key in Cmd+K shortcut handler

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/new-chat-task-actions.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/new-chat-task-actions.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => "/",
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/hooks/use-is-apple-platform", () => ({
+  default: () => false,
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  SheetClose: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarMenu: ({ children }: { children: React.ReactNode }) => (
+    <ul>{children}</ul>
+  ),
+  SidebarMenuButton: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
+  SidebarMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+import NewChatTaskActions from "@/app/components/sidebar/components/new-chat-task-actions";
+
+describe("NewChatTaskActions keyboard shortcut", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+  });
+
+  it("does not throw when event.key is undefined", () => {
+    render(<NewChatTaskActions />);
+
+    expect(() => {
+      fireEvent.keyDown(window, { key: undefined, metaKey: true });
+    }).not.toThrow();
+
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("navigates to /chat on Cmd+K", () => {
+    render(<NewChatTaskActions />);
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    expect(pushMock).toHaveBeenCalledWith("/chat");
+  });
+
+  it("navigates to /chat on Ctrl+K", () => {
+    render(<NewChatTaskActions />);
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+
+    expect(pushMock).toHaveBeenCalledWith("/chat");
+  });
+
+  it("ignores Cmd+K when an input element is the event target", () => {
+    render(<NewChatTaskActions />);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    fireEvent.keyDown(input, { key: "k", metaKey: true });
+
+    expect(pushMock).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it("ignores non-matching keys", () => {
+    render(<NewChatTaskActions />);
+
+    fireEvent.keyDown(window, { key: "j", metaKey: true });
+
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx
@@ -28,19 +28,19 @@ export default function NewChatTaskActions() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key.toLowerCase() !== "k" ||
-        !(event.metaKey || event.ctrlKey)
-      ) {
-        return;
-      }
-
       const target = event.target;
       if (target instanceof HTMLElement) {
         const tag = target.tagName;
         if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
           return;
         }
+      }
+
+      if (
+        event.key?.toLowerCase() !== "k" ||
+        !(event.metaKey || event.ctrlKey)
+      ) {
+        return;
       }
 
       event.preventDefault();

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -17,6 +17,12 @@ import { PrismaClient } from "./generated/prisma/client.js";
  * ```
  */
 export function createPrismaClient(databaseUrl: string): PrismaClient {
-  const adapter = new PrismaPg({ connectionString: databaseUrl });
+  const adapter = new PrismaPg({
+    connectionString: databaseUrl,
+    // Detect dead TCP connections before the next query hits them.
+    // Without this, a server-side idle-timeout closure looks like
+    // "server conn crashed?" mid-transaction in serverless runtimes.
+    keepAlive: true,
+  });
   return new PrismaClient({ adapter });
 }

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -22,7 +22,11 @@ export function createPrismaClient(databaseUrl: string): PrismaClient {
     // Detect dead TCP connections before the next query hits them.
     // Without this, a server-side idle-timeout closure looks like
     // "server conn crashed?" mid-transaction in serverless runtimes.
+    // keepAliveInitialDelayMillis must be set explicitly: the OS default
+    // (tcp_keepalive_time, typically 7200 s on Linux) is far longer than
+    // the 60 s between cron invocations, so probes would never fire in time.
     keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
   });
   return new PrismaClient({ adapter });
 }


### PR DESCRIPTION
## Summary

Two production Sentry errors investigated and fixed.

### Fix 1 — SOKOSUMI-P7: `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`

**File:** `apps/web/src/app/(app)/components/sidebar/components/new-chat-task-actions.tsx`

`event.key` can be `undefined` for certain synthetic/browser-specific keyboard events (observed on Mac + Chrome 149, `/account` page, triggered while a URL input was focused). The handler called `event.key.toLowerCase()` unconditionally, crashing before it could reach the input-field guard.

**Changes:**
- Added optional chaining: `event.key?.toLowerCase()`
- Moved the `INPUT`/`TEXTAREA`/`contentEditable` focus guard _before_ the key check, so form-focused keydown events are skipped entirely (also prevents the crash when `event.key` is undefined inside an input)
- Added 5 tests covering: undefined key, Cmd+K navigation, Ctrl+K navigation, key pressed in focused input, and non-matching key

---

### Fix 2 — SOKOSUMI-CORE-12: `DriverAdapterError: server conn crashed?`

**File:** `packages/database/src/client.ts`

14 occurrences, 6 users affected, ongoing since March. The `GET /sync/jobs` Vercel cron job (runs every minute) intermittently crashes with a Prisma `DriverAdapterError` mid-transaction.

**Root cause:** In Vercel serverless, function instances stay warm between cron invocations. The `pg.Pool` holds open TCP connections. If the database server closes the connection on its end (idle timeout, network blip) while the Node.js side hasn't detected it yet, the next transaction attempt hits a half-open socket — which `pg` surfaces as "server conn crashed?".

**Fix:** Pass `keepAlive: true` to `PrismaPg`. This enables OS-level TCP keepalive probes on idle pool connections so broken sockets are detected and evicted before the next query tries to use them.

## Test plan

- [ ] `pnpm web:test` — all 232 test files pass, 5 new tests added for the keyboard handler
- [ ] `pnpm check` — Biome clean
- [ ] `pnpm --filter @sokosumi/database build` — TypeScript compiles without errors
- [ ] Monitor Sentry after deploy: SOKOSUMI-P7 (`/account` keyboard crash) and SOKOSUMI-CORE-12 (`/sync/jobs` DriverAdapterError) should stop recurring

## Sentry issues

- [SOKOSUMI-P7](https://masumi.sentry.io/issues/SOKOSUMI-P7) — `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`
- [SOKOSUMI-CORE-12](https://masumi.sentry.io/issues/SOKOSUMI-CORE-12) — `DriverAdapterError: server conn crashed?`

https://claude.ai/code/session_01EgFr8YXdS1J4A69z91qigr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgFr8YXdS1J4A69z91qigr)_