### PR TITLE
fix(cursor): sapphire artifact-aware resume for new sessions

### DIFF
--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -49,3 +49,4 @@ Keep it scannable. Bullets over paragraphs. Real paths as markdown links.
 
 - **Sapphire orchestrator (default):** After Investigator complete, continue to Phase 2 (Tech Lead) in the **same run** per `SKILL.md` — do not stop early.
 - **Standalone Investigator** (user invoked Investigator only): Stop after `**Sapphire · Investigator complete**`; Tech Lead runs in a separate session.
+- **New session resume:** Linear may show Investigator = `done` without **session investigation** — orchestrator re-runs Investigator before Tech Lead per `SKILL.md` **Resume and idempotency**.

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -112,17 +112,19 @@ Reviewer sets In Review (state only, after status table saved):
 
 ## Idempotency
 
-Use `## Sapphire status` as the source of truth — same rules as `SKILL.md` **Resume and idempotency**.
+Use `## Sapphire status` for progress on Linear; **session artifacts** decide whether a `done` row can be skipped — same rules as `SKILL.md` **Resume and idempotency**.
 
 Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; strip them on the next description write.
 
 | Condition | Action |
 |-----------|--------|
-| Status Investigator = `done` | Skip Investigator unless user asked to re-run |
-| Status Tech Lead = `done` | Skip Tech Lead unless user asked to re-spec |
-| Tech Lead = `done`, Coder pending, **no session spec** | Re-run Tech Lead (new session) before Coder |
-| `**PR handoff**` + open PR | Skip Coder; run Reviewer |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup |
+| Same session — Investigator = `done` + **session investigation** in context | Skip Investigator unless user asked to re-run |
+| Same session — Tech Lead = `done` + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
+| New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
+| New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
+| `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
+| `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, then set `In Review` when criteria pass |
 
 ## Post-run response
 

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -4,13 +4,13 @@
 
 Runs after Coder posts `**PR handoff**`. Same issue — no sub-tasks.
 
-**Sapphire orchestrator:** Phase 4 runs in the **same session** as Phases 1–3 — do not exit after Coder complete.
+**Sapphire orchestrator:** Phase 4 runs in the **same session** as Phases 1–3 — do not exit after Coder complete. In a **new session**, do not start Reviewer without **session spec** — rebuild Tech Lead (and Investigator if needed) first per `SKILL.md`.
 
 ## `/goal` loop
 
 Prefix work with `/goal`. Do **not** stop after one failed pass when fixes are possible:
 
-1. Read **session spec** (and `## Requirement` on Linear for intent).
+1. Read **session spec** (required — orchestrator rebuilds Tech Lead when missing in a new session; see `SKILL.md` **Resume and idempotency**) and `## Requirement` on Linear for intent.
 2. Resolve PR via **PR execution trust** — GitHub first, not latest comment alone.
 3. Compare diff to **Contract / behavior**, **Verification**, **Out of scope**.
 4. Run **Verification command trust** only.

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -70,11 +70,11 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
 - If `## Sapphire status` is **missing**, insert the initial status block per `LINEAR-MCP.md` (full-description merge via `save_issue`) **first** — do not run resume or cleanup rules until the table exists; then start Investigator (or the user’s explicit start phase).
 - If `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone):
   1. Set `target` = user start phase if specified, else first row not `done` (Investigator → Tech Lead → Coder → Reviewer).
-  2. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
-  3. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
-  4. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`), keep their phase — skip steps 2–3.
+  2. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`) → run `target` and stop.
+  3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
+  4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
   5. Run from `target` through all later phases in this session.
-- If `**PR handoff**` + open PR exist and Coder = `done`, `target` is normally **Reviewer** — steps 2–3 still apply when session spec or investigation is missing.
+- If `**PR handoff**` + open PR exist and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
 - If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass set `In Review` and post `**Sapphire · Reviewer complete**`.
 - If **every** status row is `done` and issue is **`In Review`**, stop — await human merge.
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -68,14 +68,14 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
 - Optional: start phase (`investigator`, `tech-lead`, `coder`, `reviewer`) when resuming a stalled run — still apply **artifact-aware resume** when downstream phases need session investigation or spec (unless user explicitly asked to run that phase only).
 - Load issue with `get_issue`. Read `## Requirement` (or requirement body before Sapphire sections exist).
 - If `## Sapphire status` is **missing**, insert the initial status block per `LINEAR-MCP.md` (full-description merge via `save_issue`) **first** — do not run resume or cleanup rules until the table exists; then start Investigator (or the user’s explicit start phase).
-- If start phase is not specified **and** `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone):
-  1. Let `candidate` = first row not `done` (Investigator → Tech Lead → Coder → Reviewer).
-  2. If `candidate` is Coder or Reviewer and there is no **session spec** in this run → set start to **Tech Lead** (even when Tech Lead = `done` on Linear).
-  3. If start is Tech Lead (from step 1 or 2) and there is no **session investigation** in this run → set start to **Investigator** (even when Investigator = `done` on Linear).
-  4. If `**PR handoff**` + open PR exist and Coder = `done`, start **Reviewer** — session spec optional; use PR + Requirement per `REVIEWER.md`.
-  5. Run from start phase through all later phases in this session.
-- If user **did** specify start phase, apply steps 2–4 above before starting (unless they explicitly requested that phase only).
-- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — verify PR + `/goal`; on pass set `In Review` and post `**Sapphire · Reviewer complete**`; do not re-run earlier phases unless the user asked.
+- If `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone):
+  1. Set `target` = user start phase if specified, else first row not `done` (Investigator → Tech Lead → Coder → Reviewer).
+  2. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
+  3. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
+  4. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`), keep their phase — skip steps 2–3.
+  5. Run from `target` through all later phases in this session.
+- If `**PR handoff**` + open PR exist and Coder = `done`, `target` is normally **Reviewer** — steps 2–3 still apply when session spec or investigation is missing.
+- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass set `In Review` and post `**Sapphire · Reviewer complete**`.
 - If **every** status row is `done` and issue is **`In Review`**, stop — await human merge.
 
 ## Workflow
@@ -133,9 +133,10 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | Same session — Investigator = done + **session investigation** in context | Skip Investigator unless user asked to re-run |
 | Same session — Tech Lead = done + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
-| New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder (Investigator first if investigation missing) |
-| `**PR handoff**` comment + open PR | Skip Coder; run Reviewer (use session spec if same run; else PR + Requirement) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — set `In Review` when criteria pass; do not restart Investigator–Coder |
+| New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
+| `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
+| `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, then set `In Review` when criteria pass |
 | Issue `In Review` + Reviewer done | Stop — await human merge |
 
 ## Output

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -29,7 +29,7 @@ Run the squad in order on the **same issue** `_task` created (or any SOK issue t
 
 **Never** treat Investigator, Tech Lead, or Coder as standalone jobs when you were delegated from `_task` or invoked as `_team-sapphire` on a full issue. Phase comments (`**Sapphire · … complete**`) mark progress — they are **not** exit signals.
 
-Resume runs: start at the first phase still `pending` in `## Sapphire status`, then **continue through all later phases in the same session** unless a stop condition above applies.
+Resume runs: pick start phase with **artifact-aware resume** (below) — not status table alone — then **continue through all later phases in the same session** unless a stop condition above applies.
 
 ## Runtime
 
@@ -60,15 +60,21 @@ Investigation and spec are **working documents for this agent run**. Keep them i
 
 When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and the Sapphire footer. Strip legacy `## Investigation` / `## Spec` blocks if present — do not re-add them.
 
-**Resume in a new session:** `## Sapphire status` shows progress, but investigation/spec are not on Linear. Re-run from the first `pending` phase; if Coder or Reviewer is pending without session artifacts, re-run Tech Lead (and Investigator if needed) before implementing or reviewing.
+**Resume in a new session:** `## Sapphire status` shows progress, but investigation/spec are not on Linear. A row marked `done` does **not** skip a phase when its session artifact is missing — rebuild artifacts before downstream phases (Investigator → Tech Lead → Coder/Reviewer).
 
 ## Intake
 
 - Required: Linear issue id/URL (e.g. `SOK-XXX`) — usually from `_task` handoff on the same issue.
-- Optional: start phase (`investigator`, `tech-lead`, `coder`, `reviewer`) when resuming a stalled run.
+- Optional: start phase (`investigator`, `tech-lead`, `coder`, `reviewer`) when resuming a stalled run — still apply **artifact-aware resume** when downstream phases need session investigation or spec (unless user explicitly asked to run that phase only).
 - Load issue with `get_issue`. Read `## Requirement` (or requirement body before Sapphire sections exist).
 - If `## Sapphire status` is **missing**, insert the initial status block per `LINEAR-MCP.md` (full-description merge via `save_issue`) **first** — do not run resume or cleanup rules until the table exists; then start Investigator (or the user’s explicit start phase).
-- If start phase is not specified **and** `## Sapphire status` is present, read the table and resume at the **first** phase whose status is not `done`, in order: Investigator → Tech Lead → Coder → Reviewer.
+- If start phase is not specified **and** `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone):
+  1. Let `candidate` = first row not `done` (Investigator → Tech Lead → Coder → Reviewer).
+  2. If `candidate` is Coder or Reviewer and there is no **session spec** in this run → set start to **Tech Lead** (even when Tech Lead = `done` on Linear).
+  3. If start is Tech Lead (from step 1 or 2) and there is no **session investigation** in this run → set start to **Investigator** (even when Investigator = `done` on Linear).
+  4. If `**PR handoff**` + open PR exist and Coder = `done`, start **Reviewer** — session spec optional; use PR + Requirement per `REVIEWER.md`.
+  5. Run from start phase through all later phases in this session.
+- If user **did** specify start phase, apply steps 2–4 above before starting (unless they explicitly requested that phase only).
 - If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — verify PR + `/goal`; on pass set `In Review` and post `**Sapphire · Reviewer complete**`; do not re-run earlier phases unless the user asked.
 - If **every** status row is `done` and issue is **`In Review`**, stop — await human merge.
 
@@ -120,13 +126,14 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 ## Resume and idempotency
 
-Use `## Sapphire status` as the source of truth for which phase to run. Legacy `## Investigation` / `## Spec` on Linear (older runs) are ignored — strip on the next status write.
+Use `## Sapphire status` for progress on Linear; **session artifacts** decide whether a `done` row can be skipped. Legacy `## Investigation` / `## Spec` on Linear (older runs) are ignored — strip on the next status write.
 
 | Condition | Action |
 |-----------|--------|
-| `## Sapphire status` — Investigator = done | Skip Investigator unless user asked to re-run |
-| `## Sapphire status` — Tech Lead = done | Skip Tech Lead unless user asked to re-spec |
-| Tech Lead = done but no **session spec** (new session) | Re-run Tech Lead before Coder |
+| Same session — Investigator = done + **session investigation** in context | Skip Investigator unless user asked to re-run |
+| Same session — Tech Lead = done + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
+| New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
+| New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder (Investigator first if investigation missing) |
 | `**PR handoff**` comment + open PR | Skip Coder; run Reviewer (use session spec if same run; else PR + Requirement) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — set `In Review` when criteria pass; do not restart Investigator–Coder |
 | Issue `In Review` + Reviewer done | Stop — await human merge |

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -47,3 +47,4 @@ Post `**Sapphire · Tech Lead complete**` with:
 
 - **Sapphire orchestrator (default):** After Tech Lead complete, continue to Phase 3 (Coder) in the **same run** per `SKILL.md` — do not stop early.
 - **Standalone Tech Lead** (user invoked Tech Lead only): Stop after `**Sapphire · Tech Lead complete**`; Coder runs in a separate session.
+- **New session resume:** Linear may show Tech Lead = `done` without a **session spec**, or Investigator = `done` without **session investigation** — orchestrator re-runs missing upstream phases first per `SKILL.md` **Resume and idempotency**.

--- a/.cursor/skills/_team-sapphire/WORKFLOW.md
+++ b/.cursor/skills/_team-sapphire/WORKFLOW.md
@@ -22,7 +22,7 @@ flowchart LR
 
 The orchestrator runs **Investigator → Tech Lead → Coder → Reviewer** in one agent session. Phase completion comments are audit markers — not handoff to a new run.
 
-Resume: start at the first `pending` row in `## Sapphire status`, then finish every later phase in the same session. Investigation and spec are **not** on Linear — re-run Tech Lead (and Investigator if needed) when resuming Coder or Reviewer in a new session.
+Resume: use **artifact-aware resume** in `SKILL.md` — status `done` does not skip a phase when session investigation or spec is missing. Rebuild Investigator → Tech Lead before Coder or Reviewer in a new session; then finish every later phase in the same session.
 
 ## Roles
 


### PR DESCRIPTION
## Summary

- Fix Sapphire resume intake so a `done` status row does not skip phases when session investigation or spec is missing in a new run.
- Add artifact-aware resume steps: rebuild Investigator and/or Tech Lead before Coder or Reviewer when needed.
- Align `WORKFLOW.md`, `INVESTIGATOR.md`, and `TECH-LEAD.md` with the updated idempotency rules.

Follow-up to #3110 (Bugbot review #4478429321).

## Test plan

- [ ] Resume a stalled issue in a new session with Tech Lead = `done` and Coder = `pending` — confirm Tech Lead re-runs before Coder.
- [ ] Resume with Investigator = `done` and Tech Lead = `pending` — confirm Investigator re-runs before Tech Lead.
- [ ] Same-session continuous run still skips completed phases when artifacts are in context.
- [ ] PR handoff + open PR still starts Reviewer without requiring session spec.


Made with [Cursor](https://cursor.com)