### PR TITLE
feat(chat): default welcome composer to chat mode

### DIFF
--- a/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
+++ b/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
@@ -57,7 +57,7 @@ export default function WelcomeScreen({
   showGreetingAndSuggestions = true,
   userName,
   onSendMessage,
-  welcomeComposeKind = "task",
+  welcomeComposeKind = "chat",
   onWelcomeComposeKindChange,
   welcomeSendBlocked = false,
   input,

--- a/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/welcome-compose-preferences.test.ts
@@ -138,8 +138,8 @@ describe("resolveHydratedWelcomeSelection", () => {
         urlCoworkerSlug: false,
       }),
     ).toEqual({
-      composeKind: "task",
-      coworker: coworkers[0],
+      composeKind: "chat",
+      coworker: null,
       model: null,
     });
   });

--- a/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
+++ b/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
@@ -98,7 +98,7 @@ export function resolveHydratedWelcomeSelection(
   coworker: Coworker | null;
   model: { id: string; name: string } | null;
 } {
-  const defaultCompose: ChatComposeKind = "task";
+  const defaultCompose: ChatComposeKind = "chat";
   if (!stored) {
     return {
       composeKind: defaultCompose,

--- a/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
+++ b/apps/web/src/app/(app)/chat/utils/welcome-compose-preferences.ts
@@ -102,10 +102,7 @@ export function resolveHydratedWelcomeSelection(
   if (!stored) {
     return {
       composeKind: defaultCompose,
-      coworker:
-        defaultCompose === "task"
-          ? firstCoworkerWithCapability(coworkers, "tasks")
-          : null,
+      coworker: null,
       model: null,
     };
   }

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -193,7 +193,7 @@ function PureMultimodalInput({
   const activeUploadControllersRef = useRef(new Set<AbortController>());
   const [windowWidth, setWindowWidth] = useState<number | undefined>(undefined);
   const [internalComposeKind, setInternalComposeKind] =
-    useState<ChatComposeKind>("task");
+    useState<ChatComposeKind>("chat");
   const isComposeKindControlled = controlledComposeKind !== undefined;
   // Compose-kind toggle is hidden when `chatId` is set; force chat so task-only state cannot block send.
   const storedComposeKind = controlledComposeKind ?? internalComposeKind;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changes the default compose mode from "task" to "chat" for the welcome screen on cold start. This makes chat the primary entry point for users opening a new chat with no stored preferences, URL coworker selection, or explicit props.

## Changes

- **`welcome-compose-preferences.ts`**: Changed `defaultCompose` from `"task"` to `"chat"`
- **`welcome-screen.tsx`**: Updated default prop `welcomeComposeKind` from `"task"` to `"chat"`
- **`multimodal-input.tsx`**: Changed internal state default from `"task"` to `"chat"`
- **Test file**: Updated test expectation to match new default behavior

## Preserved Behavior

- Stored preferences from SOK-459 are still restored
- Existing conversations (with chatId) remain chat-only
- Manual toggle between chat/task still works
- Task onboarding seed applies when user manually switches to task mode

## Verification

- ✅ `pnpm web:check` passes
- ✅ `pnpm web:test` passes (232 test files, 1389 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-560](https://linear.app/masumi/issue/SOK-560/improvechat-default-welcome-composer-to-chat-mode)

<div><a href="https://cursor.com/agents/bc-cd654fb4-ea33-4096-8050-6f733fb2338f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd654fb4-ea33-4096-8050-6f733fb2338f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

