### PR TITLE
fix(chat): clean up DESIGN.md when switching to chat mode

### DIFF
--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -416,6 +416,14 @@ function PureMultimodalInput({
     );
   }, [initialDesignMdAttachment, isTaskComposer, setInput]);
 
+  useEffect(() => {
+    if (composeKind !== "chat") {
+      return;
+    }
+
+    setInput((prev) => removeDesignMdAttachmentLinks(prev));
+  }, [composeKind, setInput]);
+
   const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(event.target.value);
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOK-563

## Summary

Adds a reactive cleanup effect that strips DESIGN.md attachment links when `composeKind` is `chat`. This prevents DESIGN.md from persisting in chat mode input due to localStorage rehydration from prior task sessions.

## Implementation

- Added a `useEffect` that runs whenever `composeKind` changes
- Effect guards on `composeKind === "chat"` and calls `removeDesignMdAttachmentLinks`
- Reuses existing utility function from `task-attachments.ts`
- Covers mount-time localStorage rehydration and manual mode toggles

## Testing

- ✅ Lint checks passed (`pnpm web:check`)
- ✅ All tests passed (`pnpm web:test`)
- Manual verification steps from spec pending

## Related

- Investigation: SOK-563 Investigation section
- Tech Lead spec: SOK-563 Spec section
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-563](https://linear.app/masumi/issue/SOK-563/fixchat-stop-design-md-on-welcome-chat-composer)

<div><a href="https://cursor.com/agents/bc-ecc02b9d-5151-4b3f-8b0d-2445f47f1ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecc02b9d-5151-4b3f-8b0d-2445f47f1ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

