### PR TITLE
fix(web): decode relayed auth cookie values to avoid double-encoding

### DIFF
--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -168,6 +168,75 @@ describe("auth facade", () => {
       },
     );
   });
+  it("decodes percent-encoded cookie values so Next's re-encoding does not double-encode them", async () => {
+    signInEmailMock.mockImplementation(
+      async (
+        _body: unknown,
+        fetchOptions: {
+          onResponse?: (context: { response: Response }) => Promise<void>;
+        },
+      ) => {
+        const response = new Response("{}");
+        response.headers.append(
+          "set-cookie",
+          "sokosumi.session_token=tok.sig%2Fwith%2Bencoded%3D; Path=/; HttpOnly; SameSite=Lax",
+        );
+        await fetchOptions.onResponse?.({ response });
+        return { data: { redirect: false }, error: null };
+      },
+    );
+
+    const { auth } = await import("../auth");
+    await auth.api.signInEmail({
+      body: { email: "jane@example.com", password: "pw-123456" },
+      headers: new Headers(),
+    });
+
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "sokosumi.session_token",
+      "tok.sig/with+encoded=",
+      {
+        httpOnly: true,
+        path: "/",
+        sameSite: "lax",
+      },
+    );
+  });
+
+  it("relays a malformed percent sequence verbatim instead of throwing", async () => {
+    signInEmailMock.mockImplementation(
+      async (
+        _body: unknown,
+        fetchOptions: {
+          onResponse?: (context: { response: Response }) => Promise<void>;
+        },
+      ) => {
+        const response = new Response("{}");
+        response.headers.append(
+          "set-cookie",
+          "sokosumi.session_token=raw%ZZvalue; Path=/; SameSite=Lax",
+        );
+        await fetchOptions.onResponse?.({ response });
+        return { data: { redirect: false }, error: null };
+      },
+    );
+
+    const { auth } = await import("../auth");
+    await auth.api.signInEmail({
+      body: { email: "jane@example.com", password: "pw-123456" },
+      headers: new Headers(),
+    });
+
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "sokosumi.session_token",
+      "raw%ZZvalue",
+      {
+        path: "/",
+        sameSite: "lax",
+      },
+    );
+  });
+
   it("skips the Set-Cookie relay in read-only (RSC) contexts instead of failing the call", async () => {
     cookieSetMock.mockImplementation(() => {
       throw new Error(

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -166,9 +166,20 @@ function parseSetCookie(raw: string): ParsedSetCookie | null {
   }
 
   const name = nameValue.slice(0, separatorIndex).trim();
-  const value = nameValue.slice(separatorIndex + 1).trim();
+  const rawValue = nameValue.slice(separatorIndex + 1).trim();
   if (!name) {
     return null;
+  }
+
+  // The wire value is already percent-encoded (Better Auth serializes with
+  // encodeURIComponent) and Next's cookieStore.set encodes again on write, so
+  // relay the decoded value or the session token reaches core double-encoded
+  // and fails signature verification.
+  let value = rawValue;
+  try {
+    value = decodeURIComponent(rawValue);
+  } catch {
+    // Not valid percent-encoding — relay verbatim.
   }
 
   const options: ParsedSetCookie["options"] = {};


### PR DESCRIPTION
## Problem

After #3142/#3147, sign-in succeeds but every subsequent request fails with `Invalid, expired or missing session` (401 from core's session middleware).

## Root cause

Core's `Set-Cookie` values arrive percent-encoded on the wire (Better Auth serializes with `encodeURIComponent`, e.g. `...Ms%2BgpTDJPCopc%3D`). `relaySetCookies` in `apps/web/src/lib/auth/auth.ts` passed that wire value straight to Next's `cookieStore.set`, which encodes again — the browser stored a double-encoded session token (`%252B`). Core then decoded it once, got a literal `%2B` in the signature, failed verification, and returned no session.

Verified against a local core instance:
- `get-session` with the single-encoded wire cookie → session returned
- same cookie with `%` → `%25` (what the relay produced) → `null`

Sign-in "worked" because its response body doesn't depend on the cookie round-trip.

## Fix

Decode the parsed cookie value with `decodeURIComponent` before re-setting it, so Next's re-encoding restores the original wire value. Malformed percent sequences are relayed verbatim.

## Verification

- `pnpm --filter web test` — 233 files, 1353 tests pass (includes new regression tests for encoded and malformed values)
- `pnpm check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)