### PR TITLE
fix(core): set default value for BETTER_AUTH_COOKIE_DOMAIN and simplify cookie domain configuration

### DIFF
--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -51,7 +51,7 @@ const envSchema = z.object({
   // Better Auth
   BETTER_AUTH_SECRET: z.string().min(1),
   BETTER_AUTH_URL: z.url(),
-  BETTER_AUTH_COOKIE_DOMAIN: z.string().optional(),
+  BETTER_AUTH_COOKIE_DOMAIN: z.string().default("localhost"),
   BETTER_AUTH_RP_ID: z.string().min(1).default("localhost"),
   BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE: z.coerce
     .number()

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -90,7 +90,7 @@ const {
 
 function getDefaultEnv() {
   return {
-    BETTER_AUTH_COOKIE_DOMAIN: undefined,
+    BETTER_AUTH_COOKIE_DOMAIN: "localhost",
     BETTER_AUTH_EMAIL_VERIFICATION_EXPIRES_IN: 172800,
     BETTER_AUTH_ORG_INVITATION_EXPIRES_IN: 604800,
     BETTER_AUTH_ORG_INVITATION_LIMIT: 100,
@@ -548,16 +548,14 @@ describe("core auth config", () => {
     });
   });
 
-  it("disables cross-subdomain cookies when no cookie domain is configured", async () => {
-    getEnvMock.mockReturnValue({
-      ...getDefaultEnv(),
-      BETTER_AUTH_COOKIE_DOMAIN: undefined,
-    });
-
+  it("always enables cross-subdomain cookies with the default localhost domain", async () => {
     await import("./auth");
 
     const config = getBetterAuthConfig();
-    expect(config.advanced.crossSubDomainCookies).toBeUndefined();
+    expect(config.advanced.crossSubDomainCookies).toEqual({
+      enabled: true,
+      domain: "localhost",
+    });
     expect(config.advanced.cookiePrefix).toBe("sokosumi-localhost-preprod");
   });
 

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -240,14 +240,10 @@ export const auth = betterAuth({
       generateId: "uuid",
     },
     cookiePrefix: betterAuthCookiePrefix,
-    ...(env.BETTER_AUTH_COOKIE_DOMAIN
-      ? {
-          crossSubDomainCookies: {
-            enabled: true,
-            domain: env.BETTER_AUTH_COOKIE_DOMAIN,
-          },
-        }
-      : {}),
+    crossSubDomainCookies: {
+      enabled: true,
+      domain: env.BETTER_AUTH_COOKIE_DOMAIN,
+    },
     ipAddress: {
       ipAddressHeaders: ["x-vercel-forwarded-for", "x-forwarded-for"],
     },


### PR DESCRIPTION
## Summary

- Default `BETTER_AUTH_COOKIE_DOMAIN` to `localhost` in core env config so local dev always has an explicit cookie domain.
- Always enable Better Auth `crossSubDomainCookies` using that env value, removing the conditional spread that skipped cross-domain cookies when the variable was unset.

## Key changes

- **`apps/core/src/config/env.ts`**: `BETTER_AUTH_COOKIE_DOMAIN` is now `z.string().default("localhost")` instead of optional.
- **`apps/core/src/lib/auth.ts`**: `crossSubDomainCookies` is always configured with `enabled: true` and `domain: env.BETTER_AUTH_COOKIE_DOMAIN`.

## Why

Cross-subdomain session cookies (web ↔ core) need a stable domain. Making the env var required-with-default avoids silently disabling cross-domain cookies in dev, while production can still override via `BETTER_AUTH_COOKIE_DOMAIN` (e.g. `.sokosumi.com`).

## Test plan

- [ ] Local dev: sign in on web with core running; session persists across web/core requests
- [ ] Verify auth cookies are set with `Domain=localhost` locally
- [ ] Staging/prod: set `BETTER_AUTH_COOKIE_DOMAIN` to the parent domain and confirm cookies work across subdomains
- [ ] `pnpm core:test` (if auth-related tests exist)


Made with [Cursor](https://cursor.com)