### PR TITLE
chore: ignore .playwright-mcp session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ lint-report.json
 
 # next-agents-md
 /.next-docs/
+
+# playwright mcp session artifacts
+/.playwright-mcp/


### PR DESCRIPTION
## Summary

Adds `/.playwright-mcp/` to `.gitignore`. The folder holds local Playwright MCP session artifacts (console logs, page snapshots) regenerated on every browser session — machine-specific debug output with no value in the repo.

## Verification

- `git status` no longer reports `.playwright-mcp/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)