### PR TITLE
fix(web): defer toggle group render until client hydration

### DIFF
--- a/apps/web/src/app/(app)/account/components/preferences-section.tsx
+++ b/apps/web/src/app/(app)/account/components/preferences-section.tsx
@@ -4,7 +4,6 @@ import { Languages, Monitor, Moon, Sun } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { useMemo, useState } from "react";
-
 import {
   Card,
   CardContent,
@@ -20,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import useIsClient from "@/hooks/use-is-client";
 import {
   parseLocalePreference,
   serializeLocaleCookie,
@@ -33,6 +33,7 @@ import {
 } from "@/i18n/locales";
 
 export function PreferencesSection() {
+  const isClient = useIsClient();
   const themeTranslations = useTranslations("App.Account.Theme");
   const languageTranslations = useTranslations("App.Account.Language");
   const currentLocale = useLocale();
@@ -47,12 +48,16 @@ export function PreferencesSection() {
   );
 
   const selectedTheme = useMemo(() => {
+    if (!isClient) {
+      return "system";
+    }
+
     if (theme === "light" || theme === "dark" || theme === "system") {
       return theme;
     }
 
     return "system";
-  }, [theme]);
+  }, [isClient, theme]);
 
   const handleThemeChange = (nextTheme: string) => {
     if (

--- a/apps/web/src/app/(app)/tasks/components/view-mode-switch.tsx
+++ b/apps/web/src/app/(app)/tasks/components/view-mode-switch.tsx
@@ -8,7 +8,6 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import { useCallback } from "react";
-
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -17,6 +16,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import useIsClient from "@/hooks/use-is-client";
 import type { TasksDensity } from "@/lib/ui-preferences/tasks-density";
 
 export interface ViewModeSwitchProps {
@@ -41,6 +41,7 @@ export function ViewModeSwitch({
   onDensityChange,
   labels,
 }: ViewModeSwitchProps) {
+  const isClient = useIsClient();
   const handleChange = useCallback(
     (next: string) => {
       if (next === "board" || next === "list") {
@@ -67,77 +68,79 @@ export function ViewModeSwitch({
           <span className="hidden sm:inline">{labels.button}</span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-56 space-y-3">
-        <div className="space-y-3">
-          <p className="text-sm font-medium">{labels.button}</p>
-          <ToggleGroup
-            type="single"
-            value={value}
-            onValueChange={handleChange}
-            className="bg-background grid w-full grid-cols-2 gap-0.5"
-          >
-            <PopoverClose asChild>
-              <ToggleGroupItem
-                value="board"
-                aria-label={labels.board}
-                className="h-full p-2"
-              >
-                <div className="flex flex-col items-center gap-1 text-xs">
-                  <LayoutGrid className="size-4" aria-hidden />
-                  <span>{labels.board}</span>
-                </div>
-              </ToggleGroupItem>
-            </PopoverClose>
-            <PopoverClose asChild>
-              <ToggleGroupItem
-                value="list"
-                aria-label={labels.list}
-                className="h-full p-2"
-              >
-                <div className="flex flex-col items-center gap-1 text-xs">
-                  <List className="size-4" aria-hidden />
-                  <span>{labels.list}</span>
-                </div>
-              </ToggleGroupItem>
-            </PopoverClose>
-          </ToggleGroup>
-        </div>
+      {isClient ? (
+        <PopoverContent align="end" className="w-56 space-y-3">
+          <div className="space-y-3">
+            <p className="text-sm font-medium">{labels.button}</p>
+            <ToggleGroup
+              type="single"
+              value={value}
+              onValueChange={handleChange}
+              className="bg-background grid w-full grid-cols-2 gap-0.5"
+            >
+              <PopoverClose asChild>
+                <ToggleGroupItem
+                  value="board"
+                  aria-label={labels.board}
+                  className="h-full p-2"
+                >
+                  <div className="flex flex-col items-center gap-1 text-xs">
+                    <LayoutGrid className="size-4" aria-hidden />
+                    <span>{labels.board}</span>
+                  </div>
+                </ToggleGroupItem>
+              </PopoverClose>
+              <PopoverClose asChild>
+                <ToggleGroupItem
+                  value="list"
+                  aria-label={labels.list}
+                  className="h-full p-2"
+                >
+                  <div className="flex flex-col items-center gap-1 text-xs">
+                    <List className="size-4" aria-hidden />
+                    <span>{labels.list}</span>
+                  </div>
+                </ToggleGroupItem>
+              </PopoverClose>
+            </ToggleGroup>
+          </div>
 
-        <div className="space-y-3 pt-3 border-t">
-          <p className="text-sm font-medium">{labels.density}</p>
-          <ToggleGroup
-            type="single"
-            value={density}
-            onValueChange={handleDensityChange}
-            className="bg-background grid w-full grid-cols-2 gap-0.5"
-          >
-            <PopoverClose asChild>
-              <ToggleGroupItem
-                value="normal"
-                aria-label={labels.normal}
-                className="h-full p-2"
-              >
-                <div className="flex flex-col items-center gap-1 text-xs">
-                  <Rows3 className="size-4" aria-hidden />
-                  <span>{labels.normal}</span>
-                </div>
-              </ToggleGroupItem>
-            </PopoverClose>
-            <PopoverClose asChild>
-              <ToggleGroupItem
-                value="compact"
-                aria-label={labels.compact}
-                className="h-full p-2"
-              >
-                <div className="flex flex-col items-center gap-1 text-xs">
-                  <Columns3 className="size-4" aria-hidden />
-                  <span>{labels.compact}</span>
-                </div>
-              </ToggleGroupItem>
-            </PopoverClose>
-          </ToggleGroup>
-        </div>
-      </PopoverContent>
+          <div className="space-y-3 pt-3 border-t">
+            <p className="text-sm font-medium">{labels.density}</p>
+            <ToggleGroup
+              type="single"
+              value={density}
+              onValueChange={handleDensityChange}
+              className="bg-background grid w-full grid-cols-2 gap-0.5"
+            >
+              <PopoverClose asChild>
+                <ToggleGroupItem
+                  value="normal"
+                  aria-label={labels.normal}
+                  className="h-full p-2"
+                >
+                  <div className="flex flex-col items-center gap-1 text-xs">
+                    <Rows3 className="size-4" aria-hidden />
+                    <span>{labels.normal}</span>
+                  </div>
+                </ToggleGroupItem>
+              </PopoverClose>
+              <PopoverClose asChild>
+                <ToggleGroupItem
+                  value="compact"
+                  aria-label={labels.compact}
+                  className="h-full p-2"
+                >
+                  <div className="flex flex-col items-center gap-1 text-xs">
+                    <Columns3 className="size-4" aria-hidden />
+                    <span>{labels.compact}</span>
+                  </div>
+                </ToggleGroupItem>
+              </PopoverClose>
+            </ToggleGroup>
+          </div>
+        </PopoverContent>
+      ) : null}
     </Popover>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a React hydration mismatch on `ToggleGroupItem` where Radix rendered `data-state="off"` on the server but `data-state="on"` on the client.

## Root cause

Radix `ToggleGroup` inside a portaled `PopoverContent` can compute pressed state differently during SSR vs the first client render. The Task Manager display popover (`ViewModeSwitch`) hit this on `/tasks`.

Account theme preferences had the same pattern via `next-themes`, which resolves the active theme from browser storage after hydration.

## Changes

- **Task Manager (`view-mode-switch.tsx`)**: Render `PopoverContent` (and its toggle groups) only after client hydration via `useIsClient()`.
- **Account preferences (`preferences-section.tsx`)**: Keep theme toggle selection at `"system"` until hydration, then sync to the resolved theme.

## Verification

- `pnpm --filter web format`
- Reload `/tasks` and open the display settings popover — hydration warning should be gone
- Reload `/account` and confirm theme toggle still works after hydration
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e4caa0-7a4e-4761-8c05-3ea0d2985c7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e4caa0-7a4e-4761-8c05-3ea0d2985c7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

