### PR TITLE
feat(core): port the customer.created handler and welcome coupon to the stripe webhook receiver

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -48,6 +48,9 @@ STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID="<stripe-pro-subscription-product-id>"
 # Stripe one-time credit top-up product (invoice.paid credit engine)
 STRIPE_CREDIT_PRODUCT_ID="<stripe-credit-product-id>"
 
+# Welcome coupon granted to new user customers (customer.created handler)
+STRIPE_WELCOME_COUPON="<stripe-welcome-coupon>"
+
 # Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
 STRIPE_WEBHOOK_SECRET="<stripe-webhook-secret>"
 LOCK_TIMEOUT="120000"

--- a/apps/core/src/clients/stripe.client.test.ts
+++ b/apps/core/src/clients/stripe.client.test.ts
@@ -175,10 +175,14 @@ describe("stripeClient", () => {
       "grant-coupon_1-user-1",
     );
 
+    // The description is part of Stripe's idempotent request body — it must
+    // stay byte-identical to the web client so cross-app replays of the same
+    // key succeed instead of failing with idempotency_error.
     expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         customer: "cus_1",
         quantity: 500,
+        description: "Referral credit redemption (500 credits) - 1 of 1",
       }),
       expect.anything(),
     );

--- a/apps/core/src/clients/stripe.client.test.ts
+++ b/apps/core/src/clients/stripe.client.test.ts
@@ -1,14 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { stripeConstructorMock, stripeCustomersCreateMock } = vi.hoisted(() => ({
+const {
+  stripeConstructorMock,
+  stripeCouponsRetrieveMock,
+  stripeCustomersCreateMock,
+  stripeInvoiceItemsCreateMock,
+  stripeInvoicesCreateMock,
+  stripeInvoicesFinalizeMock,
+  stripePricesListMock,
+  stripeProductsRetrieveMock,
+} = vi.hoisted(() => ({
   stripeConstructorMock: vi.fn(),
+  stripeCouponsRetrieveMock: vi.fn(),
   stripeCustomersCreateMock: vi.fn(),
+  stripeInvoiceItemsCreateMock: vi.fn(),
+  stripeInvoicesCreateMock: vi.fn(),
+  stripeInvoicesFinalizeMock: vi.fn(),
+  stripePricesListMock: vi.fn(),
+  stripeProductsRetrieveMock: vi.fn(),
 }));
 
 vi.mock("stripe", () => ({
   default: class StripeMock {
     customers = {
       create: (...args: unknown[]) => stripeCustomersCreateMock(...args),
+    };
+
+    coupons = {
+      retrieve: (...args: unknown[]) => stripeCouponsRetrieveMock(...args),
+    };
+
+    products = {
+      retrieve: (...args: unknown[]) => stripeProductsRetrieveMock(...args),
+    };
+
+    prices = {
+      list: (...args: unknown[]) => stripePricesListMock(...args),
+    };
+
+    invoiceItems = {
+      create: (...args: unknown[]) => stripeInvoiceItemsCreateMock(...args),
+    };
+
+    invoices = {
+      create: (...args: unknown[]) => stripeInvoicesCreateMock(...args),
+      finalizeInvoice: (...args: unknown[]) =>
+        stripeInvoicesFinalizeMock(...args),
     };
 
     constructor(secretKey: string, options?: unknown) {
@@ -19,9 +56,34 @@ vi.mock("stripe", () => ({
 
 vi.mock("@/config/env", () => ({
   getEnv: () => ({
+    STRIPE_CREDIT_PRODUCT_ID: "prod_credit",
     STRIPE_SECRET_KEY: "sk_test_core",
   }),
 }));
+
+function mockCreditProductAndCoupon(
+  couponMetadata: Record<string, string> = { credits: "500" },
+): void {
+  stripeProductsRetrieveMock.mockResolvedValue({
+    default_price: {
+      id: "price_credits",
+      currency: "eur",
+      unit_amount: 120,
+      unit_amount_decimal: "120",
+    },
+  });
+  stripeCouponsRetrieveMock.mockResolvedValue({
+    id: "coupon_1",
+    metadata: couponMetadata,
+    percent_off: 100,
+  });
+  stripeInvoiceItemsCreateMock.mockResolvedValue({ id: "ii_1" });
+  stripeInvoicesCreateMock.mockResolvedValue({ id: "in_1" });
+  stripeInvoicesFinalizeMock.mockResolvedValue({
+    id: "in_1",
+    status: "paid",
+  });
+}
 
 describe("stripeClient", () => {
   beforeEach(() => {
@@ -94,5 +156,185 @@ describe("stripeClient", () => {
         timeout: 2500,
       },
     );
+  });
+
+  it("returns null when a coupon lookup fails", async () => {
+    stripeCouponsRetrieveMock.mockRejectedValue(new Error("missing"));
+    const { stripeClient } = await import("./stripe.client");
+
+    await expect(stripeClient.getCouponById("coupon_gone")).resolves.toBeNull();
+  });
+
+  it("creates invoice items with quantity matching coupon credits", async () => {
+    mockCreditProductAndCoupon();
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "grant-coupon_1-user-1",
+    );
+
+    expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_1",
+        quantity: 500,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("passes derived idempotency keys to every stripe call", async () => {
+    mockCreditProductAndCoupon();
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "welcome-coupon_1-user-1",
+    );
+
+    expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        idempotencyKey: "welcome-coupon_1-user-1-item-1",
+      },
+    );
+    expect(stripeInvoicesCreateMock).toHaveBeenCalledWith(expect.anything(), {
+      idempotencyKey: "welcome-coupon_1-user-1-invoice",
+    });
+    expect(stripeInvoicesFinalizeMock).toHaveBeenCalledWith(
+      "in_1",
+      {},
+      { idempotencyKey: "welcome-coupon_1-user-1-finalize" },
+    );
+  });
+
+  it("derives a distinct idempotency key per referral invoice item", async () => {
+    mockCreditProductAndCoupon();
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "referral-coupon_1-user-1-2",
+      undefined,
+      2,
+    );
+
+    expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledTimes(2);
+    expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        idempotencyKey: "referral-coupon_1-user-1-2-item-1",
+      },
+    );
+    expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        idempotencyKey: "referral-coupon_1-user-1-2-item-2",
+      },
+    );
+  });
+
+  it("propagates custom metadata onto invoice metadata", async () => {
+    mockCreditProductAndCoupon();
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "welcome-coupon_1-user-1",
+      {
+        redemption_type: "welcome_coupon",
+        welcome_source: "customer.created",
+      },
+    );
+
+    expect(stripeInvoicesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          coupon_id: "coupon_1",
+          price_id: "price_credits",
+          redemption_type: "welcome_coupon",
+          welcome_source: "customer.created",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("propagates coupon ttl_days metadata onto invoice metadata", async () => {
+    mockCreditProductAndCoupon({ credits: "500", ttl_days: "90" });
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.applyInvoiceCreditsToCustomer(
+      "cus_1",
+      "coupon_1",
+      "grant-coupon_1-user-1",
+    );
+
+    expect(stripeInvoicesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          coupon_id: "coupon_1",
+          price_id: "price_credits",
+          ttl_days: "90",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to listed prices when the default price is not a valid credit price", async () => {
+    stripeProductsRetrieveMock.mockResolvedValue({
+      default_price: {
+        id: "price_bad",
+        currency: "gbp",
+        unit_amount: 120,
+        unit_amount_decimal: "120",
+      },
+    });
+    stripePricesListMock.mockResolvedValue({
+      data: [
+        {
+          id: "price_usd",
+          currency: "usd",
+          unit_amount: 100,
+          unit_amount_decimal: "100",
+        },
+        {
+          id: "price_eur",
+          currency: "eur",
+          unit_amount: 120,
+          unit_amount_decimal: "120",
+        },
+      ],
+    });
+    const { stripeClient } = await import("./stripe.client");
+
+    const price = await stripeClient.getPriceByProductId("prod_credit");
+
+    // eur is preferred over usd regardless of list order
+    expect(price).toEqual({
+      id: "price_eur",
+      amountPerCredit: 120,
+      currency: "eur",
+    });
+  });
+
+  it("rejects coupons without positive integer credits metadata", async () => {
+    mockCreditProductAndCoupon({ credits: "-5" });
+    const { stripeClient } = await import("./stripe.client");
+
+    await expect(
+      stripeClient.applyInvoiceCreditsToCustomer(
+        "cus_1",
+        "coupon_1",
+        "grant-coupon_1-user-1",
+      ),
+    ).rejects.toThrow("Coupon metadata credits must be a positive integer");
+
+    expect(stripeInvoiceItemsCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -15,9 +15,23 @@ interface CreateUserCustomerInput {
   userId: string;
 }
 
+export interface CreditPrice {
+  id: string;
+  amountPerCredit: number;
+  currency: string;
+}
+
 const stripe = new Stripe(getEnv().STRIPE_SECRET_KEY, {
   maxNetworkRetries: 0,
 });
+
+// Mirrors the web stripe client's credit-price selection
+// (`apps/web/src/lib/clients/stripe.client.ts`).
+const MAX_REFERRAL_COUNT = 4; // max number of referral credits to apply
+const SUPPORTED_CREDIT_PRICE_CURRENCIES = ["eur", "usd"] as const;
+const SUPPORTED_CREDIT_PRICE_CURRENCY_SET = new Set<string>(
+  SUPPORTED_CREDIT_PRICE_CURRENCIES,
+);
 
 function withIdempotencyKey(
   idempotencyKey: string,
@@ -28,6 +42,87 @@ function withIdempotencyKey(
     idempotencyKey,
     maxNetworkRetries: requestOptions?.maxNetworkRetries ?? 0,
   };
+}
+
+function isSupportedCreditPriceCurrency(currency: string): boolean {
+  return SUPPORTED_CREDIT_PRICE_CURRENCY_SET.has(currency);
+}
+
+function getStripeUnitAmount(price: Stripe.Price): number | null {
+  if (price.unit_amount_decimal !== null) {
+    const decimalAmount = Number(price.unit_amount_decimal);
+    return Number.isFinite(decimalAmount) ? decimalAmount : null;
+  }
+
+  if (price.unit_amount !== null) {
+    return price.unit_amount;
+  }
+
+  return null;
+}
+
+function isValidCreditPrice(price: Stripe.Price): boolean {
+  const amountPerCredit = getStripeUnitAmount(price);
+  return (
+    isSupportedCreditPriceCurrency(price.currency) &&
+    amountPerCredit !== null &&
+    amountPerCredit > 0
+  );
+}
+
+function selectPreferredCreditPrice(
+  prices: Stripe.Price[],
+): Stripe.Price | null {
+  for (const currency of SUPPORTED_CREDIT_PRICE_CURRENCIES) {
+    const matchedPrice = prices.find(
+      (price) => price.currency === currency && isValidCreditPrice(price),
+    );
+    if (matchedPrice) {
+      return matchedPrice;
+    }
+  }
+
+  return null;
+}
+
+function validatePrice(price: Stripe.Price): CreditPrice {
+  const amountPerCredit = getStripeUnitAmount(price);
+
+  if (!isSupportedCreditPriceCurrency(price.currency)) {
+    throw new Error(`Unsupported credit price currency: ${price.currency}`);
+  }
+  if (amountPerCredit === null) {
+    throw new Error("Price unit_amount and unit_amount_decimal are invalid");
+  }
+  if (amountPerCredit <= 0) {
+    throw new Error(
+      "Price unit_amount is 0 (free product) – cannot use for credit purchase",
+    );
+  }
+  return {
+    id: price.id,
+    amountPerCredit,
+    currency: price.currency,
+  };
+}
+
+function getCreditsForCoupon(coupon: Stripe.Coupon): number {
+  if (!coupon.percent_off) {
+    throw new Error("Coupon must have percent_off");
+  }
+
+  const creditsRaw = coupon.metadata?.credits;
+  if (!creditsRaw) {
+    throw new Error(
+      "Coupon metadata must include credits as a positive integer",
+    );
+  }
+
+  const credits = Number(creditsRaw);
+  if (!Number.isFinite(credits) || !Number.isInteger(credits) || credits <= 0) {
+    throw new Error("Coupon metadata credits must be a positive integer");
+  }
+  return credits;
 }
 
 export const stripeClient = {
@@ -150,5 +245,139 @@ export const stripeClient = {
       signature,
       getEnv().STRIPE_WEBHOOK_SECRET,
     );
+  },
+
+  async getCouponById(couponId: string): Promise<Stripe.Coupon | null> {
+    try {
+      return await stripe.coupons.retrieve(couponId);
+    } catch {
+      return null;
+    }
+  },
+
+  async getPriceByProductId(productId: string): Promise<CreditPrice> {
+    try {
+      const product = await stripe.products.retrieve(productId, {
+        expand: ["default_price"],
+      });
+
+      if (
+        typeof product.default_price === "object" &&
+        product.default_price !== null &&
+        isValidCreditPrice(product.default_price)
+      ) {
+        return validatePrice(product.default_price);
+      }
+
+      const productPrices = await stripe.prices.list({
+        product: productId,
+        active: true,
+        limit: 100,
+      });
+      const fallbackPrice = selectPreferredCreditPrice(productPrices.data);
+      if (!fallbackPrice) {
+        throw new Error(
+          `No valid credit price found for product ${productId}. Expected currencies: ${SUPPORTED_CREDIT_PRICE_CURRENCIES.join(", ")}`,
+        );
+      }
+
+      return validatePrice(fallbackPrice);
+    } catch (error) {
+      console.error("Error retrieving price", error);
+      throw error;
+    }
+  },
+
+  /**
+   * Grants free credits by creating discounted invoice items and a
+   * zero-total invoice. Port of the web stripe client's method — the derived
+   * idempotency keys and request params MUST stay identical so a
+   * `customer.created` redelivery that already ran through the web handler
+   * replays the original grant instead of failing or double-granting.
+   *
+   * `idempotencyKeyBase` makes the whole grant idempotent against retries:
+   * every Stripe call derives its own key from the base (`-item-N`,
+   * `-invoice`, `-finalize`). The base MUST be stable across retries of the
+   * same logical grant and unique per legitimately distinct grant — derive it
+   * from domain identifiers, never from timestamps or randomness.
+   */
+  async applyInvoiceCreditsToCustomer(
+    customerId: string,
+    couponId: string,
+    idempotencyKeyBase: string,
+    metadata?: Record<string, string>,
+    referralCount: number = 1,
+  ): Promise<Stripe.Invoice> {
+    const productId = getEnv().STRIPE_CREDIT_PRODUCT_ID;
+    const price = await this.getPriceByProductId(productId);
+
+    const coupon = await stripe.coupons.retrieve(couponId);
+    if (!coupon) throw new Error("Coupon not found");
+    if (!coupon.percent_off) {
+      throw new Error("Coupon must have percent_off");
+    }
+    const credits = getCreditsForCoupon(coupon);
+    const couponTtlDays = coupon.metadata?.ttl_days;
+
+    // 1) Add invoice items representing the free credits
+    const itemsToCreate = Math.min(referralCount, MAX_REFERRAL_COUNT);
+    await Promise.all(
+      Array.from({ length: itemsToCreate }).map((_, index) =>
+        stripe.invoiceItems.create(
+          {
+            customer: customerId,
+            pricing: { price: price.id },
+            currency: price.currency,
+            quantity: credits,
+            description: `Referral credit redemption (${credits} credits) - ${index + 1} of ${itemsToCreate}`,
+            metadata: {
+              coupon_id: couponId,
+              redemption_type: "free_coupon",
+              ...(couponTtlDays ? { ttl_days: couponTtlDays } : {}),
+              ...(metadata ?? {}),
+            },
+            discounts: [{ coupon: couponId }],
+          },
+          {
+            idempotencyKey: `${idempotencyKeyBase}-item-${index + 1}`,
+          },
+        ),
+      ),
+    );
+
+    // 2) Create & finalize zero-total invoice with the coupon discount
+    const invoice = await stripe.invoices.create(
+      {
+        customer: customerId,
+        currency: price.currency,
+        pending_invoice_items_behavior: "include",
+        collection_method: "charge_automatically",
+        auto_advance: true,
+        metadata: {
+          coupon_id: couponId,
+          price_id: price.id,
+          ...(couponTtlDays ? { ttl_days: couponTtlDays } : {}),
+          ...(metadata ?? {}),
+        },
+        expand: ["lines.data.price.product"],
+      },
+      {
+        idempotencyKey: `${idempotencyKeyBase}-invoice`,
+      },
+    );
+
+    if (!invoice.id) {
+      throw new Error("Failed to create credit invoice");
+    }
+
+    const finalizedInvoice = await stripe.invoices.finalizeInvoice(
+      invoice.id,
+      {},
+      {
+        idempotencyKey: `${idempotencyKeyBase}-finalize`,
+      },
+    );
+
+    return finalizedInvoice;
   },
 };

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -97,6 +97,9 @@ const envSchema = z.object({
   // Stripe one-time credit top-up product (invoice.paid credit engine)
   STRIPE_CREDIT_PRODUCT_ID: z.string().min(1),
 
+  // Welcome coupon granted to new user customers (customer.created handler)
+  STRIPE_WELCOME_COUPON: z.string().min(1),
+
   // Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
   STRIPE_WEBHOOK_SECRET: z.string().min(1),
 

--- a/apps/core/src/services/stripe-customer-created.service.test.ts
+++ b/apps/core/src/services/stripe-customer-created.service.test.ts
@@ -1,0 +1,279 @@
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  applyInvoiceCreditsToCustomerMock,
+  ensureInitialLocalFreeSubscriptionPeriodMock,
+  getCouponByIdMock,
+  getUserByIdMock,
+  prismaOrganizationUpdateMock,
+  prismaUserUpdateMock,
+} = vi.hoisted(() => ({
+  applyInvoiceCreditsToCustomerMock: vi.fn(),
+  ensureInitialLocalFreeSubscriptionPeriodMock: vi.fn(),
+  getCouponByIdMock: vi.fn(),
+  getUserByIdMock: vi.fn(),
+  prismaOrganizationUpdateMock: vi.fn(),
+  prismaUserUpdateMock: vi.fn(),
+}));
+
+vi.mock("@sokosumi/database/helpers", () => ({
+  ensureInitialLocalFreeSubscriptionPeriod:
+    ensureInitialLocalFreeSubscriptionPeriodMock,
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  userRepository: {
+    getUserById: getUserByIdMock,
+  },
+}));
+
+vi.mock("@/clients/stripe.client", () => ({
+  stripeClient: {
+    applyInvoiceCreditsToCustomer: applyInvoiceCreditsToCustomerMock,
+    getCouponById: getCouponByIdMock,
+  },
+}));
+
+vi.mock("@/config/env", () => ({
+  getEnv: () => ({
+    STRIPE_WELCOME_COUPON: "coupon_welcome",
+  }),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: (callback: (tx: unknown) => unknown) => callback({}),
+    organization: {
+      update: (...args: unknown[]) => prismaOrganizationUpdateMock(...args),
+    },
+    user: {
+      update: (...args: unknown[]) => prismaUserUpdateMock(...args),
+    },
+  },
+}));
+
+async function getService() {
+  return await import("./stripe-customer-created.service");
+}
+
+describe("handleCustomerCreatedEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ensureInitialLocalFreeSubscriptionPeriodMock.mockResolvedValue(undefined);
+    prismaUserUpdateMock.mockResolvedValue({
+      createdAt: new Date("2026-04-09T07:03:48.591Z"),
+      id: "user-1",
+    });
+    prismaOrganizationUpdateMock.mockResolvedValue({
+      createdAt: new Date("2026-04-09T07:03:48.591Z"),
+      id: "org-1",
+    });
+    getUserByIdMock.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+      stripeCustomerId: "cus_user_1",
+    });
+    getCouponByIdMock.mockResolvedValue({ id: "coupon_welcome" });
+    applyInvoiceCreditsToCustomerMock.mockResolvedValue({
+      id: "in_welcome_1",
+      status: "paid",
+    });
+  });
+
+  it("stores Stripe customer ids for newly created organization customers without claiming a coupon", async () => {
+    const { handleCustomerCreatedEvent } = await getService();
+
+    await handleCustomerCreatedEvent({
+      id: "cus_org_1",
+      metadata: {
+        customerType: "organization",
+        organizationId: "org-1",
+      },
+    } as never);
+
+    expect(prismaOrganizationUpdateMock).toHaveBeenCalledWith({
+      where: { id: "org-1" },
+      data: { stripeCustomerId: "cus_org_1" },
+    });
+    expect(ensureInitialLocalFreeSubscriptionPeriodMock).toHaveBeenCalledWith(
+      {
+        createdAt: new Date("2026-04-09T07:03:48.591Z"),
+        kind: "organization",
+        organizationId: "org-1",
+        stripeCustomerId: "cus_org_1",
+      },
+      expect.anything(),
+    );
+    expect(applyInvoiceCreditsToCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("claims the welcome coupon for user customers with the stable idempotency key base", async () => {
+    const { handleCustomerCreatedEvent } = await getService();
+
+    await handleCustomerCreatedEvent({
+      id: "cus_user_1",
+      metadata: {
+        customerType: "user",
+        userId: "user-1",
+      },
+    } as never);
+
+    expect(prismaUserUpdateMock).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { stripeCustomerId: "cus_user_1" },
+    });
+    expect(ensureInitialLocalFreeSubscriptionPeriodMock).toHaveBeenCalledWith(
+      {
+        createdAt: new Date("2026-04-09T07:03:48.591Z"),
+        kind: "user",
+        stripeCustomerId: "cus_user_1",
+        userId: "user-1",
+      },
+      expect.anything(),
+    );
+    expect(applyInvoiceCreditsToCustomerMock).toHaveBeenCalledWith(
+      "cus_user_1",
+      "coupon_welcome",
+      "welcome-coupon_welcome-user-1",
+      {
+        redemption_type: "welcome_coupon",
+        welcome_source: "customer.created",
+        user_id: "user-1",
+        user_email: "user@example.com",
+      },
+    );
+  });
+
+  it("ignores customers with an unknown customer type", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const { handleCustomerCreatedEvent } = await getService();
+
+      await handleCustomerCreatedEvent({
+        id: "cus_other_1",
+        metadata: { customerType: "something-else" },
+      } as never);
+
+      expect(prismaUserUpdateMock).not.toHaveBeenCalled();
+      expect(prismaOrganizationUpdateMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Unknown customer type something-else",
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
+  });
+
+  it("does not fail customer creation when the welcome coupon claim fails", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    applyInvoiceCreditsToCustomerMock.mockRejectedValue(
+      new Error("stripe down"),
+    );
+
+    try {
+      const { handleCustomerCreatedEvent } = await getService();
+
+      await expect(
+        handleCustomerCreatedEvent({
+          id: "cus_user_1",
+          metadata: {
+            customerType: "user",
+            userId: "user-1",
+          },
+        } as never),
+      ).resolves.toBeUndefined();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "⚠️ Failed to claim welcome coupon for user user-1",
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("rethrows when the user write-back fails so Stripe retries the event", async () => {
+    prismaUserUpdateMock.mockRejectedValue(new Error("user missing"));
+
+    const { handleCustomerCreatedEvent } = await getService();
+
+    await expect(
+      handleCustomerCreatedEvent({
+        id: "cus_user_1",
+        metadata: {
+          customerType: "user",
+          userId: "user-1",
+        },
+      } as never),
+    ).rejects.toThrow("user missing");
+
+    expect(applyInvoiceCreditsToCustomerMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("claimWelcomeCoupon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserByIdMock.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+      stripeCustomerId: "cus_user_1",
+    });
+    getCouponByIdMock.mockResolvedValue({ id: "coupon_welcome" });
+    applyInvoiceCreditsToCustomerMock.mockResolvedValue({
+      id: "in_welcome_1",
+      status: "paid",
+    });
+  });
+
+  it("returns the paid invoice id on success", async () => {
+    const { claimWelcomeCoupon } = await getService();
+
+    await expect(claimWelcomeCoupon("user-1")).resolves.toEqual({
+      couponApplied: true,
+      invoiceId: "in_welcome_1",
+    });
+  });
+
+  it.each([
+    ["user missing", () => getUserByIdMock.mockResolvedValue(null)],
+    [
+      "user without stripe customer id",
+      () =>
+        getUserByIdMock.mockResolvedValue({
+          id: "user-1",
+          stripeCustomerId: null,
+        }),
+    ],
+    ["coupon missing", () => getCouponByIdMock.mockResolvedValue(null)],
+    [
+      "invoice not paid",
+      () =>
+        applyInvoiceCreditsToCustomerMock.mockResolvedValue({
+          id: "in_welcome_1",
+          status: "open" as Stripe.Invoice.Status,
+        }),
+    ],
+  ])("returns couponApplied false when %s", async (_label, arrange) => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    arrange();
+
+    try {
+      const { claimWelcomeCoupon } = await getService();
+
+      await expect(claimWelcomeCoupon("user-1")).resolves.toEqual({
+        couponApplied: false,
+        invoiceId: null,
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/apps/core/src/services/stripe-customer-created.service.ts
+++ b/apps/core/src/services/stripe-customer-created.service.ts
@@ -1,0 +1,133 @@
+import { ensureInitialLocalFreeSubscriptionPeriod } from "@sokosumi/database/helpers";
+import { userRepository } from "@sokosumi/database/repositories";
+import type Stripe from "stripe";
+
+import { stripeClient } from "@/clients/stripe.client";
+import { getEnv } from "@/config/env";
+import prisma from "@/lib/db/prisma";
+
+/**
+ * Port of the web app's welcome-coupon claim
+ * (`apps/web/src/lib/services/stripe.service.ts`). The idempotency key base
+ * (`welcome-{couponId}-{userId}`) MUST stay identical to the web flow so a
+ * `customer.created` redelivery replays the original grant instead of
+ * issuing a second invoice. Never throws — a failed claim is logged and
+ * reported as `couponApplied: false` so customer creation is not retried
+ * just because the coupon flow hiccupped.
+ */
+export async function claimWelcomeCoupon(
+  userId: string,
+): Promise<{ couponApplied: boolean; invoiceId: string | null }> {
+  const welcomeCouponId = getEnv().STRIPE_WELCOME_COUPON;
+
+  try {
+    const user = await userRepository.getUserById(userId, prisma);
+    if (!user) {
+      throw new Error("User not found");
+    }
+    if (!user.stripeCustomerId) {
+      throw new Error("User does not have a stripe customer id");
+    }
+
+    const coupon = await stripeClient.getCouponById(welcomeCouponId);
+    if (!coupon) {
+      throw new Error(`Coupon not found: ${welcomeCouponId}`);
+    }
+
+    // Stable per user+coupon: a `customer.created` webhook redelivery
+    // replays the original grant instead of issuing a second invoice.
+    const invoice = await stripeClient.applyInvoiceCreditsToCustomer(
+      user.stripeCustomerId,
+      coupon.id,
+      `welcome-${coupon.id}-${user.id}`,
+      {
+        redemption_type: "welcome_coupon",
+        welcome_source: "customer.created",
+        user_id: user.id,
+        user_email: user.email ?? "",
+      },
+    );
+
+    if (!invoice?.id) {
+      throw new Error("Failed to apply welcome coupon");
+    }
+    if (invoice.status !== "paid") {
+      throw new Error("Welcome coupon invoice is not paid");
+    }
+
+    return { couponApplied: true, invoiceId: invoice.id };
+  } catch (error) {
+    console.error(`Failed to claim welcome coupon for user ${userId}:`, error);
+    return { couponApplied: false, invoiceId: null };
+  }
+}
+
+/**
+ * Port of the web app's `handleCustomerCreatedEvent`
+ * (`apps/web/src/lib/stripe/webhook-handlers.ts`): writes the Stripe
+ * customer id back to the user/organization, seeds the initial local free
+ * subscription period, and claims the welcome coupon for user customers.
+ */
+export async function handleCustomerCreatedEvent(
+  customer: Stripe.Customer,
+): Promise<void> {
+  const metadata = customer.metadata;
+  switch (metadata?.customerType) {
+    case "user": {
+      const userId = metadata.userId;
+      const user = await prisma.user.update({
+        where: { id: userId },
+        data: { stripeCustomerId: customer.id },
+      });
+      console.log(`✅ Set user ${userId} stripe customer id to ${customer.id}`);
+
+      await prisma.$transaction(async (tx) => {
+        await ensureInitialLocalFreeSubscriptionPeriod(
+          {
+            createdAt: user.createdAt,
+            kind: "user",
+            stripeCustomerId: customer.id,
+            userId,
+          },
+          tx,
+        );
+      });
+
+      const { couponApplied, invoiceId } = await claimWelcomeCoupon(userId);
+      if (couponApplied && invoiceId) {
+        console.log(
+          `✅ Claimed welcome coupon for user ${userId}, invoice: ${invoiceId}`,
+        );
+      } else {
+        console.log(`⚠️ Failed to claim welcome coupon for user ${userId}`);
+      }
+      break;
+    }
+    case "organization": {
+      const organization = await prisma.organization.update({
+        where: { id: metadata.organizationId },
+        data: { stripeCustomerId: customer.id },
+      });
+      console.log(
+        `✅ Set organization ${metadata.organizationId} stripe customer id to ${customer.id}`,
+      );
+
+      await prisma.$transaction(async (tx) => {
+        await ensureInitialLocalFreeSubscriptionPeriod(
+          {
+            createdAt: organization.createdAt,
+            kind: "organization",
+            organizationId: metadata.organizationId,
+            stripeCustomerId: customer.id,
+          },
+          tx,
+        );
+      });
+      break;
+    }
+    default: {
+      console.log(`Unknown customer type ${metadata?.customerType}`);
+      break;
+    }
+  }
+}

--- a/apps/core/src/services/stripe-webhook.service.test.ts
+++ b/apps/core/src/services/stripe-webhook.service.test.ts
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   captureExceptionMock,
   getOrganizationWithRelationsByIdMock,
+  handleCustomerCreatedEventMock,
   handleInvoicePaidEventMock,
   updateOrganizationInvoiceEmailMock,
 } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
   getOrganizationWithRelationsByIdMock: vi.fn(),
+  handleCustomerCreatedEventMock: vi.fn(),
   handleInvoicePaidEventMock: vi.fn(),
   updateOrganizationInvoiceEmailMock: vi.fn(),
 }));
@@ -30,6 +32,10 @@ vi.mock("@/lib/db/prisma", () => ({
 
 vi.mock("@/services/stripe-invoice-credit.service", () => ({
   handleInvoicePaidEvent: handleInvoicePaidEventMock,
+}));
+
+vi.mock("@/services/stripe-customer-created.service", () => ({
+  handleCustomerCreatedEvent: handleCustomerCreatedEventMock,
 }));
 
 async function getStripeWebhookService() {
@@ -66,6 +72,23 @@ function createOrganizationCustomer(
   };
 }
 
+function createCustomerCreatedEvent(
+  customer: Partial<Stripe.Customer> = {},
+): Stripe.Event {
+  return {
+    id: "evt_created_123",
+    type: "customer.created",
+    data: {
+      object: {
+        id: "cus_new_123",
+        email: "new@example.com",
+        metadata: { customerType: "user", userId: "user_123" },
+        ...customer,
+      },
+    },
+  } as Stripe.Event;
+}
+
 function createInvoicePaidEvent(): Stripe.Event {
   return {
     id: "evt_inv_123",
@@ -91,6 +114,39 @@ describe("stripeWebhookService.handleEvent", () => {
       metadata: JSON.stringify({ invoiceEmail: "new@example.com" }),
     });
     handleInvoicePaidEventMock.mockResolvedValue(undefined);
+    handleCustomerCreatedEventMock.mockResolvedValue(undefined);
+  });
+
+  it("dispatches customer.created events to the customer-created handler", async () => {
+    const service = await getStripeWebhookService();
+
+    await service.handleEvent(createCustomerCreatedEvent());
+
+    expect(handleCustomerCreatedEventMock).toHaveBeenCalledTimes(1);
+    expect(handleCustomerCreatedEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "cus_new_123" }),
+    );
+  });
+
+  it("reports to Sentry and rethrows when the customer.created handler fails", async () => {
+    const failure = new Error("db down");
+    handleCustomerCreatedEventMock.mockRejectedValue(failure);
+    const service = await getStripeWebhookService();
+
+    await expect(
+      service.handleEvent(createCustomerCreatedEvent()),
+    ).rejects.toThrow("db down");
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          stripeEventType: "customer.created",
+          customerId: "cus_new_123",
+        }),
+        extra: expect.objectContaining({ eventId: "evt_created_123" }),
+      }),
+    );
   });
 
   it("dispatches invoice.paid events to the invoice credit handler", async () => {

--- a/apps/core/src/services/stripe-webhook.service.ts
+++ b/apps/core/src/services/stripe-webhook.service.ts
@@ -4,6 +4,7 @@ import { getOrganizationMetadata } from "@sokosumi/utils";
 import type Stripe from "stripe";
 
 import prisma from "@/lib/db/prisma";
+import { handleCustomerCreatedEvent } from "@/services/stripe-customer-created.service";
 import { handleInvoicePaidEvent } from "@/services/stripe-invoice-credit.service";
 
 /**
@@ -74,6 +75,26 @@ export const stripeWebhookService = {
                 typeof invoice.customer === "string"
                   ? invoice.customer
                   : invoice.customer?.id,
+            },
+          });
+          throw error;
+        }
+        break;
+      }
+      case "customer.created": {
+        const customer = event.data.object;
+        try {
+          await handleCustomerCreatedEvent(customer);
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: {
+              stripeEventType: event.type,
+              customerId: customer.id,
+            },
+            extra: {
+              eventId: event.id,
+              customer: customer.id,
+              email: customer.email,
             },
           });
           throw error;

--- a/apps/core/src/test/setup.ts
+++ b/apps/core/src/test/setup.ts
@@ -21,6 +21,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_STANDARD_SUBSCRIPTION_PRODUCT_ID: "prod_standard_test",
   STRIPE_PRO_SUBSCRIPTION_PRODUCT_ID: "prod_pro_test",
   STRIPE_CREDIT_PRODUCT_ID: "prod_credit_test",
+  STRIPE_WELCOME_COUPON: "coupon_welcome_test",
   STRIPE_WEBHOOK_SECRET: "whsec_test_example",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",


### PR DESCRIPTION
## Summary

Webhook-migration PR 4 of 5. Ports `handleCustomerCreatedEvent` and the welcome-coupon claim from web to core's webhook receiver (#3126, #3127).

- **New `stripe-customer-created.service.ts`**: faithful port of web's handler — writes `stripeCustomerId` back to the user/organization, seeds the initial local free subscription period (`ensureInitialLocalFreeSubscriptionPeriod`, shared helper), and claims the welcome coupon for user customers. Coupon-claim failure is logged but never fails the event (web parity); a failed customer write-back throws → 5xx → Stripe retries.
- **`claimWelcomeCoupon` port**: identical idempotency key base `welcome-{couponId}-{userId}` — critical, so a `customer.created` redelivery that already ran through the web handler before cutover replays the original grant on core instead of double-granting.
- **`stripeClient` additions** (ports of the web stripe client, identical request params + derived idempotency keys `-item-N`/`-invoice`/`-finalize`): `getCouponById`, `getPriceByProductId` (default-price + currency-preference fallback), `applyInvoiceCreditsToCustomer`, plus the credit-price validation helpers and coupon `credits` metadata parsing.
- Dispatcher: `customer.created` case with Sentry tagging parity to web's `onEvent`.
- New **required** env var `STRIPE_WELCOME_COUPON` (same value as web's).

**Web is intentionally untouched** — its `customer.created` case goes away in PR 5 once the dashboard partition is flipped.

## User-facing impact

None until `customer.created` is added to core's Stripe dashboard endpoint. After cutover: new-user welcome credits and customer-id write-backs are processed by core.

## ⚠️ Merge prerequisites

1. Set `STRIPE_WELCOME_COUPON` on **sokosumi-core-mainnet** and **sokosumi-core-preprod** BEFORE merging (required env — core will not boot without it). Same value as the web app's `STRIPE_WELCOME_COUPON`.

## Cutover steps (after merge + deploy)

Per the migration plan this event cuts over with **zero overlap** (the `stripe-customers` sync cron backstops any gap):
1. Remove `customer.created` from the **web** endpoint's subscribed events.
2. Add `customer.created` to the **core** endpoint's subscribed events.

(The welcome-coupon grant is idempotent via the stable key base, so accidental overlap is still safe — zero overlap is just the cleaner sequence.)

## Verification

- `pnpm --filter @sokosumi/core typecheck` ✅
- `pnpm --filter @sokosumi/core test` — 188 files / 1379 tests ✅ (web's customer.created tests ported; new: coupon-failure does not fail the event, write-back failure rethrows, claimWelcomeCoupon failure matrix, applyInvoiceCreditsToCustomer idempotency-key + metadata/ttl_days propagation + price-fallback + invalid-credits tests, dispatcher routing + Sentry parity)
- `biome check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)