### PR TITLE
fix(web): anchor auth callback URLs to web origin for Core client

### DIFF
--- a/apps/web/src/app/(app)/account/components/email-form.tsx
+++ b/apps/web/src/app/(app)/account/components/email-form.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { changeEmail } from "@/lib/auth/auth.client";
+import { getAbsoluteAuthRedirectUrl } from "@/lib/auth/auth.utils";
 import { type EmailFormType, emailFormSchema } from "@/lib/schemas";
 
 export function EmailForm() {
@@ -44,7 +45,7 @@ export function EmailForm() {
   const handleSubmit = async (values: EmailFormType) => {
     const changeEmailResult = await changeEmail({
       newEmail: values.email,
-      callbackURL: "/",
+      callbackURL: getAbsoluteAuthRedirectUrl("/"),
     });
 
     if (changeEmailResult.error) {

--- a/apps/web/src/app/(app)/connections/components/social-accounts.tsx
+++ b/apps/web/src/app/(app)/connections/components/social-accounts.tsx
@@ -9,6 +9,7 @@ import { GoogleIcon, MicrosoftIcon } from "@/components/social-icons";
 import { Button } from "@/components/ui/button";
 import type { Account } from "@/lib/auth/auth";
 import { authClient } from "@/lib/auth/auth.client";
+import { getAbsoluteAuthRedirectUrl } from "@/lib/auth/auth.utils";
 import { AccountProvider } from "@/lib/auth/types";
 
 import DisconnectModal from "./disconnect-modal";
@@ -38,7 +39,7 @@ export function SocialAccounts({ socialAccounts }: SocialAccountsProps) {
     setLoading(true);
     const result = await authClient.linkSocial({
       provider,
-      callbackURL: "/connections",
+      callbackURL: getAbsoluteAuthRedirectUrl("/connections"),
     });
     if (result.error) {
       const errorMessage = result.error.message ?? t("error", { provider });

--- a/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
+++ b/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
@@ -476,7 +476,7 @@ describe("SocialButtons", () => {
     await waitFor(() => {
       expect(mockMagicLinkSignIn).toHaveBeenCalledWith({
         email: "login-user@example.com",
-        callbackURL: "/",
+        callbackURL: `${window.location.origin}/`,
       });
     });
 

--- a/apps/web/src/app/(auth)/components/social-buttons.tsx
+++ b/apps/web/src/app/(auth)/components/social-buttons.tsx
@@ -23,8 +23,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/lib/auth/auth.client";
 import {
-  buildOAuthConsentReturnUrlFromSearchParams,
   buildAuthCallbackUrl,
+  buildOAuthConsentReturnUrlFromSearchParams,
   createAuthSessionGetter,
   getAbsoluteAuthRedirectUrl,
   normalizeAuthReturnUrl,

--- a/apps/web/src/app/(auth)/components/social-buttons.tsx
+++ b/apps/web/src/app/(auth)/components/social-buttons.tsx
@@ -24,14 +24,14 @@ import { Input } from "@/components/ui/input";
 import { authClient } from "@/lib/auth/auth.client";
 import {
   buildOAuthConsentReturnUrlFromSearchParams,
+  buildAuthCallbackUrl,
   createAuthSessionGetter,
-  getValidAuthRedirectUrl,
+  getAbsoluteAuthRedirectUrl,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";
 import { emailSchema } from "@/lib/auth/data";
 import { cn } from "@/lib/utils";
-import { buildAuthCallbackUrl } from "@/lib/utils/url";
 
 export type SocialButtonProviderId = "google" | "microsoft";
 export type SignInMethodId = SocialButtonProviderId | "passkey" | "magic-link";
@@ -192,7 +192,7 @@ export default function SocialButtons({
     try {
       const result = await authClient.signIn.magicLink({
         email: trimmedEmail,
-        callbackURL: getValidAuthRedirectUrl(effectiveReturnUrl, "/"),
+        callbackURL: getAbsoluteAuthRedirectUrl(effectiveReturnUrl, "/"),
       });
 
       if (result.error) {

--- a/apps/web/src/app/(auth)/components/social-signup-auto-initiator.tsx
+++ b/apps/web/src/app/(auth)/components/social-signup-auto-initiator.tsx
@@ -8,9 +8,8 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth/auth.client";
-import { buildOAuthConsentReturnUrlFromSearchParams } from "@/lib/auth/auth.utils";
+import { buildOAuthConsentReturnUrlFromSearchParams, buildAuthCallbackUrl } from "@/lib/auth/auth.utils";
 import type { SocialProviderId } from "@/lib/schemas";
-import { buildAuthCallbackUrl } from "@/lib/utils/url";
 
 interface SocialSignupAutoInitiatorProps {
   provider: SocialProviderId;

--- a/apps/web/src/app/(auth)/components/social-signup-auto-initiator.tsx
+++ b/apps/web/src/app/(auth)/components/social-signup-auto-initiator.tsx
@@ -8,7 +8,10 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth/auth.client";
-import { buildOAuthConsentReturnUrlFromSearchParams, buildAuthCallbackUrl } from "@/lib/auth/auth.utils";
+import {
+  buildAuthCallbackUrl,
+  buildOAuthConsentReturnUrlFromSearchParams,
+} from "@/lib/auth/auth.utils";
 import type { SocialProviderId } from "@/lib/schemas";
 
 interface SocialSignupAutoInitiatorProps {

--- a/apps/web/src/app/(auth)/forgot-password/components/form.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/components/form.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { AuthForm, SubmitButton } from "@/auth/components/form";
 import { forgotPasswordFormData } from "@/auth/forgot-password/data";
 import { requestPasswordReset } from "@/lib/auth/auth.client";
+import { getAbsoluteAuthRedirectUrl } from "@/lib/auth/auth.utils";
 import {
   type ForgotPasswordFormSchemaType,
   forgotPasswordFormSchema,
@@ -36,7 +37,7 @@ export default function ForgotPasswordForm({
   async function handleSubmit(values: ForgotPasswordFormSchemaType) {
     const requestPasswordResetResult = await requestPasswordReset({
       email: values.email,
-      redirectTo: "/reset-password",
+      redirectTo: getAbsoluteAuthRedirectUrl("/reset-password"),
     });
 
     if (requestPasswordResetResult.error) {

--- a/apps/web/src/app/(auth)/signin/components/form.tsx
+++ b/apps/web/src/app/(auth)/signin/components/form.tsx
@@ -21,7 +21,7 @@ import {
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
   getAuthOAuthRedirect,
-  getValidAuthRedirectUrl,
+  getAbsoluteAuthRedirectUrl,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";
@@ -81,7 +81,7 @@ export default function SignInForm({
       email: values.email,
       password: values.currentPassword,
       rememberMe: values.rememberMe,
-      callbackURL: getValidAuthRedirectUrl(effectiveReturnUrl, "/"),
+      callbackURL: getAbsoluteAuthRedirectUrl(effectiveReturnUrl, "/"),
     });
 
     if (result.error) {

--- a/apps/web/src/app/(auth)/signin/components/form.tsx
+++ b/apps/web/src/app/(auth)/signin/components/form.tsx
@@ -20,8 +20,8 @@ import {
   buildOAuthConsentReturnUrlFromSearchParams,
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
-  getAuthOAuthRedirect,
   getAbsoluteAuthRedirectUrl,
+  getAuthOAuthRedirect,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";

--- a/apps/web/src/app/(auth)/signup/components/form.tsx
+++ b/apps/web/src/app/(auth)/signup/components/form.tsx
@@ -19,7 +19,7 @@ import {
   buildOAuthConsentReturnUrlFromSearchParams,
   createAuthSessionGetter,
   getAuthOAuthRedirect,
-  getValidAuthRedirectUrl,
+  getAbsoluteAuthRedirectUrl,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";
@@ -81,7 +81,7 @@ export default function SignUpForm({
       termsAccepted: values.termsAccepted,
       marketingOptIn: values.marketingOptIn,
       onboardingCompleted: false,
-      callbackURL: getValidAuthRedirectUrl(effectiveReturnUrl, "/"),
+      callbackURL: getAbsoluteAuthRedirectUrl(effectiveReturnUrl, "/"),
     });
 
     if (result.error) {

--- a/apps/web/src/app/(auth)/signup/components/form.tsx
+++ b/apps/web/src/app/(auth)/signup/components/form.tsx
@@ -18,8 +18,8 @@ import { authClient, signUp } from "@/lib/auth/auth.client";
 import {
   buildOAuthConsentReturnUrlFromSearchParams,
   createAuthSessionGetter,
-  getAuthOAuthRedirect,
   getAbsoluteAuthRedirectUrl,
+  getAuthOAuthRedirect,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";

--- a/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
@@ -107,6 +107,18 @@ describe("buildAuthCallbackUrl", () => {
       "/auth/callback/signin?provider=google",
     );
   });
+
+  it("sanitizes external returnUrl to fallback during SSR", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(
+      buildAuthCallbackUrl(
+        "/auth/callback/signin",
+        "google",
+        "https://evil.example/attack",
+      ),
+    ).toBe("/auth/callback/signin?provider=google&returnUrl=%2F");
+  });
 });
 
 describe("getAbsoluteAuthRedirectUrl", () => {
@@ -149,6 +161,20 @@ describe("getAbsoluteAuthRedirectUrl", () => {
 
     expect(getAbsoluteAuthRedirectUrl("/chat", "/")).toBe("/chat");
   });
+
+  it("sanitizes an external returnUrl to fallback during SSR", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(
+      getAbsoluteAuthRedirectUrl("https://evil.example/attack", "/chat"),
+    ).toBe("/chat");
+  });
+
+  it("rejects a protocol-relative returnUrl during SSR", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(getAbsoluteAuthRedirectUrl("//evil.com", "/chat")).toBe("/chat");
+  });
 });
 
 describe("normalizeAuthReturnUrl", () => {
@@ -184,6 +210,12 @@ describe("normalizeAuthReturnUrl", () => {
     });
 
     expect(normalizeAuthReturnUrl("javascript:alert('x')")).toBe("/");
+  });
+
+  it("returns / for external returnUrl during SSR", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(normalizeAuthReturnUrl("https://evil.example/attack")).toBe("/");
   });
 });
 

--- a/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildAuthCallbackUrl,
   buildOAuthConsentReturnUrl,
   buildOAuthConsentReturnUrlFromSearchParams,
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
   getAuthOAuthRedirect,
-  getValidAuthRedirectUrl,
+  getAbsoluteAuthRedirectUrl,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";
@@ -44,31 +45,117 @@ describe("getAuthOAuthRedirect", () => {
   });
 });
 
-describe("getValidAuthRedirectUrl", () => {
-  it("returns fallback when returnUrl is missing", () => {
-    expect(getValidAuthRedirectUrl(undefined, "/chat")).toBe("/chat");
+describe("buildAuthCallbackUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it("returns relative returnUrl when it is safe", () => {
+  it("anchors the callback to the current web origin so Core redirects back to the web app", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(buildAuthCallbackUrl("/auth/callback/signin", "google")).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signin?provider=google",
+    );
+  });
+
+  it("includes the returnUrl when provided", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
     expect(
-      getValidAuthRedirectUrl("/accept-invitation/invite_123", "/chat"),
-    ).toBe("/accept-invitation/invite_123");
+      buildAuthCallbackUrl("/auth/callback/signup", "microsoft", "/chat"),
+    ).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signup?provider=microsoft&returnUrl=%2Fchat",
+    );
   });
 
-  it("returns fallback for external origins", () => {
+  it("sanitizes external returnUrl to fallback", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
     expect(
-      getValidAuthRedirectUrl("https://evil.example/attack", "/chat"),
-    ).toBe("/chat");
+      buildAuthCallbackUrl(
+        "/auth/callback/signin",
+        "google",
+        "https://evil.example/attack",
+      ),
+    ).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signin?provider=google&returnUrl=%2F",
+    );
   });
 
-  it("returns fallback for unsupported protocols", () => {
-    expect(getValidAuthRedirectUrl("javascript:alert('x')", "/chat")).toBe(
-      "/chat",
+  it("rejects a protocol-relative returnUrl to fallback", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(
+      buildAuthCallbackUrl("/auth/callback/signin", "google", "//evil.com"),
+    ).toBe(
+      "https://preprod.sokosumi.com/auth/callback/signin?provider=google&returnUrl=%2F",
+    );
+  });
+
+  it("falls back to a relative path when window is unavailable (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(buildAuthCallbackUrl("/auth/callback/signin", "google")).toBe(
+      "/auth/callback/signin?provider=google",
     );
   });
 });
 
+describe("getAbsoluteAuthRedirectUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("anchors a safe relative path to the web origin", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(getAbsoluteAuthRedirectUrl("/chat", "/")).toBe(
+      "https://preprod.sokosumi.com/chat",
+    );
+  });
+
+  it("anchors fallback when returnUrl is missing", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(getAbsoluteAuthRedirectUrl(undefined, "/")).toBe(
+      "https://preprod.sokosumi.com/",
+    );
+  });
+
+  it("returns fallback origin URL for external returnUrl", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(
+      getAbsoluteAuthRedirectUrl("https://evil.example/attack", "/chat"),
+    ).toBe("https://preprod.sokosumi.com/chat");
+  });
+
+  it("falls back to a relative path when window is unavailable (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(getAbsoluteAuthRedirectUrl("/chat", "/")).toBe("/chat");
+  });
+});
+
 describe("normalizeAuthReturnUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("returns / when returnUrl is missing", () => {
     expect(normalizeAuthReturnUrl(undefined)).toBe("/");
   });
@@ -84,7 +171,19 @@ describe("normalizeAuthReturnUrl", () => {
   });
 
   it("returns / for external returnUrl", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
     expect(normalizeAuthReturnUrl("https://evil.example/attack")).toBe("/");
+  });
+
+  it("returns / for unsupported protocols", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://preprod.sokosumi.com" },
+    });
+
+    expect(normalizeAuthReturnUrl("javascript:alert('x')")).toBe("/");
   });
 });
 

--- a/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
@@ -5,8 +5,8 @@ import {
   buildOAuthConsentReturnUrlFromSearchParams,
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
-  getAuthOAuthRedirect,
   getAbsoluteAuthRedirectUrl,
+  getAuthOAuthRedirect,
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";

--- a/apps/web/src/lib/auth/auth.utils.ts
+++ b/apps/web/src/lib/auth/auth.utils.ts
@@ -121,6 +121,12 @@ export function buildSignUpUrlFromSignIn({
   return query ? `/signup?${query}` : "/signup";
 }
 
+// Resolution base used to validate redirect paths when `window` is unavailable
+// (SSR). The `.invalid` TLD is reserved and never resolvable, so any input that
+// resolves to a different origin (absolute or protocol-relative URL) is rejected
+// while genuine same-origin relative paths are preserved.
+const SSR_REDIRECT_ORIGIN = "https://localhost.invalid";
+
 function sanitizeAuthRedirectPath(
   returnUrl: string | undefined,
   fallback: string = "/",
@@ -129,13 +135,19 @@ function sanitizeAuthRedirectPath(
     return fallback;
   }
 
-  if (typeof window === "undefined") {
-    return returnUrl;
-  }
+  // Validate against the real origin on the client and a reserved placeholder
+  // origin during SSR. Either way, only same-origin relative paths survive —
+  // absolute (`https://evil`) and protocol-relative (`//evil`) URLs resolve to
+  // a different origin and fall back, closing the open-redirect vector in both
+  // contexts.
+  const baseOrigin =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : SSR_REDIRECT_ORIGIN;
 
   try {
-    const parsedUrl = new URL(returnUrl, window.location.origin);
-    return parsedUrl.origin === window.location.origin ? returnUrl : fallback;
+    const parsedUrl = new URL(returnUrl, baseOrigin);
+    return parsedUrl.origin === baseOrigin ? returnUrl : fallback;
   } catch {
     return fallback;
   }
@@ -152,11 +164,13 @@ export function getAbsoluteAuthRedirectUrl(
   returnUrl: string | undefined,
   fallback: string = "/",
 ): string {
+  const safePath = sanitizeAuthRedirectPath(returnUrl, fallback);
+
+  // No origin to anchor to during SSR; return the sanitized relative path.
   if (typeof window === "undefined") {
-    return returnUrl ?? fallback;
+    return safePath;
   }
 
-  const safePath = sanitizeAuthRedirectPath(returnUrl, fallback);
   return new URL(safePath, window.location.origin).href;
 }
 
@@ -180,11 +194,7 @@ export function buildAuthCallbackUrl(
 ): string {
   const params = new URLSearchParams({ provider });
   if (returnUrl) {
-    const safeReturnUrl =
-      typeof window !== "undefined"
-        ? sanitizeAuthRedirectPath(returnUrl, "/")
-        : returnUrl;
-    params.set("returnUrl", safeReturnUrl);
+    params.set("returnUrl", sanitizeAuthRedirectPath(returnUrl, "/"));
   }
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   return `${origin}${path}?${params.toString()}`;

--- a/apps/web/src/lib/auth/auth.utils.ts
+++ b/apps/web/src/lib/auth/auth.utils.ts
@@ -1,3 +1,5 @@
+import type { SocialProviderId } from "@/lib/schemas";
+
 const AUTH_SESSION_INITIAL_WAIT_MS = 200;
 const AUTH_SESSION_RETRY_WAIT_MS = 500;
 const OAUTH_CONSENT_PATH = "/oauth/consent";
@@ -119,12 +121,16 @@ export function buildSignUpUrlFromSignIn({
   return query ? `/signup?${query}` : "/signup";
 }
 
-export function getValidAuthRedirectUrl(
+function sanitizeAuthRedirectPath(
   returnUrl: string | undefined,
   fallback: string = "/",
 ): string {
   if (!returnUrl) {
     return fallback;
+  }
+
+  if (typeof window === "undefined") {
+    return returnUrl;
   }
 
   try {
@@ -133,6 +139,55 @@ export function getValidAuthRedirectUrl(
   } catch {
     return fallback;
   }
+}
+
+/**
+ * Absolute callback/redirect URL for `authClient` when Better Auth runs on Core.
+ *
+ * Relative paths resolve against the auth-server origin (e.g. `api.preprod…`),
+ * so `/chat` becomes `https://api.preprod…/chat` instead of the web app.
+ * Falls back to a relative path when `window` is unavailable (SSR).
+ */
+export function getAbsoluteAuthRedirectUrl(
+  returnUrl: string | undefined,
+  fallback: string = "/",
+): string {
+  if (typeof window === "undefined") {
+    return returnUrl ?? fallback;
+  }
+
+  const safePath = sanitizeAuthRedirectPath(returnUrl, fallback);
+  return new URL(safePath, window.location.origin).href;
+}
+
+/**
+ * Builds a social-auth callback URL for `authClient.signIn.social`.
+ *
+ * The result is an **absolute** URL anchored to the current web origin. This
+ * matters when the browser `authClient` targets the Core Better Auth instance
+ * (a different origin, e.g. `api.preprod.sokosumi.com`): Better Auth resolves a
+ * relative `callbackURL` against the auth-server origin, so a bare
+ * `/auth/callback/signin` would both land on the Core domain and collide with
+ * Core's own `/auth/callback/:provider` route — surfacing as `state_not_found`.
+ * Anchoring to `window.location.origin` (already a trusted origin) sends the
+ * user back to the web app after the OAuth callback completes. Falls back to a
+ * relative path when `window` is unavailable (SSR).
+ */
+export function buildAuthCallbackUrl(
+  path: string,
+  provider: SocialProviderId,
+  returnUrl?: string,
+): string {
+  const params = new URLSearchParams({ provider });
+  if (returnUrl) {
+    const safeReturnUrl =
+      typeof window !== "undefined"
+        ? sanitizeAuthRedirectPath(returnUrl, "/")
+        : returnUrl;
+    params.set("returnUrl", safeReturnUrl);
+  }
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return `${origin}${path}?${params.toString()}`;
 }
 
 interface AuthOAuthRedirectPayload {
@@ -168,7 +223,7 @@ export function normalizeAuthReturnUrl(returnUrl: string | undefined): string {
   const sanitizedReturnUrl =
     normalized && normalized !== "/" ? normalized : undefined;
 
-  return getValidAuthRedirectUrl(sanitizedReturnUrl, "/");
+  return sanitizeAuthRedirectPath(sanitizedReturnUrl, "/");
 }
 
 type OAuthConsentParamRecord = Partial<

--- a/apps/web/src/lib/utils/__tests__/url.test.ts
+++ b/apps/web/src/lib/utils/__tests__/url.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { buildAuthCallbackUrl, getFileNameFromUrl } from "../url";
+import { getFileNameFromUrl } from "../url";
 
 describe("getFileNameFromUrl", () => {
   it("returns the last pathname segment for a valid URL", () => {
@@ -16,70 +16,6 @@ describe("getFileNameFromUrl", () => {
   it("falls back to splitting the string when URL parsing fails", () => {
     expect(getFileNameFromUrl("not-a-url/but/filename.txt")).toBe(
       "filename.txt",
-    );
-  });
-});
-
-describe("buildAuthCallbackUrl", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("anchors the callback to the current web origin so Core redirects back to the web app", () => {
-    vi.stubGlobal("window", {
-      location: { origin: "https://preprod.sokosumi.com" },
-    });
-
-    expect(buildAuthCallbackUrl("/auth/callback/signin", "google")).toBe(
-      "https://preprod.sokosumi.com/auth/callback/signin?provider=google",
-    );
-  });
-
-  it("includes the returnUrl when provided", () => {
-    vi.stubGlobal("window", {
-      location: { origin: "https://preprod.sokosumi.com" },
-    });
-
-    expect(
-      buildAuthCallbackUrl("/auth/callback/signup", "microsoft", "/chat"),
-    ).toBe(
-      "https://preprod.sokosumi.com/auth/callback/signup?provider=microsoft&returnUrl=%2Fchat",
-    );
-  });
-
-  it("sanitizes external returnUrl to fallback", () => {
-    vi.stubGlobal("window", {
-      location: { origin: "https://preprod.sokosumi.com" },
-    });
-
-    expect(
-      buildAuthCallbackUrl(
-        "/auth/callback/signin",
-        "google",
-        "https://evil.example/attack",
-      ),
-    ).toBe(
-      "https://preprod.sokosumi.com/auth/callback/signin?provider=google&returnUrl=%2F",
-    );
-  });
-
-  it("rejects a protocol-relative returnUrl to fallback", () => {
-    vi.stubGlobal("window", {
-      location: { origin: "https://preprod.sokosumi.com" },
-    });
-
-    expect(
-      buildAuthCallbackUrl("/auth/callback/signin", "google", "//evil.com"),
-    ).toBe(
-      "https://preprod.sokosumi.com/auth/callback/signin?provider=google&returnUrl=%2F",
-    );
-  });
-
-  it("falls back to a relative path when window is unavailable (SSR)", () => {
-    vi.stubGlobal("window", undefined);
-
-    expect(buildAuthCallbackUrl("/auth/callback/signin", "google")).toBe(
-      "/auth/callback/signin?provider=google",
     );
   });
 });

--- a/apps/web/src/lib/utils/url.ts
+++ b/apps/web/src/lib/utils/url.ts
@@ -1,6 +1,4 @@
 import { siteConfig } from "@/config/site";
-import { getValidAuthRedirectUrl } from "@/lib/auth/auth.utils";
-import type { SocialProviderId } from "@/lib/schemas";
 
 export function getHostname(rawUrl: string): string | null {
   try {
@@ -45,36 +43,6 @@ export function getReturnUrlFromCurrentLocation(): string {
       ? window.location.pathname + window.location.search
       : "/chat";
   return path === "/" || path === "" ? "/chat" : path;
-}
-
-/**
- * Builds a social-auth callback URL for `authClient.signIn.social`.
- *
- * The result is an **absolute** URL anchored to the current web origin. This
- * matters when the browser `authClient` targets the Core Better Auth instance
- * (a different origin, e.g. `api.preprod.sokosumi.com`): Better Auth resolves a
- * relative `callbackURL` against the auth-server origin, so a bare
- * `/auth/callback/signin` would both land on the Core domain and collide with
- * Core's own `/auth/callback/:provider` route — surfacing as `state_not_found`.
- * Anchoring to `window.location.origin` (already a trusted origin) sends the
- * user back to the web app after the OAuth callback completes. Falls back to a
- * relative path when `window` is unavailable (SSR).
- */
-export function buildAuthCallbackUrl(
-  path: string,
-  provider: SocialProviderId,
-  returnUrl?: string,
-): string {
-  const params = new URLSearchParams({ provider });
-  if (returnUrl) {
-    const safeReturnUrl =
-      typeof window !== "undefined"
-        ? getValidAuthRedirectUrl(returnUrl, "/")
-        : returnUrl;
-    params.set("returnUrl", safeReturnUrl);
-  }
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  return `${origin}${path}?${params.toString()}`;
 }
 
 export function buildJobTransactionUrl(


### PR DESCRIPTION
## Summary

- Adds `getAbsoluteAuthRedirectUrl` so `authClient` flows pass **absolute web-origin** `callbackURL` / `redirectTo` values when Better Auth runs on Core (`NEXT_PUBLIC_USE_CORE_AUTH_CLIENT=true`). Fixes post-verify redirects landing on `api.preprod.sokosumi.com` (e.g. magic link → `/chat` became `https://api.preprod…/chat`).
- Applies to magic link, email sign-in/sign-up, forgot-password reset link, change-email verification, and link-social on Connections.
- Consolidates redirect helpers in `auth.utils.ts`: private `sanitizeAuthRedirectPath`, `buildAuthCallbackUrl` moved from `url.ts` (follow-up to #3179 social OAuth fix).
- **SSR hardening (code-review follow-up):** `sanitizeAuthRedirectPath` previously returned the raw `returnUrl` when `window` was unavailable, disabling the same-origin guard server-side. It now validates against a reserved placeholder origin during SSR, so absolute (`https://evil`) and protocol-relative (`//evil`) URLs fall back in **both** client and server contexts. `getAbsoluteAuthRedirectUrl` and `buildAuthCallbackUrl` SSR branches route through the unified sanitizer.

## Problem

#3179 fixed social OAuth by anchoring `buildAuthCallbackUrl` to `window.location.origin`. Other `authClient` calls still passed relative paths (`/chat`, `/`) via `getValidAuthRedirectUrl`. Core resolves those against the auth-server origin — session is created, redirect is wrong.

## Test plan

- [x] `pnpm --filter web test src/lib/auth/__tests__/auth.utils.test.ts` (32 tests, incl. SSR open-redirect rejection for `getAbsoluteAuthRedirectUrl`, `buildAuthCallbackUrl`, `normalizeAuthReturnUrl`)
- [x] `pnpm --filter web test src/lib/utils/__tests__/url.test.ts`
- [x] `pnpm --filter web test src/app/(auth)/components/__tests__/social-buttons.test.tsx`
- [x] `pnpm --filter web test src/app/(auth)/components/__tests__/social-signup-auto-initiator.test.tsx`
- [ ] Preprod with flag on: request **new** magic link → lands on `preprod.sokosumi.com/chat` (not Core API host)
- [ ] Email sign-in/sign-up redirect to intended return URL
- [ ] Forgot-password email link opens web reset page
- [ ] Google/Microsoft SSO still works (#3179 regression)


Made with [Cursor](https://cursor.com)
