### PR TITLE
ci: rename typescript check to typecheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm check
 
   typecheck:
-    name: TypeScript
+    name: Typecheck
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Renames the `TypeScript` job in `lint.yml` to **Typecheck** — names the activity rather than the language, consistent with the `Test Web`/`Test Core`/`Test Packages` naming.

## ⚠️ Branch protection
If `TypeScript` is a required status check, replace it with `Typecheck` in the repo settings after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)