### PR TITLE
fix(core): narrow better auth trusted origins to explicit app hosts

### DIFF
--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -374,8 +374,9 @@ export const auth = betterAuth({
     storage: "database",
   },
   trustedOrigins: [
-    "https://sokosumi.com",
-    "https://*.sokosumi.com",
+    "https://app.sokosumi.com",
+    "https://preprod.sokosumi.com",
+    "https://*.preview.sokosumi.com", // Vercel preview deployment suffix
     ...(env.NODE_ENV === "development"
       ? ["http://localhost:*"] // local dev only; omit in staging/production deploys
       : []),


### PR DESCRIPTION
## Summary

Replaces the broad `https://sokosumi.com` + `https://*.sokosumi.com` Better Auth `trustedOrigins` entries with the explicit hosts that actually serve the web app:

- `https://app.sokosumi.com` (production)
- `https://preprod.sokosumi.com`
- `https://*.preview.sokosumi.com` (Vercel preview deployment suffix, confirmed configured)

The `http://localhost:*` development entry is unchanged.

## Why

Session cookies are issued for `.sokosumi.com` (`BETTER_AUTH_COOKIE_DOMAIN`), so they ride along on requests from **every** subdomain. With the wildcard, any subdomain — marketing pages, `mcp.`, or a dangling/taken-over DNS record — was accepted both as a CSRF origin and as a `callbackURL` redirect target. Restricting the list to the hosts that actually run the app shrinks that surface.

`trustedOrigins` validates the `Origin` header on cookie-bearing POSTs (see #3147, which makes web forward that header) as well as `callbackURL`/`redirectTo` values, so this list must cover every origin users sign in from — production, preprod, and preview deployments are all included.

## User-facing impact

None expected: sign-in continues to work on production, preprod, and preview deployments. Requests originating from other `sokosumi.com` subdomains are no longer trusted.

## Verification

- `pnpm exec tsc --noEmit` in `apps/core` — clean
- `pnpm exec biome check apps/core/src/lib/auth.ts` — clean
- After deploy: verify email/password sign-in on preprod and on one preview deployment (social login via `oAuthProxy` included).

## Note

`apps/core/src/config/cors-allow-origin.ts` still allows all `*.sokosumi.com` for CORS; tightening that to the same host list could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)