### PR TITLE
fix(web): anchor social auth callback URL to web origin

### DIFF
--- a/apps/web/src/lib/utils/__tests__/url.test.ts
+++ b/apps/web/src/lib/utils/__tests__/url.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getFileNameFromUrl } from "../url";
+import { buildAuthCallbackUrl, getFileNameFromUrl } from "../url";
 
 describe("getFileNameFromUrl", () => {
   it("returns the last pathname segment for a valid URL", () => {
@@ -16,6 +16,42 @@ describe("getFileNameFromUrl", () => {
   it("falls back to splitting the string when URL parsing fails", () => {
     expect(getFileNameFromUrl("not-a-url/but/filename.txt")).toBe(
       "filename.txt",
+    );
+  });
+});
+
+describe("buildAuthCallbackUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("anchors the callback to the current web origin so Core redirects back to the web app", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(buildAuthCallbackUrl("/auth/callback/signin", "google")).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signin?provider=google",
+    );
+  });
+
+  it("includes the returnUrl when provided", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(
+      buildAuthCallbackUrl("/auth/callback/signup", "microsoft", "/chat"),
+    ).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signup?provider=microsoft&returnUrl=%2Fchat",
+    );
+  });
+
+  it("falls back to a relative path when window is unavailable (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(buildAuthCallbackUrl("/auth/callback/signin", "google")).toBe(
+      "/auth/callback/signin?provider=google",
     );
   });
 });

--- a/apps/web/src/lib/utils/__tests__/url.test.ts
+++ b/apps/web/src/lib/utils/__tests__/url.test.ts
@@ -63,6 +63,18 @@ describe("buildAuthCallbackUrl", () => {
     );
   });
 
+  it("rejects a protocol-relative returnUrl to fallback", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(
+      buildAuthCallbackUrl("/auth/callback/signin", "google", "//evil.com"),
+    ).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signin?provider=google&returnUrl=%2F",
+    );
+  });
+
   it("falls back to a relative path when window is unavailable (SSR)", () => {
     vi.stubGlobal("window", undefined);
 

--- a/apps/web/src/lib/utils/__tests__/url.test.ts
+++ b/apps/web/src/lib/utils/__tests__/url.test.ts
@@ -47,6 +47,22 @@ describe("buildAuthCallbackUrl", () => {
     );
   });
 
+  it("sanitizes external returnUrl to fallback", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(
+      buildAuthCallbackUrl(
+        "/auth/callback/signin",
+        "google",
+        "https://evil.example/attack",
+      ),
+    ).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signin?provider=google&returnUrl=%2F",
+    );
+  });
+
   it("falls back to a relative path when window is unavailable (SSR)", () => {
     vi.stubGlobal("window", undefined);
 

--- a/apps/web/src/lib/utils/url.ts
+++ b/apps/web/src/lib/utils/url.ts
@@ -1,4 +1,5 @@
 import { siteConfig } from "@/config/site";
+import { getValidAuthRedirectUrl } from "@/lib/auth/auth.utils";
 import type { SocialProviderId } from "@/lib/schemas";
 
 export function getHostname(rawUrl: string): string | null {
@@ -65,7 +66,13 @@ export function buildAuthCallbackUrl(
   returnUrl?: string,
 ): string {
   const params = new URLSearchParams({ provider });
-  if (returnUrl) params.set("returnUrl", returnUrl);
+  if (returnUrl) {
+    const safeReturnUrl =
+      typeof window !== "undefined"
+        ? getValidAuthRedirectUrl(returnUrl, "/")
+        : returnUrl;
+    params.set("returnUrl", safeReturnUrl);
+  }
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   return `${origin}${path}?${params.toString()}`;
 }

--- a/apps/web/src/lib/utils/url.ts
+++ b/apps/web/src/lib/utils/url.ts
@@ -46,6 +46,19 @@ export function getReturnUrlFromCurrentLocation(): string {
   return path === "/" || path === "" ? "/chat" : path;
 }
 
+/**
+ * Builds a social-auth callback URL for `authClient.signIn.social`.
+ *
+ * The result is an **absolute** URL anchored to the current web origin. This
+ * matters when the browser `authClient` targets the Core Better Auth instance
+ * (a different origin, e.g. `api.preprod.sokosumi.com`): Better Auth resolves a
+ * relative `callbackURL` against the auth-server origin, so a bare
+ * `/auth/callback/signin` would both land on the Core domain and collide with
+ * Core's own `/auth/callback/:provider` route — surfacing as `state_not_found`.
+ * Anchoring to `window.location.origin` (already a trusted origin) sends the
+ * user back to the web app after the OAuth callback completes. Falls back to a
+ * relative path when `window` is unavailable (SSR).
+ */
 export function buildAuthCallbackUrl(
   path: string,
   provider: SocialProviderId,
@@ -53,7 +66,8 @@ export function buildAuthCallbackUrl(
 ): string {
   const params = new URLSearchParams({ provider });
   if (returnUrl) params.set("returnUrl", returnUrl);
-  return `${path}?${params.toString()}`;
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return `${origin}${path}?${params.toString()}`;
 }
 
 export function buildJobTransactionUrl(


### PR DESCRIPTION
## Problem

After a successful Google SSO sign-in on preprod, users landed on `https://api.preprod.sokosumi.com/?error=state_not_found` instead of the web app. The session was actually created (user ends up logged in at `preprod.sokosumi.com`) — the **post-auth redirect** was broken, not the login.

### Root cause

`buildAuthCallbackUrl` returned a **relative** path (`/auth/callback/signin?provider=google`). With the Core Better Auth client enabled (`NEXT_PUBLIC_USE_CORE_AUTH_CLIENT=true`), the browser `authClient.baseURL` is the Core origin (`https://api.preprod.sokosumi.com/auth`). Better Auth resolves a relative `callbackURL` against the **auth-server origin**, so the redirect:

1. Pointed at the **Core** domain instead of the web app, and
2. Collided with Core's own `/auth/callback/:provider` route (Core `basePath` is `/auth`) — Core treated `signin` as an OAuth provider, found no state cookie → `state_not_found`, then bounced to the Core API root.

Email/password login was unaffected (no OAuth `callbackURL` redirect).

## Fix

### 1. Anchor callback to web origin

Anchor `buildAuthCallbackUrl` to `window.location.origin` so the callback is an **absolute** web-origin URL. Core (`trustedOrigins` already includes `preprod.sokosumi.com` and `*.preview.sokosumi.com`) then redirects the browser back to the web app after the real `/auth/callback/google` step completes. Falls back to a relative path under SSR.

Safe in both auth-client modes: when the web auth client is used, the origin equals the web origin, so the resolved URL is identical to the previous behavior.

### 2. Sanitize `returnUrl` (defense in depth)

`buildAuthCallbackUrl` now runs `returnUrl` through `getValidAuthRedirectUrl` before embedding it in the query string (same helper magic link already uses). Off-origin values fall back to `/`, matching `social-auth-callback.tsx` behavior but blocking bad URLs earlier in the OAuth flow. Covers both `social-buttons.tsx` and `social-signup-auto-initiator.tsx` via the shared helper.

## Verification

- `pnpm --filter web test src/lib/utils/__tests__/url.test.ts` — 7/7 pass (origin-anchored URL, returnUrl encoding, off-origin sanitization, SSR fallback)
- `biome check` clean on changed files

## Test plan

- [ ] Google SSO on preprod with `NEXT_PUBLIC_USE_CORE_AUTH_CLIENT=true` → lands on web app, not Core API root
- [ ] Microsoft SSO same path
- [ ] Sign-up social auto-initiator redirect still works