### PR TITLE
fix(cursor): enforce _task defaults and sapphire continuous run

### DIFF
--- a/.cursor/skills/_task/AGENTS.md
+++ b/.cursor/skills/_task/AGENTS.md
@@ -22,3 +22,4 @@ Source of truth for drafting Sokosumi **requirement** issues before Team Sapphir
 - Draft in chat first. **Wait for approval.**
 - Keep requirements concise. No spec sections, no verification checklist.
 - After approval: one Linear issue + Sapphire handoff per `HANDOFF.md`.
+- On create, never omit `project: "Sokosumi"` (or user override) — verify with `get_issue` before handoff.

--- a/.cursor/skills/_task/HANDOFF.md
+++ b/.cursor/skills/_task/HANDOFF.md
@@ -59,7 +59,7 @@ Footer to append:
 | Reviewer | pending |
 
 ---
-_Sapphire squad — run `.cursor/skills/_team-sapphire/SKILL.md` on this issue._
+_Sapphire squad — run `.cursor/skills/_team-sapphire/SKILL.md` on this issue. Complete all four phases in one session through **In Review** — do not stop after Investigator._
 ```
 
 ### 2. Delegate to Cursor (default)
@@ -84,7 +84,7 @@ Ensure Linear MCP is enabled on the Cloud Agent run (first delegated run may nee
 ### 3. Informational comment (optional)
 
 ```markdown
-Requirement filed. Team Sapphire handoff — orchestrator runs Investigator → Tech Lead → Coder → Reviewer on this issue.
+Requirement filed. Team Sapphire handoff — orchestrator runs Investigator → Tech Lead → Coder → Reviewer on this issue in **one session** through In Review.
 ```
 
 Do **not** include `@Cursor` when `delegate` is set.

--- a/.cursor/skills/_task/LINEAR-MCP.md
+++ b/.cursor/skills/_task/LINEAR-MCP.md
@@ -15,18 +15,28 @@ const LINEAR_ASSIGNEE = "me";
 const LINEAR_LABELS = ["Feature", "Bug", "Improvement"] as const;
 ```
 
-Create exactly one issue with:
+## Required on create (never omit)
 
-- Team: `SOK`
-- Project: `Sokosumi`, unless user override
-- State: `In Progress`
-- Priority: `3` (Medium) unless user passed a different priority
-- Assignee: `me` unless user passed a different assignee
-- Label: exactly one of `Feature`, `Bug`, or `Improvement`
-- Description: approved markdown from `REQUIREMENT-TEMPLATE.md` (must include `## Requirement` heading)
-- Title: user-approved proposed title (Conventional Commit style when possible)
-- Do **not** set `delegate` on create — `HANDOFF.md` sets delegate after Sapphire footer
-- Do **not** set `parentId` unless user asked to file under an epic/parent
+Every `save_issue` **create** call (no `id`) must include **all** of:
+
+| Field | Default |
+|-------|---------|
+| `title` | user-approved proposed title |
+| `description` | approved requirement (`## Requirement`) |
+| `team` | `SOK` |
+| `project` | `Sokosumi` |
+| `state` | `In Progress` |
+| `priority` | `3` (Medium) |
+| `assignee` | `me` |
+| `labels` | exactly one of `Feature`, `Bug`, `Improvement` |
+
+Override only when the user explicitly passed a different value during intake.
+
+**Never omit `project`.** If the user did not name a project, always pass `"project": "Sokosumi"`. Linear leaves issues unscoped when `project` is missing.
+
+Do **not** set `delegate` on create — `HANDOFF.md` sets delegate after Sapphire footer.
+
+Do **not** set `parentId` unless user asked to file under an epic/parent.
 
 ## Hard rules
 
@@ -35,6 +45,7 @@ Create exactly one issue with:
 - Never call a write tool without a complete `arguments` object.
 - Stop if Linear MCP is not loaded.
 - **Never create before user approval.**
+- **Never create without `project`** — same rule as `assignee`, `state`, and `priority`.
 
 ## MCP health check
 
@@ -59,7 +70,19 @@ Expected tools: `list_teams`, `list_projects`, `list_issue_statuses`, `list_issu
 4. Priority → `3` (Medium) unless user override
 5. Assignee → `me` unless user override
 6. Label → exact match from draft
-7. Create issue via `save_issue` (no `id`, no `delegate`)
+7. Create issue via `save_issue` (no `id`, no `delegate`) — pass the full required field set above
+
+## Post-create verify (before handoff)
+
+Immediately after create:
+
+1. `get_issue` with the new identifier.
+2. If any default is missing or wrong and the user did not override it, patch with `save_issue` + `id`:
+   - `project` null/empty → `"Sokosumi"`
+   - no assignee → `"me"`
+   - state not `In Progress` → `"In Progress"`
+   - priority not Medium (`3`) → `3`
+3. Do not start `HANDOFF.md` until defaults are confirmed on the issue.
 
 ## Write-call shape
 

--- a/.cursor/skills/_task/REQUIREMENT-TEMPLATE.md
+++ b/.cursor/skills/_task/REQUIREMENT-TEMPLATE.md
@@ -31,7 +31,7 @@ Keep it short. Architectural ideas welcome; file-level plans are not required he
 
 ## Bad example (too detailed for this stage)
 
-Contract tables, file change lists, and `pnpm web:check` — Tech Lead adds those under `## Spec` after Sapphire runs.
+Contract tables, file change lists, and `pnpm web:check` — Tech Lead adds those in the session spec after Sapphire runs.
 
 ## Handoff
 
@@ -39,4 +39,4 @@ After `_task` approval, default handoff delegates **Cursor on the same issue** �
 
 Manual: `Run _team-sapphire for SOK-XXX`.
 
-Requirement section must **not** include `[repo=…]` or `## Spec` — Tech Lead adds those.
+Requirement section must **not** include `[repo=…]` or a full spec — Tech Lead adds those in session.

--- a/.cursor/skills/_task/SKILL.md
+++ b/.cursor/skills/_task/SKILL.md
@@ -58,7 +58,7 @@ See `WORKFLOW.md` for the full intake → Sapphire pipeline.
      **Requirement draft:** project Sokosumi · state In Progress · priority Medium · assignee me · label Feature
      ```
 
-   - Do **not** include: file lists, contract tables, verification commands, mermaid data-flow diagrams, or coder breakdown. Team Sapphire adds those under `## Spec`.
+   - Do **not** include: file lists, contract tables, verification commands, mermaid data-flow diagrams, or coder breakdown. Tech Lead adds those in the **session spec**.
 
 4. **Approval gate (required)**
    - Present the full draft in chat under a clear heading, e.g. `## Draft requirement — review before Linear`.

--- a/.cursor/skills/_task/SKILL.md
+++ b/.cursor/skills/_task/SKILL.md
@@ -76,7 +76,8 @@ See `WORKFLOW.md` for the full intake → Sapphire pipeline.
 5. **Publish and hand off (only after approval)**
    - Read `LINEAR-MCP.md`.
    - Run MCP health check before any write.
-   - Create the issue in `Sokosumi`, state `In Progress`, priority Medium (`3`), assignee `me`, with exactly one label.
+   - Create via `save_issue` with **all** required fields from `LINEAR-MCP.md` — always include `project: "Sokosumi"` when the user did not override project (do not skip it).
+   - After create, run post-create verify in `LINEAR-MCP.md` (`get_issue` → patch missing defaults) before handoff.
    - Read MCP tool descriptors before any call.
    - Follow `HANDOFF.md` when `handoffToSapphire` is true (default).
    - Return issue id/URL, label, delegate status, and handoff path.

--- a/.cursor/skills/_task/WORKFLOW.md
+++ b/.cursor/skills/_task/WORKFLOW.md
@@ -26,7 +26,7 @@ flowchart LR
 2. **Light discovery** — sharpen problem, goal, scope.
 3. **Draft** — `REQUIREMENT-TEMPLATE.md` in chat only.
 4. **Wait for approval** — do not touch Linear.
-5. **Publish** — create issue per `LINEAR-MCP.md`.
+5. **Publish** — create issue per `LINEAR-MCP.md` (all defaults including `project: Sokosumi`), then post-create verify before handoff.
 6. **Hand off** — `HANDOFF.md` delegates Team Sapphire on the same issue.
 
 ## What belongs on the issue at create time

--- a/.cursor/skills/_task/WORKFLOW.md
+++ b/.cursor/skills/_task/WORKFLOW.md
@@ -18,7 +18,7 @@ flowchart LR
 | Agent | Skill | Output | Approval gate |
 |-------|-------|--------|---------------|
 | **Requirement** | `_task` | Linear issue with `## Requirement` | **Yes** — user must approve draft |
-| **Sapphire squad** | `_team-sapphire` | Investigation, Spec, code, review on **same issue** | No — runs after handoff |
+| **Sapphire squad** | `_team-sapphire` | Session investigation + spec, PR, review; Linear gets status + comments | No — runs after handoff |
 
 ## _task workflow
 
@@ -34,11 +34,12 @@ flowchart LR
 - `## Requirement` — problem, goal, decisions, out of scope
 - After handoff: `## Sapphire status` footer
 
-## What Sapphire adds (same issue)
+## What Sapphire adds
 
-- `## Investigation` — Investigator
-- `## Spec` — Tech Lead
-- PR + review comments — Coder and Reviewer
+- `## Sapphire status` updates on Linear
+- Phase summary comments + PR handoff on Linear
+- Investigation + spec **in orchestrator session only** (passed to Coder / Reviewer)
+- PR + review — Coder and Reviewer
 
 ## Handoff
 

--- a/.cursor/skills/_team-sapphire/AGENTS.md
+++ b/.cursor/skills/_team-sapphire/AGENTS.md
@@ -19,3 +19,5 @@ Requirement intake and approval: `../_task/SKILL.md`.
 ## Output rule
 
 Keep specs concise. Tech Lead spec always includes a data flow diagram. All phases update the **same** Linear issue — no child issues.
+
+**Orchestrator:** Run all four phases in one session through **In Review**. Do not stop after Investigator (or any single phase) unless the user asked for that phase only or you hit an unrecoverable blocker.

--- a/.cursor/skills/_team-sapphire/AGENTS.md
+++ b/.cursor/skills/_team-sapphire/AGENTS.md
@@ -18,6 +18,6 @@ Requirement intake and approval: `../_task/SKILL.md`.
 
 ## Output rule
 
-Keep specs concise. Tech Lead spec always includes a data flow diagram. All phases update the **same** Linear issue — no child issues.
+Keep specs concise. Tech Lead spec always includes a data flow diagram. Linear holds **Requirement + status** only — investigation and spec stay in session.
 
-**Orchestrator:** Run all four phases in one session through **In Review**. Do not stop after Investigator (or any single phase) unless the user asked for that phase only or you hit an unrecoverable blocker.
+**Orchestrator:** Run all four phases in one session through **In Review**. Pass session artifacts phase to phase; do not write them to Linear.

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -1,12 +1,12 @@
 # Coder
 
-**Goal:** Implement `## Spec` on the Sapphire issue. Open a PR. Hand off to Reviewer on the **same issue**.
+**Goal:** Implement the **session spec** from Tech Lead. Open a PR. Hand off to Reviewer on the **same issue**.
 
 ## Inputs
 
-- `## Spec` — sole source of truth for behavior and deliverables
-- `## Investigation` — context only when spec is ambiguous
-- `## Requirement` — product intent when spec references goal/out of scope
+- **Session spec** — sole source of truth for behavior and deliverables
+- **Session investigation** — context only when spec is ambiguous
+- `## Requirement` on Linear — product intent when spec references goal/out of scope
 
 ## Single coder
 
@@ -30,7 +30,7 @@ When Tech Lead defined `### Coder A`, `### Coder B`, …:
 
 Each subagent prompt must include:
 
-- Its coder block from `## Spec`
+- Its coder block from the **session spec** (inline — not a Linear link)
 - File ownership table
 - "Do not edit files owned by other coders"
 - Link to Linear issue id

--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -4,7 +4,7 @@
 
 ## You produce
 
-Merge or **replace** `## Investigation` in the full issue description per `LINEAR-MCP.md`. If `## Investigation` already exists, update that section in place — do not append a second block. Comment summary when done.
+Investigation markdown per the output template below. Keep it **in orchestrator session** — pass the full text to Tech Lead. Post a short summary comment when done; do **not** merge `## Investigation` into Linear.
 
 ## Do
 

--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -44,3 +44,8 @@ Merge or **replace** `## Investigation` in the full issue description per `LINEA
 ```
 
 Keep it scannable. Bullets over paragraphs. Real paths as markdown links.
+
+## Handoff to Tech Lead
+
+- **Sapphire orchestrator (default):** After Investigator complete, continue to Phase 2 (Tech Lead) in the **same run** per `SKILL.md` — do not stop early.
+- **Standalone Investigator** (user invoked Investigator only): Stop after `**Sapphire · Investigator complete**`; Tech Lead runs in a separate session.

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -2,31 +2,49 @@
 
 Single-issue updates only. No child issues.
 
+## What goes on Linear
+
+| Write to Linear | Do not write to Linear |
+|-----------------|------------------------|
+| `## Requirement` (from `_task` — preserve) | `## Investigation` — session only |
+| `## Sapphire status` table | `## Spec` — session only |
+| Sapphire footer | Full investigation or spec in comments |
+| Issue **state** (`In Progress` → `In Review`) | |
+| Phase summary **comments** | |
+| `**PR handoff**` comment | |
+
+Investigation and spec pass **in orchestrator session** to Tech Lead → Coder → Reviewer. See `SKILL.md` **Session artifacts**.
+
 ## Hard rules
 
 - MCP only. Inspect `user-linear/tools/*.json` before writes.
 - Never call a write tool without a complete `arguments` object.
 - Stop if Linear MCP is not loaded — same reload message as `../_task/LINEAR-MCP.md`.
 - Optional smoke test: `get_user` with `{ "query": "me" }`.
+- **Never** append `## Investigation` or `## Spec` to the issue description.
 
 ## Issue description updates
 
 Use `save_issue` with `id` = issue identifier.
 
-### Description merge (required)
+### Status-only merge (required)
 
 Every `save_issue` that sets `description` must:
 
 1. Call `get_issue` first.
 2. Start from the **full** existing `description`.
-3. Insert, update, or **replace in place** the target parts (`## Sapphire status` row, `## Investigation`, `## Spec`). If a phase section already exists and you re-run that phase, replace the existing section — do not duplicate the heading.
-4. Pass the **entire** merged markdown in `description`.
+3. Keep **only** `## Requirement`, `## Sapphire status`, and the Sapphire footer (if present).
+4. **Remove** `## Investigation`, `## Spec`, and any other Sapphire phase sections — legacy or new.
+5. Update the status table row for the completed phase (or insert the initial table).
+6. Pass the **entire** trimmed markdown in `description`.
 
-Linear **replaces** the whole field — never send only a new section or you wipe `## Requirement` and the Sapphire footer.
+Linear **replaces** the whole field — never send only a status block or you wipe `## Requirement`.
+
+Prefer separate calls when possible: `save_issue` with `id` + `state` only (no `description`) for Reviewer **In Review** transition after status table is already saved.
 
 ### Initial Sapphire block (orchestrator start)
 
-If `## Sapphire status` is missing, prepend after Requirement:
+If `## Sapphire status` is missing, append after Requirement:
 
 ```markdown
 ## Sapphire status
@@ -38,9 +56,11 @@ If `## Sapphire status` is missing, prepend after Requirement:
 | Reviewer | pending |
 ```
 
+Do not add Investigation or Spec sections.
+
 ### After each phase
 
-Update the status table row to `done` and append the phase section (`## Investigation` or `## Spec`).
+Update the status table row to `done`. Post a **short summary comment** — not the full investigation or spec.
 
 ### State transitions
 
@@ -56,15 +76,15 @@ Use structured headers for audit trail:
 
 | Phase | Comment header |
 |-------|----------------|
-| Investigator | `**Sapphire · Investigator complete**` |
-| Tech Lead | `**Sapphire · Tech Lead complete**` |
+| Investigator | `**Sapphire · Investigator complete**` — 3–5 bullets |
+| Tech Lead | `**Sapphire · Tech Lead complete**` — coder count, order, 3–5 bullets |
 | Coder | `**Sapphire · Coder complete**` + `**PR handoff**` |
 | Reviewer pass | `**Sapphire · Reviewer complete**` |
 | Reviewer fail | `**Sapphire · Review failed**` |
 
 ## Write examples
 
-Update description after Investigation:
+Update status after Investigator (no investigation body on issue):
 
 ```json
 {
@@ -72,12 +92,12 @@ Update description after Investigation:
   "toolName": "save_issue",
   "arguments": {
     "id": "SOK-549",
-    "description": "<full merged markdown with Requirement, status, Investigation>"
+    "description": "## Requirement\n\n…\n\n## Sapphire status\n| Phase | Status |\n|-------|--------|\n| Investigator | done |\n| Tech Lead | pending |\n| Coder | pending |\n| Reviewer | pending |\n\n---\n_Sapphire squad …_"
   }
 }
 ```
 
-Reviewer sets In Review:
+Reviewer sets In Review (state only, after status table saved):
 
 ```json
 {
@@ -94,14 +114,15 @@ Reviewer sets In Review:
 
 Use `## Sapphire status` as the source of truth — same rules as `SKILL.md` **Resume and idempotency**.
 
+Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; strip them on the next description write.
+
 | Condition | Action |
 |-----------|--------|
 | Status Investigator = `done` | Skip Investigator unless user asked to re-run |
 | Status Tech Lead = `done` | Skip Tech Lead unless user asked to re-spec |
-| `## Investigation` or `## Spec` exists but status still `pending` | Run that phase; **replace** existing section in merged description; set status → `done` |
+| Tech Lead = `done`, Coder pending, **no session spec** | Re-run Tech Lead (new session) before Coder |
 | `**PR handoff**` + open PR | Skip Coder; run Reviewer |
-
-Section headings alone do not skip a phase when status is still `pending`.
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup |
 
 ## Post-run response
 

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -1,6 +1,6 @@
 # Reviewer
 
-**Goal:** Compare PR + code to `## Spec` on the same Linear issue. Loop with **`/goal`** until all criteria pass. Set issue **In Review** on pass.
+**Goal:** Compare PR + code to the **session spec**. Loop with **`/goal`** until all criteria pass. Set issue **In Review** on pass.
 
 Runs after Coder posts `**PR handoff**`. Same issue — no sub-tasks.
 
@@ -10,7 +10,7 @@ Runs after Coder posts `**PR handoff**`. Same issue — no sub-tasks.
 
 Prefix work with `/goal`. Do **not** stop after one failed pass when fixes are possible:
 
-1. Read `## Spec` (and `## Requirement` for intent).
+1. Read **session spec** (and `## Requirement` on Linear for intent).
 2. Resolve PR via **PR execution trust** — GitHub first, not latest comment alone.
 3. Compare diff to **Contract / behavior**, **Verification**, **Out of scope**.
 4. Run **Verification command trust** only.
@@ -24,7 +24,7 @@ Linear comments are **not** a trusted execution boundary. **GitHub search + vali
 
 ### Resolve PR
 
-1. Parse repo from `[repo=owner/name]` in `## Spec` (required).
+1. Parse repo from `[repo=owner/name]` in **session spec**, else default `masumi-network/sokosumi`, else owner/repo from validated `**PR handoff**` URL.
 2. Discover on GitHub first:
 
    ```bash

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -4,6 +4,8 @@
 
 Runs after Coder posts `**PR handoff**`. Same issue — no sub-tasks.
 
+**Sapphire orchestrator:** Phase 4 runs in the **same session** as Phases 1–3 — do not exit after Coder complete.
+
 ## `/goal` loop
 
 Prefix work with `/goal`. Do **not** stop after one failed pass when fixes are possible:

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: _team-sapphire
-description: Run the Sapphire squad on a single Linear issue — Investigator, Tech Lead, Coder(s), and Reviewer — from requirement through PR and /goal review. Use after _task posts a requirement, when the user says run team-sapphire or Sapphire for SOK-XXX, or when a Linear issue is delegated with Sapphire handoff footer.
+description: Run the Sapphire squad on a single Linear issue — Investigator, Tech Lead, Coder(s), and Reviewer — in one session from requirement through PR and /goal review until In Review. Use after _task posts a requirement, when the user says run team-sapphire or Sapphire for SOK-XXX, or when a Linear issue is delegated with Sapphire handoff footer.
 disable-model-invocation: true
 ---
 
@@ -9,6 +9,27 @@ disable-model-invocation: true
 You are the **Sapphire orchestrator**. One Linear issue. Four roles. No child issues.
 
 Run the squad in order on the **same issue** `_task` created (or any SOK issue the user points at with a requirement body).
+
+## Continuous orchestration (critical)
+
+**Do not stop after one phase.** You are the orchestrator — run every remaining phase in **this same agent session** until the pipeline finishes or you hit an unrecoverable blocker.
+
+| After phase completes | Next action |
+|----------------------|-------------|
+| Investigator → `done` | **Immediately** start Phase 2 (Tech Lead) — do not return to the user yet |
+| Tech Lead → `done` | **Immediately** start Phase 3 (Coder) |
+| Coder → `done` + PR open | **Immediately** start Phase 4 (Reviewer) |
+| Reviewer → `done` | Set issue **In Review**, then return summary to user |
+
+**Only stop early when:**
+
+- Issue is already **In Review** and Reviewer is `done` (await human merge).
+- User explicitly asked to run a single phase only (e.g. `run investigator for SOK-XXX`).
+- Unrecoverable blocker (no GitHub access, Linear MCP down, spec impossible) — report what finished, what is blocked, and the issue URL.
+
+**Never** treat Investigator, Tech Lead, or Coder as standalone jobs when you were delegated from `_task` or invoked as `_team-sapphire` on a full issue. Phase comments (`**Sapphire · … complete**`) mark progress — they are **not** exit signals.
+
+Resume runs: start at the first phase still `pending` in `## Sapphire status`, then **continue through all later phases in the same session** unless a stop condition above applies.
 
 ## Runtime
 
@@ -46,6 +67,7 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 2. Merge `## Investigation` into the **full** issue description via `save_issue` per `LINEAR-MCP.md` — never post the section alone.
 3. Post comment `**Sapphire · Investigator complete**` with a 3–5 bullet summary.
 4. Update `## Sapphire status` — Investigator → `done` (same merged `save_issue` or follow-up write with full body).
+5. **Continue in this run** — proceed to Phase 2 without stopping.
 
 ### Phase 2 — Tech Lead
 
@@ -54,6 +76,7 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 3. Merge `## Spec` into the **full** issue description per `LINEAR-MCP.md`. Include `[repo=…]`, data flow, contracts, verification hints, coder breakdown when rubric score ≥ 2.
 4. Post comment `**Sapphire · Tech Lead complete**` with execution order and coder count.
 5. Update status — Tech Lead → `done` (in the same merged write when possible).
+6. **Continue in this run** — proceed to Phase 3 without stopping.
 
 ### Phase 3 — Coder(s)
 
@@ -64,6 +87,7 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 5. Open PR; PR body must reference the Linear issue id.
 6. Post `**PR handoff**` comment per `REVIEWER.md`.
 7. Post `**Sapphire · Coder complete**`. Update status — Coder → done. Stay **In Progress** — do not set In Review yet.
+8. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
 
@@ -94,7 +118,7 @@ Use `## Sapphire status` as the source of truth for which phase to run. Section 
 
 ## Output
 
-Return issue id/URL, phases completed, PR link (if any), and current Linear state.
+Return issue id/URL, **all phases completed in this run**, PR link (if any), and current Linear state. If you stopped early, say which phase blocked and why — stopping after Investigator alone is a failure unless the user asked for a single phase.
 
 ## Supporting files
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -42,10 +42,25 @@ Resume runs: start at the first phase still `pending` in `## Sapphire status`, t
 
 | Field | Value |
 |-------|-------|
-| Repo hint | `[repo=masumi-network/sokosumi]` — Tech Lead adds near top of issue when spec is written |
+| Repo hint | `[repo=masumi-network/sokosumi]` — Tech Lead puts at top of **session spec** (not Linear) |
 | Linear team | `SOK` |
 | Linear project | `Sokosumi` |
-| Issue model | **Single issue** — requirement, investigation, spec, and progress live on one issue |
+| Issue model | **Single issue** — `## Requirement` + `## Sapphire status` on Linear; investigation and spec stay **in session** only |
+
+## Session artifacts (critical)
+
+Investigation and spec are **working documents for this agent run**. Keep them in orchestrator context and pass them to the next phase — **do not** write `## Investigation` or `## Spec` to the Linear issue description.
+
+| Artifact | Produced by | Passed to | On Linear |
+|----------|-------------|-----------|-----------|
+| Investigation | Investigator | Tech Lead (same session) | Comment summary only |
+| Spec | Tech Lead | Coder, Reviewer (same session) | Comment summary only |
+| Requirement | `_task` | All phases | Description (unchanged) |
+| Status table | Orchestrator | Resume / humans | Description |
+
+When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and the Sapphire footer. Strip legacy `## Investigation` / `## Spec` blocks if present — do not re-add them.
+
+**Resume in a new session:** `## Sapphire status` shows progress, but investigation/spec are not on Linear. Re-run from the first `pending` phase; if Coder or Reviewer is pending without session artifacts, re-run Tech Lead (and Investigator if needed) before implementing or reviewing.
 
 ## Intake
 
@@ -64,29 +79,29 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 ### Phase 1 — Investigator
 
 1. Run Investigator per `INVESTIGATOR.md` (codebase search, pitfalls, patterns — **not** a final spec).
-2. Merge `## Investigation` into the **full** issue description via `save_issue` per `LINEAR-MCP.md` — never post the section alone.
-3. Post comment `**Sapphire · Investigator complete**` with a 3–5 bullet summary.
-4. Update `## Sapphire status` — Investigator → `done` (same merged `save_issue` or follow-up write with full body).
+2. Keep the investigation markdown **in session** — pass the full text to Tech Lead. Do **not** merge `## Investigation` into the Linear description.
+3. Post comment `**Sapphire · Investigator complete**` with a 3–5 bullet summary (not the full investigation).
+4. Update `## Sapphire status` — Investigator → `done` (status-only `save_issue` per `LINEAR-MCP.md`).
 5. **Continue in this run** — proceed to Phase 2 without stopping.
 
 ### Phase 2 — Tech Lead
 
-1. Read Requirement + Investigation.
+1. Read Requirement (Linear) + Investigation (**session**).
 2. Write final spec per `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md`.
-3. Merge `## Spec` into the **full** issue description per `LINEAR-MCP.md`. Include `[repo=…]`, data flow, contracts, verification hints, coder breakdown when rubric score ≥ 2.
-4. Post comment `**Sapphire · Tech Lead complete**` with execution order and coder count.
-5. Update status — Tech Lead → `done` (in the same merged write when possible).
+3. Keep the spec markdown **in session** — pass the full text to Coder and Reviewer. Do **not** merge `## Spec` into the Linear description.
+4. Post comment `**Sapphire · Tech Lead complete**` with coder count, execution order, and 3–5 bullet spec summary (not the full spec).
+5. Update status — Tech Lead → `done` (status-only `save_issue`).
 6. **Continue in this run** — proceed to Phase 3 without stopping.
 
 ### Phase 3 — Coder(s)
 
-1. Read `## Spec` only (plus Investigation for context).
+1. Read **session spec** (plus session investigation for context). Requirement from Linear when needed.
 2. If Tech Lead defined multiple coders, launch **parallel** Task subagents — one per coder block — with non-overlapping file ownership.
 3. If single coder, implement in this run.
 4. Run allowlisted verification before PR (`REVIEWER.md` **Verification command trust**).
 5. Open PR; PR body must reference the Linear issue id.
 6. Post `**PR handoff**` comment per `REVIEWER.md`.
-7. Post `**Sapphire · Coder complete**`. Update status — Coder → done. Stay **In Progress** — do not set In Review yet.
+7. Post `**Sapphire · Coder complete**`. Update status — Coder → done (status-only `save_issue`). Stay **In Progress** — do not set In Review yet.
 8. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
@@ -94,25 +109,25 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 1. Run `/goal` per `REVIEWER.md` until all criteria pass.
 2. For UI specs, capture evidence per `VISUAL-CAPTURE.md` (Cloud: PR artifacts; IDE: screenshots; optional CLI for WebM).
 3. Fix on PR branch when needed; loop.
-4. On pass: set issue `In Review`, post `**Sapphire · Reviewer complete**` with evidence, update status — Reviewer → done.
+4. On pass: set issue `In Review`, post `**Sapphire · Reviewer complete**` with evidence, update status — Reviewer → done (status-only `save_issue` + state).
 5. Do **not** mark issue **Done** — human merges PR.
 
 ## MCP
 
 - Read `LINEAR-MCP.md` before any write.
 - Health check before first call — same message as `_task` if `user-linear` is missing.
-- Use `save_issue` to update description sections and state; use `save_comment` for phase markers.
+- Use `save_issue` for **status table**, **state**, and legacy section cleanup only — not investigation or spec; use `save_comment` for phase markers.
 
 ## Resume and idempotency
 
-Use `## Sapphire status` as the source of truth for which phase to run. Section headings (`## Investigation`, `## Spec`) alone do not skip a phase if status is still `pending`.
+Use `## Sapphire status` as the source of truth for which phase to run. Legacy `## Investigation` / `## Spec` on Linear (older runs) are ignored — strip on the next status write.
 
 | Condition | Action |
 |-----------|--------|
 | `## Sapphire status` — Investigator = done | Skip Investigator unless user asked to re-run |
 | `## Sapphire status` — Tech Lead = done | Skip Tech Lead unless user asked to re-spec |
-| `## Spec` present but Tech Lead still `pending` | Run Tech Lead — status table wins |
-| `**PR handoff**` comment + open PR | Skip Coder; run Reviewer |
+| Tech Lead = done but no **session spec** (new session) | Re-run Tech Lead before Coder |
+| `**PR handoff**` comment + open PR | Skip Coder; run Reviewer (use session spec if same run; else PR + Requirement) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — set `In Review` when criteria pass; do not restart Investigator–Coder |
 | Issue `In Review` + Reviewer done | Stop — await human merge |
 

--- a/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
+++ b/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-Tech Lead appends this as `## Spec` on the Sapphire issue. Delete sections that do not apply except **Data flow**.
+Tech Lead writes this as the **session spec** (not posted to Linear). Delete sections that do not apply except **Data flow**.
 
 ````markdown
 ## Spec
@@ -80,9 +80,9 @@ Scope hints only — agents map to allowlisted `pnpm` scripts per `REVIEWER.md`.
 - Non-goals for v1.
 ````
 
-## Before saving to Linear
+## Before handing to Coder
 
 - No YAML plan frontmatter.
 - Remove empty optional sections.
 - Keep Data flow, Verification, Out of scope.
-- Preserve `## Requirement`, `## Investigation`, and `## Sapphire status` above this section.
+- Spec stays in orchestrator session — not written to Linear.

--- a/.cursor/skills/_team-sapphire/SUBAGENT-RUBRIC.md
+++ b/.cursor/skills/_team-sapphire/SUBAGENT-RUBRIC.md
@@ -1,6 +1,6 @@
 # Subagent Rubric
 
-Tech Lead uses this before adding `Current state`, `Target architecture`, or **Coder breakdown** in `## Spec`.
+Tech Lead uses this before adding `Current state`, `Target architecture`, or **Coder breakdown** in the session spec.
 
 ## Architecture sections
 

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -1,15 +1,15 @@
 # Tech Lead
 
-**Goal:** Write the **final implementable spec** in `## Spec` on the same Linear issue, using Requirement + Investigation.
+**Goal:** Write the **final implementable spec** in session, using Requirement (Linear) + Investigation (session).
 
 ## Inputs
 
-- `## Requirement` — product intent and locked decisions
-- `## Investigation` — technical context and recommendations
+- `## Requirement` on Linear — product intent and locked decisions
+- Investigation markdown — session artifact from Investigator
 
 ## You produce
 
-- Full `## Spec` section from `SPEC-TEMPLATE.md` — merge or **replace in place** per `LINEAR-MCP.md`; never post the section alone or duplicate `## Spec`
+- Full spec from `SPEC-TEMPLATE.md` — keep **in orchestrator session**; pass to Coder and Reviewer. Do **not** write `## Spec` to Linear.
 - Apply `SUBAGENT-RUBRIC.md` for architecture sections and **Coder breakdown**
 - When rubric score ≥ 2: define named coders (`Coder A — …`) with file ownership — Tech Lead decides parallel vs sequential
 
@@ -19,14 +19,15 @@
 - Include **Data flow** mermaid always.
 - Add **Current state** / **Target architecture** when rubric says so.
 - Split work into multiple coders only when rubric score ≥ 2 — each block must be paste-ready for `CODER.md`.
-- Add `[repo=masumi-network/sokosumi]` at the top of `## Spec`.
-- Preserve `## Requirement` and `## Investigation` unchanged when updating description.
+- Add `[repo=masumi-network/sokosumi]` at the top of the session spec.
+- Do not modify `## Requirement` on Linear.
 
 ## Do not
 
 - Implement code.
-- Wait for human PRD approval — publish spec and hand to Coder in the same Sapphire run.
+- Wait for human PRD approval — finalize spec and hand to Coder in the same Sapphire run.
 - Create child Linear issues.
+- Merge investigation or spec into the Linear issue description.
 
 ## Coder breakdown format
 
@@ -40,7 +41,7 @@ Post `**Sapphire · Tech Lead complete**` with:
 
 - Coder count (1 or N)
 - Execution order one-liner
-- Link to spec section (issue URL)
+- 3–5 bullet spec summary (not the full spec — that stays in session)
 
 ## Handoff to Coder
 

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -41,3 +41,8 @@ Post `**Sapphire · Tech Lead complete**` with:
 - Coder count (1 or N)
 - Execution order one-liner
 - Link to spec section (issue URL)
+
+## Handoff to Coder
+
+- **Sapphire orchestrator (default):** After Tech Lead complete, continue to Phase 3 (Coder) in the **same run** per `SKILL.md` — do not stop early.
+- **Standalone Tech Lead** (user invoked Tech Lead only): Stop after `**Sapphire · Tech Lead complete**`; Coder runs in a separate session.

--- a/.cursor/skills/_team-sapphire/WORKFLOW.md
+++ b/.cursor/skills/_team-sapphire/WORKFLOW.md
@@ -6,11 +6,11 @@ Two skills. One Linear issue. Approval gate only on `_task`.
 flowchart LR
   user["User idea"] --> task["_task skill"]
   task --> approve{"User\napproves?"}
-  approve -->|yes| issue["Single Linear issue\nRequirement + Sapphire"]
+  approve -->|yes| issue["Linear issue\nRequirement + status"]
   approve -->|no| task
   issue --> sapphire["_team-sapphire"]
-  sapphire --> inv["Investigator"]
-  inv --> lead["Tech Lead\nfinal spec"]
+  sapphire --> inv["Investigator\n(session)"]
+  inv --> lead["Tech Lead\n(session spec)"]
   lead --> code["Coder(s)"]
   code --> pr["Pull request"]
   pr --> rev["Reviewer\n/goal loop"]
@@ -22,20 +22,20 @@ flowchart LR
 
 The orchestrator runs **Investigator → Tech Lead → Coder → Reviewer** in one agent session. Phase completion comments are audit markers — not handoff to a new run.
 
-Resume: start at the first `pending` row in `## Sapphire status`, then finish every later phase in the same session.
+Resume: start at the first `pending` row in `## Sapphire status`, then finish every later phase in the same session. Investigation and spec are **not** on Linear — re-run Tech Lead (and Investigator if needed) when resuming Coder or Reviewer in a new session.
 
 ## Roles
 
-| Role | Output | Blocks next? |
-|------|--------|--------------|
-| **Investigator** | `## Investigation` — pitfalls, similar code, technical recommendations | No |
-| **Tech Lead** | `## Spec` — implementable spec, optional coder breakdown | No |
-| **Coder** | Code + PR + `**PR handoff**` | No |
-| **Reviewer** | Evidence + issue **In Review** | Yes — human merge waits for Reviewer pass |
+| Role | Output | Where it lives |
+|------|--------|----------------|
+| **Investigator** | Pitfalls, patterns, recommendations | **Session** → Tech Lead |
+| **Tech Lead** | Implementable spec, optional coder breakdown | **Session** → Coder, Reviewer |
+| **Coder** | Code + PR + `**PR handoff**` | GitHub + Linear comments |
+| **Reviewer** | Evidence + issue **In Review** | Linear state + comments |
 
-## Issue description shape
+## Issue description shape (Linear)
 
-One growing document on the same issue:
+Only requirement and progress on the issue:
 
 ```markdown
 ## Requirement
@@ -48,15 +48,11 @@ One growing document on the same issue:
 | Tech Lead | pending / done |
 | Coder | pending / done |
 | Reviewer | pending / done |
-
-## Investigation
-(Investigator)
-
-## Spec
-(Tech Lead — includes [repo=masumi-network/sokosumi])
 ```
 
-Phase transitions also post structured comments (`**Sapphire · … complete**`) for audit trail.
+Investigation and spec stay in the orchestrator session — not in this document.
+
+Phase transitions post structured **summary** comments (`**Sapphire · … complete**`) for audit trail.
 
 ## Status lifecycle
 
@@ -75,6 +71,7 @@ Manual: `Run _team-sapphire for SOK-XXX` in Cursor.
 ## What not to do
 
 - Do not create child Linear issues for spec, code, or review.
-- Do not run Coder before `## Spec` exists.
+- Do not write `## Investigation` or `## Spec` to the Linear description.
+- Do not run Coder before **session spec** exists.
 - Do not set **In Review** when the PR opens — Reviewer sets it on pass.
 - Do not mark **Done** before human merge.

--- a/.cursor/skills/_team-sapphire/WORKFLOW.md
+++ b/.cursor/skills/_team-sapphire/WORKFLOW.md
@@ -18,6 +18,12 @@ flowchart LR
   review --> human["Human merge → Done"]
 ```
 
+## Single session rule
+
+The orchestrator runs **Investigator → Tech Lead → Coder → Reviewer** in one agent session. Phase completion comments are audit markers — not handoff to a new run.
+
+Resume: start at the first `pending` row in `## Sapphire status`, then finish every later phase in the same session.
+
 ## Roles
 
 | Role | Output | Blocks next? |


### PR DESCRIPTION
## Summary

- `_task`: require `project: Sokosumi` on every Linear create, post-create verify for defaults, and clearer handoff copy.
- `_team-sapphire`: orchestrator runs all four phases in one session through In Review; phase comments are not exit signals.
- Investigation and spec stay **in session** only — Linear keeps Requirement, status table, summary comments, and state.

## Test plan

- [ ] Run `_task` on a sample requirement — confirm `save_issue` includes `project: Sokosumi` and post-create verify runs before handoff.
- [ ] Run Team Sapphire on a delegated issue — confirm it continues past Investigator through Reviewer without stopping early.
- [ ] Confirm Linear description does not gain `## Investigation` or `## Spec`; legacy sections are stripped on status updates.
- [ ] Resume a stalled issue in a new session — confirm re-run rules when session spec is missing.
