### PR TITLE
fix(web): filter third-party analytics errors from sentry

### DIFF
--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -304,6 +304,28 @@ describe("POST /{id}/events", () => {
     expect(response.status).toBe(409);
   });
 
+  it("rethrows non-conflict transaction errors as 500", async () => {
+    prismaTransactionMock.mockRejectedValueOnce(new Error("Connection lost"));
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        status: TaskStatus.OUT_OF_CREDITS,
+        comment: "Need top-up",
+      }),
+    });
+
+    expect(response.status).toBe(500);
+  });
+
   it("rejects OUT_OF_CREDITS for users", async () => {
     const tx: TransactionMock = {
       taskEvent: {

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -280,6 +280,30 @@ describe("POST /{id}/events", () => {
     );
   });
 
+  it("returns 409 when the serializable transaction hits a write conflict", async () => {
+    prismaTransactionMock.mockRejectedValueOnce(
+      Object.assign(new Error("Transaction failed"), { code: "P2034" }),
+    );
+
+    const app = createApp({
+      actor: "coworker",
+      coworkerId: COWORKER_ID,
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        status: TaskStatus.OUT_OF_CREDITS,
+        comment: "Need top-up",
+      }),
+    });
+
+    expect(response.status).toBe(409);
+  });
+
   it("rejects OUT_OF_CREDITS for users", async () => {
     const tx: TransactionMock = {
       taskEvent: {

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -14,6 +14,7 @@ import {
 } from "@/helpers/agent";
 import { conflict, unprocessableEntity } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { isPrismaTransactionConflict } from "@/helpers/prisma";
 import { created } from "@/helpers/response";
 import {
   isTaskStatusSpendable,
@@ -119,145 +120,168 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id: taskId } = c.req.valid("param");
     const body = c.req.valid("json");
 
-    const { event, userId, masumiPayment } = await prisma.$transaction(
-      async (tx) => {
-        const task = await requireTaskCollaboration(authContext, taskId, tx);
-        const {
-          status,
-          comment,
-          credits,
-          authenticationUrl,
-          origin,
-          masumiPayment,
-        } = body;
-
-        if (status !== undefined) {
-          validateStatusTransition(authContext, task.status, status);
-          validateTaskCoworkerAssignment({
-            status,
-            coworkerId: task.coworkerId,
-          });
-
-          // Only the assigned coworker agent settles billing.
-          const isAgent = isCoworkerAgentContext(authContext);
-          const isAgentSpend = isAgent && isTaskStatusSpendable(status);
-
-          // User and delegated-coworker callers use the user transition table,
-          // and the charge branch below is gated on isAgent — so credits from
-          // them would be silently dropped. Reject it.
-          //
-          // masumiPayment needs no check here: the schema only allows it with
-          // status COMPLETED, which the user transition table can never reach,
-          // so a non-agent caller is already rejected upstream (400/422).
-          if (!isAgent && credits != null) {
-            throw unprocessableEntity(
-              "Only the assigned coworker can set credits when changing task status",
-            );
-          }
-
-          let cents: bigint | undefined;
-          let transactionId: string | null = null;
-
-          if (isAgentSpend) {
-            if (masumiPayment) {
-              console.info("[tasks] masumi task payment: using masumiPayment", {
-                masumiPayment,
-              });
-              const creditCosts = await getCreditCostsOrThrow(tx);
-              cents = calculateCentsFromMasumiAmountStrings(
-                masumiPayment.Amounts,
-                creditCosts,
-              );
-              if (cents === 0n) {
-                throw unprocessableEntity(
-                  `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
-                );
-              }
-              const creditsValue = convertCentsToCredits(cents);
-              if (creditsValue < LIMITS.MIN_CHARGEABLE_CREDITS) {
-                throw unprocessableEntity(
-                  `Credit amount is below the minimum chargeable value (${LIMITS.MIN_CHARGEABLE_CREDITS})`,
-                );
-              }
-              transactionId = await createTaskEventTransaction({
-                userId: task.userId,
-                organizationId: task.organizationId,
-                cents,
-                tx,
-              });
-            } else if (credits != null && credits > 0) {
-              cents = convertCreditsToCents(credits);
-              if (cents === 0n) {
-                throw unprocessableEntity(
-                  `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
-                );
-              }
-              transactionId = await createTaskEventTransaction({
-                userId: task.userId,
-                organizationId: task.organizationId,
-                cents,
-                tx,
-              });
-            }
-          }
-
-          const createdEvent = await tx.taskEvent.create({
-            data: {
+    const { event, userId, masumiPayment } = await (async () => {
+      try {
+        return await prisma.$transaction(
+          async (tx) => {
+            const task = await requireTaskCollaboration(
+              authContext,
               taskId,
+              tx,
+            );
+            const {
               status,
               comment,
+              credits,
               authenticationUrl,
               origin,
-              cents,
-              transactionId,
-              ...getActorData(authContext),
-            },
-          });
+              masumiPayment,
+            } = body;
 
-          const updateResult = await tx.task.updateMany({
-            where: { id: taskId, status: task.status },
-            data: { status },
-          });
-          if (updateResult.count !== 1) {
-            throw conflict("Task status was changed by another request");
-          }
+            if (status !== undefined) {
+              validateStatusTransition(authContext, task.status, status);
+              validateTaskCoworkerAssignment({
+                status,
+                coworkerId: task.coworkerId,
+              });
 
-          const payment =
-            masumiPayment !== undefined && isAgentSpend ? masumiPayment : null;
+              // Only the assigned coworker agent settles billing.
+              const isAgent = isCoworkerAgentContext(authContext);
+              const isAgentSpend = isAgent && isTaskStatusSpendable(status);
 
-          return {
-            event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
-            userId: task.userId,
-            masumiPayment: payment,
-          };
-        }
+              // User and delegated-coworker callers use the user transition table,
+              // and the charge branch below is gated on isAgent — so credits from
+              // them would be silently dropped. Reject it.
+              //
+              // masumiPayment needs no check here: the schema only allows it with
+              // status COMPLETED, which the user transition table can never reach,
+              // so a non-agent caller is already rejected upstream (400/422).
+              if (!isAgent && credits != null) {
+                throw unprocessableEntity(
+                  "Only the assigned coworker can set credits when changing task status",
+                );
+              }
 
-        if (comment === undefined) {
-          throw unprocessableEntity(
-            "Either status or comment must be provided",
-          );
-        }
+              let cents: bigint | undefined;
+              let transactionId: string | null = null;
 
-        const createdEvent = await tx.taskEvent.create({
-          data: {
-            taskId,
-            status: null,
-            comment,
-            origin,
-            ...getActorData(authContext),
+              if (isAgentSpend) {
+                if (masumiPayment) {
+                  console.info(
+                    "[tasks] masumi task payment: using masumiPayment",
+                    {
+                      masumiPayment,
+                    },
+                  );
+                  const creditCosts = await getCreditCostsOrThrow(tx);
+                  cents = calculateCentsFromMasumiAmountStrings(
+                    masumiPayment.Amounts,
+                    creditCosts,
+                  );
+                  if (cents === 0n) {
+                    throw unprocessableEntity(
+                      `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
+                    );
+                  }
+                  const creditsValue = convertCentsToCredits(cents);
+                  if (creditsValue < LIMITS.MIN_CHARGEABLE_CREDITS) {
+                    throw unprocessableEntity(
+                      `Credit amount is below the minimum chargeable value (${LIMITS.MIN_CHARGEABLE_CREDITS})`,
+                    );
+                  }
+                  transactionId = await createTaskEventTransaction({
+                    userId: task.userId,
+                    organizationId: task.organizationId,
+                    cents,
+                    tx,
+                  });
+                } else if (credits != null && credits > 0) {
+                  cents = convertCreditsToCents(credits);
+                  if (cents === 0n) {
+                    throw unprocessableEntity(
+                      `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
+                    );
+                  }
+                  transactionId = await createTaskEventTransaction({
+                    userId: task.userId,
+                    organizationId: task.organizationId,
+                    cents,
+                    tx,
+                  });
+                }
+              }
+
+              const createdEvent = await tx.taskEvent.create({
+                data: {
+                  taskId,
+                  status,
+                  comment,
+                  authenticationUrl,
+                  origin,
+                  cents,
+                  transactionId,
+                  ...getActorData(authContext),
+                },
+              });
+
+              const updateResult = await tx.task.updateMany({
+                where: { id: taskId, status: task.status },
+                data: { status },
+              });
+              if (updateResult.count !== 1) {
+                throw conflict("Task status was changed by another request");
+              }
+
+              const payment =
+                masumiPayment !== undefined && isAgentSpend
+                  ? masumiPayment
+                  : null;
+
+              return {
+                event: await mapCreatedTaskEventForResponse(
+                  tx,
+                  createdEvent.id,
+                ),
+                userId: task.userId,
+                masumiPayment: payment,
+              };
+            }
+
+            if (comment === undefined) {
+              throw unprocessableEntity(
+                "Either status or comment must be provided",
+              );
+            }
+
+            const createdEvent = await tx.taskEvent.create({
+              data: {
+                taskId,
+                status: null,
+                comment,
+                origin,
+                ...getActorData(authContext),
+              },
+            });
+
+            return {
+              event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
+              userId: task.userId,
+              masumiPayment: null,
+            };
           },
-        });
-
-        return {
-          event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
-          userId: task.userId,
-          masumiPayment: null,
-        };
-      },
-      {
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      },
-    );
+          {
+            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+          },
+        );
+      } catch (error) {
+        // Serializable transactions abort with P2034 under concurrent writes;
+        // surface that as a retryable conflict instead of a 500.
+        if (isPrismaTransactionConflict(error)) {
+          throw conflict("Task changed by a concurrent request. Please retry.");
+        }
+        throw error;
+      }
+    })();
 
     if (masumiPayment != null) {
       const taskEventId = event.id;

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -4,6 +4,7 @@ import { thirdPartyDomMutationIgnoreErrors } from "@/lib/sentry/third-party-dom-
 import {
   beforeSendClientEvent,
   thirdPartyAnalyticsDenyUrls,
+  thirdPartyAnalyticsIgnoreErrors,
 } from "@/lib/sentry/third-party-fetch-errors";
 
 Sentry.init({
@@ -17,7 +18,10 @@ Sentry.init({
   // https://github.com/getsentry/sentry-javascript/issues/16542
 
   denyUrls: thirdPartyAnalyticsDenyUrls,
-  ignoreErrors: thirdPartyDomMutationIgnoreErrors,
+  ignoreErrors: [
+    ...thirdPartyDomMutationIgnoreErrors,
+    ...thirdPartyAnalyticsIgnoreErrors,
+  ],
   beforeSend: beforeSendClientEvent,
 
   integrations: [Sentry.replayIntegration({})],

--- a/apps/web/src/lib/sentry/__tests__/third-party-fetch-errors.test.ts
+++ b/apps/web/src/lib/sentry/__tests__/third-party-fetch-errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   beforeSendClientEvent,
   isThirdPartyAnalyticsFetchFailure,
+  thirdPartyAnalyticsIgnoreErrors,
 } from "@/lib/sentry/third-party-fetch-errors";
 
 describe("isThirdPartyAnalyticsFetchFailure", () => {
@@ -11,6 +12,13 @@ describe("isThirdPartyAnalyticsFetchFailure", () => {
       isThirdPartyAnalyticsFetchFailure(
         "TypeError: Failed to fetch (plausible.io)",
       ),
+    ).toBe(true);
+  });
+
+  it("returns true for exception values without the TypeError prefix", () => {
+    // Sentry stores the type separately, so real events arrive in this shape.
+    expect(
+      isThirdPartyAnalyticsFetchFailure("Failed to fetch (plausible.io)"),
     ).toBe(true);
   });
 
@@ -37,6 +45,30 @@ describe("isThirdPartyAnalyticsFetchFailure", () => {
   });
 });
 
+describe("thirdPartyAnalyticsIgnoreErrors", () => {
+  function matchesIgnoreErrors(message: string): boolean {
+    return thirdPartyAnalyticsIgnoreErrors.some((pattern) =>
+      pattern.test(message),
+    );
+  }
+
+  it("matches the Chromium/Firefox clarity message", () => {
+    expect(matchesIgnoreErrors("window.clarity is not a function")).toBe(true);
+  });
+
+  it("matches the WebKit clarity message", () => {
+    expect(
+      matchesIgnoreErrors(
+        "window.clarity is not a function. (In 'window.clarity(\"event\",\"sign_up\")', 'window.clarity' is undefined)",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated not-a-function errors", () => {
+    expect(matchesIgnoreErrors("foo.bar is not a function")).toBe(false);
+  });
+});
+
 describe("beforeSendClientEvent", () => {
   it("drops third-party analytics fetch error events", () => {
     const result = beforeSendClientEvent(
@@ -46,6 +78,25 @@ describe("beforeSendClientEvent", () => {
           values: [
             {
               value: "TypeError: Failed to fetch (plausible.io)",
+            },
+          ],
+        },
+      },
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("drops events whose exception value lacks the TypeError prefix", () => {
+    const result = beforeSendClientEvent(
+      {
+        type: undefined,
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: "Failed to fetch (plausible.io)",
             },
           ],
         },

--- a/apps/web/src/lib/sentry/third-party-fetch-errors.ts
+++ b/apps/web/src/lib/sentry/third-party-fetch-errors.ts
@@ -19,8 +19,21 @@ export const thirdPartyAnalyticsDenyUrls: RegExp[] = [
   /doubleclick\.net/i,
 ];
 
+/**
+ * Tags injected by GTM call `window.clarity(...)` before the Clarity snippet
+ * loads (or when it is blocked), throwing from gtm.js — never from our code
+ * (see SOKOSUMI-CD, SOKOSUMI-6W). Message shape differs per engine:
+ * Chromium/Firefox report `window.clarity is not a function`, WebKit appends
+ * `. (In 'window.clarity(...)', 'window.clarity' is undefined)`.
+ */
+export const thirdPartyAnalyticsIgnoreErrors: RegExp[] = [
+  /window\.clarity is not a function/,
+];
+
+// Sentry stores the exception type separately, so the value usually arrives
+// without the `TypeError: ` prefix; accept both shapes.
 const thirdPartyFetchFailurePattern =
-  /^TypeError: Failed to fetch \(([^)]+)\)$/;
+  /^(?:TypeError: )?Failed to fetch \(([^)]+)\)$/;
 
 function getEventErrorMessage(event: ErrorEvent): string {
   const exceptionValue = event.exception?.values?.[0]?.value;


### PR DESCRIPTION
## Summary

Investigated the top unresolved production Sentry errors and landed fixes for the two root-cause clusters that are first-party bugs. Combined they account for ~750 events, including the currently **escalating** plausible.io issue.

### 1. Web Sentry filter never matched real events (third-party analytics noise)

**Issues:** [SOKOSUMI-PG](https://masumi.sentry.io/issues/SOKOSUMI-PG) (100 events, escalating), [SOKOSUMI-PE](https://masumi.sentry.io/issues/SOKOSUMI-PE), [SOKOSUMI-CD](https://masumi.sentry.io/issues/SOKOSUMI-CD) (615 events since Nov), [SOKOSUMI-6W](https://masumi.sentry.io/issues/SOKOSUMI-6W)

- `beforeSendClientEvent` matched fetch failures against `/^TypeError: Failed to fetch \(...\)$/`, but Sentry stores the exception **type** separately from the **value** — real events arrive as `Failed to fetch (plausible.io)` with no prefix, so the filter never fired (verified against production event data: `error.type: TypeError`, `error.value: Failed to fetch (plausible.io)`). The prefix is now optional.
- Added `window.clarity is not a function` to `ignoreErrors`: GTM-injected tags call `window.clarity(...)` before the Clarity snippet loads (or when it's blocked by the browser). The stack is 100% `gtm.js` frames; `clarity` is never called from app code. The existing `googletagmanager.com` denyUrl can't catch it because the throwing frame is the Sentry instrumentation wrapper.

### 2. Core: task event creation 500s on concurrent writes

**Issue:** [SOKOSUMI-CORE-13](https://masumi.sentry.io/issues/SOKOSUMI-CORE-13) (fatal, 4 users, last seen 1 day ago)

`POST /v1/tasks/:id/events` runs a `Serializable` transaction; under concurrent writes Postgres aborts with a serialization failure (Prisma `P2034`: *"Transaction failed due to a write conflict or a deadlock. Please retry your transaction"*), which bubbled up as an unhandled fatal 500. Now mapped to a retryable **409 Conflict**, exactly mirroring the existing handling in `tasks/[id]/links/post.ts` (the endpoint already returns 409 for the optimistic-lock race on `task.updateMany`). Callers are coworker agents that can retry on 409.

### Not fixed (triage notes)

- **`CoreApiRequestError: Invalid, expired or missing session`** (SOKOSUMI-P5/NF/MV, ~12 events): server-rendered pages (e.g. `/tasks`) crash when the web session cookie passes `getSession()` but Core rejects it as expired. A proper fix needs a shared "Core 401 during RSC render → redirect to `/signin`" path rather than per-page catches; left as follow-up since it's low-volume and architecturally broader.
- Remaining web issues (`Load failed` on `/signin`, injected-script `touches` error, Postmark inactive-recipient bounce) are third-party/network noise or expected upstream behavior with single-digit events.
- The other high-count core issues (`/sync/jobs` Prisma errors, ZodErrors) were last seen 16+ days ago on old releases and appear already remediated.

## Verification

- `pnpm core:test` — 182 files, 1302 tests passed
- `pnpm web:test` — 232 files, 1419 tests passed
- `pnpm check` (Biome) and `tsc --noEmit` for both apps — clean
- New tests: production-shaped (unprefixed) fetch-failure events are dropped; clarity messages (Chromium + WebKit shapes) match the ignore pattern; `POST /{id}/events` returns 409 on `P2034`

https://claude.ai/code/session_01U6HxkKVAspc16t3N4jaqpX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6HxkKVAspc16t3N4jaqpX)_