### PR TITLE
feat(core): add passkey and lastLoginMethod auth plugins

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -12,6 +12,7 @@ BETTER_AUTH_SECRET="TFVfK91TGv2YVyVYFk0lu87Md5a13E4l7AjEaoZD8dQ="
 BETTER_AUTH_URL="http://localhost:8787"
 BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"
 # BETTER_AUTH_PROFILE_PICTURE_TIMEOUT=10000
+BETTER_AUTH_RP_ID=localhost
 GOOGLE_CLIENT_ID="<replace-with-your-google-client-id>"
 GOOGLE_CLIENT_SECRET="<replace-with-your-google-client-secret>"
 MICROSOFT_CLIENT_ID="<replace-with-your-microsoft-client-id>"

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -34,6 +34,7 @@
     "@better-auth/api-key": "1.6.18",
     "@better-auth/i18n": "1.6.18",
     "@better-auth/oauth-provider": "1.6.18",
+    "@better-auth/passkey": "1.6.18",
     "@better-auth/prisma-adapter": "1.6.18",
     "@better-auth/utils": "0.4.1",
     "@hono/node-server": "2.0.4",

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -60,6 +60,7 @@ const envSchema = z.object({
     .number()
     .min(0)
     .default(60 * 5), // 5 minutes
+  BETTER_AUTH_RP_ID: z.string().min(1).default("localhost"),
   GOOGLE_CLIENT_ID: z.string().min(1),
   GOOGLE_CLIENT_SECRET: z.string().min(1),
   MICROSOFT_CLIENT_ID: z.string().min(1),

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -10,11 +10,13 @@ const {
   getWebAppBaseUrlMock,
   i18nPluginMock,
   jwtPluginMock,
+  lastLoginMethodPluginMock,
   oauthProviderPluginMock,
   oAuthProxyPluginMock,
   openAPIPluginMock,
   organizationPluginMock,
   magicLinkPluginMock,
+  passkeyPluginMock,
   postmarkSendEmailMock,
   prismaAdapterMock,
   renderMagicLinkEmailMock,
@@ -33,11 +35,13 @@ const {
   getWebAppBaseUrlMock: vi.fn(),
   i18nPluginMock: vi.fn(),
   jwtPluginMock: vi.fn(),
+  lastLoginMethodPluginMock: vi.fn(),
   oauthProviderPluginMock: vi.fn(),
   oAuthProxyPluginMock: vi.fn(),
   openAPIPluginMock: vi.fn(),
   organizationPluginMock: vi.fn(),
   magicLinkPluginMock: vi.fn(),
+  passkeyPluginMock: vi.fn(),
   postmarkSendEmailMock: vi.fn(),
   prismaAdapterMock: vi.fn(),
   renderMagicLinkEmailMock: vi.fn(),
@@ -52,6 +56,7 @@ function getDefaultEnv() {
   return {
     BETTER_AUTH_COOKIE_DOMAIN: undefined,
     BETTER_AUTH_PROFILE_PICTURE_TIMEOUT: 5_000,
+    BETTER_AUTH_RP_ID: "example.com",
     BETTER_AUTH_SECRET: "test-secret",
     BETTER_AUTH_SESSION_COOKIE_CACHE_MAX_AGE: 60,
     GOOGLE_CLIENT_ID: "google-client-id",
@@ -79,10 +84,15 @@ vi.mock("@better-auth/prisma-adapter", () => ({
 vi.mock("better-auth/plugins", () => ({
   admin: (...args: unknown[]) => adminPluginMock(...args),
   jwt: (...args: unknown[]) => jwtPluginMock(...args),
+  lastLoginMethod: (...args: unknown[]) => lastLoginMethodPluginMock(...args),
   magicLink: (...args: unknown[]) => magicLinkPluginMock(...args),
   oAuthProxy: (...args: unknown[]) => oAuthProxyPluginMock(...args),
   openAPI: (...args: unknown[]) => openAPIPluginMock(...args),
   organization: (...args: unknown[]) => organizationPluginMock(...args),
+}));
+
+vi.mock("@better-auth/passkey", () => ({
+  passkey: (...args: unknown[]) => passkeyPluginMock(...args),
 }));
 
 vi.mock("@better-auth/api-key", () => ({
@@ -165,11 +175,13 @@ describe("core auth config", () => {
     getBetterAuthPublicBaseUrlMock.mockReturnValue("https://example.com/auth");
     getWebAppBaseUrlMock.mockReturnValue("https://example.com");
     jwtPluginMock.mockReturnValue("jwt-plugin");
+    lastLoginMethodPluginMock.mockReturnValue("last-login-method-plugin");
     magicLinkPluginMock.mockReturnValue("magic-link-plugin");
     oAuthProxyPluginMock.mockReturnValue("oauth-proxy-plugin");
     oauthProviderPluginMock.mockReturnValue("oauth-provider-plugin");
     openAPIPluginMock.mockReturnValue("openapi-plugin");
     organizationPluginMock.mockReturnValue("organization-plugin");
+    passkeyPluginMock.mockReturnValue("passkey-plugin");
     postmarkSendEmailMock.mockResolvedValue({ MessageID: "message_123" });
     prismaAdapterMock.mockReturnValue("prisma-adapter");
     renderMagicLinkEmailMock.mockResolvedValue({
@@ -354,6 +366,29 @@ describe("core auth config", () => {
     );
   });
 
+  it("registers the passkey plugin with the Sokosumi relying party configuration", async () => {
+    await import("./auth");
+
+    expect(passkeyPluginMock).toHaveBeenCalledWith({
+      rpID: "example.com",
+      rpName: "Sokosumi",
+    });
+  });
+
+  it("configures lastLoginMethod with the computed cookie name", async () => {
+    getEnvMock.mockReturnValue({
+      ...getDefaultEnv(),
+      NETWORK: "Mainnet",
+      VERCEL_ENV: "production",
+    });
+
+    await import("./auth");
+
+    expect(lastLoginMethodPluginMock).toHaveBeenCalledWith({
+      cookieName: "sokosumi.last_used_login_method",
+    });
+  });
+
   it("registers the Better Auth admin plugin", async () => {
     await import("./auth");
 
@@ -389,6 +424,8 @@ describe("core auth config", () => {
         "i18n-plugin",
         "openapi-plugin",
         "organization-plugin",
+        "passkey-plugin",
+        "last-login-method-plugin",
         "oauth-provider-plugin",
         "oauth-proxy-plugin",
       ]),

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { apiKey } from "@better-auth/api-key";
 import { i18n } from "@better-auth/i18n";
 import { oauthProvider } from "@better-auth/oauth-provider";
+import { passkey } from "@better-auth/passkey";
 import { prismaAdapter } from "@better-auth/prisma-adapter";
 import { z } from "@hono/zod-openapi";
 import * as Sentry from "@sentry/node";
@@ -10,12 +11,14 @@ import { renderMagicLinkEmail } from "@sokosumi/email";
 import { authTranslations } from "@sokosumi/masumi/auth";
 import {
   getStoredUserName,
+  resolveBetterAuthCookieName,
   resolveBetterAuthCookiePrefix,
 } from "@sokosumi/utils";
 import { betterAuth } from "better-auth/minimal";
 import {
   admin,
   jwt,
+  lastLoginMethod,
   magicLink,
   oAuthProxy,
   openAPI,
@@ -38,11 +41,14 @@ import { webhookService } from "@/services/webhook.service";
 const env = getEnv();
 const webAppBaseUrl = getWebAppBaseUrl();
 const betterAuthBaseUrl = getBetterAuthPublicBaseUrl();
-const betterAuthCookiePrefix = resolveBetterAuthCookiePrefix({
+const betterAuthCookiePrefixParams = {
   network: env.NETWORK,
   vercelEnv: env.VERCEL_ENV,
   vercelGitCommitRef: env.VERCEL_GIT_COMMIT_REF,
-});
+};
+const betterAuthCookiePrefix = resolveBetterAuthCookiePrefix(
+  betterAuthCookiePrefixParams,
+);
 
 async function ensureWorkspaceForCreatedUser(user: {
   email: string;
@@ -303,6 +309,16 @@ export const auth = betterAuth({
           },
         },
       },
+    }),
+    passkey({
+      rpID: env.BETTER_AUTH_RP_ID,
+      rpName: "Sokosumi",
+    }),
+    lastLoginMethod({
+      cookieName: resolveBetterAuthCookieName(
+        betterAuthCookiePrefixParams,
+        "last_used_login_method",
+      ),
     }),
     oauthProvider({
       loginPage: `${webAppBaseUrl}/signin`,

--- a/apps/core/src/test/setup.ts
+++ b/apps/core/src/test/setup.ts
@@ -5,6 +5,7 @@ const envDefaults: Record<string, string> = {
   DATABASE_URL: "https://example.com/database",
   BETTER_AUTH_SECRET: "test-secret",
   BETTER_AUTH_URL: "https://example.com/auth",
+  BETTER_AUTH_RP_ID: "localhost",
   GOOGLE_CLIENT_ID: "test-google-client-id",
   GOOGLE_CLIENT_SECRET: "test-google-client-secret",
   MICROSOFT_CLIENT_ID: "test-microsoft-client-id",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@better-auth/oauth-provider':
         specifier: 1.6.18
         version: 1.6.18(bbe4d1db2871483d9c0aac0a3fb4d575)
+      '@better-auth/passkey':
+        specifier: 1.6.18
+        version: 1.6.18(e6623558d3a2f88f739ebe5f18adc7b2)
       '@better-auth/prisma-adapter':
         specifier: 1.6.18
         version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))
@@ -174,7 +177,7 @@ importers:
         version: 1.6.18(bbe4d1db2871483d9c0aac0a3fb4d575)
       '@better-auth/passkey':
         specifier: 1.6.18
-        version: 1.6.18(2dbe3dc0c64f4969d4ee77bebdfcde25)
+        version: 1.6.18(e6623558d3a2f88f739ebe5f18adc7b2)
       '@better-auth/prisma-adapter':
         specifier: 1.6.18
         version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))
@@ -9259,7 +9262,7 @@ snapshots:
       jose: 6.2.3
       zod: 4.4.3
 
-  '@better-auth/passkey@1.6.18(2dbe3dc0c64f4969d4ee77bebdfcde25)':
+  '@better-auth/passkey@1.6.18(e6623558d3a2f88f739ebe5f18adc7b2)':
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1


### PR DESCRIPTION
## Summary

- Add `@better-auth/passkey` to Core Better Auth with `BETTER_AUTH_RP_ID` and Sokosumi `rpName`.
- Add `lastLoginMethod` plugin with the same cookie name resolution as web (`resolveBetterAuthCookieName` + `last_used_login_method`).
- Extend `auth.test.ts` for passkey RP config and last-login cookie naming.

Part of Web → Core auth migration (C2). Browser still uses Web `/api/auth` until `NEXT_PUBLIC_USE_CORE_AUTH_CLIENT` is enabled.

## Test plan

- [x] `pnpm --filter @sokosumi/core test src/lib/auth.test.ts`
- [x] `pnpm --filter @sokosumi/core check`
- [ ] After C3: enable flag on preprod and verify passkey sign-in + account passkey management


Made with [Cursor](https://cursor.com)