### PR TITLE
docs(agents): configure issue tracker, triage labels, and domain docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,20 @@ docs(readme): update setup instructions
 - Reference existing code rather than duplicating it
 - Use `@/lib/*` aliases for imports
 
+## Agent skills
+
+### Issue tracker
+
+Issues live in Linear (team "Sokosumi", key `SOK`), accessed via the Linear MCP tools. See [`docs/agents/issue-tracker.md`](./docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Hybrid mapping: native Linear statuses for needs-triage (Triage) and wontfix (Canceled); labels `needs-info` / `ready-for-agent` / `ready-for-human`. See [`docs/agents/triage-labels.md`](./docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). See [`docs/agents/domain.md`](./docs/agents/domain.md).
+
 ## Additional Rules
 
 - [Linting](.cursor/rules/lint.mdc)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,21 @@ a short kebab-case description — e.g. for `SOK-555`, name the branch
 `sok-555-short-description`. Prefer the `gitBranchName` Linear provides for the
 issue when available.
 
+## Agent skills
+
+### Issue tracker
+
+Issues live in Linear (team "Sokosumi", key `SOK`), accessed via the Linear MCP
+tools. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Hybrid mapping: native Linear statuses for needs-triage (Triage) and wontfix
+(Canceled); labels `needs-info` / `ready-for-agent` / `ready-for-human`. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily).
+See `docs/agents/domain.md`.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,21 +36,3 @@ a short kebab-case description — e.g. for `SOK-555`, name the branch
 `sok-555-short-description`. Prefer the `gitBranchName` Linear provides for the
 issue when available.
 
-## Agent skills
-
-### Issue tracker
-
-Issues live in Linear (team "Sokosumi", key `SOK`), accessed via the Linear MCP
-tools. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Hybrid mapping: native Linear statuses for needs-triage (Triage) and wontfix
-(Canceled); labels `needs-info` / `ready-for-agent` / `ready-for-human`. See
-`docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily).
-See `docs/agents/domain.md`.
-

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a **single-context** repo: one shared domain language (jobs, agents, credits, seats, organizations) spans the whole monorepo, so there is one `CONTEXT.md` and one `docs/adr/` at the root — not per app or package.
+
+```
+/
+├── CONTEXT.md                 ← created lazily by /grill-with-docs
+├── docs/adr/                  ← created lazily; system-wide decisions
+├── apps/
+│   ├── web/
+│   └── core/
+└── packages/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,27 @@
+# Issue tracker: Linear
+
+Issues and PRDs for this repo live in **Linear**, team **Sokosumi** (issue key `SOK`). Use the Linear MCP tools (`mcp__claude_ai_Linear__*`) for all operations — there is no CLI.
+
+## Conventions
+
+- **Create an issue**: `save_issue` with `team: "Sokosumi"`, a title, and a markdown description. Apply domain labels (Bug, Feature, Improvement, Core, App, …) where obvious.
+- **Read an issue**: `get_issue` by identifier (e.g. `SOK-555`), plus `list_comments` for the discussion.
+- **List issues**: `list_issues` filtered by team, state, label, or assignee.
+- **Comment on an issue**: `save_comment`.
+- **Update status / labels**: `save_issue` with the issue id and the new state or labels.
+
+## Team workflow states
+
+`Triage` → `Backlog` → `Todo` → `In Progress` → `In Review` → `Done`, plus `Canceled` and `Duplicate`. Triage-role mapping lives in `docs/agents/triage-labels.md`.
+
+## Branch naming (repo rule)
+
+Branches for a Linear issue MUST start with the lowercased issue identifier followed by a short kebab-case description — for `SOK-555`, `sok-555-short-description`. Prefer the `gitBranchName` Linear provides for the issue when available.
+
+## When a skill says "publish to the issue tracker"
+
+Create a Linear issue in the Sokosumi team.
+
+## When a skill says "fetch the relevant ticket"
+
+`get_issue` for the identifier, then `list_comments` for context.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,18 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This repo tracks issues in Linear (team Sokosumi), which expresses two of the roles as native workflow states; the rest are labels.
+
+| Canonical role    | Linear mapping            | Meaning                                  |
+| ----------------- | ------------------------- | ---------------------------------------- |
+| `needs-triage`    | status **Triage**         | Maintainer needs to evaluate this issue  |
+| `needs-info`      | label `needs-info`        | Waiting on reporter for more information |
+| `ready-for-agent` | label `ready-for-agent`   | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | label `ready-for-human`   | Requires human implementation            |
+| `wontfix`         | status **Canceled**       | Will not be actioned                     |
+
+Rules:
+
+- When a skill says "apply the needs-triage label", move the issue to the **Triage** status instead.
+- When a skill says "apply wontfix", move the issue to **Canceled** (optionally with a closing comment) instead.
+- Applying `ready-for-agent` or `ready-for-human` also moves the issue from Triage to **Todo** — the label says *who* should pick it up; the status says it is ready.
+- The three labels (`needs-info`, `ready-for-agent`, `ready-for-human`) do not exist in the Sokosumi team yet — create them on first use (`create_issue_label`).


### PR DESCRIPTION
## Summary

Scaffolds the per-repo configuration that the Matt Pocock engineering skills (`to-issues`, `triage`, `to-prd`, `diagnose`, `tdd`, `improve-codebase-architecture`, `grill-with-docs`) read:

- **`docs/agents/issue-tracker.md`** — issues live in Linear (team "Sokosumi", key `SOK`) via the Linear MCP tools; documents create/read/list/comment conventions, the team's workflow states, and restates the repo's branch-naming rule.
- **`docs/agents/triage-labels.md`** — hybrid triage mapping: native Linear statuses for needs-triage (**Triage**) and wontfix (**Canceled**); labels `needs-info` / `ready-for-agent` / `ready-for-human` (created on first use; `ready-for-*` also moves the issue to Todo).
- **`docs/agents/domain.md`** — single-context layout: one `CONTEXT.md` + `docs/adr/` at the repo root, created lazily by `/grill-with-docs`.
- **`AGENTS.md`** — new `## Agent skills` section pointing at the three docs. Placed in `AGENTS.md` (not `CLAUDE.md`) so it reaches every AGENTS.md-aware tool — Cursor, Codex, etc. — and Claude Code via the existing `@AGENTS.md` import. `CLAUDE.md` is unchanged.

Docs only — no runtime impact.

## Verification

- `pnpm format:check` clean
- `CLAUDE.md` diff is empty (section moved to `AGENTS.md` in bca8e5296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)