### PR TITLE
feat(core): port the invoice.paid credit engine to the stripe webhook receiver

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -45,6 +45,9 @@ STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID="<stripe-starter-subscription-product-id>
 STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID="<stripe-standard-subscription-product-id>"
 STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID="<stripe-pro-subscription-product-id>"
 
+# Stripe one-time credit top-up product (invoice.paid credit engine)
+STRIPE_CREDIT_PRODUCT_ID="<stripe-credit-product-id>"
+
 # Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
 STRIPE_WEBHOOK_SECRET="<stripe-webhook-secret>"
 LOCK_TIMEOUT="120000"

--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -78,6 +78,17 @@ export const stripeClient = {
     return await stripe.products.retrieve(productId, {}, requestOptions);
   },
 
+  async retrieveProductWithDefaultPrice(
+    productId: string,
+    requestOptions?: Stripe.RequestOptions,
+  ): Promise<Stripe.Product> {
+    return await stripe.products.retrieve(
+      productId,
+      { expand: ["default_price"] },
+      requestOptions,
+    );
+  },
+
   async retrieveSubscriptionWithItems(
     subscriptionId: string,
     requestOptions?: Stripe.RequestOptions,

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -94,6 +94,9 @@ const envSchema = z.object({
   STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: z.string().min(1),
   STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: z.string().min(1),
 
+  // Stripe one-time credit top-up product (invoice.paid credit engine)
+  STRIPE_CREDIT_PRODUCT_ID: z.string().min(1),
+
   // Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
   STRIPE_WEBHOOK_SECRET: z.string().min(1),
 

--- a/apps/core/src/services/organization-seat.service.ts
+++ b/apps/core/src/services/organization-seat.service.ts
@@ -1,8 +1,4 @@
-import {
-  CreditBucketReferenceType,
-  type Prisma,
-  TaskEventOrigin,
-} from "@sokosumi/database";
+import { CreditBucketReferenceType, type Prisma } from "@sokosumi/database";
 import {
   buildOrganizationSeatAssignmentSubscriptionReferenceId,
   countOrganizationSubscriptionPeriodSeatGrants,
@@ -15,28 +11,16 @@ import {
   resolvePurchasedSeats,
 } from "@sokosumi/database/helpers";
 import { subscriptionRepository } from "@sokosumi/database/repositories";
-import {
-  CORE_API_ERROR_KINDS,
-  convertCreditsToCents,
-  TaskStatus,
-} from "@sokosumi/utils";
+import { CORE_API_ERROR_KINDS, convertCreditsToCents } from "@sokosumi/utils";
 import { HTTPException } from "hono/http-exception";
 
 import { badRequest, notFound } from "@/helpers/error";
 import { getSubscriptionSeatCredits } from "@/services/subscription-seat-credits.service";
+import { markOutOfCreditsTasksAsToppedUp } from "@/services/task-topup.service";
 
 export interface GrantUnusedSeatSubscriptionCreditsResult {
   creditsGranted: number;
   granted: boolean;
-}
-
-function isPrismaRecordNotFoundError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "P2025"
-  );
 }
 
 /**
@@ -62,50 +46,6 @@ export function mapSeatRepositoryError(error: unknown): never {
   }
 
   throw error;
-}
-
-async function markOutOfCreditsTasksAsToppedUp(params: {
-  organizationId: string;
-  tx: Prisma.TransactionClient;
-  userId: string;
-}): Promise<void> {
-  const tasks = await params.tx.task.findMany({
-    where: {
-      organizationId: params.organizationId,
-      status: TaskStatus.OUT_OF_CREDITS,
-    },
-    select: {
-      id: true,
-    },
-  });
-
-  for (const task of tasks) {
-    try {
-      await params.tx.task.update({
-        where: {
-          id: task.id,
-          status: TaskStatus.OUT_OF_CREDITS,
-        },
-        data: {
-          status: TaskStatus.CREDITS_TOPPED_UP,
-          events: {
-            create: {
-              status: TaskStatus.CREDITS_TOPPED_UP,
-              origin: TaskEventOrigin.SOKOSUMI,
-              userId: params.userId,
-              coworkerId: null,
-            },
-          },
-        },
-      });
-    } catch (error) {
-      if (isPrismaRecordNotFoundError(error)) {
-        continue;
-      }
-
-      throw error;
-    }
-  }
 }
 
 async function resolveCreditsPerSeatForSubscription(

--- a/apps/core/src/services/stripe-invoice-credit.service.test.ts
+++ b/apps/core/src/services/stripe-invoice-credit.service.test.ts
@@ -1,0 +1,1539 @@
+import {
+  buildLocalFreeOrganizationMemberSubscriptionReferenceId,
+  buildOrganizationInvoiceCreditReferenceId,
+  buildOrganizationMemberSubscriptionReferenceId,
+  buildUserInvoiceCreditReferenceId,
+  escapeStringForLike,
+  getCreditExpiryDate,
+} from "@sokosumi/database/helpers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserByStripeCustomerIdMock = vi.fn();
+const getOrganizationByStripeCustomerIdMock = vi.fn();
+const getMembersByOrganizationIdMock = vi.fn();
+const getAssignedMemberUserIdsMock = vi.fn();
+const getUnassignedMemberUserIdsMock = vi.fn();
+const getSubscriptionCatalogMock = vi.fn();
+const findExistingBucketMock = vi.fn();
+const findExistingLocalFreeBucketMock = vi.fn();
+const findExistingOrganizationInvoiceSubscriptionBucketMock = vi.fn();
+const createTransactionMock = vi.fn();
+const findOutOfCreditsTasksMock = vi.fn();
+const updateTaskMock = vi.fn();
+const resolveOrganizationBillingPlanMock = vi.fn();
+
+const transactionMock = vi.fn(async (callback: (tx: unknown) => unknown) =>
+  callback({
+    creditBucket: {
+      findUnique: (...args: unknown[]) => findExistingBucketMock(...args),
+      findFirst: (...args: unknown[]) =>
+        findExistingLocalFreeBucketMock(...args),
+    },
+    transaction: {
+      create: (...args: unknown[]) => createTransactionMock(...args),
+    },
+    task: {
+      findMany: (...args: unknown[]) => findOutOfCreditsTasksMock(...args),
+      update: (...args: unknown[]) => updateTaskMock(...args),
+    },
+  }),
+);
+
+vi.mock("@/config/env", () => ({
+  getEnv: () => ({
+    STRIPE_CREDIT_PRODUCT_ID: "prod_credit",
+    STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: "prod_pro",
+    STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: "prod_standard",
+    STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID: "prod_starter",
+  }),
+}));
+
+vi.mock("@sokosumi/database/helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@sokosumi/database/helpers")>();
+  return {
+    ...actual,
+    resolveOrganizationBillingPlan: (...args: unknown[]) =>
+      resolveOrganizationBillingPlanMock(...args),
+  };
+});
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  memberRepository: {
+    getAssignedMemberUserIds: (...args: unknown[]) =>
+      getAssignedMemberUserIdsMock(...args),
+    getUnassignedMemberUserIds: (...args: unknown[]) =>
+      getUnassignedMemberUserIdsMock(...args),
+    getMembersByOrganizationId: (...args: unknown[]) =>
+      getMembersByOrganizationIdMock(...args),
+  },
+  organizationRepository: {
+    getOrganizationByStripeCustomerId: (...args: unknown[]) =>
+      getOrganizationByStripeCustomerIdMock(...args),
+  },
+  userRepository: {
+    getUserByStripeCustomerId: (...args: unknown[]) =>
+      getUserByStripeCustomerIdMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: (callback: (tx: unknown) => unknown) =>
+      transactionMock(callback),
+    creditBucket: {
+      findFirst: (...args: unknown[]) =>
+        findExistingOrganizationInvoiceSubscriptionBucketMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/services/subscription-catalog.service", () => ({
+  getSubscriptionCatalog: (...args: unknown[]) =>
+    getSubscriptionCatalogMock(...args),
+}));
+
+const DEFAULT_PERIOD_END_UNIX = 1_735_689_600;
+const DEFAULT_INVOICE_CREATED_UNIX = 1_735_689_600;
+const DEFAULT_PERIOD_DURATION_SECONDS = 2_592_000;
+const SUBSCRIPTION_CATALOG = {
+  free: { credits: 250, monthlyAmount: 0, productId: "local-free" },
+  pro: { credits: 14000, monthlyAmount: 20000, productId: "prod_pro" },
+  standard: {
+    credits: 5250,
+    monthlyAmount: 7500,
+    productId: "prod_standard",
+  },
+  starter: {
+    credits: 1750,
+    monthlyAmount: 2500,
+    productId: "prod_starter",
+  },
+};
+
+interface OrganizationMemberFixture {
+  role: "member" | "owner";
+  userId: string;
+}
+
+interface CreatedTransactionCall {
+  data: {
+    amount: bigint;
+    sourceCreditBucket: {
+      create: {
+        amount?: bigint;
+        expiresAt?: Date | null;
+        referenceId: string;
+        referenceType?: string;
+        userId?: string;
+      };
+    };
+    organization: {
+      connect: {
+        id: string;
+      };
+    };
+    user: {
+      connect: {
+        id: string;
+      };
+    };
+  };
+}
+
+function mockSubscriptionCatalog(): void {
+  getSubscriptionCatalogMock.mockResolvedValue(SUBSCRIPTION_CATALOG);
+}
+
+function mockSelfServeOrganizationBillingPlan(
+  plan: "free" | "pro" | "standard" | "starter" = "starter",
+): void {
+  resolveOrganizationBillingPlanMock.mockResolvedValue({
+    mode: "self_serve",
+    plan,
+    purchasedSeats: 1,
+    subscriptionId: "sub-org-1",
+    cancelAtPeriodEnd: false,
+    periodEnd: new Date("2026-03-01T00:00:00.000Z"),
+  });
+}
+
+function mockOrganizationInvoiceContext(
+  members: OrganizationMemberFixture[],
+  organizationId = "org-1",
+  assignedMemberUserIds?: string[],
+  unassignedMemberUserIds?: string[],
+): void {
+  mockSelfServeOrganizationBillingPlan();
+  getUserByStripeCustomerIdMock.mockResolvedValue(null);
+  getOrganizationByStripeCustomerIdMock.mockResolvedValue({
+    id: organizationId,
+  });
+  getMembersByOrganizationIdMock.mockResolvedValue(members);
+  const assigned =
+    assignedMemberUserIds ?? members.map((member) => member.userId).toSorted();
+  getAssignedMemberUserIdsMock.mockResolvedValue(assigned);
+  getUnassignedMemberUserIdsMock.mockResolvedValue(
+    unassignedMemberUserIds ??
+      members
+        .map((member) => member.userId)
+        .filter((memberUserId) => !assigned.includes(memberUserId))
+        .toSorted(),
+  );
+}
+
+function getTransactionCallsByReferenceId(): Map<
+  string,
+  CreatedTransactionCall
+> {
+  return new Map(
+    createTransactionMock.mock.calls.map((call) => {
+      const createCall = call[0] as CreatedTransactionCall;
+      return [
+        createCall.data.sourceCreditBucket.create.referenceId,
+        createCall,
+      ];
+    }),
+  );
+}
+
+function createInvoice(params: {
+  amountPaid?: number;
+  billingReason:
+    | "manual"
+    | "subscription_create"
+    | "subscription_cycle"
+    | "subscription_update";
+  created?: number;
+  id: string;
+  metadata?: Record<string, string>;
+  lines: Array<{
+    amount?: number;
+    periodStart?: number | null;
+    periodEnd?: number | null;
+    productId: string;
+    quantity?: number;
+  }>;
+}) {
+  return {
+    amount_paid: params.amountPaid ?? 1000,
+    billing_reason: params.billingReason,
+    created: params.created ?? DEFAULT_INVOICE_CREATED_UNIX,
+    customer: "cus_1",
+    id: params.id,
+    metadata: params.metadata ?? {},
+    lines: {
+      data: params.lines.map((line) => ({
+        amount: line.amount ?? 1000,
+        pricing: {
+          price_details: {
+            product: line.productId,
+          },
+        },
+        quantity: line.quantity ?? 1,
+        ...(line.periodEnd === null
+          ? {}
+          : (() => {
+              const periodEnd = line.periodEnd ?? DEFAULT_PERIOD_END_UNIX;
+              const period = {
+                end: periodEnd,
+                ...(line.periodStart === null
+                  ? {}
+                  : {
+                      start:
+                        line.periodStart ??
+                        periodEnd - DEFAULT_PERIOD_DURATION_SECONDS,
+                    }),
+              };
+
+              return { period };
+            })()),
+      })),
+    },
+  };
+}
+
+describe("handleInvoicePaidEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserByStripeCustomerIdMock.mockResolvedValue({
+      id: "user-1",
+    });
+    getOrganizationByStripeCustomerIdMock.mockResolvedValue(null);
+    getMembersByOrganizationIdMock.mockResolvedValue([
+      { role: "owner", userId: "user-1" },
+    ]);
+    getUnassignedMemberUserIdsMock.mockResolvedValue([]);
+    findExistingBucketMock.mockResolvedValue(null);
+    findExistingLocalFreeBucketMock.mockResolvedValue(null);
+    findExistingOrganizationInvoiceSubscriptionBucketMock.mockResolvedValue(
+      null,
+    );
+    createTransactionMock.mockResolvedValue({});
+    findOutOfCreditsTasksMock.mockResolvedValue([]);
+    updateTaskMock.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("throws for an unknown Stripe customer so the webhook responds 5xx and Stripe retries", async () => {
+    getUserByStripeCustomerIdMock.mockResolvedValue(null);
+    getOrganizationByStripeCustomerIdMock.mockResolvedValue(null);
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await expect(
+      handleInvoicePaidEvent(
+        createInvoice({
+          billingReason: "manual",
+          id: "in_unknown_customer",
+          lines: [{ productId: "prod_credit", quantity: 1 }],
+          metadata: { credits: "100" },
+        }) as never,
+      ),
+    ).rejects.toThrow(
+      "Stripe customer cus_1 not found in our system for invoice in_unknown_customer",
+    );
+
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not grant subscription credits for unpaid subscription_update invoices", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "subscription_update",
+        id: "in_sub_update",
+        lines: [{ productId: "prod_starter", quantity: 1 }],
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not grant subscription credits for legacy Stripe free product lines on personal subscription_update", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "subscription_update",
+        id: "in_legacy_free_personal",
+        lines: [{ amount: 0, productId: "prod_free", quantity: 1 }],
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not grant subscription credits for legacy Stripe free product lines on organization subscription_update", async () => {
+    mockOrganizationInvoiceContext([
+      { role: "member", userId: "member-1" },
+      { role: "owner", userId: "owner-2" },
+    ]);
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "subscription_update",
+        id: "in_legacy_free_org",
+        lines: [{ amount: 0, productId: "prod_free", quantity: 2 }],
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("splits organization subscription cycle credits equally with deterministic remainder", async () => {
+    mockOrganizationInvoiceContext([
+      { role: "member", userId: "user-c" },
+      { role: "owner", userId: "user-b" },
+      { role: "member", userId: "user-a" },
+    ]);
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_org_cycle_split",
+        lines: [{ productId: "prod_starter", quantity: 1 }],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(3);
+
+    const callsByReference = getTransactionCallsByReferenceId();
+
+    const userAReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "user-a",
+      "in_org_cycle_split:subscription",
+    );
+    const userBReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "user-b",
+      "in_org_cycle_split:subscription",
+    );
+    const userCReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "user-c",
+      "in_org_cycle_split:subscription",
+    );
+
+    const userACall = callsByReference.get(userAReferenceId);
+    const userBCall = callsByReference.get(userBReferenceId);
+    const userCCall = callsByReference.get(userCReferenceId);
+
+    expect(userACall?.data.amount).toBe(BigInt("5840000000000"));
+    expect(userBCall?.data.amount).toBe(BigInt("5830000000000"));
+    expect(userCCall?.data.amount).toBe(BigInt("5830000000000"));
+
+    expect(userACall?.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_SUBSCRIPTION_PERIOD",
+    );
+    expect(userACall?.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(1_735_689_600 * 1000),
+    );
+    expect(userACall?.data.organization.connect.id).toBe("org-1");
+    expect(userACall?.data.user.connect.id).toBe("user-a");
+    expect(userACall?.data.sourceCreditBucket.create.userId).toBe("user-a");
+  });
+
+  it("keeps organization invoice grants stable on retry when membership changes", async () => {
+    mockOrganizationInvoiceContext([
+      { role: "member", userId: "member-1" },
+      { role: "owner", userId: "owner-2" },
+      { role: "member", userId: "new-member-3" },
+    ]);
+    mockSubscriptionCatalog();
+    findExistingOrganizationInvoiceSubscriptionBucketMock.mockResolvedValue({
+      id: "existing-org-invoice-bucket",
+    });
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_org_cycle_retry_membership_changed",
+        lines: [{ productId: "prod_starter", quantity: 1 }],
+      }) as never,
+    );
+
+    expect(
+      findExistingOrganizationInvoiceSubscriptionBucketMock,
+    ).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org-1",
+        referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
+        referenceId: {
+          startsWith: "member:",
+          endsWith: escapeStringForLike(
+            ":in_org_cycle_retry_membership_changed:subscription",
+          ),
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(createTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps organization top-up grants shared", async () => {
+    mockOrganizationInvoiceContext([
+      { role: "member", userId: "member-1" },
+      { role: "owner", userId: "owner-2" },
+    ]);
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "manual",
+        id: "in_org_topup",
+        lines: [{ productId: "prod_credit", quantity: 1 }],
+        metadata: { credits: "100" },
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.organization.connect.id).toBe("org-1");
+    expect(createCall.data.user.connect.id).toBe("owner-2");
+    expect(createCall.data.amount).toBe(BigInt("1000000000000"));
+    expect(createCall.data.sourceCreditBucket.create.referenceId).toBe(
+      buildOrganizationInvoiceCreditReferenceId(
+        "org-1",
+        "in_org_topup",
+        "topup",
+      ),
+    );
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_TOPUP",
+    );
+    expect(createCall.data.sourceCreditBucket.create.userId).toBe("owner-2");
+  });
+
+  it("splits paid organization proration credits after amount-based calculation", async () => {
+    mockOrganizationInvoiceContext([
+      { role: "member", userId: "member-1" },
+      { role: "owner", userId: "owner-2" },
+    ]);
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 1250,
+        billingReason: "subscription_update",
+        created: 1_735_689_600,
+        id: "in_org_proration",
+        lines: [
+          {
+            amount: 1250,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 1,
+          },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(2);
+
+    const callsByReference = getTransactionCallsByReferenceId();
+
+    const memberReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "member-1",
+      "in_org_proration:subscription",
+    );
+    const ownerReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "owner-2",
+      "in_org_proration:subscription",
+    );
+
+    const memberCall = callsByReference.get(memberReferenceId);
+    const ownerCall = callsByReference.get(ownerReferenceId);
+
+    expect(memberCall?.data.amount).toBe(BigInt("4380000000000"));
+    expect(ownerCall?.data.amount).toBe(BigInt("4370000000000"));
+    expect(memberCall?.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_SUBSCRIPTION_PERIOD",
+    );
+    expect(memberCall?.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(1_736_294_400 * 1000),
+    );
+  });
+
+  it("caps paid organization proration credits when billed seats exceed active members", async () => {
+    mockOrganizationInvoiceContext([
+      { role: "member", userId: "member-1" },
+      { role: "owner", userId: "owner-2" },
+    ]);
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 1250,
+        billingReason: "subscription_update",
+        created: 1_735_689_600,
+        id: "in_org_proration_capped",
+        lines: [
+          {
+            amount: 1250,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 5,
+          },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(2);
+
+    const callsByReference = getTransactionCallsByReferenceId();
+
+    const memberReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "member-1",
+      "in_org_proration_capped:subscription",
+    );
+    const ownerReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "owner-2",
+      "in_org_proration_capped:subscription",
+    );
+
+    const memberCall = callsByReference.get(memberReferenceId);
+    const ownerCall = callsByReference.get(ownerReferenceId);
+
+    expect(memberCall?.data.amount).toBe(BigInt("1750000000000"));
+    expect(ownerCall?.data.amount).toBe(BigInt("1750000000000"));
+  });
+
+  it("logs seat-credit cap when billed organization seats exceed assigned members", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    mockOrganizationInvoiceContext(
+      [
+        { role: "member", userId: "member-1" },
+        { role: "owner", userId: "owner-2" },
+      ],
+      "org-1",
+      ["member-1"],
+    );
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    try {
+      await handleInvoicePaidEvent(
+        createInvoice({
+          billingReason: "subscription_cycle",
+          id: "in_org_cycle_cap_log",
+          lines: [{ productId: "prod_starter", quantity: 5 }],
+        }) as never,
+      );
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("seat_credit_cap_applied"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("invoiceId=in_org_cycle_cap_log"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("organizationId=org-1"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("billedSeats=5"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("activeMembers=1"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("grantedSeats=1"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("droppedSeats=4"),
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
+  });
+
+  it("grants only free monthly credits to unassigned members when no seats are assigned", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    mockOrganizationInvoiceContext(
+      [
+        { role: "member", userId: "member-1" },
+        { role: "owner", userId: "owner-2" },
+      ],
+      "org-1",
+      [],
+    );
+    mockSubscriptionCatalog();
+    vi.setSystemTime(new Date(1_733_011_200 * 1000));
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    try {
+      await handleInvoicePaidEvent(
+        createInvoice({
+          billingReason: "subscription_cycle",
+          id: "in_org_no_assigned_seats",
+          lines: [{ productId: "prod_starter", quantity: 5 }],
+        }) as never,
+      );
+
+      // Paid subscription credits are skipped (no assigned seats)...
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Skipping subscription credits for invoice in_org_no_assigned_seats",
+        ),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("organization org-1 has no assigned seats"),
+      );
+
+      // ...but both unassigned members receive the free monthly tier.
+      expect(createTransactionMock).toHaveBeenCalledTimes(2);
+
+      const periodEnd = new Date(1_735_689_600 * 1000);
+      const callsByReference = getTransactionCallsByReferenceId();
+      for (const memberUserId of ["member-1", "owner-2"]) {
+        const referenceId =
+          buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+            memberUserId,
+            "org-1",
+            periodEnd,
+          );
+        const call = callsByReference.get(referenceId);
+        expect(call?.data.amount).toBe(BigInt("2500000000000"));
+        expect(call?.data.sourceCreditBucket.create.referenceType).toBe(
+          "STRIPE_SUBSCRIPTION_PERIOD",
+        );
+        expect(call?.data.sourceCreditBucket.create.expiresAt).toEqual(
+          periodEnd,
+        );
+      }
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
+  });
+
+  it("skips unassigned free credits while an enterprise contract is consumable", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    mockOrganizationInvoiceContext(
+      [
+        { role: "member", userId: "member-1" },
+        { role: "owner", userId: "owner-2" },
+      ],
+      "org-1",
+      [],
+    );
+    resolveOrganizationBillingPlanMock.mockResolvedValue({
+      activatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      cancelAtPeriodEnd: false,
+      contractId: "contract-1",
+      endsAt: new Date("2027-01-01T00:00:00.000Z"),
+      isConsumable: true,
+      mode: "enterprise_contract",
+      periodEnd: null,
+      plan: "enterprise",
+      purchasedSeats: 5,
+    });
+    mockSubscriptionCatalog();
+    vi.setSystemTime(new Date(1_733_011_200 * 1000));
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    try {
+      await handleInvoicePaidEvent(
+        createInvoice({
+          billingReason: "subscription_cycle",
+          id: "in_org_enterprise_consumable",
+          lines: [{ productId: "prod_starter", quantity: 5 }],
+        }) as never,
+      );
+
+      expect(createTransactionMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Invoice in_org_enterprise_consumable has no grantable credits",
+        ),
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
+  });
+
+  it("grants unassigned free credits for post-term enterprise contracts", async () => {
+    mockOrganizationInvoiceContext(
+      [
+        { role: "member", userId: "member-1" },
+        { role: "owner", userId: "owner-2" },
+      ],
+      "org-1",
+      [],
+    );
+    resolveOrganizationBillingPlanMock.mockResolvedValue({
+      activatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      cancelAtPeriodEnd: false,
+      contractId: "contract-1",
+      endsAt: new Date("2026-02-01T00:00:00.000Z"),
+      isConsumable: false,
+      mode: "enterprise_contract",
+      periodEnd: null,
+      plan: "enterprise",
+      purchasedSeats: 5,
+    });
+    mockSubscriptionCatalog();
+    vi.setSystemTime(new Date(1_733_011_200 * 1000));
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_org_enterprise_post_term",
+        lines: [{ productId: "prod_starter", quantity: 5 }],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("grants only free monthly credits to unassigned members on subscription_update when no seats are assigned", async () => {
+    mockOrganizationInvoiceContext(
+      [
+        { role: "member", userId: "member-1" },
+        { role: "owner", userId: "owner-2" },
+      ],
+      "org-1",
+      [],
+    );
+    mockSubscriptionCatalog();
+    vi.setSystemTime(new Date(1_733_011_200 * 1000));
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 1250,
+        billingReason: "subscription_update",
+        created: 1_735_689_600,
+        id: "in_org_update_no_assigned",
+        lines: [
+          {
+            amount: 1250,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+          },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(2);
+
+    const periodEnd = new Date(1_736_294_400 * 1000);
+    const callsByReference = getTransactionCallsByReferenceId();
+    for (const memberUserId of ["member-1", "owner-2"]) {
+      const referenceId =
+        buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+          memberUserId,
+          "org-1",
+          periodEnd,
+        );
+      const call = callsByReference.get(referenceId);
+      expect(call?.data.amount).toBe(BigInt("2500000000000"));
+      expect(call?.data.sourceCreditBucket.create.expiresAt).toEqual(periodEnd);
+    }
+  });
+
+  it("grants paid credits to assigned members and free credits to unassigned members", async () => {
+    mockOrganizationInvoiceContext(
+      [
+        { role: "owner", userId: "assigned-1" },
+        { role: "member", userId: "unassigned-2" },
+      ],
+      "org-1",
+      ["assigned-1"],
+    );
+    mockSubscriptionCatalog();
+    vi.setSystemTime(new Date(1_733_011_200 * 1000));
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_org_mixed_seats",
+        lines: [{ productId: "prod_starter", quantity: 1 }],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(2);
+
+    const periodEnd = new Date(1_735_689_600 * 1000);
+    const callsByReference = getTransactionCallsByReferenceId();
+
+    const paidReferenceId = buildOrganizationMemberSubscriptionReferenceId(
+      "assigned-1",
+      "in_org_mixed_seats:subscription",
+    );
+    const freeReferenceId =
+      buildLocalFreeOrganizationMemberSubscriptionReferenceId(
+        "unassigned-2",
+        "org-1",
+        periodEnd,
+      );
+
+    expect(callsByReference.get(paidReferenceId)?.data.amount).toBe(
+      BigInt("17500000000000"),
+    );
+    expect(callsByReference.get(freeReferenceId)?.data.amount).toBe(
+      BigInt("2500000000000"),
+    );
+  });
+
+  it("skips free monthly credits for unassigned members that already hold a current free grant", async () => {
+    mockOrganizationInvoiceContext(
+      [{ role: "member", userId: "member-1" }],
+      "org-1",
+      [],
+    );
+    mockSubscriptionCatalog();
+    vi.setSystemTime(new Date(1_733_011_200 * 1000));
+    findExistingLocalFreeBucketMock.mockResolvedValue({
+      id: "existing-local-free-bucket",
+    });
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_org_free_idempotent",
+        lines: [{ productId: "prod_starter", quantity: 1 }],
+      }) as never,
+    );
+
+    expect(createTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("grants positive prorated credits for paid subscription_update invoices", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 1250,
+        billingReason: "subscription_update",
+        created: 1_735_689_600,
+        id: "in_sub_upgrade",
+        lines: [
+          {
+            amount: 1250,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 1,
+          },
+        ],
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).toHaveBeenCalledTimes(1);
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceId).toBe(
+      buildUserInvoiceCreditReferenceId(
+        "user-1",
+        "in_sub_upgrade",
+        "subscription",
+      ),
+    );
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_SUBSCRIPTION_PERIOD",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(1_736_294_400 * 1000),
+    );
+    expect(createCall.data.sourceCreditBucket.create.amount).toBe(
+      BigInt("8750000000000"),
+    );
+  });
+
+  it("uses net proration amount for subscription_update invoices with negative lines", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 7491,
+        billingReason: "subscription_update",
+        created: 1_735_689_600,
+        id: "in_sub_update_net",
+        lines: [
+          {
+            amount: 7491,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 3,
+          },
+          {
+            amount: 7491,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 3,
+          },
+          {
+            amount: 7491,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 3,
+          },
+          {
+            amount: -7491,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 3,
+          },
+          {
+            amount: -7491,
+            periodEnd: 1_736_294_400,
+            periodStart: 1_735_689_600,
+            productId: "prod_starter",
+            quantity: 3,
+          },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceId).toBe(
+      buildUserInvoiceCreditReferenceId(
+        "user-1",
+        "in_sub_update_net",
+        "subscription",
+      ),
+    );
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_SUBSCRIPTION_PERIOD",
+    );
+    expect(createCall.data.amount).toBe(BigInt("52430000000000"));
+  });
+
+  it("uses period end for paid subscription_update invoices when created timestamp is missing", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    const invoice = createInvoice({
+      amountPaid: 1250,
+      billingReason: "subscription_update",
+      id: "in_sub_upgrade_missing_created",
+      lines: [{ amount: 1250, productId: "prod_starter", quantity: 1 }],
+    }) as Record<string, unknown>;
+    delete invoice.created;
+
+    await handleInvoicePaidEvent(invoice as never);
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(DEFAULT_PERIOD_END_UNIX * 1000),
+    );
+  });
+
+  it("uses period end for paid subscription_update invoices when period start is missing", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 1250,
+        billingReason: "subscription_update",
+        created: 1_735_689_600,
+        id: "in_sub_upgrade_missing_period_start",
+        lines: [
+          {
+            amount: 1250,
+            periodEnd: 1_735_689_600,
+            periodStart: null,
+            productId: "prod_starter",
+            quantity: 1,
+          },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(1_735_689_600 * 1000),
+    );
+  });
+
+  it("grants subscription credits for subscription_cycle invoices", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_sub_cycle",
+        lines: [{ productId: "prod_starter", quantity: 2 }],
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+    expect(createCall.data.sourceCreditBucket.create.referenceId).toBe(
+      buildUserInvoiceCreditReferenceId(
+        "user-1",
+        "in_sub_cycle",
+        "subscription",
+      ),
+    );
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_SUBSCRIPTION_PERIOD",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(1_735_689_600 * 1000),
+    );
+    // 1750 credits * quantity 2
+    expect(createCall.data.sourceCreditBucket.create.amount).toBe(
+      BigInt("35000000000000"),
+    );
+  });
+
+  it("skips unknown subscription products and grants credits for known lines", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_mixed_unknown_and_starter",
+        lines: [
+          { productId: "prod_unknown", quantity: 1 },
+          { productId: "prod_starter", quantity: 1 },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+    expect(createCall.data.sourceCreditBucket.create.amount).toBe(
+      BigInt("17500000000000"),
+    );
+  });
+
+  it("uses invoice metadata credits for checkout-based top-up grants", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "manual",
+        id: "in_topup_metadata",
+        lines: [{ productId: "prod_credit", quantity: 1 }],
+        metadata: { credits: "123" },
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+    expect(createCall.data.sourceCreditBucket.create.referenceId).toBe(
+      buildUserInvoiceCreditReferenceId("user-1", "in_topup_metadata", "topup"),
+    );
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_TOPUP",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
+    expect(createCall.data.sourceCreditBucket.create.amount).toBe(
+      BigInt("1230000000000"),
+    );
+  });
+
+  it("keeps one-time top-up crediting working regardless of billing reason", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "manual",
+        id: "in_topup",
+        lines: [{ productId: "prod_credit", quantity: 3 }],
+      }) as never,
+    );
+
+    expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+    expect(createCall.data.sourceCreditBucket.create.referenceId).toBe(
+      buildUserInvoiceCreditReferenceId("user-1", "in_topup", "topup"),
+    );
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_TOPUP",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
+    // quantity-based top-up credits: quantity 3 => 3 credits
+    expect(createCall.data.sourceCreditBucket.create.amount).toBe(
+      BigInt("30000000000"),
+    );
+  });
+
+  it("classifies free top-up invoices as STRIPE_FREE with no expiry when ttl_days is omitted", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "manual",
+        id: "in_topup_free_coupon",
+        lines: [{ productId: "prod_credit", quantity: 3 }],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_FREE",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
+  });
+
+  it("uses ttl_days invoice metadata for free top-up expiry", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "manual",
+        id: "in_topup_free_coupon_ttl_90",
+        lines: [{ productId: "prod_credit", quantity: 3 }],
+        metadata: { ttl_days: "90" },
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_FREE",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
+      getCreditExpiryDate(new Date(DEFAULT_PERIOD_END_UNIX * 1000), 90),
+    );
+  });
+
+  it("applies ttl_days expiry to paid (non-zero) top-ups while keeping STRIPE_TOPUP", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 5000,
+        billingReason: "manual",
+        id: "in_admin_grant_paid_ttl_30",
+        lines: [{ productId: "prod_credit", quantity: 1 }],
+        metadata: { credits: "500", ttl_days: "30" },
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_TOPUP",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toEqual(
+      getCreditExpiryDate(new Date(DEFAULT_INVOICE_CREATED_UNIX * 1000), 30),
+    );
+  });
+
+  it("sets no expiry for free top-up when ttl_days is 0", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "manual",
+        id: "in_topup_free_coupon_ttl_0",
+        lines: [{ productId: "prod_credit", quantity: 3 }],
+        metadata: { ttl_days: "0" },
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_FREE",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
+  });
+
+  it("sets no expiry for free top-up when ttl_days metadata is invalid", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        amountPaid: 0,
+        billingReason: "manual",
+        id: "in_topup_free_coupon_ttl_invalid",
+        lines: [{ productId: "prod_credit", quantity: 3 }],
+        metadata: { ttl_days: "null" },
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+
+    const createCall = createTransactionMock.mock
+      .calls[0][0] as CreatedTransactionCall;
+
+    expect(createCall.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_FREE",
+    );
+    expect(createCall.data.sourceCreditBucket.create.expiresAt).toBeNull();
+  });
+
+  it("splits top-up and subscription credits into separate buckets when both are present", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "subscription_cycle",
+        id: "in_mixed",
+        lines: [
+          { productId: "prod_credit", quantity: 3 },
+          { productId: "prod_starter", quantity: 1, periodEnd: 1_735_689_600 },
+        ],
+      }) as never,
+    );
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(2);
+
+    const callsByReference = getTransactionCallsByReferenceId();
+
+    const topupCall = callsByReference.get(
+      buildUserInvoiceCreditReferenceId("user-1", "in_mixed", "topup"),
+    );
+    expect(topupCall).toBeDefined();
+    expect(topupCall?.data.amount).toBe(BigInt("30000000000"));
+    expect(topupCall?.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_TOPUP",
+    );
+    expect(topupCall?.data.sourceCreditBucket.create.expiresAt).toBeNull();
+
+    const subscriptionCall = callsByReference.get(
+      buildUserInvoiceCreditReferenceId("user-1", "in_mixed", "subscription"),
+    );
+    expect(subscriptionCall).toBeDefined();
+    expect(subscriptionCall?.data.amount).toBe(BigInt("17500000000000"));
+    expect(subscriptionCall?.data.sourceCreditBucket.create.referenceType).toBe(
+      "STRIPE_SUBSCRIPTION_PERIOD",
+    );
+    expect(subscriptionCall?.data.sourceCreditBucket.create.expiresAt).toEqual(
+      new Date(1_735_689_600 * 1000),
+    );
+  });
+
+  it("fails when subscription period end is missing", async () => {
+    mockSubscriptionCatalog();
+
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    await expect(
+      handleInvoicePaidEvent(
+        createInvoice({
+          billingReason: "subscription_cycle",
+          id: "in_missing_period",
+          lines: [{ productId: "prod_starter", quantity: 1, periodEnd: null }],
+        }) as never,
+      ),
+    ).rejects.toThrow(
+      "Missing subscription period end for invoice in_missing_period",
+    );
+
+    expect(createTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("creates CREDITS_TOPPED_UP events for tasks in OUT_OF_CREDITS when credits are granted", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    findOutOfCreditsTasksMock.mockResolvedValue([
+      { id: "task-1" },
+      { id: "task-2" },
+    ]);
+
+    await handleInvoicePaidEvent(
+      createInvoice({
+        billingReason: "manual",
+        id: "in_topup_with_tasks",
+        metadata: { credits: "2" },
+        lines: [{ productId: "prod_credit", quantity: 2 }],
+      }) as never,
+    );
+
+    expect(findOutOfCreditsTasksMock).toHaveBeenCalledWith({
+      where: {
+        status: "OUT_OF_CREDITS",
+        userId: "user-1",
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(updateTaskMock).toHaveBeenCalledTimes(2);
+    expect(updateTaskMock).toHaveBeenNthCalledWith(1, {
+      where: {
+        id: "task-1",
+        status: "OUT_OF_CREDITS",
+      },
+      data: {
+        status: "CREDITS_TOPPED_UP",
+        events: {
+          create: {
+            coworkerId: null,
+            origin: "SOKOSUMI",
+            status: "CREDITS_TOPPED_UP",
+            userId: "user-1",
+          },
+        },
+      },
+    });
+    expect(updateTaskMock).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: "task-2",
+        status: "OUT_OF_CREDITS",
+      },
+      data: {
+        status: "CREDITS_TOPPED_UP",
+        events: {
+          create: {
+            coworkerId: null,
+            origin: "SOKOSUMI",
+            status: "CREDITS_TOPPED_UP",
+            userId: "user-1",
+          },
+        },
+      },
+    });
+  });
+
+  it("does not roll back granted credits when a task is updated concurrently", async () => {
+    const { handleInvoicePaidEvent } = await import(
+      "./stripe-invoice-credit.service"
+    );
+
+    findOutOfCreditsTasksMock.mockResolvedValue([
+      { id: "task-1" },
+      { id: "task-2" },
+    ]);
+    updateTaskMock
+      .mockRejectedValueOnce({ code: "P2025" })
+      .mockResolvedValueOnce({});
+
+    await expect(
+      handleInvoicePaidEvent(
+        createInvoice({
+          billingReason: "manual",
+          id: "in_topup_with_task_race",
+          metadata: { credits: "2" },
+          lines: [{ productId: "prod_credit", quantity: 2 }],
+        }) as never,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(createTransactionMock).toHaveBeenCalledTimes(1);
+    expect(updateTaskMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/core/src/services/stripe-invoice-credit.service.ts
+++ b/apps/core/src/services/stripe-invoice-credit.service.ts
@@ -1,0 +1,810 @@
+import { CreditBucketReferenceType, MemberRole } from "@sokosumi/database";
+import {
+  buildOrganizationInvoiceCreditReferenceId,
+  buildOrganizationMemberSubscriptionReferenceId,
+  buildUserInvoiceCreditReferenceId,
+  escapeStringForLike,
+  getCreditExpiryDate,
+  grantFreeOrganizationMemberSubscriptionCredits,
+  ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX,
+  resolveOrganizationBillingPlan,
+} from "@sokosumi/database/helpers";
+import {
+  memberRepository,
+  organizationRepository,
+  userRepository,
+} from "@sokosumi/database/repositories";
+import { convertCentsToCredits, convertCreditsToCents } from "@sokosumi/utils";
+import type Stripe from "stripe";
+
+import { getEnv } from "@/config/env";
+import prisma from "@/lib/db/prisma";
+import { getSubscriptionCatalog } from "@/services/subscription-catalog.service";
+import { markOutOfCreditsTasksAsToppedUp } from "@/services/task-topup.service";
+
+/**
+ * Port of the web app's `handleInvoicePaidEvent`
+ * (`apps/web/src/lib/stripe/webhook-handlers.ts`). One deliberate behavior
+ * change: an unknown Stripe customer THROWS instead of silently returning, so
+ * the webhook responds 5xx and Stripe retries — the web path's silent 200
+ * permanently lost the credits when the customer-id write-back had not landed
+ * yet.
+ */
+
+const SUBSCRIPTION_METADATA_CREDIT_BILLING_REASONS = new Set([
+  "subscription_create",
+  "subscription_cycle",
+]);
+const SUBSCRIPTION_UPDATE_BILLING_REASON = "subscription_update";
+
+interface InvoiceCreditGrant {
+  credits: number;
+  expiresAt: Date | null;
+  referenceId: string;
+  referenceType: CreditBucketReferenceType;
+  userId: string;
+}
+
+interface SubscriptionLine {
+  lineItem: Stripe.InvoiceLineItem;
+  productId: string;
+}
+
+interface CreditScope {
+  resolveDefaultQuantity: () => Promise<number>;
+}
+
+interface SubscriptionCreditTotals {
+  maxSubscriptionPeriodEndUnix: number | null;
+  paidOrCycleSubscriptionCredits: number;
+}
+
+interface AppliedSubscriptionCredits {
+  subscriptionCredits: number;
+  subscriptionCreditsExpiry: Date | null;
+}
+
+interface BuildInvoiceCreditGrantsParams {
+  oneTimeTopUpExpiresAt: Date | null;
+  oneTimeTopUpCredits: number;
+  oneTimeTopUpReferenceType: CreditBucketReferenceType;
+  organizationId: string | null;
+  organizationMemberUserIds: string[];
+  skipOrganizationSubscriptionSplit: boolean;
+  subscriptionCredits: number;
+  subscriptionCreditsExpiry: Date | null;
+  userId: string;
+  invoiceId: string;
+}
+
+function getTopUpCreditsFromInvoiceMetadata(
+  invoice: Stripe.Invoice,
+): number | null {
+  const metadataCredits = invoice.metadata?.credits;
+  if (!metadataCredits) {
+    return null;
+  }
+
+  const credits = Number(metadataCredits);
+  if (!Number.isInteger(credits) || credits <= 0) {
+    return null;
+  }
+
+  return credits;
+}
+
+/**
+ * Reads `ttl_days` from invoice metadata for credit grants.
+ * - Missing, empty, invalid, negative, or zero → no expiry (`expiresAt` null).
+ * - Positive integer → expiry after that many days from the invoice time.
+ */
+function getTopUpExpiryDaysFromInvoiceMetadata(
+  invoice: Stripe.Invoice,
+): number | null {
+  const ttlDaysRaw = invoice.metadata?.ttl_days;
+  if (ttlDaysRaw === undefined) {
+    return null;
+  }
+
+  const normalizedTtlDays = ttlDaysRaw.trim();
+  if (!normalizedTtlDays) {
+    return null;
+  }
+
+  const ttlDays = Number(normalizedTtlDays);
+  if (!Number.isInteger(ttlDays) || ttlDays <= 0) {
+    return null;
+  }
+
+  return ttlDays;
+}
+
+function resolveInvoiceCreatedAt(invoice: Stripe.Invoice): Date {
+  if (typeof invoice.created === "number" && Number.isFinite(invoice.created)) {
+    return new Date(invoice.created * 1000);
+  }
+
+  return new Date();
+}
+
+function resolveTopUpGrantPolicy(invoice: Stripe.Invoice): {
+  expiresAt: Date | null;
+  referenceType: CreditBucketReferenceType;
+} {
+  // Honor an explicit `ttl_days` expiry whenever it is present, regardless of
+  // the paid amount. Standard paid top-ups never set `ttl_days`, so they keep
+  // their non-expiring behavior; admin-granted credits can opt into an expiry
+  // even on non-zero invoices.
+  const invoiceCreatedAt = resolveInvoiceCreatedAt(invoice);
+  const topUpExpiryDays = getTopUpExpiryDaysFromInvoiceMetadata(invoice);
+  const expiresAt =
+    topUpExpiryDays === null
+      ? null
+      : getCreditExpiryDate(invoiceCreatedAt, topUpExpiryDays);
+
+  return {
+    expiresAt,
+    referenceType:
+      invoice.amount_paid > 0
+        ? CreditBucketReferenceType.STRIPE_TOPUP
+        : CreditBucketReferenceType.STRIPE_FREE,
+  };
+}
+
+function getSubscriptionCreditExpiry(params: {
+  invoiceId: string;
+  maxPeriodEndUnix: number | null;
+}): Date {
+  if (params.maxPeriodEndUnix === null) {
+    throw new Error(
+      `Missing subscription period end for invoice ${params.invoiceId}`,
+    );
+  }
+
+  return new Date(params.maxPeriodEndUnix * 1000);
+}
+
+function calculateProratedSubscriptionCredits(params: {
+  invoiceId: string;
+  lineAmount: number;
+  monthlyAmount: number;
+  planCredits: number;
+  productId: string;
+}): number {
+  if (params.lineAmount === 0) {
+    return 0;
+  }
+
+  if (params.monthlyAmount <= 0) {
+    throw new Error(
+      `Invalid monthly amount for subscription product ${params.productId} on invoice ${params.invoiceId}`,
+    );
+  }
+
+  return Math.trunc(
+    (params.lineAmount * params.planCredits) / params.monthlyAmount,
+  );
+}
+
+function shouldGrantSubscriptionCreditsForLine(params: {
+  billingReason: Stripe.Invoice.BillingReason | null;
+  invoiceAmountPaid: number;
+  lineAmount: number;
+}): boolean {
+  const { billingReason } = params;
+  if (billingReason === null) {
+    return false;
+  }
+
+  if (SUBSCRIPTION_METADATA_CREDIT_BILLING_REASONS.has(billingReason)) {
+    return true;
+  }
+
+  if (billingReason !== SUBSCRIPTION_UPDATE_BILLING_REASON) {
+    return false;
+  }
+
+  return params.invoiceAmountPaid > 0 && params.lineAmount !== 0;
+}
+
+async function calculateSubscriptionCreditTotals(params: {
+  invoiceId: string;
+  isSubscriptionUpdate: boolean;
+  maxSeatGrantQuantity: number | null;
+  organizationId: string | null;
+  resolveDefaultQuantity: () => Promise<number>;
+  subscriptionLines: SubscriptionLine[];
+}): Promise<SubscriptionCreditTotals> {
+  let paidOrCycleSubscriptionCredits = 0;
+  let maxSubscriptionPeriodEndUnix: number | null = null;
+
+  if (params.subscriptionLines.length === 0) {
+    return {
+      maxSubscriptionPeriodEndUnix,
+      paidOrCycleSubscriptionCredits,
+    };
+  }
+
+  if (params.organizationId !== null && params.maxSeatGrantQuantity === 0) {
+    console.log(
+      `Skipping subscription credits for invoice ${params.invoiceId}: organization ${params.organizationId} has no assigned seats`,
+    );
+    return {
+      maxSubscriptionPeriodEndUnix,
+      paidOrCycleSubscriptionCredits,
+    };
+  }
+
+  const subscriptionCatalog = await getSubscriptionCatalog();
+  const catalogPlans = [
+    subscriptionCatalog.free,
+    subscriptionCatalog.starter,
+    subscriptionCatalog.standard,
+    subscriptionCatalog.pro,
+  ];
+  const catalogByProductId = new Map(
+    catalogPlans.map((plan) => [
+      plan.productId,
+      {
+        credits: plan.credits,
+        monthlyAmount: plan.monthlyAmount,
+      },
+    ]),
+  );
+
+  function logSeatCreditCapApplied(data: {
+    activeMembers: number;
+    billedSeats: number;
+    grantedSeats: number;
+    productId: string;
+  }): void {
+    console.log(
+      `⚠️ seat_credit_cap_applied invoiceId=${params.invoiceId} organizationId=${params.organizationId ?? "none"} productId=${data.productId} billedSeats=${data.billedSeats} activeMembers=${data.activeMembers} grantedSeats=${data.grantedSeats} droppedSeats=${data.billedSeats - data.grantedSeats}`,
+    );
+  }
+
+  function capSeatsToActiveMembers(
+    billedSeats: number,
+    productId: string,
+  ): number {
+    if (params.maxSeatGrantQuantity === null) {
+      return billedSeats;
+    }
+
+    const grantedSeats = Math.min(billedSeats, params.maxSeatGrantQuantity);
+    if (billedSeats > grantedSeats) {
+      logSeatCreditCapApplied({
+        activeMembers: params.maxSeatGrantQuantity,
+        billedSeats,
+        grantedSeats,
+        productId,
+      });
+    }
+
+    return grantedSeats;
+  }
+
+  for (const { lineItem, productId } of params.subscriptionLines) {
+    const catalogPlan = catalogByProductId.get(productId);
+    if (!catalogPlan) {
+      throw new Error(
+        `No credits found in subscription catalog for product ${productId}`,
+      );
+    }
+
+    const lineAmount = lineItem.amount ?? 0;
+
+    if (params.isSubscriptionUpdate) {
+      let proratedCredits = calculateProratedSubscriptionCredits({
+        invoiceId: params.invoiceId,
+        lineAmount,
+        monthlyAmount: catalogPlan.monthlyAmount,
+        planCredits: catalogPlan.credits,
+        productId,
+      });
+
+      const billedQuantity = lineItem.quantity ?? 0;
+      if (billedQuantity > 0) {
+        const grantedQuantity = capSeatsToActiveMembers(
+          billedQuantity,
+          productId,
+        );
+        if (grantedQuantity <= 0) {
+          continue;
+        }
+
+        proratedCredits = Math.trunc(
+          (proratedCredits * grantedQuantity) / billedQuantity,
+        );
+      }
+
+      paidOrCycleSubscriptionCredits += proratedCredits;
+    } else {
+      let quantity = lineItem.quantity ?? 0;
+      if (quantity <= 0) {
+        quantity = await params.resolveDefaultQuantity();
+      }
+
+      quantity = capSeatsToActiveMembers(quantity, productId);
+
+      if (quantity <= 0) {
+        continue;
+      }
+
+      paidOrCycleSubscriptionCredits += catalogPlan.credits * quantity;
+    }
+
+    const periodEnd = lineItem.period?.end;
+    if (typeof periodEnd === "number" && periodEnd > 0) {
+      maxSubscriptionPeriodEndUnix = Math.max(
+        periodEnd,
+        maxSubscriptionPeriodEndUnix ?? 0,
+      );
+    }
+  }
+
+  return {
+    maxSubscriptionPeriodEndUnix,
+    paidOrCycleSubscriptionCredits,
+  };
+}
+
+async function finalizeAppliedSubscriptionCredits(params: {
+  invoiceId: string;
+  isSubscriptionUpdate: boolean;
+  totals: SubscriptionCreditTotals;
+}): Promise<AppliedSubscriptionCredits> {
+  let paidOrCycleSubscriptionCredits =
+    params.totals.paidOrCycleSubscriptionCredits;
+  if (params.isSubscriptionUpdate && paidOrCycleSubscriptionCredits < 0) {
+    paidOrCycleSubscriptionCredits = 0;
+  }
+
+  const subscriptionCredits = paidOrCycleSubscriptionCredits;
+
+  const subscriptionCreditsExpiry =
+    subscriptionCredits > 0
+      ? getSubscriptionCreditExpiry({
+          invoiceId: params.invoiceId,
+          maxPeriodEndUnix: params.totals.maxSubscriptionPeriodEndUnix,
+        })
+      : null;
+
+  return {
+    subscriptionCredits,
+    subscriptionCreditsExpiry,
+  };
+}
+
+function splitCreditsByMember(params: {
+  memberUserIds: string[];
+  totalCredits: number;
+}): Array<{ credits: number; userId: string }> {
+  const { memberUserIds, totalCredits } = params;
+  if (totalCredits <= 0 || memberUserIds.length === 0) {
+    return [];
+  }
+
+  const baseCredits = Math.floor(totalCredits / memberUserIds.length);
+  const remainder = totalCredits % memberUserIds.length;
+
+  return memberUserIds
+    .map((memberUserId, index) => ({
+      userId: memberUserId,
+      credits: baseCredits + (index < remainder ? 1 : 0),
+    }))
+    .filter((allocation) => allocation.credits > 0);
+}
+
+function resolveSubscriptionLinesPeriodEndUnix(
+  subscriptionLines: SubscriptionLine[],
+): number | null {
+  let maxPeriodEndUnix: number | null = null;
+
+  for (const { lineItem } of subscriptionLines) {
+    const periodEnd = lineItem.period?.end;
+    if (typeof periodEnd === "number" && periodEnd > 0) {
+      maxPeriodEndUnix = Math.max(periodEnd, maxPeriodEndUnix ?? 0);
+    }
+  }
+
+  return maxPeriodEndUnix;
+}
+
+function buildInvoiceCreditGrants(
+  params: BuildInvoiceCreditGrantsParams,
+): InvoiceCreditGrant[] {
+  const creditGrants: InvoiceCreditGrant[] = [];
+
+  if (params.oneTimeTopUpCredits > 0) {
+    const topUpReferenceId = params.organizationId
+      ? buildOrganizationInvoiceCreditReferenceId(
+          params.organizationId,
+          params.invoiceId,
+          "topup",
+        )
+      : buildUserInvoiceCreditReferenceId(
+          params.userId,
+          params.invoiceId,
+          "topup",
+        );
+
+    creditGrants.push({
+      credits: params.oneTimeTopUpCredits,
+      expiresAt: params.oneTimeTopUpExpiresAt,
+      referenceId: topUpReferenceId,
+      referenceType: params.oneTimeTopUpReferenceType,
+      userId: params.userId,
+    });
+  }
+
+  if (params.subscriptionCredits <= 0) {
+    return creditGrants;
+  }
+
+  if (!params.organizationId) {
+    creditGrants.push({
+      credits: params.subscriptionCredits,
+      expiresAt: params.subscriptionCreditsExpiry,
+      referenceId: buildUserInvoiceCreditReferenceId(
+        params.userId,
+        params.invoiceId,
+        "subscription",
+      ),
+      referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
+      userId: params.userId,
+    });
+
+    return creditGrants;
+  }
+
+  if (params.skipOrganizationSubscriptionSplit) {
+    return creditGrants;
+  }
+
+  if (params.organizationMemberUserIds.length === 0) {
+    return creditGrants;
+  }
+
+  const subscriptionReferenceSuffix = `${params.invoiceId}:subscription`;
+  const splitGrants = splitCreditsByMember({
+    memberUserIds: params.organizationMemberUserIds,
+    totalCredits: params.subscriptionCredits,
+  });
+
+  for (const splitGrant of splitGrants) {
+    creditGrants.push({
+      credits: splitGrant.credits,
+      expiresAt: params.subscriptionCreditsExpiry,
+      referenceId: buildOrganizationMemberSubscriptionReferenceId(
+        splitGrant.userId,
+        subscriptionReferenceSuffix,
+      ),
+      referenceType: "STRIPE_SUBSCRIPTION_PERIOD",
+      userId: splitGrant.userId,
+    });
+  }
+
+  return creditGrants;
+}
+
+export async function handleInvoicePaidEvent(
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  // Validate invoice has required data
+  if (!invoice.id) {
+    console.log(`Invoice has no ID`);
+    return;
+  }
+  const invoiceId = invoice.id;
+
+  if (!invoice.customer) {
+    console.log(`Invoice ${invoiceId} has no customer`);
+    return;
+  }
+
+  if (invoice.amount_paid === null) {
+    console.log(`Invoice ${invoiceId} has no amount paid`);
+    return;
+  }
+
+  // Get the Stripe customer ID from the invoice
+  const stripeCustomerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : invoice.customer.id;
+
+  // Look up the user or organization by stripeCustomerId
+  let userId: string;
+  let organizationId: string | null = null;
+  let organizationMemberUserIds: string[] = [];
+  let organizationUnassignedMemberUserIds: string[] = [];
+
+  // First, try to find a user with this stripeCustomerId
+  const user = await userRepository.getUserByStripeCustomerId(
+    stripeCustomerId,
+    prisma,
+  );
+
+  if (user) {
+    // This is a user purchase
+    userId = user.id;
+  } else {
+    // Try to find an organization with this stripeCustomerId
+    const organization =
+      await organizationRepository.getOrganizationByStripeCustomerId(
+        stripeCustomerId,
+        prisma,
+      );
+
+    if (organization) {
+      // This is an organization purchase
+      organizationId = organization.id;
+
+      const [members, assignedMemberUserIds, unassignedMemberUserIds] =
+        await Promise.all([
+          memberRepository.getMembersByOrganizationId(organizationId, prisma),
+          memberRepository.getAssignedMemberUserIds(organizationId, prisma),
+          memberRepository.getUnassignedMemberUserIds(organizationId, prisma),
+        ]);
+
+      if (members.length === 0) {
+        console.log(`No members found for organization ${organizationId}`);
+        return;
+      }
+
+      organizationMemberUserIds = assignedMemberUserIds;
+      organizationUnassignedMemberUserIds = unassignedMemberUserIds;
+
+      const ownerMember = members.find((m) => m.role === MemberRole.OWNER);
+
+      if (!ownerMember) {
+        console.log(`No owner found for organization ${organizationId}`);
+        return;
+      }
+      userId = ownerMember.userId;
+    } else {
+      // Unlike the web handler, throw so the webhook responds 5xx and Stripe
+      // retries — a silent 200 permanently drops the credits when the
+      // customer-id write-back has not landed yet.
+      throw new Error(
+        `Stripe customer ${stripeCustomerId} not found in our system for invoice ${invoiceId}`,
+      );
+    }
+  }
+
+  const creditScope: CreditScope = organizationId
+    ? {
+        resolveDefaultQuantity: async () => organizationMemberUserIds.length,
+      }
+    : {
+        resolveDefaultQuantity: async () => 1,
+      };
+
+  const env = getEnv();
+  const creditProductId = env.STRIPE_CREDIT_PRODUCT_ID;
+  const subscriptionProductIds = new Set([
+    env.STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID,
+    env.STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID,
+    env.STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID,
+  ]);
+
+  // Ensure invoice has line items
+  const lineItems = invoice.lines?.data;
+  if (!lineItems || lineItems.length === 0) {
+    console.log(`Invoice ${invoiceId} has no line items to process`);
+    return;
+  }
+
+  const billingReason = invoice.billing_reason;
+  const topUpCreditsFromMetadata = getTopUpCreditsFromInvoiceMetadata(invoice);
+  let oneTimeTopUpCredits = topUpCreditsFromMetadata ?? 0;
+  const oneTimeTopUpGrantPolicy = resolveTopUpGrantPolicy(invoice);
+  const subscriptionLines: SubscriptionLine[] = [];
+
+  for (const lineItem of lineItems) {
+    if (lineItem.pricing && typeof lineItem.pricing === "object") {
+      const productId = lineItem.pricing.price_details?.product;
+      if (!productId || typeof productId !== "string") {
+        continue;
+      }
+
+      if (productId === creditProductId) {
+        if (topUpCreditsFromMetadata === null) {
+          oneTimeTopUpCredits += lineItem.quantity ?? 0;
+        }
+        continue;
+      }
+
+      const lineAmount = lineItem.amount ?? 0;
+      if (
+        !shouldGrantSubscriptionCreditsForLine({
+          billingReason,
+          invoiceAmountPaid: invoice.amount_paid,
+          lineAmount,
+        })
+      ) {
+        continue;
+      }
+
+      if (subscriptionProductIds.has(productId)) {
+        subscriptionLines.push({ lineItem, productId });
+      }
+    }
+  }
+
+  if (
+    billingReason &&
+    !SUBSCRIPTION_METADATA_CREDIT_BILLING_REASONS.has(billingReason) &&
+    billingReason !== SUBSCRIPTION_UPDATE_BILLING_REASON
+  ) {
+    console.log(
+      `Skipping subscription credits for invoice ${invoiceId} due to billing reason ${billingReason}`,
+    );
+  }
+  const isSubscriptionUpdate =
+    billingReason === SUBSCRIPTION_UPDATE_BILLING_REASON;
+  const subscriptionCreditTotals = await calculateSubscriptionCreditTotals({
+    invoiceId,
+    isSubscriptionUpdate,
+    maxSeatGrantQuantity: organizationId
+      ? organizationMemberUserIds.length
+      : null,
+    organizationId,
+    resolveDefaultQuantity: creditScope.resolveDefaultQuantity,
+    subscriptionLines,
+  });
+  const { subscriptionCredits, subscriptionCreditsExpiry } =
+    await finalizeAppliedSubscriptionCredits({
+      invoiceId,
+      isSubscriptionUpdate,
+      totals: subscriptionCreditTotals,
+    });
+
+  let skipOrganizationSubscriptionSplit = false;
+  if (subscriptionCredits > 0 && organizationId) {
+    const existingOrganizationInvoiceSubscriptionBucket =
+      await prisma.creditBucket.findFirst({
+        where: {
+          organizationId,
+          referenceType: CreditBucketReferenceType.STRIPE_SUBSCRIPTION_PERIOD,
+          referenceId: {
+            startsWith: ORGANIZATION_MEMBER_SUBSCRIPTION_REFERENCE_PREFIX,
+            endsWith: escapeStringForLike(`:${invoiceId}:subscription`),
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+
+    if (existingOrganizationInvoiceSubscriptionBucket) {
+      console.log(
+        `✅ Organization invoice ${invoiceId} subscription grants already exist; skipping replay split`,
+      );
+      skipOrganizationSubscriptionSplit = true;
+    }
+  }
+
+  const creditGrants = buildInvoiceCreditGrants({
+    invoiceId,
+    oneTimeTopUpExpiresAt: oneTimeTopUpGrantPolicy.expiresAt,
+    oneTimeTopUpCredits,
+    oneTimeTopUpReferenceType: oneTimeTopUpGrantPolicy.referenceType,
+    organizationId,
+    organizationMemberUserIds,
+    skipOrganizationSubscriptionSplit,
+    subscriptionCredits,
+    subscriptionCreditsExpiry,
+    userId,
+  });
+
+  const freeTierPeriodEndUnix =
+    resolveSubscriptionLinesPeriodEndUnix(subscriptionLines);
+  let shouldGrantUnassignedFreeCredits =
+    organizationId !== null &&
+    subscriptionLines.length > 0 &&
+    freeTierPeriodEndUnix !== null &&
+    organizationUnassignedMemberUserIds.length > 0;
+
+  if (shouldGrantUnassignedFreeCredits && organizationId) {
+    const billingPlan = await resolveOrganizationBillingPlan(
+      organizationId,
+      prisma,
+    );
+    if (
+      billingPlan.mode === "enterprise_contract" &&
+      billingPlan.isConsumable
+    ) {
+      shouldGrantUnassignedFreeCredits = false;
+    }
+  }
+
+  if (creditGrants.length === 0 && !shouldGrantUnassignedFreeCredits) {
+    console.log(
+      `Invoice ${invoiceId} has no grantable credits (billing reason: ${invoice.billing_reason})`,
+    );
+    return;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    let creditsGranted = false;
+
+    for (const grant of creditGrants) {
+      const existingBucket = await tx.creditBucket.findUnique({
+        where: {
+          referenceId_referenceType: {
+            referenceId: grant.referenceId,
+            referenceType: grant.referenceType,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (existingBucket) {
+        console.log(
+          `✅ Bucket already exists for invoice reference ${grant.referenceId}, skipping creation`,
+        );
+        continue;
+      }
+
+      const cents = convertCreditsToCents(grant.credits);
+      await tx.transaction.create({
+        data: {
+          amount: cents,
+          user: { connect: { id: grant.userId } },
+          ...(organizationId && {
+            organization: { connect: { id: organizationId } },
+          }),
+          sourceCreditBucket: {
+            create: {
+              amount: cents,
+              expiresAt: grant.expiresAt,
+              referenceId: grant.referenceId,
+              referenceType: grant.referenceType,
+              userId: grant.userId,
+              organizationId,
+            },
+          },
+        },
+      });
+
+      creditsGranted = true;
+
+      console.log(
+        `✅ Processed invoice ${invoiceId}: Created transaction and bucket with ${convertCentsToCredits(cents)} credits for ${organizationId ? `organization ${organizationId} member ${grant.userId}` : `user ${grant.userId}`}${grant.expiresAt ? ` (expires ${grant.expiresAt.toISOString()})` : ""}`,
+      );
+    }
+
+    if (
+      shouldGrantUnassignedFreeCredits &&
+      organizationId &&
+      freeTierPeriodEndUnix !== null
+    ) {
+      const freeGrantsCreated =
+        await grantFreeOrganizationMemberSubscriptionCredits(
+          {
+            memberUserIds: organizationUnassignedMemberUserIds,
+            organizationId,
+            periodEnd: new Date(freeTierPeriodEndUnix * 1000),
+          },
+          tx,
+        );
+
+      if (freeGrantsCreated > 0) {
+        creditsGranted = true;
+        console.log(
+          `✅ Processed invoice ${invoiceId}: Granted free monthly credits to ${freeGrantsCreated} unassigned member(s) of organization ${organizationId}`,
+        );
+      }
+    }
+
+    if (creditsGranted) {
+      await markOutOfCreditsTasksAsToppedUp({
+        userId,
+        organizationId,
+        tx,
+      });
+    }
+  });
+}

--- a/apps/core/src/services/stripe-webhook.service.test.ts
+++ b/apps/core/src/services/stripe-webhook.service.test.ts
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   captureExceptionMock,
   getOrganizationWithRelationsByIdMock,
+  handleInvoicePaidEventMock,
   updateOrganizationInvoiceEmailMock,
 } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
   getOrganizationWithRelationsByIdMock: vi.fn(),
+  handleInvoicePaidEventMock: vi.fn(),
   updateOrganizationInvoiceEmailMock: vi.fn(),
 }));
 
@@ -24,6 +26,10 @@ vi.mock("@sokosumi/database/repositories", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {},
+}));
+
+vi.mock("@/services/stripe-invoice-credit.service", () => ({
+  handleInvoicePaidEvent: handleInvoicePaidEventMock,
 }));
 
 async function getStripeWebhookService() {
@@ -60,6 +66,19 @@ function createOrganizationCustomer(
   };
 }
 
+function createInvoicePaidEvent(): Stripe.Event {
+  return {
+    id: "evt_inv_123",
+    type: "invoice.paid",
+    data: {
+      object: {
+        id: "in_123",
+        customer: "cus_123",
+      },
+    },
+  } as Stripe.Event;
+}
+
 describe("stripeWebhookService.handleEvent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,6 +90,42 @@ describe("stripeWebhookService.handleEvent", () => {
       id: "org_123",
       metadata: JSON.stringify({ invoiceEmail: "new@example.com" }),
     });
+    handleInvoicePaidEventMock.mockResolvedValue(undefined);
+  });
+
+  it("dispatches invoice.paid events to the invoice credit handler", async () => {
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(createInvoicePaidEvent());
+
+    expect(handleInvoicePaidEventMock).toHaveBeenCalledTimes(1);
+    expect(handleInvoicePaidEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "in_123" }),
+    );
+  });
+
+  it("reports to Sentry and rethrows when the invoice.paid handler fails", async () => {
+    const failure = new Error("unknown customer");
+    handleInvoicePaidEventMock.mockRejectedValue(failure);
+    const service = await getStripeWebhookService();
+
+    await expect(service.handleEvent(createInvoicePaidEvent())).rejects.toThrow(
+      "unknown customer",
+    );
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          stripeEventType: "invoice.paid",
+          invoiceId: "in_123",
+        }),
+        extra: expect.objectContaining({
+          eventId: "evt_inv_123",
+          customer: "cus_123",
+        }),
+      }),
+    );
   });
 
   it("updates the organization invoice email when the customer email changed", async () => {
@@ -189,13 +244,14 @@ describe("stripeWebhookService.handleEvent", () => {
 
       await service.handleEvent({
         id: "evt_456",
-        type: "invoice.paid",
+        type: "charge.succeeded",
         data: { object: {} },
       } as Stripe.Event);
 
       expect(getOrganizationWithRelationsByIdMock).not.toHaveBeenCalled();
+      expect(handleInvoicePaidEventMock).not.toHaveBeenCalled();
       expect(consoleInfoSpy).toHaveBeenCalledWith(
-        "[webhooks/stripe] Unhandled Stripe event type: invoice.paid",
+        "[webhooks/stripe] Unhandled Stripe event type: charge.succeeded",
       );
     } finally {
       consoleInfoSpy.mockRestore();

--- a/apps/core/src/services/stripe-webhook.service.ts
+++ b/apps/core/src/services/stripe-webhook.service.ts
@@ -4,6 +4,7 @@ import { getOrganizationMetadata } from "@sokosumi/utils";
 import type Stripe from "stripe";
 
 import prisma from "@/lib/db/prisma";
+import { handleInvoicePaidEvent } from "@/services/stripe-invoice-credit.service";
 
 /**
  * Sync an organization's stored invoice email when its Stripe customer
@@ -56,6 +57,29 @@ export const stripeWebhookService = {
    */
   async handleEvent(event: Stripe.Event): Promise<void> {
     switch (event.type) {
+      case "invoice.paid": {
+        const invoice = event.data.object;
+        try {
+          await handleInvoicePaidEvent(invoice);
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: {
+              stripeEventType: event.type,
+              invoiceId: invoice.id,
+            },
+            extra: {
+              eventId: event.id,
+              invoice: invoice.id,
+              customer:
+                typeof invoice.customer === "string"
+                  ? invoice.customer
+                  : invoice.customer?.id,
+            },
+          });
+          throw error;
+        }
+        break;
+      }
       case "customer.updated": {
         const customer = event.data.object;
         try {

--- a/apps/core/src/services/subscription-catalog.service.test.ts
+++ b/apps/core/src/services/subscription-catalog.service.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getEnvMock, retrieveProductWithDefaultPriceMock } = vi.hoisted(() => ({
+  getEnvMock: vi.fn(),
+  retrieveProductWithDefaultPriceMock: vi.fn(),
+}));
+
+vi.mock("@/config/env", () => ({
+  getEnv: getEnvMock,
+}));
+
+vi.mock("@/clients/stripe.client", () => ({
+  stripeClient: {
+    retrieveProductWithDefaultPrice: retrieveProductWithDefaultPriceMock,
+  },
+}));
+
+const ENV = {
+  STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID: "prod_starter",
+  STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: "prod_standard",
+  STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: "prod_pro",
+};
+
+interface MockProductParams {
+  credits?: number;
+  interval?: "day" | "month" | "week" | "year";
+  intervalCount?: number;
+  planName: "pro" | "standard" | "starter";
+  priceId: string;
+  productId: string;
+  unitAmount: number;
+}
+
+function createMockProduct(params: MockProductParams): unknown {
+  return {
+    active: true,
+    default_price: {
+      id: params.priceId,
+      recurring: {
+        interval: params.interval ?? "month",
+        interval_count: params.intervalCount ?? 1,
+      },
+      type: "recurring",
+      unit_amount: params.unitAmount,
+      currency: "eur",
+      metadata: {},
+    },
+    metadata: {
+      slug: params.planName,
+      ...(params.credits === undefined
+        ? {}
+        : { credits: String(params.credits) }),
+    },
+    id: params.productId,
+  };
+}
+
+function createBaseProducts(): Record<string, unknown> {
+  return {
+    [ENV.STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID]: createMockProduct({
+      planName: "starter",
+      priceId: "price_starter",
+      productId: ENV.STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID,
+      credits: 1750,
+      unitAmount: 2500,
+    }),
+    [ENV.STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID]: createMockProduct({
+      planName: "standard",
+      priceId: "price_standard",
+      productId: ENV.STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID,
+      credits: 5250,
+      unitAmount: 7500,
+    }),
+    [ENV.STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID]: createMockProduct({
+      planName: "pro",
+      priceId: "price_pro",
+      productId: ENV.STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID,
+      credits: 14000,
+      unitAmount: 20000,
+    }),
+  };
+}
+
+function mockProducts(overrides: Record<string, unknown> = {}): void {
+  const products = {
+    ...createBaseProducts(),
+    ...overrides,
+  };
+
+  retrieveProductWithDefaultPriceMock.mockImplementation(
+    async (productId: string) => {
+      const product = products[productId];
+      if (!product) {
+        throw new Error(`Unexpected product id: ${productId}`);
+      }
+
+      return product;
+    },
+  );
+}
+
+describe("subscription-catalog.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    getEnvMock.mockReturnValue(ENV);
+  });
+
+  it("builds catalog from paid product metadata and a synthetic local free tier", async () => {
+    mockProducts();
+
+    const { getSubscriptionCatalog } = await import(
+      "./subscription-catalog.service"
+    );
+
+    const catalog = await getSubscriptionCatalog();
+    expect(catalog.free.credits).toBe(250);
+    expect(catalog.free.productId).toBe("local-free");
+    expect(catalog.free.monthlyAmount).toBe(0);
+    expect(catalog.starter.credits).toBe(1750);
+    expect(catalog.standard.monthlyAmount).toBe(7500);
+    expect(catalog.pro.priceId).toBe("price_pro");
+    expect(retrieveProductWithDefaultPriceMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws when paid product metadata credits are missing", async () => {
+    mockProducts({
+      [ENV.STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID]: createMockProduct({
+        planName: "starter",
+        priceId: "price_starter",
+        productId: ENV.STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID,
+        unitAmount: 2500,
+      }),
+    });
+
+    const { getSubscriptionCatalog } = await import(
+      "./subscription-catalog.service"
+    );
+
+    await expect(getSubscriptionCatalog()).rejects.toThrow(
+      "Missing credits metadata for starter plan",
+    );
+  });
+
+  it("throws when the default price is not monthly recurring", async () => {
+    mockProducts({
+      [ENV.STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID]: createMockProduct({
+        planName: "pro",
+        priceId: "price_pro",
+        productId: ENV.STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID,
+        credits: 14000,
+        unitAmount: 20000,
+        interval: "year",
+      }),
+    });
+
+    const { getSubscriptionCatalog } = await import(
+      "./subscription-catalog.service"
+    );
+
+    await expect(getSubscriptionCatalog()).rejects.toThrow(
+      "pro plan must have monthly recurring pricing",
+    );
+  });
+
+  it("does not cache failed loads and retries on the next call", async () => {
+    retrieveProductWithDefaultPriceMock.mockRejectedValueOnce(
+      new Error("stripe down"),
+    );
+
+    const { getSubscriptionCatalog } = await import(
+      "./subscription-catalog.service"
+    );
+
+    await expect(getSubscriptionCatalog()).rejects.toThrow();
+
+    mockProducts();
+    const catalog = await getSubscriptionCatalog();
+    expect(catalog.starter.credits).toBe(1750);
+  });
+
+  it("invalidates the cached catalog on demand", async () => {
+    mockProducts();
+
+    const { getSubscriptionCatalog, invalidateSubscriptionCatalogCache } =
+      await import("./subscription-catalog.service");
+
+    await getSubscriptionCatalog();
+    await getSubscriptionCatalog();
+    expect(retrieveProductWithDefaultPriceMock).toHaveBeenCalledTimes(3);
+
+    invalidateSubscriptionCatalogCache();
+
+    await getSubscriptionCatalog();
+    expect(retrieveProductWithDefaultPriceMock).toHaveBeenCalledTimes(6);
+  });
+});

--- a/apps/core/src/services/subscription-catalog.service.ts
+++ b/apps/core/src/services/subscription-catalog.service.ts
@@ -1,0 +1,177 @@
+import {
+  FREE_SUBSCRIPTION_MONTHLY_CREDITS,
+  type PaidSubscriptionPlanName,
+  type SelfServeSubscriptionPlanName,
+} from "@sokosumi/utils";
+import type Stripe from "stripe";
+
+import { stripeClient } from "@/clients/stripe.client";
+import { getEnv } from "@/config/env";
+
+/**
+ * Port of the web app's subscription catalog
+ * (`apps/web/src/lib/stripe/subscription-catalog.ts`) for core's invoice
+ * credit engine. Deliberately keeps its own cache, separate from
+ * `subscription-seat-credits.service`, so a stricter catalog validation
+ * failure (price/slug metadata) cannot break the seat-assignment grant flow.
+ */
+export interface SubscriptionCatalogPlan {
+  credits: number;
+  currency: string;
+  monthlyAmount: number;
+  name: SelfServeSubscriptionPlanName;
+  priceId: string;
+  productId: string;
+  slug: string;
+}
+
+export interface SubscriptionCatalog {
+  free: SubscriptionCatalogPlan;
+  pro: SubscriptionCatalogPlan;
+  standard: SubscriptionCatalogPlan;
+  starter: SubscriptionCatalogPlan;
+}
+
+interface RawPlanConfig {
+  name: PaidSubscriptionPlanName;
+  productId: string;
+}
+
+type MonthlyStripePrice = Stripe.Price & { unit_amount: number };
+
+let catalogCache: Promise<SubscriptionCatalog> | null = null;
+
+function getPaidPlanConfig(): RawPlanConfig[] {
+  const env = getEnv();
+
+  return [
+    {
+      name: "starter",
+      productId: env.STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID,
+    },
+    {
+      name: "standard",
+      productId: env.STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID,
+    },
+    {
+      name: "pro",
+      productId: env.STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID,
+    },
+  ];
+}
+
+function parseCredits(rawValue: string | undefined, planName: string): number {
+  if (!rawValue) {
+    throw new Error(`Missing credits metadata for ${planName} plan`);
+  }
+
+  const credits = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(credits) || credits <= 0) {
+    throw new Error(`Invalid credits metadata for ${planName} plan`);
+  }
+  return credits;
+}
+
+function parseSlug(rawValue: string | undefined, planName: string): string {
+  if (!rawValue) {
+    throw new Error(`Missing slug metadata for ${planName} plan`);
+  }
+
+  const slug = rawValue.trim().toLowerCase();
+  if (slug !== planName) {
+    throw new Error(`Unexpected slug metadata for ${planName} plan: ${slug}`);
+  }
+  return slug;
+}
+
+function parsePrice(
+  defaultPrice: Stripe.Price | string | null | undefined,
+  planName: PaidSubscriptionPlanName,
+): MonthlyStripePrice {
+  if (!defaultPrice || typeof defaultPrice === "string") {
+    throw new Error(`Default price is not expanded for ${planName} plan`);
+  }
+
+  if (defaultPrice.type !== "recurring" || !defaultPrice.recurring) {
+    throw new Error(`${planName} plan must have recurring pricing`);
+  }
+
+  if (
+    defaultPrice.recurring.interval !== "month" ||
+    defaultPrice.recurring.interval_count !== 1
+  ) {
+    throw new Error(`${planName} plan must have monthly recurring pricing`);
+  }
+
+  if (defaultPrice.unit_amount === null || defaultPrice.unit_amount < 0) {
+    throw new Error(`Invalid unit amount for ${planName} plan`);
+  }
+
+  return defaultPrice as MonthlyStripePrice;
+}
+
+async function loadCatalog(): Promise<SubscriptionCatalog> {
+  const paidEntries = await Promise.all(
+    getPaidPlanConfig().map(async (rawPlan) => {
+      const product = await stripeClient.retrieveProductWithDefaultPrice(
+        rawPlan.productId,
+      );
+
+      const price = parsePrice(product.default_price, rawPlan.name);
+      const slug = parseSlug(product.metadata.slug, rawPlan.name);
+      const credits = parseCredits(product.metadata.credits, rawPlan.name);
+
+      return [
+        rawPlan.name,
+        {
+          credits,
+          currency: price.currency,
+          monthlyAmount: price.unit_amount,
+          name: rawPlan.name,
+          priceId: price.id,
+          productId: rawPlan.productId,
+          slug,
+        },
+      ] as const;
+    }),
+  );
+
+  const paidCatalog = Object.fromEntries(paidEntries) as Omit<
+    SubscriptionCatalog,
+    "free"
+  >;
+
+  const freePlan: SubscriptionCatalogPlan = {
+    credits: FREE_SUBSCRIPTION_MONTHLY_CREDITS,
+    currency: paidCatalog.starter.currency,
+    monthlyAmount: 0,
+    name: "free",
+    priceId: "",
+    productId: "local-free",
+    slug: "free",
+  };
+
+  return {
+    free: freePlan,
+    ...paidCatalog,
+  };
+}
+
+export function invalidateSubscriptionCatalogCache(): void {
+  catalogCache = null;
+}
+
+/**
+ * Resolves the full self-serve subscription catalog from Stripe, caching the
+ * result for the process lifetime (a failed load is not cached and is retried
+ * on the next call).
+ */
+export async function getSubscriptionCatalog(): Promise<SubscriptionCatalog> {
+  if (!catalogCache) {
+    catalogCache = loadCatalog().catch((err) => {
+      catalogCache = null;
+      throw err;
+    });
+  }
+  return await catalogCache;
+}

--- a/apps/core/src/services/task-topup.service.ts
+++ b/apps/core/src/services/task-topup.service.ts
@@ -1,0 +1,63 @@
+import { type Prisma, TaskEventOrigin } from "@sokosumi/database";
+import { TaskStatus } from "@sokosumi/utils";
+
+function isPrismaRecordNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "P2025"
+  );
+}
+
+/**
+ * Flip OUT_OF_CREDITS tasks to CREDITS_TOPPED_UP after a credit grant, scoped
+ * to the organization when one is given, otherwise to the user. Tasks updated
+ * concurrently (P2025) are skipped so the surrounding grant transaction is
+ * never rolled back by a task race.
+ */
+export async function markOutOfCreditsTasksAsToppedUp(params: {
+  organizationId: string | null;
+  tx: Prisma.TransactionClient;
+  userId: string;
+}): Promise<void> {
+  const tasks = await params.tx.task.findMany({
+    where: {
+      ...(params.organizationId
+        ? { organizationId: params.organizationId }
+        : { userId: params.userId }),
+      status: TaskStatus.OUT_OF_CREDITS,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  for (const task of tasks) {
+    try {
+      await params.tx.task.update({
+        where: {
+          id: task.id,
+          status: TaskStatus.OUT_OF_CREDITS,
+        },
+        data: {
+          status: TaskStatus.CREDITS_TOPPED_UP,
+          events: {
+            create: {
+              status: TaskStatus.CREDITS_TOPPED_UP,
+              origin: TaskEventOrigin.SOKOSUMI,
+              userId: params.userId,
+              coworkerId: null,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (isPrismaRecordNotFoundError(error)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+}

--- a/apps/core/src/test/setup.ts
+++ b/apps/core/src/test/setup.ts
@@ -20,6 +20,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID: "prod_starter_test",
   STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: "prod_standard_test",
   STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: "prod_pro_test",
+  STRIPE_CREDIT_PRODUCT_ID: "prod_credit_test",
   STRIPE_WEBHOOK_SECRET: "whsec_test_example",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",


### PR DESCRIPTION
## Summary

Webhook-migration PR 3 of 5. Ports `handleInvoicePaidEvent` — the credits engine — from `apps/web/src/lib/stripe/webhook-handlers.ts` to core's webhook receiver (#3126).

- **New `stripe-invoice-credit.service.ts`**: faithful port of the ~320-line invoice.paid handler (top-up grants with `credits`/`ttl_days` metadata, subscription cycle/create/update credits, proration, seat-cap, org member split with deterministic remainder, unassigned-member free tier, enterprise-contract gating, replay idempotency via `CreditBucket @@unique([referenceId,referenceType])` + membership-change replay guard).
- **Deliberate behavior change (the lost-credits bug fix from the migration plan)**: an unknown `stripeCustomerId` now **throws → webhook responds 5xx → Stripe retries**. The web path silently returned 200, so an invoice arriving before the customer-id write-back landed lost its credits **permanently**. All other early-returns (no id/customer/amount/lines, no members, no owner) keep exact web parity.
- **New `subscription-catalog.service.ts`**: port of web's Stripe catalog (credits + monthlyAmount + priceId per plan, slug/price validation, synthetic local-free tier, promise cache with failed-load retry). Kept **separate** from `subscription-seat-credits.service` so the stricter catalog validation cannot affect the seat-assignment grant flow (#3109).
- **Consolidation**: `markOutOfCreditsTasksAsToppedUp` was duplicated verbatim between web's webhook handlers and core's `organization-seat.service` (#3109). Now a single shared `task-topup.service.ts` (generalized to org-or-user scope); `organization-seat.service` drops its private copy.
- Dispatcher: `invoice.paid` case with Sentry tagging parity to web's `onEvent` (tags `stripeEventType`/`invoiceId`, extra `eventId`/`invoice`/`customer`).
- `stripeClient.retrieveProductWithDefaultPrice` (expand `default_price`) for the catalog load.
- New **required** env var `STRIPE_CREDIT_PRODUCT_ID` (same value as web's).

**Web is intentionally untouched.** `invoice.paid` grants are dedupe-safe (unique reference ids + in-txn existence checks), so both endpoints may receive events during the dashboard partition window. Web's `handleInvoicePaidEvent` also backs the admin invoice replay flow (`invoice-admin.service`), so it stays until that service migrates.

## User-facing impact

None until `invoice.paid` is added to core's Stripe dashboard endpoint subscription. After cutover: credit grants for paid invoices are processed by core, and a race that could permanently lose credits becomes a retried event.

## ⚠️ Merge prerequisites

1. Set `STRIPE_CREDIT_PRODUCT_ID` on **sokosumi-core-mainnet** and **sokosumi-core-preprod** BEFORE merging (required env — core will not boot without it). Same value as the web app's `STRIPE_CREDIT_PRODUCT_ID`.

## Cutover steps (after merge + deploy)

1. Add `invoice.paid` to the core dashboard endpoint's subscribed events.
2. Remove `invoice.paid` from the web endpoint's subscribed events (brief overlap is safe — grants are idempotent).

## Verification

- `pnpm --filter @sokosumi/core typecheck` ✅
- `pnpm --filter @sokosumi/core test` — 187 files / 1359 tests ✅ (all ~28 web invoice.paid tests ported 1:1 including exact BigInt amounts, plus new tests: unknown-customer throws, dispatcher invoice.paid routing + Sentry parity, catalog build/validation/cache)
- `biome check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)