### PR TITLE
chore(database): remove unused repository methods

### DIFF
--- a/packages/database/src/repositories/__tests__/subscription.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/subscription.repository.test.ts
@@ -66,35 +66,6 @@ describe("subscriptionRepository", () => {
     assert.equal(call.where.periodEnd.gt, now);
   });
 
-  it("getLatestActiveSubscriptionByReferenceId orders by periodEnd only", async () => {
-    const fallbackRow = { id: "fallback" };
-    let findFirstCall: unknown;
-    const tx = {
-      subscription: {
-        findFirst: async (args: unknown) => {
-          findFirstCall = args;
-          return fallbackRow;
-        },
-      },
-    } as unknown as Prisma.TransactionClient;
-
-    const result =
-      await subscriptionRepository.getLatestActiveSubscriptionByReferenceId(
-        "reference-1",
-        tx,
-      );
-
-    assert.equal(result, fallbackRow);
-    assert.deepEqual((findFirstCall as { orderBy: unknown }).orderBy, [
-      { periodEnd: { sort: "desc", nulls: "last" } },
-      { updatedAt: "desc" },
-    ]);
-    assert.equal(
-      (findFirstCall as { where: { periodStart?: unknown } }).where.periodStart,
-      undefined,
-    );
-  });
-
   it("resolveActiveSubscriptionByReferenceId prefers in-period over latest by periodEnd", async () => {
     const inPeriodRow = { id: "current-period" };
     const calls: unknown[] = [];

--- a/packages/database/src/repositories/invitation.repository.ts
+++ b/packages/database/src/repositories/invitation.repository.ts
@@ -27,27 +27,6 @@ export const invitationRepository = {
     });
   },
 
-  /**
-   * Checks if there is at least one pending invitation for a given email.
-   *
-   * @param email - The email address to search invitations for.
-   * @param tx - Optional Prisma transaction client.
-   * @returns Promise resolving to true if there is at least one pending invitation for the given email, false otherwise.
-   */
-  async hasPendingInvitationByEmail(
-    email: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<boolean> {
-    const count = await tx.invitation.count({
-      where: {
-        email,
-        status: InvitationStatus.PENDING,
-      },
-      take: 1,
-    });
-    return count > 0;
-  },
-
   async getPendingInvitationsByOrganizationId(
     organizationId: string,
     tx: Prisma.TransactionClient,

--- a/packages/database/src/repositories/job.repository.ts
+++ b/packages/database/src/repositories/job.repository.ts
@@ -11,7 +11,6 @@ import {
   finalizedAgentJobStatuses,
   type JobWithSokosumiStatus,
   jobInclude,
-  jobOrderBy,
 } from "../types/job.js";
 import { creditBucketRepository } from "./credit-bucket.repository.js";
 
@@ -67,96 +66,6 @@ type CreateJobData = CreatePaidJobData | CreateFreeJobData;
  * creating new jobs, updating job status, and handling job lifecycle operations.
  */
 export const jobRepository = {
-  /**
-   * Retrieves all jobs associated with a specific user
-   * @param userId - The unique identifier of the user
-   * @returns Promise containing an array of jobs with their relations
-   */
-  async getJobsByUserId(
-    userId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<JobWithSokosumiStatus[]> {
-    const jobs = await tx.job.findMany({
-      where: { userId },
-      include: jobInclude,
-      orderBy: jobOrderBy,
-    });
-    return jobs.map(mapJobWithStatus);
-  },
-
-  /**
-   * Retrieves the average execution duration in seconds for a specific agent
-   * @param agentId - The unique identifier of the agent
-   * @returns Promise containing the average execution duration in seconds
-   */
-  async getAverageExecutionDurationByAgentId(
-    agentId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<number | null> {
-    const result = await tx.$queryRaw<
-      [{ avg_duration_seconds: Prisma.Decimal | null }]
-    >`
-    SELECT 
-      COALESCE(AVG(EXTRACT(EPOCH FROM (completed."createdAt" - initiated."createdAt"))), 0) as avg_duration_seconds
-    FROM "Job" j
-    INNER JOIN "jobEvent" initiated ON initiated."jobId" = j.id
-      AND initiated."status" = 'INITIATED'::"AgentJobStatus"
-    INNER JOIN "jobEvent" completed ON completed."jobId" = j.id
-      AND completed."status" = 'COMPLETED'::"AgentJobStatus"
-    WHERE j."agentId" = ${agentId}
-    AND j."jobType" != 'DEMO'
-    AND j."createdAt" >= NOW() - INTERVAL '90 days'
-  `;
-    const averageDurationSeconds = result[0]?.avg_duration_seconds;
-    if (!averageDurationSeconds) {
-      return null;
-    }
-    return averageDurationSeconds.toNumber();
-  },
-
-  /**
-   * Retrieves the number of executed jobs for a specific agent (not demo jobs)
-   * @param agentId - The unique identifier of the agent
-   * @returns Promise containing the number of executed jobs
-   */
-  async getExecutedJobsCountByAgentId(
-    agentId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<number> {
-    return await tx.job.count({
-      where: {
-        agentId,
-        jobType: {
-          not: JobType.DEMO,
-        },
-      },
-    });
-  },
-
-  /**
-   * Retrieves all jobs associated with a specific agent and user (not demo jobs)
-   * @param agentId - The unique identifier of the agent
-   * @param userId - The unique identifier of the user
-   * @returns Promise containing an array of jobs with their relations
-   */
-  async getJobsByAgentIdAndUserId(
-    agentId: string,
-    userId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<JobWithSokosumiStatus[]> {
-    const jobs = await tx.job.findMany({
-      where: { agentId, userId },
-      include: jobInclude,
-      orderBy: jobOrderBy,
-    });
-
-    if (!jobs) {
-      return [];
-    }
-
-    return jobs.map(mapJobWithStatus);
-  },
-
   async getJobById(
     jobId: string,
     tx: Prisma.TransactionClient,
@@ -169,17 +78,6 @@ export const jobRepository = {
       return null;
     }
     return mapJobWithStatus(job);
-  },
-
-  async getJobByBlockchainIdentifier(
-    blockchainIdentifier: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<JobWithSokosumiStatus | null> {
-    const job = await tx.job.findUnique({
-      where: { blockchainIdentifier },
-      include: jobInclude,
-    });
-    return job ? mapJobWithStatus(job) : null;
   },
 
   async createDemoJob(
@@ -370,19 +268,6 @@ export const jobRepository = {
         throw new Error(`Unsupported job type: ${_exhaustive}`);
       }
     }
-  },
-
-  async updateJobNameById(
-    jobId: string,
-    name: string | null,
-    tx: Prisma.TransactionClient,
-  ): Promise<JobWithSokosumiStatus> {
-    const job = await tx.job.update({
-      where: { id: jobId },
-      data: { name },
-      include: jobInclude,
-    });
-    return mapJobWithStatus(job);
   },
 
   /**

--- a/packages/database/src/repositories/member.repository.ts
+++ b/packages/database/src/repositories/member.repository.ts
@@ -189,48 +189,6 @@ export const memberRepository = (() => {
     });
   }
 
-  /**
-   * Retrieves the count of members by role for a given organization.
-   *
-   * @param organizationId - The ID of the organization.
-   * @param tx - Optional Prisma transaction client.
-   * @returns An object with the count of members by role.
-   */
-  async function getPerRoleCountByOrganizationId(
-    organizationId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<{ [key in MemberRole]: number }> {
-    const memberCounts = await tx.member.groupBy({
-      by: ["role"],
-      where: { organizationId },
-      _count: {
-        role: true,
-      },
-    });
-
-    const counts: { [key in MemberRole]: number } = Object.values(
-      MemberRole,
-    ).reduce(
-      (acc, role) => {
-        acc[role] = 0;
-        return acc;
-      },
-      {} as { [key in MemberRole]: number },
-    );
-
-    memberCounts.forEach((group) => {
-      const {
-        role,
-        _count: { role: roleCount },
-      } = group;
-      if (role in counts) {
-        counts[role as MemberRole] = roleCount;
-      }
-    });
-
-    return counts;
-  }
-
   async function getAssignedMemberCount(
     organizationId: string,
     tx: Prisma.TransactionClient,
@@ -377,7 +335,6 @@ export const memberRepository = (() => {
     getMembersWithUser,
     getMembersWithUserAndLastSeen,
     getMembersByOrganizationId,
-    getPerRoleCountByOrganizationId,
     unassignSeat,
   };
 })();

--- a/packages/database/src/repositories/organization.repository.ts
+++ b/packages/database/src/repositories/organization.repository.ts
@@ -67,20 +67,6 @@ export const organizationRepository = {
   },
 
   /**
-   * Retrieves an organization with its relations by organization slug.
-   *
-   * @param slug - The slug of the organization.
-   * @param tx - Optional Prisma transaction client.
-   * @returns The OrganizationWithRelations object if found, otherwise null.
-   */
-  async getOrganizationWithRelationsBySlug(
-    slug: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<OrganizationWithRelations | null> {
-    return await this.getUniqueOrganizationWithRelations({ slug }, tx);
-  },
-
-  /**
    * Updates an organization by its ID with the provided data.
    *
    * @param organizationId - The ID of the organization to update.
@@ -203,53 +189,6 @@ export const organizationRepository = {
   ): Promise<Organization | null> {
     return await tx.organization.findUnique({
       where: { stripeCustomerId },
-    });
-  },
-
-  /**
-   * Retrieves all organizations that do not have a Stripe customer ID.
-   *
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to an array of Organization objects without Stripe customer IDs.
-   */
-  async getOrganizationsWithoutStripeCustomerId(
-    tx: Prisma.TransactionClient,
-  ): Promise<Organization[]> {
-    return await tx.organization.findMany({
-      where: {
-        stripeCustomerId: null,
-      },
-    });
-  },
-
-  /**
-   * Retrieves a page of organization IDs ordered by ID, starting after an optional cursor.
-   *
-   * @param cursorId - The last processed organization ID, or null to start from the beginning.
-   * @param limit - The maximum number of organizations to return.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to an array of organizations containing only IDs.
-   */
-  async getOrganizationsBatchAfterCursor(
-    cursorId: string | null,
-    limit: number,
-    tx: Prisma.TransactionClient,
-  ): Promise<Array<Pick<Organization, "id">>> {
-    return await tx.organization.findMany({
-      where: cursorId
-        ? {
-            id: {
-              gt: cursorId,
-            },
-          }
-        : undefined,
-      orderBy: {
-        id: "asc",
-      },
-      select: {
-        id: true,
-      },
-      take: limit,
     });
   },
 };

--- a/packages/database/src/repositories/subscription.repository.ts
+++ b/packages/database/src/repositories/subscription.repository.ts
@@ -72,26 +72,6 @@ export const subscriptionRepository = {
   },
 
   /**
-   * Active subscription with the latest `periodEnd` (any status window).
-   * Ignores whether `now` falls inside that period.
-   */
-  async getLatestActiveSubscriptionByReferenceId(
-    referenceId: string,
-    tx: Prisma.TransactionClient,
-  ): Promise<Subscription | null> {
-    return await tx.subscription.findFirst({
-      where: {
-        referenceId,
-        ...activeSubscriptionStatusWhere(),
-      },
-      orderBy: [
-        { periodEnd: { sort: "desc", nulls: "last" } },
-        { updatedAt: "desc" },
-      ],
-    });
-  },
-
-  /**
    * Active subscription with the latest `periodEnd` among rows whose period has
    * started (`periodStart` null or `<= now`). Excludes pre-created successors
    * whose `periodStart` is still in the future.

--- a/packages/database/src/repositories/user.repository.ts
+++ b/packages/database/src/repositories/user.repository.ts
@@ -36,22 +36,6 @@ export const userRepository = {
   },
 
   /**
-   * Retrieves all users that do not have a Stripe customer ID.
-   *
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to an array of User objects without Stripe customer IDs.
-   */
-  getUsersWithoutStripeCustomerId: async (
-    tx: Prisma.TransactionClient,
-  ): Promise<User[]> => {
-    return tx.user.findMany({
-      where: {
-        stripeCustomerId: null,
-      },
-    });
-  },
-
-  /**
    * Searches users by name or email using a case-insensitive partial match.
    *
    * @param query - The search term to match against user name and email.
@@ -80,69 +64,6 @@ export const userRepository = {
       orderBy: { name: "asc" },
       take: limit,
     });
-  },
-
-  /**
-   * Retrieves a page of user IDs ordered by ID, starting after an optional cursor.
-   *
-   * @param cursorId - The last processed user ID, or null to start from the beginning.
-   * @param limit - The maximum number of users to return.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to an array of users containing only IDs.
-   */
-  getUsersBatchAfterCursor: async (
-    cursorId: string | null,
-    limit: number,
-    tx: Prisma.TransactionClient,
-  ): Promise<Array<Pick<User, "id">>> => {
-    return tx.user.findMany({
-      where: cursorId
-        ? {
-            id: {
-              gt: cursorId,
-            },
-          }
-        : undefined,
-      orderBy: {
-        id: "asc",
-      },
-      select: {
-        id: true,
-      },
-      take: limit,
-    });
-  },
-
-  /**
-   * Updates the termsAccepted status for a user.
-   *
-   * @param userId - The unique identifier of the user.
-   * @param termsAccepted - The new terms accepted status to set.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to the updated User object.
-   */
-  updateTermsAccepted: async (
-    userId: string,
-    termsAccepted: boolean,
-    tx: Prisma.TransactionClient,
-  ): Promise<User> => {
-    return tx.user.update({ where: { id: userId }, data: { termsAccepted } });
-  },
-
-  /**
-   * Updates the marketingOptIn status for a user.
-   *
-   * @param userId - The unique identifier of the user.
-   * @param marketingOptIn - The new marketing opt in status to set.
-   * @param tx - (Optional) The Prisma transaction client to use. Defaults to the main Prisma client.
-   * @returns A promise that resolves to the updated User object.
-   */
-  updateMarketingOptIn: async (
-    userId: string,
-    marketingOptIn: boolean,
-    tx: Prisma.TransactionClient,
-  ): Promise<User> => {
-    return tx.user.update({ where: { id: userId }, data: { marketingOptIn } });
   },
 
   /**


### PR DESCRIPTION
## Summary

Pure-deletion cleanup as part of the web→core DB-access migration: removes repository methods in `packages/database/src/repositories` that no longer have any callers. 368 deleted lines, zero additions besides import trimming. No API, schema, or behavior changes.

## Methodology

For every public method of `organizationRepository`, `memberRepository`, `subscriptionRepository`, `userRepository`, `invitationRepository`, and `jobRepository`, the whole repo (`apps/`, `packages/`, `scripts/`, all `*.ts`/`*.tsx`/`*.js`/`*.mjs`, excluding `src/generated`) was grepped with word-boundary matching. A method was deleted only if its sole references were its own definition/export (and, for one case, its own unit test). Methods referenced from `packages/database/src/helpers`, other packages, or internally by live methods in the same repository file were kept.

## Deleted methods (grep evidence: zero references outside own definition)

`organization.repository.ts`
- `getOrganizationWithRelationsBySlug` — last caller rewired to the core client in #3099; only remaining reference was its own definition
- `getOrganizationsWithoutStripeCustomerId` — no references anywhere (incl. `scripts/`)
- `getOrganizationsBatchAfterCursor` — no references anywhere (incl. `scripts/`)

`member.repository.ts`
- `getPerRoleCountByOrganizationId` — only references: definition + export entry

`subscription.repository.ts`
- `getLatestActiveSubscriptionByReferenceId` — only references: definition + its own test case (removed) in `__tests__/subscription.repository.test.ts`

`user.repository.ts`
- `getUsersWithoutStripeCustomerId`
- `getUsersBatchAfterCursor`
- `updateTermsAccepted`
- `updateMarketingOptIn`
— each: only reference was its own definition

`invitation.repository.ts`
- `hasPendingInvitationByEmail` — only reference was its own definition

`job.repository.ts`
- `getJobsByUserId`
- `getAverageExecutionDurationByAgentId`
- `getExecutedJobsCountByAgentId`
- `getJobsByAgentIdAndUserId`
- `getJobByBlockchainIdentifier`
- `updateJobNameById`
— each: only reference was its own definition. Also drops the now-unused `jobOrderBy` import.

## Kept despite zero external callers (alive via internal callers)

- `organizationRepository.getUniqueOrganizationWithRelations` — called by `getOrganizationWithRelationsById`
- `memberRepository.getMemberByIdAndOrganizationId` — called by `assignSeat`/`unassignSeat`
- `memberRepository.getMembersWithUser` — called by `getMembersWithUserAndLastSeen`
- `subscriptionRepository.getCurrentInPeriodActiveSubscriptionByReferenceId` and `getLatestStartedActiveSubscriptionByReferenceId` — called by `resolveActiveSubscriptionByReferenceId`

## Verification

- `pnpm --filter @sokosumi/database typecheck` ✅
- `pnpm --filter @sokosumi/core typecheck` ✅
- `pnpm --filter web typecheck` ✅
- `pnpm --filter @sokosumi/database test` ✅ (28 files passed, 190 tests passed, 2 skipped)
- `pnpm check` (repo-wide Biome) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)