### PR TITLE
feat(core): add Stripe Better Auth plugin for subscriptions

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -60,8 +60,12 @@ STRIPE_WELCOME_COUPON="<stripe-welcome-coupon>"
 # 100%-off coupon used to issue admin credit grants free of charge
 STRIPE_SUPPORT_COUPON="<stripe-support-coupon>"
 
-# Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
+# Signing secret for Core billing webhook (POST /webhooks/stripe)
 STRIPE_WEBHOOK_SECRET="<stripe-webhook-secret>"
+
+# Signing secret for Better Auth Stripe plugin (POST /auth/stripe/webhook).
+# Separate Stripe Dashboard endpoint while testing Core auth cutover.
+STRIPE_BA_WEBHOOK_SECRET="<stripe-better-auth-webhook-secret>"
 LOCK_TIMEOUT="120000"
 LOCK_TIMEOUT_BUFFER="25000"
 INSTANCE_ID="<instance-id>"

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -36,6 +36,7 @@
     "@better-auth/oauth-provider": "1.6.18",
     "@better-auth/passkey": "1.6.18",
     "@better-auth/prisma-adapter": "1.6.18",
+    "@better-auth/stripe": "1.6.18",
     "@better-auth/utils": "0.4.1",
     "@hono/node-server": "2.0.4",
     "@hono/zod-openapi": "1.4.0",

--- a/apps/core/scripts/write-openapi-for-web.mts
+++ b/apps/core/scripts/write-openapi-for-web.mts
@@ -36,6 +36,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_WELCOME_COUPON: "coupon_welcome_test",
   STRIPE_SUPPORT_COUPON: "coupon_support_test",
   STRIPE_WEBHOOK_SECRET: "whsec_test_example",
+  STRIPE_BA_WEBHOOK_SECRET: "whsec_ba_test_example",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",
   INSTANCE_ID: "test-instance-id",

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -116,8 +116,11 @@ const envSchema = z.object({
   // 100%-off coupon used to issue admin credit grants free of charge
   STRIPE_SUPPORT_COUPON: z.string().min(1),
 
-  // Signing secret for core's own Stripe webhook endpoint (POST /webhooks/stripe)
+  // Signing secret for Core billing webhook (POST /webhooks/stripe).
   STRIPE_WEBHOOK_SECRET: z.string().min(1),
+
+  // Signing secret for Better Auth Stripe plugin (POST /auth/stripe/webhook).
+  STRIPE_BA_WEBHOOK_SECRET: z.string().min(1),
 
   // Sync lock configuration
   LOCK_TIMEOUT: z.coerce

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -7,7 +7,10 @@ const {
   getBetterAuthPublicBaseUrlMock,
   getEnvMock,
   getBetterAuthProductionUrlMock,
+  getBetterAuthSubscriptionPlansMock,
   getWebAppBaseUrlMock,
+  hasConsumableEnterpriseContractMock,
+  handleSubscriptionDeletedEventMock,
   i18nPluginMock,
   jwtPluginMock,
   lastLoginMethodPluginMock,
@@ -16,12 +19,15 @@ const {
   openAPIPluginMock,
   organizationPluginMock,
   magicLinkPluginMock,
+  getMemberByUserIdAndOrganizationIdMock,
   passkeyPluginMock,
   postmarkSendEmailMock,
   prismaAdapterMock,
+  reconcileActiveStripeBackedSubscriptionMock,
   renderMagicLinkEmailMock,
   sentryCaptureExceptionMock,
   stripeCreateUserCustomerMock,
+  stripePluginMock,
   uploadProfileImageMock,
   webhookCallAccountCreatedMock,
   workspaceUpsertMock,
@@ -32,7 +38,10 @@ const {
   getBetterAuthPublicBaseUrlMock: vi.fn(),
   getEnvMock: vi.fn(),
   getBetterAuthProductionUrlMock: vi.fn(),
+  getBetterAuthSubscriptionPlansMock: vi.fn(),
   getWebAppBaseUrlMock: vi.fn(),
+  hasConsumableEnterpriseContractMock: vi.fn(),
+  handleSubscriptionDeletedEventMock: vi.fn(),
   i18nPluginMock: vi.fn(),
   jwtPluginMock: vi.fn(),
   lastLoginMethodPluginMock: vi.fn(),
@@ -41,12 +50,15 @@ const {
   openAPIPluginMock: vi.fn(),
   organizationPluginMock: vi.fn(),
   magicLinkPluginMock: vi.fn(),
+  getMemberByUserIdAndOrganizationIdMock: vi.fn(),
   passkeyPluginMock: vi.fn(),
   postmarkSendEmailMock: vi.fn(),
   prismaAdapterMock: vi.fn(),
+  reconcileActiveStripeBackedSubscriptionMock: vi.fn(),
   renderMagicLinkEmailMock: vi.fn(),
   sentryCaptureExceptionMock: vi.fn(),
   stripeCreateUserCustomerMock: vi.fn(),
+  stripePluginMock: vi.fn(),
   uploadProfileImageMock: vi.fn(),
   webhookCallAccountCreatedMock: vi.fn(),
   workspaceUpsertMock: vi.fn(),
@@ -68,6 +80,7 @@ function getDefaultEnv() {
     POSTMARK_FROM_EMAIL: "no-reply@example.com",
     POSTMARK_SERVER_ID: "postmark-server-id",
     STRIPE_SECRET_KEY: "sk_test_123",
+    STRIPE_WEBHOOK_SECRET: "whsec_test_123",
     VERCEL_ENV: undefined,
     VERCEL_GIT_COMMIT_REF: "",
   };
@@ -95,6 +108,10 @@ vi.mock("@better-auth/passkey", () => ({
   passkey: (...args: unknown[]) => passkeyPluginMock(...args),
 }));
 
+vi.mock("@better-auth/stripe", () => ({
+  stripe: (...args: unknown[]) => stripePluginMock(...args),
+}));
+
 vi.mock("@better-auth/api-key", () => ({
   apiKey: (...args: unknown[]) => apiKeyPluginMock(...args),
 }));
@@ -111,7 +128,21 @@ vi.mock("@sentry/node", () => ({
   captureException: (...args: unknown[]) => sentryCaptureExceptionMock(...args),
 }));
 
+vi.mock("@sokosumi/database/helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@sokosumi/database/helpers")>();
+  return {
+    ...actual,
+    hasConsumableEnterpriseContract: (...args: unknown[]) =>
+      hasConsumableEnterpriseContractMock(...args),
+  };
+});
+
 vi.mock("@sokosumi/database/repositories", () => ({
+  memberRepository: {
+    getMemberByUserIdAndOrganizationId: (...args: unknown[]) =>
+      getMemberByUserIdAndOrganizationIdMock(...args),
+  },
   workspaceRepository: {
     upsertOrganizationWorkspace: (...args: unknown[]) =>
       workspaceUpsertMock(...args),
@@ -158,6 +189,18 @@ vi.mock("@/services/webhook.service", () => ({
   },
 }));
 
+vi.mock("@/services/subscription-catalog.service", () => ({
+  getBetterAuthSubscriptionPlans: (...args: unknown[]) =>
+    getBetterAuthSubscriptionPlansMock(...args),
+}));
+
+vi.mock("@/services/stripe-backed-subscription.service", () => ({
+  handleSubscriptionDeletedEvent: (...args: unknown[]) =>
+    handleSubscriptionDeletedEventMock(...args),
+  reconcileActiveStripeBackedSubscription: (...args: unknown[]) =>
+    reconcileActiveStripeBackedSubscriptionMock(...args),
+}));
+
 vi.mock("@sokosumi/email", () => ({
   renderMagicLinkEmail: (...args: unknown[]) =>
     renderMagicLinkEmailMock(...args),
@@ -182,6 +225,7 @@ describe("core auth config", () => {
     openAPIPluginMock.mockReturnValue("openapi-plugin");
     organizationPluginMock.mockReturnValue("organization-plugin");
     passkeyPluginMock.mockReturnValue("passkey-plugin");
+    reconcileActiveStripeBackedSubscriptionMock.mockResolvedValue(undefined);
     postmarkSendEmailMock.mockResolvedValue({ MessageID: "message_123" });
     prismaAdapterMock.mockReturnValue("prisma-adapter");
     renderMagicLinkEmailMock.mockResolvedValue({
@@ -192,9 +236,13 @@ describe("core auth config", () => {
     stripeCreateUserCustomerMock.mockResolvedValue({ id: "cus_123" });
     uploadProfileImageMock.mockResolvedValue("https://blob.example/avatar.png");
     webhookCallAccountCreatedMock.mockResolvedValue(undefined);
+    stripePluginMock.mockReturnValue("stripe-plugin");
     workspaceUpsertMock.mockResolvedValue({ id: "workspace_123" });
     betterAuthMock.mockReturnValue({ api: {}, handler: vi.fn() });
     getBetterAuthProductionUrlMock.mockReturnValue("https://example.com/auth");
+    getBetterAuthSubscriptionPlansMock.mockResolvedValue([]);
+    hasConsumableEnterpriseContractMock.mockResolvedValue(false);
+    handleSubscriptionDeletedEventMock.mockResolvedValue(undefined);
   });
 
   it("configures Google and Microsoft social providers for auth parity", async () => {
@@ -389,6 +437,139 @@ describe("core auth config", () => {
     });
   });
 
+  it("configures subscription checkout for billing, tax IDs, and customer updates", async () => {
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [
+        {
+          subscription: {
+            getCheckoutSessionParams: () => Promise<{
+              params?: {
+                billing_address_collection?: string;
+                customer_update?: {
+                  address?: string;
+                  name?: string;
+                };
+                tax_id_collection?: {
+                  enabled: boolean;
+                };
+              };
+            }>;
+          };
+        },
+      ]
+    >;
+
+    const sessionParams = await config.subscription.getCheckoutSessionParams();
+
+    expect(sessionParams).toEqual({
+      params: {
+        billing_address_collection: "required",
+        customer_update: {
+          address: "auto",
+          name: "auto",
+        },
+        tax_id_collection: {
+          enabled: true,
+        },
+      },
+    });
+  });
+
+  it("handles customer.subscription.deleted via the Stripe webhook handlers", async () => {
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [
+        {
+          onEvent: (event: {
+            data: {
+              object: {
+                id: string;
+              };
+            };
+            id: string;
+            type: string;
+          }) => Promise<void>;
+        },
+      ]
+    >;
+
+    await config.onEvent({
+      data: {
+        object: {
+          id: "sub_123",
+        },
+      },
+      id: "evt_123",
+      type: "customer.subscription.deleted",
+    });
+
+    expect(handleSubscriptionDeletedEventMock).toHaveBeenCalledWith({
+      id: "sub_123",
+    });
+  });
+
+  it.each([
+    "onSubscriptionCreated",
+    "onSubscriptionUpdate",
+  ] as const)("reconciles local free rows from Better Auth subscription callback %s", async (callbackName) => {
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [
+        {
+          subscription: {
+            onSubscriptionCreated: (params: {
+              event: {
+                id: string;
+                type: string;
+              };
+              subscription: {
+                id: string;
+                referenceId: string;
+                stripeSubscriptionId?: string | null;
+              };
+            }) => Promise<void>;
+            onSubscriptionUpdate: (params: {
+              event: {
+                id: string;
+                type: string;
+              };
+              subscription: {
+                id: string;
+                referenceId: string;
+                stripeSubscriptionId?: string | null;
+              };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    const subscription = {
+      id: "sub_local_enterprise",
+      referenceId: "org-enterprise",
+      stripeSubscriptionId: "sub_enterprise",
+    };
+
+    await config.subscription[callbackName]({
+      event: {
+        id: "evt_enterprise",
+        type:
+          callbackName === "onSubscriptionCreated"
+            ? "customer.subscription.created"
+            : "customer.subscription.updated",
+      },
+      subscription,
+    });
+
+    expect(reconcileActiveStripeBackedSubscriptionMock).toHaveBeenCalledWith(
+      subscription,
+    );
+  });
+
   it("registers the Better Auth admin plugin", async () => {
     await import("./auth");
 
@@ -428,6 +609,7 @@ describe("core auth config", () => {
         "last-login-method-plugin",
         "oauth-provider-plugin",
         "oauth-proxy-plugin",
+        "stripe-plugin",
       ]),
     );
     expect(apiKeyPluginMock).toHaveBeenCalledWith(

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -1,4 +1,16 @@
+import { MemberRole } from "@sokosumi/database";
+import { ENTERPRISE_SUBSCRIPTION_EXCLUSIVITY_MESSAGE } from "@sokosumi/database/helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface AuthorizeReferenceConfig {
+  subscription: {
+    authorizeReference: (params: {
+      referenceId: string;
+      user: { id: string };
+      action?: string;
+    }) => Promise<boolean>;
+  };
+}
 
 const {
   adminPluginMock,
@@ -572,6 +584,128 @@ describe("core auth config", () => {
     expect(reconcileActiveStripeBackedSubscriptionMock).toHaveBeenCalledWith(
       subscription,
     );
+  });
+
+  it("denies subscription management for non-members", async () => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue(null);
+
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [AuthorizeReferenceConfig]
+    >;
+
+    await expect(
+      config.subscription.authorizeReference({
+        referenceId: "org_123",
+        user: { id: "user_123" },
+        action: "upgrade-subscription",
+      }),
+    ).resolves.toBe(false);
+
+    expect(getMemberByUserIdAndOrganizationIdMock).toHaveBeenCalledWith(
+      "user_123",
+      "org_123",
+      { __prisma: true },
+    );
+    expect(hasConsumableEnterpriseContractMock).not.toHaveBeenCalled();
+  });
+
+  it("denies subscription management for members without owner or admin role", async () => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
+      role: MemberRole.MEMBER,
+    });
+
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [AuthorizeReferenceConfig]
+    >;
+
+    await expect(
+      config.subscription.authorizeReference({
+        referenceId: "org_123",
+        user: { id: "user_123" },
+        action: "upgrade-subscription",
+      }),
+    ).resolves.toBe(false);
+    expect(hasConsumableEnterpriseContractMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    MemberRole.OWNER,
+    MemberRole.ADMIN,
+  ] as const)("allows subscription management for %s without an enterprise contract", async (role) => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({ role });
+    hasConsumableEnterpriseContractMock.mockResolvedValue(false);
+
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [AuthorizeReferenceConfig]
+    >;
+
+    await expect(
+      config.subscription.authorizeReference({
+        referenceId: "org_123",
+        user: { id: "user_123" },
+        action: "upgrade-subscription",
+      }),
+    ).resolves.toBe(true);
+
+    expect(hasConsumableEnterpriseContractMock).toHaveBeenCalledWith(
+      "org_123",
+      { __prisma: true },
+    );
+  });
+
+  it("throws enterprise exclusivity error when upgrading an org with a consumable enterprise contract", async () => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
+      role: MemberRole.OWNER,
+    });
+    hasConsumableEnterpriseContractMock.mockResolvedValue(true);
+
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [AuthorizeReferenceConfig]
+    >;
+
+    await expect(
+      config.subscription.authorizeReference({
+        referenceId: "org_123",
+        user: { id: "user_123" },
+        action: "upgrade-subscription",
+      }),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: {
+        code: "ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE",
+        message: ENTERPRISE_SUBSCRIPTION_EXCLUSIVITY_MESSAGE,
+      },
+    });
+  });
+
+  it("allows non-upgrade actions even with a consumable enterprise contract", async () => {
+    getMemberByUserIdAndOrganizationIdMock.mockResolvedValue({
+      role: MemberRole.OWNER,
+    });
+    hasConsumableEnterpriseContractMock.mockResolvedValue(true);
+
+    await import("./auth");
+
+    const [[config]] = stripePluginMock.mock.calls as Array<
+      [AuthorizeReferenceConfig]
+    >;
+
+    await expect(
+      config.subscription.authorizeReference({
+        referenceId: "org_123",
+        user: { id: "user_123" },
+        action: "cancel-subscription",
+      }),
+    ).resolves.toBe(true);
+    expect(hasConsumableEnterpriseContractMock).not.toHaveBeenCalled();
   });
 
   it("registers the Better Auth admin plugin", async () => {

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -81,6 +81,7 @@ function getDefaultEnv() {
     POSTMARK_SERVER_ID: "postmark-server-id",
     STRIPE_SECRET_KEY: "sk_test_123",
     STRIPE_WEBHOOK_SECRET: "whsec_test_123",
+    STRIPE_BA_WEBHOOK_SECRET: "whsec_ba_test_123",
     VERCEL_ENV: undefined,
     VERCEL_GIT_COMMIT_REF: "",
   };
@@ -443,6 +444,7 @@ describe("core auth config", () => {
     const [[config]] = stripePluginMock.mock.calls as Array<
       [
         {
+          stripeWebhookSecret: string;
           subscription: {
             getCheckoutSessionParams: () => Promise<{
               params?: {
@@ -460,6 +462,8 @@ describe("core auth config", () => {
         },
       ]
     >;
+
+    expect(config.stripeWebhookSecret).toBe("whsec_ba_test_123");
 
     const sessionParams = await config.subscription.getCheckoutSessionParams();
 

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -3,10 +3,18 @@ import { i18n } from "@better-auth/i18n";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { passkey } from "@better-auth/passkey";
 import { prismaAdapter } from "@better-auth/prisma-adapter";
+import { stripe } from "@better-auth/stripe";
 import { z } from "@hono/zod-openapi";
 import * as Sentry from "@sentry/node";
-import type { User } from "@sokosumi/database";
-import { workspaceRepository } from "@sokosumi/database/repositories";
+import { MemberRole, type User } from "@sokosumi/database";
+import {
+  ENTERPRISE_SUBSCRIPTION_EXCLUSIVITY_MESSAGE,
+  hasConsumableEnterpriseContract,
+} from "@sokosumi/database/helpers";
+import {
+  memberRepository,
+  workspaceRepository,
+} from "@sokosumi/database/repositories";
 import { renderMagicLinkEmail } from "@sokosumi/email";
 import { authTranslations } from "@sokosumi/masumi/auth";
 import {
@@ -14,6 +22,7 @@ import {
   resolveBetterAuthCookieName,
   resolveBetterAuthCookiePrefix,
 } from "@sokosumi/utils";
+import { APIError } from "better-auth/api";
 import { betterAuth } from "better-auth/minimal";
 import {
   admin,
@@ -25,6 +34,7 @@ import {
   organization,
 } from "better-auth/plugins";
 import pTimeout from "p-timeout";
+import Stripe from "stripe";
 import { postmarkClient } from "@/clients/postmark.client";
 import { stripeClient } from "@/clients/stripe.client";
 import { getBetterAuthProductionUrl } from "@/config/better-auth-production-url";
@@ -36,9 +46,18 @@ import {
 } from "@/config/env";
 import { uploadProfileImage } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
+import {
+  handleSubscriptionDeletedEvent,
+  reconcileActiveStripeBackedSubscription,
+} from "@/services/stripe-backed-subscription.service";
+import { getBetterAuthSubscriptionPlans } from "@/services/subscription-catalog.service";
 import { webhookService } from "@/services/webhook.service";
 
+const ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE =
+  "ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE";
+
 const env = getEnv();
+const stripeInstance = new Stripe(env.STRIPE_SECRET_KEY);
 const webAppBaseUrl = getWebAppBaseUrl();
 const betterAuthBaseUrl = getBetterAuthPublicBaseUrl();
 const betterAuthCookiePrefixParams = {
@@ -93,6 +112,38 @@ async function ensureWorkspaceForCreatedOrganization(organization: {
         organizationName: organization.name,
       },
     });
+  }
+}
+
+type StripeBackedLocalSubscription = NonNullable<
+  Parameters<typeof reconcileActiveStripeBackedSubscription>[0]
+>;
+
+async function handleStripeBackedSubscriptionLifecycle({
+  event,
+  subscription,
+}: {
+  event: {
+    id: string;
+    type: string;
+  };
+  subscription: StripeBackedLocalSubscription;
+}): Promise<void> {
+  try {
+    await reconcileActiveStripeBackedSubscription(subscription);
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: {
+        stripeEventType: event.type,
+        stripeSubscriptionId: subscription.stripeSubscriptionId,
+      },
+      extra: {
+        eventId: event.id,
+        localSubscriptionId: subscription.id,
+        referenceId: subscription.referenceId,
+      },
+    });
+    throw error;
   }
 }
 
@@ -341,6 +392,91 @@ export const auth = betterAuth({
     }),
     oAuthProxy({
       productionURL: getBetterAuthProductionUrl(),
+    }),
+    stripe({
+      stripeClient: stripeInstance,
+      stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
+      createCustomerOnSignUp: false,
+      subscription: {
+        enabled: true,
+        plans: async () => await getBetterAuthSubscriptionPlans(),
+        onSubscriptionCreated: handleStripeBackedSubscriptionLifecycle,
+        onSubscriptionUpdate: handleStripeBackedSubscriptionLifecycle,
+        getCheckoutSessionParams: async () => ({
+          params: {
+            billing_address_collection: "required",
+            customer_update: {
+              address: "auto",
+              name: "auto",
+            },
+            tax_id_collection: {
+              enabled: true,
+            },
+          },
+        }),
+        authorizeReference: async ({ referenceId, user, action }) => {
+          const member =
+            await memberRepository.getMemberByUserIdAndOrganizationId(
+              user.id,
+              referenceId,
+              prisma,
+            );
+
+          if (
+            !member ||
+            (member.role !== MemberRole.OWNER &&
+              member.role !== MemberRole.ADMIN)
+          ) {
+            return false;
+          }
+
+          if (
+            action === "upgrade-subscription" &&
+            (await hasConsumableEnterpriseContract(referenceId, prisma))
+          ) {
+            throw new APIError("BAD_REQUEST", {
+              code: ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE,
+              message: ENTERPRISE_SUBSCRIPTION_EXCLUSIVITY_MESSAGE,
+            });
+          }
+
+          return true;
+        },
+      },
+      organization: {
+        enabled: true,
+      },
+      onEvent: async (event) => {
+        switch (event.type) {
+          case "customer.subscription.deleted": {
+            const subscription = event.data.object as Stripe.Subscription;
+            try {
+              await handleSubscriptionDeletedEvent(subscription);
+            } catch (error) {
+              Sentry.captureException(error, {
+                tags: {
+                  stripeEventType: "customer.subscription.deleted",
+                  stripeSubscriptionId: subscription.id,
+                },
+                extra: {
+                  customer:
+                    typeof subscription.customer === "string"
+                      ? subscription.customer
+                      : subscription.customer.id,
+                  eventId: event.id,
+                  subscription: subscription.id,
+                },
+              });
+              throw error;
+            }
+            break;
+          }
+          default: {
+            console.info(`Unhandled Stripe event type: ${event.type}`);
+            break;
+          }
+        }
+      },
     }),
   ],
 });

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -393,9 +393,12 @@ export const auth = betterAuth({
     oAuthProxy({
       productionURL: getBetterAuthProductionUrl(),
     }),
+    // Subscription/checkout webhooks use a separate Stripe Dashboard endpoint
+    // (POST /auth/stripe/webhook, STRIPE_BA_WEBHOOK_SECRET) — same split as web
+    // today vs Core billing (POST /webhooks/stripe). Consolidate after cutover.
     stripe({
       stripeClient: stripeInstance,
-      stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
+      stripeWebhookSecret: env.STRIPE_BA_WEBHOOK_SECRET,
       createCustomerOnSignUp: false,
       subscription: {
         enabled: true,

--- a/apps/core/src/services/stripe-backed-subscription.service.test.ts
+++ b/apps/core/src/services/stripe-backed-subscription.service.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const transitionToNextLocalFreeSubscriptionPeriodMock = vi.fn();
+const getSubscriptionByStripeSubscriptionIdMock = vi.fn();
+const resolveActiveSubscriptionByReferenceIdMock = vi.fn();
+const subscriptionUpdateManyMock = vi.fn();
+
+const transactionMock = vi.fn(async (callback: (tx: unknown) => unknown) =>
+  callback({
+    subscription: {
+      updateMany: (...args: unknown[]) => subscriptionUpdateManyMock(...args),
+    },
+  }),
+);
+
+vi.mock("@sokosumi/database/helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@sokosumi/database/helpers")>();
+  return {
+    ...actual,
+    transitionToNextLocalFreeSubscriptionPeriod: (...args: unknown[]) =>
+      transitionToNextLocalFreeSubscriptionPeriodMock(...args),
+  };
+});
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  subscriptionRepository: {
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
+    getSubscriptionByStripeSubscriptionId: (...args: unknown[]) =>
+      getSubscriptionByStripeSubscriptionIdMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  __esModule: true,
+  default: {
+    $transaction: (callback: (tx: unknown) => unknown) =>
+      transactionMock(callback),
+  },
+}));
+
+describe("reconcileActiveStripeBackedSubscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subscriptionUpdateManyMock.mockResolvedValue({ count: 2 });
+  });
+
+  it("cancels active local free rows for the same reference when a Stripe-backed subscription is active", async () => {
+    const { reconcileActiveStripeBackedSubscription } = await import(
+      "./stripe-backed-subscription.service"
+    );
+
+    await reconcileActiveStripeBackedSubscription({
+      id: "sub_local_paid",
+      plan: "pro",
+      referenceId: "org-enterprise",
+      status: "active",
+      stripeSubscriptionId: "sub_enterprise",
+    });
+
+    expect(subscriptionUpdateManyMock).toHaveBeenCalledWith({
+      where: {
+        id: {
+          not: "sub_local_paid",
+        },
+        plan: "free",
+        referenceId: "org-enterprise",
+        status: {
+          in: ["active", "trialing", "past_due", "unpaid"],
+        },
+        stripeSubscriptionId: null,
+      },
+      data: {
+        canceledAt: expect.any(Date),
+        endedAt: expect.any(Date),
+        status: "canceled",
+      },
+    });
+  });
+
+  it("does not cancel local free rows for non-active local subscription statuses", async () => {
+    const { reconcileActiveStripeBackedSubscription } = await import(
+      "./stripe-backed-subscription.service"
+    );
+
+    await reconcileActiveStripeBackedSubscription({
+      id: "sub_local_paid",
+      plan: "pro",
+      referenceId: "org-enterprise",
+      status: "incomplete",
+      stripeSubscriptionId: "sub_enterprise",
+    });
+
+    expect(subscriptionUpdateManyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel local free rows when the Stripe-backed local row is still free", async () => {
+    const { reconcileActiveStripeBackedSubscription } = await import(
+      "./stripe-backed-subscription.service"
+    );
+
+    await reconcileActiveStripeBackedSubscription({
+      id: "sub_local_free",
+      plan: "free",
+      referenceId: "org-enterprise",
+      status: "active",
+      stripeSubscriptionId: "sub_free",
+    });
+
+    expect(subscriptionUpdateManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSubscriptionDeletedEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transitionToNextLocalFreeSubscriptionPeriodMock.mockResolvedValue(
+      undefined,
+    );
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+    getSubscriptionByStripeSubscriptionIdMock.mockResolvedValue({
+      canceledAt: new Date("2026-04-09T07:39:30.188Z"),
+      createdAt: new Date("2026-03-09T07:39:30.188Z"),
+      endedAt: null,
+      id: "sub_local_1",
+      periodEnd: new Date("2026-04-09T07:40:10.000Z"),
+      plan: "free",
+      referenceId: "user-1",
+      seats: 1,
+      stripeCustomerId: "cus_123",
+      stripeSubscriptionId: "sub_123",
+    });
+  });
+
+  it("creates the first local free successor when a Stripe free subscription ends", async () => {
+    const { handleSubscriptionDeletedEvent } = await import(
+      "./stripe-backed-subscription.service"
+    );
+
+    await handleSubscriptionDeletedEvent({
+      id: "sub_123",
+    } as never);
+
+    expect(getSubscriptionByStripeSubscriptionIdMock).toHaveBeenCalledWith(
+      "sub_123",
+      expect.anything(),
+    );
+    expect(resolveActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.anything(),
+    );
+    expect(
+      transitionToNextLocalFreeSubscriptionPeriodMock,
+    ).toHaveBeenCalledWith(
+      {
+        setCanceledAt: true,
+        subscription: {
+          canceledAt: new Date("2026-04-09T07:39:30.188Z"),
+          createdAt: new Date("2026-03-09T07:39:30.188Z"),
+          endedAt: null,
+          id: "sub_local_1",
+          periodEnd: new Date("2026-04-09T07:40:10.000Z"),
+          referenceId: "user-1",
+          seats: 1,
+          stripeCustomerId: "cus_123",
+          stripeSubscriptionId: "sub_123",
+        },
+      },
+      expect.anything(),
+    );
+  });
+
+  it("skips the free fallback when another paid subscription is still active", async () => {
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      id: "sub_active_paid_2",
+      plan: "pro",
+    });
+
+    const { handleSubscriptionDeletedEvent } = await import(
+      "./stripe-backed-subscription.service"
+    );
+
+    await handleSubscriptionDeletedEvent({
+      id: "sub_123",
+    } as never);
+
+    expect(
+      transitionToNextLocalFreeSubscriptionPeriodMock,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/services/stripe-backed-subscription.service.ts
+++ b/apps/core/src/services/stripe-backed-subscription.service.ts
@@ -1,0 +1,105 @@
+import {
+  FREE_SUBSCRIPTION_PLAN,
+  isActiveSubscriptionStatus,
+  transitionToNextLocalFreeSubscriptionPeriod,
+} from "@sokosumi/database/helpers";
+import { subscriptionRepository } from "@sokosumi/database/repositories";
+import type Stripe from "stripe";
+
+import prisma from "@/lib/db/prisma";
+
+interface StripeBackedSubscriptionForReconciliation {
+  id: string;
+  plan: string;
+  referenceId: string;
+  status: string;
+  stripeSubscriptionId?: string | null;
+}
+
+export async function reconcileActiveStripeBackedSubscription(
+  localSubscription: StripeBackedSubscriptionForReconciliation | null,
+): Promise<void> {
+  if (
+    !localSubscription?.stripeSubscriptionId ||
+    !isActiveSubscriptionStatus(localSubscription.status) ||
+    localSubscription.plan === FREE_SUBSCRIPTION_PLAN
+  ) {
+    return;
+  }
+
+  const settledAt = new Date();
+  await prisma.$transaction(async (tx) => {
+    const result = await tx.subscription.updateMany({
+      where: {
+        id: {
+          not: localSubscription.id,
+        },
+        plan: FREE_SUBSCRIPTION_PLAN,
+        referenceId: localSubscription.referenceId,
+        status: {
+          in: ["active", "trialing", "past_due", "unpaid"],
+        },
+        stripeSubscriptionId: null,
+      },
+      data: {
+        canceledAt: settledAt,
+        endedAt: settledAt,
+        status: "canceled",
+      },
+    });
+
+    if (result.count > 0) {
+      console.log(
+        `✅ Closed ${result.count} local free subscription(s) for reference ${localSubscription.referenceId} after Stripe subscription ${localSubscription.stripeSubscriptionId} became ${localSubscription.status}`,
+      );
+    }
+  });
+}
+
+export async function handleSubscriptionDeletedEvent(
+  subscription: Stripe.Subscription,
+): Promise<void> {
+  const localSubscription =
+    await subscriptionRepository.getSubscriptionByStripeSubscriptionId(
+      subscription.id,
+      prisma,
+    );
+
+  if (!localSubscription || localSubscription.stripeSubscriptionId === null) {
+    return;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const latestActiveSubscription =
+      await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
+        localSubscription.referenceId,
+        tx,
+      );
+
+    if (
+      latestActiveSubscription &&
+      latestActiveSubscription.id !== localSubscription.id &&
+      latestActiveSubscription.plan !== FREE_SUBSCRIPTION_PLAN
+    ) {
+      return;
+    }
+
+    await transitionToNextLocalFreeSubscriptionPeriod(
+      {
+        setCanceledAt: true,
+        subscription: {
+          canceledAt: localSubscription.canceledAt,
+          createdAt: localSubscription.createdAt,
+          endedAt: localSubscription.endedAt,
+          id: localSubscription.id,
+          periodEnd: localSubscription.periodEnd,
+          referenceId: localSubscription.referenceId,
+          seats: localSubscription.seats,
+          stripeCustomerId: localSubscription.stripeCustomerId,
+          stripeSubscriptionId: localSubscription.stripeSubscriptionId,
+        },
+      },
+      tx,
+    );
+  });
+}

--- a/apps/core/src/services/subscription-catalog.service.ts
+++ b/apps/core/src/services/subscription-catalog.service.ts
@@ -1,3 +1,4 @@
+import type { StripePlan } from "@better-auth/stripe";
 import {
   FREE_SUBSCRIPTION_MONTHLY_CREDITS,
   type PaidSubscriptionPlanName,
@@ -174,4 +175,28 @@ export async function getSubscriptionCatalog(): Promise<SubscriptionCatalog> {
     });
   }
   return await catalogCache;
+}
+
+export async function getBetterAuthSubscriptionPlans(): Promise<StripePlan[]> {
+  const catalog = await getSubscriptionCatalog();
+  const selfServePlans: PaidSubscriptionPlanName[] = [
+    "starter",
+    "standard",
+    "pro",
+  ];
+
+  return selfServePlans.flatMap((name) => {
+    const plan = catalog[name];
+    if (!plan) return [];
+
+    return [
+      {
+        limits: {
+          credits: plan.credits,
+        },
+        name,
+        priceId: plan.priceId,
+      },
+    ];
+  });
 }

--- a/apps/core/src/test/setup.ts
+++ b/apps/core/src/test/setup.ts
@@ -29,6 +29,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_WELCOME_COUPON: "coupon_welcome_test",
   STRIPE_SUPPORT_COUPON: "coupon_support_test",
   STRIPE_WEBHOOK_SECRET: "whsec_test_example",
+  STRIPE_BA_WEBHOOK_SECRET: "whsec_ba_test_example",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",
   INSTANCE_ID: "test-instance-id",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@better-auth/prisma-adapter':
         specifier: 1.6.18
         version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))
+      '@better-auth/stripe':
+        specifier: 1.6.18
+        version: 1.6.18(4950023cab6149e79c10e6fb84fe2216)
       '@better-auth/utils':
         specifier: 0.4.1
         version: 0.4.1
@@ -183,7 +186,7 @@ importers:
         version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))
       '@better-auth/stripe':
         specifier: 1.6.18
-        version: 1.6.18(0eeb3c3d8a50bddac1526ea60af91721)
+        version: 1.6.18(4950023cab6149e79c10e6fb84fe2216)
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9282,7 +9285,7 @@ snapshots:
       '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3)
       prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
 
-  '@better-auth/stripe@1.6.18(0eeb3c3d8a50bddac1526ea60af91721)':
+  '@better-auth/stripe@1.6.18(4950023cab6149e79c10e6fb84fe2216)':
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       better-auth: 1.6.18(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(vue@3.5.34(typescript@6.0.3))


### PR DESCRIPTION
## Summary

- Add `@better-auth/stripe` to Core Better Auth with subscription plans from `getBetterAuthSubscriptionPlans`, checkout session params, and org `authorizeReference` (owner/admin + enterprise exclusivity on upgrade).
- Port `reconcileActiveStripeBackedSubscription` and `handleSubscriptionDeletedEvent` to `stripe-backed-subscription.service.ts` (from web `webhook-handlers.ts`).
- Wire `customer.subscription.deleted` on the BA plugin `onEvent` hook.
- Add `STRIPE_BA_WEBHOOK_SECRET` for the Better Auth Stripe webhook (`POST /auth/stripe/webhook`). Billing events stay on `POST /webhooks/stripe` with `STRIPE_WEBHOOK_SECRET` — same two-endpoint split as web today. Consolidate to one BA-managed endpoint after auth cutover.

Part of Web → Core auth migration (C3). Browser still uses Web `/api/auth` until `NEXT_PUBLIC_USE_CORE_AUTH_CLIENT` is enabled.

## Stripe webhook setup (preprod / cutover testing)

| Stripe Dashboard endpoint | Core URL | Env secret | Events |
| --- | --- | --- | --- |
| Billing (existing) | `POST /webhooks/stripe` | `STRIPE_WEBHOOK_SECRET` | `invoice.paid`, `customer.created`, `customer.updated` |
| Better Auth (new) | `POST /auth/stripe/webhook` | `STRIPE_BA_WEBHOOK_SECRET` | `checkout.session.completed`, `customer.subscription.*` |

After flag flip: repoint web BA webhook from `{web}/api/auth/stripe/webhook` to Core `{core}/auth/stripe/webhook` using the BA endpoint signing secret.

## Test plan

- [x] `pnpm --filter @sokosumi/core test src/lib/auth.test.ts src/services/stripe-backed-subscription.service.test.ts`
- [x] `pnpm --filter @sokosumi/core check`
- [x] Set `STRIPE_BA_WEBHOOK_SECRET` on Core (second Stripe Dashboard endpoint)
- [ ] After flag flip on preprod: org subscription upgrade, billing portal, cancel → free fallback