### PR TITLE
fix(web): sanitize auth cookies forwarded to core after migration

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -10,7 +10,8 @@ WEB_APP_BASE_URL="http://localhost:3000"
 # Public base URL of this Core API (Better Auth baseURL when not on Vercel Preview).
 BETTER_AUTH_SECRET="TFVfK91TGv2YVyVYFk0lu87Md5a13E4l7AjEaoZD8dQ="
 BETTER_AUTH_URL="http://localhost:8787"
-BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"
+# Use `localhost` locally (Core forces this when NODE_ENV=development). Production: sokosumi.com
+BETTER_AUTH_COOKIE_DOMAIN="localhost"
 BETTER_AUTH_RP_ID="localhost"
 # BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE="300"
 # BETTER_AUTH_ORG_INVITATION_LIMIT="100"

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -559,6 +559,21 @@ describe("core auth config", () => {
     expect(config.advanced.cookiePrefix).toBe("sokosumi-localhost-preprod");
   });
 
+  it("forces localhost cookie domain in development even when env says sokosumi.com", async () => {
+    getEnvMock.mockReturnValue({
+      ...getDefaultEnv(),
+      NODE_ENV: "development",
+      BETTER_AUTH_COOKIE_DOMAIN: "sokosumi.com",
+    });
+
+    await import("./auth");
+
+    expect(getBetterAuthConfig().advanced.crossSubDomainCookies).toEqual({
+      enabled: true,
+      domain: "localhost",
+    });
+  });
+
   it("uses the configured cookie domain when provided", async () => {
     getEnvMock.mockReturnValue({
       ...getDefaultEnv(),

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -30,6 +30,7 @@ import {
   ORGANIZATION_HAS_ADDITIONAL_MEMBERS_ERROR_CODE,
   resolveBetterAuthCookieName,
   resolveBetterAuthCookiePrefix,
+  resolveBetterAuthIssuerCookieDomain,
 } from "@sokosumi/utils";
 import {
   APIError,
@@ -78,10 +79,10 @@ const betterAuthCookiePrefixParams = {
 const betterAuthCookiePrefix = resolveBetterAuthCookiePrefix(
   betterAuthCookiePrefixParams,
 );
-// Local .env files often copy production `sokosumi.com`; browsers reject that
-// domain on localhost, which breaks sign-in. Development always uses localhost.
-const betterAuthCookieDomain =
-  env.NODE_ENV === "development" ? "localhost" : env.BETTER_AUTH_COOKIE_DOMAIN;
+const betterAuthCookieDomain = resolveBetterAuthIssuerCookieDomain(
+  env.BETTER_AUTH_COOKIE_DOMAIN,
+  env.NODE_ENV,
+);
 
 const fromEmail = env.POSTMARK_FROM_EMAIL;
 const stripeInstance = new Stripe(env.STRIPE_SECRET_KEY);

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -78,6 +78,10 @@ const betterAuthCookiePrefixParams = {
 const betterAuthCookiePrefix = resolveBetterAuthCookiePrefix(
   betterAuthCookiePrefixParams,
 );
+// Local .env files often copy production `sokosumi.com`; browsers reject that
+// domain on localhost, which breaks sign-in. Development always uses localhost.
+const betterAuthCookieDomain =
+  env.NODE_ENV === "development" ? "localhost" : env.BETTER_AUTH_COOKIE_DOMAIN;
 
 const fromEmail = env.POSTMARK_FROM_EMAIL;
 const stripeInstance = new Stripe(env.STRIPE_SECRET_KEY);
@@ -242,7 +246,7 @@ export const auth = betterAuth({
     cookiePrefix: betterAuthCookiePrefix,
     crossSubDomainCookies: {
       enabled: true,
-      domain: env.BETTER_AUTH_COOKIE_DOMAIN,
+      domain: betterAuthCookieDomain,
     },
     ipAddress: {
       ipAddressHeaders: ["x-vercel-forwarded-for", "x-forwarded-for"],

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -49,9 +49,9 @@ PAYMENT_API_KEY=<payment-api-key>
 DATABASE_URL="postgresql://abc:abc@cde:5432/sokosumi?schema=public"
 CORE_APP_BASE_URL="http://localhost:8787"
 
-# Better Auth
-BETTER_AUTH_URL=http://localhost:3000
-BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"
+# Better Auth (session cookies are issued by Core — see CORE_APP_BASE_URL)
+# Leave BETTER_AUTH_COOKIE_DOMAIN unset locally; Core forces `localhost` in development.
+# BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"
 BETTER_AUTH_SECRET=<better-auth-secret>
 BETTER_AUTH_ORG_INVITATION_LIMIT=<organization-invitation-limit>
 

--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -64,7 +64,8 @@ describe("proxy", () => {
     );
     expect(getSessionCookieMock).not.toHaveBeenCalled();
   });
-  describe("session-rescope shim", () => {
+
+  describe("shared auth session cookie shim", () => {
     function buildEnv(cookieDomain: string | undefined) {
       return {
         BETTER_AUTH_COOKIE_DOMAIN: cookieDomain,
@@ -75,7 +76,7 @@ describe("proxy", () => {
       };
     }
 
-    it("re-scopes the host-only session cookie and sets the marker", async () => {
+    it("re-scopes the host-only session cookie on a matching remote host", async () => {
       getEnvSecretsMock.mockReturnValue(buildEnv("sokosumi.com"));
       const { NextRequest } = await import("next/server");
       const { proxy } = await import("../proxy");
@@ -97,6 +98,51 @@ describe("proxy", () => {
       ).toMatchObject({
         value: "1",
         domain: "sokosumi.com",
+      });
+    });
+
+    it("re-scopes host-only session cookies on localhost for cross-port core access", async () => {
+      getEnvSecretsMock.mockReturnValue(buildEnv(undefined));
+      const { NextRequest } = await import("next/server");
+      const { proxy } = await import("../proxy");
+      const request = new NextRequest("http://localhost:3000/tasks");
+      request.cookies.set("sokosumi.session_token", "tok");
+
+      const response = await proxy(request);
+
+      expect(response.cookies.get("sokosumi.session_token")).toMatchObject({
+        value: "tok",
+        domain: "localhost",
+        httpOnly: true,
+        path: "/",
+        sameSite: "lax",
+      });
+      expect(
+        response.cookies.get("sokosumi.session_token_rescoped"),
+      ).toMatchObject({
+        value: "1",
+        domain: "localhost",
+      });
+    });
+
+    it("uses localhost on local dev even when a production cookie domain is configured", async () => {
+      getEnvSecretsMock.mockReturnValue(buildEnv("sokosumi.com"));
+      const { NextRequest } = await import("next/server");
+      const { proxy } = await import("../proxy");
+      const request = new NextRequest("http://localhost:3000/dashboard");
+      request.cookies.set("sokosumi.session_token", "tok");
+
+      const response = await proxy(request);
+
+      expect(response.cookies.get("sokosumi.session_token")).toMatchObject({
+        value: "tok",
+        domain: "localhost",
+      });
+      expect(
+        response.cookies.get("sokosumi.session_token_rescoped"),
+      ).toMatchObject({
+        value: "1",
+        domain: "localhost",
       });
     });
 
@@ -131,11 +177,38 @@ describe("proxy", () => {
       expect(response.cookies.get("sokosumi.session_token")).toBeUndefined();
     });
 
-    it("does nothing without a configured cookie domain", async () => {
+    it("does nothing when the legacy localhost marker cookie is already present", async () => {
+      getEnvSecretsMock.mockReturnValue(buildEnv(undefined));
+      const { NextRequest } = await import("next/server");
+      const { proxy } = await import("../proxy");
+      const request = new NextRequest("http://localhost:3000/tasks");
+      request.cookies.set("sokosumi.session_token", "tok");
+      request.cookies.set("sokosumi.session_cross_port_scoped", "1");
+
+      const response = await proxy(request);
+
+      expect(response.cookies.get("sokosumi.session_token")).toBeUndefined();
+    });
+
+    it("does nothing on remote hosts without a configured cookie domain", async () => {
       getEnvSecretsMock.mockReturnValue(buildEnv(undefined));
       const { NextRequest } = await import("next/server");
       const { proxy } = await import("../proxy");
       const request = new NextRequest("https://app.sokosumi.com/dashboard");
+      request.cookies.set("sokosumi.session_token", "tok-123");
+
+      const response = await proxy(request);
+
+      expect(response.cookies.get("sokosumi.session_token")).toBeUndefined();
+    });
+
+    it("does nothing when the remote host does not match the configured cookie domain", async () => {
+      getEnvSecretsMock.mockReturnValue(buildEnv("sokosumi.com"));
+      const { NextRequest } = await import("next/server");
+      const { proxy } = await import("../proxy");
+      const request = new NextRequest(
+        "https://my-app.example.vercel.app/dashboard",
+      );
       request.cookies.set("sokosumi.session_token", "tok-123");
 
       const response = await proxy(request);

--- a/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
@@ -1,10 +1,10 @@
 import { render, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthSessionGuard } from "@/app/components/auth-session-guard";
-import { authClient } from "@/lib/auth/auth.client";
 
 const replaceMock = vi.fn();
+const fetchMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -12,45 +12,43 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("@/lib/auth/auth.client", () => ({
-  authClient: {
-    getSession: vi.fn(),
-  },
-}));
-
 describe("AuthSessionGuard", () => {
   beforeEach(() => {
     replaceMock.mockReset();
-    vi.mocked(authClient.getSession).mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
 
     window.history.replaceState({}, "", "/agents?view=grid");
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("revalidates the session without cookie cache on mount", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
         session: {
           activeOrganizationId: null,
         },
-      },
-      error: null,
+      }),
     });
 
     render(<AuthSessionGuard />);
 
     await waitFor(() => {
-      expect(authClient.getSession).toHaveBeenCalledWith({
-        query: {
-          disableCookieCache: true,
-        },
+      expect(fetchMock).toHaveBeenCalledWith("/api/auth/session", {
+        cache: "no-store",
+        credentials: "include",
       });
     });
   });
 
   it("redirects to sign-in when the session is missing", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: null,
-      error: null,
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ session: null }),
     });
 
     render(<AuthSessionGuard />);
@@ -63,13 +61,13 @@ describe("AuthSessionGuard", () => {
   });
 
   it("revalidates again on focus without redirecting when the session is present", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
         session: {
           activeOrganizationId: null,
         },
-      },
-      error: null,
+      }),
     });
 
     render(<AuthSessionGuard />);
@@ -77,7 +75,7 @@ describe("AuthSessionGuard", () => {
     window.dispatchEvent(new Event("focus"));
 
     await waitFor(() => {
-      expect(authClient.getSession).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     expect(replaceMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx
@@ -16,6 +16,11 @@ vi.mock("next/headers", () => ({
   headers: async () => new Headers(),
 }));
 
+vi.mock("@/lib/auth/forward-cookies", () => ({
+  buildAuthRequestHeadersForForwarding: vi.fn(async () => new Headers()),
+  sanitizeForwardCookieHeader: (cookieHeader: string) => cookieHeader,
+}));
+
 vi.mock("stripe", () => ({
   __esModule: true,
   default: vi.fn(function MockStripe() {

--- a/apps/web/src/app/(app)/components/auth-session-guard.tsx
+++ b/apps/web/src/app/(app)/components/auth-session-guard.tsx
@@ -3,20 +3,30 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useEffectEvent, useRef } from "react";
 
-import { authClient } from "@/lib/auth/auth.client";
 import { createAuthSessionGetter } from "@/lib/utils/auth-redirect";
 import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
+
+async function fetchBrowserSession() {
+  const response = await fetch("/api/auth/session", {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    return { data: { session: null } };
+  }
+
+  const payload = (await response.json()) as {
+    session: unknown;
+  };
+
+  return { data: { session: payload.session ?? null } };
+}
 
 export function AuthSessionGuard() {
   const router = useRouter();
   const isRedirectingRef = useRef(false);
-  const getFreshSession = createAuthSessionGetter(() =>
-    authClient.getSession({
-      query: {
-        disableCookieCache: true,
-      },
-    }),
-  );
+  const getFreshSession = createAuthSessionGetter(fetchBrowserSession);
 
   const validateSession = useEffectEvent(async () => {
     if (isRedirectingRef.current) {

--- a/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
@@ -1,6 +1,5 @@
 import { MemberRole } from "@sokosumi/database";
 import type { SubscriptionPlanName } from "@sokosumi/utils";
-import { headers } from "next/headers";
 import { Suspense } from "react";
 import Stripe from "stripe";
 import {
@@ -10,6 +9,7 @@ import {
 } from "@/components/billing/subscription-plan-utils";
 import { getEnvSecrets } from "@/config/env.secrets";
 import { auth } from "@/lib/auth/auth";
+import { buildAuthRequestHeadersForForwarding } from "@/lib/auth/forward-cookies";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import type { Organization } from "@/lib/clients/generated/core";
 import { organizationSeatService, userService } from "@/lib/services";
@@ -136,7 +136,7 @@ export async function OnboardingDialogLoader({
     let personalActiveSubscriptions: ActiveSubscription[] = [];
     try {
       personalActiveSubscriptions = (await auth.api.listActiveSubscriptions({
-        headers: await headers(),
+        headers: await buildAuthRequestHeadersForForwarding(),
         query: {
           customerType: "user",
         },

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+import { getSession } from "@/lib/auth/utils";
+
+export async function GET() {
+  const session = await getSession({ refresh: true });
+
+  if (!session) {
+    return NextResponse.json({ session: null }, { status: 401 });
+  }
+
+  return NextResponse.json({ session });
+}

--- a/apps/web/src/lib/actions/auth/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/auth/__tests__/action.test.ts
@@ -19,15 +19,16 @@ const signInEmailMock = vi.fn();
 const signInMagicLinkMock = vi.fn();
 const setPasswordMock = vi.fn();
 const handleUTMConversionMock = vi.fn();
-const headersMock = vi.fn();
+const buildAuthRequestHeadersForForwardingMock = vi.fn();
 const betterAuthApiErrorSafeParseMock = vi.fn<
   (value: unknown) => BetterAuthApiErrorParseResult
 >(() => ({
   success: false,
 }));
 
-vi.mock("next/headers", () => ({
-  headers: headersMock,
+vi.mock("@/lib/auth/forward-cookies", () => ({
+  buildAuthRequestHeadersForForwarding: () =>
+    buildAuthRequestHeadersForForwardingMock(),
 }));
 
 vi.mock("@/lib/actions", () => ({
@@ -64,7 +65,7 @@ vi.mock("@/lib/services/utm.service", () => ({
 describe("auth actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    headersMock.mockResolvedValue(new Headers());
+    buildAuthRequestHeadersForForwardingMock.mockResolvedValue(new Headers());
     betterAuthApiErrorSafeParseMock.mockReturnValue({ success: false });
   });
 
@@ -219,7 +220,7 @@ describe("auth actions", () => {
 
     const cookieHeaders = new Headers();
     cookieHeaders.set("cookie", "session_token=fake-session");
-    headersMock.mockResolvedValue(cookieHeaders);
+    buildAuthRequestHeadersForForwardingMock.mockResolvedValue(cookieHeaders);
 
     const { signUpEmail } = await import("../action");
 

--- a/apps/web/src/lib/actions/auth/action.ts
+++ b/apps/web/src/lib/actions/auth/action.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import type { User } from "better-auth";
-import { headers } from "next/headers";
 
 import {
   type ActionError,
@@ -11,6 +10,7 @@ import {
 } from "@/lib/actions";
 import { auth } from "@/lib/auth/auth";
 import { emailSchema } from "@/lib/auth/data";
+import { buildAuthRequestHeadersForForwarding } from "@/lib/auth/forward-cookies";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import {
   type NewPasswordFormType,
@@ -99,7 +99,7 @@ export async function signUpEmail(
         termsAccepted: parsed.termsAccepted,
         onboardingCompleted: false,
       },
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
     });
     const user = signUpResult.user;
     if (!user) {
@@ -184,7 +184,7 @@ export async function signInEmail(
         rememberMe: parsed.rememberMe,
         callbackURL: safeCallbackURL,
       },
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
     });
 
     const oauthResponse = signInResult as {
@@ -245,7 +245,7 @@ export async function requestMagicLinkSignIn(
         email: parsedResult.data,
         callbackURL: safeCallbackURL,
       },
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
     });
 
     return Ok();

--- a/apps/web/src/lib/actions/subscription/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/subscription/__tests__/action.test.ts
@@ -5,9 +5,11 @@ export {};
 vi.mock("server-only", () => ({}));
 
 const headersMock = vi.fn(async () => new Headers());
+const buildAuthRequestHeadersForForwardingMock = vi.fn();
 const cookieDeleteMock = vi.fn();
 const cookiesMock = vi.fn(async () => ({
   delete: cookieDeleteMock,
+  getAll: () => [],
 }));
 const upgradeSubscriptionMock = vi.fn();
 const createBillingPortalMock = vi.fn();
@@ -16,6 +18,12 @@ const updateOrganizationSeatsImmediatelyMock = vi.fn();
 vi.mock("next/headers", () => ({
   cookies: cookiesMock,
   headers: headersMock,
+}));
+
+vi.mock("@/lib/auth/forward-cookies", () => ({
+  buildAuthRequestHeadersForForwarding: () =>
+    buildAuthRequestHeadersForForwardingMock(),
+  sanitizeForwardCookieHeader: (cookieHeader: string) => cookieHeader,
 }));
 
 vi.mock("@/lib/auth/auth", () => ({
@@ -73,6 +81,7 @@ const organizationSession = {
 describe("subscription actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    buildAuthRequestHeadersForForwardingMock.mockResolvedValue(new Headers());
   });
 
   it("returns BAD_INPUT for invalid plan names", async () => {

--- a/apps/web/src/lib/actions/subscription/action.ts
+++ b/apps/web/src/lib/actions/subscription/action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { headers } from "next/headers";
 import * as z from "zod";
 import {
   type ActionError,
@@ -9,6 +8,7 @@ import {
 } from "@/lib/actions/errors";
 import { clearSubscriptionOnboardingGateSessionCookie } from "@/lib/actions/onboarding";
 import { auth } from "@/lib/auth/auth";
+import { buildAuthRequestHeadersForForwarding } from "@/lib/auth/forward-cookies";
 import { organizationSubscriptionService } from "@/lib/services";
 import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
@@ -130,7 +130,7 @@ export const upgradePersonalSubscription = withSession<
       parsed.data.returnPath ?? "/billing?tab=subscription";
 
     const result = await auth.api.upgradeSubscription({
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
       body: {
         plan: parsed.data.plan,
         customerType: "user",
@@ -172,7 +172,7 @@ export const openPersonalBillingPortal = withSession<
 
   try {
     const result = await auth.api.createBillingPortal({
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
       body: {
         customerType: "user",
         returnUrl: parsedReturnPath.data ?? "/billing?tab=subscription",
@@ -218,7 +218,7 @@ export const upgradeOrganizationSubscription = withSession<
 
   try {
     const result = await auth.api.upgradeSubscription({
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
       body: {
         plan: parsed.data.plan,
         customerType: "organization",
@@ -270,7 +270,7 @@ export const openOrganizationBillingPortal = withSession<
 
   try {
     const result = await auth.api.createBillingPortal({
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
       body: {
         customerType: "organization",
         referenceId: parsed.data.organizationId,

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -47,7 +47,7 @@ describe("auth facade", () => {
     createAuthClientMock.mockReturnValue(buildClientStub());
   });
 
-  it("forwards only allow-listed headers and revives session dates", async () => {
+  it("forwards only allow-listed headers, sanitizes cookies, and revives session dates", async () => {
     const expiresAt = "2026-06-19T12:00:00.000Z";
     getSessionMock.mockResolvedValue({
       data: {
@@ -60,7 +60,8 @@ describe("auth facade", () => {
     const { auth } = await import("../auth");
     const requestHeaders = new Headers({
       authorization: "Bearer should-not-forward",
-      cookie: "sokosumi.session_token=abc",
+      cookie:
+        "sokosumi.session_token=stale; __Secure-sokosumi.session_token=abc",
       "accept-language": "de-DE",
       "x-internal-header": "nope",
     });
@@ -74,11 +75,30 @@ describe("auth facade", () => {
       headers: Headers;
     };
     expect(fetchOptions.headers.get("cookie")).toBe(
-      "sokosumi.session_token=abc",
+      "__Secure-sokosumi.session_token=abc",
     );
     expect(fetchOptions.headers.get("accept-language")).toBe("de-DE");
     expect(fetchOptions.headers.get("authorization")).toBeNull();
     expect(fetchOptions.headers.get("x-internal-header")).toBeNull();
+  });
+
+  it("synthesizes origin from host when server actions omit origin", async () => {
+    getSessionMock.mockResolvedValue({
+      data: null,
+      error: { status: 401, statusText: "Unauthorized" },
+    });
+
+    const { auth } = await import("../auth");
+    const requestHeaders = new Headers({
+      host: "localhost:3000",
+    });
+
+    await auth.api.getSession({ headers: requestHeaders });
+
+    const fetchOptions = getSessionMock.mock.calls[0]?.[0]?.fetchOptions as {
+      headers: Headers;
+    };
+    expect(fetchOptions.headers.get("origin")).toBe("http://localhost:3000");
   });
 
   it("returns null from getSession when core responds 401", async () => {
@@ -142,10 +162,10 @@ describe("auth facade", () => {
     const { auth } = await import("../auth");
     await auth.api.signInEmail({
       body: { email: "jane@example.com", password: "pw-123456" },
-      headers: new Headers(),
+      headers: new Headers({ host: "localhost:3000" }),
     });
 
-    expect(cookieSetMock).toHaveBeenCalledTimes(2);
+    expect(cookieSetMock).toHaveBeenCalledTimes(3);
     expect(cookieSetMock).toHaveBeenCalledWith(
       "sokosumi.session_token",
       "tok",
@@ -165,6 +185,92 @@ describe("auth facade", () => {
         path: "/",
         sameSite: "lax",
         secure: true,
+      },
+    );
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "__Secure-sokosumi.session_data",
+      "",
+      {
+        maxAge: 0,
+        path: "/",
+        sameSite: "lax",
+        secure: true,
+      },
+    );
+  });
+
+  it("scopes host-only relayed cookies to localhost in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    signInEmailMock.mockImplementation(
+      async (
+        _body: unknown,
+        fetchOptions: {
+          onResponse?: (context: { response: Response }) => Promise<void>;
+        },
+      ) => {
+        const response = new Response("{}");
+        response.headers.append(
+          "set-cookie",
+          "sokosumi-localhost-preprod.session_token=tok; Max-Age=604800; Path=/; HttpOnly; SameSite=Lax",
+        );
+        await fetchOptions.onResponse?.({ response });
+        return { data: { redirect: false }, error: null };
+      },
+    );
+
+    const { auth } = await import("../auth");
+    await auth.api.signInEmail({
+      body: { email: "jane@example.com", password: "pw-123456" },
+      headers: new Headers({ host: "localhost:3000" }),
+    });
+
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "sokosumi-localhost-preprod.session_token",
+      "tok",
+      {
+        domain: "localhost",
+        httpOnly: true,
+        maxAge: 604800,
+        path: "/",
+        sameSite: "lax",
+      },
+    );
+  });
+
+  it("does not clear host-only duplicates when relaying localhost domain cookies", async () => {
+    signInEmailMock.mockImplementation(
+      async (
+        _body: unknown,
+        fetchOptions: {
+          onResponse?: (context: { response: Response }) => Promise<void>;
+        },
+      ) => {
+        const response = new Response("{}");
+        response.headers.append(
+          "set-cookie",
+          "sokosumi-localhost-preprod.session_token=tok; Domain=localhost; Max-Age=604800; Path=/; HttpOnly; SameSite=Lax",
+        );
+        await fetchOptions.onResponse?.({ response });
+        return { data: { redirect: false }, error: null };
+      },
+    );
+
+    const { auth } = await import("../auth");
+    await auth.api.signInEmail({
+      body: { email: "jane@example.com", password: "pw-123456" },
+      headers: new Headers({ host: "localhost:3000" }),
+    });
+
+    expect(cookieSetMock).toHaveBeenCalledTimes(1);
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "sokosumi-localhost-preprod.session_token",
+      "tok",
+      {
+        domain: "localhost",
+        httpOnly: true,
+        maxAge: 604800,
+        path: "/",
+        sameSite: "lax",
       },
     );
   });

--- a/apps/web/src/lib/auth/__tests__/forward-cookies.test.ts
+++ b/apps/web/src/lib/auth/__tests__/forward-cookies.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -25,12 +25,12 @@ describe("sanitizeForwardCookieHeader", () => {
     expect(sanitized).not.toContain("stale-host-only");
   });
 
-  it("drops a trailing stale duplicate of the same cookie name", () => {
+  it("keeps the first value when the same cookie name appears twice", () => {
     const sanitized = sanitizeForwardCookieHeader(
       "sokosumi.session_token=valid; other=1; sokosumi.session_token=stale",
     );
 
-    expect(sanitized).toBe("sokosumi.session_token=stale; other=1");
+    expect(sanitized).toBe("sokosumi.session_token=valid; other=1");
   });
 
   it("collapses secure and non-secure session_data cookies", () => {

--- a/apps/web/src/lib/auth/__tests__/forward-cookies.test.ts
+++ b/apps/web/src/lib/auth/__tests__/forward-cookies.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+  headers: vi.fn(),
+}));
+
+import { sanitizeForwardCookieHeader } from "../forward-cookies";
+
+describe("sanitizeForwardCookieHeader", () => {
+  it("prefers __Secure- session_token over a stale host-only duplicate", () => {
+    const sanitized = sanitizeForwardCookieHeader(
+      [
+        "sokosumi.session_token=stale-host-only",
+        "__Secure-sokosumi.session_token=valid-secure",
+        "other=value",
+      ].join("; "),
+    );
+
+    expect(sanitized).toBe(
+      "__Secure-sokosumi.session_token=valid-secure; other=value",
+    );
+    expect(sanitized).not.toContain("stale-host-only");
+  });
+
+  it("drops a trailing stale duplicate of the same cookie name", () => {
+    const sanitized = sanitizeForwardCookieHeader(
+      "sokosumi.session_token=valid; other=1; sokosumi.session_token=stale",
+    );
+
+    expect(sanitized).toBe("sokosumi.session_token=stale; other=1");
+  });
+
+  it("collapses secure and non-secure session_data cookies", () => {
+    const sanitized = sanitizeForwardCookieHeader(
+      [
+        "sokosumi.session_data=old-cache",
+        "__Secure-sokosumi.session_data=new-cache",
+      ].join("; "),
+    );
+
+    expect(sanitized).toBe("__Secure-sokosumi.session_data=new-cache");
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/utils.test.ts
@@ -13,6 +13,12 @@ vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/forward-cookies", () => ({
+  buildAuthRequestHeadersForForwarding: vi.fn(async () =>
+    Promise.resolve(new Headers({ cookie: "session=abc" })),
+  ),
+}));
+
 vi.mock("@/lib/auth/auth", () => ({
   auth: {
     api: {

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -15,6 +15,7 @@ import {
 } from "better-auth/client/plugins";
 import { cookies } from "next/headers";
 
+import { sanitizeForwardCookieHeader } from "@/lib/auth/forward-cookies";
 import { getServerCoreAuthBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 
 /**
@@ -82,6 +83,43 @@ const FORWARDED_HEADER_NAMES = [
   "x-vercel-forwarded-for",
 ] as const;
 
+function resolveRequestOrigin(requestHeaders: Headers): string | null {
+  const origin = requestHeaders.get("origin");
+  if (origin) {
+    return origin;
+  }
+
+  const referer = requestHeaders.get("referer");
+  if (referer) {
+    try {
+      return new URL(referer).origin;
+    } catch {
+      // ignore invalid referer
+    }
+  }
+
+  const host =
+    requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host");
+  if (!host) {
+    return null;
+  }
+
+  const hostname = host.split(",")[0]?.trim();
+  if (!hostname) {
+    return null;
+  }
+
+  const proto = requestHeaders.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const protocol =
+    proto === "https" || proto === "http"
+      ? proto
+      : hostname.includes("localhost") || hostname.startsWith("127.")
+        ? "http"
+        : "https";
+
+  return `${protocol}://${hostname}`;
+}
+
 function buildForwardHeaders(requestHeaders?: Headers): Headers {
   const forwarded = new Headers();
   if (!requestHeaders) {
@@ -90,8 +128,20 @@ function buildForwardHeaders(requestHeaders?: Headers): Headers {
 
   for (const name of FORWARDED_HEADER_NAMES) {
     const value = requestHeaders.get(name);
-    if (value) {
-      forwarded.set(name, value);
+    if (!value) {
+      continue;
+    }
+    if (name === "cookie") {
+      forwarded.set("cookie", sanitizeForwardCookieHeader(value));
+      continue;
+    }
+    forwarded.set(name, value);
+  }
+
+  if (!forwarded.has("origin")) {
+    const origin = resolveRequestOrigin(requestHeaders);
+    if (origin) {
+      forwarded.set("origin", origin);
     }
   }
 
@@ -223,6 +273,27 @@ function parseSetCookie(raw: string): ParsedSetCookie | null {
   return { name, value, options };
 }
 
+function shouldClearHostOnlySessionDuplicate(
+  domain: string | undefined,
+): boolean {
+  if (!domain) {
+    return false;
+  }
+
+  const normalized = domain.replace(/^\./, "").toLowerCase();
+  return normalized !== "localhost" && normalized !== "127.0.0.1";
+}
+
+function withLocalhostRelayCookieDomain(
+  options: ParsedSetCookie["options"],
+): ParsedSetCookie["options"] {
+  if (options.domain || process.env.NODE_ENV !== "development") {
+    return options;
+  }
+
+  return { ...options, domain: "localhost" };
+}
+
 /**
  * Re-sets cookies issued by core onto the Next.js response. Next only allows
  * cookie writes in server actions and route handlers; in RSC render paths
@@ -243,7 +314,20 @@ async function relaySetCookies(response: Response): Promise<void> {
       continue;
     }
     try {
-      cookieStore.set(parsed.name, parsed.value, parsed.options);
+      const options = withLocalhostRelayCookieDomain(parsed.options);
+      cookieStore.set(parsed.name, parsed.value, options);
+      if (shouldClearHostOnlySessionDuplicate(options.domain)) {
+        // Production migration only: drop stale host-only duplicates after
+        // re-scoping to the shared parent domain. Never do this for localhost
+        // — it races with the domain cookie we just set on email sign-in.
+        cookieStore.set(parsed.name, "", {
+          httpOnly: options.httpOnly,
+          maxAge: 0,
+          path: options.path ?? "/",
+          sameSite: options.sameSite,
+          secure: options.secure,
+        });
+      }
     } catch {
       // Read-only context (RSC render) — skip, matching nextCookies().
     }

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -5,6 +5,8 @@ import { stripeClient } from "@better-auth/stripe/client";
 import {
   betterAuthOrganizationAdditionalFields,
   betterAuthUserAdditionalFields,
+  resolveBetterAuthIssuerCookieDomain,
+  shouldClearHostOnlyAuthCookieDuplicate,
 } from "@sokosumi/utils";
 import { APIError } from "better-auth/api";
 import { createAuthClient } from "better-auth/client";
@@ -273,17 +275,6 @@ function parseSetCookie(raw: string): ParsedSetCookie | null {
   return { name, value, options };
 }
 
-function shouldClearHostOnlySessionDuplicate(
-  domain: string | undefined,
-): boolean {
-  if (!domain) {
-    return false;
-  }
-
-  const normalized = domain.replace(/^\./, "").toLowerCase();
-  return normalized !== "localhost" && normalized !== "127.0.0.1";
-}
-
 function withLocalhostRelayCookieDomain(
   options: ParsedSetCookie["options"],
 ): ParsedSetCookie["options"] {
@@ -291,7 +282,10 @@ function withLocalhostRelayCookieDomain(
     return options;
   }
 
-  return { ...options, domain: "localhost" };
+  return {
+    ...options,
+    domain: resolveBetterAuthIssuerCookieDomain("localhost", "development"),
+  };
 }
 
 /**
@@ -316,7 +310,7 @@ async function relaySetCookies(response: Response): Promise<void> {
     try {
       const options = withLocalhostRelayCookieDomain(parsed.options);
       cookieStore.set(parsed.name, parsed.value, options);
-      if (shouldClearHostOnlySessionDuplicate(options.domain)) {
+      if (shouldClearHostOnlyAuthCookieDuplicate(options.domain)) {
         // Production migration only: drop stale host-only duplicates after
         // re-scoping to the shared parent domain. Never do this for localhost
         // — it races with the domain cookie we just set on email sign-in.

--- a/apps/web/src/lib/auth/forward-cookies.ts
+++ b/apps/web/src/lib/auth/forward-cookies.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import { cookies, headers } from "next/headers";
+
+const SECURE_COOKIE_PREFIX = "__Secure-";
+
+function stripSecureCookiePrefix(cookieName: string): string {
+  if (cookieName.startsWith(SECURE_COOKIE_PREFIX)) {
+    return cookieName.slice(SECURE_COOKIE_PREFIX.length);
+  }
+  return cookieName;
+}
+
+function parseCookieHeader(cookieHeader: string): Map<string, string> {
+  const parsed = new Map<string, string>();
+  for (const chunk of cookieHeader.split(";")) {
+    const eq = chunk.indexOf("=");
+    if (eq === -1) {
+      continue;
+    }
+    const name = chunk.slice(0, eq).trim();
+    const value = chunk.slice(eq + 1).trim();
+    if (name) {
+      parsed.set(name, value);
+    }
+  }
+  return parsed;
+}
+
+function isBetterAuthStatefulCookie(logicalName: string): boolean {
+  return (
+    logicalName.endsWith(".session_token") ||
+    logicalName.endsWith(".session_data") ||
+    logicalName.endsWith(".dont_remember") ||
+    logicalName.endsWith(".account_data") ||
+    logicalName.includes(".session_data.") ||
+    logicalName.includes(".account_data.")
+  );
+}
+
+/**
+ * After the web→core Better Auth migration, browsers may send both a stale
+ * host-only session cookie and a domain-scoped __Secure- cookie with
+ * different values. Better Auth prefers __Secure- when reading, but duplicate
+ * same-name entries are last-wins in the Cookie header. Collapse auth cookies
+ * to one physical name per logical key, preferring __Secure-.
+ */
+export function sanitizeForwardCookieHeader(cookieHeader: string): string {
+  if (!cookieHeader) {
+    return cookieHeader;
+  }
+
+  const parsed = parseCookieHeader(cookieHeader);
+  const authLogicalNames = new Set<string>();
+  const passthrough: Array<[string, string]> = [];
+
+  for (const [name, value] of parsed) {
+    const logical = stripSecureCookiePrefix(name);
+    if (isBetterAuthStatefulCookie(logical)) {
+      authLogicalNames.add(logical);
+    } else {
+      passthrough.push([name, value]);
+    }
+  }
+
+  const serialized: string[] = [];
+
+  for (const logical of authLogicalNames) {
+    const secureName = `${SECURE_COOKIE_PREFIX}${logical}`;
+    if (parsed.has(secureName)) {
+      serialized.push(`${secureName}=${parsed.get(secureName)!}`);
+      continue;
+    }
+    if (parsed.has(logical)) {
+      serialized.push(`${logical}=${parsed.get(logical)!}`);
+    }
+  }
+
+  for (const [name, value] of passthrough) {
+    serialized.push(`${name}=${value}`);
+  }
+
+  return serialized.join("; ");
+}
+
+export async function buildAuthRequestHeadersForForwarding(): Promise<Headers> {
+  const headerList = await headers();
+  const cookieStore = await cookies();
+  const merged = new Headers(headerList);
+
+  const cookieFromStore = cookieStore
+    .getAll()
+    .map((entry) => `${entry.name}=${entry.value}`)
+    .join("; ");
+  const rawCookieHeader = cookieFromStore || headerList.get("cookie") || "";
+  const sanitized = sanitizeForwardCookieHeader(rawCookieHeader);
+  if (sanitized) {
+    merged.set("cookie", sanitized);
+  } else {
+    merged.delete("cookie");
+  }
+
+  return merged;
+}

--- a/apps/web/src/lib/auth/forward-cookies.ts
+++ b/apps/web/src/lib/auth/forward-cookies.ts
@@ -20,7 +20,7 @@ function parseCookieHeader(cookieHeader: string): Map<string, string> {
     }
     const name = chunk.slice(0, eq).trim();
     const value = chunk.slice(eq + 1).trim();
-    if (name) {
+    if (name && !parsed.has(name)) {
       parsed.set(name, value);
     }
   }

--- a/apps/web/src/lib/auth/utils.ts
+++ b/apps/web/src/lib/auth/utils.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { cache } from "react";
 
 import { auth, type Session } from "@/lib/auth/auth";
+import { buildAuthRequestHeadersForForwarding } from "@/lib/auth/forward-cookies";
 
 interface GetSessionOptions {
   refresh?: boolean;
@@ -19,7 +20,7 @@ interface GetSessionOptions {
  */
 const getCachedSession = cache(async (): Promise<Session | null> => {
   const session = await auth.api.getSession({
-    headers: await headers(),
+    headers: await buildAuthRequestHeadersForForwarding(),
   });
 
   return session;
@@ -33,7 +34,7 @@ export async function getSession(
       query: {
         disableCookieCache: true,
       },
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
     });
   }
 

--- a/apps/web/src/lib/clients/__tests__/core.client.test.ts
+++ b/apps/web/src/lib/clients/__tests__/core.client.test.ts
@@ -19,13 +19,15 @@ const deleteJobsByIdShareMock = vi.fn();
 const deleteTasksByIdShareMock = vi.fn();
 const postAgentsByIdJobsMock = vi.fn();
 const createClientMock = vi.fn();
-const headersMock = vi.fn();
+const buildAuthRequestHeadersForForwardingMock = vi.fn();
 const mockClient = {
   id: "core-client",
 } as never;
 
-vi.mock("next/headers", () => ({
-  headers: () => headersMock(),
+vi.mock("@/lib/auth/forward-cookies", () => ({
+  buildAuthRequestHeadersForForwarding: () =>
+    buildAuthRequestHeadersForForwardingMock(),
+  sanitizeForwardCookieHeader: (cookieHeader: string) => cookieHeader,
 }));
 
 vi.mock("@/lib/clients/utils/core-api-base-url", () => ({
@@ -60,7 +62,7 @@ describe("core.client", () => {
     vi.clearAllMocks();
     vi.resetModules();
 
-    headersMock.mockResolvedValue(
+    buildAuthRequestHeadersForForwardingMock.mockResolvedValue(
       new Headers({
         cookie: "session=abc",
         "x-organization-slug": "my-org",

--- a/apps/web/src/lib/clients/core.client.ts
+++ b/apps/web/src/lib/clients/core.client.ts
@@ -1,7 +1,9 @@
 import "server-only";
 
-import { headers } from "next/headers";
-
+import {
+  buildAuthRequestHeadersForForwarding,
+  sanitizeForwardCookieHeader,
+} from "@/lib/auth/forward-cookies";
 import { createClient } from "@/lib/clients/generated/core/client";
 import { getServerCoreApiBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 
@@ -21,7 +23,7 @@ export function buildAuthHeaders(requestHeaders: Headers): HeadersInit {
   const cookie = requestHeaders.get("cookie");
 
   if (cookie) {
-    authHeaders.cookie = cookie;
+    authHeaders.cookie = sanitizeForwardCookieHeader(cookie);
   }
 
   return authHeaders;
@@ -30,7 +32,7 @@ export function buildAuthHeaders(requestHeaders: Headers): HeadersInit {
 async function createCoreGeneratedClient() {
   return createClient({
     baseUrl: getServerCoreApiBaseUrl(),
-    headers: buildAuthHeaders(await headers()),
+    headers: buildAuthHeaders(await buildAuthRequestHeadersForForwarding()),
   });
 }
 

--- a/apps/web/src/lib/clients/utils/build-core-chat-proxy-headers.ts
+++ b/apps/web/src/lib/clients/utils/build-core-chat-proxy-headers.ts
@@ -6,11 +6,13 @@
  * on outbound requests with `InvalidArgumentError: invalid transfer-encoding header`,
  * which surfaces as `TypeError: fetch failed` and a 500 from `/api/chat`.
  */
+import { sanitizeForwardCookieHeader } from "@/lib/auth/forward-cookies";
+
 export function buildCoreChatProxyHeaders(headerSource: Headers): Headers {
   const out = new Headers();
   const cookie = headerSource.get("cookie");
   if (cookie) {
-    out.set("cookie", cookie);
+    out.set("cookie", sanitizeForwardCookieHeader(cookie));
   }
   const authorization = headerSource.get("authorization");
   if (authorization) {

--- a/apps/web/src/lib/services/__tests__/user.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/user.service.test.ts
@@ -45,6 +45,11 @@ vi.mock("@/lib/auth/utils", () => ({
   getSession: (...args: unknown[]) => getSessionMock(...args),
 }));
 
+vi.mock("@/lib/auth/forward-cookies", () => ({
+  buildAuthRequestHeadersForForwarding: vi.fn(async () => new Headers()),
+  sanitizeForwardCookieHeader: (cookieHeader: string) => cookieHeader,
+}));
+
 vi.mock("@/lib/auth/auth", () => ({
   auth: {
     api: {

--- a/apps/web/src/lib/services/user.service.ts
+++ b/apps/web/src/lib/services/user.service.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
 import type { Member, MemberWithOrganization } from "@sokosumi/database";
-import { headers } from "next/headers";
 import { cache } from "react";
 
 import { auth, type Session } from "@/lib/auth/auth";
+import { buildAuthRequestHeadersForForwarding } from "@/lib/auth/forward-cookies";
 import { getSession } from "@/lib/auth/utils";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import type { Organization } from "@/lib/clients/generated/core";
@@ -127,7 +127,7 @@ export const userService = (() => {
         // the session cookie cache stays in sync — same approach as
         // markOnboardingCompleteForMe below.
         await auth.api.updateUser({
-          headers: await headers(),
+          headers: await buildAuthRequestHeadersForForwarding(),
           body: { onboardingCompleted: true },
         });
         return false;
@@ -158,7 +158,7 @@ export const userService = (() => {
     // Update via Better Auth to keep session in sync (cookie cache, etc.)
     // This has to be done, because the screen wasn't getting synced with the DB causing users to keep in the same screen.
     await auth.api.updateUser({
-      headers: await headers(),
+      headers: await buildAuthRequestHeadersForForwarding(),
       body: { onboardingCompleted: true },
     });
   }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -8,25 +8,64 @@ import { getEnvSecrets } from "@/config/env.secrets";
 /**
  * TEMPORARY session-survival shim for the Better Auth web → core migration.
  *
- * Before the migration the session cookie was host-only on the web origin, so
- * browsers would not send it to core's host and every existing session would
- * be logged out at cutover. This re-sets the same cookie value scoped to the
- * shared parent domain (BETTER_AUTH_COOKIE_DOMAIN) so core — which signs with
- * the same BETTER_AUTH_SECRET — accepts it. A companion marker cookie
- * prevents re-setting on every request.
+ * Auth cookies must be visible to both origins:
+ * - **Local dev**: web (:3000) and core (:8787) share `Domain=localhost`.
+ * - **Deployed**: web (e.g. app.sokosumi.com) and core (e.g. core.sokosumi.com)
+ *   share `BETTER_AUTH_COOKIE_DOMAIN`.
+ *
+ * Sign-in often leaves a host-only cookie on the web origin; browsers will not
+ * send it to core's host. This re-sets the same value with the shared domain
+ * core uses (`crossSubDomainCookies`), plus a marker cookie so we only do it
+ * once per session.
  *
  * REMOVE after one full session max-age window (Better Auth default: 7 days)
  * has passed in production — by then every live session cookie has either
  * been re-scoped or expired.
- *
- * The host-only original is deliberately left in place: browsers send both
- * (older first) and Better Auth's cookie parsing is last-occurrence-wins, so
- * the re-scoped cookie takes effect; the original expires with its session.
  */
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // Better Auth default session expiry
 const MARKER_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+const LEGACY_CROSS_PORT_MARKER_SUFFIX = "session_cross_port_scoped";
 
-function applySessionCookieRescopeShim(
+function resolveSharedAuthCookieDomain(
+  request: NextRequest,
+  configuredDomain: string | undefined,
+): string | undefined {
+  const hostname = request.nextUrl.hostname.toLowerCase();
+
+  // Mirror apps/core/src/lib/auth.ts: development cookies always use localhost,
+  // even when .env copies production `sokosumi.com` (browsers reject that here).
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return "localhost";
+  }
+
+  if (!configuredDomain) {
+    return undefined;
+  }
+
+  const domain = configuredDomain.replace(/^\./, "").toLowerCase();
+  if (hostname === domain || hostname.endsWith(`.${domain}`)) {
+    return domain;
+  }
+
+  return undefined;
+}
+
+function hasSharedAuthCookieShimMarker(
+  request: NextRequest,
+  cookiePrefix: string,
+): boolean {
+  const markerName = `${cookiePrefix}.session_token_rescoped`;
+  if (request.cookies.has(markerName)) {
+    return true;
+  }
+
+  // Legacy marker from an earlier localhost-only shim — treat as done.
+  return request.cookies.has(
+    `${cookiePrefix}.${LEGACY_CROSS_PORT_MARKER_SUFFIX}`,
+  );
+}
+
+function applySharedAuthSessionCookieShim(
   request: NextRequest,
   response: NextResponse,
   cookiePrefix: string,
@@ -36,8 +75,7 @@ function applySessionCookieRescopeShim(
     return;
   }
 
-  const markerName = `${cookiePrefix}.session_token_rescoped`;
-  if (request.cookies.has(markerName)) {
+  if (hasSharedAuthCookieShimMarker(request, cookiePrefix)) {
     return;
   }
 
@@ -52,6 +90,15 @@ function applySessionCookieRescopeShim(
   }
 
   const secure = Boolean(secureCookie);
+  const markerName = `${cookiePrefix}.session_token_rescoped`;
+
+  response.cookies.set(sessionCookie.name, "", {
+    httpOnly: true,
+    maxAge: 0,
+    path: "/",
+    sameSite: "lax",
+    secure,
+  });
   response.cookies.set(sessionCookie.name, sessionCookie.value, {
     domain: cookieDomain,
     httpOnly: true,
@@ -123,11 +170,11 @@ export async function proxy(request: NextRequest) {
   response.headers.set("x-pathname", pathname);
   response.headers.set("x-search-params", searchParams);
   applyDocumentSecurityHeaders(response);
-  applySessionCookieRescopeShim(
+  applySharedAuthSessionCookieShim(
     request,
     response,
     betterAuthCookiePrefix,
-    env.BETTER_AUTH_COOKIE_DOMAIN,
+    resolveSharedAuthCookieDomain(request, env.BETTER_AUTH_COOKIE_DOMAIN),
   );
 
   // Skip session check for excluded paths (but still set headers above)

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,4 +1,7 @@
-import { resolveBetterAuthCookiePrefix } from "@sokosumi/utils";
+import {
+  resolveBetterAuthCookiePrefix,
+  resolveBetterAuthRequestCookieDomain,
+} from "@sokosumi/utils";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -25,30 +28,6 @@ import { getEnvSecrets } from "@/config/env.secrets";
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // Better Auth default session expiry
 const MARKER_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 const LEGACY_CROSS_PORT_MARKER_SUFFIX = "session_cross_port_scoped";
-
-function resolveSharedAuthCookieDomain(
-  request: NextRequest,
-  configuredDomain: string | undefined,
-): string | undefined {
-  const hostname = request.nextUrl.hostname.toLowerCase();
-
-  // Mirror apps/core/src/lib/auth.ts: development cookies always use localhost,
-  // even when .env copies production `sokosumi.com` (browsers reject that here).
-  if (hostname === "localhost" || hostname === "127.0.0.1") {
-    return "localhost";
-  }
-
-  if (!configuredDomain) {
-    return undefined;
-  }
-
-  const domain = configuredDomain.replace(/^\./, "").toLowerCase();
-  if (hostname === domain || hostname.endsWith(`.${domain}`)) {
-    return domain;
-  }
-
-  return undefined;
-}
 
 function hasSharedAuthCookieShimMarker(
   request: NextRequest,
@@ -174,7 +153,10 @@ export async function proxy(request: NextRequest) {
     request,
     response,
     betterAuthCookiePrefix,
-    resolveSharedAuthCookieDomain(request, env.BETTER_AUTH_COOKIE_DOMAIN),
+    resolveBetterAuthRequestCookieDomain({
+      hostname: request.nextUrl.hostname,
+      configuredDomain: env.BETTER_AUTH_COOKIE_DOMAIN,
+    }),
   );
 
   // Skip session check for excluded paths (but still set headers above)

--- a/packages/utils/src/__tests__/better-auth-cookie-domain.test.ts
+++ b/packages/utils/src/__tests__/better-auth-cookie-domain.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  resolveBetterAuthIssuerCookieDomain,
+  resolveBetterAuthRequestCookieDomain,
+  shouldClearHostOnlyAuthCookieDuplicate,
+} from "../better-auth-cookie-domain.js";
+
+describe("resolveBetterAuthIssuerCookieDomain", () => {
+  it("forces localhost in development", () => {
+    assert.equal(
+      resolveBetterAuthIssuerCookieDomain("sokosumi.com", "development"),
+      "localhost",
+    );
+  });
+
+  it("normalizes production domain", () => {
+    assert.equal(
+      resolveBetterAuthIssuerCookieDomain(".sokosumi.com", "production"),
+      "sokosumi.com",
+    );
+  });
+});
+
+describe("resolveBetterAuthRequestCookieDomain", () => {
+  it("uses localhost for local hosts even when production domain is configured", () => {
+    assert.equal(
+      resolveBetterAuthRequestCookieDomain({
+        hostname: "localhost",
+        configuredDomain: "sokosumi.com",
+      }),
+      "localhost",
+    );
+  });
+
+  it("returns the configured domain for matching subdomains", () => {
+    assert.equal(
+      resolveBetterAuthRequestCookieDomain({
+        hostname: "app.sokosumi.com",
+        configuredDomain: "sokosumi.com",
+      }),
+      "sokosumi.com",
+    );
+  });
+
+  it("returns undefined for unrelated preview hosts", () => {
+    assert.equal(
+      resolveBetterAuthRequestCookieDomain({
+        hostname: "my-app.example.vercel.app",
+        configuredDomain: "sokosumi.com",
+      }),
+      undefined,
+    );
+  });
+
+  it("returns undefined without a configured domain on remote hosts", () => {
+    assert.equal(
+      resolveBetterAuthRequestCookieDomain({
+        hostname: "app.example.com",
+        configuredDomain: undefined,
+      }),
+      undefined,
+    );
+  });
+});
+
+describe("shouldClearHostOnlyAuthCookieDuplicate", () => {
+  it("skips localhost domains", () => {
+    assert.equal(shouldClearHostOnlyAuthCookieDuplicate("localhost"), false);
+  });
+
+  it("clears for shared parent domains", () => {
+    assert.equal(shouldClearHostOnlyAuthCookieDuplicate("sokosumi.com"), true);
+  });
+});

--- a/packages/utils/src/better-auth-cookie-domain.ts
+++ b/packages/utils/src/better-auth-cookie-domain.ts
@@ -1,0 +1,68 @@
+const LOCAL_AUTH_COOKIE_DOMAIN = "localhost";
+
+function normalizeCookieDomain(domain: string): string {
+  return domain.replace(/^\./, "").toLowerCase();
+}
+
+function isLocalHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1";
+}
+
+/**
+ * Domain Better Auth uses when issuing cookies (core `crossSubDomainCookies`).
+ * Development always uses `localhost` so copied production env values do not
+ * break local sign-in.
+ */
+export function resolveBetterAuthIssuerCookieDomain(
+  configuredDomain: string,
+  nodeEnv: string | undefined,
+): string {
+  if (nodeEnv === "development") {
+    return LOCAL_AUTH_COOKIE_DOMAIN;
+  }
+
+  return normalizeCookieDomain(configuredDomain);
+}
+
+export interface ResolveBetterAuthRequestCookieDomainParams {
+  hostname: string;
+  configuredDomain: string | undefined;
+}
+
+/**
+ * Shared cookie domain for a browser request (web proxy shim, cookie relay).
+ * Returns `undefined` when the host cannot safely receive domain-scoped auth
+ * cookies (e.g. unrelated Vercel preview URLs).
+ */
+export function resolveBetterAuthRequestCookieDomain(
+  params: ResolveBetterAuthRequestCookieDomainParams,
+): string | undefined {
+  const hostname = params.hostname.toLowerCase();
+
+  if (isLocalHostname(hostname)) {
+    return LOCAL_AUTH_COOKIE_DOMAIN;
+  }
+
+  if (!params.configuredDomain) {
+    return undefined;
+  }
+
+  const domain = normalizeCookieDomain(params.configuredDomain);
+  if (hostname === domain || hostname.endsWith(`.${domain}`)) {
+    return domain;
+  }
+
+  return undefined;
+}
+
+/** Host-only duplicate clearing is unsafe on localhost (sign-in race). */
+export function shouldClearHostOnlyAuthCookieDuplicate(
+  domain: string | undefined,
+): boolean {
+  if (!domain) {
+    return false;
+  }
+
+  return !isLocalHostname(normalizeCookieDomain(domain));
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,6 +7,12 @@ export {
   betterAuthUserAdditionalFields,
 } from "./better-auth-additional-fields.js";
 export {
+  type ResolveBetterAuthRequestCookieDomainParams,
+  resolveBetterAuthIssuerCookieDomain,
+  resolveBetterAuthRequestCookieDomain,
+  shouldClearHostOnlyAuthCookieDuplicate,
+} from "./better-auth-cookie-domain.js";
+export {
   type ResolveBetterAuthCookiePrefixParams,
   resolveBetterAuthCookieName,
   resolveBetterAuthCookiePrefix,


### PR DESCRIPTION
## Summary

- Sanitize duplicate Better Auth cookies before web forwards them to core, and merge cookie store + request headers for server-side auth calls.
- Relay sign-in Set-Cookie with localhost domain in dev; avoid clearing host-only duplicates on localhost during relay.
- Unify the proxy session shim for localhost and remote hosts (shared `BETTER_AUTH_COOKIE_DOMAIN`), and route client session checks through `/api/auth/session`.
- Force core dev cookie domain to `localhost` when `NODE_ENV=development`.

## Test plan

- [x] `pnpm --filter web test src/__tests__/proxy.test.ts`
- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.test.ts`
- [ ] Sign in via email on localhost; confirm no redirect loop and session cookie has `Domain=localhost`
- [ ] Verify onboarding loads without `listActiveSubscriptions` 401 in server logs
- [ ] Deploy preview/production with matching `BETTER_AUTH_COOKIE_DOMAIN` on web and core


Made with [Cursor](https://cursor.com)