### PR TITLE
chore(web): use dedicated secret for design-md job tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 env:
   DATABASE_URL: "postgresql://user:password@localhost:5432/sokosumi"
   BETTER_AUTH_SECRET: "ci-build-better-auth-secret"
+  DESIGN_MD_JOB_TOKEN_SECRET: "ci-design-md-job-token-secret"
   POSTMARK_SERVER_ID: "ci-postmark-server-id"
   POSTMARK_FROM_EMAIL: "ci@sokosumi.com"
   NEXT_PUBLIC_NETWORK: "Preprod"

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -52,11 +52,7 @@ CORE_APP_BASE_URL="http://localhost:8787"
 # Better Auth
 BETTER_AUTH_URL=http://localhost:3000
 BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"
-BETTER_AUTH_SECRET=<better-auth-secret>
 BETTER_AUTH_ORG_INVITATION_LIMIT=<organization-invitation-limit>
-
-# Postmark
-
 
 # Vercel blob storage
 BLOB_READ_WRITE_TOKEN=<your-vercel-blob-read-write-token>
@@ -64,6 +60,8 @@ BLOB_READ_WRITE_TOKEN=<your-vercel-blob-read-write-token>
 # Masumi DESIGN.md generator (optional; required to generate DESIGN.md from a URL)
 MASUMI_DESIGN_MD_API_KEY=<your-masumi-design-md-api-key>
 # MASUMI_DESIGN_MD_API_URL=https://www.masumi.network/api/v1
+# HMAC key for short-lived DESIGN.md job tokens; any high-entropy string
+DESIGN_MD_JOB_TOKEN_SECRET=<design-md-job-token-secret>
 
 # Cron auth — shared bearer for /api/internal/* cron routes.
 # Vercel Cron automatically attaches this when set as an env var.

--- a/apps/web/src/config/env.secrets.ts
+++ b/apps/web/src/config/env.secrets.ts
@@ -101,12 +101,12 @@ const envSecretsSchema = z.object({
   MASUMI_DESIGN_MD_API_URL: z
     .url()
     .default("https://www.masumi.network/api/v1"),
+  DESIGN_MD_JOB_TOKEN_SECRET: z.string().min(1),
 
   // Social Secrets
   // Better Auth Settings
   BETTER_AUTH_URL: z.url().default("http://localhost:3000"),
   BETTER_AUTH_COOKIE_DOMAIN: z.string().optional(),
-  BETTER_AUTH_SECRET: z.string().min(1),
   BETTER_AUTH_ORG_INVITATION_LIMIT: z.coerce.number().min(0).default(100),
   REGISTRY_API_URL: z.url().default("https://registry.masumi.network/api/v1"),
   REGISTRY_API_KEY: z.string().min(1),

--- a/apps/web/src/lib/services/__tests__/design-md.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/design-md.service.test.ts
@@ -27,13 +27,13 @@ vi.mock("@/config/env.public", () => ({
 }));
 
 interface EnvSecretsMock {
-  BETTER_AUTH_SECRET: string;
+  DESIGN_MD_JOB_TOKEN_SECRET: string;
   MASUMI_DESIGN_MD_API_KEY?: string;
   MASUMI_DESIGN_MD_API_URL: string;
 }
 
 const getEnvSecretsMock = vi.fn<() => EnvSecretsMock>(() => ({
-  BETTER_AUTH_SECRET: "test-secret",
+  DESIGN_MD_JOB_TOKEN_SECRET: "test-secret",
   MASUMI_DESIGN_MD_API_KEY: "api-key",
   MASUMI_DESIGN_MD_API_URL: "https://masumi.example/api/v1",
 }));
@@ -261,7 +261,7 @@ describe("designMdService", () => {
 
   it("throws unconfigured when the Masumi API key is missing", async () => {
     getEnvSecretsMock.mockReturnValueOnce({
-      BETTER_AUTH_SECRET: "test-secret",
+      DESIGN_MD_JOB_TOKEN_SECRET: "test-secret",
       MASUMI_DESIGN_MD_API_URL: "https://masumi.example/api/v1",
     });
 

--- a/apps/web/src/lib/services/design-md.service.ts
+++ b/apps/web/src/lib/services/design-md.service.ts
@@ -105,7 +105,7 @@ function assertDonePayload(payload: DesignMdJobPayload): DesignMdDonePayload {
 }
 
 function getJobTokenSecret(): string {
-  return getEnvSecrets().BETTER_AUTH_SECRET;
+  return getEnvSecrets().DESIGN_MD_JOB_TOKEN_SECRET;
 }
 
 function assertValidJobToken(


### PR DESCRIPTION
## Summary

Follow-up to #3142. The DESIGN.md job-token HMAC (`design-md.service.ts`) reused `BETTER_AUTH_SECRET` as its signing key — the last remaining use of that variable in the web app now that the Better Auth instance lives on core.

- Introduce `DESIGN_MD_JOB_TOKEN_SECRET` (required) and use it in `getJobTokenSecret()`
- Drop `BETTER_AUTH_SECRET` from the web env schema and `.env.example`
- Add the new var to the CI build env

## Impact

- **Deploy prerequisite:** set `DESIGN_MD_JOB_TOKEN_SECRET` (any high-entropy string) on the web Vercel projects **before** merging — the env schema requires it, so the build/runtime fails without it. `BETTER_AUTH_SECRET` can then be removed from the web projects (keep it on core).
- In-flight DESIGN.md job tokens (max 1 h TTL) are invalidated at deploy; restarting the generation is the only recovery needed.
- No behavior change otherwise; web's secret no longer needs to match core's.

## Verification

- `pnpm --filter web test` — 1351 passed
- `pnpm --filter web exec tsc --noEmit` — clean
- `biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)