### PR TITLE
feat(web): fetch server session from Core Better Auth

### DIFF
--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getSessionMock = vi.fn();
+const fetchMock = vi.fn();
 const headersMock = vi.fn();
 
 vi.mock("server-only", () => ({}));
@@ -13,12 +13,8 @@ vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
 }));
 
-vi.mock("@/lib/auth/auth", () => ({
-  auth: {
-    api: {
-      getSession: (...args: unknown[]) => getSessionMock(...args),
-    },
-  },
+vi.mock("@/lib/clients/utils/core-api-base-url", () => ({
+  getServerCoreAppBaseUrl: () => "http://localhost:8787",
 }));
 
 describe("auth.server", () => {
@@ -26,16 +22,20 @@ describe("auth.server", () => {
     vi.resetModules();
     vi.clearAllMocks();
     headersMock.mockResolvedValue(new Headers({ cookie: "session=abc" }));
+    vi.stubGlobal("fetch", fetchMock);
   });
 
   it("gets a refreshed session by disabling Better Auth cookie cache", async () => {
-    getSessionMock.mockResolvedValue({
-      session: {
-        activeOrganizationId: null,
-      },
-      user: {
-        id: "user_123",
-      },
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: {
+          activeOrganizationId: null,
+        },
+        user: {
+          id: "user_123",
+        },
+      }),
     });
 
     const { getSession } = await import("../auth.server");
@@ -49,11 +49,34 @@ describe("auth.server", () => {
       },
     });
 
-    expect(getSessionMock).toHaveBeenCalledWith({
-      query: {
-        disableCookieCache: true,
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("http://localhost:8787/auth/get-session?disableCookieCache=true"),
+      {
+        headers: { cookie: "session=abc" },
+        cache: "no-store",
       },
-      headers: expect.any(Headers),
+    );
+  });
+
+  it("returns null when Core reports no session", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => null,
     });
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).resolves.toBeNull();
+  });
+
+  it("returns null when Core responds with a non-ok status", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => null,
+    });
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).resolves.toBeNull();
   });
 });

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -54,6 +54,7 @@ describe("auth.server", () => {
       {
         headers: { cookie: "session=abc" },
         cache: "no-store",
+        signal: expect.any(AbortSignal),
       },
     );
   });
@@ -73,6 +74,27 @@ describe("auth.server", () => {
     fetchMock.mockResolvedValue({
       ok: false,
       json: async () => null,
+    });
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).resolves.toBeNull();
+  });
+
+  it("returns null when the fetch rejects instead of throwing", async () => {
+    fetchMock.mockRejectedValue(new Error("Core unreachable"));
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).resolves.toBeNull();
+  });
+
+  it("returns null when the response body is not valid JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("Unexpected token < in JSON");
+      },
     });
 
     const { getSession } = await import("../auth.server");

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -7,6 +7,7 @@ import { cache } from "react";
 import type { Session } from "@/lib/auth/auth";
 import { buildAuthHeaders } from "@/lib/clients/core.client";
 import { getServerCoreAppBaseUrl } from "@/lib/clients/utils/core-api-base-url";
+import { joinCoreApiPath } from "@/lib/clients/utils/core-api-base-url.shared";
 
 export type { Session };
 
@@ -15,36 +16,47 @@ interface GetSessionOptions {
 }
 
 const CORE_GET_SESSION_PATH = "/auth/get-session";
+const CORE_GET_SESSION_TIMEOUT_MS = 5000;
 
 async function fetchSession(
   requestHeaders: Headers,
   options?: GetSessionOptions,
 ): Promise<Session | null> {
+  // Concatenate rather than `new URL(path, base)` so a base URL with a
+  // sub-path (e.g. `https://host/core`) is preserved instead of dropped by
+  // absolute-path resolution.
   const sessionUrl = new URL(
-    CORE_GET_SESSION_PATH,
-    `${getServerCoreAppBaseUrl()}/`,
+    joinCoreApiPath(getServerCoreAppBaseUrl(), CORE_GET_SESSION_PATH),
   );
 
   if (options?.refresh) {
     sessionUrl.searchParams.set("disableCookieCache", "true");
   }
 
-  const response = await fetch(sessionUrl, {
-    headers: buildAuthHeaders(requestHeaders),
-    cache: "no-store",
-  });
+  try {
+    const response = await fetch(sessionUrl, {
+      headers: buildAuthHeaders(requestHeaders),
+      cache: "no-store",
+      signal: AbortSignal.timeout(CORE_GET_SESSION_TIMEOUT_MS),
+    });
 
-  if (!response.ok) {
+    if (!response.ok) {
+      return null;
+    }
+
+    const body = (await response.json()) as Session | null;
+
+    if (!body?.session || !body.user) {
+      return null;
+    }
+
+    return body;
+  } catch (error) {
+    // Core unreachable, timed out, or returned a non-JSON body. Preserve the
+    // null-returning contract callers rely on instead of throwing.
+    console.error("Failed to fetch session from Core", error);
     return null;
   }
-
-  const body = (await response.json()) as Session | null;
-
-  if (!body?.session || !body.user) {
-    return null;
-  }
-
-  return body;
 }
 
 const getCachedSession = cache(async (): Promise<Session | null> => {

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -4,7 +4,9 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
 
-import { auth, type Session } from "@/lib/auth/auth";
+import type { Session } from "@/lib/auth/auth";
+import { buildAuthHeaders } from "@/lib/clients/core.client";
+import { getServerCoreAppBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 
 export type { Session };
 
@@ -12,15 +14,37 @@ interface GetSessionOptions {
   refresh?: boolean;
 }
 
+const CORE_GET_SESSION_PATH = "/auth/get-session";
+
 async function fetchSession(
   requestHeaders: Headers,
   options?: GetSessionOptions,
 ): Promise<Session | null> {
-  return auth.api.getSession({
-    headers: requestHeaders,
-    // Bypass the cookie cache so a refreshed session is read from the DB.
-    ...(options?.refresh ? { query: { disableCookieCache: true } } : {}),
+  const sessionUrl = new URL(
+    CORE_GET_SESSION_PATH,
+    `${getServerCoreAppBaseUrl()}/`,
+  );
+
+  if (options?.refresh) {
+    sessionUrl.searchParams.set("disableCookieCache", "true");
+  }
+
+  const response = await fetch(sessionUrl, {
+    headers: buildAuthHeaders(requestHeaders),
+    cache: "no-store",
   });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const body = (await response.json()) as Session | null;
+
+  if (!body?.session || !body.user) {
+    return null;
+  }
+
+  return body;
 }
 
 const getCachedSession = cache(async (): Promise<Session | null> => {

--- a/apps/web/src/lib/clients/__tests__/core-api-base-url.test.ts
+++ b/apps/web/src/lib/clients/__tests__/core-api-base-url.test.ts
@@ -85,6 +85,14 @@ describe("getCoreApiBaseUrl", () => {
     expect(coreApiBaseUrl).toBe("http://localhost:8787/v1");
   });
 
+  it("resolves the server core app url without the /v1 suffix", async () => {
+    const { getServerCoreAppBaseUrl } = await import(
+      "../utils/core-api-base-url"
+    );
+
+    expect(getServerCoreAppBaseUrl()).toBe("http://localhost:8787");
+  });
+
   it("reads the browser core API url from public env", async () => {
     const { getBrowserCoreApiBaseUrl } = await import(
       "../utils/core-api-base-url.browser"

--- a/apps/web/src/lib/clients/utils/core-api-base-url.shared.ts
+++ b/apps/web/src/lib/clients/utils/core-api-base-url.shared.ts
@@ -22,6 +22,10 @@ export function normalizeCoreApiBaseUrl(baseUrl: string): string {
     : `${withoutTrailingSlash}/v1`;
 }
 
+export function stripCoreApiVersionSuffix(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
 /**
  * Joins a Core API base URL to a path the same way the generated OpenAPI
  * client does: strip trailing slashes from the base, ensure the path starts

--- a/apps/web/src/lib/clients/utils/core-api-base-url.ts
+++ b/apps/web/src/lib/clients/utils/core-api-base-url.ts
@@ -7,17 +7,24 @@ import { getEnvSecrets } from "@/config/env.secrets";
 import {
   getCoreRelatedProjectName,
   normalizeCoreApiBaseUrl,
+  stripCoreApiVersionSuffix,
 } from "@/lib/clients/utils/core-api-base-url.shared";
 
-export function getServerCoreApiBaseUrl(): string {
-  const resolvedCoreApiHost = withRelatedProject({
+function resolveServerCoreHost(): string {
+  return withRelatedProject({
     projectName: getCoreRelatedProjectName(
       getEnvPublicConfig().NEXT_PUBLIC_NETWORK,
     ),
     defaultHost: getEnvSecrets().CORE_APP_BASE_URL,
   });
+}
 
-  return normalizeCoreApiBaseUrl(resolvedCoreApiHost);
+export function getServerCoreAppBaseUrl(): string {
+  return stripCoreApiVersionSuffix(resolveServerCoreHost());
+}
+
+export function getServerCoreApiBaseUrl(): string {
+  return normalizeCoreApiBaseUrl(resolveServerCoreHost());
 }
 
 export const getCoreApiBaseUrl = getServerCoreApiBaseUrl;


### PR DESCRIPTION
## Summary

- Route `getSession` / `getSessionOrRedirect` / `verifyUserId` through Core Better Auth over HTTP instead of local `auth.api.getSession`
- Forward incoming request cookies via `buildAuthHeaders` (same pattern as the Core v1 client)
- Preserve `disableCookieCache=true` on refresh and `React.cache()` for the default path
- Add `getServerCoreAppBaseUrl()` for Core routes outside `/v1` (auth lives at `/auth`)

## Endpoint

`GET {coreAppBaseUrl}/auth/get-session` with optional `?disableCookieCache=true`

## Test plan

- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.server.test.ts`
- [x] `pnpm --filter web test src/middleware/__tests__/auth-middleware.test.ts`
- [x] `pnpm --filter web check`


Made with [Cursor](https://cursor.com)