### PR TITLE
feat(core): port remaining Better Auth hooks and email flows for cutover

### DIFF
--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -170,6 +170,24 @@ export const stripeClient = {
     );
   },
 
+  async updateCustomerEmail(
+    customerId: string,
+    email: string | null,
+    requestOptions?: Stripe.RequestOptions,
+  ): Promise<Stripe.Customer> {
+    return await stripe.customers.update(
+      customerId,
+      {
+        email: email ?? undefined,
+      },
+      {
+        ...requestOptions,
+        idempotencyKey: `${customerId}-${email ?? "null"}`,
+        maxNetworkRetries: requestOptions?.maxNetworkRetries ?? 0,
+      },
+    );
+  },
+
   async retrieveProduct(
     productId: string,
     requestOptions?: Stripe.RequestOptions,

--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -181,8 +181,11 @@ export const stripeClient = {
         email: email ?? undefined,
       },
       {
+        // No fixed idempotency key: email updates are naturally last-write-wins,
+        // and a stable `${customerId}-${email}` key would make Stripe replay the
+        // cached response when an email is reused (e.g. A→B→A within the 24h
+        // idempotency window), silently skipping the real update.
         ...requestOptions,
-        idempotencyKey: `${customerId}-${email ?? "null"}`,
         maxNetworkRetries: requestOptions?.maxNetworkRetries ?? 0,
       },
     );

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -41,11 +41,17 @@ const {
   resolveActiveOrganizationIdForSessionMock,
   sentryCaptureExceptionMock,
   stripeCreateUserCustomerMock,
+  stripeCreateOrganizationCustomerMock,
   stripePluginMock,
   uploadProfileImageMock,
   webhookCallAccountCreatedMock,
   webhookCallUserCreatedMock,
   webhookCallUserUpdatedMock,
+  ensureCanAcceptOrganizationInvitationMock,
+  syncLocalFreeSeatsAndCreditsForCurrentMembersMock,
+  prepareStripeEmailSyncForUserUpdateMock,
+  handleUserUpdateStripeEmailSyncMock,
+  syncUserEmailWithStripeMock,
   workspaceUpsertMock,
 } = vi.hoisted(() => ({
   adminPluginMock: vi.fn(),
@@ -76,11 +82,17 @@ const {
   resolveActiveOrganizationIdForSessionMock: vi.fn(),
   sentryCaptureExceptionMock: vi.fn(),
   stripeCreateUserCustomerMock: vi.fn(),
+  stripeCreateOrganizationCustomerMock: vi.fn(),
   stripePluginMock: vi.fn(),
   uploadProfileImageMock: vi.fn(),
   webhookCallAccountCreatedMock: vi.fn(),
   webhookCallUserCreatedMock: vi.fn(),
   webhookCallUserUpdatedMock: vi.fn(),
+  ensureCanAcceptOrganizationInvitationMock: vi.fn(),
+  syncLocalFreeSeatsAndCreditsForCurrentMembersMock: vi.fn(),
+  prepareStripeEmailSyncForUserUpdateMock: vi.fn(),
+  handleUserUpdateStripeEmailSyncMock: vi.fn(),
+  syncUserEmailWithStripeMock: vi.fn(),
   workspaceUpsertMock: vi.fn(),
 }));
 
@@ -145,6 +157,17 @@ vi.mock("@better-auth/i18n", () => ({
   i18n: (...args: unknown[]) => i18nPluginMock(...args),
 }));
 
+// Keep the real APIError (the hooks throw it and tests assert its shape) but
+// reduce createAuthMiddleware to an identity wrapper so the terms guards can be
+// invoked directly with a plain context in unit tests.
+vi.mock("better-auth/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("better-auth/api")>();
+  return {
+    ...actual,
+    createAuthMiddleware: (callback: unknown) => callback,
+  };
+});
+
 vi.mock("@sentry/node", () => ({
   captureException: (...args: unknown[]) => sentryCaptureExceptionMock(...args),
 }));
@@ -184,6 +207,8 @@ vi.mock("@/clients/stripe.client", () => ({
   stripeClient: {
     createUserCustomer: (...args: unknown[]) =>
       stripeCreateUserCustomerMock(...args),
+    createOrganizationCustomer: (...args: unknown[]) =>
+      stripeCreateOrganizationCustomerMock(...args),
   },
 }));
 
@@ -234,14 +259,19 @@ vi.mock("@/services/preferred-organization.service", () => ({
 }));
 
 vi.mock("@/services/organization-subscription-auth.service", () => ({
-  ensureCanAcceptOrganizationInvitation: vi.fn(),
-  syncLocalFreeSeatsAndCreditsForCurrentMembers: vi.fn(),
+  ensureCanAcceptOrganizationInvitation: (...args: unknown[]) =>
+    ensureCanAcceptOrganizationInvitationMock(...args),
+  syncLocalFreeSeatsAndCreditsForCurrentMembers: (...args: unknown[]) =>
+    syncLocalFreeSeatsAndCreditsForCurrentMembersMock(...args),
 }));
 
 vi.mock("@/services/stripe-user-email.service", () => ({
-  prepareStripeEmailSyncForUserUpdate: vi.fn(),
-  handleUserUpdateStripeEmailSync: vi.fn(),
-  syncUserEmailWithStripe: vi.fn(),
+  prepareStripeEmailSyncForUserUpdate: (...args: unknown[]) =>
+    prepareStripeEmailSyncForUserUpdateMock(...args),
+  handleUserUpdateStripeEmailSync: (...args: unknown[]) =>
+    handleUserUpdateStripeEmailSyncMock(...args),
+  syncUserEmailWithStripe: (...args: unknown[]) =>
+    syncUserEmailWithStripeMock(...args),
 }));
 
 vi.mock("@sokosumi/email", () => ({
@@ -288,6 +318,16 @@ describe("core auth config", () => {
     getBetterAuthSubscriptionPlansMock.mockResolvedValue([]);
     hasConsumableEnterpriseContractMock.mockResolvedValue(false);
     handleSubscriptionDeletedEventMock.mockResolvedValue(undefined);
+    stripeCreateOrganizationCustomerMock.mockResolvedValue({
+      id: "cus_org_123",
+    });
+    ensureCanAcceptOrganizationInvitationMock.mockResolvedValue(undefined);
+    syncLocalFreeSeatsAndCreditsForCurrentMembersMock.mockResolvedValue(
+      undefined,
+    );
+    prepareStripeEmailSyncForUserUpdateMock.mockResolvedValue(undefined);
+    handleUserUpdateStripeEmailSyncMock.mockResolvedValue(undefined);
+    syncUserEmailWithStripeMock.mockResolvedValue(undefined);
   });
 
   it("configures Google and Microsoft social providers for auth parity", async () => {
@@ -1541,6 +1581,400 @@ describe("core auth config", () => {
       id: "user_123",
       email: "test@example.com",
       name: "Test",
+    });
+  });
+
+  it("rejects email sign-up when terms are not accepted", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          hooks: {
+            before: (ctx: {
+              body?: Record<string, unknown>;
+              path: string;
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await expect(
+      config.hooks.before({ body: {}, path: "/sign-up/email" }),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: { code: "TERMS_NOT_ACCEPTED" },
+    });
+  });
+
+  it("allows email sign-up when terms are accepted", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          hooks: {
+            before: (ctx: {
+              body?: Record<string, unknown>;
+              path: string;
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await expect(
+      config.hooks.before({
+        body: { termsAccepted: true },
+        path: "/sign-up/email",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects sign-in when the user has not accepted the terms", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          hooks: {
+            after: (ctx: {
+              context: { newSession?: { user?: { termsAccepted?: boolean } } };
+              path: string;
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await expect(
+      config.hooks.after({
+        context: { newSession: { user: { termsAccepted: false } } },
+        path: "/sign-in/email",
+      }),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: { code: "TERMS_NOT_ACCEPTED" },
+    });
+  });
+
+  it("allows sign-in when the user has accepted the terms", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          hooks: {
+            after: (ctx: {
+              context: { newSession?: { user?: { termsAccepted?: boolean } } };
+              path: string;
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await expect(
+      config.hooks.after({
+        context: { newSession: { user: { termsAccepted: true } } },
+        path: "/sign-in/email",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("checks the subscription before accepting an organization invitation", async () => {
+    await import("./auth");
+
+    const [[config]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          organizationHooks: {
+            beforeAcceptInvitation: (input: {
+              organization: { id: string };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await config.organizationHooks.beforeAcceptInvitation({
+      organization: { id: "org-1" },
+    });
+
+    expect(ensureCanAcceptOrganizationInvitationMock).toHaveBeenCalledWith(
+      "org-1",
+    );
+  });
+
+  it("syncs local free seats and credits after accepting an invitation", async () => {
+    await import("./auth");
+
+    const [[config]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          organizationHooks: {
+            afterAcceptInvitation: (input: {
+              organization: { id: string };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await config.organizationHooks.afterAcceptInvitation({
+      organization: { id: "org-1" },
+    });
+
+    expect(
+      syncLocalFreeSeatsAndCreditsForCurrentMembersMock,
+    ).toHaveBeenCalledWith("org-1");
+  });
+
+  it("syncs local free seats and credits after adding a member", async () => {
+    await import("./auth");
+
+    const [[config]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          organizationHooks: {
+            afterAddMember: (input: {
+              organization: { id: string };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await config.organizationHooks.afterAddMember({
+      organization: { id: "org-1" },
+    });
+
+    expect(
+      syncLocalFreeSeatsAndCreditsForCurrentMembersMock,
+    ).toHaveBeenCalledWith("org-1");
+  });
+
+  it("creates a Stripe customer when an organization is created", async () => {
+    await import("./auth");
+
+    const [[config]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          organizationHooks: {
+            afterCreateOrganization: (input: {
+              organization: {
+                id: string;
+                metadata?: string | null;
+                name: string;
+                slug: string;
+              };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await config.organizationHooks.afterCreateOrganization({
+      organization: {
+        id: "org-1",
+        metadata: null,
+        name: "Org One",
+        slug: "org-one",
+      },
+    });
+
+    expect(stripeCreateOrganizationCustomerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-1",
+        name: "Org One",
+        slug: "org-one",
+      }),
+    );
+  });
+
+  it("reports Stripe organization customer creation failures to Sentry", async () => {
+    stripeCreateOrganizationCustomerMock.mockRejectedValueOnce(
+      new Error("stripe org failed"),
+    );
+
+    await import("./auth");
+
+    const [[config]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          organizationHooks: {
+            afterCreateOrganization: (input: {
+              organization: {
+                id: string;
+                metadata?: string | null;
+                name: string;
+                slug: string;
+              };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await config.organizationHooks.afterCreateOrganization({
+      organization: {
+        id: "org-1",
+        metadata: null,
+        name: "Org One",
+        slug: "org-one",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(expect.any(Error), {
+      extra: {
+        organizationId: "org-1",
+        organizationName: "Org One",
+        organizationSlug: "org-one",
+      },
+      tags: {
+        context: "stripe_organization_customer_creation",
+      },
+    });
+  });
+
+  it("prepares the Stripe email sync before a user update", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          databaseHooks: {
+            user: {
+              update: {
+                before: (
+                  data: Record<string, unknown>,
+                  ctx: unknown,
+                ) => Promise<{ data: Record<string, unknown> }>;
+              };
+            };
+          };
+        },
+      ]
+    >;
+
+    const updateData = { email: "new@example.com" };
+    const ctx = { session: { user: { id: "user_123" } } };
+
+    const result = await config.databaseHooks.user.update.before(
+      updateData,
+      ctx,
+    );
+
+    expect(prepareStripeEmailSyncForUserUpdateMock).toHaveBeenCalledWith(
+      updateData,
+      ctx,
+      { __prisma: true },
+    );
+    expect(result).toEqual({ data: updateData });
+  });
+
+  it("calls the user updated webhook and Stripe email sync after a user update", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          databaseHooks: {
+            user: {
+              update: {
+                after: (user: {
+                  email: string;
+                  id: string;
+                  name: string;
+                }) => Promise<void>;
+              };
+            };
+          };
+        },
+      ]
+    >;
+
+    const user = { id: "user_123", email: "new@example.com", name: "Andreas" };
+
+    await config.databaseHooks.user.update.after(user);
+
+    expect(webhookCallUserUpdatedMock).toHaveBeenCalledWith(user);
+    expect(handleUserUpdateStripeEmailSyncMock).toHaveBeenCalledWith(user);
+  });
+
+  it("reports user updated webhook failures to Sentry", async () => {
+    webhookCallUserUpdatedMock.mockRejectedValueOnce(new Error("webhook down"));
+
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          databaseHooks: {
+            user: {
+              update: {
+                after: (user: {
+                  email: string;
+                  id: string;
+                  name: string;
+                }) => Promise<void>;
+              };
+            };
+          };
+        },
+      ]
+    >;
+
+    await config.databaseHooks.user.update.after({
+      id: "user_123",
+      email: "new@example.com",
+      name: "Andreas",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(expect.any(Error), {
+      extra: { userId: "user_123" },
+      tags: { context: "user_updated_webhook" },
+    });
+  });
+
+  it("reports preferred organization resolution failures to Sentry and keeps the session", async () => {
+    resolveActiveOrganizationIdForSessionMock.mockRejectedValueOnce(
+      new Error("preferred org failed"),
+    );
+
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          databaseHooks: {
+            session: {
+              create: {
+                before: (session: { userId: string }) => Promise<{
+                  data: {
+                    activeOrganizationId?: string | null;
+                    userId: string;
+                  };
+                }>;
+              };
+            };
+          };
+        },
+      ]
+    >;
+
+    const result = await config.databaseHooks.session.create.before({
+      userId: "user_123",
+    });
+
+    expect(result.data).toEqual({ userId: "user_123" });
+    expect(result.data.activeOrganizationId).toBeUndefined();
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(expect.any(Error), {
+      extra: { userId: "user_123" },
+      tags: { context: "session_create_preferred_organization" },
     });
   });
 });

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -32,16 +32,20 @@ const {
   organizationPluginMock,
   magicLinkPluginMock,
   getMemberByUserIdAndOrganizationIdMock,
+  getMembersByOrganizationIdMock,
   passkeyPluginMock,
   postmarkSendEmailMock,
   prismaAdapterMock,
   reconcileActiveStripeBackedSubscriptionMock,
   renderMagicLinkEmailMock,
+  resolveActiveOrganizationIdForSessionMock,
   sentryCaptureExceptionMock,
   stripeCreateUserCustomerMock,
   stripePluginMock,
   uploadProfileImageMock,
   webhookCallAccountCreatedMock,
+  webhookCallUserCreatedMock,
+  webhookCallUserUpdatedMock,
   workspaceUpsertMock,
 } = vi.hoisted(() => ({
   adminPluginMock: vi.fn(),
@@ -63,16 +67,20 @@ const {
   organizationPluginMock: vi.fn(),
   magicLinkPluginMock: vi.fn(),
   getMemberByUserIdAndOrganizationIdMock: vi.fn(),
+  getMembersByOrganizationIdMock: vi.fn(),
   passkeyPluginMock: vi.fn(),
   postmarkSendEmailMock: vi.fn(),
   prismaAdapterMock: vi.fn(),
   reconcileActiveStripeBackedSubscriptionMock: vi.fn(),
   renderMagicLinkEmailMock: vi.fn(),
+  resolveActiveOrganizationIdForSessionMock: vi.fn(),
   sentryCaptureExceptionMock: vi.fn(),
   stripeCreateUserCustomerMock: vi.fn(),
   stripePluginMock: vi.fn(),
   uploadProfileImageMock: vi.fn(),
   webhookCallAccountCreatedMock: vi.fn(),
+  webhookCallUserCreatedMock: vi.fn(),
+  webhookCallUserUpdatedMock: vi.fn(),
   workspaceUpsertMock: vi.fn(),
 }));
 
@@ -155,6 +163,8 @@ vi.mock("@sokosumi/database/repositories", () => ({
   memberRepository: {
     getMemberByUserIdAndOrganizationId: (...args: unknown[]) =>
       getMemberByUserIdAndOrganizationIdMock(...args),
+    getMembersByOrganizationId: (...args: unknown[]) =>
+      getMembersByOrganizationIdMock(...args),
   },
   workspaceRepository: {
     upsertOrganizationWorkspace: (...args: unknown[]) =>
@@ -199,6 +209,10 @@ vi.mock("@/services/webhook.service", () => ({
   webhookService: {
     callAccountCreated: (...args: unknown[]) =>
       webhookCallAccountCreatedMock(...args),
+    callUserCreated: (...args: unknown[]) =>
+      webhookCallUserCreatedMock(...args),
+    callUserUpdated: (...args: unknown[]) =>
+      webhookCallUserUpdatedMock(...args),
   },
 }));
 
@@ -212,6 +226,20 @@ vi.mock("@/services/stripe-backed-subscription.service", () => ({
     handleSubscriptionDeletedEventMock(...args),
   reconcileActiveStripeBackedSubscription: (...args: unknown[]) =>
     reconcileActiveStripeBackedSubscriptionMock(...args),
+}));
+
+vi.mock("@/services/preferred-organization.service", () => ({
+  resolveActiveOrganizationIdForSession: (...args: unknown[]) =>
+    resolveActiveOrganizationIdForSessionMock(...args),
+}));
+
+vi.mock("@/services/organization-subscription-auth.service", () => ({
+  ensureCanAcceptOrganizationInvitation: vi.fn(),
+  syncLocalFreeSeatsAndCreditsForCurrentMembers: vi.fn(),
+}));
+
+vi.mock("@/services/stripe-user-email.service", () => ({
+  syncUserEmailWithStripe: vi.fn(),
 }));
 
 vi.mock("@sokosumi/email", () => ({
@@ -1075,7 +1103,7 @@ describe("core auth config", () => {
     expect(config.advanced.cookiePrefix).toBe("sokosumi-preview-preprod");
   });
 
-  it("uses English for magic-link emails", async () => {
+  it("prefers the locale cookie over accept-language for magic-link emails", async () => {
     await import("./auth");
 
     const [[config]] = magicLinkPluginMock.mock.calls as Array<
@@ -1122,7 +1150,7 @@ describe("core auth config", () => {
     );
 
     expect(renderMagicLinkEmailMock).toHaveBeenCalledWith({
-      locale: "en",
+      locale: "de",
       magicLink: "https://example.com/auth/magic-link/verify?token=secret",
       name: "Andreas",
     });
@@ -1405,6 +1433,110 @@ describe("core auth config", () => {
       tags: {
         context: "workspace_organization_creation",
       },
+    });
+  });
+
+  it("blocks organization deletion when additional members remain", async () => {
+    getMembersByOrganizationIdMock.mockResolvedValue([
+      { userId: "user-1" },
+      { userId: "user-2" },
+    ]);
+
+    await import("./auth");
+
+    const [[config]] = organizationPluginMock.mock.calls as Array<
+      [
+        {
+          organizationHooks: {
+            beforeDeleteOrganization: (input: {
+              organization: { id: string };
+              user: { id: string };
+            }) => Promise<void>;
+          };
+        },
+      ]
+    >;
+
+    await expect(
+      config.organizationHooks.beforeDeleteOrganization({
+        organization: { id: "org-1" },
+        user: { id: "user-1" },
+      }),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: {
+        code: "ORGANIZATION_HAS_ADDITIONAL_MEMBERS",
+        message: "Remove all other members before deleting this organization.",
+      },
+    });
+
+    expect(getMembersByOrganizationIdMock).toHaveBeenCalledWith("org-1", {
+      __prisma: true,
+    });
+  });
+
+  it("sets activeOrganizationId from preferred organization on session create", async () => {
+    resolveActiveOrganizationIdForSessionMock.mockResolvedValue("org_pref");
+
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          databaseHooks: {
+            session: {
+              create: {
+                before: (session: { userId: string }) => Promise<{
+                  data: { activeOrganizationId: string | null; userId: string };
+                }>;
+              };
+            };
+          };
+        },
+      ]
+    >;
+
+    const result = await config.databaseHooks.session.create.before({
+      userId: "user_123",
+    });
+
+    expect(result.data.activeOrganizationId).toBe("org_pref");
+    expect(resolveActiveOrganizationIdForSessionMock).toHaveBeenCalledWith(
+      "user_123",
+    );
+  });
+
+  it("calls user created webhook after user create", async () => {
+    await import("./auth");
+
+    const [[config]] = betterAuthMock.mock.calls as Array<
+      [
+        {
+          databaseHooks: {
+            user: {
+              create: {
+                after: (user: {
+                  email: string;
+                  id: string;
+                  name: string;
+                }) => Promise<void>;
+              };
+            };
+          };
+        },
+      ]
+    >;
+
+    await config.databaseHooks.user.create.after({
+      id: "user_123",
+      email: "test@example.com",
+      name: "Test",
+    });
+
+    expect(webhookCallUserCreatedMock).toHaveBeenCalledWith({
+      id: "user_123",
+      email: "test@example.com",
+      name: "Test",
     });
   });
 });

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -239,6 +239,8 @@ vi.mock("@/services/organization-subscription-auth.service", () => ({
 }));
 
 vi.mock("@/services/stripe-user-email.service", () => ({
+  prepareStripeEmailSyncForUserUpdate: vi.fn(),
+  handleUserUpdateStripeEmailSync: vi.fn(),
   syncUserEmailWithStripe: vi.fn(),
 }));
 

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -277,6 +277,8 @@ describe("core auth config", () => {
     stripeCreateUserCustomerMock.mockResolvedValue({ id: "cus_123" });
     uploadProfileImageMock.mockResolvedValue("https://blob.example/avatar.png");
     webhookCallAccountCreatedMock.mockResolvedValue(undefined);
+    webhookCallUserCreatedMock.mockResolvedValue(undefined);
+    webhookCallUserUpdatedMock.mockResolvedValue(undefined);
     stripePluginMock.mockReturnValue("stripe-plugin");
     workspaceUpsertMock.mockResolvedValue({ id: "workspace_123" });
     betterAuthMock.mockReturnValue({ api: {}, handler: vi.fn() });

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -253,10 +253,19 @@ export const auth = betterAuth({
     account: {
       create: {
         after: async (account, _ctx) => {
-          void webhookService.callAccountCreated(
-            account.userId,
-            account.providerId,
-          );
+          void webhookService
+            .callAccountCreated(account.userId, account.providerId)
+            .catch((error) => {
+              Sentry.captureException(error, {
+                tags: {
+                  context: "account_created_webhook",
+                },
+                extra: {
+                  userId: account.userId,
+                  providerId: account.providerId,
+                },
+              });
+            });
         },
       },
     },
@@ -317,12 +326,36 @@ export const auth = betterAuth({
                 },
               });
             });
-          void webhookService.callUserCreated(user);
+          void webhookService.callUserCreated(user).catch((error) => {
+            Sentry.captureException(error, {
+              tags: {
+                context: "user_created_webhook",
+              },
+              extra: {
+                userId: user.id,
+              },
+            });
+          });
         },
       },
       update: {
         after: async (user, _ctx) => {
-          void webhookService.callUserUpdated(user);
+          void webhookService.callUserUpdated(user).catch((error) => {
+            Sentry.captureException(error, {
+              tags: {
+                context: "user_updated_webhook",
+              },
+              extra: {
+                userId: user.id,
+              },
+            });
+          });
+          // Keep the user's Stripe customer email in sync when the account
+          // email changes via change-email (applied directly to the user row
+          // when the current email is unverified, so it never hits the
+          // /verify-email after-hook). syncUserEmailWithStripe no-ops when the
+          // user has no Stripe customer.
+          void syncUserEmailWithStripe(user.id, user.email);
         },
       },
     },
@@ -368,9 +401,7 @@ export const auth = betterAuth({
       if (ctx.path === "/verify-email" && ctx.context.newSession?.user) {
         const user = ctx.context.newSession.user;
         if (user.stripeCustomerId) {
-          void syncUserEmailWithStripe(user.id, user.email).catch((error) => {
-            console.error("Failed to sync user email with Stripe:", error);
-          });
+          void syncUserEmailWithStripe(user.id, user.email);
         }
       }
     }),
@@ -388,14 +419,25 @@ export const auth = betterAuth({
         resetLink: url,
       });
 
-      await postmarkClient.sendEmail({
-        From: env.POSTMARK_FROM_EMAIL,
-        To: user.email,
-        Tag: "reset-password",
-        Subject: email.subject,
-        HtmlBody: email.html,
-        MessageStream: "authentications",
-      });
+      void postmarkClient
+        .sendEmail({
+          From: env.POSTMARK_FROM_EMAIL,
+          To: user.email,
+          Tag: "reset-password",
+          Subject: email.subject,
+          HtmlBody: email.html,
+          MessageStream: "authentications",
+        })
+        .catch((error) => {
+          Sentry.captureException(error, {
+            tags: {
+              context: "reset_password_email",
+            },
+            extra: {
+              userId: user.id,
+            },
+          });
+        });
     },
   },
   emailVerification: {
@@ -406,14 +448,25 @@ export const auth = betterAuth({
         verificationLink: url,
       });
 
-      await postmarkClient.sendEmail({
-        From: env.POSTMARK_FROM_EMAIL,
-        To: user.email,
-        Tag: "verification-email",
-        Subject: email.subject,
-        HtmlBody: email.html,
-        MessageStream: "authentications",
-      });
+      void postmarkClient
+        .sendEmail({
+          From: env.POSTMARK_FROM_EMAIL,
+          To: user.email,
+          Tag: "verification-email",
+          Subject: email.subject,
+          HtmlBody: email.html,
+          MessageStream: "authentications",
+        })
+        .catch((error) => {
+          Sentry.captureException(error, {
+            tags: {
+              context: "verification_email",
+            },
+            extra: {
+              userId: user.id,
+            },
+          });
+        });
     },
     sendOnSignUp: true,
     sendOnSignIn: true,
@@ -565,14 +618,26 @@ export const auth = betterAuth({
           organizationName: data.organization.name,
         });
 
-        await postmarkClient.sendEmail({
-          From: env.POSTMARK_FROM_EMAIL,
-          To: data.email,
-          Tag: "invitation-email",
-          Subject: email.subject,
-          HtmlBody: email.html,
-          MessageStream: "organizations",
-        });
+        void postmarkClient
+          .sendEmail({
+            From: env.POSTMARK_FROM_EMAIL,
+            To: data.email,
+            Tag: "invitation-email",
+            Subject: email.subject,
+            HtmlBody: email.html,
+            MessageStream: "organizations",
+          })
+          .catch((error) => {
+            Sentry.captureException(error, {
+              tags: {
+                context: "organization_invitation_email",
+              },
+              extra: {
+                invitationId: data.id,
+                organizationId: data.organization.id,
+              },
+            });
+          });
       },
       invitationLimit: LIMITS.ORGANIZATION_INVITATION_LIMIT,
       cancelPendingInvitationsOnReInvite: true,

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -62,7 +62,10 @@ import {
   handleSubscriptionDeletedEvent,
   reconcileActiveStripeBackedSubscription,
 } from "@/services/stripe-backed-subscription.service";
-import { syncUserEmailWithStripe } from "@/services/stripe-user-email.service";
+import {
+  handleUserUpdateStripeEmailSync,
+  prepareStripeEmailSyncForUserUpdate,
+} from "@/services/stripe-user-email.service";
 import { getBetterAuthSubscriptionPlans } from "@/services/subscription-catalog.service";
 import { webhookService } from "@/services/webhook.service";
 
@@ -339,6 +342,10 @@ export const auth = betterAuth({
         },
       },
       update: {
+        before: async (data, ctx) => {
+          await prepareStripeEmailSyncForUserUpdate(data, ctx, prisma);
+          return { data };
+        },
         after: async (user, _ctx) => {
           void webhookService.callUserUpdated(user).catch((error) => {
             Sentry.captureException(error, {
@@ -350,12 +357,7 @@ export const auth = betterAuth({
               },
             });
           });
-          // Keep the user's Stripe customer email in sync when the account
-          // email changes via change-email (applied directly to the user row
-          // when the current email is unverified, so it never hits the
-          // /verify-email after-hook). syncUserEmailWithStripe no-ops when the
-          // user has no Stripe customer.
-          void syncUserEmailWithStripe(user.id, user.email);
+          void handleUserUpdateStripeEmailSync(user);
         },
       },
     },
@@ -395,13 +397,6 @@ export const auth = betterAuth({
           throw new APIError("BAD_REQUEST", {
             code: "TERMS_NOT_ACCEPTED",
           });
-        }
-      }
-
-      if (ctx.path === "/verify-email" && ctx.context.newSession?.user) {
-        const user = ctx.context.newSession.user;
-        if (user.stripeCustomerId) {
-          void syncUserEmailWithStripe(user.id, user.email);
         }
       }
     }),

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -528,14 +528,25 @@ export const auth = betterAuth({
           name,
         });
 
-        await postmarkClient.sendEmail({
-          From: env.POSTMARK_FROM_EMAIL,
-          To: email,
-          Tag: "magic-link",
-          Subject: renderedEmail.subject,
-          HtmlBody: renderedEmail.html,
-          MessageStream: "authentications",
-        });
+        void postmarkClient
+          .sendEmail({
+            From: env.POSTMARK_FROM_EMAIL,
+            To: email,
+            Tag: "magic-link",
+            Subject: renderedEmail.subject,
+            HtmlBody: renderedEmail.html,
+            MessageStream: "authentications",
+          })
+          .catch((error) => {
+            Sentry.captureException(error, {
+              tags: {
+                context: "magic_link_email",
+              },
+              extra: {
+                email,
+              },
+            });
+          });
       },
     }),
     i18n({

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -15,14 +15,20 @@ import {
   memberRepository,
   workspaceRepository,
 } from "@sokosumi/database/repositories";
-import { renderMagicLinkEmail } from "@sokosumi/email";
+import {
+  renderMagicLinkEmail,
+  renderOrganizationInvitationEmail,
+  renderResetPasswordEmail,
+  renderVerificationEmail,
+} from "@sokosumi/email";
 import { authTranslations } from "@sokosumi/masumi/auth";
 import {
+  getOrganizationMetadata,
   getStoredUserName,
   resolveBetterAuthCookieName,
   resolveBetterAuthCookiePrefix,
 } from "@sokosumi/utils";
-import { APIError } from "better-auth/api";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { betterAuth } from "better-auth/minimal";
 import {
   admin,
@@ -46,15 +52,24 @@ import {
 } from "@/config/env";
 import { uploadProfileImage } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
+import { getEmailLocale } from "@/lib/email-locale";
+import {
+  ensureCanAcceptOrganizationInvitation,
+  syncLocalFreeSeatsAndCreditsForCurrentMembers,
+} from "@/services/organization-subscription-auth.service";
+import { resolveActiveOrganizationIdForSession } from "@/services/preferred-organization.service";
 import {
   handleSubscriptionDeletedEvent,
   reconcileActiveStripeBackedSubscription,
 } from "@/services/stripe-backed-subscription.service";
+import { syncUserEmailWithStripe } from "@/services/stripe-user-email.service";
 import { getBetterAuthSubscriptionPlans } from "@/services/subscription-catalog.service";
 import { webhookService } from "@/services/webhook.service";
 
 const ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE =
   "ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE";
+const ORGANIZATION_HAS_ADDITIONAL_MEMBERS =
+  "ORGANIZATION_HAS_ADDITIONAL_MEMBERS";
 
 const env = getEnv();
 const stripeInstance = new Stripe(env.STRIPE_SECRET_KEY);
@@ -111,6 +126,41 @@ async function ensureWorkspaceForCreatedOrganization(organization: {
         organizationId: organization.id,
         organizationName: organization.name,
       },
+    });
+  }
+}
+
+async function ensureStripeCustomerForCreatedOrganization(organization: {
+  id: string;
+  metadata?: string | null;
+  name: string;
+  slug: string;
+}): Promise<void> {
+  const { invoiceEmail } = getOrganizationMetadata(organization.metadata);
+  await stripeClient.createOrganizationCustomer({
+    organizationId: organization.id,
+    slug: organization.slug,
+    name: organization.name,
+    invoiceEmail,
+  });
+}
+
+async function ensureOrganizationHasNoAdditionalMembers(
+  organizationId: string,
+  userId: string,
+): Promise<void> {
+  const members = await memberRepository.getMembersByOrganizationId(
+    organizationId,
+    prisma,
+  );
+  const hasAdditionalMembers = members.some(
+    (member) => member.userId !== userId,
+  );
+
+  if (hasAdditionalMembers) {
+    throw new APIError("BAD_REQUEST", {
+      code: ORGANIZATION_HAS_ADDITIONAL_MEMBERS,
+      message: "Remove all other members before deleting this organization.",
     });
   }
 }
@@ -210,6 +260,33 @@ export const auth = betterAuth({
         },
       },
     },
+    session: {
+      create: {
+        before: async (session, _ctx) => {
+          try {
+            const activeOrganizationId =
+              await resolveActiveOrganizationIdForSession(session.userId);
+
+            return {
+              data: {
+                ...session,
+                activeOrganizationId,
+              },
+            };
+          } catch (error) {
+            Sentry.captureException(error, {
+              tags: {
+                context: "session_create_preferred_organization",
+              },
+              extra: {
+                userId: session.userId,
+              },
+            });
+            return { data: session };
+          }
+        },
+      },
+    },
     user: {
       create: {
         before: async (user, _ctx) => {
@@ -222,7 +299,7 @@ export const auth = betterAuth({
         },
         after: async (user, _ctx) => {
           await ensureWorkspaceForCreatedUser(user);
-          stripeClient
+          void stripeClient
             .createUserCustomer({
               email: user.email,
               name: user.name,
@@ -240,6 +317,12 @@ export const auth = betterAuth({
                 },
               });
             });
+          void webhookService.callUserCreated(user);
+        },
+      },
+      update: {
+        after: async (user, _ctx) => {
+          void webhookService.callUserUpdated(user);
         },
       },
     },
@@ -258,8 +341,90 @@ export const auth = betterAuth({
       ? ["http://localhost:*"] // local dev only; omit in staging/production deploys
       : []),
   ],
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      switch (ctx.path) {
+        case "/sign-up/email": {
+          if (!ctx.body?.termsAccepted) {
+            throw new APIError("BAD_REQUEST", {
+              code: "TERMS_NOT_ACCEPTED",
+            });
+          }
+
+          break;
+        }
+      }
+    }),
+    after: createAuthMiddleware(async (ctx) => {
+      if (ctx.path.startsWith("/sign-in")) {
+        const user = ctx.context.newSession?.user;
+        if (user && !user.termsAccepted) {
+          throw new APIError("BAD_REQUEST", {
+            code: "TERMS_NOT_ACCEPTED",
+          });
+        }
+      }
+
+      if (ctx.path === "/verify-email" && ctx.context.newSession?.user) {
+        const user = ctx.context.newSession.user;
+        if (user.stripeCustomerId) {
+          void syncUserEmailWithStripe(user.id, user.email).catch((error) => {
+            console.error("Failed to sync user email with Stripe:", error);
+          });
+        }
+      }
+    }),
+  },
+  emailAndPassword: {
+    enabled: true,
+    maxPasswordLength: LIMITS.PASSWORD_MAX_LENGTH,
+    minPasswordLength: LIMITS.PASSWORD_MIN_LENGTH,
+    requireEmailVerification: false,
+    autoSignIn: true,
+    sendResetPassword: async ({ user, url }, request) => {
+      const email = await renderResetPasswordEmail({
+        locale: getEmailLocale(request),
+        name: user.name,
+        resetLink: url,
+      });
+
+      await postmarkClient.sendEmail({
+        From: env.POSTMARK_FROM_EMAIL,
+        To: user.email,
+        Tag: "reset-password",
+        Subject: email.subject,
+        HtmlBody: email.html,
+        MessageStream: "authentications",
+      });
+    },
+  },
+  emailVerification: {
+    sendVerificationEmail: async ({ user, url }, request) => {
+      const email = await renderVerificationEmail({
+        locale: getEmailLocale(request),
+        name: user.name,
+        verificationLink: url,
+      });
+
+      await postmarkClient.sendEmail({
+        From: env.POSTMARK_FROM_EMAIL,
+        To: user.email,
+        Tag: "verification-email",
+        Subject: email.subject,
+        HtmlBody: email.html,
+        MessageStream: "authentications",
+      });
+    },
+    sendOnSignUp: true,
+    sendOnSignIn: true,
+    expiresIn: TIME.EMAIL_VERIFICATION_EXPIRES,
+    autoSignInAfterVerification: true,
+  },
   user: {
-    emailAndPassword: {
+    changeEmail: {
+      enabled: true,
+    },
+    deleteUser: {
       enabled: true,
     },
     additionalFields: {
@@ -302,13 +467,15 @@ export const auth = betterAuth({
   },
   plugins: [
     magicLink({
-      expiresIn: 60 * 60 * 48, // 48 hours in seconds
+      disableSignUp: false,
+      expiresIn: 60 * 10, // 10 minutes
       storeToken: "hashed",
       sendMagicLink: async ({ email, url }, ctx) => {
+        const locale = getEmailLocale(ctx?.request, ctx?.headers);
         const name =
           typeof ctx?.body?.name === "string" ? ctx.body.name : undefined;
         const renderedEmail = await renderMagicLinkEmail({
-          locale: "en",
+          locale,
           magicLink: url,
           name,
         });
@@ -346,6 +513,35 @@ export const auth = betterAuth({
       organizationHooks: {
         afterCreateOrganization: async ({ organization }) => {
           await ensureWorkspaceForCreatedOrganization(organization);
+          void ensureStripeCustomerForCreatedOrganization(organization).catch(
+            (error) => {
+              Sentry.captureException(error, {
+                tags: {
+                  context: "stripe_organization_customer_creation",
+                },
+                extra: {
+                  organizationId: organization.id,
+                  organizationName: organization.name,
+                  organizationSlug: organization.slug,
+                },
+              });
+            },
+          );
+        },
+        beforeAcceptInvitation: async ({ organization }) => {
+          await ensureCanAcceptOrganizationInvitation(organization.id);
+        },
+        afterAcceptInvitation: async ({ organization }) => {
+          await syncLocalFreeSeatsAndCreditsForCurrentMembers(organization.id);
+        },
+        afterAddMember: async ({ organization }) => {
+          await syncLocalFreeSeatsAndCreditsForCurrentMembers(organization.id);
+        },
+        beforeDeleteOrganization: async ({ organization, user }) => {
+          await ensureOrganizationHasNoAdditionalMembers(
+            organization.id,
+            user.id,
+          );
         },
       },
       schema: {
@@ -360,6 +556,31 @@ export const auth = betterAuth({
           },
         },
       },
+      async sendInvitationEmail(data, request) {
+        const inviteLink = `${webAppBaseUrl}/accept-invitation/${data.id}`;
+        const email = await renderOrganizationInvitationEmail({
+          invitationLink: inviteLink,
+          invitorUsername: data.inviter.user.name,
+          locale: getEmailLocale(request),
+          organizationName: data.organization.name,
+        });
+
+        await postmarkClient.sendEmail({
+          From: env.POSTMARK_FROM_EMAIL,
+          To: data.email,
+          Tag: "invitation-email",
+          Subject: email.subject,
+          HtmlBody: email.html,
+          MessageStream: "organizations",
+        });
+      },
+      invitationLimit: LIMITS.ORGANIZATION_INVITATION_LIMIT,
+      cancelPendingInvitationsOnReInvite: true,
+      allowUserToCreateOrganization(user) {
+        return user.emailVerified;
+      },
+      organizationLimit: LIMITS.ORGANIZATION_LIMIT,
+      invitationExpiresIn: TIME.INVITATION_EXPIRES,
     }),
     passkey({
       rpID: env.BETTER_AUTH_RP_ID,

--- a/apps/core/src/lib/email-locale.ts
+++ b/apps/core/src/lib/email-locale.ts
@@ -1,0 +1,67 @@
+import { resolveRequestLocale } from "@/lib/i18n/locale-resolution";
+import {
+  type AppLocale,
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE_NAME,
+} from "@/lib/i18n/locales";
+
+function getEmailLocaleCookieValue(
+  cookieHeader?: null | string,
+): null | string {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  let legacyLocale: null | string = null;
+
+  for (const rawCookie of cookieHeader.split(";")) {
+    const separatorIndex = rawCookie.indexOf("=");
+
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    const cookieName = rawCookie.slice(0, separatorIndex).trim();
+    const cookieValue = rawCookie.slice(separatorIndex + 1).trim();
+
+    if (!cookieValue) {
+      continue;
+    }
+
+    const decoded = (() => {
+      try {
+        return decodeURIComponent(cookieValue);
+      } catch {
+        return cookieValue;
+      }
+    })();
+
+    if (cookieName === LOCALE_COOKIE_NAME) {
+      return decoded;
+    }
+
+    if (cookieName === "locale" && legacyLocale === null) {
+      legacyLocale = decoded;
+    }
+  }
+
+  return legacyLocale;
+}
+
+export function getEmailLocale(
+  request?: Request,
+  fallbackHeaders?: Headers,
+): AppLocale {
+  const cookieHeader =
+    request?.headers.get("cookie") ?? fallbackHeaders?.get("cookie") ?? null;
+  const acceptLanguageHeader =
+    request?.headers.get("accept-language") ??
+    fallbackHeaders?.get("accept-language") ??
+    null;
+
+  return resolveRequestLocale({
+    cookieLocale: getEmailLocaleCookieValue(cookieHeader),
+    acceptLanguageHeader,
+    defaultLocale: DEFAULT_LOCALE,
+  });
+}

--- a/apps/core/src/lib/i18n/locale-resolution.test.ts
+++ b/apps/core/src/lib/i18n/locale-resolution.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseLocalePreference,
+  resolveLocaleFromAcceptLanguage,
+  resolveRequestLocale,
+} from "@/lib/i18n/locale-resolution";
+import { DEFAULT_LOCALE } from "@/lib/i18n/locales";
+
+describe("parseLocalePreference", () => {
+  it("returns exact locale match when supported", () => {
+    expect(parseLocalePreference("es")).toBe("es");
+  });
+
+  it("maps normalized values to supported locales", () => {
+    expect(parseLocalePreference("de_de")).toBe("de");
+    expect(parseLocalePreference("es-MX")).toBe("es");
+  });
+
+  it("returns null for unsupported values", () => {
+    expect(parseLocalePreference("pt-BR")).toBeNull();
+    expect(parseLocalePreference("xx")).toBeNull();
+    expect(parseLocalePreference(null)).toBeNull();
+  });
+});
+
+describe("resolveLocaleFromAcceptLanguage", () => {
+  it("resolves first supported locale from header", () => {
+    expect(
+      resolveLocaleFromAcceptLanguage("fr-CA,fr;q=0.9,en-US;q=0.8,en;q=0.7"),
+    ).toBe("en");
+  });
+
+  it("prefers the locale with higher q-value", () => {
+    expect(resolveLocaleFromAcceptLanguage("de;q=0.1,en;q=0.9")).toBe("en");
+  });
+
+  it("ignores locales with q=0", () => {
+    expect(resolveLocaleFromAcceptLanguage("fr;q=0,de;q=0.8")).toBe("de");
+  });
+
+  it("keeps a supported locale whose q-value is malformed at default quality", () => {
+    // Regression: a garbled or empty q must not drop the language entirely.
+    expect(resolveLocaleFromAcceptLanguage("de;q=oops,en;q=0.8")).toBe("de");
+    expect(resolveLocaleFromAcceptLanguage("de;q=,en;q=0.8")).toBe("de");
+  });
+
+  it("maps regional language tags to supported base locale", () => {
+    expect(resolveLocaleFromAcceptLanguage("es-MX,fr;q=0.8")).toBe("es");
+  });
+});
+
+describe("resolveRequestLocale", () => {
+  it("prefers cookie locale over accept-language header", () => {
+    expect(
+      resolveRequestLocale({
+        cookieLocale: "de",
+        acceptLanguageHeader: "es-ES,es;q=0.8",
+        defaultLocale: DEFAULT_LOCALE,
+      }),
+    ).toBe("de");
+  });
+
+  it("ignores unsupported cookie locale and uses accept-language fallback", () => {
+    expect(
+      resolveRequestLocale({
+        cookieLocale: "pt-BR",
+        acceptLanguageHeader: "de-DE,de;q=0.8",
+        defaultLocale: DEFAULT_LOCALE,
+      }),
+    ).toBe("de");
+  });
+
+  it("falls back to default locale when nothing matches", () => {
+    expect(
+      resolveRequestLocale({
+        cookieLocale: null,
+        acceptLanguageHeader: "xx-ZZ",
+        defaultLocale: DEFAULT_LOCALE,
+      }),
+    ).toBe(DEFAULT_LOCALE);
+  });
+});

--- a/apps/core/src/lib/i18n/locale-resolution.ts
+++ b/apps/core/src/lib/i18n/locale-resolution.ts
@@ -1,0 +1,142 @@
+import { type AppLocale, SUPPORTED_LOCALES } from "@/lib/i18n/locales";
+
+const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);
+
+interface ParsedLanguagePreference {
+  tag: string;
+  quality: number;
+  index: number;
+}
+
+function normalizeLocaleTag(rawTag: string): string | null {
+  const trimmed = rawTag.trim();
+  if (!trimmed || trimmed === "*") {
+    return null;
+  }
+
+  const normalized = trimmed.replaceAll("_", "-");
+  try {
+    return Intl.getCanonicalLocales(normalized).at(0) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function toSupportedLocale(localeTag: string): AppLocale | null {
+  if (SUPPORTED_LOCALE_SET.has(localeTag)) return localeTag as AppLocale;
+
+  const baseLanguage = localeTag.split("-").at(0);
+  if (!baseLanguage) {
+    return null;
+  }
+
+  if (SUPPORTED_LOCALE_SET.has(baseLanguage)) return baseLanguage as AppLocale;
+
+  return null;
+}
+
+export function parseLocalePreference(
+  value: string | null | undefined,
+): AppLocale | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = normalizeLocaleTag(value);
+  if (!normalized) {
+    return null;
+  }
+
+  return toSupportedLocale(normalized);
+}
+
+export function resolveLocaleFromAcceptLanguage(
+  acceptLanguageHeader: string | null,
+): AppLocale | null {
+  if (!acceptLanguageHeader) {
+    return null;
+  }
+
+  const preferences = acceptLanguageHeader
+    .split(",")
+    .map((part, index): ParsedLanguagePreference | null => {
+      const [rawTag, ...rawParams] = part.split(";");
+      const normalizedTag = normalizeLocaleTag(rawTag ?? "");
+      if (!normalizedTag) {
+        return null;
+      }
+
+      let quality = 1;
+
+      for (const rawParam of rawParams) {
+        const [rawKey, rawValue] = rawParam.split("=");
+        const key = rawKey?.trim().toLowerCase();
+
+        if (key !== "q") {
+          continue;
+        }
+
+        if (!rawValue) {
+          return null;
+        }
+
+        const parsedQuality = Number.parseFloat(rawValue.trim());
+        if (
+          Number.isNaN(parsedQuality) ||
+          parsedQuality < 0 ||
+          parsedQuality > 1
+        ) {
+          return null;
+        }
+
+        quality = parsedQuality;
+        break;
+      }
+
+      if (quality === 0) {
+        return null;
+      }
+
+      return {
+        tag: normalizedTag,
+        quality,
+        index,
+      };
+    })
+    .filter((preference): preference is ParsedLanguagePreference =>
+      Boolean(preference),
+    )
+    .sort((a, b) => {
+      if (a.quality !== b.quality) {
+        return b.quality - a.quality;
+      }
+
+      return a.index - b.index;
+    });
+
+  for (const preference of preferences) {
+    const resolved = toSupportedLocale(preference.tag);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+export function resolveRequestLocale({
+  cookieLocale,
+  acceptLanguageHeader,
+  defaultLocale,
+}: {
+  cookieLocale: string | null | undefined;
+  acceptLanguageHeader: string | null;
+  defaultLocale: AppLocale;
+}): AppLocale {
+  const preference = parseLocalePreference(cookieLocale);
+  if (preference) {
+    return preference;
+  }
+
+  return resolveLocaleFromAcceptLanguage(acceptLanguageHeader) ?? defaultLocale;
+}

--- a/apps/core/src/lib/i18n/locale-resolution.ts
+++ b/apps/core/src/lib/i18n/locale-resolution.ts
@@ -76,8 +76,11 @@ export function resolveLocaleFromAcceptLanguage(
           continue;
         }
 
+        // A malformed quality value (missing or unparseable) is ignored rather
+        // than dropping the whole language preference: keep the default quality
+        // of 1 so e.g. `de;q=` or `de;q=oops` still resolves to German.
         if (!rawValue) {
-          return null;
+          continue;
         }
 
         const parsedQuality = Number.parseFloat(rawValue.trim());
@@ -86,7 +89,7 @@ export function resolveLocaleFromAcceptLanguage(
           parsedQuality < 0 ||
           parsedQuality > 1
         ) {
-          return null;
+          continue;
         }
 
         quality = parsedQuality;

--- a/apps/core/src/lib/i18n/locales.ts
+++ b/apps/core/src/lib/i18n/locales.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_LOCALE = "en";
+
+export const SUPPORTED_LOCALES = [DEFAULT_LOCALE, "de", "es"] as const;
+
+export type AppLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export const LOCALE_COOKIE_NAME = "sokosumi.locale";

--- a/apps/core/src/services/__tests__/organization-subscription-auth.service.test.ts
+++ b/apps/core/src/services/__tests__/organization-subscription-auth.service.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  resolveOrganizationBillingPlanMock,
+  resolvePurchasedSeatsMock,
+  ensureLocalFreeSubscriptionPeriodMock,
+  grantFreeOrganizationMemberSubscriptionCreditsMock,
+  resolveActiveSubscriptionByReferenceIdMock,
+  getUnassignedMemberUserIdsMock,
+  getOrganizationMemberUserIdsMock,
+} = vi.hoisted(() => ({
+  resolveOrganizationBillingPlanMock: vi.fn(),
+  resolvePurchasedSeatsMock: vi.fn(),
+  ensureLocalFreeSubscriptionPeriodMock: vi.fn(),
+  grantFreeOrganizationMemberSubscriptionCreditsMock: vi.fn(),
+  resolveActiveSubscriptionByReferenceIdMock: vi.fn(),
+  getUnassignedMemberUserIdsMock: vi.fn(),
+  getOrganizationMemberUserIdsMock: vi.fn(),
+}));
+
+vi.mock("@sokosumi/database/helpers", () => ({
+  resolveOrganizationBillingPlan: (...args: unknown[]) =>
+    resolveOrganizationBillingPlanMock(...args),
+  resolvePurchasedSeats: (...args: unknown[]) =>
+    resolvePurchasedSeatsMock(...args),
+  ensureLocalFreeSubscriptionPeriod: (...args: unknown[]) =>
+    ensureLocalFreeSubscriptionPeriodMock(...args),
+  grantFreeOrganizationMemberSubscriptionCredits: (...args: unknown[]) =>
+    grantFreeOrganizationMemberSubscriptionCreditsMock(...args),
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  subscriptionRepository: {
+    resolveActiveSubscriptionByReferenceId: (...args: unknown[]) =>
+      resolveActiveSubscriptionByReferenceIdMock(...args),
+  },
+  memberRepository: {
+    getUnassignedMemberUserIds: (...args: unknown[]) =>
+      getUnassignedMemberUserIdsMock(...args),
+    getOrganizationMemberUserIds: (...args: unknown[]) =>
+      getOrganizationMemberUserIdsMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: { __prisma: true },
+}));
+
+import { ensureCanAcceptOrganizationInvitation } from "@/services/organization-subscription-auth.service";
+
+describe("ensureCanAcceptOrganizationInvitation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows enterprise contracts that have at least one purchased seat", async () => {
+    resolveOrganizationBillingPlanMock.mockResolvedValue({
+      mode: "enterprise_contract",
+      isConsumable: true,
+      purchasedSeats: 5,
+    });
+
+    await expect(
+      ensureCanAcceptOrganizationInvitation("org-1"),
+    ).resolves.toBeUndefined();
+
+    // Enterprise contracts must not require a Stripe-backed subscription lookup.
+    expect(resolveActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects enterprise contracts without any purchased seats", async () => {
+    resolveOrganizationBillingPlanMock.mockResolvedValue({
+      mode: "enterprise_contract",
+      isConsumable: true,
+      purchasedSeats: 0,
+    });
+
+    await expect(
+      ensureCanAcceptOrganizationInvitation("org-1"),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: {
+        message:
+          "Enterprise contract has no purchased seats configured for this organization.",
+      },
+    });
+  });
+
+  it("allows self-serve organizations that have an active subscription", async () => {
+    resolveOrganizationBillingPlanMock.mockResolvedValue({
+      mode: "self_serve",
+      isConsumable: false,
+      purchasedSeats: 1,
+    });
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue({
+      id: "sub-1",
+      createdAt: new Date(),
+      periodEnd: new Date(),
+      periodStart: new Date(),
+      seats: 1,
+      stripeSubscriptionId: "sub_stripe_1",
+    });
+
+    await expect(
+      ensureCanAcceptOrganizationInvitation("org-1"),
+    ).resolves.toBeUndefined();
+
+    expect(resolveActiveSubscriptionByReferenceIdMock).toHaveBeenCalledWith(
+      "org-1",
+      { __prisma: true },
+    );
+  });
+
+  it("rejects self-serve organizations without an active subscription", async () => {
+    resolveOrganizationBillingPlanMock.mockResolvedValue({
+      mode: "self_serve",
+      isConsumable: false,
+      purchasedSeats: 1,
+    });
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+
+    await expect(
+      ensureCanAcceptOrganizationInvitation("org-1"),
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: {
+        message:
+          "An active organization subscription is required before adding members.",
+      },
+    });
+  });
+});

--- a/apps/core/src/services/__tests__/stripe-user-email.service.test.ts
+++ b/apps/core/src/services/__tests__/stripe-user-email.service.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getUserByIdMock, updateCustomerEmailMock } = vi.hoisted(() => ({
+  getUserByIdMock: vi.fn(),
+  updateCustomerEmailMock: vi.fn(),
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  userRepository: {
+    getUserById: (...args: unknown[]) => getUserByIdMock(...args),
+  },
+}));
+
+vi.mock("@/clients/stripe.client", () => ({
+  stripeClient: {
+    updateCustomerEmail: (...args: unknown[]) =>
+      updateCustomerEmailMock(...args),
+  },
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+}));
+
+import {
+  handleUserUpdateStripeEmailSync,
+  markPendingStripeEmailSyncForUserUpdate,
+  prepareStripeEmailSyncForUserUpdate,
+  resetStripeEmailSyncStateForTests,
+  syncUserEmailWithStripe,
+} from "@/services/stripe-user-email.service";
+
+describe("stripe-user-email.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStripeEmailSyncStateForTests();
+    getUserByIdMock.mockResolvedValue({
+      id: "user_1",
+      stripeCustomerId: "cus_1",
+      email: "new@example.com",
+    });
+    updateCustomerEmailMock.mockResolvedValue({ id: "cus_1" });
+  });
+
+  describe("markPendingStripeEmailSyncForUserUpdate", () => {
+    it("does not mark sync when email is unchanged", async () => {
+      markPendingStripeEmailSyncForUserUpdate(
+        { email: "same@example.com" },
+        "user_1",
+        "same@example.com",
+      );
+
+      await handleUserUpdateStripeEmailSync({
+        id: "user_1",
+        email: "same@example.com",
+      });
+
+      expect(updateCustomerEmailMock).not.toHaveBeenCalled();
+    });
+
+    it("syncs only when email changed", async () => {
+      markPendingStripeEmailSyncForUserUpdate(
+        { email: "new@example.com" },
+        "user_1",
+        "old@example.com",
+      );
+
+      await handleUserUpdateStripeEmailSync({
+        id: "user_1",
+        email: "new@example.com",
+      });
+
+      expect(updateCustomerEmailMock).toHaveBeenCalledWith(
+        "cus_1",
+        "new@example.com",
+      );
+    });
+
+    it("falls back to normalized email when user id is unknown in before hook", async () => {
+      markPendingStripeEmailSyncForUserUpdate(
+        { email: "New@Example.com" },
+        null,
+        null,
+      );
+
+      await handleUserUpdateStripeEmailSync({
+        id: "user_1",
+        email: "new@example.com",
+      });
+
+      expect(updateCustomerEmailMock).toHaveBeenCalledWith(
+        "cus_1",
+        "new@example.com",
+      );
+    });
+  });
+
+  describe("prepareStripeEmailSyncForUserUpdate", () => {
+    it("marks sync when session user email changes", async () => {
+      getUserByIdMock.mockResolvedValueOnce({
+        id: "user_1",
+        email: "old@example.com",
+        stripeCustomerId: "cus_1",
+      });
+
+      await prepareStripeEmailSyncForUserUpdate(
+        { email: "new@example.com" },
+        {
+          session: {
+            user: { id: "user_1" },
+          },
+        },
+        {} as never,
+      );
+
+      await handleUserUpdateStripeEmailSync({
+        id: "user_1",
+        email: "new@example.com",
+      });
+
+      expect(getUserByIdMock).toHaveBeenCalled();
+      expect(updateCustomerEmailMock).toHaveBeenCalledWith(
+        "cus_1",
+        "new@example.com",
+      );
+    });
+  });
+
+  describe("syncUserEmailWithStripe", () => {
+    it("no-ops when user has no stripe customer", async () => {
+      getUserByIdMock.mockResolvedValueOnce({
+        id: "user_1",
+        stripeCustomerId: null,
+        email: "new@example.com",
+      });
+
+      await syncUserEmailWithStripe("user_1", "new@example.com");
+
+      expect(updateCustomerEmailMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/core/src/services/organization-subscription-auth.service.ts
+++ b/apps/core/src/services/organization-subscription-auth.service.ts
@@ -1,0 +1,202 @@
+import {
+  ensureLocalFreeSubscriptionPeriod,
+  grantFreeOrganizationMemberSubscriptionCredits,
+  resolveOrganizationBillingPlan,
+  resolvePurchasedSeats,
+} from "@sokosumi/database/helpers";
+import {
+  memberRepository,
+  subscriptionRepository,
+} from "@sokosumi/database/repositories";
+import { APIError } from "better-auth/api";
+
+import prisma from "@/lib/db/prisma";
+
+interface ActiveOrganizationSubscription {
+  createdAt: Date;
+  id: string;
+  periodEnd: Date | null;
+  periodStart: Date | null;
+  seats: number | null;
+  stripeSubscriptionId: string | null;
+}
+
+async function resolveActiveOrganizationSubscription(
+  organizationId: string,
+): Promise<ActiveOrganizationSubscription | null> {
+  const subscription =
+    await subscriptionRepository.resolveActiveSubscriptionByReferenceId(
+      organizationId,
+      prisma,
+    );
+
+  if (!subscription) {
+    return null;
+  }
+
+  return {
+    createdAt: subscription.createdAt,
+    id: subscription.id,
+    periodEnd: subscription.periodEnd,
+    periodStart: subscription.periodStart,
+    seats: subscription.seats,
+    stripeSubscriptionId: subscription.stripeSubscriptionId,
+  };
+}
+
+async function ensureActiveOrganizationSubscription(
+  organizationId: string,
+  missingSubscriptionMessage: string,
+): Promise<ActiveOrganizationSubscription> {
+  const activeSubscription =
+    await resolveActiveOrganizationSubscription(organizationId);
+  if (!activeSubscription) {
+    throw new APIError("BAD_REQUEST", {
+      message: missingSubscriptionMessage,
+    });
+  }
+
+  return activeSubscription;
+}
+
+function ensureSubscriptionPeriodDate(
+  value: Date | null,
+  fieldName: string,
+): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  throw new APIError("INTERNAL_SERVER_ERROR", {
+    message: `Organization subscription is missing its ${fieldName}. Please contact support.`,
+  });
+}
+
+async function syncPaidOrganizationUnassignedFreeCredits(
+  organizationId: string,
+  activeSubscription: ActiveOrganizationSubscription,
+): Promise<number> {
+  const purchasedSeats = resolvePurchasedSeats(activeSubscription.seats);
+  const periodEnd = activeSubscription.periodEnd;
+
+  if (!periodEnd || periodEnd <= new Date()) {
+    return purchasedSeats;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const unassignedMemberUserIds =
+      await memberRepository.getUnassignedMemberUserIds(organizationId, tx);
+
+    await grantFreeOrganizationMemberSubscriptionCredits(
+      {
+        memberUserIds: unassignedMemberUserIds,
+        organizationId,
+        periodEnd,
+      },
+      tx,
+    );
+  });
+
+  return purchasedSeats;
+}
+
+async function syncLocalFreeOrganizationPeriodCredits(
+  organizationId: string,
+  activeSubscription: ActiveOrganizationSubscription,
+): Promise<number> {
+  const periodStart = ensureSubscriptionPeriodDate(
+    activeSubscription.periodStart,
+    "period start",
+  );
+  const periodEnd = ensureSubscriptionPeriodDate(
+    activeSubscription.periodEnd,
+    "period end",
+  );
+  const purchasedSeats = resolvePurchasedSeats(activeSubscription.seats);
+
+  return await prisma.$transaction(async (tx) => {
+    const memberUserIds = await memberRepository.getOrganizationMemberUserIds(
+      organizationId,
+      tx,
+    );
+
+    await ensureLocalFreeSubscriptionPeriod(
+      {
+        billingAnchorDate: activeSubscription.createdAt,
+        memberUserIds,
+        organizationId,
+        periodEnd,
+        periodStart,
+        purchasedSeats,
+        referenceId: organizationId,
+      },
+      tx,
+    );
+
+    return purchasedSeats;
+  });
+}
+
+async function syncLocalFreeSeatsAndCreditsForCurrentMembersInternal(
+  organizationId: string,
+  activeSubscription?: ActiveOrganizationSubscription | null,
+): Promise<number> {
+  const billingPlan = await resolveOrganizationBillingPlan(
+    organizationId,
+    prisma,
+  );
+  if (billingPlan.mode === "enterprise_contract" && billingPlan.isConsumable) {
+    return resolvePurchasedSeats(billingPlan.purchasedSeats);
+  }
+
+  const currentActiveSubscription =
+    activeSubscription ??
+    (await resolveActiveOrganizationSubscription(organizationId));
+
+  if (!currentActiveSubscription) {
+    return resolvePurchasedSeats(undefined);
+  }
+
+  if (currentActiveSubscription.stripeSubscriptionId) {
+    return syncPaidOrganizationUnassignedFreeCredits(
+      organizationId,
+      currentActiveSubscription,
+    );
+  }
+
+  return syncLocalFreeOrganizationPeriodCredits(
+    organizationId,
+    currentActiveSubscription,
+  );
+}
+
+export async function ensureCanAcceptOrganizationInvitation(
+  organizationId: string,
+): Promise<void> {
+  const billingPlan = await resolveOrganizationBillingPlan(
+    organizationId,
+    prisma,
+  );
+
+  if (billingPlan.mode === "enterprise_contract") {
+    if (billingPlan.purchasedSeats < 1) {
+      throw new APIError("BAD_REQUEST", {
+        message:
+          "Enterprise contract has no purchased seats configured for this organization.",
+      });
+    }
+
+    return;
+  }
+
+  await ensureActiveOrganizationSubscription(
+    organizationId,
+    "An active organization subscription is required before adding members.",
+  );
+}
+
+export async function syncLocalFreeSeatsAndCreditsForCurrentMembers(
+  organizationId: string,
+): Promise<void> {
+  await syncLocalFreeSeatsAndCreditsForCurrentMembersInternal(organizationId);
+}

--- a/apps/core/src/services/preferred-organization.service.ts
+++ b/apps/core/src/services/preferred-organization.service.ts
@@ -1,0 +1,25 @@
+import {
+  memberRepository,
+  userRepository,
+} from "@sokosumi/database/repositories";
+
+import prisma from "@/lib/db/prisma";
+
+export async function resolveActiveOrganizationIdForSession(
+  userId: string,
+): Promise<string | null> {
+  const user = await userRepository.getUserById(userId, prisma);
+  const preferredOrganizationId = user?.preferredOrganizationId ?? null;
+
+  if (!preferredOrganizationId) {
+    return null;
+  }
+
+  const member = await memberRepository.getMemberByUserIdAndOrganizationId(
+    userId,
+    preferredOrganizationId,
+    prisma,
+  );
+
+  return member ? preferredOrganizationId : null;
+}

--- a/apps/core/src/services/stripe-user-email.service.ts
+++ b/apps/core/src/services/stripe-user-email.service.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import { userRepository } from "@sokosumi/database/repositories";
 
 import { stripeClient } from "@/clients/stripe.client";
@@ -6,26 +7,23 @@ import prisma from "@/lib/db/prisma";
 export async function syncUserEmailWithStripe(
   userId: string,
   newEmail: string,
-): Promise<boolean> {
+): Promise<void> {
   try {
     const user = await userRepository.getUserById(userId, prisma);
 
     if (!user?.stripeCustomerId) {
-      return true;
+      return;
     }
 
     await stripeClient.updateCustomerEmail(user.stripeCustomerId, newEmail);
-
-    console.log(
-      `✅ Synced user ${userId} email to Stripe customer ${user.stripeCustomerId}`,
-    );
-
-    return true;
   } catch (error) {
-    console.error(
-      `Error syncing user email with Stripe for user ${userId}:`,
-      error,
-    );
-    return false;
+    Sentry.captureException(error, {
+      tags: {
+        context: "stripe_user_email_sync",
+      },
+      extra: {
+        userId,
+      },
+    });
   }
 }

--- a/apps/core/src/services/stripe-user-email.service.ts
+++ b/apps/core/src/services/stripe-user-email.service.ts
@@ -1,0 +1,31 @@
+import { userRepository } from "@sokosumi/database/repositories";
+
+import { stripeClient } from "@/clients/stripe.client";
+import prisma from "@/lib/db/prisma";
+
+export async function syncUserEmailWithStripe(
+  userId: string,
+  newEmail: string,
+): Promise<boolean> {
+  try {
+    const user = await userRepository.getUserById(userId, prisma);
+
+    if (!user?.stripeCustomerId) {
+      return true;
+    }
+
+    await stripeClient.updateCustomerEmail(user.stripeCustomerId, newEmail);
+
+    console.log(
+      `✅ Synced user ${userId} email to Stripe customer ${user.stripeCustomerId}`,
+    );
+
+    return true;
+  } catch (error) {
+    console.error(
+      `Error syncing user email with Stripe for user ${userId}:`,
+      error,
+    );
+    return false;
+  }
+}

--- a/apps/core/src/services/stripe-user-email.service.ts
+++ b/apps/core/src/services/stripe-user-email.service.ts
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/node";
-import type { PrismaClient } from "@sokosumi/database";
 import { userRepository } from "@sokosumi/database/repositories";
 
 import { stripeClient } from "@/clients/stripe.client";
@@ -42,8 +41,11 @@ function resolveDatabaseHookUserId(
   }
 
   const user = (sessionCandidate as Record<string, unknown>).user;
-  if (user && typeof user === "object" && typeof user.id === "string") {
-    return user.id;
+  if (user && typeof user === "object") {
+    const userId = (user as Record<string, unknown>).id;
+    if (typeof userId === "string") {
+      return userId;
+    }
   }
 
   return null;
@@ -97,7 +99,7 @@ function consumePendingStripeEmailSync(user: {
 export async function prepareStripeEmailSyncForUserUpdate(
   updateData: Record<string, unknown>,
   ctx: unknown,
-  prisma: PrismaClient,
+  prismaClient: typeof prisma,
 ): Promise<void> {
   if (
     !Object.hasOwn(updateData, "email") ||
@@ -108,7 +110,7 @@ export async function prepareStripeEmailSyncForUserUpdate(
 
   const userId = resolveDatabaseHookUserId(ctx, updateData);
   const existingEmail = userId
-    ? ((await userRepository.getUserById(userId, prisma))?.email ?? null)
+    ? ((await userRepository.getUserById(userId, prismaClient))?.email ?? null)
     : null;
 
   markPendingStripeEmailSyncForUserUpdate(updateData, userId, existingEmail);

--- a/apps/core/src/services/stripe-user-email.service.ts
+++ b/apps/core/src/services/stripe-user-email.service.ts
@@ -1,8 +1,129 @@
 import * as Sentry from "@sentry/node";
+import type { PrismaClient } from "@sokosumi/database";
 import { userRepository } from "@sokosumi/database/repositories";
 
 import { stripeClient } from "@/clients/stripe.client";
 import prisma from "@/lib/db/prisma";
+
+const pendingStripeEmailSyncUserIds = new Set<string>();
+const pendingStripeEmailSyncByNormalizedEmail = new Set<string>();
+
+export function resetStripeEmailSyncStateForTests(): void {
+  pendingStripeEmailSyncUserIds.clear();
+  pendingStripeEmailSyncByNormalizedEmail.clear();
+}
+
+function resolveDatabaseHookUserId(
+  ctx: unknown,
+  updateData: Record<string, unknown>,
+): string | null {
+  if (typeof updateData.id === "string") {
+    return updateData.id;
+  }
+
+  if (!ctx || typeof ctx !== "object") {
+    return null;
+  }
+
+  const record = ctx as Record<string, unknown>;
+  const nestedContext =
+    record.context && typeof record.context === "object"
+      ? (record.context as Record<string, unknown>)
+      : null;
+
+  const sessionCandidate =
+    record.session ??
+    nestedContext?.session ??
+    nestedContext?.newSession ??
+    null;
+
+  if (!sessionCandidate || typeof sessionCandidate !== "object") {
+    return null;
+  }
+
+  const user = (sessionCandidate as Record<string, unknown>).user;
+  if (user && typeof user === "object" && typeof user.id === "string") {
+    return user.id;
+  }
+
+  return null;
+}
+
+export function markPendingStripeEmailSyncForUserUpdate(
+  updateData: Record<string, unknown>,
+  userId: string | null,
+  existingEmail: string | null,
+): void {
+  if (
+    !Object.hasOwn(updateData, "email") ||
+    typeof updateData.email !== "string"
+  ) {
+    return;
+  }
+
+  const normalizedNewEmail = updateData.email.toLowerCase();
+  if (existingEmail && existingEmail.toLowerCase() === normalizedNewEmail) {
+    return;
+  }
+
+  if (userId) {
+    pendingStripeEmailSyncUserIds.add(userId);
+    return;
+  }
+
+  pendingStripeEmailSyncByNormalizedEmail.add(normalizedNewEmail);
+}
+
+function consumePendingStripeEmailSync(user: {
+  id: string;
+  email: string;
+}): boolean {
+  const normalizedEmail = user.email.toLowerCase();
+  let shouldSync = false;
+
+  if (pendingStripeEmailSyncUserIds.has(user.id)) {
+    pendingStripeEmailSyncUserIds.delete(user.id);
+    shouldSync = true;
+  }
+
+  if (pendingStripeEmailSyncByNormalizedEmail.has(normalizedEmail)) {
+    pendingStripeEmailSyncByNormalizedEmail.delete(normalizedEmail);
+    shouldSync = true;
+  }
+
+  return shouldSync;
+}
+
+export async function prepareStripeEmailSyncForUserUpdate(
+  updateData: Record<string, unknown>,
+  ctx: unknown,
+  prisma: PrismaClient,
+): Promise<void> {
+  if (
+    !Object.hasOwn(updateData, "email") ||
+    typeof updateData.email !== "string"
+  ) {
+    return;
+  }
+
+  const userId = resolveDatabaseHookUserId(ctx, updateData);
+  const existingEmail = userId
+    ? ((await userRepository.getUserById(userId, prisma))?.email ?? null)
+    : null;
+
+  markPendingStripeEmailSyncForUserUpdate(updateData, userId, existingEmail);
+}
+
+export async function handleUserUpdateStripeEmailSync(user: {
+  id: string;
+  email: string;
+}): Promise<void> {
+  if (!consumePendingStripeEmailSync(user)) {
+    return;
+  }
+
+  await syncUserEmailWithStripe(user.id, user.email);
+}
 
 export async function syncUserEmailWithStripe(
   userId: string,

--- a/apps/web/src/i18n/__tests__/locale-resolution.test.ts
+++ b/apps/web/src/i18n/__tests__/locale-resolution.test.ts
@@ -38,8 +38,9 @@ describe("resolveLocaleFromAcceptLanguage", () => {
     expect(resolveLocaleFromAcceptLanguage("fr;q=0,de;q=0.8")).toBe("de");
   });
 
-  it("ignores entries with malformed q-values", () => {
-    expect(resolveLocaleFromAcceptLanguage("fr;q=oops,en;q=0.8")).toBe("en");
+  it("keeps a supported locale whose q-value is malformed at default quality", () => {
+    expect(resolveLocaleFromAcceptLanguage("de;q=oops,en;q=0.8")).toBe("de");
+    expect(resolveLocaleFromAcceptLanguage("de;q=,en;q=0.8")).toBe("de");
   });
 
   it("maps regional language tags to supported base locale", () => {

--- a/apps/web/src/i18n/locale-resolution.ts
+++ b/apps/web/src/i18n/locale-resolution.ts
@@ -80,8 +80,11 @@ export function resolveLocaleFromAcceptLanguage(
           continue;
         }
 
+        // A malformed quality value (missing or unparseable) is ignored rather
+        // than dropping the whole language preference: keep the default quality
+        // of 1 so e.g. `de;q=` or `de;q=oops` still resolves to German.
         if (!rawValue) {
-          return null;
+          continue;
         }
 
         const parsedQuality = Number.parseFloat(rawValue.trim());
@@ -90,7 +93,7 @@ export function resolveLocaleFromAcceptLanguage(
           parsedQuality < 0 ||
           parsedQuality > 1
         ) {
-          return null;
+          continue;
         }
 
         quality = parsedQuality;

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -595,14 +595,25 @@ export const auth = betterAuth({
           name,
         });
 
-        await postmarkClient.sendEmail({
-          From: fromEmail,
-          To: email,
-          Tag: "magic-link",
-          Subject: renderedEmail.subject,
-          HtmlBody: renderedEmail.html,
-          MessageStream: "authentications",
-        });
+        void postmarkClient
+          .sendEmail({
+            From: fromEmail,
+            To: email,
+            Tag: "magic-link",
+            Subject: renderedEmail.subject,
+            HtmlBody: renderedEmail.html,
+            MessageStream: "authentications",
+          })
+          .catch((error) => {
+            Sentry.captureException(error, {
+              tags: {
+                context: "magic_link_email",
+              },
+              extra: {
+                email,
+              },
+            });
+          });
       },
     }),
     passkey({


### PR DESCRIPTION
## Summary

Port remaining Web Better Auth hooks and email flows to Core (migration **C4**). Browser still uses Web `/api/auth` until `NEXT_PUBLIC_USE_CORE_AUTH_CLIENT` is enabled on preprod.

### Core (`apps/core`)

- Terms guards, email/password reset, email verification, locale-aware emails (magic link, reset, verify, org invite).
- Session `activeOrganizationId` from preferred org; user created/updated webhooks; org invitation seat checks; seat/credit sync on invite/add; org delete guard; Stripe org customer on create.
- New services: `organization-subscription-auth`, `preferred-organization`, `stripe-user-email`; i18n locale helpers for auth emails.

### Hardening & follow-ups (same PR)

- Auth emails (reset, verify, invite, **Core magic link**) are fire-and-forget with Sentry so Postmark outages do not fail auth flows.
- User/account webhook calls use `.catch` → Sentry.
- Stripe customer email sync: Sentry internally, last-write-wins (no `${customerId}-${email}` idempotency key), **only when user email actually changes** (`user.update.before/after` gating).
- Accept-Language: malformed `q` keeps language at default quality — **Core + Web** aligned; tests in both apps.
- **Web magic link** matches Core fire-and-forget + Sentry while Web handler remains active.

### Deferred (not this PR)

- Consolidate `organization-subscription-auth.service` with web `organization-subscription.service`.
- Web reset/verify/invite emails still lack `.catch` → Sentry (magic link only aligned here).
- Preprod flag flip + full auth E2E.

## Test plan

- [x] `pnpm --filter @sokosumi/core test src/lib/auth.test.ts src/lib/i18n/locale-resolution.test.ts src/services/__tests__/stripe-user-email.service.test.ts`
- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.test.ts src/i18n/__tests__/locale-resolution.test.ts`
- [x] `pnpm --filter @sokosumi/core check` / `pnpm --filter web check`
- [x] CI green (Build, Test Core/Web/Packages, Typecheck, Biome)
- [ ] After flag flip on preprod: sign-up terms, org invite, org delete with members, email reset/verify/magic-link flows