### PR TITLE
fix(core): narrow better auth trusted origins to explicit app hosts

### DIFF
--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -155,8 +155,9 @@ export const auth = betterAuth({
     storage: "database",
   },
   trustedOrigins: [
-    "https://sokosumi.com",
-    "https://*.sokosumi.com",
+    "https://app.sokosumi.com",
+    "https://preprod.sokosumi.com",
+    "https://*.preview.sokosumi.com", // Vercel preview deployment suffix
     ...(env.NODE_ENV === "development"
       ? ["http://localhost:*"] // local dev only; omit in staging/production deploys
       : []),


### PR DESCRIPTION
## Summary

Re-applies the trusted-origins narrowing from #3148 to the **core** Better Auth instance after the revert in #3153 restored the broad `https://*.sokosumi.com` wildcard there.

The core auth instance predates #3142 and survived the revert; the wildcard trusts every subdomain for origin/CSRF checks. This narrows it to the explicit app hosts:

- `https://app.sokosumi.com`
- `https://preprod.sokosumi.com`
- `https://*.preview.sokosumi.com` (Vercel preview deployment suffix)

The web Better Auth instance is intentionally left unchanged — the web→core auth migration continues in smaller steps.

(This commit was originally pushed to the #3153 branch but landed after the squash-merge, so it is re-submitted here off `main`.)

## Verification

- `pnpm core:test` — 196 files / 1446 passed
- `pnpm check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)