### PR TITLE
feat(core): add stripe webhook receiver and port customer.updated handler

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -44,6 +44,9 @@ STRIPE_SECRET_KEY="<stripe-secret-key>"
 STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID="<stripe-starter-subscription-product-id>"
 STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID="<stripe-standard-subscription-product-id>"
 STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID="<stripe-pro-subscription-product-id>"
+
+# Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
+STRIPE_WEBHOOK_SECRET="<stripe-webhook-secret>"
 LOCK_TIMEOUT="120000"
 LOCK_TIMEOUT_BUFFER="25000"
 INSTANCE_ID="<instance-id>"

--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -124,4 +124,20 @@ export const stripeClient = {
       requestOptions,
     );
   },
+
+  /**
+   * Verify a Stripe webhook payload against the core endpoint's signing
+   * secret and parse it into a typed event. Throws when the signature is
+   * invalid or the payload is malformed.
+   */
+  async constructWebhookEvent(
+    payload: string,
+    signature: string,
+  ): Promise<Stripe.Event> {
+    return await stripe.webhooks.constructEventAsync(
+      payload,
+      signature,
+      getEnv().STRIPE_WEBHOOK_SECRET,
+    );
+  },
 };

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -94,6 +94,9 @@ const envSchema = z.object({
   STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: z.string().min(1),
   STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: z.string().min(1),
 
+  // Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
+  STRIPE_WEBHOOK_SECRET: z.string().min(1),
+
   // Sync lock configuration
   LOCK_TIMEOUT: z.coerce
     .number()

--- a/apps/core/src/index.test.ts
+++ b/apps/core/src/index.test.ts
@@ -69,6 +69,10 @@ vi.mock("@/routes/sync/index", () => {
   return { default: new Hono() };
 });
 
+vi.mock("@/routes/webhooks/index", () => {
+  return { default: new Hono() };
+});
+
 vi.mock("@/routes/v1/index", () => {
   const app = new Hono();
   app.get("/openapi.json", (c) => {

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -19,6 +19,7 @@ import authRouter from "@/routes/auth/index";
 import debugRouter from "@/routes/debug/index";
 import syncRouter from "@/routes/sync/index";
 import apiV1 from "@/routes/v1/index";
+import webhooksRouter from "@/routes/webhooks/index";
 import { hermesInboxSyncService } from "@/services/hermes-inbox-sync.service";
 
 validateEnv();
@@ -49,6 +50,7 @@ app.route("/auth", authRouter);
 app.route("/v1", apiV1);
 app.route("/debug", debugRouter);
 app.route("/sync", syncRouter);
+app.route("/webhooks", webhooksRouter);
 
 app.get(
   "/",

--- a/apps/core/src/routes/webhooks/index.test.ts
+++ b/apps/core/src/routes/webhooks/index.test.ts
@@ -1,0 +1,127 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { constructWebhookEventMock, handleEventMock } = vi.hoisted(() => ({
+  constructWebhookEventMock: vi.fn(),
+  handleEventMock: vi.fn(),
+}));
+
+vi.mock("@/clients/stripe.client", () => ({
+  stripeClient: {
+    constructWebhookEvent: constructWebhookEventMock,
+  },
+}));
+
+vi.mock("@/services/stripe-webhook.service", () => ({
+  stripeWebhookService: {
+    handleEvent: handleEventMock,
+  },
+}));
+
+async function createApp() {
+  const { default: webhooksRouter } = await import("./index");
+  const app = new Hono();
+  app.route("/webhooks", webhooksRouter);
+  return app;
+}
+
+function postStripeWebhook(
+  app: Hono,
+  options: { body?: string; signature?: string } = {},
+) {
+  const { body = "{}", signature } = options;
+  return app.request("http://localhost/webhooks/stripe", {
+    method: "POST",
+    body,
+    headers: signature ? { "stripe-signature": signature } : {},
+  });
+}
+
+describe("POST /webhooks/stripe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    constructWebhookEventMock.mockResolvedValue({
+      id: "evt_123",
+      type: "customer.updated",
+      data: { object: { id: "cus_123" } },
+    });
+    handleEventMock.mockResolvedValue(undefined);
+  });
+
+  it("returns 400 when the stripe-signature header is missing", async () => {
+    const app = await createApp();
+
+    const response = await postStripeWebhook(app);
+
+    expect(response.status).toBe(400);
+    expect(constructWebhookEventMock).not.toHaveBeenCalled();
+    expect(handleEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when signature verification fails", async () => {
+    constructWebhookEventMock.mockRejectedValue(
+      new Error("No signatures found matching the expected signature"),
+    );
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    try {
+      const app = await createApp();
+
+      const response = await postStripeWebhook(app, {
+        signature: "t=1,v1=bad",
+      });
+
+      expect(response.status).toBe(400);
+      expect(handleEventMock).not.toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("verifies the raw body against the signature header", async () => {
+    const app = await createApp();
+    const body = JSON.stringify({ id: "evt_123" });
+
+    const response = await postStripeWebhook(app, {
+      body,
+      signature: "t=1,v1=abc",
+    });
+
+    expect(response.status).toBe(200);
+    expect(constructWebhookEventMock).toHaveBeenCalledWith(body, "t=1,v1=abc");
+  });
+
+  it("dispatches the verified event and returns 200", async () => {
+    const app = await createApp();
+
+    const response = await postStripeWebhook(app, { signature: "t=1,v1=abc" });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ received: true });
+    expect(handleEventMock).toHaveBeenCalledTimes(1);
+    expect(handleEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "evt_123", type: "customer.updated" }),
+    );
+  });
+
+  it("returns 500 when the handler fails so Stripe retries", async () => {
+    handleEventMock.mockRejectedValue(new Error("db down"));
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      const app = await createApp();
+
+      const response = await postStripeWebhook(app, {
+        signature: "t=1,v1=abc",
+      });
+
+      expect(response.status).toBe(500);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/apps/core/src/routes/webhooks/index.ts
+++ b/apps/core/src/routes/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import mountPostStripeWebhook from "./stripe/post.js";
+
+const app = new Hono();
+
+mountPostStripeWebhook(app);
+
+export default app;

--- a/apps/core/src/routes/webhooks/stripe/post.ts
+++ b/apps/core/src/routes/webhooks/stripe/post.ts
@@ -1,0 +1,42 @@
+import type { Hono } from "hono";
+import type Stripe from "stripe";
+
+import { stripeClient } from "@/clients/stripe.client";
+import { stripeWebhookService } from "@/services/stripe-webhook.service";
+
+export default function mount(app: Hono) {
+  app.post("/stripe", async (c) => {
+    const signature = c.req.header("stripe-signature");
+    if (!signature) {
+      return c.json({ message: "Missing stripe-signature header" }, 400);
+    }
+
+    // Signature verification needs the exact raw body, so this route stays
+    // outside the OpenAPI app and must not parse the payload before here.
+    const payload = await c.req.text();
+
+    let event: Stripe.Event;
+    try {
+      event = await stripeClient.constructWebhookEvent(payload, signature);
+    } catch (error) {
+      console.warn(
+        "[webhooks/stripe] Signature verification failed:",
+        error instanceof Error ? error.message : error,
+      );
+      return c.json({ message: "Invalid signature" }, 400);
+    }
+
+    try {
+      await stripeWebhookService.handleEvent(event);
+    } catch (error) {
+      console.error(
+        `[webhooks/stripe] Handler failed for ${event.type} (${event.id}):`,
+        error,
+      );
+      // 5xx so Stripe retries the event.
+      return c.json({ message: "Webhook handler failed" }, 500);
+    }
+
+    return c.json({ received: true }, 200);
+  });
+}

--- a/apps/core/src/services/stripe-webhook.service.test.ts
+++ b/apps/core/src/services/stripe-webhook.service.test.ts
@@ -1,0 +1,204 @@
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  captureExceptionMock,
+  getOrganizationWithRelationsByIdMock,
+  updateOrganizationInvoiceEmailMock,
+} = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+  getOrganizationWithRelationsByIdMock: vi.fn(),
+  updateOrganizationInvoiceEmailMock: vi.fn(),
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: captureExceptionMock,
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  organizationRepository: {
+    getOrganizationWithRelationsById: getOrganizationWithRelationsByIdMock,
+    updateOrganizationInvoiceEmail: updateOrganizationInvoiceEmailMock,
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {},
+}));
+
+async function getStripeWebhookService() {
+  const module = await import("./stripe-webhook.service");
+  return module.stripeWebhookService;
+}
+
+function createCustomerUpdatedEvent(
+  customer: Partial<Stripe.Customer>,
+): Stripe.Event {
+  return {
+    id: "evt_123",
+    type: "customer.updated",
+    data: {
+      object: {
+        id: "cus_123",
+        email: "new@example.com",
+        metadata: {},
+        ...customer,
+      },
+    },
+  } as Stripe.Event;
+}
+
+function createOrganizationCustomer(
+  overrides: Partial<Stripe.Customer> = {},
+): Partial<Stripe.Customer> {
+  return {
+    metadata: {
+      customerType: "organization",
+      organizationId: "org_123",
+    },
+    ...overrides,
+  };
+}
+
+describe("stripeWebhookService.handleEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getOrganizationWithRelationsByIdMock.mockResolvedValue({
+      id: "org_123",
+      metadata: JSON.stringify({ invoiceEmail: "old@example.com" }),
+    });
+    updateOrganizationInvoiceEmailMock.mockResolvedValue({
+      id: "org_123",
+      metadata: JSON.stringify({ invoiceEmail: "new@example.com" }),
+    });
+  });
+
+  it("updates the organization invoice email when the customer email changed", async () => {
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(
+      createCustomerUpdatedEvent(createOrganizationCustomer()),
+    );
+
+    expect(getOrganizationWithRelationsByIdMock).toHaveBeenCalledWith(
+      "org_123",
+      expect.anything(),
+    );
+    expect(updateOrganizationInvoiceEmailMock).toHaveBeenCalledWith(
+      "org_123",
+      "new@example.com",
+      expect.anything(),
+    );
+  });
+
+  it("clears the organization invoice email when the customer email is null", async () => {
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(
+      createCustomerUpdatedEvent(createOrganizationCustomer({ email: null })),
+    );
+
+    expect(updateOrganizationInvoiceEmailMock).toHaveBeenCalledWith(
+      "org_123",
+      null,
+      expect.anything(),
+    );
+  });
+
+  it("skips the write when the invoice email is unchanged", async () => {
+    getOrganizationWithRelationsByIdMock.mockResolvedValue({
+      id: "org_123",
+      metadata: JSON.stringify({ invoiceEmail: "new@example.com" }),
+    });
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(
+      createCustomerUpdatedEvent(createOrganizationCustomer()),
+    );
+
+    expect(updateOrganizationInvoiceEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the organization no longer exists", async () => {
+    getOrganizationWithRelationsByIdMock.mockResolvedValue(null);
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(
+      createCustomerUpdatedEvent(createOrganizationCustomer()),
+    );
+
+    expect(updateOrganizationInvoiceEmailMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-organization customers", async () => {
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(
+      createCustomerUpdatedEvent({
+        metadata: { customerType: "user", userId: "user_123" },
+      }),
+    );
+
+    expect(getOrganizationWithRelationsByIdMock).not.toHaveBeenCalled();
+    expect(updateOrganizationInvoiceEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores organization customers without an organizationId", async () => {
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(
+      createCustomerUpdatedEvent({
+        metadata: { customerType: "organization" },
+      }),
+    );
+
+    expect(getOrganizationWithRelationsByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("reports to Sentry and rethrows when the handler fails", async () => {
+    const failure = new Error("db down");
+    getOrganizationWithRelationsByIdMock.mockRejectedValue(failure);
+    const service = await getStripeWebhookService();
+
+    await expect(
+      service.handleEvent(
+        createCustomerUpdatedEvent(createOrganizationCustomer()),
+      ),
+    ).rejects.toThrow("db down");
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          stripeEventType: "customer.updated",
+          customerId: "cus_123",
+        }),
+        extra: expect.objectContaining({ eventId: "evt_123" }),
+      }),
+    );
+  });
+
+  it("ignores unhandled event types", async () => {
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+
+    try {
+      const service = await getStripeWebhookService();
+
+      await service.handleEvent({
+        id: "evt_456",
+        type: "invoice.paid",
+        data: { object: {} },
+      } as Stripe.Event);
+
+      expect(getOrganizationWithRelationsByIdMock).not.toHaveBeenCalled();
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
+        "[webhooks/stripe] Unhandled Stripe event type: invoice.paid",
+      );
+    } finally {
+      consoleInfoSpy.mockRestore();
+    }
+  });
+});

--- a/apps/core/src/services/stripe-webhook.service.ts
+++ b/apps/core/src/services/stripe-webhook.service.ts
@@ -1,0 +1,87 @@
+import * as Sentry from "@sentry/node";
+import { organizationRepository } from "@sokosumi/database/repositories";
+import { getOrganizationMetadata } from "@sokosumi/utils";
+import type Stripe from "stripe";
+
+import prisma from "@/lib/db/prisma";
+
+/**
+ * Sync an organization's stored invoice email when its Stripe customer
+ * changes. User customers are managed through the auth system and need no
+ * action here.
+ */
+async function handleCustomerUpdatedEvent(
+  customer: Stripe.Customer,
+): Promise<void> {
+  const metadata = customer.metadata;
+  if (metadata?.customerType !== "organization" || !metadata.organizationId) {
+    return;
+  }
+
+  const organizationId = metadata.organizationId;
+  const customerEmail =
+    typeof customer.email === "string" ? customer.email : null;
+
+  const organization =
+    await organizationRepository.getOrganizationWithRelationsById(
+      organizationId,
+      prisma,
+    );
+
+  if (!organization) {
+    console.log(
+      `[webhooks/stripe] Organization ${organizationId} not found for customer ${customer.id}`,
+    );
+    return;
+  }
+
+  const { invoiceEmail } = getOrganizationMetadata(organization.metadata);
+
+  if (invoiceEmail !== customerEmail) {
+    await organizationRepository.updateOrganizationInvoiceEmail(
+      organizationId,
+      customerEmail,
+      prisma,
+    );
+    console.log(
+      `[webhooks/stripe] Updated organization ${organizationId} invoice email from ${invoiceEmail} to ${customerEmail}`,
+    );
+  }
+}
+
+export const stripeWebhookService = {
+  /**
+   * Dispatch a verified Stripe event to its handler. Throws on handler
+   * failure so the route can respond 5xx and Stripe retries the event.
+   */
+  async handleEvent(event: Stripe.Event): Promise<void> {
+    switch (event.type) {
+      case "customer.updated": {
+        const customer = event.data.object;
+        try {
+          await handleCustomerUpdatedEvent(customer);
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: {
+              stripeEventType: event.type,
+              customerId: customer.id,
+            },
+            extra: {
+              eventId: event.id,
+              customer: customer.id,
+              email: customer.email,
+            },
+          });
+          throw error;
+        }
+        break;
+      }
+      default: {
+        console.info(
+          `[webhooks/stripe] Unhandled Stripe event type: ${event.type}`,
+        );
+        break;
+      }
+    }
+  },
+};

--- a/apps/core/src/test/setup.ts
+++ b/apps/core/src/test/setup.ts
@@ -20,6 +20,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID: "prod_starter_test",
   STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: "prod_standard_test",
   STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: "prod_pro_test",
+  STRIPE_WEBHOOK_SECRET: "whsec_test_example",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",
   INSTANCE_ID: "test-instance-id",


### PR DESCRIPTION
## Summary

Webhook-migration PR 2 of 5 (plan: move the Stripe webhook from web to core incrementally). Adds core's own webhook receiver and ports the lowest-risk handler, `customer.updated`.

- New plain Hono route `POST /webhooks/stripe`, mounted beside `/sync` **outside** the OpenAPI v1 app so signature verification reads the exact raw body (`await c.req.text()`).
- Signature verification via `stripe.webhooks.constructEventAsync` against a new **required** env var `STRIPE_WEBHOOK_SECRET` (core endpoint gets its own signing secret, distinct from web's).
- New `stripeWebhookService.handleEvent` dispatcher with Sentry tagging parity to web's `onEvent` (tags: `stripeEventType`, `customerId`; extra: `eventId`, `customer`, `email`); handler failure → **500 so Stripe retries** the event.
- Ported `handleCustomerUpdatedEvent` from `apps/web/src/lib/stripe/webhook-handlers.ts`: organization customers get their stored invoice email synced (read via `getOrganizationWithRelationsById`, compare via `getOrganizationMetadata`, write via `updateOrganizationInvoiceEmail` — same repo method as the `PATCH /v1/organizations/{id}/invoice-email` endpoint from #3106). No-op for user customers, unchanged emails, and unknown organizations — exact behavior parity with web.
- Maintenance mode: the existing `maintenanceMiddleware` 503s the route → Stripe auto-retries, which is the desired behavior.

**The web handler is intentionally untouched.** `customer.updated` is dedupe-safe (email comparison before write), so both endpoints may receive it during the cutover window. The web-side `customer.updated` case will be deleted in a follow-up PR once the Stripe dashboard partition is confirmed.

## User-facing impact

None yet — the new endpoint receives no traffic until a Stripe dashboard webhook endpoint is created for it.

## ⚠️ Merge prerequisites

1. Set `STRIPE_WEBHOOK_SECRET` on **sokosumi-core-mainnet** and **sokosumi-core-preprod** BEFORE merging — the core env schema makes it required, core will not boot without it.
2. Create a new Stripe dashboard webhook endpoint pointing at core's `POST /webhooks/stripe`, subscribed to `customer.updated` **only** (partition; do not remove `customer.updated` from the web endpoint until this PR is deployed). Its signing secret is the env var value.

## Verification

- `pnpm --filter @sokosumi/core typecheck` ✅
- `pnpm --filter @sokosumi/core test` — 185 files / 1319 tests ✅ (includes new route tests: missing/invalid signature → 400, raw-body verification, dispatch → 200, handler failure → 500; and service tests: update/clear/skip/org-missing/non-org/Sentry-rethrow/unhandled-type)
- `biome check` ✅
- Rebased onto `34b919ad9` (better-auth 1.6.17 upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)