### PR TITLE
refactor(auth): migrate setPassword to Core HTTP bridge

### DIFF
--- a/apps/core/src/routes/auth/index.ts
+++ b/apps/core/src/routes/auth/index.ts
@@ -4,6 +4,7 @@ import { cors } from "hono/cors";
 import { TIME } from "@/config/constants";
 import { resolveCorsAllowOrigin } from "@/config/cors-allow-origin";
 import { auth } from "@/lib/auth.js";
+import { handleSetPassword } from "@/routes/auth/set-password.route.js";
 
 const app = new Hono();
 
@@ -19,6 +20,10 @@ app.use(
     credentials: true,
   }),
 );
+
+// Better Auth's setPassword is server-only (no HTTP route). Web's server auth
+// client calls POST /auth/set-password when linking a credential account.
+app.post("/set-password", handleSetPassword);
 
 // Mount Auth routes
 app.on(["POST", "GET"], "*", (c) => {

--- a/apps/core/src/routes/auth/set-password.route.test.ts
+++ b/apps/core/src/routes/auth/set-password.route.test.ts
@@ -1,0 +1,93 @@
+import { APIError } from "better-auth/api";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setPasswordMock = vi.fn();
+
+vi.mock("@/lib/auth.js", () => ({
+  auth: {
+    api: {
+      setPassword: (...args: unknown[]) => setPasswordMock(...args),
+    },
+  },
+}));
+
+async function createApp() {
+  const { handleSetPassword } = await import("./set-password.route.js");
+  const app = new Hono();
+  app.post("/set-password", handleSetPassword);
+  return app;
+}
+
+function postSetPassword(
+  app: Hono,
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+) {
+  return app.request("http://localhost/set-password", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /auth/set-password bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPasswordMock.mockResolvedValue(undefined);
+  });
+
+  it("delegates to auth.api.setPassword and returns success", async () => {
+    const app = await createApp();
+
+    const response = await postSetPassword(
+      app,
+      { newPassword: "Password-123456" },
+      { cookie: "session=test" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: true });
+    expect(setPasswordMock).toHaveBeenCalledWith({
+      body: { newPassword: "Password-123456" },
+      headers: expect.any(Headers),
+    });
+  });
+
+  it("returns 400 for an invalid request body", async () => {
+    const app = await createApp();
+
+    const response = await postSetPassword(app, {});
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: "BAD_REQUEST",
+      message: "Invalid request body",
+    });
+    expect(setPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it("maps Better Auth API errors to JSON responses", async () => {
+    setPasswordMock.mockRejectedValue(
+      APIError.from("BAD_REQUEST", {
+        code: "PASSWORD_ALREADY_SET",
+        message: "Password already set",
+      }),
+    );
+
+    const app = await createApp();
+
+    const response = await postSetPassword(app, {
+      newPassword: "Password-123456",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: "PASSWORD_ALREADY_SET",
+      message: "Password already set",
+    });
+  });
+});

--- a/apps/core/src/routes/auth/set-password.route.test.ts
+++ b/apps/core/src/routes/auth/set-password.route.test.ts
@@ -70,6 +70,23 @@ describe("POST /auth/set-password bridge", () => {
     expect(setPasswordMock).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for a malformed JSON body", async () => {
+    const app = await createApp();
+
+    const response = await app.request("http://localhost/set-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: "BAD_REQUEST",
+      message: "Invalid request body",
+    });
+    expect(setPasswordMock).not.toHaveBeenCalled();
+  });
+
   it("maps Better Auth API errors to JSON responses", async () => {
     setPasswordMock.mockRejectedValue(
       APIError.from("BAD_REQUEST", {

--- a/apps/core/src/routes/auth/set-password.route.ts
+++ b/apps/core/src/routes/auth/set-password.route.ts
@@ -1,0 +1,46 @@
+import { isAPIError } from "better-auth/api";
+import type { Context } from "hono";
+import * as z from "zod";
+
+import { auth } from "@/lib/auth.js";
+
+const setPasswordBodySchema = z.object({
+  newPassword: z.string(),
+});
+
+/**
+ * HTTP bridge for Better Auth's server-only `setPassword` API.
+ * Better Auth does not register that endpoint on the HTTP router, but Web's
+ * server auth client calls `/auth/set-password` when linking a credential account.
+ */
+export async function handleSetPassword(c: Context): Promise<Response> {
+  try {
+    const body = setPasswordBodySchema.parse(await c.req.json());
+
+    await auth.api.setPassword({
+      body,
+      headers: c.req.raw.headers,
+    });
+
+    return c.json({ status: true });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return c.json(
+        { code: "BAD_REQUEST", message: "Invalid request body" },
+        400,
+      );
+    }
+
+    if (isAPIError(error)) {
+      return c.json(
+        {
+          code: error.body?.code ?? error.status,
+          message: error.message,
+        },
+        error.statusCode,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/apps/core/src/routes/auth/set-password.route.ts
+++ b/apps/core/src/routes/auth/set-password.route.ts
@@ -1,6 +1,7 @@
+import { z } from "@hono/zod-openapi";
 import { isAPIError } from "better-auth/api";
 import type { Context } from "hono";
-import * as z from "zod";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 import { auth } from "@/lib/auth.js";
 
@@ -32,12 +33,17 @@ export async function handleSetPassword(c: Context): Promise<Response> {
     }
 
     if (isAPIError(error)) {
+      const status: ContentfulStatusCode =
+        error.statusCode >= 400 && error.statusCode <= 599
+          ? (error.statusCode as ContentfulStatusCode)
+          : 400;
+
       return c.json(
         {
           code: error.body?.code ?? error.status,
           message: error.message,
         },
-        error.statusCode,
+        status,
       );
     }
 

--- a/apps/core/src/routes/auth/set-password.route.ts
+++ b/apps/core/src/routes/auth/set-password.route.ts
@@ -6,8 +6,12 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { auth } from "@/lib/auth.js";
 
 const setPasswordBodySchema = z.object({
-  newPassword: z.string(),
+  newPassword: z.string().min(1),
 });
+
+function invalidRequestBody(c: Context): Response {
+  return c.json({ code: "BAD_REQUEST", message: "Invalid request body" }, 400);
+}
 
 /**
  * HTTP bridge for Better Auth's server-only `setPassword` API.
@@ -15,23 +19,26 @@ const setPasswordBodySchema = z.object({
  * server auth client calls `/auth/set-password` when linking a credential account.
  */
 export async function handleSetPassword(c: Context): Promise<Response> {
+  let raw: unknown;
   try {
-    const body = setPasswordBodySchema.parse(await c.req.json());
+    raw = await c.req.json();
+  } catch {
+    return invalidRequestBody(c);
+  }
 
+  const parsed = setPasswordBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return invalidRequestBody(c);
+  }
+
+  try {
     await auth.api.setPassword({
-      body,
+      body: parsed.data,
       headers: c.req.raw.headers,
     });
 
     return c.json({ status: true });
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return c.json(
-        { code: "BAD_REQUEST", message: "Invalid request body" },
-        400,
-      );
-    }
-
     if (isAPIError(error)) {
       const status: ContentfulStatusCode =
         error.statusCode >= 400 && error.statusCode <= 599

--- a/apps/web/src/lib/actions/auth/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/auth/__tests__/action.test.ts
@@ -1,17 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const setPasswordViaCoreMock = vi.fn();
 const handleUTMConversionMock = vi.fn();
 
-vi.mock("@/lib/auth/auth", () => ({
-  auth: {
-    api: {
-      setPassword: vi.fn(),
-    },
-  },
-}));
-
-vi.mock("next/headers", () => ({
-  headers: vi.fn(async () => new Headers()),
+vi.mock("@/lib/auth/core-auth-http.server", () => ({
+  setPasswordViaCore: (...args: unknown[]) => setPasswordViaCoreMock(...args),
 }));
 
 vi.mock("@/lib/services/utm.service", () => ({
@@ -20,6 +13,65 @@ vi.mock("@/lib/services/utm.service", () => ({
       handleUTMConversionMock(...args),
   },
 }));
+
+describe("createCredentialAccount", () => {
+  beforeEach(() => {
+    setPasswordViaCoreMock.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("sets the password through Core auth", async () => {
+    setPasswordViaCoreMock.mockResolvedValue(undefined);
+
+    const { createCredentialAccount } = await import("../action");
+
+    const result = await createCredentialAccount({
+      newPassword: "Password-123456",
+      confirmNewPassword: "Password-123456",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(setPasswordViaCoreMock).toHaveBeenCalledWith("Password-123456");
+  });
+
+  it("returns BAD_INPUT for invalid form data", async () => {
+    const { createCredentialAccount } = await import("../action");
+
+    const result = await createCredentialAccount({
+      newPassword: "short",
+      confirmNewPassword: "short",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("BAD_INPUT");
+    }
+    expect(setPasswordViaCoreMock).not.toHaveBeenCalled();
+  });
+
+  it("maps Core auth errors to action errors", async () => {
+    const error = new Error("password already set") as Error & {
+      code: string;
+    };
+    error.code = "PASSWORD_ALREADY_SET";
+    setPasswordViaCoreMock.mockRejectedValue(error);
+
+    const { createCredentialAccount } = await import("../action");
+
+    const result = await createCredentialAccount({
+      newPassword: "Password-123456",
+      confirmNewPassword: "Password-123456",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: "PASSWORD_ALREADY_SET",
+        message: "password already set",
+      });
+    }
+  });
+});
 
 describe("handleUtmConversion", () => {
   beforeEach(() => {

--- a/apps/web/src/lib/actions/auth/action.ts
+++ b/apps/web/src/lib/actions/auth/action.ts
@@ -1,13 +1,7 @@
 "use server";
 
-import { headers } from "next/headers";
-
-import {
-  type ActionError,
-  betterAuthApiErrorSchema,
-  CommonErrorCode,
-} from "@/lib/actions/errors";
-import { auth } from "@/lib/auth/auth";
+import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
+import { setPasswordViaCore } from "@/lib/auth/core-auth-http.server";
 import { type NewPasswordFormType, newPasswordFormSchema } from "@/lib/schemas";
 import { utmService } from "@/lib/services/utm.service";
 import { Err, Ok, type Result } from "@/lib/ts-res";
@@ -24,27 +18,23 @@ export async function createCredentialAccount(
   const parsed = parsedResult.data;
 
   try {
-    await auth.api.setPassword({
-      body: {
-        newPassword: parsed.newPassword,
-      },
-      headers: await headers(),
-    });
+    await setPasswordViaCore(parsed.newPassword);
     return Ok();
   } catch (error) {
     console.error("Failed to set password", error);
 
-    const parsedBetterAuthApiErrorResult =
-      betterAuthApiErrorSchema.safeParse(error);
-    if (parsedBetterAuthApiErrorResult.success) {
-      return Err({
-        code: parsedBetterAuthApiErrorResult.data.body.code,
-        message: parsedBetterAuthApiErrorResult.data.body.message,
-      });
-    }
+    const code =
+      error instanceof Error &&
+      "code" in error &&
+      typeof error.code === "string"
+        ? error.code
+        : undefined;
 
     return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      code: code ?? CommonErrorCode.INTERNAL_SERVER_ERROR,
+      ...(error instanceof Error && error.message
+        ? { message: error.message }
+        : {}),
     });
   }
 }

--- a/apps/web/src/lib/actions/auth/action.ts
+++ b/apps/web/src/lib/actions/auth/action.ts
@@ -30,12 +30,18 @@ export async function createCredentialAccount(
         ? error.code
         : undefined;
 
-    return Err({
-      code: code ?? CommonErrorCode.INTERNAL_SERVER_ERROR,
-      ...(error instanceof Error && error.message
-        ? { message: error.message }
-        : {}),
-    });
+    // Only surface a message for known (coded) auth errors. Generic infra
+    // failures (timeouts, fetch errors) must not leak their raw message.
+    if (code) {
+      return Err({
+        code,
+        ...(error instanceof Error && error.message
+          ? { message: error.message }
+          : {}),
+      });
+    }
+
+    return Err({ code: CommonErrorCode.INTERNAL_SERVER_ERROR });
   }
 }
 

--- a/apps/web/src/lib/auth/__tests__/auth.server.client.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.client.test.ts
@@ -233,40 +233,46 @@ describe("setPasswordViaCore", () => {
     vi.clearAllMocks();
   });
 
-  it("delegates to authServerClient.setPassword", async () => {
-    const setPasswordMock = vi
-      .fn()
-      .mockResolvedValue({ data: {}, error: null });
+  it("POSTs to Core /auth/set-password", async () => {
+    const fetchCoreAuthMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: true }), {
+        status: 200,
+      }),
+    );
 
     vi.doMock("../auth.server.client", () => ({
-      getAuthServerClient: () => ({
-        setPassword: setPasswordMock,
-      }),
+      fetchCoreAuth: (...args: unknown[]) => fetchCoreAuthMock(...args),
+      getCoreAuthBaseUrl: () => "https://core.example.com/auth",
     }));
 
     const { setPasswordViaCore } = await import("../core-auth-http.server");
 
     await setPasswordViaCore("new-password-123");
 
-    expect(setPasswordMock).toHaveBeenCalledWith({
-      newPassword: "new-password-123",
-    });
+    expect(fetchCoreAuthMock).toHaveBeenCalledWith(
+      "https://core.example.com/auth/set-password",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newPassword: "new-password-123" }),
+      },
+    );
   });
 
-  it("throws when authServerClient.setPassword returns an error", async () => {
-    const setPasswordMock = vi.fn().mockResolvedValue({
-      data: null,
-      error: {
-        code: "PASSWORD_ALREADY_SET",
-        message: "password already set",
-        status: 400,
-      },
-    });
+  it("throws when Core returns an error response", async () => {
+    const fetchCoreAuthMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: "PASSWORD_ALREADY_SET",
+          message: "password already set",
+        }),
+        { status: 400 },
+      ),
+    );
 
     vi.doMock("../auth.server.client", () => ({
-      getAuthServerClient: () => ({
-        setPassword: setPasswordMock,
-      }),
+      fetchCoreAuth: (...args: unknown[]) => fetchCoreAuthMock(...args),
+      getCoreAuthBaseUrl: () => "https://core.example.com/auth",
     }));
 
     const { setPasswordViaCore } = await import("../core-auth-http.server");

--- a/apps/web/src/lib/auth/__tests__/auth.server.client.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.client.test.ts
@@ -227,6 +227,57 @@ describe("updateCurrentUserViaCore", () => {
   });
 });
 
+describe("setPasswordViaCore", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("delegates to authServerClient.setPassword", async () => {
+    const setPasswordMock = vi
+      .fn()
+      .mockResolvedValue({ data: {}, error: null });
+
+    vi.doMock("../auth.server.client", () => ({
+      getAuthServerClient: () => ({
+        setPassword: setPasswordMock,
+      }),
+    }));
+
+    const { setPasswordViaCore } = await import("../core-auth-http.server");
+
+    await setPasswordViaCore("new-password-123");
+
+    expect(setPasswordMock).toHaveBeenCalledWith({
+      newPassword: "new-password-123",
+    });
+  });
+
+  it("throws when authServerClient.setPassword returns an error", async () => {
+    const setPasswordMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: {
+        code: "PASSWORD_ALREADY_SET",
+        message: "password already set",
+        status: 400,
+      },
+    });
+
+    vi.doMock("../auth.server.client", () => ({
+      getAuthServerClient: () => ({
+        setPassword: setPasswordMock,
+      }),
+    }));
+
+    const { setPasswordViaCore } = await import("../core-auth-http.server");
+
+    await expect(setPasswordViaCore("new-password-123")).rejects.toMatchObject({
+      message: "password already set",
+      code: "PASSWORD_ALREADY_SET",
+    });
+  });
+});
+
 describe("inviteOrganizationMemberViaCore", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/web/src/lib/auth/auth.server.client.ts
+++ b/apps/web/src/lib/auth/auth.server.client.ts
@@ -41,6 +41,10 @@ function resolveCallerOrigin(requestHeaders: Headers): string | undefined {
   return `${proto}://${host}`;
 }
 
+/**
+ * Server-side fetch to Core `/auth` with session cookies and Origin forwarding.
+ * Use for Better Auth server-only endpoints that are not on the typed client.
+ */
 export async function fetchCoreAuth(
   input: RequestInfo | URL,
   init?: RequestInit,

--- a/apps/web/src/lib/auth/auth.server.client.ts
+++ b/apps/web/src/lib/auth/auth.server.client.ts
@@ -12,7 +12,7 @@ import { getAuthClientPlugins } from "./auth-client.plugins";
 const CORE_AUTH_BASE_PATH = "/auth";
 const CORE_AUTH_REQUEST_TIMEOUT_MS = 5000;
 
-function getCoreAuthBaseUrl(): string {
+export function getCoreAuthBaseUrl(): string {
   return joinCoreApiPath(getServerCoreAppBaseUrl(), CORE_AUTH_BASE_PATH);
 }
 
@@ -41,7 +41,7 @@ function resolveCallerOrigin(requestHeaders: Headers): string | undefined {
   return `${proto}://${host}`;
 }
 
-async function coreAuthFetch(
+export async function fetchCoreAuth(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
@@ -76,7 +76,7 @@ function createConfiguredAuthServerClient() {
     plugins: getAuthClientPlugins(),
     disableDefaultFetchPlugins: true,
     fetchOptions: {
-      customFetchImpl: coreAuthFetch,
+      customFetchImpl: fetchCoreAuth,
     },
   });
 }

--- a/apps/web/src/lib/auth/core-auth-http.server.ts
+++ b/apps/web/src/lib/auth/core-auth-http.server.ts
@@ -24,6 +24,27 @@ export async function updateCurrentUserViaCore(
 /**
  * Creates or resends an organization invitation through Core Better Auth.
  */
+/**
+ * Sets the current user's password through Core Better Auth when they have no
+ * credential account yet (first password / link credential flow).
+ */
+export async function setPasswordViaCore(newPassword: string): Promise<void> {
+  const result = await getAuthServerClient().setPassword({ newPassword });
+
+  if (result.error) {
+    const error = new Error(
+      result.error.message ??
+        `Failed to set password via Core auth (${result.error.status})`,
+    ) as Error & { code?: string };
+
+    if (result.error.code) {
+      error.code = result.error.code;
+    }
+
+    throw error;
+  }
+}
+
 export async function inviteOrganizationMemberViaCore(body: {
   email: string;
   organizationId: string;

--- a/apps/web/src/lib/auth/core-auth-http.server.ts
+++ b/apps/web/src/lib/auth/core-auth-http.server.ts
@@ -2,7 +2,11 @@ import "server-only";
 
 import type { MemberRole } from "@sokosumi/database";
 
-import { getAuthServerClient } from "./auth.server.client";
+import {
+  fetchCoreAuth,
+  getAuthServerClient,
+  getCoreAuthBaseUrl,
+} from "./auth.server.client";
 
 /**
  * Updates the current user through Core Better Auth so the session cookie cache
@@ -22,29 +26,43 @@ export async function updateCurrentUserViaCore(
 }
 
 /**
- * Creates or resends an organization invitation through Core Better Auth.
- */
-/**
  * Sets the current user's password through Core Better Auth when they have no
  * credential account yet (first password / link credential flow).
+ *
+ * Uses a direct HTTP POST because Better Auth marks `setPassword` as
+ * server-only and omits it from the typed client surface.
  */
 export async function setPasswordViaCore(newPassword: string): Promise<void> {
-  const result = await getAuthServerClient().setPassword({ newPassword });
+  const response = await fetchCoreAuth(`${getCoreAuthBaseUrl()}/set-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ newPassword }),
+  });
 
-  if (result.error) {
-    const error = new Error(
-      result.error.message ??
-        `Failed to set password via Core auth (${result.error.status})`,
-    ) as Error & { code?: string };
-
-    if (result.error.code) {
-      error.code = result.error.code;
-    }
-
-    throw error;
+  if (response.ok) {
+    return;
   }
+
+  const body = (await response.json().catch(() => null)) as {
+    code?: string;
+    message?: string;
+  } | null;
+
+  const error = new Error(
+    body?.message ??
+      `Failed to set password via Core auth (${response.status})`,
+  ) as Error & { code?: string };
+
+  if (body?.code) {
+    error.code = body.code;
+  }
+
+  throw error;
 }
 
+/**
+ * Creates or resends an organization invitation through Core Better Auth.
+ */
 export async function inviteOrganizationMemberViaCore(body: {
   email: string;
   organizationId: string;


### PR DESCRIPTION
## Summary

- Add Core `POST /auth/set-password` bridge for Better Auth's server-only `setPassword` API.
- Route `createCredentialAccount` through `setPasswordViaCore` instead of Web `auth.api.setPassword`.

## Test plan

- [x] `pnpm --filter web test src/lib/actions/auth/__tests__/action.test.ts`
- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.server.client.test.ts`
- [x] `pnpm --filter core check`
- [x] `pnpm --filter web check`


Made with [Cursor](https://cursor.com)