### PR TITLE
refactor(web): serve internal job lookup via core

### DIFF
--- a/apps/core/src/routes/v1/agents/[id]/demo-jobs/post.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/demo-jobs/post.test.ts
@@ -87,6 +87,7 @@ function createSerializedJob(overrides: Record<string, unknown> = {}) {
         links: [],
       },
     ],
+    share: null,
     ...overrides,
   };
 }

--- a/apps/core/src/routes/v1/jobs/[id]/get.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/get.ts
@@ -84,6 +84,7 @@ const route = withGlobalHeaderParameters(
             overrideLegalOther: null,
           },
           events: [],
+          share: null,
         },
         meta: {
           timestamp: "2025-01-15T12:00:00.000Z",

--- a/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/patch.test.ts
@@ -192,6 +192,7 @@ function createSerializedJob(overrides: Record<string, unknown> = {}) {
         links: [],
       },
     ],
+    share: null,
     ...overrides,
   };
 }

--- a/apps/core/src/routes/v1/jobs/[id]/refund/post.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/refund/post.ts
@@ -84,6 +84,7 @@ const route = withGlobalHeaderParameters(
             overrideLegalOther: null,
           },
           events: [],
+          share: null,
         },
         meta: {
           timestamp: "2025-01-15T12:00:00.000Z",

--- a/apps/core/src/routes/v1/jobs/[id]/share/put.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/share/put.ts
@@ -9,10 +9,8 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import {
-  jobShareSchema,
-  putJobShareRequestSchema,
-} from "@/schemas/public-share.schema.js";
+import { putJobShareRequestSchema } from "@/schemas/public-share.schema.js";
+import { jobShareSchema } from "@/schemas/share.schema.js";
 
 const paramsSchema = z.object({
   id: z.string().openapi({

--- a/apps/core/src/routes/v1/jobs/[id]/workspace/put.test.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/workspace/put.test.ts
@@ -139,6 +139,7 @@ function createJobApi(overrides: Partial<Record<string, unknown>> = {}) {
       overrideLegalTerms: null,
     },
     events: [],
+    share: null,
     ...overrides,
   };
 }

--- a/apps/core/src/routes/v1/share/[token]/get.test.ts
+++ b/apps/core/src/routes/v1/share/[token]/get.test.ts
@@ -93,6 +93,7 @@ describe("GET /share/{token}", () => {
           overrideLegalOther: null,
         },
         events: [],
+        share: null,
       },
     });
 
@@ -210,6 +211,7 @@ describe("GET /share/{token}", () => {
             ],
           },
         ],
+        share: null,
       },
     });
 

--- a/apps/core/src/routes/v1/tasks/[id]/share/put.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/share/put.ts
@@ -7,10 +7,8 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { requireUserContext } from "@/middleware/auth";
-import {
-  putTaskShareRequestSchema,
-  taskShareSchema,
-} from "@/schemas/public-share.schema.js";
+import { putTaskShareRequestSchema } from "@/schemas/public-share.schema.js";
+import { taskShareSchema } from "@/schemas/share.schema.js";
 
 const paramsSchema = z.object({
   id: z.string().openapi({

--- a/apps/core/src/schemas/job.schema.ts
+++ b/apps/core/src/schemas/job.schema.ts
@@ -221,6 +221,9 @@ export const jobSchema = z
     workspace: workspaceSummarySchema,
     agent: jobDetailsAgentSchema,
     events: z.array(jobDetailsEventSchema),
+    // Union-with-null instead of `jobShareSchema.nullable()`: `.nullable()` on a
+    // named `.openapi(...)` schema leaks `| null` into the generated `JobShare`
+    // component itself. Keep the union so the nullability stays on this field.
     share: z.union([jobShareSchema, z.null()]).openapi({ example: null }),
   })
   .openapi("Job");

--- a/apps/core/src/schemas/job.schema.ts
+++ b/apps/core/src/schemas/job.schema.ts
@@ -13,6 +13,7 @@ import { userSummarySchema } from "@/schemas/user.schema";
 
 import { fileSchema } from "./file.schema.js";
 import { linkSchema } from "./link.schema.js";
+import { jobShareSchema } from "./share.schema.js";
 import { workspaceSummarySchema } from "./workspace.schema.js";
 
 export const JOB_NAME_MAX_LENGTH = 120;
@@ -220,6 +221,7 @@ export const jobSchema = z
     workspace: workspaceSummarySchema,
     agent: jobDetailsAgentSchema,
     events: z.array(jobDetailsEventSchema),
+    share: z.union([jobShareSchema, z.null()]).openapi({ example: null }),
   })
   .openapi("Job");
 

--- a/apps/core/src/schemas/public-share.schema.ts
+++ b/apps/core/src/schemas/public-share.schema.ts
@@ -4,26 +4,7 @@ import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime.js";
 import { jobSchema } from "@/schemas/job.schema.js";
-
-const publicShareBaseSchema = z.object({
-  id: z.string().openapi({ example: "share_123" }),
-  token: z.string().openapi({ example: "public-share-token" }),
-  allowSearchIndexing: z.boolean().openapi({ example: true }),
-  createdAt: dateTimeSchema,
-  updatedAt: dateTimeSchema,
-});
-
-export const jobShareSchema = publicShareBaseSchema
-  .extend({
-    jobId: z.string().openapi({ example: "job_123" }),
-  })
-  .openapi("JobShare");
-
-export const taskShareSchema = publicShareBaseSchema
-  .extend({
-    taskId: z.string().openapi({ example: "tsk_123" }),
-  })
-  .openapi("TaskShare");
+import { jobShareSchema, taskShareSchema } from "@/schemas/share.schema.js";
 
 export const putJobShareRequestSchema = z.object({
   allowSearchIndexing: z.boolean().openapi({ example: true }),

--- a/apps/core/src/schemas/share.schema.ts
+++ b/apps/core/src/schemas/share.schema.ts
@@ -1,0 +1,23 @@
+import { z } from "@hono/zod-openapi";
+
+import { dateTimeSchema } from "@/helpers/datetime.js";
+
+const publicShareBaseSchema = z.object({
+  id: z.string().openapi({ example: "share_123" }),
+  token: z.string().openapi({ example: "public-share-token" }),
+  allowSearchIndexing: z.boolean().openapi({ example: true }),
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
+});
+
+export const jobShareSchema = publicShareBaseSchema
+  .extend({
+    jobId: z.string().openapi({ example: "job_123" }),
+  })
+  .openapi("JobShare");
+
+export const taskShareSchema = publicShareBaseSchema
+  .extend({
+    taskId: z.string().openapi({ example: "tsk_123" }),
+  })
+  .openapi("TaskShare");

--- a/apps/core/src/schemas/task.schema.ts
+++ b/apps/core/src/schemas/task.schema.ts
@@ -9,7 +9,7 @@ import {
   jobSummariesSchema,
 } from "@/schemas/job.schema";
 import { organizationSummarySchema } from "@/schemas/organization.schema";
-import { taskShareSchema } from "@/schemas/public-share.schema";
+import { taskShareSchema } from "@/schemas/share.schema";
 import { taskLinksSchema } from "@/schemas/task-link.schema";
 import { userSummarySchema } from "@/schemas/user.schema";
 import { workspaceSummarySchema } from "@/schemas/workspace.schema";

--- a/apps/core/src/types/job.ts
+++ b/apps/core/src/types/job.ts
@@ -129,5 +129,6 @@ export function serializeJobDetails(job: JobWithSokosumiStatus) {
         jobId: job.id,
       })),
     })),
+    share: job.share ?? null,
   };
 }

--- a/apps/web/src/app/api/internal/jobs/[jobId]/route.ts
+++ b/apps/web/src/app/api/internal/jobs/[jobId]/route.ts
@@ -1,10 +1,10 @@
-import { jobRepository } from "@sokosumi/database/repositories";
 import type { NextRequest, NextResponse } from "next/server";
 import superJson from "superjson";
 
+import { mapCoreJobToJobWithSokosumiStatus } from "@/lib/agents/core-dto-mappers";
 import { createApiSuccessResponse, handleApiError } from "@/lib/api";
 import { getSession } from "@/lib/auth/utils";
-import prisma from "@/lib/db/prisma";
+import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 
 interface RouteParams {
   params: Promise<{
@@ -14,7 +14,7 @@ interface RouteParams {
 
 /**
  * Get job by ID internally
- * @description Retrieves a specific job by ID belonging to the authenticated user
+ * @description Retrieves a specific job by ID readable by the authenticated user
  */
 export async function GET(
   request: NextRequest,
@@ -31,10 +31,20 @@ export async function GET(
       throw new Error("INVALID_INPUT");
     }
 
-    const job = await jobRepository.getJobById(jobId, prisma);
-
-    if (!job || job.userId !== session.user.id) {
-      throw new Error("JOB_NOT_FOUND");
+    let job;
+    try {
+      const response = await coreClient.getJobById(jobId);
+      job = mapCoreJobToJobWithSokosumiStatus(response.data);
+    } catch (error) {
+      if (error instanceof CoreApiRequestError) {
+        if (error.status === 401) {
+          throw new Error("UNAUTHORIZED");
+        }
+        if (error.status === 403 || error.status === 404) {
+          throw new Error("JOB_NOT_FOUND");
+        }
+      }
+      throw error;
     }
 
     // Format and return the job

--- a/apps/web/src/lib/agents/__tests__/core-dto-mappers.test.ts
+++ b/apps/web/src/lib/agents/__tests__/core-dto-mappers.test.ts
@@ -494,6 +494,7 @@ describe("core dto mappers", () => {
           ],
         },
       ],
+      share: null,
     };
 
     const mappedJob = mapCoreJobToJobWithSokosumiStatus(job, { share });
@@ -585,6 +586,7 @@ describe("core dto mappers", () => {
         overrideLegalOther: null,
       },
       events: [],
+      share: null,
     } as Job;
 
     expect(mapCoreJobToJobWithSokosumiStatus(job).jobStatusSettled).toBe(true);

--- a/apps/web/src/lib/agents/core-dto-mappers.ts
+++ b/apps/web/src/lib/agents/core-dto-mappers.ts
@@ -16,6 +16,7 @@ import type {
   AgentReviews as CoreAgentReviews,
   Category as CoreCategory,
   Job as CoreJob,
+  JobShare as CoreJobShare,
   JobSummary as CoreJobSummary,
 } from "@/lib/clients/generated/core";
 import { SYNTHETIC_DEFAULT_CATEGORY } from "@/lib/constants/agent-categories";
@@ -560,6 +561,17 @@ export function mapCoreJobSummaryToJobWithSokosumiStatus(
   return mappedJob as unknown as JobWithSokosumiStatus;
 }
 
+export function mapCoreJobShare(share: CoreJobShare): JobShare {
+  return {
+    id: share.id,
+    jobId: share.jobId,
+    token: share.token,
+    allowSearchIndexing: share.allowSearchIndexing,
+    createdAt: toDate(share.createdAt),
+    updatedAt: toDate(share.updatedAt),
+  } as JobShare;
+}
+
 export function mapCoreJobToJobWithSokosumiStatus(
   job: CoreJob,
   options?: { share?: JobShare | null },
@@ -571,7 +583,7 @@ export function mapCoreJobToJobWithSokosumiStatus(
     inputSchema: job.inputSchema ?? null,
     agentJobId: job.agentJobId,
     identifierFromPurchaser: job.identifierFromPurchaser ?? null,
-    share: options?.share ?? null,
+    share: options?.share ?? (job.share ? mapCoreJobShare(job.share) : null),
     agent: mapCoreJobAgent(job.agentId, job.agent),
     events: job.events.map(mapCoreJobEvent),
     // Token-based public share pages are read-only; keep "unsettled" so

--- a/apps/web/src/lib/clients/core.job-share.ts
+++ b/apps/web/src/lib/clients/core.job-share.ts
@@ -1,7 +1,9 @@
 import type { JobShare, JobWithSokosumiStatus } from "@sokosumi/database";
-import { mapCoreJobToJobWithSokosumiStatus } from "@/lib/agents/core-dto-mappers";
+import {
+  mapCoreJobShare,
+  mapCoreJobToJobWithSokosumiStatus,
+} from "@/lib/agents/core-dto-mappers";
 import type {
-  JobShare as CoreJobShare,
   PublicSharedJobResource as CorePublicSharedJobResource,
   TaskShare as CoreTaskShare,
   PublicSharedResourceResponse,
@@ -26,17 +28,6 @@ export type PublicSharedResource =
 
 function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
-}
-
-export function mapCoreJobShare(share: CoreJobShare): JobShare {
-  return {
-    id: share.id,
-    jobId: share.jobId,
-    token: share.token,
-    allowSearchIndexing: share.allowSearchIndexing,
-    createdAt: toDate(share.createdAt),
-    updatedAt: toDate(share.updatedAt),
-  } as JobShare;
 }
 
 function mapCoreTaskShare(share: CoreTaskShare): CoreTaskShare {

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -1,10 +1,8 @@
 import type { Notice, NoticeKind } from "@sokosumi/database";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
-import {
-  mapCoreJobShare,
-  mapCorePublicSharedResourceResponse,
-} from "@/lib/clients/core.job-share";
+import { mapCoreJobShare } from "@/lib/agents/core-dto-mappers";
+import { mapCorePublicSharedResourceResponse } from "@/lib/clients/core.job-share";
 import type {
   ActivateEnterpriseContractRequest,
   CreateConversationMessageRequest,

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -1740,6 +1740,17 @@ export const JobSchema = {
                     'links'
                 ]
             }
+        },
+        share: {
+            anyOf: [
+                {
+                    $ref: '#/components/schemas/JobShare'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            example: null
         }
     },
     required: [
@@ -1756,7 +1767,8 @@ export const JobSchema = {
         'agentJobId',
         'workspace',
         'agent',
-        'events'
+        'events',
+        'share'
     ]
 } as const;
 
@@ -1879,6 +1891,46 @@ export const LinkSchema = {
         'updatedAt',
         'jobId',
         'url'
+    ]
+} as const;
+
+export const JobShareSchema = {
+    type: 'object',
+    properties: {
+        id: {
+            type: 'string',
+            example: 'share_123'
+        },
+        token: {
+            type: 'string',
+            example: 'public-share-token'
+        },
+        allowSearchIndexing: {
+            type: 'boolean',
+            example: true
+        },
+        createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2021-01-01T00:00:00.000Z'
+        },
+        updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2021-01-01T00:00:00.000Z'
+        },
+        jobId: {
+            type: 'string',
+            example: 'job_123'
+        }
+    },
+    required: [
+        'id',
+        'token',
+        'allowSearchIndexing',
+        'createdAt',
+        'updatedAt',
+        'jobId'
     ]
 } as const;
 
@@ -5687,46 +5739,6 @@ export const Job_EventSchema = {
         'status',
         'files',
         'links'
-    ]
-} as const;
-
-export const JobShareSchema = {
-    type: 'object',
-    properties: {
-        id: {
-            type: 'string',
-            example: 'share_123'
-        },
-        token: {
-            type: 'string',
-            example: 'public-share-token'
-        },
-        allowSearchIndexing: {
-            type: 'boolean',
-            example: true
-        },
-        createdAt: {
-            type: 'string',
-            format: 'date-time',
-            example: '2021-01-01T00:00:00.000Z'
-        },
-        updatedAt: {
-            type: 'string',
-            format: 'date-time',
-            example: '2021-01-01T00:00:00.000Z'
-        },
-        jobId: {
-            type: 'string',
-            example: 'job_123'
-        }
-    },
-    required: [
-        'id',
-        'token',
-        'allowSearchIndexing',
-        'createdAt',
-        'updatedAt',
-        'jobId'
     ]
 } as const;
 

--- a/apps/web/src/lib/clients/generated/core/transformers.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/transformers.gen.ts
@@ -123,6 +123,12 @@ const linkSchemaResponseTransformer = (data: any) => {
     return data;
 };
 
+const jobShareSchemaResponseTransformer = (data: any) => {
+    data.createdAt = new Date(data.createdAt);
+    data.updatedAt = new Date(data.updatedAt);
+    return data;
+};
+
 const jobSchemaResponseTransformer = (data: any) => {
     data.createdAt = new Date(data.createdAt);
     data.updatedAt = new Date(data.updatedAt);
@@ -148,6 +154,9 @@ const jobSchemaResponseTransformer = (data: any) => {
         item.links = item.links.map((item: any) => linkSchemaResponseTransformer(item));
         return item;
     });
+    if (data.share) {
+        data.share = jobShareSchemaResponseTransformer(data.share);
+    }
     return data;
 };
 
@@ -950,12 +959,6 @@ export const getJobsByIdEventsResponseTransformer = async (data: any): Promise<G
 
 export const deleteJobsByIdShareResponseTransformer = async (data: any): Promise<DeleteJobsByIdShareResponse> => {
     data.meta.timestamp = new Date(data.meta.timestamp);
-    return data;
-};
-
-const jobShareSchemaResponseTransformer = (data: any) => {
-    data.createdAt = new Date(data.createdAt);
-    data.updatedAt = new Date(data.updatedAt);
     return data;
 };
 

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -406,6 +406,7 @@ export type Job = {
         blobs: Array<File>;
         links: Array<Link>;
     }>;
+    share: JobShare | null;
 };
 
 export type File = {
@@ -449,6 +450,15 @@ export type Link = {
     jobId: string;
     url: string;
     title?: string | null;
+};
+
+export type JobShare = {
+    id: string;
+    token: string;
+    allowSearchIndexing: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    jobId: string;
 };
 
 export type GetChatUiMessagesResponseData = {
@@ -1646,15 +1656,6 @@ export type JobEvent = {
     result?: string | null;
     files: Array<File>;
     links: Array<Link>;
-};
-
-export type JobShare = {
-    id: string;
-    token: string;
-    allowSearchIndexing: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-    jobId: string;
 };
 
 export type GetInvitationResult = {


### PR DESCRIPTION
## Summary

Migrates the last direct-database web API route, `GET /api/internal/jobs/[jobId]`, off `jobRepository.getJobById`/Prisma and onto the core API.

### Web

- `apps/web/src/app/api/internal/jobs/[jobId]/route.ts` now calls `coreClient.getJobById` (session cookie forwarded) and maps the result with `mapCoreJobToJobWithSokosumiStatus`, keeping the existing superJSON response contract so `getJobQueryOptions` consumers are untouched. Core 401/403/404 errors are translated to the route's existing `UNAUTHORIZED`/`JOB_NOT_FOUND` responses.
- `mapCoreJobShare` moved from `core.job-share.ts` into `core-dto-mappers.ts` (avoids an import cycle); the job mapper now picks up `job.share` from core when no explicit share is supplied.

### Core

- `GET /v1/jobs/{id}` (and the other `serializeJobDetails` responses) now include the job's `share`, which was already loaded via `jobInclude` but dropped by the schema. The legacy web route returned it and the job share modal relies on it surviving client refetches.
- `jobShareSchema`/`taskShareSchema` moved to a new `schemas/share.schema.ts` so `job.schema.ts` can reference `jobShareSchema` without creating a `job.schema ⇄ public-share.schema` circular import.
- `share` is added to `jobSchema` as `z.union([jobShareSchema, z.null()])` so the generated `JobShare` client type stays non-nullable (`.nullable()` on the named schema leaked `| null` into the component).
- Web core client snapshot regenerated.

### Behavior note

Authorization for the internal route changes from strict job ownership to core's job-read rules (workspace-scoped via `requireJobReadForRouteVars`). This aligns the client-side refetch with the server-rendered job details page, which already uses the core endpoint and renders read-only for non-owner workspace members — previously their refetches 404'd.

## Verification

- `pnpm --filter @sokosumi/core typecheck` / `pnpm --filter web typecheck`
- `pnpm --filter @sokosumi/core test` — 1221 passed
- `pnpm --filter web test` — 1384 passed, 1 skipped
- `pnpm check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)