### PR TITLE
feat(web): add Core HTTP reads for auth server helpers

### DIFF
--- a/apps/web/src/app/(app)/account/page.tsx
+++ b/apps/web/src/app/(app)/account/page.tsx
@@ -1,20 +1,14 @@
 import { getUserMetadata } from "@sokosumi/utils";
-import { headers } from "next/headers";
-import { auth } from "@/lib/auth/auth";
+import { getSession, listUserAccounts } from "@/lib/auth/auth.server";
 import { toDesignMdProfileValue } from "@/lib/helpers/design-md-profile";
 import { designMdService } from "@/lib/services/design-md.service";
 
 import { AccountSettings } from "./components/account-settings";
 
 export default async function Page() {
-  const requestHeaders = await headers();
   const [accounts, session] = await Promise.all([
-    auth.api.listUserAccounts({
-      headers: requestHeaders,
-    }),
-    auth.api.getSession({
-      headers: requestHeaders,
-    }),
+    listUserAccounts(),
+    getSession(),
   ]);
   const userMetadata = getUserMetadata(session?.user.metadata);
   const designMdValue = toDesignMdProfileValue(

--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx
@@ -45,13 +45,9 @@ vi.mock("@/lib/clients/core.client", () => ({
   },
 }));
 
-vi.mock("@/lib/auth/auth", () => ({
-  auth: {
-    api: {
-      listActiveSubscriptions: (...args: unknown[]) =>
-        listActiveSubscriptionsMock(...args),
-    },
-  },
+vi.mock("@/lib/auth/auth.server", () => ({
+  listActiveSubscriptions: (...args: unknown[]) =>
+    listActiveSubscriptionsMock(...args),
 }));
 
 vi.mock("@/lib/services", () => ({
@@ -170,6 +166,9 @@ describe("OnboardingDialogLoader", () => {
       props.paidPlans.find((plan) => plan.name === "starter")?.isCurrent,
     ).toBe(false);
     expect(listActiveSubscriptionsMock).toHaveBeenCalledOnce();
+    expect(listActiveSubscriptionsMock).toHaveBeenCalledWith({
+      customerType: "user",
+    });
   });
 
   it("short-circuits subscription-only org gates for non-admin members without billing fetches", async () => {
@@ -232,7 +231,7 @@ describe("OnboardingDialogLoader", () => {
   });
 
   it("defaults personal plan to free when active subscriptions cannot be loaded", async () => {
-    listActiveSubscriptionsMock.mockRejectedValue(new Error("Auth outage"));
+    listActiveSubscriptionsMock.mockResolvedValue([]);
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -255,9 +254,9 @@ describe("OnboardingDialogLoader", () => {
     };
     expect(props.paidPlans.every((plan) => !plan.isCurrent)).toBe(true);
     expect(listActiveSubscriptionsMock).toHaveBeenCalledOnce();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to load active subscriptions for onboarding",
-      expect.any(Error),
-    );
+    expect(listActiveSubscriptionsMock).toHaveBeenCalledWith({
+      customerType: "user",
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
@@ -1,15 +1,13 @@
 import { MemberRole } from "@sokosumi/database";
 import type { SubscriptionPlanName } from "@sokosumi/utils";
-import { headers } from "next/headers";
 import { Suspense } from "react";
 import Stripe from "stripe";
 import {
-  type ActiveSubscription,
   type PaidSubscriptionPlanView,
   resolveCurrentPlanName,
 } from "@/components/billing/subscription-plan-utils";
 import { getEnvSecrets } from "@/config/env.secrets";
-import { auth } from "@/lib/auth/auth";
+import { listActiveSubscriptions } from "@/lib/auth/auth.server";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import type { Organization } from "@/lib/clients/generated/core";
 import { organizationSeatService, userService } from "@/lib/services";
@@ -133,20 +131,9 @@ export async function OnboardingDialogLoader({
   let personalCurrentPlan: ReturnType<typeof resolveCurrentPlanName> | null =
     null;
   if (subscriptionCheckoutMode !== "organization") {
-    let personalActiveSubscriptions: ActiveSubscription[] = [];
-    try {
-      personalActiveSubscriptions = (await auth.api.listActiveSubscriptions({
-        headers: await headers(),
-        query: {
-          customerType: "user",
-        },
-      })) as ActiveSubscription[];
-    } catch (error) {
-      console.error(
-        "Failed to load active subscriptions for onboarding",
-        error,
-      );
-    }
+    const personalActiveSubscriptions = await listActiveSubscriptions({
+      customerType: "user",
+    });
 
     personalCurrentPlan =
       resolveCurrentPlanName(personalActiveSubscriptions) ?? "free";

--- a/apps/web/src/app/(app)/connections/components/connections-page.tsx
+++ b/apps/web/src/app/(app)/connections/components/connections-page.tsx
@@ -1,7 +1,6 @@
-import { headers } from "next/headers";
 import { Suspense } from "react";
-import { type Account, auth } from "@/lib/auth/auth";
-import { getSession } from "@/lib/auth/auth.server";
+import { type Account } from "@/lib/auth/auth";
+import { getSession, listUserAccounts } from "@/lib/auth/auth.server";
 import { AccountProvider } from "@/lib/auth/types";
 
 import { ApiKeysSection } from "./api-keys";
@@ -11,11 +10,8 @@ import { McpActiveKeyView } from "./mcp-active-key-view";
 import { SocialAccounts } from "./social-accounts";
 
 export async function ConnectionsPage() {
-  const requestHeaders = await headers();
   const [accountsData, session] = await Promise.all([
-    auth.api.listUserAccounts({
-      headers: requestHeaders,
-    }),
+    listUserAccounts(),
     getSession(),
   ]);
   const accounts: Account[] = accountsData;

--- a/apps/web/src/app/(auth)/oauth/consent/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/page.tsx
@@ -1,4 +1,3 @@
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
@@ -9,7 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { auth } from "@/lib/auth/auth";
+import { getOAuthClientPublic, getSession } from "@/lib/auth/auth.server";
 
 import { ConsentActions } from "./consent-actions";
 
@@ -51,9 +50,7 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
   }
 
   // Check if user is authenticated
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
+  const session = await getSession();
 
   if (!session?.session) {
     const queryString = oauthSearchParams.toString();
@@ -61,24 +58,7 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
   }
 
   // Fetch public client info for display on consent page
-  let client;
-  try {
-    client = await auth.api.getOAuthClientPublic({
-      query: { client_id },
-      headers: await headers(),
-    });
-  } catch (_error) {
-    return (
-      <div className="container mx-auto max-w-md py-8">
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("clientNotFound.title")}</CardTitle>
-            <CardDescription>{t("clientNotFound.description")}</CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
-    );
-  }
+  const client = await getOAuthClientPublic(client_id);
 
   if (!client) {
     return (

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -101,4 +101,123 @@ describe("auth.server", () => {
 
     await expect(getSession({ refresh: true })).resolves.toBeNull();
   });
+
+  it("lists user accounts from Core", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "account_1",
+          providerId: "google",
+        },
+      ],
+    });
+
+    const { listUserAccounts } = await import("../auth.server");
+
+    await expect(listUserAccounts()).resolves.toEqual([
+      {
+        id: "account_1",
+        providerId: "google",
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("http://localhost:8787/auth/list-accounts"),
+      {
+        headers: { cookie: "session=abc" },
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      },
+    );
+  });
+
+  it("returns an empty array when user accounts cannot be loaded", async () => {
+    fetchMock.mockRejectedValue(new Error("Core unreachable"));
+
+    const { listUserAccounts } = await import("../auth.server");
+
+    await expect(listUserAccounts()).resolves.toEqual([]);
+  });
+
+  it("lists active subscriptions with customer type query params", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          plan: "pro",
+          periodEnd: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const { listActiveSubscriptions } = await import("../auth.server");
+
+    await expect(
+      listActiveSubscriptions({ customerType: "user" }),
+    ).resolves.toEqual([
+      {
+        plan: "pro",
+        periodEnd: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("http://localhost:8787/auth/subscription/list?customerType=user"),
+      {
+        headers: { cookie: "session=abc" },
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      },
+    );
+  });
+
+  it("returns an empty array when active subscriptions cannot be loaded", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => null,
+    });
+
+    const { listActiveSubscriptions } = await import("../auth.server");
+
+    await expect(
+      listActiveSubscriptions({ customerType: "user" }),
+    ).resolves.toEqual([]);
+  });
+
+  it("fetches public OAuth client metadata", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        client_id: "client_123",
+        client_name: "My App",
+      }),
+    });
+
+    const { getOAuthClientPublic } = await import("../auth.server");
+
+    await expect(getOAuthClientPublic("client_123")).resolves.toEqual({
+      client_id: "client_123",
+      client_name: "My App",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        "http://localhost:8787/auth/oauth2/public-client?client_id=client_123",
+      ),
+      {
+        headers: { cookie: "session=abc" },
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      },
+    );
+  });
+
+  it("returns null when public OAuth client metadata cannot be loaded", async () => {
+    fetchMock.mockRejectedValue(new Error("Core unreachable"));
+
+    const { getOAuthClientPublic } = await import("../auth.server");
+
+    await expect(getOAuthClientPublic("client_123")).resolves.toBeNull();
+  });
 });

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -4,7 +4,8 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
 
-import type { Session } from "@/lib/auth/auth";
+import type { ActiveSubscription } from "@/components/billing/subscription-plan-utils";
+import type { Account, Session } from "@/lib/auth/auth";
 import { buildAuthHeaders } from "@/lib/clients/core.client";
 import { getServerCoreAppBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 import { joinCoreApiPath } from "@/lib/clients/utils/core-api-base-url.shared";
@@ -15,8 +16,58 @@ interface GetSessionOptions {
   refresh?: boolean;
 }
 
+interface ListActiveSubscriptionsOptions {
+  customerType?: "organization" | "user";
+  referenceId?: string;
+}
+
+export interface OAuthClientPublic {
+  client_id?: string;
+  client_name?: string;
+}
+
 const CORE_GET_SESSION_PATH = "/auth/get-session";
-const CORE_GET_SESSION_TIMEOUT_MS = 5000;
+const CORE_LIST_ACCOUNTS_PATH = "/auth/list-accounts";
+const CORE_LIST_ACTIVE_SUBSCRIPTIONS_PATH = "/auth/subscription/list";
+const CORE_GET_OAUTH_CLIENT_PUBLIC_PATH = "/auth/oauth2/public-client";
+const CORE_AUTH_REQUEST_TIMEOUT_MS = 5000;
+
+async function fetchCoreAuth<T>(
+  path: string,
+  requestHeaders: Headers,
+  options?: {
+    failureLogMessage?: string;
+    searchParams?: Record<string, string | undefined>;
+  },
+): Promise<T | null> {
+  const url = new URL(joinCoreApiPath(getServerCoreAppBaseUrl(), path));
+
+  for (const [key, value] of Object.entries(options?.searchParams ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers: buildAuthHeaders(requestHeaders),
+      cache: "no-store",
+      signal: AbortSignal.timeout(CORE_AUTH_REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    console.error(
+      options?.failureLogMessage ?? "Failed to fetch from Core auth",
+      error,
+    );
+    return null;
+  }
+}
 
 async function fetchSession(
   requestHeaders: Headers,
@@ -37,7 +88,7 @@ async function fetchSession(
     const response = await fetch(sessionUrl, {
       headers: buildAuthHeaders(requestHeaders),
       cache: "no-store",
-      signal: AbortSignal.timeout(CORE_GET_SESSION_TIMEOUT_MS),
+      signal: AbortSignal.timeout(CORE_AUTH_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -77,6 +128,58 @@ export async function getSession(
   }
 
   return getCachedSession();
+}
+
+/**
+ * Lists accounts linked to the current user via Core Better Auth.
+ */
+export async function listUserAccounts(): Promise<Account[]> {
+  const accounts = await fetchCoreAuth<Account[]>(
+    CORE_LIST_ACCOUNTS_PATH,
+    await headers(),
+    {
+      failureLogMessage: "Failed to fetch user accounts from Core",
+    },
+  );
+
+  return accounts ?? [];
+}
+
+/**
+ * Lists active Stripe-backed subscriptions for the current user or organization.
+ */
+export async function listActiveSubscriptions(
+  options?: ListActiveSubscriptionsOptions,
+): Promise<ActiveSubscription[]> {
+  const subscriptions = await fetchCoreAuth<ActiveSubscription[]>(
+    CORE_LIST_ACTIVE_SUBSCRIPTIONS_PATH,
+    await headers(),
+    {
+      failureLogMessage: "Failed to fetch active subscriptions from Core",
+      searchParams: {
+        customerType: options?.customerType,
+        referenceId: options?.referenceId,
+      },
+    },
+  );
+
+  return subscriptions ?? [];
+}
+
+/**
+ * Fetches public OAuth client metadata for the consent screen.
+ */
+export async function getOAuthClientPublic(
+  clientId: string,
+): Promise<OAuthClientPublic | null> {
+  return fetchCoreAuth<OAuthClientPublic>(
+    CORE_GET_OAUTH_CLIENT_PUBLIC_PATH,
+    await headers(),
+    {
+      failureLogMessage: "Failed to fetch OAuth client from Core",
+      searchParams: { client_id: clientId },
+    },
+  );
 }
 
 /**

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -130,10 +130,7 @@ export async function getSession(
   return getCachedSession();
 }
 
-/**
- * Lists accounts linked to the current user via Core Better Auth.
- */
-export async function listUserAccounts(): Promise<Account[]> {
+const getCachedUserAccounts = cache(async (): Promise<Account[]> => {
   const accounts = await fetchCoreAuth<Account[]>(
     CORE_LIST_ACCOUNTS_PATH,
     await headers(),
@@ -143,7 +140,37 @@ export async function listUserAccounts(): Promise<Account[]> {
   );
 
   return accounts ?? [];
+});
+
+/**
+ * Lists accounts linked to the current user via Core Better Auth.
+ */
+export async function listUserAccounts(): Promise<Account[]> {
+  return getCachedUserAccounts();
 }
+
+// Keyed on primitive args so React `cache` dedupes across call sites that pass
+// equivalent options as separate object literals.
+const getCachedActiveSubscriptions = cache(
+  async (
+    customerType?: "organization" | "user",
+    referenceId?: string,
+  ): Promise<ActiveSubscription[]> => {
+    const subscriptions = await fetchCoreAuth<ActiveSubscription[]>(
+      CORE_LIST_ACTIVE_SUBSCRIPTIONS_PATH,
+      await headers(),
+      {
+        failureLogMessage: "Failed to fetch active subscriptions from Core",
+        searchParams: {
+          customerType,
+          referenceId,
+        },
+      },
+    );
+
+    return subscriptions ?? [];
+  },
+);
 
 /**
  * Lists active Stripe-backed subscriptions for the current user or organization.
@@ -151,20 +178,24 @@ export async function listUserAccounts(): Promise<Account[]> {
 export async function listActiveSubscriptions(
   options?: ListActiveSubscriptionsOptions,
 ): Promise<ActiveSubscription[]> {
-  const subscriptions = await fetchCoreAuth<ActiveSubscription[]>(
-    CORE_LIST_ACTIVE_SUBSCRIPTIONS_PATH,
-    await headers(),
-    {
-      failureLogMessage: "Failed to fetch active subscriptions from Core",
-      searchParams: {
-        customerType: options?.customerType,
-        referenceId: options?.referenceId,
-      },
-    },
+  return getCachedActiveSubscriptions(
+    options?.customerType,
+    options?.referenceId,
   );
-
-  return subscriptions ?? [];
 }
+
+const getCachedOAuthClientPublic = cache(
+  async (clientId: string): Promise<OAuthClientPublic | null> => {
+    return fetchCoreAuth<OAuthClientPublic>(
+      CORE_GET_OAUTH_CLIENT_PUBLIC_PATH,
+      await headers(),
+      {
+        failureLogMessage: "Failed to fetch OAuth client from Core",
+        searchParams: { client_id: clientId },
+      },
+    );
+  },
+);
 
 /**
  * Fetches public OAuth client metadata for the consent screen.
@@ -172,14 +203,7 @@ export async function listActiveSubscriptions(
 export async function getOAuthClientPublic(
   clientId: string,
 ): Promise<OAuthClientPublic | null> {
-  return fetchCoreAuth<OAuthClientPublic>(
-    CORE_GET_OAUTH_CLIENT_PUBLIC_PATH,
-    await headers(),
-    {
-      failureLogMessage: "Failed to fetch OAuth client from Core",
-      searchParams: { client_id: clientId },
-    },
-  );
+  return getCachedOAuthClientPublic(clientId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extend `auth.server.ts` with `listUserAccounts`, `listActiveSubscriptions`, and `getOAuthClientPublic` using Core HTTP + cookie forwarding (same patterns as `getSession`).
- Migrate account, connections, onboarding, and OAuth consent server call sites off `auth.api`.

## Test plan
- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.server.test.ts`
- [x] `pnpm --filter web test src/app/(app)/components/__tests__/onboarding-dialog-loader.test.tsx`
- [x] `pnpm --filter web check`


Made with [Cursor](https://cursor.com)