### PR TITLE
refactor(web): remove stripe webhook handlers migrated to core

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -31,7 +31,6 @@ STRIPE_PRICE_ID=<replace-with-your-price-id>
 STRIPE_WEBHOOK_SECRET=<replace-with-your-webhook-secret>
 STRIPE_ONBOARD_PERSONAL_COUPON=<replace-with-stripe-onboard-personal-coupon>
 STRIPE_ONBOARD_ORGANIZATION_COUPON=<replace-with-stripe-onboard-organization-coupon>
-STRIPE_WELCOME_COUPON=<replace-with-stripe-welcome-coupon>
 STRIPE_SUPPORT_COUPON=<replace-with-stripe-support-coupon>
 STRIPE_CREDIT_PRODUCT_ID=<replace-with-stripe-credit-product-id>
 STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID=<replace-with-starter-subscription-product-id>

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -217,7 +217,7 @@ Stripe **test mode** and **live mode** are separate environments. The app does n
 2. **Stripe customer** – Users have a `stripeCustomerId` in your DB; in production that ID must refer to a customer in the **live** Stripe account. New production users get a customer created in live when they first use Stripe.
 3. **Auth in server actions** – When claiming a coupon from a server action, the credits flow passes the request auth into `stripeService.claimCoupon` so it does not rely on `getAuthContext()` again (which can be null in production if cookies/headers differ).
 
-Env vars that must be set per environment: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_CREDIT_PRODUCT_ID`, `STRIPE_ONBOARD_PERSONAL_COUPON`, `STRIPE_ONBOARD_ORGANIZATION_COUPON`, `STRIPE_WELCOME_COUPON` (and optionally `STRIPE_PUBLISHABLE_KEY` for client-side).
+Env vars that must be set per environment: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_CREDIT_PRODUCT_ID`, `STRIPE_ONBOARD_PERSONAL_COUPON`, `STRIPE_ONBOARD_ORGANIZATION_COUPON` (and optionally `STRIPE_PUBLISHABLE_KEY` for client-side). The welcome coupon (`STRIPE_WELCOME_COUPON`) is configured on the core app, which owns the `customer.created` webhook.
 
 **Enterprise subscription products:** Enterprise products are discovered from Stripe product metadata, not env vars. Configure each active enterprise product with `metadata.slug=enterprise`, `metadata.credits=<positive integer>`, and a monthly recurring `default_price`.
 

--- a/apps/web/src/config/env.secrets.ts
+++ b/apps/web/src/config/env.secrets.ts
@@ -53,7 +53,6 @@ const envSecretsSchema = z.object({
   STRIPE_CREDIT_PRODUCT_ID: z.string().min(1),
   STRIPE_ONBOARD_PERSONAL_COUPON: z.string().min(1),
   STRIPE_ONBOARD_ORGANIZATION_COUPON: z.string().min(1),
-  STRIPE_WELCOME_COUPON: z.string().min(1),
   // 100%-off coupon used to issue admin credit grants free of charge.
   STRIPE_SUPPORT_COUPON: z.string().min(1),
   STRIPE_STARTER_SUBSCRIPTION_PRODUCT_ID: z.string().min(1),

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -37,9 +37,6 @@ const stripeSdkMock = vi.fn(function MockStripe() {
   return { __stripe: true };
 });
 const sentryCaptureExceptionMock = vi.fn();
-const handleCustomerCreatedEventMock = vi.fn();
-const handleCustomerUpdatedEventMock = vi.fn();
-const handleInvoicePaidEventMock = vi.fn();
 const handleSubscriptionDeletedEventMock = vi.fn();
 const reconcileActiveStripeBackedSubscriptionMock = vi.fn();
 const workspaceUpsertMock = vi.fn();
@@ -262,12 +259,6 @@ vi.mock("@/lib/stripe/subscription-catalog", () => ({
 }));
 
 vi.mock("@/lib/stripe/webhook-handlers", () => ({
-  handleCustomerCreatedEvent: (...args: unknown[]) =>
-    handleCustomerCreatedEventMock(...args),
-  handleCustomerUpdatedEvent: (...args: unknown[]) =>
-    handleCustomerUpdatedEventMock(...args),
-  handleInvoicePaidEvent: (...args: unknown[]) =>
-    handleInvoicePaidEventMock(...args),
   handleSubscriptionDeletedEvent: (...args: unknown[]) =>
     handleSubscriptionDeletedEventMock(...args),
   reconcileActiveStripeBackedSubscription: (...args: unknown[]) =>
@@ -335,9 +326,6 @@ describe("web auth config", () => {
       subject: "Sokosumi - E-Mail-Adresse bestätigen",
     });
     stripePluginMock.mockReturnValue("stripe-plugin");
-    handleCustomerCreatedEventMock.mockResolvedValue(undefined);
-    handleCustomerUpdatedEventMock.mockResolvedValue(undefined);
-    handleInvoicePaidEventMock.mockResolvedValue(undefined);
     handleSubscriptionDeletedEventMock.mockResolvedValue(undefined);
     sentryCaptureExceptionMock.mockReset();
   });

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -62,9 +62,6 @@ import {
 } from "@/lib/services";
 import { getBetterAuthSubscriptionPlans } from "@/lib/stripe/subscription-catalog";
 import {
-  handleCustomerCreatedEvent,
-  handleCustomerUpdatedEvent,
-  handleInvoicePaidEvent,
   handleSubscriptionDeletedEvent,
   reconcileActiveStripeBackedSubscription,
 } from "@/lib/stripe/webhook-handlers";
@@ -767,70 +764,10 @@ export const auth = betterAuth({
         enabled: true,
       },
       onEvent: async (event) => {
+        // invoice.paid, customer.updated, and customer.created moved to the
+        // core webhook receiver (POST /webhooks/stripe) — the Stripe dashboard
+        // endpoint for web no longer subscribes to them.
         switch (event.type) {
-          case "invoice.paid": {
-            const invoice = event.data.object as Stripe.Invoice;
-            try {
-              await handleInvoicePaidEvent(invoice);
-            } catch (error) {
-              Sentry.captureException(error, {
-                tags: {
-                  stripeEventType: "invoice.paid",
-                  invoiceId: invoice.id,
-                },
-                extra: {
-                  eventId: event.id,
-                  invoice: invoice.id,
-                  customer:
-                    typeof invoice.customer === "string"
-                      ? invoice.customer
-                      : invoice.customer?.id,
-                },
-              });
-              throw error;
-            }
-            break;
-          }
-          case "customer.updated": {
-            const customer = event.data.object as Stripe.Customer;
-            try {
-              await handleCustomerUpdatedEvent(customer);
-            } catch (error) {
-              Sentry.captureException(error, {
-                tags: {
-                  stripeEventType: "customer.updated",
-                  customerId: customer.id,
-                },
-                extra: {
-                  eventId: event.id,
-                  customer: customer.id,
-                  email: customer.email,
-                },
-              });
-              throw error;
-            }
-            break;
-          }
-          case "customer.created": {
-            const customer = event.data.object as Stripe.Customer;
-            try {
-              await handleCustomerCreatedEvent(customer);
-            } catch (error) {
-              Sentry.captureException(error, {
-                tags: {
-                  stripeEventType: "customer.created",
-                  customerId: customer.id,
-                },
-                extra: {
-                  eventId: event.id,
-                  customer: customer.id,
-                  email: customer.email,
-                },
-              });
-              throw error;
-            }
-            break;
-          }
           case "customer.subscription.deleted": {
             const subscription = event.data.object as Stripe.Subscription;
             try {

--- a/apps/web/src/lib/services/stripe.service.ts
+++ b/apps/web/src/lib/services/stripe.service.ts
@@ -247,52 +247,6 @@ export const stripeService = (() => {
       return coupon;
     },
 
-    async claimWelcomeCoupon(
-      userId: string,
-    ): Promise<{ couponApplied: boolean; invoiceId: string | null }> {
-      const welcomeCouponId = getEnvSecrets().STRIPE_WELCOME_COUPON;
-
-      try {
-        const user = await userRepository.getUserById(userId, prisma);
-        if (!user) {
-          throw new Error("User not found");
-        }
-        if (!user.stripeCustomerId) {
-          throw new Error("User does not have a stripe customer id");
-        }
-
-        const coupon = await this.getCoupon(welcomeCouponId);
-        // Stable per user+coupon: a `customer.created` webhook redelivery
-        // replays the original grant instead of issuing a second invoice.
-        const invoice = await stripeClient.applyInvoiceCreditsToCustomer(
-          user.stripeCustomerId,
-          coupon.id,
-          `welcome-${coupon.id}-${user.id}`,
-          {
-            redemption_type: "welcome_coupon",
-            welcome_source: "customer.created",
-            user_id: user.id,
-            user_email: user.email ?? "",
-          },
-        );
-
-        if (!invoice?.id) {
-          throw new Error("Failed to apply welcome coupon");
-        }
-        if (invoice.status !== "paid") {
-          throw new Error("Welcome coupon invoice is not paid");
-        }
-
-        return { couponApplied: true, invoiceId: invoice.id };
-      } catch (error) {
-        console.error(
-          `Failed to claim welcome coupon for user ${userId}:`,
-          error,
-        );
-        return { couponApplied: false, invoiceId: null };
-      }
-    },
-
     async createAndApplyReferralCredits(
       userId: string,
       organizationId: string | null,

--- a/apps/web/src/lib/stripe/__tests__/webhook-handlers.test.ts
+++ b/apps/web/src/lib/stripe/__tests__/webhook-handlers.test.ts
@@ -22,15 +22,11 @@ const findExistingOrganizationInvoiceSubscriptionBucketMock = vi.fn();
 const createTransactionMock = vi.fn();
 const findOutOfCreditsTasksMock = vi.fn();
 const updateTaskMock = vi.fn();
-const claimWelcomeCouponMock = vi.fn();
-const ensureInitialLocalFreeSubscriptionPeriodMock = vi.fn();
 const transitionToNextLocalFreeSubscriptionPeriodMock = vi.fn();
 const getSubscriptionByStripeSubscriptionIdMock = vi.fn();
 const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
 const subscriptionUpdateManyMock = vi.fn();
 const resolveOrganizationBillingPlanMock = vi.fn();
-const prismaOrganizationUpdateMock = vi.fn();
-const prismaUserUpdateMock = vi.fn();
 
 const transactionMock = vi.fn(async (callback: (tx: unknown) => unknown) =>
   callback({
@@ -67,8 +63,6 @@ vi.mock("@sokosumi/database/helpers", async (importOriginal) => {
     await importOriginal<typeof import("@sokosumi/database/helpers")>();
   return {
     ...actual,
-    ensureInitialLocalFreeSubscriptionPeriod: (...args: unknown[]) =>
-      ensureInitialLocalFreeSubscriptionPeriodMock(...args),
     transitionToNextLocalFreeSubscriptionPeriod: (...args: unknown[]) =>
       transitionToNextLocalFreeSubscriptionPeriodMock(...args),
     resolveOrganizationBillingPlan: (...args: unknown[]) =>
@@ -88,8 +82,6 @@ vi.mock("@sokosumi/database/repositories", () => ({
   organizationRepository: {
     getOrganizationByStripeCustomerId: (...args: unknown[]) =>
       getOrganizationByStripeCustomerIdMock(...args),
-    getOrganizationWithRelationsById: vi.fn(),
-    updateOrganizationInvoiceEmail: vi.fn(),
   },
   subscriptionRepository: {
     resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
@@ -112,18 +104,6 @@ vi.mock("@/lib/db/prisma", () => ({
       findFirst: (...args: unknown[]) =>
         findExistingOrganizationInvoiceSubscriptionBucketMock(...args),
     },
-    organization: {
-      update: (...args: unknown[]) => prismaOrganizationUpdateMock(...args),
-    },
-    user: {
-      update: (...args: unknown[]) => prismaUserUpdateMock(...args),
-    },
-  },
-}));
-
-vi.mock("@/lib/services", () => ({
-  stripeService: {
-    claimWelcomeCoupon: (...args: unknown[]) => claimWelcomeCouponMock(...args),
   },
 }));
 
@@ -1627,79 +1607,6 @@ describe("handleInvoicePaidEvent", () => {
 
     expect(createTransactionMock).toHaveBeenCalledTimes(1);
     expect(updateTaskMock).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe("handleCustomerCreatedEvent", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    claimWelcomeCouponMock.mockResolvedValue({
-      couponApplied: false,
-      invoiceId: null,
-    });
-    ensureInitialLocalFreeSubscriptionPeriodMock.mockResolvedValue(undefined);
-    prismaUserUpdateMock.mockResolvedValue({
-      createdAt: new Date("2026-04-09T07:03:48.591Z"),
-      id: "user-1",
-    });
-    prismaOrganizationUpdateMock.mockResolvedValue({
-      createdAt: new Date("2026-04-09T07:03:48.591Z"),
-      id: "org-1",
-    });
-  });
-
-  it("stores Stripe customer ids for newly created organization customers without creating a Stripe free subscription", async () => {
-    const { handleCustomerCreatedEvent } = await import("../webhook-handlers");
-
-    await handleCustomerCreatedEvent({
-      id: "cus_org_1",
-      metadata: {
-        customerType: "organization",
-        organizationId: "org-1",
-      },
-    } as never);
-
-    expect(prismaOrganizationUpdateMock).toHaveBeenCalledWith({
-      where: { id: "org-1" },
-      data: { stripeCustomerId: "cus_org_1" },
-    });
-    expect(ensureInitialLocalFreeSubscriptionPeriodMock).toHaveBeenCalledWith(
-      {
-        createdAt: new Date("2026-04-09T07:03:48.591Z"),
-        kind: "organization",
-        organizationId: "org-1",
-        stripeCustomerId: "cus_org_1",
-      },
-      expect.anything(),
-    );
-    expect(claimWelcomeCouponMock).not.toHaveBeenCalled();
-  });
-
-  it("claims the welcome coupon for user customers without creating a Stripe free subscription", async () => {
-    const { handleCustomerCreatedEvent } = await import("../webhook-handlers");
-
-    await handleCustomerCreatedEvent({
-      id: "cus_user_1",
-      metadata: {
-        customerType: "user",
-        userId: "user-1",
-      },
-    } as never);
-
-    expect(prismaUserUpdateMock).toHaveBeenCalledWith({
-      where: { id: "user-1" },
-      data: { stripeCustomerId: "cus_user_1" },
-    });
-    expect(ensureInitialLocalFreeSubscriptionPeriodMock).toHaveBeenCalledWith(
-      {
-        createdAt: new Date("2026-04-09T07:03:48.591Z"),
-        kind: "user",
-        stripeCustomerId: "cus_user_1",
-        userId: "user-1",
-      },
-      expect.anything(),
-    );
-    expect(claimWelcomeCouponMock).toHaveBeenCalledWith("user-1");
   });
 });
 

--- a/apps/web/src/lib/stripe/webhook-handlers.ts
+++ b/apps/web/src/lib/stripe/webhook-handlers.ts
@@ -10,7 +10,6 @@ import {
   buildOrganizationInvoiceCreditReferenceId,
   buildOrganizationMemberSubscriptionReferenceId,
   buildUserInvoiceCreditReferenceId,
-  ensureInitialLocalFreeSubscriptionPeriod,
   escapeStringForLike,
   FREE_SUBSCRIPTION_PLAN,
   getCreditExpiryDate,
@@ -29,14 +28,12 @@ import {
 import {
   convertCentsToCredits,
   convertCreditsToCents,
-  getOrganizationMetadata,
   TaskStatus,
 } from "@sokosumi/utils";
 import Stripe from "stripe";
 
 import { getEnvSecrets } from "@/config/env.secrets";
 import prisma from "@/lib/db/prisma";
-import { stripeService } from "@/lib/services";
 import { getSubscriptionCatalog } from "@/lib/stripe/subscription-catalog";
 
 const stripeInstance = new Stripe(getEnvSecrets().STRIPE_SECRET_KEY);
@@ -881,115 +878,6 @@ export async function handleInvoicePaidEvent(
       });
     }
   });
-}
-
-export async function handleCustomerCreatedEvent(
-  customer: Stripe.Customer,
-): Promise<void> {
-  const metadata = customer.metadata;
-  switch (metadata?.customerType) {
-    case "user": {
-      const userId = metadata.userId;
-      const user = await prisma.user.update({
-        where: { id: userId },
-        data: { stripeCustomerId: customer.id },
-      });
-      console.log(`✅ Set user ${userId} stripe customer id to ${customer.id}`);
-
-      await prisma.$transaction(async (tx) => {
-        await ensureInitialLocalFreeSubscriptionPeriod(
-          {
-            createdAt: user.createdAt,
-            kind: "user",
-            stripeCustomerId: customer.id,
-            userId,
-          },
-          tx,
-        );
-      });
-
-      const { couponApplied, invoiceId } =
-        await stripeService.claimWelcomeCoupon(userId);
-      if (couponApplied && invoiceId) {
-        console.log(
-          `✅ Claimed welcome coupon for user ${userId}, invoice: ${invoiceId}`,
-        );
-      } else {
-        console.log(`⚠️ Failed to claim welcome coupon for user ${userId}`);
-      }
-      break;
-    }
-    case "organization": {
-      const organization = await prisma.organization.update({
-        where: { id: metadata.organizationId },
-        data: { stripeCustomerId: customer.id },
-      });
-      console.log(
-        `✅ Set organization ${metadata.organizationId} stripe customer id to ${customer.id}`,
-      );
-
-      await prisma.$transaction(async (tx) => {
-        await ensureInitialLocalFreeSubscriptionPeriod(
-          {
-            createdAt: organization.createdAt,
-            kind: "organization",
-            organizationId: metadata.organizationId,
-            stripeCustomerId: customer.id,
-          },
-          tx,
-        );
-      });
-      break;
-    }
-    default: {
-      console.log(`Unknown customer type ${metadata?.customerType}`);
-      break;
-    }
-  }
-}
-
-export async function handleCustomerUpdatedEvent(
-  customer: Stripe.Customer,
-): Promise<void> {
-  // Check if this is an organization customer
-  const metadata = customer.metadata;
-  if (metadata?.customerType === "organization" && metadata?.organizationId) {
-    const organizationId = metadata.organizationId;
-    const customerEmail =
-      typeof customer.email === "string" ? customer.email : null;
-
-    // Get the current organization to compare emails
-    const organization =
-      await organizationRepository.getOrganizationWithRelationsById(
-        organizationId,
-        prisma,
-      );
-
-    if (!organization) {
-      console.log(
-        `Organization ${organizationId} not found for customer ${customer.id}`,
-      );
-      return;
-    }
-
-    const { invoiceEmail } = getOrganizationMetadata(organization.metadata);
-
-    // Only update if the email has actually changed
-    if (invoiceEmail !== customerEmail) {
-      await organizationRepository.updateOrganizationInvoiceEmail(
-        organizationId,
-        customerEmail,
-        prisma,
-      );
-      console.log(
-        `✅ Updated organization ${organizationId} invoice email from ${invoiceEmail} to ${customerEmail}`,
-      );
-    }
-  } else if (metadata?.type === "user" && metadata?.userId) {
-    // For user customers, we could update the user email if needed
-    // Currently, user emails are managed through the auth system
-    console.log(`User customer ${customer.id} updated, no action taken`);
-  }
 }
 
 export async function reconcileActiveStripeBackedSubscription(


### PR DESCRIPTION
## Summary

Webhook-migration PR 5 of 5 — the cleanup. The Stripe dashboard now routes `invoice.paid`, `customer.updated`, and `customer.created` to core's `POST /webhooks/stripe` (#3126, #3127, #3130 — all cutovers confirmed live), so web's copies of those paths are dead traffic-wise. Pure deletion, −328 lines:

- `auth.ts` `onEvent`: only `customer.subscription.deleted` remains (Better-Auth-fused — depends on the plugin's same-request canceled-marking order). The three migrated cases removed with a comment pointing at the core receiver.
- `webhook-handlers.ts`: `handleCustomerCreatedEvent` + `handleCustomerUpdatedEvent` deleted. **`handleInvoicePaidEvent` deliberately stays** — `invoice-admin.service` still calls it in-process for the admin invoice-replay flow (it leaves when that service migrates). `reconcileActiveStripeBackedSubscription` + `handleSubscriptionDeletedEvent` stay (plugin lifecycle).
- `stripe.service.ts`: `claimWelcomeCoupon` deleted (sole caller was the deleted customer.created handler; the core port in #3130 owns it now).
- `STRIPE_WELCOME_COUPON` removed from web's env schema + `.env.example` (no remaining web reader; the Vercel env var can be deleted from the web projects at leisure).
- Tests: `handleCustomerCreatedEvent` describe block + all orphaned mocks pruned.

## User-facing impact

None — removes code that no longer receives events.

## Verification

- `pnpm --filter web typecheck` ✅
- `pnpm --filter web test` — 231 files / 1413 tests ✅
- `biome check` ✅
- Cutover preconditions verified live by the author before this PR: core endpoint handles all three event types in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)