### PR TITLE
chore(web): remove dead db reads and orphaned repository methods

### DIFF
--- a/apps/web/src/lib/services/__tests__/user.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/user.service.test.ts
@@ -5,8 +5,6 @@ export {};
 vi.mock("server-only", () => ({}));
 
 const getSessionMock = vi.fn();
-const getJobsMock = vi.fn();
-const upsertWorkspaceForContextMock = vi.fn();
 const getMyMembersWithOrganizationsMock = vi.fn();
 const getMyMemberInOrganizationMock = vi.fn();
 
@@ -36,17 +34,9 @@ vi.mock("next/headers", () => ({
 }));
 
 vi.mock("@sokosumi/database/repositories", () => ({
-  invitationRepository: {},
-  jobRepository: {
-    getJobs: (...args: unknown[]) => getJobsMock(...args),
-  },
   memberRepository: {},
   organizationRepository: {},
   userRepository: {},
-  workspaceRepository: {
-    upsertWorkspaceForContext: (...args: unknown[]) =>
-      upsertWorkspaceForContextMock(...args),
-  },
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -56,34 +46,6 @@ vi.mock("@/lib/db/prisma", () => ({
 describe("user.service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    upsertWorkspaceForContextMock.mockResolvedValue({
-      id: "11111111-1111-7111-8111-111111111111",
-    });
-  });
-
-  it("returns only owned jobs for the active context", async () => {
-    getSessionMock.mockResolvedValue({
-      user: { id: "user-1" },
-      session: { activeOrganizationId: "org-1" },
-    });
-    getJobsMock.mockResolvedValue([
-      { id: "job-2", createdAt: new Date("2026-02-13T10:00:00.000Z") },
-      { id: "job-1", createdAt: new Date("2026-02-12T10:00:00.000Z") },
-    ]);
-
-    const { userService } = await import("../user.service");
-    const result = await userService.getMyJobs("agent-1");
-
-    expect(getJobsMock).toHaveBeenCalledTimes(1);
-    expect(getJobsMock).toHaveBeenCalledWith(
-      {
-        agentId: "agent-1",
-        userId: "user-1",
-        workspaceId: "11111111-1111-7111-8111-111111111111",
-      },
-      expect.any(Object),
-    );
-    expect(result.map((job) => job.id)).toEqual(["job-2", "job-1"]);
   });
 
   describe("getMyMembersWithOrganizations", () => {

--- a/apps/web/src/lib/services/user.service.ts
+++ b/apps/web/src/lib/services/user.service.ts
@@ -1,20 +1,14 @@
 import "server-only";
 
 import type {
-  InvitationWithRelations,
-  JobWithSokosumiStatus,
   Member,
   MemberWithOrganization,
   OrganizationWithRelations,
-  User,
 } from "@sokosumi/database";
 import {
-  invitationRepository,
-  jobRepository,
   memberRepository,
   organizationRepository,
   userRepository,
-  workspaceRepository,
 } from "@sokosumi/database/repositories";
 import { headers } from "next/headers";
 import { cache } from "react";
@@ -28,20 +22,6 @@ import prisma from "@/lib/db/prisma";
  * Service for user-related operations.
  */
 export const userService = (() => {
-  /**
-   * Retrieves the currently authenticated user from the session.
-   *
-   * @returns {Promise<User | null>} The user object if authenticated, otherwise null.
-   *
-   */
-  async function getMe(): Promise<User | null> {
-    const session = await getSession();
-    if (!session) {
-      return null;
-    }
-    return userRepository.getUserById(session.user.id, prisma);
-  }
-
   /**
    * Retrieves the active organization ID for the currently authenticated user.
    *
@@ -70,43 +50,6 @@ export const userService = (() => {
         prisma,
       );
     return organization;
-  }
-
-  /**
-   * Retrieves jobs for the currently authenticated user filtered by agent ID.
-   * If the user has an active organization, returns jobs in that organization context.
-   * Otherwise, returns personal jobs for the user and agent.
-   *
-   * @param {string} agentId - The ID of the agent to filter jobs by.
-   * @returns {Promise<JobWithSokosumiStatus[]>} An array of jobs with status for the user and agent.
-   *
-   */
-  async function getMyJobs(agentId: string): Promise<JobWithSokosumiStatus[]> {
-    const session = await getSession();
-    if (!session) {
-      return [];
-    }
-    const userId = session.user.id;
-    const activeOrganizationId = session.session.activeOrganizationId ?? null;
-    const workspace = await workspaceRepository.upsertWorkspaceForContext(
-      userId,
-      activeOrganizationId ?? null,
-      prisma,
-    );
-
-    // Get owned jobs
-    const ownedJobs = await jobRepository.getJobs(
-      {
-        agentId,
-        userId,
-        workspaceId: workspace.id,
-      },
-      prisma,
-    );
-    return ownedJobs.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
   }
 
   /**
@@ -145,32 +88,6 @@ export const userService = (() => {
     }
     const response = await coreClient.getMyMemberInOrganization(organizationId);
     return response?.data ?? null;
-  }
-
-  /**
-   * Retrieves all valid pending invitations for the currently authenticated user.
-   *
-   * @returns A promise that resolves to an array of InvitationWithRelations objects for the current user.
-   */
-  async function getMyValidPendingInvitations(): Promise<
-    InvitationWithRelations[]
-  > {
-    const session = await getSession();
-    if (!session) {
-      return [];
-    }
-    return await prisma.$transaction(async (tx) => {
-      const user = await userRepository.getUserById(session.user.id, tx);
-      if (!user?.email) {
-        console.error("User email not found");
-        return [];
-      }
-
-      return await invitationRepository.getValidPendingInvitationsByEmail(
-        user.email,
-        tx,
-      );
-    });
   }
 
   /**
@@ -216,30 +133,6 @@ export const userService = (() => {
   }
 
   /**
-   * Checks which of the provided emails already have user accounts.
-   *
-   * @param emails - Array of email addresses to check.
-   * @returns Promise resolving to array of emails that already have user accounts.
-   */
-  async function checkExistingUsers(emails: string[]): Promise<string[]> {
-    const normalizedEmails = Array.from(
-      new Set(
-        emails.map((e) => e.trim().toLowerCase()).filter((e) => e.length > 0),
-      ),
-    );
-
-    const users = await Promise.all(
-      normalizedEmails.map((email) =>
-        userRepository.getUserByEmail(email, prisma),
-      ),
-    );
-
-    return users
-      .filter((u): u is NonNullable<typeof u> => !!u)
-      .map((u) => u.email.toLowerCase());
-  }
-
-  /**
    * Marks the onboarding as completed for a specific user.
    *
    * @param userId - The ID of the user to update.
@@ -261,15 +154,11 @@ export const userService = (() => {
   }
 
   return {
-    getMe,
     getActiveOrganizationId,
     getActiveOrganization,
-    getMyJobs,
     getMyMembersWithOrganizations,
     getMyMemberInOrganization,
-    getMyValidPendingInvitations,
     showOnboarding,
-    checkExistingUsers,
     markOnboardingCompleteForMe,
   };
 })();

--- a/packages/database/src/repositories/invitation.repository.ts
+++ b/packages/database/src/repositories/invitation.repository.ts
@@ -28,29 +28,6 @@ export const invitationRepository = {
   },
 
   /**
-   * Retrieves all valid (not expired) pending invitations for a given email.
-   *
-   * @param email - The email address to search invitations for.
-   * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to an array of InvitationWithRelations.
-   */
-  async getValidPendingInvitationsByEmail(
-    email: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<InvitationWithRelations[]> {
-    return tx.invitation.findMany({
-      where: {
-        email,
-        status: InvitationStatus.PENDING,
-        expiresAt: {
-          gt: new Date(),
-        },
-      },
-      include: invitationInclude,
-    });
-  },
-
-  /**
    * Checks if there is at least one pending invitation for a given email.
    *
    * @param email - The email address to search invitations for.

--- a/packages/database/src/repositories/job.repository.ts
+++ b/packages/database/src/repositories/job.repository.ts
@@ -385,18 +385,6 @@ export const jobRepository = {
     return mapJobWithStatus(job);
   },
 
-  async getJobs(
-    where: Prisma.JobWhereInput,
-    tx: Prisma.TransactionClient,
-  ): Promise<JobWithSokosumiStatus[]> {
-    const jobs = await tx.job.findMany({
-      where,
-      include: jobInclude,
-      orderBy: jobOrderBy,
-    });
-    return jobs.map(mapJobWithStatus);
-  },
-
   /**
    * Check if user has finished job with the agent
    * @param userId - The unique identifier of the user

--- a/packages/database/src/repositories/organization.repository.ts
+++ b/packages/database/src/repositories/organization.repository.ts
@@ -100,14 +100,6 @@ export const organizationRepository = {
     });
   },
 
-  async listOrganizationsWithLimitedInfo(
-    tx: Prisma.TransactionClient,
-  ): Promise<OrganizationWithLimitedInfo[]> {
-    return await tx.organization.findMany({
-      select: organizationLimitedInfoInclude,
-    });
-  },
-
   /**
    * Searches organizations by name or slug using a case-insensitive partial
    * match.

--- a/packages/database/src/repositories/user.repository.ts
+++ b/packages/database/src/repositories/user.repository.ts
@@ -20,20 +20,6 @@ export const userRepository = {
   },
 
   /**
-   * Retrieves a user by their email address.
-   *
-   * @param email - The email address of the user.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to the User object if found, or null otherwise.
-   */
-  getUserByEmail: async (
-    email: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<User | null> => {
-    return tx.user.findUnique({ where: { email } });
-  },
-
-  /**
    * Get a user by their Stripe customer ID.
    *
    * @param stripeCustomerId - The Stripe customer ID.


### PR DESCRIPTION
## Summary

Deletion-only cleanup slice of the web->core DB migration. Removes dead DB-access code left behind by merged migrations. No new endpoints, no client regeneration, no behavior change.

## Deleted symbols (proof of deadness)

Each verified with a whole-repo grep over `apps/` + `packages/` (`*.ts`/`*.tsx`, excluding build artifacts) before deletion.

### apps/web/src/lib/services/user.service.ts
- `userService.getMe` — only hits: its definition + the service return object. Flagged unused in the #3089 audit.
- `userService.getMyValidPendingInvitations` — only hits: definition + return object.
- `userService.checkExistingUsers` — only hits: definition + return object.
- `userService.getMyJobs` — only hits: definition, return object, and its own unit test (no product callers). Deleted along with its test and the now-unused `jobRepository.getJobs` / `workspaceRepository.upsertWorkspaceForContext` mocks.
- Now-unused imports removed: `invitationRepository`, `jobRepository`, `workspaceRepository`, and types `InvitationWithRelations`, `JobWithSokosumiStatus`, `User`.

### packages/database
- `organizationRepository.listOrganizationsWithLimitedInfo` — orphaned since PR #3098 rewired breadcrumb-navigation to `/v1/users/me/members`. Only hit: its definition. The `OrganizationWithLimitedInfo` type and `organizationLimitedInfoInclude` are kept — still used by `searchOrganizations` / `getOrganizationLimitedInfoBySlug` and breadcrumb components.
- `invitationRepository.getValidPendingInvitationsByEmail` — sole caller was the deleted `getMyValidPendingInvitations`.
- `userRepository.getUserByEmail` — sole caller was the deleted `checkExistingUsers`.
- `jobRepository.getJobs` — sole caller was the deleted `getMyJobs` (note: `coreClient.getJobs` in project/task services is the generated HTTP client, unrelated). `jobInclude`/`jobOrderBy`/`mapJobWithStatus` remain in use by other methods.

Kept (still alive): `userRepository.getUserById` (many callers in apps/core + apps/web), `workspaceRepository.upsertWorkspaceForContext` (apps/core middleware + workspace PUT routes).

## Verification

- `pnpm --filter web typecheck` — pass
- `pnpm --filter @sokosumi/database typecheck` — pass
- `pnpm --filter core typecheck` — pass
- web test suite: 233 files, 1394 passed / 1 skipped
- database repo tests (user + organization): 6 passed
- `biome check` on all 6 touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)