### PR TITLE
ci: run test workspaces via matrix with descriptive check names

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,17 @@
+name: Setup
+description: Install pnpm, Node.js, and workspace dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "24"
+        cache: "pnpm"
+
+    - name: Install Dependencies
+      run: pnpm install
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,16 +58,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run Prisma Migrate
         run: pnpm prisma:migrate:dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,16 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run Biome checks
         run: pnpm check
@@ -38,16 +30,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run TypeScript typecheck
         run: pnpm typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,16 @@ env:
   DATABASE_URL: "postgresql://user:password@localhost:5432/sokosumi"
 
 jobs:
-  web:
-    name: Web
+  test:
+    name: Test ${{ matrix.target.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { name: Web, command: "pnpm web:test:ci" }
+          - { name: Core, command: "pnpm core:test:ci" }
+          - { name: Packages, command: 'pnpm --filter "./packages/*" test:ci' }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,47 +37,5 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Run Web Tests
-        run: pnpm web:test:ci
-
-  core:
-    name: Core
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Run Core Tests
-        run: pnpm core:test:ci
-
-  packages:
-    name: Packages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Run Package Tests
-        run: pnpm --filter "./packages/*" test:ci
+      - name: Run Tests
+        run: ${{ matrix.target.command }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,16 +26,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run Tests
         run: ${{ matrix.target.command }}


### PR DESCRIPTION
## Summary
Two CI cleanups:

### 1. Test matrix with descriptive check names
Collapses the three near-identical jobs in `test.yml` (`Web`, `Core`, `Packages`) into a single matrix job. Check names become **Test Web**, **Test Core**, **Test Packages** so required status checks are unambiguous in branch protection settings (bare "Core" read like the core app rather than its test suite).

- `fail-fast: false` preserves the previous behavior where one failing suite does not cancel the others.

### 2. Composite setup action
Extracts the checkout-adjacent pnpm/node/install boilerplate (repeated in `build.yml`, `lint.yml`, `test.yml`) into `.github/actions/setup`. Checkout stays in each job — a local action can only run after the repository is checked out.

## ⚠️ Branch protection update required
Required status checks are matched **by name**. After merging, update the repo settings:
- Remove required checks: `Web`, `Core`, `Packages`
- Add required checks: `Test Web`, `Test Core`, `Test Packages`

Until settings are updated, PRs based on this change will wait forever on the old check names. Open PRs must rebase onto main to pick up the new names.

## Verification
- CI on this PR runs all jobs through the composite action and the three matrix targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)