### PR TITLE
fix(web): show active workspace logo in header avatar

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-user-menu.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-user-menu.client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { MemberRole, type MemberWithOrganization } from "@sokosumi/database";
-import gravatarUrl from "gravatar-url";
 import {
   BookOpen,
   Bot,
@@ -22,9 +21,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type ComponentType, useState } from "react";
 
-import UserAvatarContent from "@/app/components/user-avatar/user-avatar-content";
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
-import { Avatar } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -38,6 +35,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { SessionUser } from "@/lib/auth/auth";
+
+import HeaderWorkspaceAvatar from "./header-workspace-avatar";
 
 interface HeaderUserMenuProps {
   sessionUser: SessionUser;
@@ -208,22 +207,13 @@ export default function HeaderUserMenu({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="hover:opacity-80 transition-opacity"
+          className="hover:opacity-80 flex shrink-0 items-center transition-opacity"
           aria-label={tUserAvatar("settings")}
         >
-          <Avatar className="size-8">
-            <UserAvatarContent
-              className="size-8"
-              imageUrl={
-                sessionUser.image ??
-                gravatarUrl(sessionUser.email, {
-                  size: 80,
-                  default: "404",
-                })
-              }
-              imageAlt={sessionUser.name ?? "User avatar"}
-            />
-          </Avatar>
+          <HeaderWorkspaceAvatar
+            sessionUser={sessionUser}
+            organization={activeOrganizationMember?.organization ?? null}
+          />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-72" align="end">

--- a/apps/web/src/app/(app)/components/header/header-workspace-avatar.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-avatar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { Organization } from "@sokosumi/database";
+import gravatarUrl from "gravatar-url";
+
+import UserAvatarContent from "@/app/components/user-avatar/user-avatar-content";
+import { OrganizationLogo } from "@/components/organizations";
+import { Avatar } from "@/components/ui/avatar";
+import type { SessionUser } from "@/lib/auth/auth";
+import { cn } from "@/lib/utils";
+
+interface HeaderWorkspaceAvatarProps {
+  sessionUser: SessionUser;
+  organization?: Organization | null;
+  className?: string;
+  logoSize?: number;
+}
+
+export default function HeaderWorkspaceAvatar({
+  sessionUser,
+  organization,
+  className = "size-8 md:size-8",
+  logoSize = 18,
+}: HeaderWorkspaceAvatarProps) {
+  if (organization) {
+    return (
+      <Avatar className={cn("bg-muted items-center justify-center", className)}>
+        <OrganizationLogo organization={organization} size={logoSize} />
+      </Avatar>
+    );
+  }
+
+  return (
+    <UserAvatarContent
+      className={className}
+      imageUrl={
+        sessionUser.image ??
+        gravatarUrl(sessionUser.email, {
+          size: 80,
+          default: "404",
+        })
+      }
+      imageAlt={sessionUser.name ?? "User avatar"}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -1,16 +1,11 @@
 "use client";
 
 import type { MemberWithOrganization } from "@sokosumi/database";
-import gravatarUrl from "gravatar-url";
 import { Check, ChevronsUpDown, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 
-import UserAvatarContent from "@/app/components/user-avatar/user-avatar-content";
-import {
-  OrganizationInformationModal,
-  OrganizationLogo,
-} from "@/components/organizations";
+import { OrganizationInformationModal } from "@/components/organizations";
 import { Avatar } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -23,6 +18,8 @@ import {
 import useModal from "@/hooks/use-modal";
 import type { SessionUser } from "@/lib/auth/auth";
 import { cn } from "@/lib/utils";
+
+import HeaderWorkspaceAvatar from "./header-workspace-avatar";
 
 interface HeaderWorkspaceSwitchProps {
   sessionUser: SessionUser;
@@ -68,25 +65,12 @@ function WorkspaceAvatar({
   sessionUser: SessionUser;
   workspace: WorkspaceItem;
 }) {
-  if (workspace.organization) {
-    return (
-      <Avatar className="bg-muted size-6 items-center justify-center">
-        <OrganizationLogo organization={workspace.organization} size={14} />
-      </Avatar>
-    );
-  }
-
   return (
-    <UserAvatarContent
+    <HeaderWorkspaceAvatar
+      sessionUser={sessionUser}
+      organization={workspace.organization ?? null}
       className="size-6 md:size-6"
-      imageUrl={
-        sessionUser.image ??
-        gravatarUrl(sessionUser.email, {
-          size: 80,
-          default: "404",
-        })
-      }
-      imageAlt={sessionUser.name ?? "User avatar"}
+      logoSize={14}
     />
   );
 }

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -28,7 +28,7 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full object-cover", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary

- Fix header avatar alignment by removing nested `Avatar` wrappers and locking size to `size-8`
- Show the active workspace organization logo in the header avatar when an org is selected
- Extract shared `HeaderWorkspaceAvatar` used by the header menu and workspace switcher
- Add `object-cover` to base `AvatarImage` for proper image cropping

## Test plan

- [ ] Open app header with personal account selected — user avatar shows
- [ ] Switch to an organization workspace — header avatar shows org logo/icon
- [ ] Verify avatar aligns with workspace name and chat trigger
- [ ] Confirm workspace dropdown items still show correct avatars


Made with [Cursor](https://cursor.com)