### PR TITLE
fix(web): add stripe idempotency keys to credit invoice creation

### DIFF
--- a/apps/web/src/lib/clients/__tests__/stripe.client.test.ts
+++ b/apps/web/src/lib/clients/__tests__/stripe.client.test.ts
@@ -450,14 +450,97 @@ describe("stripe.client lookup-key pricing", () => {
     });
 
     const { stripeClient } = await import("../stripe.client");
-    await stripeClient.applyInvoiceCreditsToCustomer("cus_1", "coupon_1");
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "grant-coupon_1-user-1",
+    );
 
     expect(invoiceItemsCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         customer: "cus_1",
         quantity: 500,
       }),
+      expect.anything(),
     );
+  });
+
+  it("passes derived idempotency keys to every stripe call", async () => {
+    productsRetrieveMock.mockResolvedValue({
+      default_price: createMockStripePrice({
+        currency: "eur",
+        id: "price_credits",
+        unitAmount: 120,
+      }),
+    });
+    couponsRetrieveMock.mockResolvedValue({
+      id: "coupon_1",
+      metadata: { credits: "500" },
+      percent_off: 100,
+    });
+    invoiceItemsCreateMock.mockResolvedValue({ id: "ii_1" });
+    invoicesCreateMock.mockResolvedValue({ id: "in_1" });
+    invoicesFinalizeInvoiceMock.mockResolvedValue({
+      id: "in_1",
+      status: "paid",
+    });
+
+    const { stripeClient } = await import("../stripe.client");
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "welcome-coupon_1-user-1",
+    );
+
+    expect(invoiceItemsCreateMock).toHaveBeenCalledWith(expect.anything(), {
+      idempotencyKey: "welcome-coupon_1-user-1-item-1",
+    });
+    expect(invoicesCreateMock).toHaveBeenCalledWith(expect.anything(), {
+      idempotencyKey: "welcome-coupon_1-user-1-invoice",
+    });
+    expect(invoicesFinalizeInvoiceMock).toHaveBeenCalledWith(
+      "in_1",
+      {},
+      { idempotencyKey: "welcome-coupon_1-user-1-finalize" },
+    );
+  });
+
+  it("derives a distinct idempotency key per referral invoice item", async () => {
+    productsRetrieveMock.mockResolvedValue({
+      default_price: createMockStripePrice({
+        currency: "eur",
+        id: "price_credits",
+        unitAmount: 120,
+      }),
+    });
+    couponsRetrieveMock.mockResolvedValue({
+      id: "coupon_1",
+      metadata: { credits: "500" },
+      percent_off: 100,
+    });
+    invoiceItemsCreateMock.mockResolvedValue({ id: "ii_1" });
+    invoicesCreateMock.mockResolvedValue({ id: "in_1" });
+    invoicesFinalizeInvoiceMock.mockResolvedValue({
+      id: "in_1",
+      status: "paid",
+    });
+
+    const { stripeClient } = await import("../stripe.client");
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "referral-coupon_1-user-1-2",
+      undefined,
+      2,
+    );
+
+    expect(invoiceItemsCreateMock).toHaveBeenCalledTimes(2);
+    expect(invoiceItemsCreateMock).toHaveBeenCalledWith(expect.anything(), {
+      idempotencyKey: "referral-coupon_1-user-1-2-item-1",
+    });
+    expect(invoiceItemsCreateMock).toHaveBeenCalledWith(expect.anything(), {
+      idempotencyKey: "referral-coupon_1-user-1-2-item-2",
+    });
   });
 
   it("propagates custom coupon metadata onto invoice metadata", async () => {
@@ -481,10 +564,15 @@ describe("stripe.client lookup-key pricing", () => {
     });
 
     const { stripeClient } = await import("../stripe.client");
-    await stripeClient.applyInvoiceCreditsToCustomer("cus_1", "coupon_1", {
-      redemption_type: "welcome_coupon",
-      welcome_source: "customer.created",
-    });
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "welcome-coupon_1-user-1",
+      {
+        redemption_type: "welcome_coupon",
+        welcome_source: "customer.created",
+      },
+    );
 
     expect(invoicesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -495,6 +583,7 @@ describe("stripe.client lookup-key pricing", () => {
           welcome_source: "customer.created",
         }),
       }),
+      expect.anything(),
     );
   });
 
@@ -519,7 +608,11 @@ describe("stripe.client lookup-key pricing", () => {
     });
 
     const { stripeClient } = await import("../stripe.client");
-    await stripeClient.applyInvoiceCreditsToCustomer("cus_1", "coupon_1");
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "grant-coupon_1-user-1",
+    );
 
     expect(invoicesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -529,6 +622,7 @@ describe("stripe.client lookup-key pricing", () => {
           ttl_days: "90",
         }),
       }),
+      expect.anything(),
     );
   });
 
@@ -553,7 +647,11 @@ describe("stripe.client lookup-key pricing", () => {
     });
 
     const { stripeClient } = await import("../stripe.client");
-    await stripeClient.applyInvoiceCreditsToCustomer("cus_1", "coupon_1");
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "grant-coupon_1-user-1",
+    );
 
     expect(invoicesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -563,6 +661,7 @@ describe("stripe.client lookup-key pricing", () => {
           ttl_days: "0",
         }),
       }),
+      expect.anything(),
     );
   });
 
@@ -587,7 +686,11 @@ describe("stripe.client lookup-key pricing", () => {
     });
 
     const { stripeClient } = await import("../stripe.client");
-    await stripeClient.applyInvoiceCreditsToCustomer("cus_1", "coupon_1");
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "grant-coupon_1-user-1",
+    );
 
     expect(invoicesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -597,6 +700,7 @@ describe("stripe.client lookup-key pricing", () => {
           ttl_days: "null",
         }),
       }),
+      expect.anything(),
     );
   });
 });

--- a/apps/web/src/lib/clients/stripe.client.ts
+++ b/apps/web/src/lib/clients/stripe.client.ts
@@ -678,9 +678,25 @@ export const stripeClient = (() => {
       });
     },
 
+    /**
+     * Grants free credits by creating discounted invoice items and a
+     * zero-total invoice.
+     *
+     * `idempotencyKeyBase` makes the whole grant idempotent against retries
+     * (e.g. Stripe webhook redeliveries): every Stripe call derives its own
+     * key from the base (`-item-N`, `-invoice`, `-finalize`), so a replayed
+     * grant returns the original invoice instead of creating a second one.
+     * The base MUST be stable across retries of the same logical grant and
+     * unique per legitimately distinct grant — derive it from domain
+     * identifiers (user id, coupon id, …), never from timestamps or
+     * randomness. Stripe rejects a reused key whose request params differ
+     * (`idempotency_error`), so anything that changes the params (e.g. the
+     * coupon's `credits` metadata) must also change the base.
+     */
     async applyInvoiceCreditsToCustomer(
       customerId: string,
       couponId: string,
+      idempotencyKeyBase: string,
       metadata?: Record<string, string>,
       referralCount: number = 1,
     ): Promise<Stripe.Invoice> {
@@ -699,41 +715,55 @@ export const stripeClient = (() => {
       const itemsToCreate = Math.min(referralCount, MAX_REFERRAL_COUNT);
       await Promise.all(
         Array.from({ length: itemsToCreate }).map((_, index) =>
-          stripe.invoiceItems.create({
-            customer: customerId,
-            pricing: { price: price.id },
-            currency: price.currency,
-            quantity: credits,
-            description: `Referral credit redemption (${credits} credits) - ${index + 1} of ${itemsToCreate}`,
-            metadata: {
-              coupon_id: couponId,
-              redemption_type: "free_coupon",
-              ...(couponTtlDays ? { ttl_days: couponTtlDays } : {}),
-              ...(metadata ?? {}),
+          stripe.invoiceItems.create(
+            {
+              customer: customerId,
+              pricing: { price: price.id },
+              currency: price.currency,
+              quantity: credits,
+              description: `Referral credit redemption (${credits} credits) - ${index + 1} of ${itemsToCreate}`,
+              metadata: {
+                coupon_id: couponId,
+                redemption_type: "free_coupon",
+                ...(couponTtlDays ? { ttl_days: couponTtlDays } : {}),
+                ...(metadata ?? {}),
+              },
+              discounts: [{ coupon: couponId }],
             },
-            discounts: [{ coupon: couponId }],
-          }),
+            {
+              idempotencyKey: `${idempotencyKeyBase}-item-${index + 1}`,
+            },
+          ),
         ),
       );
 
       // 2) Create & finalize zero-total invoice with the coupon discount
-      const invoice = await stripe.invoices.create({
-        customer: customerId,
-        currency: price.currency,
-        pending_invoice_items_behavior: "include",
-        collection_method: "charge_automatically",
-        auto_advance: true,
-        metadata: {
-          coupon_id: couponId,
-          price_id: price.id,
-          ...(couponTtlDays ? { ttl_days: couponTtlDays } : {}),
-          ...(metadata ?? {}),
+      const invoice = await stripe.invoices.create(
+        {
+          customer: customerId,
+          currency: price.currency,
+          pending_invoice_items_behavior: "include",
+          collection_method: "charge_automatically",
+          auto_advance: true,
+          metadata: {
+            coupon_id: couponId,
+            price_id: price.id,
+            ...(couponTtlDays ? { ttl_days: couponTtlDays } : {}),
+            ...(metadata ?? {}),
+          },
+          expand: ["lines.data.price.product"],
         },
-        expand: ["lines.data.price.product"],
-      });
+        {
+          idempotencyKey: `${idempotencyKeyBase}-invoice`,
+        },
+      );
 
       const finalizedInvoice = await stripe.invoices.finalizeInvoice(
         invoice.id!,
+        {},
+        {
+          idempotencyKey: `${idempotencyKeyBase}-finalize`,
+        },
       );
 
       return finalizedInvoice;

--- a/apps/web/src/lib/services/stripe.service.ts
+++ b/apps/web/src/lib/services/stripe.service.ts
@@ -262,9 +262,12 @@ export const stripeService = (() => {
         }
 
         const coupon = await this.getCoupon(welcomeCouponId);
+        // Stable per user+coupon: a `customer.created` webhook redelivery
+        // replays the original grant instead of issuing a second invoice.
         const invoice = await stripeClient.applyInvoiceCreditsToCustomer(
           user.stripeCustomerId,
           coupon.id,
+          `welcome-${coupon.id}-${user.id}`,
           {
             redemption_type: "welcome_coupon",
             welcome_source: "customer.created",
@@ -307,9 +310,13 @@ export const stripeService = (() => {
         getEnvSecrets().STRIPE_ONBOARD_PERSONAL_COUPON,
       );
 
+      // Scoped to user+coupon+count: retries of the same redemption replay
+      // the original grant, while a later redemption with a higher referral
+      // count is a legitimately distinct grant (and distinct request params).
       const personalInvoice = await stripeClient.applyInvoiceCreditsToCustomer(
         user.stripeCustomerId,
         personalCoupon.id,
+        `referral-${personalCoupon.id}-user-${user.id}-${referralCount}`,
         {
           referral_user_id: String(user.id),
           referral_email: String(user.email ?? ""),
@@ -361,6 +368,7 @@ export const stripeService = (() => {
         const orgInvoice = await stripeClient.applyInvoiceCreditsToCustomer(
           orgStripeCustomerId,
           orgCoupon.id,
+          `referral-${orgCoupon.id}-org-${organizationId}-${referralCount}`,
           {
             referral_user_id: String(userId),
             referral_email: String(user?.email ?? ""),


### PR DESCRIPTION
## Summary

Live money bug: `applyInvoiceCreditsToCustomer` (`apps/web/src/lib/clients/stripe.client.ts`) created invoice items and created/finalized the credit-grant invoice with **no Stripe idempotency keys**. Its live caller `claimWelcomeCoupon` (`apps/web/src/lib/services/stripe.service.ts`) runs from the `customer.created` webhook handler, so a Stripe webhook redelivery or retry produced two **distinct** paid invoices and double-granted credits — the `invoice.paid` dedupe keys on `invoiceId`, so cross-invoice duplicates passed it.

This is also webhook-migration PR 1 from the scoping plan, and independently valuable on its own.

## Changes

- `applyInvoiceCreditsToCustomer` now takes a required `idempotencyKeyBase` (3rd param) and derives a per-request key for every Stripe call (Stripe idempotency keys are per-request):
  - each invoice item: `{base}-item-{n}` (1-based, stable per loop index)
  - `invoices.create`: `{base}-invoice`
  - `invoices.finalizeInvoice`: `{base}-finalize` (safe because a replayed create returns the original invoice id, so finalize params are identical on retry)
- Callers pass a base derived from stable domain identifiers (never timestamps/randomness, well under 255 chars):
  - **welcome coupon** (`claimWelcomeCoupon`, live via `customer.created` webhook): `welcome-{couponId}-{userId}` — one grant per user+coupon; a redelivery replays the original grant.
  - **referral personal** (`createAndApplyReferralCredits`, currently has no callers): `referral-{couponId}-user-{userId}-{referralCount}`
  - **referral org**: `referral-{couponId}-org-{organizationId}-{referralCount}` — the count is part of the key because a later redemption with a higher referral count is a legitimately distinct grant (and produces different request params, see below).
- Tests: existing `applyInvoiceCreditsToCustomer` tests updated for the new signature; new tests assert the idempotency key is passed in the options arg of `invoiceItems.create`, `invoices.create`, and `invoices.finalizeInvoice`, including distinct per-item keys for `referralCount > 1`.

## Idempotency-error consideration

Stripe rejects a reused key whose request params differ (`idempotency_error`) rather than replaying. Retried calls here rebuild byte-identical params from the same inputs (user, coupon, price), with two known edges, both preferable to a silent double grant:

- If the coupon's `credits` / `ttl_days` metadata is edited between the original attempt and a redelivery, the replayed params differ and Stripe errors; `claimWelcomeCoupon` already catches and logs, returning `couponApplied: false`.
- `user_email` in grant metadata could in principle change between retries; webhook redeliveries happen within Stripe's retry window, so this is a non-issue in practice and would likewise fail loudly, not double-grant.

This mirrors the `withIdempotencyKey` approach already used in `apps/core/src/clients/stripe.client.ts` and the inline `idempotencyKey` options web's client already uses for customer/promotion-code creation.

## Verification

- `pnpm --filter web typecheck`
- `pnpm --filter web test src/lib/clients/__tests__/stripe.client.test.ts` (20 passed)
- `pnpm --filter web test src/lib/stripe/__tests__/webhook-handlers.test.ts` (40 passed)
- `pnpm check` (Biome, repo-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)