### PR TITLE
feat(core): enable session support for API keys in betterAuth configuration

### DIFF
--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -243,6 +243,7 @@ export const auth = betterAuth({
         maxRequests: LIMITS.API_KEY_MAX_REQUESTS_PER_MINUTE,
       },
       enableMetadata: true,
+      enableSessionForAPIKeys: true,
     }),
     jwt({ disableSettingJwtHeader: true }),
     organization({


### PR DESCRIPTION
## Summary

- Enables Better Auth API key sessions on the Core auth instance by setting `enableSessionForAPIKeys: true` on the `apiKey` plugin.
- Aligns Core with the existing Web Better Auth configuration so API keys can participate in session-based auth flows handled by Core.

## Key changes

- `apps/core/src/lib/auth.ts`: add `enableSessionForAPIKeys: true` to the `apiKey` plugin options.

## Architecture

Core middleware accepts Better Auth session cookies and user API keys. With session support enabled for API keys, Core can issue and validate session-backed API key auth consistently with Web during the auth migration.

## Test plan

- [ ] `pnpm --filter core test src/lib/auth.test.ts`
- [ ] Verify API key auth against Core endpoints that expect a session context


Made with [Cursor](https://cursor.com)