### PR TITLE
feat(core): add machine-readable error kinds to the error envelope

### DIFF
--- a/apps/core/src/helpers/error.test.ts
+++ b/apps/core/src/helpers/error.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { getErrorName, payloadTooLarge } from "./error";
+import {
+  badRequest,
+  forbidden,
+  getErrorName,
+  notFound,
+  payloadTooLarge,
+} from "./error";
 
 describe("payloadTooLarge", () => {
   it("creates HTTP 413 exceptions", () => {
@@ -8,6 +14,24 @@ describe("payloadTooLarge", () => {
 
     expect(error.status).toBe(413);
     expect(error.message).toBe("Request is too large");
+  });
+});
+
+describe("error kind metadata", () => {
+  it.each([
+    [badRequest, 400],
+    [forbidden, 403],
+    [notFound, 404],
+  ] as const)("carries the kind in the exception cause (%#)", (helper, status) => {
+    const error = helper("Some message", { kind: "some_kind" });
+
+    expect(error.status).toBe(status);
+    expect(error.message).toBe("Some message");
+    expect(error.cause).toEqual({ kind: "some_kind" });
+  });
+
+  it("leaves the cause unset without metadata", () => {
+    expect(notFound("Not Found").cause).toBeUndefined();
   });
 });
 

--- a/apps/core/src/helpers/error.ts
+++ b/apps/core/src/helpers/error.ts
@@ -21,6 +21,13 @@ export const errorResponseSchema = z.object({
   /** Human-readable description of the error */
   message: z.string().openapi({ example: "Authentication required" }),
 
+  /**
+   * Optional stable machine-readable error kind (snake_case). Clients should
+   * match on this instead of `message`, which may be reworded at any time.
+   * Omitted when no kind has been assigned to the error.
+   */
+  kind: z.string().optional().openapi({ example: "organization_not_found" }),
+
   /** Metadata about the request and response */
   meta: z.object({
     /** ISO timestamp when the error was generated */
@@ -69,8 +76,11 @@ function createHTTPException(
  * 400 Bad Request
  * The server cannot process the request due to client error
  */
-export const badRequest = (message: string = "Bad Request"): HTTPException => {
-  return createHTTPException(400, message);
+export const badRequest = (
+  message: string = "Bad Request",
+  metadata?: HTTPExceptionMetadata,
+): HTTPException => {
+  return createHTTPException(400, message, metadata);
 };
 
 /**
@@ -87,16 +97,22 @@ export const unauthorized = (
  * 403 Forbidden
  * The client does not have access rights to the content
  */
-export const forbidden = (message: string = "Forbidden"): HTTPException => {
-  return createHTTPException(403, message);
+export const forbidden = (
+  message: string = "Forbidden",
+  metadata?: HTTPExceptionMetadata,
+): HTTPException => {
+  return createHTTPException(403, message, metadata);
 };
 
 /**
  * 404 Not Found
  * The server cannot find the requested resource
  */
-export const notFound = (message: string = "Not Found"): HTTPException => {
-  return createHTTPException(404, message);
+export const notFound = (
+  message: string = "Not Found",
+  metadata?: HTTPExceptionMetadata,
+): HTTPException => {
+  return createHTTPException(404, message, metadata);
 };
 
 /**

--- a/apps/core/src/helpers/organization.ts
+++ b/apps/core/src/helpers/organization.ts
@@ -1,4 +1,5 @@
 import { MemberRole, type Prisma } from "@sokosumi/database";
+import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 
 import { forbidden, notFound } from "@/helpers/error";
 
@@ -70,19 +71,25 @@ async function resolveMemberAccess(
   input: ResolveMemberOrganizationInputBase,
 ) {
   if (!organization) {
-    throw notFound("Organization not found");
+    throw notFound("Organization not found", {
+      kind: CORE_API_ERROR_KINDS.ORGANIZATION_NOT_FOUND,
+    });
   }
 
   const member = await getMemberAccess(input.tx, input.userId, organization.id);
   if (!member) {
-    throw forbidden("You are not a member of this organization");
+    throw forbidden("You are not a member of this organization", {
+      kind: CORE_API_ERROR_KINDS.ORGANIZATION_MEMBERSHIP_REQUIRED,
+    });
   }
 
   if (
     input.allowedRoles &&
     !input.allowedRoles.includes(member.role as MemberRole)
   ) {
-    throw forbidden(`You must be ${input.allowedRoles.join(", ")}`);
+    throw forbidden(`You must be ${input.allowedRoles.join(", ")}`, {
+      kind: CORE_API_ERROR_KINDS.ORGANIZATION_ROLE_FORBIDDEN,
+    });
   }
 
   return {

--- a/apps/core/src/routes/v1/organizations/[id]/subscription/seats/put.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/subscription/seats/put.ts
@@ -10,6 +10,7 @@ import {
   memberRepository,
   subscriptionRepository,
 } from "@sokosumi/database/repositories";
+import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 
 import { stripeClient } from "@/clients/stripe.client";
 import { badRequest, internalServerError } from "@/helpers/error";
@@ -131,7 +132,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           );
         } catch (error) {
           if (error instanceof OrganizationSubscriptionExclusivityError) {
-            throw badRequest(error.message);
+            throw badRequest(error.message, {
+              kind: CORE_API_ERROR_KINDS.SUBSCRIPTION_CHANGE_NOT_ALLOWED,
+            });
           }
           throw error;
         }
@@ -144,6 +147,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         if (!subscription) {
           throw badRequest(
             "An active organization subscription is required before updating seats.",
+            { kind: CORE_API_ERROR_KINDS.SUBSCRIPTION_NOT_ACTIVE },
           );
         }
 
@@ -158,6 +162,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             error instanceof Error
               ? error.message
               : `Seats must be at least ${assignedCount} to cover all assigned members`,
+            { kind: CORE_API_ERROR_KINDS.SUBSCRIPTION_SEATS_BELOW_ASSIGNED },
           );
         }
 

--- a/apps/core/src/services/organization-seat.service.ts
+++ b/apps/core/src/services/organization-seat.service.ts
@@ -15,7 +15,11 @@ import {
   resolvePurchasedSeats,
 } from "@sokosumi/database/helpers";
 import { subscriptionRepository } from "@sokosumi/database/repositories";
-import { convertCreditsToCents, TaskStatus } from "@sokosumi/utils";
+import {
+  CORE_API_ERROR_KINDS,
+  convertCreditsToCents,
+  TaskStatus,
+} from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 
 import { badRequest, notFound } from "@/helpers/error";
@@ -45,12 +49,15 @@ export function mapSeatRepositoryError(error: unknown): never {
   }
 
   if (error.message === "Member not found") {
-    throw notFound("Member not found");
+    throw notFound("Member not found", {
+      kind: CORE_API_ERROR_KINDS.MEMBER_NOT_FOUND,
+    });
   }
 
   if (error.message.includes("exceeds purchased seats")) {
     throw badRequest(
       "No unused seats available. Purchase more seats or unassign another member.",
+      { kind: CORE_API_ERROR_KINDS.SEAT_CAPACITY_EXCEEDED },
     );
   }
 

--- a/apps/web/src/app/(app)/billing/page.tsx
+++ b/apps/web/src/app/(app)/billing/page.tsx
@@ -160,7 +160,16 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
           throw error;
         }),
     ]);
-    const currentSeats = seatSummary.purchasedSeats;
+    // `getSeatSummary` resolves null when core reports a stale membership
+    // (403/404); fall back to zero counts so the page still renders, matching
+    // the onboarding loader's behavior.
+    const seatCounts = seatSummary ?? {
+      assignedCount: 0,
+      memberCount: 0,
+      purchasedSeats: 0,
+      unusedSeats: 0,
+    };
+    const currentSeats = seatCounts.purchasedSeats;
     const displayCredits = formatCreditsForDisplay(
       organizationCredits.data.credits.total,
     );
@@ -200,11 +209,11 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             <BalanceSection
               title={t("balanceTitle")}
               description={t("balanceDescriptionOrganization", {
-                assigned: seatSummary.assignedCount,
-                members: seatSummary.memberCount,
+                assigned: seatCounts.assignedCount,
+                members: seatCounts.memberCount,
                 organization: activeOrganization.name,
-                purchased: seatSummary.purchasedSeats,
-                unused: seatSummary.unusedSeats,
+                purchased: seatCounts.purchasedSeats,
+                unused: seatCounts.unusedSeats,
               })}
               creditsLabel={t("balanceCreditsLabel", {
                 credits: displayCredits,
@@ -224,14 +233,14 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             showCreditsTab
             subscriptionContent={
               <OrganizationSubscriptionSection
-                assignedSeatCount={seatSummary.assignedCount}
+                assignedSeatCount={seatCounts.assignedCount}
                 cancelAtPeriodEnd={billingPlan.cancelAtPeriodEnd}
                 currentPlan={currentPlan}
                 currentPeriodEnd={billingPlan.periodEnd}
                 currentSeats={currentSeats}
                 isEnterpriseConsumable={isEnterpriseConsumable}
                 isEnterpriseContract={isEnterpriseContract}
-                memberCount={seatSummary.memberCount}
+                memberCount={seatCounts.memberCount}
                 organizationId={activeOrganization.id}
                 plans={orgPlans}
                 returnPath="/billing?tab=subscription"

--- a/apps/web/src/lib/actions/organization/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/organization/__tests__/action.test.ts
@@ -13,11 +13,13 @@ const syncOrganizationInvoiceEmailWithStripeMock = vi.fn();
 const updateOrganizationInvoiceEmailMock = vi.fn();
 
 class MockCoreApiRequestError extends Error {
+  kind?: string;
   status?: number;
 
-  constructor(message: string, options?: { status?: number }) {
+  constructor(message: string, options?: { kind?: string; status?: number }) {
     super(message);
     this.name = "CoreApiRequestError";
+    this.kind = options?.kind;
     this.status = options?.status;
   }
 }
@@ -383,6 +385,31 @@ describe("updateOrganizationInvoiceEmail", () => {
       error: {
         code: "UNAUTHORIZED",
         message: "Organization not found",
+      },
+    });
+    expect(syncOrganizationInvoiceEmailWithStripeMock).not.toHaveBeenCalled();
+  });
+
+  it("maps the organization_role_forbidden kind to UNAUTHORIZED even when the message is reworded", async () => {
+    updateOrganizationInvoiceEmailMock.mockRejectedValue(
+      new MockCoreApiRequestError("Owners and admins only", {
+        kind: "organization_role_forbidden",
+        status: 403,
+      }),
+    );
+    const { updateOrganizationInvoiceEmail } = await import("../action");
+
+    const result = await updateOrganizationInvoiceEmail({
+      organizationId: "org-1",
+      invoiceEmail: "billing@acme.example",
+      session,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Owners and admins only",
       },
     });
     expect(syncOrganizationInvoiceEmailWithStripeMock).not.toHaveBeenCalled();

--- a/apps/web/src/lib/actions/organization/action.ts
+++ b/apps/web/src/lib/actions/organization/action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { MemberRole } from "@sokosumi/database";
+import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 import * as z from "zod";
 
 import { getEnvSecrets } from "@/config/env.secrets";
@@ -91,9 +92,16 @@ export const updateOrganizationInvoiceEmail = withSession<
     );
     persisted = data;
   } catch (error) {
+    // Core reports missing access via stable kinds (organization missing, no
+    // membership, insufficient role); the status fallback covers responses
+    // without a kind.
     if (
       error instanceof CoreApiRequestError &&
-      (error.status === 403 || error.status === 404)
+      (error.kind === CORE_API_ERROR_KINDS.ORGANIZATION_NOT_FOUND ||
+        error.kind === CORE_API_ERROR_KINDS.ORGANIZATION_MEMBERSHIP_REQUIRED ||
+        error.kind === CORE_API_ERROR_KINDS.ORGANIZATION_ROLE_FORBIDDEN ||
+        error.status === 403 ||
+        error.status === 404)
     ) {
       return Err({
         code: CommonErrorCode.UNAUTHORIZED,

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -180,15 +180,23 @@ export interface CoreApiResponse<T> {
 
 export class CoreApiRequestError extends Error {
   details?: unknown;
+  /**
+   * Stable machine-readable error kind from the Core error envelope (e.g.
+   * `organization_not_found`). Prefer matching on this over `message`, which
+   * may be reworded at any time. See `CORE_API_ERROR_KINDS` in
+   * `@sokosumi/utils`.
+   */
+  kind?: string;
   status?: number;
 
   constructor(
     message: string,
-    options?: { details?: unknown; status?: number },
+    options?: { details?: unknown; kind?: string; status?: number },
   ) {
     super(message);
     this.name = "CoreApiRequestError";
     this.details = options?.details;
+    this.kind = options?.kind;
     this.status = options?.status;
   }
 }
@@ -283,6 +291,18 @@ function extractErrorMessage(error: unknown, status?: number): string {
   return "Failed to communicate with Core API";
 }
 
+function extractErrorKind(error: unknown): string | undefined {
+  if (error && typeof error === "object") {
+    const typedError = error as { kind?: unknown };
+
+    if (typeof typedError.kind === "string" && typedError.kind.length > 0) {
+      return typedError.kind;
+    }
+  }
+
+  return undefined;
+}
+
 async function executeOperation<TData, TError>(
   getClient: GetClient,
   operation: (client: Client) => Promise<CoreOperationResult<TData, TError>>,
@@ -304,6 +324,7 @@ async function executeOperation<TData, TError>(
     const message = extractErrorMessage(result.error, result.response?.status);
     throw new CoreApiRequestError(message, {
       details: result.error,
+      kind: extractErrorKind(result.error),
       status: result.response?.status,
     });
   }

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -2079,6 +2079,7 @@ export type SearchAdminUsersErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2092,6 +2093,7 @@ export type SearchAdminUsersErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2138,6 +2140,7 @@ export type SearchAdminOrganizationsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2151,6 +2154,7 @@ export type SearchAdminOrganizationsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2194,6 +2198,7 @@ export type GetAdminOrganizationBySlugErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2207,6 +2212,7 @@ export type GetAdminOrganizationBySlugErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2220,6 +2226,7 @@ export type GetAdminOrganizationBySlugErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2288,6 +2295,7 @@ export type GetAgentsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2301,6 +2309,7 @@ export type GetAgentsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2358,6 +2367,7 @@ export type GetAgentsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2371,6 +2381,7 @@ export type GetAgentsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2437,6 +2448,7 @@ export type GetAgentsByIdReviewsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2450,6 +2462,7 @@ export type GetAgentsByIdReviewsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2507,6 +2520,7 @@ export type GetAgentsByIdReviewsMeErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2520,6 +2534,7 @@ export type GetAgentsByIdReviewsMeErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2577,6 +2592,7 @@ export type GetAgentsByIdRatingsEligibilityErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2590,6 +2606,7 @@ export type GetAgentsByIdRatingsEligibilityErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2647,6 +2664,7 @@ export type PostAgentsByIdRatingsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2660,6 +2678,7 @@ export type PostAgentsByIdRatingsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2673,6 +2692,7 @@ export type PostAgentsByIdRatingsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2686,6 +2706,7 @@ export type PostAgentsByIdRatingsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2743,6 +2764,7 @@ export type GetAgentsByIdInputSchemaErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2756,6 +2778,7 @@ export type GetAgentsByIdInputSchemaErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -2769,6 +2792,7 @@ export type GetAgentsByIdInputSchemaErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -3774,6 +3798,7 @@ export type GetAgentsByIdJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -3787,6 +3812,7 @@ export type GetAgentsByIdJobsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -3800,6 +3826,7 @@ export type GetAgentsByIdJobsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -3813,6 +3840,7 @@ export type GetAgentsByIdJobsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -4816,6 +4844,7 @@ export type PostAgentsByIdJobsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -4829,6 +4858,7 @@ export type PostAgentsByIdJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -4842,6 +4872,7 @@ export type PostAgentsByIdJobsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -4855,6 +4886,7 @@ export type PostAgentsByIdJobsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -4868,6 +4900,7 @@ export type PostAgentsByIdJobsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -4881,6 +4914,7 @@ export type PostAgentsByIdJobsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -5882,6 +5916,7 @@ export type PostAgentsByIdDemoJobsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -5895,6 +5930,7 @@ export type PostAgentsByIdDemoJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -5908,6 +5944,7 @@ export type PostAgentsByIdDemoJobsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -5921,6 +5958,7 @@ export type PostAgentsByIdDemoJobsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -5934,6 +5972,7 @@ export type PostAgentsByIdDemoJobsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -5947,6 +5986,7 @@ export type PostAgentsByIdDemoJobsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6002,6 +6042,7 @@ export type GetCategoriesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6070,6 +6111,7 @@ export type GetChatErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6083,6 +6125,7 @@ export type GetChatErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6096,6 +6139,7 @@ export type GetChatErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6109,6 +6153,7 @@ export type GetChatErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6122,6 +6167,7 @@ export type GetChatErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6273,6 +6319,7 @@ export type PostChatErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6286,6 +6333,7 @@ export type PostChatErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6299,6 +6347,7 @@ export type PostChatErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6312,6 +6361,7 @@ export type PostChatErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6325,6 +6375,7 @@ export type PostChatErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6338,6 +6389,7 @@ export type PostChatErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6351,6 +6403,7 @@ export type PostChatErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6404,6 +6457,7 @@ export type GetChatStreamByConversationIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6417,6 +6471,7 @@ export type GetChatStreamByConversationIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6430,6 +6485,7 @@ export type GetChatStreamByConversationIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6443,6 +6499,7 @@ export type GetChatStreamByConversationIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6495,6 +6552,7 @@ export type GetConversationsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6508,6 +6566,7 @@ export type GetConversationsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6521,6 +6580,7 @@ export type GetConversationsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6576,6 +6636,7 @@ export type PostConversationsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6589,6 +6650,7 @@ export type PostConversationsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6602,6 +6664,7 @@ export type PostConversationsErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6615,6 +6678,7 @@ export type PostConversationsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6675,6 +6739,7 @@ export type GetConversationsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6688,6 +6753,7 @@ export type GetConversationsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6701,6 +6767,7 @@ export type GetConversationsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6714,6 +6781,7 @@ export type GetConversationsByIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6774,6 +6842,7 @@ export type PatchConversationsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6787,6 +6856,7 @@ export type PatchConversationsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6800,6 +6870,7 @@ export type PatchConversationsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6813,6 +6884,7 @@ export type PatchConversationsByIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6873,6 +6945,7 @@ export type PatchConversationsByIdArchiveErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6886,6 +6959,7 @@ export type PatchConversationsByIdArchiveErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6899,6 +6973,7 @@ export type PatchConversationsByIdArchiveErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6912,6 +6987,7 @@ export type PatchConversationsByIdArchiveErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6981,6 +7057,7 @@ export type GetConversationsByIdMessagesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -6994,6 +7071,7 @@ export type GetConversationsByIdMessagesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7007,6 +7085,7 @@ export type GetConversationsByIdMessagesErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7020,6 +7099,7 @@ export type GetConversationsByIdMessagesErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7080,6 +7160,7 @@ export type PostConversationsByIdMessagesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7093,6 +7174,7 @@ export type PostConversationsByIdMessagesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7106,6 +7188,7 @@ export type PostConversationsByIdMessagesErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7119,6 +7202,7 @@ export type PostConversationsByIdMessagesErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7160,6 +7244,7 @@ export type GetCreditCostsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7173,6 +7258,7 @@ export type GetCreditCostsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7214,6 +7300,7 @@ export type PostCreditCostsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7227,6 +7314,7 @@ export type PostCreditCostsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7240,6 +7328,7 @@ export type PostCreditCostsErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7283,6 +7372,7 @@ export type DeleteCreditCostsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7296,6 +7386,7 @@ export type DeleteCreditCostsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7309,6 +7400,7 @@ export type DeleteCreditCostsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7352,6 +7444,7 @@ export type GetCreditCostsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7365,6 +7458,7 @@ export type GetCreditCostsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7378,6 +7472,7 @@ export type GetCreditCostsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7421,6 +7516,7 @@ export type PatchCreditCostsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7434,6 +7530,7 @@ export type PatchCreditCostsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7447,6 +7544,7 @@ export type PatchCreditCostsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7491,6 +7589,7 @@ export type GetEnterpriseContractsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7504,6 +7603,7 @@ export type GetEnterpriseContractsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7517,6 +7617,7 @@ export type GetEnterpriseContractsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7558,6 +7659,7 @@ export type PostEnterpriseContractsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7571,6 +7673,7 @@ export type PostEnterpriseContractsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7584,6 +7687,7 @@ export type PostEnterpriseContractsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7597,6 +7701,7 @@ export type PostEnterpriseContractsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7645,6 +7750,7 @@ export type GetEnterpriseContractsByIdPeriodsPreviewErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7658,6 +7764,7 @@ export type GetEnterpriseContractsByIdPeriodsPreviewErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7671,6 +7778,7 @@ export type GetEnterpriseContractsByIdPeriodsPreviewErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7684,6 +7792,7 @@ export type GetEnterpriseContractsByIdPeriodsPreviewErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7697,6 +7806,7 @@ export type GetEnterpriseContractsByIdPeriodsPreviewErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7740,6 +7850,7 @@ export type GetEnterpriseContractsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7753,6 +7864,7 @@ export type GetEnterpriseContractsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7766,6 +7878,7 @@ export type GetEnterpriseContractsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7809,6 +7922,7 @@ export type PatchEnterpriseContractsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7822,6 +7936,7 @@ export type PatchEnterpriseContractsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7835,6 +7950,7 @@ export type PatchEnterpriseContractsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7848,6 +7964,7 @@ export type PatchEnterpriseContractsByIdErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7861,6 +7978,7 @@ export type PatchEnterpriseContractsByIdErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7904,6 +8022,7 @@ export type PostEnterpriseContractsByIdActivateErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7917,6 +8036,7 @@ export type PostEnterpriseContractsByIdActivateErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7930,6 +8050,7 @@ export type PostEnterpriseContractsByIdActivateErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7947,6 +8068,7 @@ export type PostEnterpriseContractsByIdActivateErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -7990,6 +8112,7 @@ export type PostEnterpriseContractsByIdCancelErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8003,6 +8126,7 @@ export type PostEnterpriseContractsByIdCancelErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8016,6 +8140,7 @@ export type PostEnterpriseContractsByIdCancelErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8029,6 +8154,7 @@ export type PostEnterpriseContractsByIdCancelErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8084,6 +8210,7 @@ export type PostHermesChatErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8097,6 +8224,7 @@ export type PostHermesChatErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8110,6 +8238,7 @@ export type PostHermesChatErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8134,6 +8263,7 @@ export type PostHermesChatErrors = {
     413: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8147,6 +8277,7 @@ export type PostHermesChatErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8202,6 +8333,7 @@ export type DeleteHermesMeInstanceErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8215,6 +8347,7 @@ export type DeleteHermesMeInstanceErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8228,6 +8361,7 @@ export type DeleteHermesMeInstanceErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8283,6 +8417,7 @@ export type GetHermesMeInstanceErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8296,6 +8431,7 @@ export type GetHermesMeInstanceErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8309,6 +8445,7 @@ export type GetHermesMeInstanceErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8364,6 +8501,7 @@ export type PatchHermesMeInstanceErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8377,6 +8515,7 @@ export type PatchHermesMeInstanceErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8390,6 +8529,7 @@ export type PatchHermesMeInstanceErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8403,6 +8543,7 @@ export type PatchHermesMeInstanceErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8416,6 +8557,7 @@ export type PatchHermesMeInstanceErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8471,6 +8613,7 @@ export type PostHermesMeInstanceErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8484,6 +8627,7 @@ export type PostHermesMeInstanceErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8497,6 +8641,7 @@ export type PostHermesMeInstanceErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8510,6 +8655,7 @@ export type PostHermesMeInstanceErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8574,6 +8720,7 @@ export type GetHermesMeMessagesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8587,6 +8734,7 @@ export type GetHermesMeMessagesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8642,6 +8790,7 @@ export type GetHermesMeUnreadCountErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8655,6 +8804,7 @@ export type GetHermesMeUnreadCountErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8710,6 +8860,7 @@ export type PostHermesMeInboxSeenErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8723,6 +8874,7 @@ export type PostHermesMeInboxSeenErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8736,6 +8888,7 @@ export type PostHermesMeInboxSeenErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8791,6 +8944,7 @@ export type PostHermesMeSecretsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8804,6 +8958,7 @@ export type PostHermesMeSecretsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8817,6 +8972,7 @@ export type PostHermesMeSecretsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8830,6 +8986,7 @@ export type PostHermesMeSecretsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8843,6 +9000,7 @@ export type PostHermesMeSecretsErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8898,6 +9056,7 @@ export type PostHermesMeInstanceOnboardErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8911,6 +9070,7 @@ export type PostHermesMeInstanceOnboardErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8924,6 +9084,7 @@ export type PostHermesMeInstanceOnboardErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8937,6 +9098,7 @@ export type PostHermesMeInstanceOnboardErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -8992,6 +9154,7 @@ export type GetHermesMeInstanceOnboardingProgressErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9005,6 +9168,7 @@ export type GetHermesMeInstanceOnboardingProgressErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9018,6 +9182,7 @@ export type GetHermesMeInstanceOnboardingProgressErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9073,6 +9238,7 @@ export type GetHermesMeInstanceIntegrationsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9086,6 +9252,7 @@ export type GetHermesMeInstanceIntegrationsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9099,6 +9266,7 @@ export type GetHermesMeInstanceIntegrationsErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9154,6 +9322,7 @@ export type GetHermesMeInstanceSchedulesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9167,6 +9336,7 @@ export type GetHermesMeInstanceSchedulesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9180,6 +9350,7 @@ export type GetHermesMeInstanceSchedulesErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9237,6 +9408,7 @@ export type PatchHermesMeInstanceSchedulesByScheduleIdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9250,6 +9422,7 @@ export type PatchHermesMeInstanceSchedulesByScheduleIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9263,6 +9436,7 @@ export type PatchHermesMeInstanceSchedulesByScheduleIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9276,6 +9450,7 @@ export type PatchHermesMeInstanceSchedulesByScheduleIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9289,6 +9464,7 @@ export type PatchHermesMeInstanceSchedulesByScheduleIdErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9346,6 +9522,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdApproveErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9359,6 +9536,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdApproveErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9372,6 +9550,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdApproveErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9385,6 +9564,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdApproveErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9442,6 +9622,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdRejectErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9455,6 +9636,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdRejectErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9468,6 +9650,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdRejectErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9481,6 +9664,7 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdRejectErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9538,6 +9722,7 @@ export type DeleteHermesMeInstanceIntegrationsByProviderErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9551,6 +9736,7 @@ export type DeleteHermesMeInstanceIntegrationsByProviderErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9564,6 +9750,7 @@ export type DeleteHermesMeInstanceIntegrationsByProviderErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9619,6 +9806,7 @@ export type PostHermesMeInstanceIntegrationsInitiateErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9632,6 +9820,7 @@ export type PostHermesMeInstanceIntegrationsInitiateErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9645,6 +9834,7 @@ export type PostHermesMeInstanceIntegrationsInitiateErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9658,6 +9848,7 @@ export type PostHermesMeInstanceIntegrationsInitiateErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9713,6 +9904,7 @@ export type PostHermesMeInstanceIntegrationsFinalizeErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9726,6 +9918,7 @@ export type PostHermesMeInstanceIntegrationsFinalizeErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9739,6 +9932,7 @@ export type PostHermesMeInstanceIntegrationsFinalizeErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9752,6 +9946,7 @@ export type PostHermesMeInstanceIntegrationsFinalizeErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9836,6 +10031,7 @@ export type GetHistoryErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9849,6 +10045,7 @@ export type GetHistoryErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9862,6 +10059,7 @@ export type GetHistoryErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9875,6 +10073,7 @@ export type GetHistoryErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9921,6 +10120,7 @@ export type GetUsersRegisteredErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9934,6 +10134,7 @@ export type GetUsersRegisteredErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -9947,6 +10148,7 @@ export type GetUsersRegisteredErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10016,6 +10218,7 @@ export type GetUsersByIdCreditsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10029,6 +10232,7 @@ export type GetUsersByIdCreditsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10042,6 +10246,7 @@ export type GetUsersByIdCreditsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10055,6 +10260,7 @@ export type GetUsersByIdCreditsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10163,6 +10369,7 @@ export type GetUsersByIdDesignMdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10176,6 +10383,7 @@ export type GetUsersByIdDesignMdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10189,6 +10397,7 @@ export type GetUsersByIdDesignMdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10202,6 +10411,7 @@ export type GetUsersByIdDesignMdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10248,6 +10458,7 @@ export type PutUsersByIdDesignMdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10261,6 +10472,7 @@ export type PutUsersByIdDesignMdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10274,6 +10486,7 @@ export type PutUsersByIdDesignMdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10287,6 +10500,7 @@ export type PutUsersByIdDesignMdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10300,6 +10514,7 @@ export type PutUsersByIdDesignMdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10313,6 +10528,7 @@ export type PutUsersByIdDesignMdErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10359,6 +10575,7 @@ export type GetUsersByIdMembersErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10372,6 +10589,7 @@ export type GetUsersByIdMembersErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10385,6 +10603,7 @@ export type GetUsersByIdMembersErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10398,6 +10617,7 @@ export type GetUsersByIdMembersErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10444,6 +10664,7 @@ export type GetUsersByIdOrganizationsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10457,6 +10678,7 @@ export type GetUsersByIdOrganizationsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10470,6 +10692,7 @@ export type GetUsersByIdOrganizationsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10483,6 +10706,7 @@ export type GetUsersByIdOrganizationsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10533,6 +10757,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdCreditsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10546,6 +10771,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdCreditsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10559,6 +10785,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdCreditsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10572,6 +10799,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdCreditsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10684,6 +10912,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdMemberErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10697,6 +10926,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdMemberErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10710,6 +10940,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdMemberErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10723,6 +10954,7 @@ export type GetUsersByIdOrganizationsByOrganizationIdMemberErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10769,6 +11001,7 @@ export type GetUsersByIdPreferencesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10782,6 +11015,7 @@ export type GetUsersByIdPreferencesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10795,6 +11029,7 @@ export type GetUsersByIdPreferencesErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10808,6 +11043,7 @@ export type GetUsersByIdPreferencesErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10872,6 +11108,7 @@ export type PatchUsersByIdPreferencesErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10885,6 +11122,7 @@ export type PatchUsersByIdPreferencesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10898,6 +11136,7 @@ export type PatchUsersByIdPreferencesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10911,6 +11150,7 @@ export type PatchUsersByIdPreferencesErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10975,6 +11215,7 @@ export type DeleteUsersByIdOauthConsentsByConsentIdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -10988,6 +11229,7 @@ export type DeleteUsersByIdOauthConsentsByConsentIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11001,6 +11243,7 @@ export type DeleteUsersByIdOauthConsentsByConsentIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11014,6 +11257,7 @@ export type DeleteUsersByIdOauthConsentsByConsentIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11027,6 +11271,7 @@ export type DeleteUsersByIdOauthConsentsByConsentIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11075,6 +11320,7 @@ export type GetUsersByIdOnboardingErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11088,6 +11334,7 @@ export type GetUsersByIdOnboardingErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11101,6 +11348,7 @@ export type GetUsersByIdOnboardingErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11114,6 +11362,7 @@ export type GetUsersByIdOnboardingErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11165,6 +11414,7 @@ export type PostUsersByIdOnboardingErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11178,6 +11428,7 @@ export type PostUsersByIdOnboardingErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11191,6 +11442,7 @@ export type PostUsersByIdOnboardingErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11204,6 +11456,7 @@ export type PostUsersByIdOnboardingErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11255,6 +11508,7 @@ export type GetUsersByIdNoticesPendingErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11268,6 +11522,7 @@ export type GetUsersByIdNoticesPendingErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11281,6 +11536,7 @@ export type GetUsersByIdNoticesPendingErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11294,6 +11550,7 @@ export type GetUsersByIdNoticesPendingErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11346,6 +11603,7 @@ export type PostUsersByIdNoticesByNoticeIdAcknowledgeErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11359,6 +11617,7 @@ export type PostUsersByIdNoticesByNoticeIdAcknowledgeErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11372,6 +11631,7 @@ export type PostUsersByIdNoticesByNoticeIdAcknowledgeErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11385,6 +11645,7 @@ export type PostUsersByIdNoticesByNoticeIdAcknowledgeErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11398,6 +11659,7 @@ export type PostUsersByIdNoticesByNoticeIdAcknowledgeErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11448,6 +11710,7 @@ export type GetUsersByIdUploadsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11461,6 +11724,7 @@ export type GetUsersByIdUploadsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11474,6 +11738,7 @@ export type GetUsersByIdUploadsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11487,6 +11752,7 @@ export type GetUsersByIdUploadsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11500,6 +11766,7 @@ export type GetUsersByIdUploadsErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11551,6 +11818,7 @@ export type PostUsersByIdUploadsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11564,6 +11832,7 @@ export type PostUsersByIdUploadsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11577,6 +11846,7 @@ export type PostUsersByIdUploadsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11590,6 +11860,7 @@ export type PostUsersByIdUploadsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11603,6 +11874,7 @@ export type PostUsersByIdUploadsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11616,6 +11888,7 @@ export type PostUsersByIdUploadsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11629,6 +11902,7 @@ export type PostUsersByIdUploadsErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11675,6 +11949,7 @@ export type PostUsersByIdUtmAttributionErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11688,6 +11963,7 @@ export type PostUsersByIdUtmAttributionErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11701,6 +11977,7 @@ export type PostUsersByIdUtmAttributionErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11714,6 +11991,7 @@ export type PostUsersByIdUtmAttributionErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11774,6 +12052,7 @@ export type GetUsersByIdStripeCustomerErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11787,6 +12066,7 @@ export type GetUsersByIdStripeCustomerErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11800,6 +12080,7 @@ export type GetUsersByIdStripeCustomerErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11813,6 +12094,7 @@ export type GetUsersByIdStripeCustomerErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11873,6 +12155,7 @@ export type GetUsersByIdSubscriptionErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11886,6 +12169,7 @@ export type GetUsersByIdSubscriptionErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11899,6 +12183,7 @@ export type GetUsersByIdSubscriptionErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11912,6 +12197,7 @@ export type GetUsersByIdSubscriptionErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11958,6 +12244,7 @@ export type GetUsersByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11971,6 +12258,7 @@ export type GetUsersByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11984,6 +12272,7 @@ export type GetUsersByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -11997,6 +12286,7 @@ export type GetUsersByIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12043,6 +12333,7 @@ export type GetOrganizationBySlugErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12056,6 +12347,7 @@ export type GetOrganizationBySlugErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12069,6 +12361,7 @@ export type GetOrganizationBySlugErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12082,6 +12375,7 @@ export type GetOrganizationBySlugErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12128,6 +12422,7 @@ export type GetOrganizationsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12141,6 +12436,7 @@ export type GetOrganizationsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12154,6 +12450,7 @@ export type GetOrganizationsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12167,6 +12464,7 @@ export type GetOrganizationsByIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12213,6 +12511,7 @@ export type GetOrganizationsByIdMembersErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12226,6 +12525,7 @@ export type GetOrganizationsByIdMembersErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12239,6 +12539,7 @@ export type GetOrganizationsByIdMembersErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12252,6 +12553,7 @@ export type GetOrganizationsByIdMembersErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12302,6 +12604,7 @@ export type DeleteOrganizationsByIdMembersByMemberIdSeatErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12315,6 +12618,7 @@ export type DeleteOrganizationsByIdMembersByMemberIdSeatErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12328,6 +12632,7 @@ export type DeleteOrganizationsByIdMembersByMemberIdSeatErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12341,6 +12646,7 @@ export type DeleteOrganizationsByIdMembersByMemberIdSeatErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12391,6 +12697,7 @@ export type PutOrganizationsByIdMembersByMemberIdSeatErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12404,6 +12711,7 @@ export type PutOrganizationsByIdMembersByMemberIdSeatErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12417,6 +12725,7 @@ export type PutOrganizationsByIdMembersByMemberIdSeatErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12430,6 +12739,7 @@ export type PutOrganizationsByIdMembersByMemberIdSeatErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12443,6 +12753,7 @@ export type PutOrganizationsByIdMembersByMemberIdSeatErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12489,6 +12800,7 @@ export type GetOrganizationsByIdInvitationsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12502,6 +12814,7 @@ export type GetOrganizationsByIdInvitationsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12515,6 +12828,7 @@ export type GetOrganizationsByIdInvitationsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12528,6 +12842,7 @@ export type GetOrganizationsByIdInvitationsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12574,6 +12889,7 @@ export type GetOrganizationsByIdSeatSummaryErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12587,6 +12903,7 @@ export type GetOrganizationsByIdSeatSummaryErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12600,6 +12917,7 @@ export type GetOrganizationsByIdSeatSummaryErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12613,6 +12931,7 @@ export type GetOrganizationsByIdSeatSummaryErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12659,6 +12978,7 @@ export type GetOrganizationsByIdBillingPlanErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12672,6 +12992,7 @@ export type GetOrganizationsByIdBillingPlanErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12685,6 +13006,7 @@ export type GetOrganizationsByIdBillingPlanErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12698,6 +13020,7 @@ export type GetOrganizationsByIdBillingPlanErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12744,6 +13067,7 @@ export type GetOrganizationEnterpriseContractSummaryErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12757,6 +13081,7 @@ export type GetOrganizationEnterpriseContractSummaryErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12770,6 +13095,7 @@ export type GetOrganizationEnterpriseContractSummaryErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12783,6 +13109,7 @@ export type GetOrganizationEnterpriseContractSummaryErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12829,6 +13156,7 @@ export type GetOrganizationsByIdStripeCustomerErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12842,6 +13170,7 @@ export type GetOrganizationsByIdStripeCustomerErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12855,6 +13184,7 @@ export type GetOrganizationsByIdStripeCustomerErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12868,6 +13198,7 @@ export type GetOrganizationsByIdStripeCustomerErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12914,6 +13245,7 @@ export type GetOrganizationsByIdSubscriptionErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12927,6 +13259,7 @@ export type GetOrganizationsByIdSubscriptionErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12940,6 +13273,7 @@ export type GetOrganizationsByIdSubscriptionErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12953,6 +13287,7 @@ export type GetOrganizationsByIdSubscriptionErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -12999,6 +13334,7 @@ export type PutOrganizationsByIdSubscriptionSeatsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13012,6 +13348,7 @@ export type PutOrganizationsByIdSubscriptionSeatsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13025,6 +13362,7 @@ export type PutOrganizationsByIdSubscriptionSeatsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13038,6 +13376,7 @@ export type PutOrganizationsByIdSubscriptionSeatsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13051,6 +13390,7 @@ export type PutOrganizationsByIdSubscriptionSeatsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13097,6 +13437,7 @@ export type GetOrganizationsByIdDesignMdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13110,6 +13451,7 @@ export type GetOrganizationsByIdDesignMdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13123,6 +13465,7 @@ export type GetOrganizationsByIdDesignMdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13136,6 +13479,7 @@ export type GetOrganizationsByIdDesignMdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13182,6 +13526,7 @@ export type PutOrganizationsByIdDesignMdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13195,6 +13540,7 @@ export type PutOrganizationsByIdDesignMdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13208,6 +13554,7 @@ export type PutOrganizationsByIdDesignMdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13221,6 +13568,7 @@ export type PutOrganizationsByIdDesignMdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13234,6 +13582,7 @@ export type PutOrganizationsByIdDesignMdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13247,6 +13596,7 @@ export type PutOrganizationsByIdDesignMdErrors = {
     503: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13293,6 +13643,7 @@ export type PatchOrganizationsByIdInvoiceEmailErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13306,6 +13657,7 @@ export type PatchOrganizationsByIdInvoiceEmailErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13319,6 +13671,7 @@ export type PatchOrganizationsByIdInvoiceEmailErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13332,6 +13685,7 @@ export type PatchOrganizationsByIdInvoiceEmailErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13345,6 +13699,7 @@ export type PatchOrganizationsByIdInvoiceEmailErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13409,6 +13764,7 @@ export type GetProjectsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13422,6 +13778,7 @@ export type GetProjectsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13435,6 +13792,7 @@ export type GetProjectsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13490,6 +13848,7 @@ export type PostProjectsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13503,6 +13862,7 @@ export type PostProjectsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13563,6 +13923,7 @@ export type GetProjectsStatsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13576,6 +13937,7 @@ export type GetProjectsStatsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13589,6 +13951,7 @@ export type GetProjectsStatsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13646,6 +14009,7 @@ export type PostProjectsByIdJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13659,6 +14023,7 @@ export type PostProjectsByIdJobsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13672,6 +14037,7 @@ export type PostProjectsByIdJobsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13685,6 +14051,7 @@ export type PostProjectsByIdJobsErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13743,6 +14110,7 @@ export type DeleteProjectsByIdJobsByJobIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13756,6 +14124,7 @@ export type DeleteProjectsByIdJobsByJobIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13769,6 +14138,7 @@ export type DeleteProjectsByIdJobsByJobIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13826,6 +14196,7 @@ export type PostProjectsByIdTasksErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13839,6 +14210,7 @@ export type PostProjectsByIdTasksErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13852,6 +14224,7 @@ export type PostProjectsByIdTasksErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13865,6 +14238,7 @@ export type PostProjectsByIdTasksErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13923,6 +14297,7 @@ export type DeleteProjectsByIdTasksByTaskIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13936,6 +14311,7 @@ export type DeleteProjectsByIdTasksByTaskIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -13949,6 +14325,7 @@ export type DeleteProjectsByIdTasksByTaskIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14006,6 +14383,7 @@ export type DeleteProjectsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14019,6 +14397,7 @@ export type DeleteProjectsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14032,6 +14411,7 @@ export type DeleteProjectsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14089,6 +14469,7 @@ export type GetProjectsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14102,6 +14483,7 @@ export type GetProjectsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14115,6 +14497,7 @@ export type GetProjectsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14172,6 +14555,7 @@ export type PatchProjectsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14185,6 +14569,7 @@ export type PatchProjectsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14198,6 +14583,7 @@ export type PatchProjectsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14211,6 +14597,7 @@ export type PatchProjectsByIdErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14291,6 +14678,7 @@ export type GetJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14304,6 +14692,7 @@ export type GetJobsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14317,6 +14706,7 @@ export type GetJobsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14374,6 +14764,7 @@ export type GetJobsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14387,6 +14778,7 @@ export type GetJobsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14400,6 +14792,7 @@ export type GetJobsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14413,6 +14806,7 @@ export type GetJobsByIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14472,6 +14866,7 @@ export type PatchJobsByIdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14485,6 +14880,7 @@ export type PatchJobsByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14498,6 +14894,7 @@ export type PatchJobsByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14511,6 +14908,7 @@ export type PatchJobsByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14524,6 +14922,7 @@ export type PatchJobsByIdErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14581,6 +14980,7 @@ export type PostJobsByIdRefundErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14594,6 +14994,7 @@ export type PostJobsByIdRefundErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14607,6 +15008,7 @@ export type PostJobsByIdRefundErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14620,6 +15022,7 @@ export type PostJobsByIdRefundErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14633,6 +15036,7 @@ export type PostJobsByIdRefundErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14690,6 +15094,7 @@ export type GetJobsByIdFilesErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14703,6 +15108,7 @@ export type GetJobsByIdFilesErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14716,6 +15122,7 @@ export type GetJobsByIdFilesErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14729,6 +15136,7 @@ export type GetJobsByIdFilesErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14786,6 +15194,7 @@ export type GetJobsByIdLinksErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14799,6 +15208,7 @@ export type GetJobsByIdLinksErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14812,6 +15222,7 @@ export type GetJobsByIdLinksErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14825,6 +15236,7 @@ export type GetJobsByIdLinksErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14882,6 +15294,7 @@ export type GetJobsByIdInputRequestErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14895,6 +15308,7 @@ export type GetJobsByIdInputRequestErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14908,6 +15322,7 @@ export type GetJobsByIdInputRequestErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14921,6 +15336,7 @@ export type GetJobsByIdInputRequestErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -14993,6 +15409,7 @@ export type PostJobsByIdInputsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15006,6 +15423,7 @@ export type PostJobsByIdInputsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15019,6 +15437,7 @@ export type PostJobsByIdInputsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15032,6 +15451,7 @@ export type PostJobsByIdInputsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15045,6 +15465,7 @@ export type PostJobsByIdInputsErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15058,6 +15479,7 @@ export type PostJobsByIdInputsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15071,6 +15493,7 @@ export type PostJobsByIdInputsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15128,6 +15551,7 @@ export type GetJobsByIdEventsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15141,6 +15565,7 @@ export type GetJobsByIdEventsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15154,6 +15579,7 @@ export type GetJobsByIdEventsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15167,6 +15593,7 @@ export type GetJobsByIdEventsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15224,6 +15651,7 @@ export type DeleteJobsByIdShareErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15237,6 +15665,7 @@ export type DeleteJobsByIdShareErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15250,6 +15679,7 @@ export type DeleteJobsByIdShareErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15311,6 +15741,7 @@ export type PutJobsByIdShareErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15324,6 +15755,7 @@ export type PutJobsByIdShareErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15337,6 +15769,7 @@ export type PutJobsByIdShareErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15396,6 +15829,7 @@ export type PutJobsByIdWorkspaceErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15409,6 +15843,7 @@ export type PutJobsByIdWorkspaceErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15422,6 +15857,7 @@ export type PutJobsByIdWorkspaceErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15435,6 +15871,7 @@ export type PutJobsByIdWorkspaceErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15448,6 +15885,7 @@ export type PutJobsByIdWorkspaceErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15494,6 +15932,7 @@ export type GetInvitationsByIdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15537,6 +15976,7 @@ export type GetShareByTokenErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15587,6 +16027,7 @@ export type GetCoworkersErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15600,6 +16041,7 @@ export type GetCoworkersErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15662,6 +16104,7 @@ export type PostCoworkersErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15675,6 +16118,7 @@ export type PostCoworkersErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15688,6 +16132,7 @@ export type PostCoworkersErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15729,6 +16174,7 @@ export type GetCoworkersMeErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15742,6 +16188,7 @@ export type GetCoworkersMeErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15755,6 +16202,7 @@ export type GetCoworkersMeErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15805,6 +16253,7 @@ export type GetCoworkersMeEventsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15818,6 +16267,7 @@ export type GetCoworkersMeEventsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15831,6 +16281,7 @@ export type GetCoworkersMeEventsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15878,6 +16329,7 @@ export type PostCoworkersMeUsageErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15891,6 +16343,7 @@ export type PostCoworkersMeUsageErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15904,6 +16357,7 @@ export type PostCoworkersMeUsageErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15917,6 +16371,7 @@ export type PostCoworkersMeUsageErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15930,6 +16385,7 @@ export type PostCoworkersMeUsageErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15984,6 +16440,7 @@ export type GetCoworkersByIdApiKeysErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -15997,6 +16454,7 @@ export type GetCoworkersByIdApiKeysErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16010,6 +16468,7 @@ export type GetCoworkersByIdApiKeysErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16056,6 +16515,7 @@ export type PostCoworkersByIdApiKeysErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16069,6 +16529,7 @@ export type PostCoworkersByIdApiKeysErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16082,6 +16543,7 @@ export type PostCoworkersByIdApiKeysErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16126,6 +16588,7 @@ export type DeleteCoworkersByIdApiKeysByKeyIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16139,6 +16602,7 @@ export type DeleteCoworkersByIdApiKeysByKeyIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16152,6 +16616,7 @@ export type DeleteCoworkersByIdApiKeysByKeyIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16199,6 +16664,7 @@ export type PatchCoworkersByIdApiKeysByKeyIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16212,6 +16678,7 @@ export type PatchCoworkersByIdApiKeysByKeyIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16225,6 +16692,7 @@ export type PatchCoworkersByIdApiKeysByKeyIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16268,6 +16736,7 @@ export type DeleteCoworkersByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16281,6 +16750,7 @@ export type DeleteCoworkersByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16294,6 +16764,7 @@ export type DeleteCoworkersByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16337,6 +16808,7 @@ export type GetCoworkersByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16350,6 +16822,7 @@ export type GetCoworkersByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16414,6 +16887,7 @@ export type PatchCoworkersByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16427,6 +16901,7 @@ export type PatchCoworkersByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16440,6 +16915,7 @@ export type PatchCoworkersByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16485,6 +16961,7 @@ export type PatchCoworkersByIdWhitelistErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16498,6 +16975,7 @@ export type PatchCoworkersByIdWhitelistErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16511,6 +16989,7 @@ export type PatchCoworkersByIdWhitelistErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16595,6 +17074,7 @@ export type GetTasksErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16608,6 +17088,7 @@ export type GetTasksErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16621,6 +17102,7 @@ export type GetTasksErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16686,6 +17168,7 @@ export type PostTasksErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16699,6 +17182,7 @@ export type PostTasksErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16712,6 +17196,7 @@ export type PostTasksErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16725,6 +17210,7 @@ export type PostTasksErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16768,6 +17254,7 @@ export type GetTasksByIdLinksErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16781,6 +17268,7 @@ export type GetTasksByIdLinksErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16828,6 +17316,7 @@ export type PostTasksByIdLinksErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16841,6 +17330,7 @@ export type PostTasksByIdLinksErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16854,6 +17344,7 @@ export type PostTasksByIdLinksErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16867,6 +17358,7 @@ export type PostTasksByIdLinksErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16880,6 +17372,7 @@ export type PostTasksByIdLinksErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16924,6 +17417,7 @@ export type DeleteTasksByIdLinksByLinkIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16937,6 +17431,7 @@ export type DeleteTasksByIdLinksByLinkIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16950,6 +17445,7 @@ export type DeleteTasksByIdLinksByLinkIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -16997,6 +17493,7 @@ export type PatchTasksByIdLinksByLinkIdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17010,6 +17507,7 @@ export type PatchTasksByIdLinksByLinkIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17023,6 +17521,7 @@ export type PatchTasksByIdLinksByLinkIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17036,6 +17535,7 @@ export type PatchTasksByIdLinksByLinkIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17079,6 +17579,7 @@ export type DeleteTasksByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17092,6 +17593,7 @@ export type DeleteTasksByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17105,6 +17607,7 @@ export type DeleteTasksByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17118,6 +17621,7 @@ export type DeleteTasksByIdErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17161,6 +17665,7 @@ export type GetTasksByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17174,6 +17679,7 @@ export type GetTasksByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17222,6 +17728,7 @@ export type PatchTasksByIdErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17235,6 +17742,7 @@ export type PatchTasksByIdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17248,6 +17756,7 @@ export type PatchTasksByIdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17261,6 +17770,7 @@ export type PatchTasksByIdErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17274,6 +17784,7 @@ export type PatchTasksByIdErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17317,6 +17828,7 @@ export type DeleteTasksByIdShareErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17330,6 +17842,7 @@ export type DeleteTasksByIdShareErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17343,6 +17856,7 @@ export type DeleteTasksByIdShareErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17390,6 +17904,7 @@ export type PutTasksByIdShareErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17403,6 +17918,7 @@ export type PutTasksByIdShareErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17416,6 +17932,7 @@ export type PutTasksByIdShareErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17461,6 +17978,7 @@ export type PutTasksByIdWorkspaceErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17474,6 +17992,7 @@ export type PutTasksByIdWorkspaceErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17487,6 +18006,7 @@ export type PutTasksByIdWorkspaceErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17500,6 +18020,7 @@ export type PutTasksByIdWorkspaceErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17513,6 +18034,7 @@ export type PutTasksByIdWorkspaceErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17556,6 +18078,7 @@ export type GetTasksByIdEventsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17569,6 +18092,7 @@ export type GetTasksByIdEventsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17625,6 +18149,7 @@ export type PostTasksByIdEventsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17638,6 +18163,7 @@ export type PostTasksByIdEventsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17651,6 +18177,7 @@ export type PostTasksByIdEventsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17664,6 +18191,7 @@ export type PostTasksByIdEventsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17677,6 +18205,7 @@ export type PostTasksByIdEventsErrors = {
     409: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17690,6 +18219,7 @@ export type PostTasksByIdEventsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17703,6 +18233,7 @@ export type PostTasksByIdEventsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17746,6 +18277,7 @@ export type GetTasksByIdJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -17759,6 +18291,7 @@ export type GetTasksByIdJobsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18749,6 +19282,7 @@ export type PostTasksByIdJobsErrors = {
     400: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18762,6 +19296,7 @@ export type PostTasksByIdJobsErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18775,6 +19310,7 @@ export type PostTasksByIdJobsErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18788,6 +19324,7 @@ export type PostTasksByIdJobsErrors = {
     404: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18801,6 +19338,7 @@ export type PostTasksByIdJobsErrors = {
     422: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18814,6 +19352,7 @@ export type PostTasksByIdJobsErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18855,6 +19394,7 @@ export type GetWorkspacesDesignMdErrors = {
     401: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18868,6 +19408,7 @@ export type GetWorkspacesDesignMdErrors = {
     403: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;
@@ -18881,6 +19422,7 @@ export type GetWorkspacesDesignMdErrors = {
     500: {
         error: string;
         message: string;
+        kind?: string;
         meta: {
             timestamp: Date;
             requestId: string;

--- a/apps/web/src/lib/services/__tests__/organization-seat.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/organization-seat.service.test.ts
@@ -24,11 +24,13 @@ const {
 }));
 
 class MockCoreApiRequestError extends Error {
+  kind?: string;
   status?: number;
 
-  constructor(message: string, options?: { status?: number }) {
+  constructor(message: string, options?: { kind?: string; status?: number }) {
     super(message);
     this.name = "CoreApiRequestError";
+    this.kind = options?.kind;
     this.status = options?.status;
   }
 }
@@ -45,8 +47,8 @@ vi.mock("@/lib/clients/core.client", () => ({
   },
 }));
 
-function coreError(status: number, message: string) {
-  return new MockCoreApiRequestError(message, { status });
+function coreError(status: number, message: string, kind?: string) {
+  return new MockCoreApiRequestError(message, { kind, status });
 }
 
 describe("organizationSeatService", () => {
@@ -81,6 +83,47 @@ describe("organizationSeatService", () => {
       unusedSeats: 2,
     });
     expect(getOrganizationSeatSummaryMock).toHaveBeenCalledWith("org-1");
+  });
+
+  it("resolves the seat summary to null when core responds 403", async () => {
+    getOrganizationSeatSummaryMock.mockRejectedValue(
+      coreError(403, "You are not a member of this organization"),
+    );
+
+    const { organizationSeatService } = await import(
+      "../organization-seat.service"
+    );
+
+    await expect(
+      organizationSeatService.getSeatSummary("org-1"),
+    ).resolves.toBeNull();
+  });
+
+  it("resolves the seat summary to null when core responds 404", async () => {
+    getOrganizationSeatSummaryMock.mockRejectedValue(
+      coreError(404, "Organization not found", "organization_not_found"),
+    );
+
+    const { organizationSeatService } = await import(
+      "../organization-seat.service"
+    );
+
+    await expect(
+      organizationSeatService.getSeatSummary("org-1"),
+    ).resolves.toBeNull();
+  });
+
+  it("rethrows other seat summary errors", async () => {
+    const failure = coreError(500, "Internal Server Error");
+    getOrganizationSeatSummaryMock.mockRejectedValue(failure);
+
+    const { organizationSeatService } = await import(
+      "../organization-seat.service"
+    );
+
+    await expect(organizationSeatService.getSeatSummary("org-1")).rejects.toBe(
+      failure,
+    );
   });
 
   it("assigns a seat through core", async () => {
@@ -144,6 +187,67 @@ describe("organizationSeatService", () => {
       status: "FORBIDDEN",
       message:
         "Only organization owners and admins can manage seat assignments",
+    });
+  });
+
+  it("maps the organization_not_found kind to FORBIDDEN even when the message is reworded", async () => {
+    assignOrganizationSeatMock.mockRejectedValue(
+      coreError(
+        404,
+        "We could not find that organization",
+        "organization_not_found",
+      ),
+    );
+
+    const { organizationSeatService } = await import(
+      "../organization-seat.service"
+    );
+
+    await expect(
+      organizationSeatService.assignSeat("user-1", "org-1", "member-1"),
+    ).rejects.toMatchObject({
+      status: "FORBIDDEN",
+      message:
+        "Only organization owners and admins can manage seat assignments",
+    });
+  });
+
+  it("maps the member_not_found kind to NOT_FOUND", async () => {
+    assignOrganizationSeatMock.mockRejectedValue(
+      coreError(404, "Member not found", "member_not_found"),
+    );
+
+    const { organizationSeatService } = await import(
+      "../organization-seat.service"
+    );
+
+    await expect(
+      organizationSeatService.assignSeat("user-1", "org-1", "member-1"),
+    ).rejects.toMatchObject({
+      status: "NOT_FOUND",
+      message: "Member not found",
+    });
+  });
+
+  it("maps the seat_capacity_exceeded kind to BAD_REQUEST", async () => {
+    assignOrganizationSeatMock.mockRejectedValue(
+      coreError(
+        400,
+        "No unused seats available. Purchase more seats or unassign another member.",
+        "seat_capacity_exceeded",
+      ),
+    );
+
+    const { organizationSeatService } = await import(
+      "../organization-seat.service"
+    );
+
+    await expect(
+      organizationSeatService.assignSeat("user-1", "org-1", "member-1"),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      message:
+        "No unused seats available. Purchase more seats or unassign another member.",
     });
   });
 

--- a/apps/web/src/lib/services/__tests__/organization-subscription.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/organization-subscription.service.test.ts
@@ -25,11 +25,13 @@ const updateSubscriptionRecordMock = vi.fn();
 const updateOrganizationSubscriptionSeatsMock = vi.fn();
 
 class MockCoreApiRequestError extends Error {
+  kind?: string;
   status?: number;
 
-  constructor(message: string, options?: { status?: number }) {
+  constructor(message: string, options?: { kind?: string; status?: number }) {
     super(message);
     this.name = "CoreApiRequestError";
+    this.kind = options?.kind;
     this.status = options?.status;
   }
 }
@@ -289,6 +291,29 @@ describe("organizationSubscriptionService", () => {
     it("maps a missing organization to the owner/admin FORBIDDEN error", async () => {
       updateOrganizationSubscriptionSeatsMock.mockRejectedValue(
         new MockCoreApiRequestError("Organization not found", {
+          status: 404,
+        }),
+      );
+
+      const { organizationSubscriptionService } = await import(
+        "../organization-subscription.service"
+      );
+
+      await expect(
+        organizationSubscriptionService.updateOrganizationSeatsImmediately(
+          "user-1",
+          "org-1",
+          3,
+        ),
+      ).rejects.toThrow(
+        "Only organization owners and admins can manage subscriptions",
+      );
+    });
+
+    it("maps the organization_not_found kind to FORBIDDEN even when the message is reworded", async () => {
+      updateOrganizationSubscriptionSeatsMock.mockRejectedValue(
+        new MockCoreApiRequestError("We could not find that organization", {
+          kind: "organization_not_found",
           status: 404,
         }),
       );

--- a/apps/web/src/lib/services/organization-seat.service.ts
+++ b/apps/web/src/lib/services/organization-seat.service.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
-import type { OrganizationBillingPlanName } from "@sokosumi/utils";
+import {
+  CORE_API_ERROR_KINDS,
+  type OrganizationBillingPlanName,
+} from "@sokosumi/utils";
 import { APIError } from "better-auth/api";
 
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
@@ -20,6 +23,10 @@ export interface OrganizationSeatSummary {
  * admin and 404 when the organization is missing — both surfaced as FORBIDDEN
  * like the previous in-process guard. A 404 for the member and a 400 for
  * exhausted capacity keep Core's message.
+ *
+ * Disambiguation matches the machine-readable `kind` from the Core error
+ * envelope first; the legacy status(+message) checks remain as a fallback for
+ * responses without a kind.
  */
 function mapCoreSeatWriteError(error: unknown): never {
   if (!(error instanceof CoreApiRequestError)) {
@@ -27,6 +34,7 @@ function mapCoreSeatWriteError(error: unknown): never {
   }
 
   if (
+    error.kind === CORE_API_ERROR_KINDS.ORGANIZATION_NOT_FOUND ||
     error.status === 403 ||
     (error.status === 404 && error.message === "Organization not found")
   ) {
@@ -36,13 +44,19 @@ function mapCoreSeatWriteError(error: unknown): never {
     });
   }
 
-  if (error.status === 404) {
+  if (
+    error.kind === CORE_API_ERROR_KINDS.MEMBER_NOT_FOUND ||
+    error.status === 404
+  ) {
     throw new APIError("NOT_FOUND", {
       message: error.message,
     });
   }
 
-  if (error.status === 400) {
+  if (
+    error.kind === CORE_API_ERROR_KINDS.SEAT_CAPACITY_EXCEEDED ||
+    error.status === 400
+  ) {
     throw new APIError("BAD_REQUEST", {
       message: error.message,
     });
@@ -53,11 +67,30 @@ function mapCoreSeatWriteError(error: unknown): never {
 
 export const organizationSeatService = (() => {
   return {
+    /**
+     * Returns the seat summary, or `null` when Core reports the caller has no
+     * access to the organization (403) or the organization is missing (404) —
+     * e.g. a stale active organization after a revoked membership. Callers
+     * render a no-seat-data fallback in that case.
+     */
     async getSeatSummary(
       organizationId: string,
-    ): Promise<OrganizationSeatSummary> {
-      const { data } =
-        await coreClient.getOrganizationSeatSummary(organizationId);
+    ): Promise<OrganizationSeatSummary | null> {
+      let data: Awaited<
+        ReturnType<typeof coreClient.getOrganizationSeatSummary>
+      >["data"];
+      try {
+        ({ data } =
+          await coreClient.getOrganizationSeatSummary(organizationId));
+      } catch (error) {
+        if (
+          error instanceof CoreApiRequestError &&
+          (error.status === 403 || error.status === 404)
+        ) {
+          return null;
+        }
+        throw error;
+      }
 
       return {
         assignedCount: data.assignedCount,

--- a/apps/web/src/lib/services/organization-subscription.service.ts
+++ b/apps/web/src/lib/services/organization-subscription.service.ts
@@ -10,6 +10,7 @@ import {
   memberRepository,
   subscriptionRepository,
 } from "@sokosumi/database/repositories";
+import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 import { APIError } from "better-auth/api";
 
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
@@ -54,6 +55,10 @@ async function resolveActiveOrganizationSubscription(
  * surfaced as FORBIDDEN like the previous in-process guard. A 400 (no active
  * subscription, seats below assigned members, or enterprise exclusivity)
  * keeps Core's message.
+ *
+ * Disambiguation matches the machine-readable `kind` from the Core error
+ * envelope first; the legacy status(+message) checks remain as a fallback for
+ * responses without a kind.
  */
 function mapCoreSubscriptionSeatsWriteError(error: unknown): never {
   if (!(error instanceof CoreApiRequestError)) {
@@ -61,6 +66,7 @@ function mapCoreSubscriptionSeatsWriteError(error: unknown): never {
   }
 
   if (
+    error.kind === CORE_API_ERROR_KINDS.ORGANIZATION_NOT_FOUND ||
     error.status === 403 ||
     (error.status === 404 && error.message === "Organization not found")
   ) {

--- a/packages/utils/src/core-api-error-kind.ts
+++ b/packages/utils/src/core-api-error-kind.ts
@@ -1,0 +1,22 @@
+/**
+ * Stable machine-readable identifiers carried in the Core API error
+ * envelope's optional `kind` field.
+ *
+ * Consumers (the web app) MUST match on these constants instead of the
+ * human-readable `message`, which may be reworded at any time. Values are
+ * part of the public API contract: never change an existing value, only add
+ * new ones.
+ */
+export const CORE_API_ERROR_KINDS = {
+  MEMBER_NOT_FOUND: "member_not_found",
+  ORGANIZATION_MEMBERSHIP_REQUIRED: "organization_membership_required",
+  ORGANIZATION_NOT_FOUND: "organization_not_found",
+  ORGANIZATION_ROLE_FORBIDDEN: "organization_role_forbidden",
+  SEAT_CAPACITY_EXCEEDED: "seat_capacity_exceeded",
+  SUBSCRIPTION_CHANGE_NOT_ALLOWED: "subscription_change_not_allowed",
+  SUBSCRIPTION_NOT_ACTIVE: "subscription_not_active",
+  SUBSCRIPTION_SEATS_BELOW_ASSIGNED: "subscription_seats_below_assigned",
+} as const;
+
+export type CoreApiErrorKind =
+  (typeof CORE_API_ERROR_KINDS)[keyof typeof CORE_API_ERROR_KINDS];

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -18,6 +18,10 @@ export {
   CHAT_UI_NON_REASONING_PART_TYPES,
   isChatUiProviderReasoningPartType,
 } from "./chat-ui-non-reasoning-part-types.js";
+export {
+  CORE_API_ERROR_KINDS,
+  type CoreApiErrorKind,
+} from "./core-api-error-kind.js";
 export { convertCentsToCredits, convertCreditsToCents } from "./credit.js";
 export {
   FILE_EXTENSION_ALLOWLIST,


### PR DESCRIPTION
## Summary

Web disambiguated Core errors by literal message text (e.g. `error.status === 404 && error.message === "Organization not found"`) in several mappers — any reworded message silently broke the mapping. This PR adds an optional, stable, machine-readable `kind` field to the Core API error envelope and switches the web mappers to match on it (with the old status/message checks kept as a safety fallback).

## Changes

### Shared (`@sokosumi/utils`)
- New `CORE_API_ERROR_KINDS` constants + `CoreApiErrorKind` type union in `packages/utils/src/core-api-error-kind.ts` — defined once and imported by both core (producer) and web (consumer), since web cannot import from core:
  - `member_not_found`
  - `organization_membership_required`
  - `organization_not_found`
  - `organization_role_forbidden`
  - `seat_capacity_exceeded`
  - `subscription_change_not_allowed`
  - `subscription_not_active`
  - `subscription_seats_below_assigned`

### Core
- `errorResponseSchema` gains an optional `kind` (snake_case) field — the central `errorHandler` already emitted `kind` from the `HTTPException` cause (`HTTPExceptionMetadata`), it was just undeclared in the OpenAPI schema. Backwards compatible: omitted when not set, messages unchanged.
- `badRequest`/`forbidden`/`notFound` now accept the optional `HTTPExceptionMetadata` argument (matching the existing `conflict`/`serviceUnavailable` style).
- Kinds set at the throw sites web disambiguates:
  - `resolveMemberOrganizationById`/`BySlug` (`apps/core/src/helpers/organization.ts`): `organization_not_found`, `organization_membership_required`, `organization_role_forbidden` — covers the seat, invoice-email, and subscription-seats routes.
  - `mapSeatRepositoryError` (`apps/core/src/services/organization-seat.service.ts`): `member_not_found`, `seat_capacity_exceeded`.
  - Subscription-seats guards (`.../subscription/seats/put.ts`): `subscription_change_not_allowed`, `subscription_not_active`, `subscription_seats_below_assigned`.

### Web
- Regenerated Core API client (`pnpm --filter web generate:core:snapshot`) — error types now carry `kind?: string`.
- `CoreApiRequestError` exposes `kind`, extracted from the Core error body.
- Mappers now match on `kind` first, status(+message) as fallback:
  - `mapCoreSeatWriteError` (`organization-seat.service.ts`)
  - `mapCoreSubscriptionSeatsWriteError` (`organization-subscription.service.ts`)
  - `updateOrganizationInvoiceEmail` (`actions/organization/action.ts`)
- Deferred minor fixed: `organizationSeatService.getSeatSummary` no longer surfaces unmapped `CoreApiRequestError` to server components — a 403/404 (stale membership / missing organization) now resolves to `null`; the organization page and onboarding loader already handled null, the billing page falls back to zero seat counts.

## Notes
- `mapSeatRepositoryError` still matches the member repository's `Error` messages internally (`"Member not found"`, `includes("exceeds purchased seats")`). Changing the repository to throw coded errors was deemed too invasive for this PR; the message matching is now confined to core-internal code and no longer crosses the core→web boundary.
- The pre-existing `maintenance-mode` kind (kebab-case) is left untouched; new kinds are snake_case per convention.

## Verification
- `pnpm --filter @sokosumi/core typecheck` ✅
- `pnpm --filter @sokosumi/core test` (error, error-handler, organization helpers, seat put/delete, subscription seats, invoice-email routes — 53 tests) ✅
- `pnpm --filter web typecheck` ✅
- `pnpm --filter web test` (seat service, subscription service, organization action, billing page, onboarding loader — 61 tests) ✅
- `pnpm --filter @sokosumi/utils test` ✅
- `pnpm check` (repo-wide Biome) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)