### PR TITLE
fix(web): show name in avatar menu and link sidebar logo home

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-user-menu.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-user-menu.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MemberRole, type MemberWithOrganization } from "@sokosumi/database";
+import { getStoredUserName } from "@sokosumi/utils";
 import {
   BookOpen,
   Bot,
@@ -20,7 +21,6 @@ import {
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type ComponentType, useState } from "react";
-
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
 import {
   DropdownMenu,
@@ -34,6 +34,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+
 import type { SessionUser } from "@/lib/auth/auth";
 
 import HeaderWorkspaceAvatar from "./header-workspace-avatar";
@@ -219,7 +220,7 @@ export default function HeaderUserMenu({
       <DropdownMenuContent className="w-72" align="end">
         <DropdownMenuLabel className="truncate">
           <span className="block truncate text-sm font-medium">
-            {sessionUser.email}
+            {getStoredUserName(sessionUser.name, sessionUser.email)}
           </span>
           {secondaryLabel ? (
             <span className="text-muted-foreground mt-0.5 block truncate text-xs font-normal">

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-logo.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-logo.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PanelLeft } from "lucide-react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import {
@@ -41,7 +42,9 @@ export default function SidebarLogo() {
 
   return (
     <div className="flex h-8 items-center pl-2">
-      <ThemedLogo LogoComponent={SokosumiLogo} height={16} width={123} />
+      <Link href="/" className="hover:opacity-80 transition-opacity">
+        <ThemedLogo LogoComponent={SokosumiLogo} height={16} width={123} />
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Avatar dropdown shows the user's name instead of email (falls back to email prefix when name is blank).
- Expanded sidebar logo links to `/` home; collapsed icon behavior is unchanged.

## Test plan
- [ ] Open avatar menu and confirm name shows in header label
- [ ] Expand sidebar and click logo — should navigate to `/`
- [ ] Collapsed sidebar icon still expands sidebar on click


Made with [Cursor](https://cursor.com)