### PR TITLE
fix(web): forward origin and referer headers to core auth

### DIFF
--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -74,6 +74,10 @@ const FORWARDED_HEADER_NAMES = [
   "cookie",
   "accept-language",
   "user-agent",
+  // Better Auth's CSRF origin check rejects cookie-bearing POSTs that lack an
+  // origin/referer header, so both must survive the server-to-server hop.
+  "origin",
+  "referer",
   "x-forwarded-for",
   "x-vercel-forwarded-for",
 ] as const;


### PR DESCRIPTION
## Summary

Email/password sign-in on preprod failed with a "Missing or null Origin" toast. Since the Better Auth instance moved from web (in-process) to core (HTTP) in #3142, the web server-side auth facade forwards only a whitelist of headers to core — and `origin`/`referer` were not on it. Better Auth's CSRF origin check rejects cookie-bearing POSTs that lack both headers, so every sign-in from a browser with existing cookies was rejected with 403 `MISSING_OR_NULL_ORIGIN`.

This adds `origin` and `referer` to `FORWARDED_HEADER_NAMES` in `apps/web/src/lib/auth/auth.ts`, so the browser's `Origin` header survives the server-to-server hop and is validated against core's `trustedOrigins` as intended.

## User-facing impact

Email/password sign-in (and any other cookie-bearing auth mutation routed through the web facade, e.g. sign-up, magic link request, subscription upgrade) works again on deployed environments.

## Verification

- `pnpm --filter web test src/lib/auth/__tests__/auth.test.ts src/lib/auth/__tests__/auth.client.test.ts` — 9/9 pass
- `pnpm exec biome check apps/web/src/lib/auth/auth.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)