### PR TITLE
fix(web): scope breadcrumb organizations to the session user

### DIFF
--- a/apps/web/src/components/breadcrumb-navigation/breadcrumb-navigation.tsx
+++ b/apps/web/src/components/breadcrumb-navigation/breadcrumb-navigation.tsx
@@ -1,11 +1,13 @@
-import type { AgentWithRelations } from "@sokosumi/database";
-import { organizationRepository } from "@sokosumi/database/repositories";
+import type {
+  AgentWithRelations,
+  OrganizationWithLimitedInfo,
+} from "@sokosumi/database";
 import { getMessages } from "next-intl/server";
 import { Suspense } from "react";
 
 import { mapCoreAgentsToAgentWithCreditsPrice } from "@/lib/agents/core-dto-mappers";
 import { getAllCoreAgents } from "@/lib/agents/core-loaders";
-import prisma from "@/lib/db/prisma";
+import { userService } from "@/lib/services";
 
 import BreadcrumbNavigationClient from "./breadcrumb-navigation.client";
 import BreadcrumbNavigationSkeleton from "./breadcrumb-navigation.skeleton";
@@ -39,10 +41,12 @@ async function BreadcrumbNavigationInner({
   className?: string | undefined;
   segmentLabels?: Record<string, string>;
 }) {
-  // Breadcrumb labels are nice-to-have, not load-bearing. The agent catalog is
-  // served by Core (cached) and organizations from the DB; each lookup degrades
-  // to an empty fallback independently rather than blowing up the app shell
-  // with an unhandled server-component throw.
+  // Breadcrumb labels are nice-to-have, not load-bearing. Both lookups go
+  // through Core (the agent catalog cached, the user's memberships deduped via
+  // React cache); each degrades to an empty fallback independently rather than
+  // blowing up the app shell with an unhandled server-component throw. Only
+  // the session user's own organizations are fetched — slug routes redirect
+  // non-members anyway, so foreign orgs never legitimately resolve here.
   const [messages, agents, organizations] = await Promise.all([
     getMessages(),
     getAllCoreAgents()
@@ -54,18 +58,23 @@ async function BreadcrumbNavigationInner({
         );
         return [] as AgentWithRelations[];
       }),
-    // Known intermittent: Neon's serverless pooler cold-starts and the query
-    // trips its short timeout. Page renders fine with an empty fallback;
-    // logging — not Sentry-capturing — so the dev-overlay doesn't surface this
-    // every cold start.
-    organizationRepository
-      .listOrganizationsWithLimitedInfo(prisma)
+    userService
+      .getMyMembersWithOrganizations()
+      .then((members) =>
+        members.map(
+          ({ organization }): OrganizationWithLimitedInfo => ({
+            id: organization.id,
+            name: organization.name,
+            slug: organization.slug,
+          }),
+        ),
+      )
       .catch((error) => {
         console.warn(
-          "[breadcrumb] organization lookup timed out, using empty fallback",
+          "[breadcrumb] organization lookup failed, using empty fallback",
           { message: (error as Error)?.message },
         );
-        return [];
+        return [] as OrganizationWithLimitedInfo[];
       }),
   ]);
 


### PR DESCRIPTION
## Data exposure

`BreadcrumbNavigation` (rendered in the `(app)` layout header for every authenticated user) fetched **all organizations** via `organizationRepository.listOrganizationsWithLimitedInfo(prisma)` and passed the full list as props into the `"use client"` breadcrumb component — so every org's `id`, `name`, and `slug` was serialized into the RSC payload of every authenticated user's browser.

The list is used only to map a `/organizations/[organizationSlug]` URL segment to an org name, and those routes already redirect non-members, so only the user's **own** organizations ever legitimately resolve in the breadcrumb.

## Fix

- Fetch only the session user's memberships via the **existing** Core endpoint `GET /v1/users/me/members` (`userService.getMyMembersWithOrganizations`, deduped per request via React `cache` — the header's `UserAvatar`/`ProfileSwitch` already call it, so no extra Core round-trip).
- Map the result to the `{ id, name, slug }` (`OrganizationWithLimitedInfo`) shape the client component already expects — no client component changes.
- Remove the `@sokosumi/database` repository and Prisma imports from `breadcrumb-navigation.tsx`, completing this web→core migration slice. No new Core endpoint; no changes to `core.shared.ts` or the generated client.
- Error posture unchanged: the lookup degrades to an empty fallback with a `console.warn` rather than crashing the app shell, matching the agent-catalog fetch next to it.

## Intended edge-case behavior change

A user manually visiting another org's slug URL now briefly sees the raw slug in the breadcrumb before the page's membership check redirects. Accepted — foreign org names should not be resolvable.

## Follow-up

`organizationRepository.listOrganizationsWithLimitedInfo` in `packages/database` now has no callers and can be removed in a separate cleanup.

## Verification

- `pnpm --filter web typecheck` ✓
- `pnpm exec biome check --write apps/web/src/components/breadcrumb-navigation/breadcrumb-navigation.tsx` ✓
- `pnpm check` (whole repo) ✓
- `pnpm --filter web test:ci src/components/breadcrumb-navigation/__tests__/breadcrumb-navigation.client.test.tsx` ✓ (2 passed; tests target the unchanged client component, no repository mocks involved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)