### PR TITLE
chore(skills): add blocking phase gates to team-sapphire

### DIFF
--- a/.cursor/skills/_team-sapphire/AGENTS.md
+++ b/.cursor/skills/_team-sapphire/AGENTS.md
@@ -5,12 +5,13 @@ Single-issue squad: Investigator → Tech Lead → Coder(s) → Reviewer.
 ## Load order
 
 1. Read `SKILL.md`.
-2. Read `WORKFLOW.md`.
-3. Read role file for the current phase: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, or `REVIEWER.md`.
-4. Read `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md` before Tech Lead phase.
-5. Read `LINEAR-MCP.md` before Linear writes.
-6. Read `VISUAL-CAPTURE.md` before Reviewer phase (UI evidence).
-7. Read `CURSOR-AUTOMATION.md` when configuring optional Linear-triggered Cloud Agents.
+2. Read `PHASE-GATE.md` — blocking Linear writes per phase; exit verification.
+3. Read `WORKFLOW.md`.
+4. Read role file for the current phase: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, or `REVIEWER.md`.
+5. Read `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md` before Tech Lead phase.
+6. Read `LINEAR-MCP.md` before Linear writes.
+7. Read `VISUAL-CAPTURE.md` before Reviewer phase (UI evidence).
+8. Read `CURSOR-AUTOMATION.md` when configuring optional Linear-triggered Cloud Agents.
 
 ## Upstream
 
@@ -20,4 +21,4 @@ Requirement intake and approval: `../_task/SKILL.md`.
 
 Keep specs concise. Tech Lead spec always includes a data flow diagram. Linear holds **Requirement + status** only — investigation and spec stay in session.
 
-**Orchestrator:** Run all four phases in one session through **In Review**. Pass session artifacts phase to phase; do not write them to Linear.
+**Orchestrator:** Run all four phases in one session through **In Review**. Pass session artifacts phase to phase; do not write them to Linear. **Each phase must pass its gate** (`PHASE-GATE.md`) before the next phase starts.

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -65,3 +65,13 @@ Each subagent prompt must include:
 ## Pre-PR verification
 
 Map spec **Verification** scope to allowlisted commands in `REVIEWER.md` **Verification command trust**. Run the narrowest set covering your deliverables.
+
+## Phase gate (blocking)
+
+Before Reviewer starts:
+
+1. `save_comment` — `**PR handoff**` (PR URL, branch, one-line summary)
+2. `save_comment` — `**Sapphire · Coder complete**`
+3. `save_issue` — Coder row → `done` (issue stays **In Progress**)
+
+Do **not** run `/goal` or set **In Review** until all three succeed. See `PHASE-GATE.md`.

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -50,7 +50,7 @@ Each subagent prompt must include:
 ## Handoff to Reviewer
 
 - **Sapphire orchestrator (default):** After Coder complete, continue to Phase 4 (Reviewer) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Coder** (user invoked Coder only): Complete **Phase gate (blocking)** below (PR handoff + Coder complete + status row), then stop; Reviewer runs in a separate session.
+- **Standalone Coder** (user invoked Coder only): Complete **Phase gate (blocking)** below (PR handoff + Coder complete + status row), then **Exit gate** (`PHASE-GATE.md`), then stop; Reviewer runs in a separate session.
 
 ## PR handoff comment
 

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -16,8 +16,9 @@ When Tech Lead defined one coder block (or no breakdown section):
 2. Follow repo conventions (`AGENTS.md`, scoped app guides).
 3. Run allowlisted verification before PR.
 4. Open PR — body references Linear issue id (e.g. `SOK-549`).
-5. Post `**PR handoff**` on the issue (see `REVIEWER.md`).
-6. Post `**Sapphire · Coder complete**`. Issue stays **In Progress**.
+5. Post `**PR handoff**` on the issue (see below).
+6. Post `**Sapphire · Coder complete**`.
+7. `save_issue` — Coder row → `done` (issue stays **In Progress**). See **Phase gate (blocking)**.
 
 ## Multiple coders
 
@@ -49,7 +50,7 @@ Each subagent prompt must include:
 ## Handoff to Reviewer
 
 - **Sapphire orchestrator (default):** After Coder complete, continue to Phase 4 (Reviewer) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Coder** (user invoked Coder only): Stop after `**Sapphire · Coder complete**`; Reviewer runs in a separate session.
+- **Standalone Coder** (user invoked Coder only): Complete **Phase gate (blocking)** below (PR handoff + Coder complete + status row), then stop; Reviewer runs in a separate session.
 
 ## PR handoff comment
 

--- a/.cursor/skills/_team-sapphire/CURSOR-AUTOMATION.md
+++ b/.cursor/skills/_team-sapphire/CURSOR-AUTOMATION.md
@@ -43,7 +43,7 @@ Documented for teams that **stop using `_task` MCP delegate entirely** and accep
 | Trigger | Linear — Delegate assigned → `Cursor` |
 | Filter | Team SOK; description contains `## Sapphire status` |
 | Tools | Linear MCP, GitHub MCP — computer use is built into Cloud Agents |
-| Instructions | Read repo `.cursor/skills/_team-sapphire/SKILL.md`. Run full squad on this issue. Single issue only. Reviewer: PR artifacts per `VISUAL-CAPTURE.md`. |
+| Instructions | Read repo `.cursor/skills/_team-sapphire/SKILL.md`. Run full squad on this issue. Single issue only. **Mandatory:** `PHASE-GATE.md` — post phase comment + update status table after each phase; run exit gate before finishing. Reviewer: PR artifacts per `VISUAL-CAPTURE.md`. |
 
 Filter on `## Sapphire status`, **not** `[repo=…]` alone.
 

--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -48,7 +48,7 @@ Keep it scannable. Bullets over paragraphs. Real paths as markdown links.
 ## Handoff to Tech Lead
 
 - **Sapphire orchestrator (default):** After Investigator complete, continue to Phase 2 (Tech Lead) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Investigator** (user invoked Investigator only): Stop after `**Sapphire · Investigator complete**`; Tech Lead runs in a separate session.
+- **Standalone Investigator** (user invoked Investigator only): Complete **Phase gate (blocking)** below (comment + status row), then stop; Tech Lead runs in a separate session.
 - **New session resume:** Linear may show Investigator = `done` without **session investigation** — orchestrator re-runs Investigator before Tech Lead per `SKILL.md` **Resume and idempotency**.
 
 ## Phase gate (blocking)

--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -48,7 +48,7 @@ Keep it scannable. Bullets over paragraphs. Real paths as markdown links.
 ## Handoff to Tech Lead
 
 - **Sapphire orchestrator (default):** After Investigator complete, continue to Phase 2 (Tech Lead) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Investigator** (user invoked Investigator only): Complete **Phase gate (blocking)** below (comment + status row), then stop; Tech Lead runs in a separate session.
+- **Standalone Investigator** (user invoked Investigator only): Complete **Phase gate (blocking)** below (comment + status row), then **Exit gate** (`PHASE-GATE.md`), then stop; Tech Lead runs in a separate session.
 - **New session resume:** Linear may show Investigator = `done` without **session investigation** — orchestrator re-runs Investigator before Tech Lead per `SKILL.md` **Resume and idempotency**.
 
 ## Phase gate (blocking)

--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -50,3 +50,12 @@ Keep it scannable. Bullets over paragraphs. Real paths as markdown links.
 - **Sapphire orchestrator (default):** After Investigator complete, continue to Phase 2 (Tech Lead) in the **same run** per `SKILL.md` — do not stop early.
 - **Standalone Investigator** (user invoked Investigator only): Stop after `**Sapphire · Investigator complete**`; Tech Lead runs in a separate session.
 - **New session resume:** Linear may show Investigator = `done` without **session investigation** — orchestrator re-runs Investigator before Tech Lead per `SKILL.md` **Resume and idempotency**.
+
+## Phase gate (blocking)
+
+Before Tech Lead starts:
+
+1. `save_comment` — `**Sapphire · Investigator complete**` + 3–5 bullets
+2. `save_issue` — Investigator row → `done` (full description merge per `LINEAR-MCP.md`)
+
+Do **not** write code or start Tech Lead until both succeed. See `PHASE-GATE.md`.

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -86,7 +86,7 @@ Use structured headers for audit trail:
 |-------|----------------|
 | Investigator | `**Sapphire · Investigator complete**` — 3–5 bullets |
 | Tech Lead | `**Sapphire · Tech Lead complete**` — coder count, order, 3–5 bullets |
-| Coder | `**Sapphire · Coder complete**` + `**PR handoff**` |
+| Coder | `**PR handoff**` + `**Sapphire · Coder complete**` |
 | Reviewer pass | `**Sapphire · Reviewer complete**` |
 | Reviewer fail | `**Sapphire · Review failed**` |
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -132,7 +132,7 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
 | `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, then set `In Review` when criteria pass |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 
 ## Post-run response
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -68,7 +68,7 @@ Update the status table row to `done`. Post a **short summary comment** — not 
 
 ### Exit verification
 
-Before the orchestrator returns to the user, `get_issue` + `list_comments` must confirm every completed phase has its comment header and matching `done` row. If the table still shows `pending` for a completed phase, repair per `PHASE-GATE.md` **Repair** — do not exit.
+Before the orchestrator returns to the user, `get_issue` + `list_comments` must confirm every `done` row has its comment header(s) and issue state matches ( **In Review** when Reviewer row is `done`). If the table still shows `pending` for a completed phase, or state is wrong, repair per `PHASE-GATE.md` **Repair** — do not exit.
 
 ### State transitions
 
@@ -138,4 +138,4 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 
 Return issue id/URL, phases completed, Linear state, PR URL if any.
 
-Confirm exit gate passed: all completed phases have comments + status rows `done`. If not, say what was repaired or what is still missing.
+Confirm exit gate passed: every `done` row has comment(s), no stale `pending` rows for finished work, and issue state matches ( **In Review** when Reviewer is `done`). If not, say what was repaired or what is still missing.

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -2,6 +2,8 @@
 
 Single-issue updates only. No child issues.
 
+**Phase gates:** Every phase ends with `save_comment` + status row update before the next phase. See `PHASE-GATE.md` — skipping gates is a failed run.
+
 ## What goes on Linear
 
 | Write to Linear | Do not write to Linear |
@@ -61,6 +63,12 @@ Do not add Investigation or Spec sections.
 ### After each phase
 
 Update the status table row to `done`. Post a **short summary comment** — not the full investigation or spec.
+
+**Order:** `save_comment` first, then `save_issue` with merged description. Do **not** start the next Sapphire phase until both succeed.
+
+### Exit verification
+
+Before the orchestrator returns to the user, `get_issue` + `list_comments` must confirm every completed phase has its comment header and matching `done` row. If the table still shows `pending` for a completed phase, repair per `PHASE-GATE.md` **Repair** — do not exit.
 
 ### State transitions
 
@@ -129,3 +137,5 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 ## Post-run response
 
 Return issue id/URL, phases completed, Linear state, PR URL if any.
+
+Confirm exit gate passed: all completed phases have comments + status rows `done`. If not, say what was repaired or what is still missing.

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -48,14 +48,21 @@ After Phase 4 (or early stop), **verify Linear** before finishing:
 1. `get_issue` — read `## Sapphire status` and issue state
 2. `list_comments` — confirm phase headers exist
 
-| Completed in this run | Must be true on Linear |
-|-----------------------|-------------------------|
-| Investigator | Comment `**Sapphire · Investigator complete**` + row `done` |
-| Tech Lead | Comment `**Sapphire · Tech Lead complete**` + row `done` |
-| Coder | Comments `**PR handoff**` + `**Sapphire · Coder complete**` + row `done` |
-| Reviewer pass | Comment `**Sapphire · Reviewer complete**` + row `done` + state **In Review** |
+Check **every** status row marked `done` on the issue — including rows from prior sessions or bad runs, not only phases finished in the current run. Each `done` row must have its matching comment(s) on Linear.
 
-**All four rows must be `done` when the run finishes through Reviewer.** Issue state **In Review** with any row still `pending` is a **failed exit gate**.
+| Status row on Linear | Must be true on Linear |
+|----------------------|-------------------------|
+| Investigator → `done` | Comment `**Sapphire · Investigator complete**` |
+| Tech Lead → `done` | Comment `**Sapphire · Tech Lead complete**` |
+| Coder → `done` | Comments `**PR handoff**` + `**Sapphire · Coder complete**` |
+| Reviewer → `done` | Comment `**Sapphire · Reviewer complete**` + issue state **In Review** |
+
+**Failed exit gate examples:**
+
+- Any `done` row missing its comment header(s)
+- Any row still `pending` when the run claimed to finish through that phase
+- All four rows `done` but issue state is still **In Progress** (missing Reviewer state-only `save_issue`)
+- Issue state **In Review** while any row is still `pending`
 
 ### Repair (retroactive)
 
@@ -63,8 +70,9 @@ If work is done but gates were skipped:
 
 1. Reconstruct summaries from session artifacts (investigation, spec, PR URL)
 2. Post missing comments in phase order (Investigator → Tech Lead → PR handoff → Coder → Reviewer)
-3. `save_issue` with full merged description — all completed rows → `done`
-4. Re-run exit gate; only then return to user
+3. `save_issue` with full merged description — set each completed row → `done`
+4. If Reviewer pass criteria are met and issue is not **In Review**, `save_issue` with `state: "In Review"` only (no `description`)
+5. Re-run exit gate (comments, all `done` rows, and issue state); only then return to user
 
 Do **not** tell the user the run succeeded when exit gate fails — repair first or report which gates are missing.
 

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -11,7 +11,7 @@ Every Sapphire phase ends with **mandatory Linear writes**. These are not option
 | 1 | `save_comment` | Phase summary with exact header (see table below) |
 | 2 | `save_issue` | Update `## Sapphire status` row → `done` (status-only merge per `LINEAR-MCP.md`) |
 
-Coder adds a third write between the two above: `**PR handoff**` comment **before** `**Sapphire · Coder complete**`.
+Coder uses **three writes** instead of two: (1) `save_comment` → `**PR handoff**`, (2) `save_comment` → `**Sapphire · Coder complete**`, (3) `save_issue` → Coder row `done`.
 
 Reviewer adds a state write **after** status table is saved: `save_issue` with `state: "In Review"` only (no `description`).
 

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -1,0 +1,95 @@
+# Phase gates (blocking)
+
+Every Sapphire phase ends with **mandatory Linear writes**. These are not optional audit niceties — they are **hard gates**.
+
+**Do not start the next phase until the current phase gate passes.**
+
+## Two writes per phase
+
+| Step | Tool | Purpose |
+|------|------|---------|
+| 1 | `save_comment` | Phase summary with exact header (see table below) |
+| 2 | `save_issue` | Update `## Sapphire status` row → `done` (status-only merge per `LINEAR-MCP.md`) |
+
+Coder adds a third write between the two above: `**PR handoff**` comment **before** `**Sapphire · Coder complete**`.
+
+Reviewer adds a state write **after** status table is saved: `save_issue` with `state: "In Review"` only (no `description`).
+
+## Gate table
+
+| Phase | Required comment header(s) | Status row after gate |
+|-------|---------------------------|------------------------|
+| Investigator | `**Sapphire · Investigator complete**` | Investigator → `done` |
+| Tech Lead | `**Sapphire · Tech Lead complete**` | Tech Lead → `done` |
+| Coder | `**PR handoff**` then `**Sapphire · Coder complete**` | Coder → `done` |
+| Reviewer | `**Sapphire · Reviewer complete**` (or `**Sapphire · Review failed**` while looping) | Reviewer → `done` + `state: "In Review"` on pass |
+
+Comment headers must match **exactly** (including bold markers). Summaries belong in the comment body — not only in the Cloud Agent thread.
+
+## Anti-pattern: batch-at-end
+
+**Failed run example (SOK-569):** Agent implemented code, opened PR, set **In Review**, and posted one final summary — but skipped Investigator / Tech Lead / Coder comments and left the status table on `pending`.
+
+That breaks resume, hides progress from humans, and makes runs incomparable to good runs (e.g. SOK-568).
+
+**Never:**
+
+- Defer all `save_comment` / status updates to the end of the session
+- Rely on the Cursor agent thread as the only audit trail
+- Set **In Review** while status rows still say `pending`
+- Post only `**Sapphire · Reviewer complete**` when earlier phase comments are missing
+
+**If you catch yourself coding before Investigator gate passed:** stop, run the missing gates in order, then continue.
+
+## Exit gate (before returning to user)
+
+After Phase 4 (or early stop), **verify Linear** before finishing:
+
+1. `get_issue` — read `## Sapphire status` and issue state
+2. `list_comments` — confirm phase headers exist
+
+| Completed in this run | Must be true on Linear |
+|-----------------------|-------------------------|
+| Investigator | Comment `**Sapphire · Investigator complete**` + row `done` |
+| Tech Lead | Comment `**Sapphire · Tech Lead complete**` + row `done` |
+| Coder | Comments `**PR handoff**` + `**Sapphire · Coder complete**` + row `done` |
+| Reviewer pass | Comment `**Sapphire · Reviewer complete**` + row `done` + state **In Review** |
+
+**All four rows must be `done` when the run finishes through Reviewer.** Issue state **In Review** with any row still `pending` is a **failed exit gate**.
+
+### Repair (retroactive)
+
+If work is done but gates were skipped:
+
+1. Reconstruct summaries from session artifacts (investigation, spec, PR URL)
+2. Post missing comments in phase order (Investigator → Tech Lead → PR handoff → Coder → Reviewer)
+3. `save_issue` with full merged description — all completed rows → `done`
+4. Re-run exit gate; only then return to user
+
+Do **not** tell the user the run succeeded when exit gate fails — repair first or report which gates are missing.
+
+## Orchestrator checklist (copy per phase)
+
+After each phase, mentally confirm before continuing:
+
+```
+[ ] save_comment posted with exact phase header
+[ ] save_issue updated status row to done (full description merge)
+[ ] get_issue confirms row shows done (optional but recommended on Cloud)
+[ ] Next phase may start
+```
+
+Coder additionally:
+
+```
+[ ] PR open on GitHub (validated via gh)
+[ ] **PR handoff** comment posted before Coder complete
+```
+
+Reviewer additionally:
+
+```
+[ ] /goal criteria pass
+[ ] Reviewer row done saved before state change
+[ ] save_issue state In Review (description omitted)
+```

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -16,7 +16,7 @@ Prefix work with `/goal`. Do **not** stop after one failed pass when fixes are p
 4. Run **Verification command trust** only.
 5. Capture screenshot or recording for user-facing changes — see `VISUAL-CAPTURE.md`.
 6. Fix on PR branch, push, rerun until pass or true blocker.
-7. On pass: `save_issue` → `In Review`; post `**Sapphire · Reviewer complete**` with evidence.
+7. On pass: run **Completion** gate below — `save_comment` → Reviewer complete, `save_issue` → Reviewer row `done`, then `save_issue` → `state: "In Review"` only (`PHASE-GATE.md`).
 
 ## PR execution trust
 
@@ -91,7 +91,7 @@ Follow `VISUAL-CAPTURE.md` — **Cloud Agent:** computer use + PR artifacts; **I
 
 | Outcome | Action |
 |---------|--------|
-| All pass | Issue → **In Review**; comment evidence |
+| All pass | **Completion** gate — comment, all status rows `done`, then **In Review** |
 | Fixable fail | Fix, push, loop |
 | Blocker | Comment blocker; stay **In Progress** |
 | Max iterations (optional cap) | Escalate to human |

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -98,10 +98,12 @@ Follow `VISUAL-CAPTURE.md` — **Cloud Agent:** computer use + PR artifacts; **I
 
 ## Completion
 
-1. `save_comment` — checklist, command summary, screenshot links
-2. `save_issue` with `id` + `state: "In Review"`
-3. Post `**Sapphire · Reviewer complete**`
+1. `save_comment` — `**Sapphire · Reviewer complete**` with checklist, command summary, screenshot links
+2. `save_issue` — Reviewer row → `done` (full description merge; all four rows must be `done`)
+3. `save_issue` — `state: "In Review"` only (no `description`)
 4. Do **not** mark **Done** — human merges PR
+
+Run **Exit gate** in `PHASE-GATE.md` before the orchestrator returns to the user.
 
 ## Failure comment
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -77,7 +77,7 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
   5. Run from `target` through all later phases in this session.
 - If `**PR handoff**` + open PR exist and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
-- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass set `In Review` and post `**Sapphire · Reviewer complete**`.
+- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass run **Completion** gate per `REVIEWER.md` (comment → Reviewer row `done` if needed → `state: "In Review"` only), then **Exit gate** per `PHASE-GATE.md`.
 - If **every** status row is `done` and issue is **`In Review`**, stop — await human merge.
 
 ## Workflow
@@ -140,7 +140,7 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
 | `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, then set `In Review` when criteria pass |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 | Issue `In Review` + Reviewer done | Stop — await human merge |
 
 ## Output

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -119,7 +119,7 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 ### Exit gate (blocking)
 
-Before returning to the user, run **Exit gate** in `PHASE-GATE.md`: `get_issue` + `list_comments`. If any completed phase lacks its comment or status row, **repair retroactively** — do not report success with a stale `pending` table.
+Before returning to the user, run **Exit gate** in `PHASE-GATE.md`: `get_issue` + `list_comments`. Verify every `done` row has matching comment(s) and issue state matches ( **In Review** when Reviewer row is `done`). If anything fails, **repair retroactively** — do not report success with a stale `pending` table or wrong state.
 
 ## MCP
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -14,14 +14,14 @@ Run the squad in order on the **same issue** `_task` created (or any SOK issue t
 
 **Do not stop after one phase.** You are the orchestrator — run every remaining phase in **this same agent session** until the pipeline finishes or you hit an unrecoverable blocker.
 
-**Do not batch Linear updates.** Each phase ends with a **blocking gate** — `save_comment` + status row `done` via `save_issue` — before the next phase starts. See `PHASE-GATE.md`. Skipping gates (e.g. only posting a final Reviewer comment while the status table stays `pending`) is a **failed run** — repair before exit.
+**Do not batch Linear updates.** Each phase ends with a **blocking gate** before the next phase starts — typically `save_comment` then `save_issue` to mark the row `done` (Coder: `**PR handoff**` comment, then Coder complete comment, then `save_issue`). See `PHASE-GATE.md`. Skipping gates (e.g. only posting a final Reviewer comment while the status table stays `pending`) is a **failed run** — repair before exit.
 
 | After phase completes | Next action |
 |----------------------|-------------|
 | Investigator → `done` | **Immediately** start Phase 2 (Tech Lead) — do not return to the user yet |
 | Tech Lead → `done` | **Immediately** start Phase 3 (Coder) |
 | Coder → `done` + PR open | **Immediately** start Phase 4 (Reviewer) |
-| Reviewer → `done` | Set issue **In Review**, then return summary to user |
+| Reviewer → `done` | Run **Completion** gate — comment, all status rows `done`, then `state: "In Review"`; return summary to user |
 
 **Only stop early when:**
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -21,13 +21,13 @@ Run the squad in order on the **same issue** `_task` created (or any SOK issue t
 | Investigator → `done` | **Immediately** start Phase 2 (Tech Lead) — do not return to the user yet |
 | Tech Lead → `done` | **Immediately** start Phase 3 (Coder) |
 | Coder → `done` + PR open | **Immediately** start Phase 4 (Reviewer) |
-| Reviewer → `done` | Run **Completion** gate — comment, all status rows `done`, then `state: "In Review"`; return summary to user |
+| Reviewer → `done` | Run **Completion** gate — comment, all status rows `done`, then `state: "In Review"`; then **Exit gate** (`PHASE-GATE.md`); return summary to user |
 
 **Only stop early when:**
 
-- Issue is already **In Review** and Reviewer is `done` (await human merge).
-- User explicitly asked to run a single phase only (e.g. `run investigator for SOK-XXX`).
-- Unrecoverable blocker (no GitHub access, Linear MCP down, spec impossible) — report what finished, what is blocked, and the issue URL.
+- Issue is already **In Review** and Reviewer is `done` — run **Exit gate** first; on pass, await human merge.
+- User explicitly asked to run a single phase only (e.g. `run investigator for SOK-XXX`) — run **Exit gate** for completed rows, then stop.
+- Unrecoverable blocker (no GitHub access, Linear MCP down, spec impossible) — report what finished, what is blocked, and the issue URL (Exit gate when Linear MCP is available).
 
 **Never** treat Investigator, Tech Lead, or Coder as standalone jobs when you were delegated from `_task` or invoked as `_team-sapphire` on a full issue. Phase comments (`**Sapphire · … complete**`) mark progress — they are **not** exit signals.
 
@@ -72,13 +72,13 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
 - If `## Sapphire status` is **missing**, insert the initial status block per `LINEAR-MCP.md` (full-description merge via `save_issue`) **first** — do not run resume or cleanup rules until the table exists; then start Investigator (or the user’s explicit start phase).
 - If `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone):
   1. Set `target` = user start phase if specified, else first row not `done` (Investigator → Tech Lead → Coder → Reviewer).
-  2. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`) → run `target` and stop.
+  2. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`) → run `target`, then **Exit gate**, then stop.
   3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
   5. Run from `target` through all later phases in this session.
 - If `**PR handoff**` + open PR exist and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
 - If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass run **Completion** gate per `REVIEWER.md` (comment → Reviewer row `done` if needed → `state: "In Review"` only), then **Exit gate** per `PHASE-GATE.md`.
-- If **every** status row is `done` and issue is **`In Review`**, stop — await human merge.
+- If **every** status row is `done` and issue is **`In Review`**, run **Exit gate**; on pass, stop — await human merge.
 
 ## Workflow
 
@@ -141,7 +141,7 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
-| Issue `In Review` + Reviewer done | Stop — await human merge |
+| Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |
 
 ## Output
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: _team-sapphire
-description: Run the Sapphire squad on a single Linear issue — Investigator, Tech Lead, Coder(s), and Reviewer — in one session from requirement through PR and /goal review until In Review. Use after _task posts a requirement, when the user says run team-sapphire or Sapphire for SOK-XXX, or when a Linear issue is delegated with Sapphire handoff footer.
+description: Run the Sapphire squad on a single Linear issue — Investigator, Tech Lead, Coder(s), and Reviewer — in one session from requirement through PR and /goal review until In Review. Mandatory phase gates (comment + status table per phase) per PHASE-GATE.md. Use after _task posts a requirement, when the user says run team-sapphire or Sapphire for SOK-XXX, or when a Linear issue is delegated with Sapphire handoff footer.
 disable-model-invocation: true
 ---
 
@@ -13,6 +13,8 @@ Run the squad in order on the **same issue** `_task` created (or any SOK issue t
 ## Continuous orchestration (critical)
 
 **Do not stop after one phase.** You are the orchestrator — run every remaining phase in **this same agent session** until the pipeline finishes or you hit an unrecoverable blocker.
+
+**Do not batch Linear updates.** Each phase ends with a **blocking gate** — `save_comment` + status row `done` via `save_issue` — before the next phase starts. See `PHASE-GATE.md`. Skipping gates (e.g. only posting a final Reviewer comment while the status table stays `pending`) is a **failed run** — repair before exit.
 
 | After phase completes | Next action |
 |----------------------|-------------|
@@ -86,18 +88,16 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 1. Run Investigator per `INVESTIGATOR.md` (codebase search, pitfalls, patterns — **not** a final spec).
 2. Keep the investigation markdown **in session** — pass the full text to Tech Lead. Do **not** merge `## Investigation` into the Linear description.
-3. Post comment `**Sapphire · Investigator complete**` with a 3–5 bullet summary (not the full investigation).
-4. Update `## Sapphire status` — Investigator → `done` (status-only `save_issue` per `LINEAR-MCP.md`).
-5. **Continue in this run** — proceed to Phase 2 without stopping.
+3. **Gate (blocking):** `save_comment` → `**Sapphire · Investigator complete**` (3–5 bullets). Then `save_issue` → Investigator row `done`. Do **not** open Phase 2 until both succeed (`PHASE-GATE.md`).
+4. **Continue in this run** — proceed to Phase 2 without stopping.
 
 ### Phase 2 — Tech Lead
 
 1. Read Requirement (Linear) + Investigation (**session**).
 2. Write final spec per `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md`.
 3. Keep the spec markdown **in session** — pass the full text to Coder and Reviewer. Do **not** merge `## Spec` into the Linear description.
-4. Post comment `**Sapphire · Tech Lead complete**` with coder count, execution order, and 3–5 bullet spec summary (not the full spec).
-5. Update status — Tech Lead → `done` (status-only `save_issue`).
-6. **Continue in this run** — proceed to Phase 3 without stopping.
+4. **Gate (blocking):** `save_comment` → `**Sapphire · Tech Lead complete**` (coder count, order, 3–5 bullets). Then `save_issue` → Tech Lead row `done`. Do **not** open Phase 3 until both succeed.
+5. **Continue in this run** — proceed to Phase 3 without stopping.
 
 ### Phase 3 — Coder(s)
 
@@ -106,20 +106,24 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 3. If single coder, implement in this run.
 4. Run allowlisted verification before PR (`REVIEWER.md` **Verification command trust**).
 5. Open PR; PR body must reference the Linear issue id.
-6. Post `**PR handoff**` comment per `REVIEWER.md`.
-7. Post `**Sapphire · Coder complete**`. Update status — Coder → done (status-only `save_issue`). Stay **In Progress** — do not set In Review yet.
-8. **Continue in this run** — proceed to Phase 4 without stopping.
+6. **Gate (blocking):** `save_comment` → `**PR handoff**`. Then `save_comment` → `**Sapphire · Coder complete**`. Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until all three succeed.
+7. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
 
 1. Run `/goal` per `REVIEWER.md` until all criteria pass.
 2. For UI specs, capture evidence per `VISUAL-CAPTURE.md` (Cloud: PR artifacts; IDE: screenshots; optional CLI for WebM).
 3. Fix on PR branch when needed; loop.
-4. On pass: set issue `In Review`, post `**Sapphire · Reviewer complete**` with evidence, update status — Reviewer → done (status-only `save_issue` + state).
+4. **Gate (blocking):** On pass — `save_comment` → `**Sapphire · Reviewer complete**` with evidence; `save_issue` → Reviewer row `done` (full description merge); then `save_issue` → `state: "In Review"` only. All four status rows must be `done` before exit.
 5. Do **not** mark issue **Done** — human merges PR.
+
+### Exit gate (blocking)
+
+Before returning to the user, run **Exit gate** in `PHASE-GATE.md`: `get_issue` + `list_comments`. If any completed phase lacks its comment or status row, **repair retroactively** — do not report success with a stale `pending` table.
 
 ## MCP
 
+- Read `PHASE-GATE.md` before the first phase — gates are blocking.
 - Read `LINEAR-MCP.md` before any write.
 - Health check before first call — same message as `_task` if `user-linear` is missing.
 - Use `save_issue` for **status table**, **state**, and legacy section cleanup only — not investigation or spec; use `save_comment` for phase markers.
@@ -145,6 +149,7 @@ Return issue id/URL, **all phases completed in this run**, PR link (if any), and
 
 ## Supporting files
 
+- `PHASE-GATE.md` — blocking comment + status writes per phase; exit verification
 - `WORKFLOW.md` — pipeline diagram and status lifecycle
 - `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, `REVIEWER.md` — role contracts
 - `SPEC-TEMPLATE.md` — Tech Lead output shape

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -48,3 +48,12 @@ Post `**Sapphire · Tech Lead complete**` with:
 - **Sapphire orchestrator (default):** After Tech Lead complete, continue to Phase 3 (Coder) in the **same run** per `SKILL.md` — do not stop early.
 - **Standalone Tech Lead** (user invoked Tech Lead only): Stop after `**Sapphire · Tech Lead complete**`; Coder runs in a separate session.
 - **New session resume:** Linear may show Tech Lead = `done` without a **session spec**, or Investigator = `done` without **session investigation** — orchestrator re-runs missing upstream phases first per `SKILL.md` **Resume and idempotency**.
+
+## Phase gate (blocking)
+
+Before Coder starts:
+
+1. `save_comment` — `**Sapphire · Tech Lead complete**` + coder count, order, 3–5 bullets
+2. `save_issue` — Tech Lead row → `done`
+
+Do **not** implement or open a PR until both succeed. See `PHASE-GATE.md`.

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -46,7 +46,7 @@ Post `**Sapphire · Tech Lead complete**` with:
 ## Handoff to Coder
 
 - **Sapphire orchestrator (default):** After Tech Lead complete, continue to Phase 3 (Coder) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Tech Lead** (user invoked Tech Lead only): Stop after `**Sapphire · Tech Lead complete**`; Coder runs in a separate session.
+- **Standalone Tech Lead** (user invoked Tech Lead only): Complete **Phase gate (blocking)** below (comment + status row), then stop; Coder runs in a separate session.
 - **New session resume:** Linear may show Tech Lead = `done` without a **session spec**, or Investigator = `done` without **session investigation** — orchestrator re-runs missing upstream phases first per `SKILL.md` **Resume and idempotency**.
 
 ## Phase gate (blocking)

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -46,7 +46,7 @@ Post `**Sapphire · Tech Lead complete**` with:
 ## Handoff to Coder
 
 - **Sapphire orchestrator (default):** After Tech Lead complete, continue to Phase 3 (Coder) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Tech Lead** (user invoked Tech Lead only): Complete **Phase gate (blocking)** below (comment + status row), then stop; Coder runs in a separate session.
+- **Standalone Tech Lead** (user invoked Tech Lead only): Complete **Phase gate (blocking)** below (comment + status row), then **Exit gate** (`PHASE-GATE.md`), then stop; Coder runs in a separate session.
 - **New session resume:** Linear may show Tech Lead = `done` without a **session spec**, or Investigator = `done` without **session investigation** — orchestrator re-runs missing upstream phases first per `SKILL.md` **Resume and idempotency**.
 
 ## Phase gate (blocking)

--- a/.cursor/skills/_team-sapphire/WORKFLOW.md
+++ b/.cursor/skills/_team-sapphire/WORKFLOW.md
@@ -52,7 +52,7 @@ Only requirement and progress on the issue:
 
 Investigation and spec stay in the orchestrator session — not in this document.
 
-Phase transitions post structured **summary** comments (`**Sapphire · … complete**`) for audit trail.
+Phase transitions post structured **summary** comments (`**Sapphire · … complete**`) for audit trail. These are **blocking gates** — see `PHASE-GATE.md`. Do not defer them to the end of the run.
 
 ## Status lifecycle
 
@@ -75,3 +75,4 @@ Manual: `Run _team-sapphire for SOK-XXX` in Cursor.
 - Do not run Coder before **session spec** exists.
 - Do not set **In Review** when the PR opens — Reviewer sets it on pass.
 - Do not mark **Done** before human merge.
+- Do not batch phase comments or status updates at the end — each phase gate must pass before the next phase (`PHASE-GATE.md`).


### PR DESCRIPTION
## Summary

- Adds `PHASE-GATE.md` with blocking Linear writes per Sapphire phase (comment + status table row before the next phase).
- Documents SOK-569 batch-at-end anti-pattern and an exit gate with retroactive repair steps.
- Updates orchestrator, role, workflow, Linear MCP, and Cloud automation docs to treat phase gates as mandatory.

## Test plan

- [ ] Review `PHASE-GATE.md` gate table and exit verification checklist
- [ ] Confirm load order in `AGENTS.md` references phase gates before Linear writes
- [ ] Run a delegated Sapphire issue and verify each phase posts comment + updates status table before continuing


Made with [Cursor](https://cursor.com)