### PR TITLE
test(core): align trustedOrigins with web and extend auth parity tests

### DIFF
--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -188,7 +188,7 @@ Environment variables are accessed via `process.env`, validated at startup with 
 ### CORS and Better Auth origins
 
 - **CORS** (`src/config/cors-allow-origin.ts`): `Access-Control-Allow-Origin` is echoed only for `https://sokosumi.com` / `https://*.sokosumi.com` in non-development, or for `localhost` with `http`/`https` when `NODE_ENV=development`. Wildcard Vercel preview hosts are not allowlisted.
-- **Better Auth** (`src/lib/auth.ts`, web `src/lib/auth/auth.ts`): `trustedOrigins` includes `https://sokosumi.com` (apex; `https://*.sokosumi.com` does not match the apex), `https://*.sokosumi.com`, and in development only `http://localhost:*`. Keep these consistent with CORS so browser requests from the web app succeed.
+- **Better Auth** (`src/lib/auth.ts`, web `src/lib/auth/auth.ts`): `trustedOrigins` lists explicit web app hosts (`https://app.sokosumi.com`, `https://preprod.sokosumi.com`, `https://*.preview.sokosumi.com`) plus in development only `http://localhost:*`. Keep Core and Web lists identical. CORS remains broader (`https://sokosumi.com` / `https://*.sokosumi.com`); do not widen `trustedOrigins` to match CORS — it is a CSRF allowlist, not general API access control.
 
 Cross-origin calls from the web app require the web deployment to use a hostname that satisfies both checks (e.g. `*.sokosumi.com` in hosted environments).
 

--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -214,7 +214,7 @@ Additional behavior:
 - Methods and headers are configured per route group (`/auth` vs `/v1`)
 - Preflight responses set `Access-Control-Max-Age` to `TIME.CORS_MAX_AGE` (see `src/config/constants.ts`; browsers may cap effective cache duration)
 
-Better Auth’s `trustedOrigins` in Core and the web app should stay aligned with CORS: production trusts `https://sokosumi.com` and `https://*.sokosumi.com` (the wildcard does not match the apex); development adds `http://localhost:*` for local browsers.
+Better Auth’s `trustedOrigins` in Core and the web app should stay identical: `https://app.sokosumi.com`, `https://preprod.sokosumi.com`, and `https://*.preview.sokosumi.com`; development adds `http://localhost:*` for local browsers. CORS allowlisting is broader (`https://sokosumi.com` and `https://*.sokosumi.com`); do not widen `trustedOrigins` to match — it is a CSRF allowlist for browser auth flows, not general API access control.
 
 ## Authentication
 

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -215,7 +215,7 @@ describe("core auth config", () => {
     });
   });
 
-  it("aligns trustedOrigins with the web app for hosted Sokosumi domains", async () => {
+  it("uses explicit Sokosumi app trustedOrigins in production", async () => {
     getEnvMock.mockReturnValue({
       ...getDefaultEnv(),
       NODE_ENV: "production",
@@ -228,8 +228,9 @@ describe("core auth config", () => {
     >;
 
     expect(config.trustedOrigins).toEqual([
-      "https://sokosumi.com",
-      "https://*.sokosumi.com",
+      "https://app.sokosumi.com",
+      "https://preprod.sokosumi.com",
+      "https://*.preview.sokosumi.com",
     ]);
   });
 
@@ -246,8 +247,9 @@ describe("core auth config", () => {
     >;
 
     expect(config.trustedOrigins).toEqual([
-      "https://sokosumi.com",
-      "https://*.sokosumi.com",
+      "https://app.sokosumi.com",
+      "https://preprod.sokosumi.com",
+      "https://*.preview.sokosumi.com",
       "http://localhost:*",
     ]);
   });

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -176,6 +176,155 @@ describe("core auth config", () => {
     expect(config.plugins).toEqual(expect.arrayContaining(["admin-plugin"]));
   });
 
+  it("uses basePath /auth and registers core auth plugins", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          basePath: string;
+          plugins: unknown[];
+        },
+      ]
+    >;
+
+    expect(config.basePath).toBe("/auth");
+    expect(config.plugins).toEqual(
+      expect.arrayContaining([
+        "admin-plugin",
+        "api-key-plugin",
+        "jwt-plugin",
+        "magic-link-plugin",
+        "i18n-plugin",
+        "openapi-plugin",
+        "organization-plugin",
+        "oauth-provider-plugin",
+        "oauth-proxy-plugin",
+      ]),
+    );
+    expect(apiKeyPluginMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configId: "default",
+        references: "user",
+        enableMetadata: true,
+        enableSessionForAPIKeys: true,
+      }),
+    );
+    expect(jwtPluginMock).toHaveBeenCalledWith({
+      disableSettingJwtHeader: true,
+    });
+  });
+
+  it("aligns trustedOrigins with the web app for hosted Sokosumi domains", async () => {
+    getEnvMock.mockReturnValue({
+      ...getDefaultEnv(),
+      NODE_ENV: "production",
+    });
+
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [{ trustedOrigins: string[] }]
+    >;
+
+    expect(config.trustedOrigins).toEqual([
+      "https://sokosumi.com",
+      "https://*.sokosumi.com",
+    ]);
+  });
+
+  it("allows localhost trustedOrigins in development only", async () => {
+    getEnvMock.mockReturnValue({
+      ...getDefaultEnv(),
+      NODE_ENV: "development",
+    });
+
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [{ trustedOrigins: string[] }]
+    >;
+
+    expect(config.trustedOrigins).toEqual([
+      "https://sokosumi.com",
+      "https://*.sokosumi.com",
+      "http://localhost:*",
+    ]);
+  });
+
+  it("uses uuid database ids and database-backed rate limits", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          advanced: {
+            database: {
+              generateId: string;
+            };
+          };
+          experimental: {
+            joins: boolean;
+          };
+          rateLimit: {
+            storage: string;
+          };
+        },
+      ]
+    >;
+
+    expect(config.advanced.database.generateId).toBe("uuid");
+    expect(config.experimental.joins).toBe(true);
+    expect(config.rateLimit.storage).toBe("database");
+  });
+
+  it("defines user and organization additional fields for auth parity", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          user: {
+            additionalFields: Record<string, { type: string }>;
+          };
+        },
+      ]
+    >;
+
+    expect(Object.keys(config.user.additionalFields)).toEqual(
+      expect.arrayContaining([
+        "termsAccepted",
+        "marketingOptIn",
+        "notificationsOptIn",
+        "logo",
+        "metadata",
+        "stripeCustomerId",
+        "onboardingCompleted",
+      ]),
+    );
+
+    const [[organizationConfig]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          schema: {
+            organization: {
+              additionalFields: Record<string, { input?: boolean }>;
+            };
+          };
+        },
+      ]
+    >;
+
+    expect(organizationConfig.schema.organization.additionalFields).toEqual({
+      stripeCustomerId: {
+        type: "string",
+        required: false,
+        defaultValue: null,
+        input: false,
+      },
+    });
+  });
+
   it("configures the magic link plugin", async () => {
     await import("./auth");
 

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -159,8 +159,9 @@ export const auth = betterAuth({
     storage: "database",
   },
   trustedOrigins: [
-    "https://sokosumi.com",
-    "https://*.sokosumi.com",
+    "https://app.sokosumi.com",
+    "https://preprod.sokosumi.com",
+    "https://*.preview.sokosumi.com", // Vercel preview deployment suffix
     ...(env.NODE_ENV === "development"
       ? ["http://localhost:*"] // local dev only; omit in staging/production deploys
       : []),

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -159,9 +159,8 @@ export const auth = betterAuth({
     storage: "database",
   },
   trustedOrigins: [
-    "https://app.sokosumi.com",
-    "https://preprod.sokosumi.com",
-    "https://*.preview.sokosumi.com", // Vercel preview deployment suffix
+    "https://sokosumi.com",
+    "https://*.sokosumi.com",
     ...(env.NODE_ENV === "development"
       ? ["http://localhost:*"] // local dev only; omit in staging/production deploys
       : []),

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -424,8 +424,9 @@ export const auth = betterAuth({
     },
   },
   trustedOrigins: [
-    "https://sokosumi.com",
-    "https://*.sokosumi.com",
+    "https://app.sokosumi.com",
+    "https://preprod.sokosumi.com",
+    "https://*.preview.sokosumi.com", // Vercel preview deployment suffix
     ...(secrets.NODE_ENV === "development"
       ? ["http://localhost:*"] // local dev only; omit in staging/production deploys
       : []),


### PR DESCRIPTION
## Summary

- Keeps Core Better Auth `trustedOrigins` on the explicit app-host allowlist from #3154 (`app`, `preprod`, `*.preview.sokosumi.com`).
- Aligns Web `trustedOrigins` to the same list (replaces broad `sokosumi.com` / `*.sokosumi.com`).
- Extends `apps/core/src/lib/auth.test.ts` with parity coverage: `basePath`, plugin inventory, API key session flag, `trustedOrigins` prod/dev, uuid ids, rate-limit storage, and user/org additional fields.
- Documents that CORS stays broader than `trustedOrigins` (CSRF allowlist vs API access).

## Test plan

- [x] `pnpm --filter core test src/lib/auth.test.ts`