### PR TITLE
refactor(core): centralize serializable transaction conflict handling

### DIFF
--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -109,6 +109,10 @@ For low-frequency, user-triggered mutations that are easy to retry, last-write-w
 
 Examples include workspace move operations for tasks and jobs. Do not add `updateMany`-style stale-write guards there unless the product requirement explicitly needs conflict detection.
 
+#### Serializable Transactions
+
+When a flow does need `Serializable` isolation (e.g. credit consumption, idempotency checks), use `serializableTransaction()` from `@/lib/db/transaction` instead of calling `prisma.$transaction` with `isolationLevel` directly. Postgres aborts serializable transactions with a serialization failure (Prisma `P2034`) under concurrent writes; the helper maps that to a retryable 409 conflict (`kind: "concurrency_conflict"`) instead of an unhandled 500. Routes using it must declare `409: jsonErrorResponse("Conflict")` in their OpenAPI responses.
+
 ### Authentication Classes
 
 Use type-safe Hono classes that automatically apply authentication:

--- a/apps/core/src/helpers/job.ts
+++ b/apps/core/src/helpers/job.ts
@@ -33,6 +33,7 @@ import {
   getCreditCostsOrThrow,
 } from "@/helpers/agent";
 import prisma from "@/lib/db/prisma";
+import { serializableTransaction } from "@/lib/db/transaction";
 import type { UserContext } from "@/middleware/auth";
 import type { WorkspaceContext } from "@/middleware/workspace";
 import {
@@ -446,43 +447,38 @@ export async function createAgentJobForUser(
       throw unprocessableEntity("Agent pricing type not supported");
   }
 
-  const job = await prisma.$transaction(
-    async (tx) => {
-      await validateCreditBalance(
-        owner.userId,
-        owner.organizationId,
-        cost.cents,
-        tx,
-      );
+  const job = await serializableTransaction(async (tx) => {
+    await validateCreditBalance(
+      owner.userId,
+      owner.organizationId,
+      cost.cents,
+      tx,
+    );
 
-      if (agent.pricing.pricingType === PricingType.FREE) {
-        if (!freeJobResult) {
-          throw unprocessableEntity("Free agent job start failed");
-        }
-
-        return await createFreeJob(
-          { ...jobInput, name: jobName },
-          freeJobResult,
-          tx,
-        );
+    if (agent.pricing.pricingType === PricingType.FREE) {
+      if (!freeJobResult) {
+        throw unprocessableEntity("Free agent job start failed");
       }
 
-      if (!paidJobResult || !identifierFromPurchaser) {
-        throw unprocessableEntity("Paid agent job start failed");
-      }
-
-      return await createPaidJob(
+      return await createFreeJob(
         { ...jobInput, name: jobName },
-        agent.cost,
-        paidJobResult,
-        identifierFromPurchaser,
+        freeJobResult,
         tx,
       );
-    },
-    {
-      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-    },
-  );
+    }
+
+    if (!paidJobResult || !identifierFromPurchaser) {
+      throw unprocessableEntity("Paid agent job start failed");
+    }
+
+    return await createPaidJob(
+      { ...jobInput, name: jobName },
+      agent.cost,
+      paidJobResult,
+      identifierFromPurchaser,
+      tx,
+    );
+  }, "Job creation conflicted with a concurrent request. Please retry.");
 
   if (
     agent.pricing.pricingType === PricingType.FIXED &&

--- a/apps/core/src/lib/db/transaction.test.ts
+++ b/apps/core/src/lib/db/transaction.test.ts
@@ -1,0 +1,61 @@
+import { Prisma } from "@sokosumi/database";
+import { HTTPException } from "hono/http-exception";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { serializableTransaction } from "./transaction";
+
+const { prismaTransactionMock } = vi.hoisted(() => ({
+  prismaTransactionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: prismaTransactionMock,
+  },
+}));
+
+describe("serializableTransaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs the callback in a Serializable transaction and returns its result", async () => {
+    const callback = vi.fn().mockResolvedValue("result");
+    prismaTransactionMock.mockImplementation(
+      async (cb: () => unknown) => await cb(),
+    );
+
+    const result = await serializableTransaction(callback, "Conflict message");
+
+    expect(result).toBe("result");
+    expect(prismaTransactionMock).toHaveBeenCalledWith(callback, {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    });
+  });
+
+  it("maps P2034 serialization failures to a 409 conflict", async () => {
+    prismaTransactionMock.mockRejectedValueOnce(
+      Object.assign(new Error("Transaction failed"), { code: "P2034" }),
+    );
+
+    const promise = serializableTransaction(
+      vi.fn(),
+      "Resource changed. Please retry.",
+    );
+
+    await expect(promise).rejects.toMatchObject({
+      status: 409,
+      message: "Resource changed. Please retry.",
+    });
+    await expect(promise).rejects.toBeInstanceOf(HTTPException);
+  });
+
+  it("rethrows non-conflict errors unchanged", async () => {
+    const error = new Error("Connection lost");
+    prismaTransactionMock.mockRejectedValueOnce(error);
+
+    await expect(
+      serializableTransaction(vi.fn(), "Conflict message"),
+    ).rejects.toBe(error);
+  });
+});

--- a/apps/core/src/lib/db/transaction.test.ts
+++ b/apps/core/src/lib/db/transaction.test.ts
@@ -2,7 +2,10 @@ import { Prisma } from "@sokosumi/database";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { serializableTransaction } from "./transaction";
+import {
+  CONCURRENCY_CONFLICT_KIND,
+  serializableTransaction,
+} from "./transaction";
 
 const { prismaTransactionMock } = vi.hoisted(() => ({
   prismaTransactionMock: vi.fn(),
@@ -46,6 +49,7 @@ describe("serializableTransaction", () => {
     await expect(promise).rejects.toMatchObject({
       status: 409,
       message: "Resource changed. Please retry.",
+      cause: { kind: CONCURRENCY_CONFLICT_KIND },
     });
     await expect(promise).rejects.toBeInstanceOf(HTTPException);
   });

--- a/apps/core/src/lib/db/transaction.ts
+++ b/apps/core/src/lib/db/transaction.ts
@@ -1,0 +1,27 @@
+import { Prisma } from "@sokosumi/database";
+
+import { conflict } from "@/helpers/error";
+import { isPrismaTransactionConflict } from "@/helpers/prisma";
+import prisma from "@/lib/db/prisma";
+
+/**
+ * Runs the callback in a Serializable transaction. Postgres aborts such
+ * transactions with a serialization failure (Prisma P2034) under concurrent
+ * writes; that is an expected, retryable outcome, so it surfaces as a 409
+ * conflict with the given message instead of an unhandled 500.
+ */
+export async function serializableTransaction<T>(
+  callback: (tx: Prisma.TransactionClient) => Promise<T>,
+  conflictMessage: string,
+): Promise<T> {
+  try {
+    return await prisma.$transaction(callback, {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    });
+  } catch (error) {
+    if (isPrismaTransactionConflict(error)) {
+      throw conflict(conflictMessage);
+    }
+    throw error;
+  }
+}

--- a/apps/core/src/lib/db/transaction.ts
+++ b/apps/core/src/lib/db/transaction.ts
@@ -5,6 +5,13 @@ import { isPrismaTransactionConflict } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
 
 /**
+ * Stable error kind for 409s caused by serialization failures. Unlike
+ * semantic conflicts (e.g. an idempotency key reused with different
+ * parameters), these are transient and safe to retry verbatim.
+ */
+export const CONCURRENCY_CONFLICT_KIND = "concurrency_conflict";
+
+/**
  * Runs the callback in a Serializable transaction. Postgres aborts such
  * transactions with a serialization failure (Prisma P2034) under concurrent
  * writes; that is an expected, retryable outcome, so it surfaces as a 409
@@ -20,7 +27,7 @@ export async function serializableTransaction<T>(
     });
   } catch (error) {
     if (isPrismaTransactionConflict(error)) {
-      throw conflict(conflictMessage);
+      throw conflict(conflictMessage, { kind: CONCURRENCY_CONFLICT_KIND });
     }
     throw error;
   }

--- a/apps/core/src/routes/v1/agents/[id]/jobs/post.ts
+++ b/apps/core/src/routes/v1/agents/[id]/jobs/post.ts
@@ -41,6 +41,7 @@ const route = withGlobalHeaderParameters(
       401: jsonErrorResponse("Unauthorized"),
       403: jsonErrorResponse("Forbidden"),
       404: jsonErrorResponse("Agent not found"),
+      409: jsonErrorResponse("Conflict"),
       422: jsonErrorResponse("Unprocessable Entity"),
       500: jsonErrorResponse("Internal Server Error"),
     },

--- a/apps/core/src/routes/v1/coworkers/me/usage/post.ts
+++ b/apps/core/src/routes/v1/coworkers/me/usage/post.ts
@@ -10,7 +10,7 @@ import { requireCoworkerCapability } from "@/helpers/access-control";
 import { badRequest, conflict } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { created, ok } from "@/helpers/response";
-import prisma from "@/lib/db/prisma";
+import { serializableTransaction } from "@/lib/db/transaction";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { requireCoworkerAuthContext } from "@/middleware/auth";
 import { coworkerUsageSchema } from "@/schemas/coworker-usage.schema";
@@ -93,115 +93,108 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       c.req.valid("json");
     const coworkerId = authContext.coworkerId;
 
-    const result = await prisma.$transaction(
-      async (tx) => {
-        const existing = await tx.coworkerUsage.findUnique({
-          where: {
-            coworkerId_idempotencyKey: {
-              coworkerId,
-              idempotencyKey,
-            },
-          },
-        });
-
-        if (existing) {
-          const requestedCents = convertCreditsToCents(credits);
-
-          if (existing.userId !== userId) {
-            throw conflict(
-              "Idempotency key already used with different user id",
-            );
-          }
-          if (existing.cents !== requestedCents) {
-            throw conflict(
-              "Idempotency key already used with different parameters",
-            );
-          }
-          if (existing.referenceId !== (referenceId ?? null)) {
-            throw conflict(
-              "Idempotency key already used with different reference id",
-            );
-          }
-          if (existing.organizationId !== organizationId) {
-            throw conflict(
-              "Idempotency key already used with different organization id",
-            );
-          }
-
-          return { usage: existing, created: false };
-        }
-
-        if (organizationId !== null) {
-          const member = await tx.member.findUnique({
-            where: {
-              userId_organizationId: {
-                userId,
-                organizationId,
-              },
-            },
-            select: { userId: true },
-          });
-
-          if (!member) {
-            throw badRequest(
-              "User is not a member of the specified organization",
-            );
-          }
-        }
-
-        const cents = convertCreditsToCents(credits);
-        const consumptions = await prepareConsumptions(
-          userId,
-          organizationId,
-          cents,
-          tx,
-        );
-
-        const transaction = await tx.transaction.create({
-          data: {
-            amount: cents * BigInt(-1),
-            user: { connect: { id: userId } },
-            ...(organizationId
-              ? {
-                  organization: { connect: { id: organizationId } },
-                }
-              : {}),
-            creditConsumptions: {
-              createMany: {
-                data: consumptions.map((consumption) => ({
-                  bucketId: consumption.bucketId,
-                  amount: consumption.amount,
-                })),
-              },
-            },
-          },
-          select: {
-            id: true,
-          },
-        });
-
-        const usage = await tx.coworkerUsage.create({
-          data: {
+    const result = await serializableTransaction(async (tx) => {
+      const existing = await tx.coworkerUsage.findUnique({
+        where: {
+          coworkerId_idempotencyKey: {
+            coworkerId,
             idempotencyKey,
-            referenceId: referenceId ?? null,
-            cents,
-            coworker: { connect: { id: coworkerId } },
-            user: { connect: { id: userId } },
-            ...(organizationId
-              ? {
-                  organization: { connect: { id: organizationId } },
-                }
-              : {}),
-            transaction: { connect: { id: transaction.id } },
           },
+        },
+      });
+
+      if (existing) {
+        const requestedCents = convertCreditsToCents(credits);
+
+        if (existing.userId !== userId) {
+          throw conflict("Idempotency key already used with different user id");
+        }
+        if (existing.cents !== requestedCents) {
+          throw conflict(
+            "Idempotency key already used with different parameters",
+          );
+        }
+        if (existing.referenceId !== (referenceId ?? null)) {
+          throw conflict(
+            "Idempotency key already used with different reference id",
+          );
+        }
+        if (existing.organizationId !== organizationId) {
+          throw conflict(
+            "Idempotency key already used with different organization id",
+          );
+        }
+
+        return { usage: existing, created: false };
+      }
+
+      if (organizationId !== null) {
+        const member = await tx.member.findUnique({
+          where: {
+            userId_organizationId: {
+              userId,
+              organizationId,
+            },
+          },
+          select: { userId: true },
         });
 
-        return { usage, created: true };
-      },
-      {
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      },
-    );
+        if (!member) {
+          throw badRequest(
+            "User is not a member of the specified organization",
+          );
+        }
+      }
+
+      const cents = convertCreditsToCents(credits);
+      const consumptions = await prepareConsumptions(
+        userId,
+        organizationId,
+        cents,
+        tx,
+      );
+
+      const transaction = await tx.transaction.create({
+        data: {
+          amount: cents * BigInt(-1),
+          user: { connect: { id: userId } },
+          ...(organizationId
+            ? {
+                organization: { connect: { id: organizationId } },
+              }
+            : {}),
+          creditConsumptions: {
+            createMany: {
+              data: consumptions.map((consumption) => ({
+                bucketId: consumption.bucketId,
+                amount: consumption.amount,
+              })),
+            },
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      const usage = await tx.coworkerUsage.create({
+        data: {
+          idempotencyKey,
+          referenceId: referenceId ?? null,
+          cents,
+          coworker: { connect: { id: coworkerId } },
+          user: { connect: { id: userId } },
+          ...(organizationId
+            ? {
+                organization: { connect: { id: organizationId } },
+              }
+            : {}),
+          transaction: { connect: { id: transaction.id } },
+        },
+      });
+
+      return { usage, created: true };
+    }, "Usage recording conflicted with a concurrent request. Please retry.");
 
     const response = serializeUsage(result.usage);
 

--- a/apps/core/src/routes/v1/jobs/[id]/workspace/put.ts
+++ b/apps/core/src/routes/v1/jobs/[id]/workspace/put.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { jobInclude, Prisma } from "@sokosumi/database";
+import { jobInclude } from "@sokosumi/database";
 import { mapJobWithStatus } from "@sokosumi/database/helpers";
 import { workspaceRepository } from "@sokosumi/database/repositories";
 
@@ -8,7 +8,7 @@ import { conflict, forbidden, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
-import prisma from "@/lib/db/prisma";
+import { serializableTransaction } from "@/lib/db/transaction";
 import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
@@ -61,90 +61,85 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id } = c.req.valid("param");
     const { organizationId: targetOrganizationId } = c.req.valid("json");
 
-    const job = await prisma.$transaction(
-      async (tx) => {
-        // A delegated coworker may only move a job whose task is assigned to it.
-        await requireJobCollaboration(c.var.authContext, id, tx);
+    const job = await serializableTransaction(async (tx) => {
+      // A delegated coworker may only move a job whose task is assigned to it.
+      await requireJobCollaboration(c.var.authContext, id, tx);
 
-        const currentJob = await tx.job.findFirst({
-          where: {
-            id,
-            userId: userContext.userId,
-          },
-          select: {
-            taskId: true,
-            workspace: {
-              select: {
-                organizationId: true,
-              },
+      const currentJob = await tx.job.findFirst({
+        where: {
+          id,
+          userId: userContext.userId,
+        },
+        select: {
+          taskId: true,
+          workspace: {
+            select: {
+              organizationId: true,
             },
           },
-        });
+        },
+      });
 
-        if (!currentJob) {
-          throw forbidden("You can only access your own jobs");
-        }
+      if (!currentJob) {
+        throw forbidden("You can only access your own jobs");
+      }
 
-        if (currentJob.taskId !== null) {
-          throw conflict("Task-attached jobs inherit their task workspace");
-        }
+      if (currentJob.taskId !== null) {
+        throw conflict("Task-attached jobs inherit their task workspace");
+      }
 
-        const workspaceChanged =
-          targetOrganizationId !== currentJob.workspace.organizationId;
+      const workspaceChanged =
+        targetOrganizationId !== currentJob.workspace.organizationId;
 
-        if (!workspaceChanged) {
-          const existingJob = await tx.job.findUnique({
-            where: { id },
-            include: jobInclude,
-          });
-
-          if (!existingJob) {
-            throw notFound("Job not found");
-          }
-
-          return serializeJobDetails(mapJobWithStatus(existingJob));
-        }
-
-        // `null` targets the authenticated user's personal workspace.
-        if (targetOrganizationId !== null) {
-          await resolveMemberOrganizationById({
-            id: targetOrganizationId,
-            userId: userContext.userId,
-            tx,
-          });
-        }
-
-        const workspace = await workspaceRepository.upsertWorkspaceForContext(
-          userContext.userId,
-          targetOrganizationId ?? null,
-          tx,
-        );
-
-        await tx.job.update({
-          where: {
-            id,
-          },
-          data: {
-            workspaceId: workspace.id,
-            projectId: null,
-          },
-        });
-
-        const updatedJob = await tx.job.findUnique({
+      if (!workspaceChanged) {
+        const existingJob = await tx.job.findUnique({
           where: { id },
           include: jobInclude,
         });
 
-        if (!updatedJob) {
+        if (!existingJob) {
           throw notFound("Job not found");
         }
 
-        return serializeJobDetails(mapJobWithStatus(updatedJob));
-      },
-      {
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      },
-    );
+        return serializeJobDetails(mapJobWithStatus(existingJob));
+      }
+
+      // `null` targets the authenticated user's personal workspace.
+      if (targetOrganizationId !== null) {
+        await resolveMemberOrganizationById({
+          id: targetOrganizationId,
+          userId: userContext.userId,
+          tx,
+        });
+      }
+
+      const workspace = await workspaceRepository.upsertWorkspaceForContext(
+        userContext.userId,
+        targetOrganizationId ?? null,
+        tx,
+      );
+
+      await tx.job.update({
+        where: {
+          id,
+        },
+        data: {
+          workspaceId: workspace.id,
+          projectId: null,
+        },
+      });
+
+      const updatedJob = await tx.job.findUnique({
+        where: { id },
+        include: jobInclude,
+      });
+
+      if (!updatedJob) {
+        throw notFound("Job not found");
+      }
+
+      return serializeJobDetails(mapJobWithStatus(updatedJob));
+    }, "Job changed by a concurrent request. Please retry.");
 
     return ok(c, jobSchema.parse(job));
   });

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -14,7 +14,6 @@ import {
 } from "@/helpers/agent";
 import { conflict, unprocessableEntity } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
-import { isPrismaTransactionConflict } from "@/helpers/prisma";
 import { created } from "@/helpers/response";
 import {
   isTaskStatusSpendable,
@@ -25,7 +24,7 @@ import {
 } from "@/helpers/task";
 import { createTaskEventTransaction } from "@/helpers/task-credits";
 import { publishTaskEventData } from "@/lib/ably/publish";
-import prisma from "@/lib/db/prisma";
+import { serializableTransaction } from "@/lib/db/transaction";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import {
   type AuthenticationContext,
@@ -120,168 +119,143 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id: taskId } = c.req.valid("param");
     const body = c.req.valid("json");
 
-    const { event, userId, masumiPayment } = await (async () => {
-      try {
-        return await prisma.$transaction(
-          async (tx) => {
-            const task = await requireTaskCollaboration(
-              authContext,
-              taskId,
-              tx,
+    const { event, userId, masumiPayment } = await serializableTransaction(
+      async (tx) => {
+        const task = await requireTaskCollaboration(authContext, taskId, tx);
+        const {
+          status,
+          comment,
+          credits,
+          authenticationUrl,
+          origin,
+          masumiPayment,
+        } = body;
+
+        if (status !== undefined) {
+          validateStatusTransition(authContext, task.status, status);
+          validateTaskCoworkerAssignment({
+            status,
+            coworkerId: task.coworkerId,
+          });
+
+          // Only the assigned coworker agent settles billing.
+          const isAgent = isCoworkerAgentContext(authContext);
+          const isAgentSpend = isAgent && isTaskStatusSpendable(status);
+
+          // User and delegated-coworker callers use the user transition table,
+          // and the charge branch below is gated on isAgent — so credits from
+          // them would be silently dropped. Reject it.
+          //
+          // masumiPayment needs no check here: the schema only allows it with
+          // status COMPLETED, which the user transition table can never reach,
+          // so a non-agent caller is already rejected upstream (400/422).
+          if (!isAgent && credits != null) {
+            throw unprocessableEntity(
+              "Only the assigned coworker can set credits when changing task status",
             );
-            const {
-              status,
-              comment,
-              credits,
-              authenticationUrl,
-              origin,
-              masumiPayment,
-            } = body;
+          }
 
-            if (status !== undefined) {
-              validateStatusTransition(authContext, task.status, status);
-              validateTaskCoworkerAssignment({
-                status,
-                coworkerId: task.coworkerId,
+          let cents: bigint | undefined;
+          let transactionId: string | null = null;
+
+          if (isAgentSpend) {
+            if (masumiPayment) {
+              console.info("[tasks] masumi task payment: using masumiPayment", {
+                masumiPayment,
               });
-
-              // Only the assigned coworker agent settles billing.
-              const isAgent = isCoworkerAgentContext(authContext);
-              const isAgentSpend = isAgent && isTaskStatusSpendable(status);
-
-              // User and delegated-coworker callers use the user transition table,
-              // and the charge branch below is gated on isAgent — so credits from
-              // them would be silently dropped. Reject it.
-              //
-              // masumiPayment needs no check here: the schema only allows it with
-              // status COMPLETED, which the user transition table can never reach,
-              // so a non-agent caller is already rejected upstream (400/422).
-              if (!isAgent && credits != null) {
+              const creditCosts = await getCreditCostsOrThrow(tx);
+              cents = calculateCentsFromMasumiAmountStrings(
+                masumiPayment.Amounts,
+                creditCosts,
+              );
+              if (cents === 0n) {
                 throw unprocessableEntity(
-                  "Only the assigned coworker can set credits when changing task status",
+                  `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
                 );
               }
-
-              let cents: bigint | undefined;
-              let transactionId: string | null = null;
-
-              if (isAgentSpend) {
-                if (masumiPayment) {
-                  console.info(
-                    "[tasks] masumi task payment: using masumiPayment",
-                    {
-                      masumiPayment,
-                    },
-                  );
-                  const creditCosts = await getCreditCostsOrThrow(tx);
-                  cents = calculateCentsFromMasumiAmountStrings(
-                    masumiPayment.Amounts,
-                    creditCosts,
-                  );
-                  if (cents === 0n) {
-                    throw unprocessableEntity(
-                      `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
-                    );
-                  }
-                  const creditsValue = convertCentsToCredits(cents);
-                  if (creditsValue < LIMITS.MIN_CHARGEABLE_CREDITS) {
-                    throw unprocessableEntity(
-                      `Credit amount is below the minimum chargeable value (${LIMITS.MIN_CHARGEABLE_CREDITS})`,
-                    );
-                  }
-                  transactionId = await createTaskEventTransaction({
-                    userId: task.userId,
-                    organizationId: task.organizationId,
-                    cents,
-                    tx,
-                  });
-                } else if (credits != null && credits > 0) {
-                  cents = convertCreditsToCents(credits);
-                  if (cents === 0n) {
-                    throw unprocessableEntity(
-                      `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
-                    );
-                  }
-                  transactionId = await createTaskEventTransaction({
-                    userId: task.userId,
-                    organizationId: task.organizationId,
-                    cents,
-                    tx,
-                  });
-                }
+              const creditsValue = convertCentsToCredits(cents);
+              if (creditsValue < LIMITS.MIN_CHARGEABLE_CREDITS) {
+                throw unprocessableEntity(
+                  `Credit amount is below the minimum chargeable value (${LIMITS.MIN_CHARGEABLE_CREDITS})`,
+                );
               }
-
-              const createdEvent = await tx.taskEvent.create({
-                data: {
-                  taskId,
-                  status,
-                  comment,
-                  authenticationUrl,
-                  origin,
-                  cents,
-                  transactionId,
-                  ...getActorData(authContext),
-                },
-              });
-
-              const updateResult = await tx.task.updateMany({
-                where: { id: taskId, status: task.status },
-                data: { status },
-              });
-              if (updateResult.count !== 1) {
-                throw conflict("Task status was changed by another request");
-              }
-
-              const payment =
-                masumiPayment !== undefined && isAgentSpend
-                  ? masumiPayment
-                  : null;
-
-              return {
-                event: await mapCreatedTaskEventForResponse(
-                  tx,
-                  createdEvent.id,
-                ),
+              transactionId = await createTaskEventTransaction({
                 userId: task.userId,
-                masumiPayment: payment,
-              };
+                organizationId: task.organizationId,
+                cents,
+                tx,
+              });
+            } else if (credits != null && credits > 0) {
+              cents = convertCreditsToCents(credits);
+              if (cents === 0n) {
+                throw unprocessableEntity(
+                  `Credit amount rounds to zero; minimum chargeable amount is ${LIMITS.MIN_CHARGEABLE_CREDITS} credits`,
+                );
+              }
+              transactionId = await createTaskEventTransaction({
+                userId: task.userId,
+                organizationId: task.organizationId,
+                cents,
+                tx,
+              });
             }
+          }
 
-            if (comment === undefined) {
-              throw unprocessableEntity(
-                "Either status or comment must be provided",
-              );
-            }
+          const createdEvent = await tx.taskEvent.create({
+            data: {
+              taskId,
+              status,
+              comment,
+              authenticationUrl,
+              origin,
+              cents,
+              transactionId,
+              ...getActorData(authContext),
+            },
+          });
 
-            const createdEvent = await tx.taskEvent.create({
-              data: {
-                taskId,
-                status: null,
-                comment,
-                origin,
-                ...getActorData(authContext),
-              },
-            });
+          const updateResult = await tx.task.updateMany({
+            where: { id: taskId, status: task.status },
+            data: { status },
+          });
+          if (updateResult.count !== 1) {
+            throw conflict("Task status was changed by another request");
+          }
 
-            return {
-              event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
-              userId: task.userId,
-              masumiPayment: null,
-            };
-          },
-          {
-            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-          },
-        );
-      } catch (error) {
-        // Serializable transactions abort with P2034 under concurrent writes;
-        // surface that as a retryable conflict instead of a 500.
-        if (isPrismaTransactionConflict(error)) {
-          throw conflict("Task changed by a concurrent request. Please retry.");
+          const payment =
+            masumiPayment !== undefined && isAgentSpend ? masumiPayment : null;
+
+          return {
+            event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
+            userId: task.userId,
+            masumiPayment: payment,
+          };
         }
-        throw error;
-      }
-    })();
+
+        if (comment === undefined) {
+          throw unprocessableEntity(
+            "Either status or comment must be provided",
+          );
+        }
+
+        const createdEvent = await tx.taskEvent.create({
+          data: {
+            taskId,
+            status: null,
+            comment,
+            origin,
+            ...getActorData(authContext),
+          },
+        });
+
+        return {
+          event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
+          userId: task.userId,
+          masumiPayment: null,
+        };
+      },
+      "Task changed by a concurrent request. Please retry.",
+    );
 
     if (masumiPayment != null) {
       const taskEventId = event.id;

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/post.ts
@@ -38,6 +38,7 @@ const route = createRoute({
     401: jsonErrorResponse("Unauthorized"),
     403: jsonErrorResponse("Forbidden"),
     404: jsonErrorResponse("Not Found"),
+    409: jsonErrorResponse("Conflict"),
     422: jsonErrorResponse("Unprocessable Entity"),
     500: jsonErrorResponse("Internal Server Error"),
   },

--- a/apps/core/src/routes/v1/tasks/[id]/links/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/links/post.ts
@@ -1,20 +1,16 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { Prisma } from "@sokosumi/database";
 
 import { requireTaskOwnership } from "@/helpers/access-control";
 import { conflict, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
-import {
-  isPrismaTransactionConflict,
-  isPrismaUniqueViolation,
-} from "@/helpers/prisma";
+import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import { created } from "@/helpers/response";
 import {
   assertTaskLinkAllowed,
   mapTaskLink,
   mapTaskLinkRelationToWriteData,
 } from "@/helpers/task-link";
-import prisma from "@/lib/db/prisma";
+import { serializableTransaction } from "@/lib/db/transaction";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { requireUserContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
@@ -64,61 +60,43 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const body = c.req.valid("json");
     const { toTaskId: peerTaskId, relation, note } = body;
 
-    const { link, peerTask } = await (async () => {
+    const { link, peerTask } = await serializableTransaction(async (tx) => {
+      await requireTaskOwnership(userContext, id, tx);
+      assertTaskLinkAllowed(id, peerTaskId);
+      const linkData = mapTaskLinkRelationToWriteData(id, peerTaskId, relation);
+
+      const peerTask = await tx.task.findFirst({
+        where: {
+          id: peerTaskId,
+          userId: userContext.userId,
+          workspaceId: workspaceContext.workspaceId,
+        },
+        select: taskLinkPeerTaskSelect,
+      });
+
+      if (!peerTask) {
+        throw notFound("Task not found");
+      }
+
       try {
-        return await prisma.$transaction(
-          async (tx) => {
-            await requireTaskOwnership(userContext, id, tx);
-            assertTaskLinkAllowed(id, peerTaskId);
-            const linkData = mapTaskLinkRelationToWriteData(
-              id,
-              peerTaskId,
-              relation,
-            );
-
-            const peerTask = await tx.task.findFirst({
-              where: {
-                id: peerTaskId,
-                userId: userContext.userId,
-                workspaceId: workspaceContext.workspaceId,
-              },
-              select: taskLinkPeerTaskSelect,
-            });
-
-            if (!peerTask) {
-              throw notFound("Task not found");
-            }
-
-            try {
-              const link = await tx.taskLink.create({
-                data: {
-                  ...linkData,
-                  note: note ?? null,
-                },
-              });
-
-              return {
-                link,
-                peerTask,
-              };
-            } catch (error) {
-              if (isPrismaUniqueViolation(error)) {
-                throw conflict("This task link already exists");
-              }
-              throw error;
-            }
+        const link = await tx.taskLink.create({
+          data: {
+            ...linkData,
+            note: note ?? null,
           },
-          {
-            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-          },
-        );
+        });
+
+        return {
+          link,
+          peerTask,
+        };
       } catch (error) {
-        if (isPrismaTransactionConflict(error)) {
-          throw conflict("Task changed while creating the link. Please retry.");
+        if (isPrismaUniqueViolation(error)) {
+          throw conflict("This task link already exists");
         }
         throw error;
       }
-    })();
+    }, "Task changed while creating the link. Please retry.");
 
     return created(c, mapTaskLink(id, link, peerTask));
   });

--- a/apps/core/src/routes/v1/tasks/[id]/workspace/put.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/workspace/put.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { Prisma } from "@sokosumi/database";
 import { workspaceRepository } from "@sokosumi/database/repositories";
 
 import { conflict, notFound } from "@/helpers/error";
@@ -7,7 +6,7 @@ import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import { mapTask } from "@/helpers/task";
-import prisma from "@/lib/db/prisma";
+import { serializableTransaction } from "@/lib/db/transaction";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { requireUserContext } from "@/middleware/auth";
 import { taskSchema } from "@/schemas/task.schema";
@@ -56,95 +55,90 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id } = c.req.valid("param");
     const { organizationId: targetOrganizationId } = c.req.valid("json");
 
-    const task = await prisma.$transaction(
-      async (tx) => {
-        const task = await tx.task.findFirst({
-          where: {
-            id,
-            userId: userContext.userId,
-            archivedAt: null,
-          },
-          select: {
-            workspaceId: true,
-            workspace: {
-              select: {
-                organizationId: true,
-              },
+    const task = await serializableTransaction(async (tx) => {
+      const task = await tx.task.findFirst({
+        where: {
+          id,
+          userId: userContext.userId,
+          archivedAt: null,
+        },
+        select: {
+          workspaceId: true,
+          workspace: {
+            select: {
+              organizationId: true,
             },
           },
-        });
+        },
+      });
 
-        if (!task) {
-          throw notFound("Task not found");
-        }
+      if (!task) {
+        throw notFound("Task not found");
+      }
 
-        const workspaceChanged =
-          targetOrganizationId !== task.workspace.organizationId;
+      const workspaceChanged =
+        targetOrganizationId !== task.workspace.organizationId;
 
-        if (!workspaceChanged) {
-          return await tx.task.findUniqueOrThrow({
-            where: { id },
-            include: buildTaskIncludeForViewer(authContext, task.workspaceId),
-          });
-        }
-
-        // `null` targets the authenticated user's personal workspace.
-        if (targetOrganizationId !== null) {
-          await resolveMemberOrganizationById({
-            id: targetOrganizationId,
-            userId: userContext.userId,
-            tx,
-          });
-        }
-
-        const workspace = await workspaceRepository.upsertWorkspaceForContext(
-          userContext.userId,
-          targetOrganizationId ?? null,
-          tx,
-        );
-
-        const existingLink = await tx.taskLink.findFirst({
-          where: {
-            OR: [{ fromTaskId: id }, { toTaskId: id }],
-          },
-          select: {
-            id: true,
-          },
-        });
-
-        if (existingLink) {
-          throw conflict(
-            "Cannot move a task with related tasks. Remove its links first.",
-          );
-        }
-
-        await tx.task.update({
-          where: {
-            id,
-          },
-          data: {
-            workspaceId: workspace.id,
-            projectId: null,
-          },
-        });
-
-        await tx.job.updateMany({
-          where: { taskId: id },
-          data: {
-            workspaceId: workspace.id,
-            projectId: null,
-          },
-        });
-
+      if (!workspaceChanged) {
         return await tx.task.findUniqueOrThrow({
           where: { id },
-          include: buildTaskIncludeForViewer(authContext, workspace.id),
+          include: buildTaskIncludeForViewer(authContext, task.workspaceId),
         });
-      },
-      {
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      },
-    );
+      }
+
+      // `null` targets the authenticated user's personal workspace.
+      if (targetOrganizationId !== null) {
+        await resolveMemberOrganizationById({
+          id: targetOrganizationId,
+          userId: userContext.userId,
+          tx,
+        });
+      }
+
+      const workspace = await workspaceRepository.upsertWorkspaceForContext(
+        userContext.userId,
+        targetOrganizationId ?? null,
+        tx,
+      );
+
+      const existingLink = await tx.taskLink.findFirst({
+        where: {
+          OR: [{ fromTaskId: id }, { toTaskId: id }],
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      if (existingLink) {
+        throw conflict(
+          "Cannot move a task with related tasks. Remove its links first.",
+        );
+      }
+
+      await tx.task.update({
+        where: {
+          id,
+        },
+        data: {
+          workspaceId: workspace.id,
+          projectId: null,
+        },
+      });
+
+      await tx.job.updateMany({
+        where: { taskId: id },
+        data: {
+          workspaceId: workspace.id,
+          projectId: null,
+        },
+      });
+
+      return await tx.task.findUniqueOrThrow({
+        where: { id },
+        include: buildTaskIncludeForViewer(authContext, workspace.id),
+      });
+    }, "Task changed by a concurrent request. Please retry.");
 
     return ok(c, taskSchema.parse(mapTask(task)));
   });

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -4895,6 +4895,20 @@ export type PostAgentsByIdJobsErrors = {
         };
     };
     /**
+     * Conflict
+     */
+    409: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
      * Unprocessable Entity
      */
     422: {
@@ -19322,6 +19336,20 @@ export type PostTasksByIdJobsErrors = {
      * Not Found
      */
     404: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
+     * Conflict
+     */
+    409: {
         error: string;
         message: string;
         kind?: string;


### PR DESCRIPTION
## Summary

Fast-follow to #3122. That PR mapped Prisma `P2034` (Postgres serialization failure) to a retryable 409 on `POST /v1/tasks/:id/events` — but the handling was copy-pasted from the task-links route, and four more `Serializable`-transaction sites still surface write conflicts as fatal 500s + Sentry events (the same bug class as SOKOSUMI-CORE-13).

This PR moves the mechanism to a single place and covers every call site.

### Changes

- **New `serializableTransaction()` helper** (`apps/core/src/lib/db/transaction.ts`): runs the callback via `prisma.$transaction` at `Serializable` isolation and maps `P2034` to a 409 conflict with a route-specific message. Unit-tested (success, P2034→409, non-conflict rethrow).
- **Migrated all six call sites** (grep for `isolationLevel` — none remain outside the helper):
  - `tasks/:id/events` + `tasks/:id/links` — replace the two copy-pasted try/catch blocks; behavior unchanged (existing 409 tests still pass).
  - `tasks/:id/workspace` (PUT) + `jobs/:id/workspace` (PUT) — previously fatal 500 on conflict; both already declared 409 in their OpenAPI responses.
  - `coworkers/me/usage` (POST) — previously fatal 500; already declared 409.
  - `helpers/job.ts` `createAgentJobForUser` (job creation with credit consumption) — previously fatal 500; added `409: Conflict` to the two routes that surface it (`agents/:id/jobs`, `tasks/:id/jobs`).
- **Regenerated the web Core API client snapshot** (`pnpm --filter web generate:core:snapshot`) for the new 409 response declarations — generated files committed as-is.

### Verification

- `pnpm core:test` — 183 files, 1306 tests passed
- `pnpm web:test` — 232 files, 1419 tests passed (regenerated client)
- `pnpm check` (Biome) and `tsc --noEmit` for core and web — clean

https://claude.ai/code/session_01U6HxkKVAspc16t3N4jaqpX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6HxkKVAspc16t3N4jaqpX)_