### PR TITLE
fix(web): decode relayed auth cookie values to prevent double encoding

### DIFF
--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -168,6 +168,75 @@ describe("auth facade", () => {
       },
     );
   });
+
+  it("decodes percent-encoded cookie values so Next's re-encoding restores the wire format", async () => {
+    // Better Auth serializes signed session tokens with encodeURIComponent
+    // (the HMAC part contains "+", "/", "="). Next's cookies().set encodes
+    // again, so relaying the raw wire value double-encodes it ("%2B" →
+    // "%252B") and core's signature check rejects every forwarded request.
+    signInEmailMock.mockImplementation(
+      async (
+        _body: unknown,
+        fetchOptions: {
+          onResponse?: (context: { response: Response }) => Promise<void>;
+        },
+      ) => {
+        const response = new Response("{}");
+        response.headers.append(
+          "set-cookie",
+          "sokosumi.session_token=tok.MeMjd%2B6mLNIb1Dy8lw%2BotxFqPKsYu%2BTCnHdwZI096cA%3D; Path=/; HttpOnly; SameSite=Lax",
+        );
+        await fetchOptions.onResponse?.({ response });
+        return { data: { redirect: false }, error: null };
+      },
+    );
+
+    const { auth } = await import("../auth");
+    await auth.api.signInEmail({
+      body: { email: "jane@example.com", password: "pw-123456" },
+      headers: new Headers(),
+    });
+
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "sokosumi.session_token",
+      "tok.MeMjd+6mLNIb1Dy8lw+otxFqPKsYu+TCnHdwZI096cA=",
+      {
+        httpOnly: true,
+        path: "/",
+        sameSite: "lax",
+      },
+    );
+  });
+
+  it("relays a value with a literal % that is not a valid escape sequence as-is", async () => {
+    signInEmailMock.mockImplementation(
+      async (
+        _body: unknown,
+        fetchOptions: {
+          onResponse?: (context: { response: Response }) => Promise<void>;
+        },
+      ) => {
+        const response = new Response("{}");
+        response.headers.append(
+          "set-cookie",
+          "sokosumi.weird=100%legacy; Path=/",
+        );
+        await fetchOptions.onResponse?.({ response });
+        return { data: { redirect: false }, error: null };
+      },
+    );
+
+    const { auth } = await import("../auth");
+    await auth.api.signInEmail({
+      body: { email: "jane@example.com", password: "pw-123456" },
+      headers: new Headers(),
+    });
+
+    expect(cookieSetMock).toHaveBeenCalledWith("sokosumi.weird", "100%legacy", {
+      path: "/",
+    });
+  });
+
   it("skips the Set-Cookie relay in read-only (RSC) contexts instead of failing the call", async () => {
     cookieSetMock.mockImplementation(() => {
       throw new Error(

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -154,6 +154,22 @@ interface ParsedSetCookie {
   };
 }
 
+/**
+ * Core serializes cookie values with encodeURIComponent (Better Auth signed
+ * tokens contain "+", "/", "="), and Next's `cookies().set` encodes again on
+ * write. Relaying the wire value verbatim therefore double-encodes it ("%2B"
+ * → "%252B") and core rejects the session signature on every forwarded
+ * request. Decode once so Next's re-encoding reproduces the original wire
+ * value.
+ */
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value; // not percent-encoded (e.g. a stray literal "%")
+  }
+}
+
 function parseSetCookie(raw: string): ParsedSetCookie | null {
   const [nameValue, ...attributeParts] = raw.split(";");
   if (!nameValue) {
@@ -166,7 +182,7 @@ function parseSetCookie(raw: string): ParsedSetCookie | null {
   }
 
   const name = nameValue.slice(0, separatorIndex).trim();
-  const value = nameValue.slice(separatorIndex + 1).trim();
+  const value = decodeCookieValue(nameValue.slice(separatorIndex + 1).trim());
   if (!name) {
     return null;
   }


### PR DESCRIPTION
## Problem

After the Better Auth move to core (#3142), sign-in succeeds but every subsequent `/v1/*` request fails with 401 `Invalid, expired or missing session` (locally and deployed).

## Root cause

Core serializes Better Auth cookie values with `encodeURIComponent` — signed session tokens contain `+`, `/`, `=`, so the wire value carries `%2B`/`%3D`. The web auth facade's `relaySetCookies` re-sets that raw wire value via Next's `cookies().set`, which encodes **again** (`%2B` → `%252B`). The browser stores a double-encoded session token, core's HMAC check fails instantly, and `getSession` returns null for every forwarded request.

Empirically verified against a local core:

| cookie value sent to core | `GET /v1/projects` |
| --- | --- |
| verbatim wire value | 200 |
| double-encoded (what the relay produced) | 401 in 3ms |

Note: `GET /auth/get-session` returns **200 with body `null`** when there is no valid session, so the 200s in the request log masked the failure.

## Fix

Decode the parsed cookie value once before handing it to Next, so Next's re-encoding reproduces the original wire value. Values with a stray literal `%` that is not a valid escape sequence are relayed as-is.

## Verification

- `pnpm --filter web test` — 233 files, 1353 tests pass
- New facade tests: percent-encoded value round-trip + literal-`%` fallback
- Manual: decode → `ResponseCookies.set` re-encode equals the original Set-Cookie wire value; live local core accepts it (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)