### PR TITLE
feat(auth): enable Better Auth cookie cache with configurable max age

### DIFF
--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -52,6 +52,10 @@ const envSchema = z.object({
   BETTER_AUTH_SECRET: z.string().min(1),
   BETTER_AUTH_URL: z.url(),
   BETTER_AUTH_COOKIE_DOMAIN: z.string().optional(),
+  BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE: z.coerce
+    .number()
+    .min(0)
+    .default(60 * 5), // 5 minutes
   POSTMARK_SERVER_ID: z.string().min(1),
   POSTMARK_FROM_EMAIL: z.email(),
 

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -48,6 +48,7 @@ function getDefaultEnv() {
   return {
     BETTER_AUTH_COOKIE_DOMAIN: undefined,
     BETTER_AUTH_SECRET: "test-secret",
+    BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE: 60,
     NETWORK: "Preprod",
     NODE_ENV: "production",
     POSTMARK_FROM_EMAIL: "no-reply@example.com",
@@ -199,21 +200,27 @@ describe("core auth config", () => {
     });
   });
 
-  it("disables Better Auth cookie cache for core sessions", async () => {
+  it("enables Better Auth cookie cache for core sessions", async () => {
     await import("./auth");
 
     const [[config]] = betterAuthMock.mock.calls as Array<
       [
         {
           session: {
-            cookieCache?: unknown;
+            cookieCache?: {
+              enabled: boolean;
+              maxAge: number;
+            };
             storeSessionInDatabase?: boolean;
           };
         },
       ]
     >;
 
-    expect(config.session.cookieCache).toBeUndefined();
+    expect(config.session.cookieCache).toEqual({
+      enabled: true,
+      maxAge: 60,
+    });
     expect(config.session.storeSessionInDatabase).toBe(true);
   });
 

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -108,6 +108,10 @@ export const auth = betterAuth({
     joins: true,
   },
   session: {
+    cookieCache: {
+      enabled: true,
+      maxAge: env.BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE,
+    },
     storeSessionInDatabase: true,
   },
   database: prismaAdapter(prisma, {

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -341,6 +341,30 @@ describe("web auth config", () => {
     });
   });
 
+  it("enables Better Auth cookie cache for web sessions", async () => {
+    await import("../auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          session: {
+            cookieCache?: {
+              enabled: boolean;
+              maxAge: number;
+            };
+            storeSessionInDatabase?: boolean;
+          };
+        },
+      ]
+    >;
+
+    expect(config.session.cookieCache).toEqual({
+      enabled: true,
+      maxAge: 60,
+    });
+    expect(config.session.storeSessionInDatabase).toBe(true);
+  });
+
   it("configures subscription checkout for billing, tax IDs, and customer updates", async () => {
     await import("../auth");
 


### PR DESCRIPTION
## Summary

- Enables Better Auth session cookie cache on the Core auth instance, matching the existing Web configuration.
- Adds `BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE` to Core env validation (default 5 minutes).
- Updates Core and Web auth config tests to assert cookie cache is enabled.

## Key changes

- `apps/core/src/lib/auth.ts`: `session.cookieCache` with `enabled: true` and configurable `maxAge`.
- `apps/core/src/config/env.ts`: new `BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE` env var.
- `apps/core/src/lib/auth.test.ts`: expect cookie cache enabled instead of disabled.
- `apps/web/src/lib/auth/__tests__/auth.test.ts`: explicit test that Web auth keeps cookie cache enabled.

## Architecture

Core middleware and API routes use `auth.api.getSession()` from Core auth. Cookie cache reduces database reads for session validation on Core while Web retains its own cookie cache during the auth migration period.

## Deployment

Set `BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE` on the Core deployment if you need a non-default TTL. Web already uses the same variable locally; defaults to 300 seconds when unset.

## Test plan

- [x] `pnpm --filter core test src/lib/auth.test.ts`
- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.test.ts`


Made with [Cursor](https://cursor.com)