### PR TITLE
refactor(web): initiate subscription checkout via server actions

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
@@ -7,8 +7,8 @@ const pushMock = vi.fn();
 const trackMock = vi.fn();
 const completeOnboardingMock = vi.fn();
 const markSubscriptionOnboardingGateSessionSeenMock = vi.fn();
-const upgradeOrganizationSubscriptionClientMock = vi.fn();
-const upgradePersonalSubscriptionClientMock = vi.fn();
+const upgradeOrganizationSubscriptionMock = vi.fn();
+const upgradePersonalSubscriptionMock = vi.fn();
 
 vi.mock("@vercel/analytics", () => ({
   track: (...args: unknown[]) => trackMock(...args),
@@ -82,11 +82,11 @@ vi.mock("@/lib/actions/onboarding", () => ({
     markSubscriptionOnboardingGateSessionSeenMock(...args),
 }));
 
-vi.mock("@/lib/auth/subscription.client", () => ({
-  upgradeOrganizationSubscriptionClient: (...args: unknown[]) =>
-    upgradeOrganizationSubscriptionClientMock(...args),
-  upgradePersonalSubscriptionClient: (...args: unknown[]) =>
-    upgradePersonalSubscriptionClientMock(...args),
+vi.mock("@/lib/actions/subscription", () => ({
+  upgradeOrganizationSubscription: (...args: unknown[]) =>
+    upgradeOrganizationSubscriptionMock(...args),
+  upgradePersonalSubscription: (...args: unknown[]) =>
+    upgradePersonalSubscriptionMock(...args),
 }));
 
 import { OnboardingDialog } from "../onboarding-dialog";
@@ -122,11 +122,11 @@ describe("OnboardingDialog organization subscription", () => {
       data: { redirectUrl: "/tasks" },
       ok: true,
     });
-    upgradeOrganizationSubscriptionClientMock.mockResolvedValue({
+    upgradeOrganizationSubscriptionMock.mockResolvedValue({
       data: { mode: "complete" },
       ok: true,
     });
-    upgradePersonalSubscriptionClientMock.mockResolvedValue({
+    upgradePersonalSubscriptionMock.mockResolvedValue({
       data: { mode: "complete" },
       ok: true,
     });
@@ -177,7 +177,7 @@ describe("OnboardingDialog organization subscription", () => {
     );
 
     await waitFor(() => {
-      expect(upgradeOrganizationSubscriptionClientMock).toHaveBeenCalledWith({
+      expect(upgradeOrganizationSubscriptionMock).toHaveBeenCalledWith({
         organizationId: "org-1",
         plan: "standard",
         returnPath: "/tasks?onboarding_subscription=1",
@@ -211,7 +211,7 @@ describe("OnboardingDialog organization subscription", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Errors.badInput");
     });
-    expect(upgradeOrganizationSubscriptionClientMock).not.toHaveBeenCalled();
+    expect(upgradeOrganizationSubscriptionMock).not.toHaveBeenCalled();
   });
 
   it("opens once for a new subscription-only login and stores the login id", async () => {
@@ -281,7 +281,7 @@ describe("OnboardingDialog organization subscription", () => {
       ).not.toHaveBeenCalled();
     });
     expect(completeOnboardingMock).not.toHaveBeenCalled();
-    expect(upgradePersonalSubscriptionClientMock).not.toHaveBeenCalled();
-    expect(upgradeOrganizationSubscriptionClientMock).not.toHaveBeenCalled();
+    expect(upgradePersonalSubscriptionMock).not.toHaveBeenCalled();
+    expect(upgradeOrganizationSubscriptionMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/components/onboarding-dialog.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog.tsx
@@ -37,9 +37,9 @@ import {
   markSubscriptionOnboardingGateSessionSeen,
 } from "@/lib/actions/onboarding";
 import {
-  upgradeOrganizationSubscriptionClient,
-  upgradePersonalSubscriptionClient,
-} from "@/lib/auth/subscription.client";
+  upgradeOrganizationSubscription,
+  upgradePersonalSubscription,
+} from "@/lib/actions/subscription";
 
 const INTRO_STEP_COUNT = 5;
 const DEFAULT_SELECTED_PLAN: PaidSubscriptionPlanName = "standard";
@@ -568,13 +568,13 @@ export function OnboardingDialog({
 
     try {
       const result = organizationId
-        ? await upgradeOrganizationSubscriptionClient({
+        ? await upgradeOrganizationSubscription({
             organizationId,
             plan: selectedPlan,
             returnPath: "/tasks?onboarding_subscription=1",
             seats: targetSeats,
           })
-        : await upgradePersonalSubscriptionClient({
+        : await upgradePersonalSubscription({
             plan: selectedPlan,
             returnPath: "/tasks?onboarding_subscription=1",
           });

--- a/apps/web/src/components/billing/__tests__/organization-subscription-section.test.tsx
+++ b/apps/web/src/components/billing/__tests__/organization-subscription-section.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const refreshMock = vi.fn();
 const pushMock = vi.fn();
 const updateOrganizationSubscriptionSeatsMock = vi.fn();
-const upgradeOrganizationSubscriptionClientMock = vi.fn();
+const upgradeOrganizationSubscriptionMock = vi.fn();
 const subscriptionPlanCardMock = vi.fn();
 const subscriptionEnterprisePlanCardMock = vi.fn();
 const subscriptionFreePlanRowMock = vi.fn();
@@ -35,11 +35,8 @@ vi.mock("sonner", () => ({
 vi.mock("@/lib/actions/subscription", () => ({
   updateOrganizationSubscriptionSeats: (...args: unknown[]) =>
     updateOrganizationSubscriptionSeatsMock(...args),
-}));
-
-vi.mock("@/lib/auth/subscription.client", () => ({
-  upgradeOrganizationSubscriptionClient: (...args: unknown[]) =>
-    upgradeOrganizationSubscriptionClientMock(...args),
+  upgradeOrganizationSubscription: (...args: unknown[]) =>
+    upgradeOrganizationSubscriptionMock(...args),
 }));
 
 vi.mock("../subscription-plan-card", () => ({
@@ -98,7 +95,7 @@ describe("OrganizationSubscriptionSection", () => {
       data: { seats: 3 },
       ok: true,
     });
-    upgradeOrganizationSubscriptionClientMock.mockResolvedValue({
+    upgradeOrganizationSubscriptionMock.mockResolvedValue({
       data: { mode: "redirect", url: "https://checkout.stripe.com/test" },
       ok: true,
     });
@@ -270,7 +267,7 @@ describe("OrganizationSubscriptionSection", () => {
     await currentPlanProps?.onAction("standard");
 
     await waitFor(() => {
-      expect(upgradeOrganizationSubscriptionClientMock).toHaveBeenCalledWith({
+      expect(upgradeOrganizationSubscriptionMock).toHaveBeenCalledWith({
         organizationId: "org-1",
         plan: "standard",
         returnPath: "/billing?tab=subscription",
@@ -280,7 +277,7 @@ describe("OrganizationSubscriptionSection", () => {
   });
 
   it("shows success toast and refreshes when upgrade completes without checkout redirect", async () => {
-    upgradeOrganizationSubscriptionClientMock.mockResolvedValue({
+    upgradeOrganizationSubscriptionMock.mockResolvedValue({
       data: { mode: "complete" },
       ok: true,
     });

--- a/apps/web/src/components/billing/__tests__/personal-subscription-section.test.tsx
+++ b/apps/web/src/components/billing/__tests__/personal-subscription-section.test.tsx
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const refreshMock = vi.fn();
-const upgradePersonalSubscriptionClientMock = vi.fn();
+const upgradePersonalSubscriptionMock = vi.fn();
 const subscriptionPlanCardMock = vi.fn();
 const subscriptionFreePlanRowMock = vi.fn();
 
@@ -28,9 +28,9 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("@/lib/auth/subscription.client", () => ({
-  upgradePersonalSubscriptionClient: (...args: unknown[]) =>
-    upgradePersonalSubscriptionClientMock(...args),
+vi.mock("@/lib/actions/subscription", () => ({
+  upgradePersonalSubscription: (...args: unknown[]) =>
+    upgradePersonalSubscriptionMock(...args),
 }));
 
 vi.mock("../subscription-plan-card", () => ({
@@ -78,7 +78,7 @@ function createPlans() {
 describe("PersonalSubscriptionSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    upgradePersonalSubscriptionClientMock.mockResolvedValue({
+    upgradePersonalSubscriptionMock.mockResolvedValue({
       data: { mode: "redirect", url: "https://checkout.stripe.com/test" },
       ok: true,
     });
@@ -153,7 +153,7 @@ describe("PersonalSubscriptionSection", () => {
     await currentPlanProps?.onAction("standard");
 
     await waitFor(() => {
-      expect(upgradePersonalSubscriptionClientMock).toHaveBeenCalledWith({
+      expect(upgradePersonalSubscriptionMock).toHaveBeenCalledWith({
         plan: "standard",
         returnPath: "/billing?tab=subscription",
       });
@@ -161,7 +161,7 @@ describe("PersonalSubscriptionSection", () => {
   });
 
   it("shows success toast and refreshes when upgrade completes without checkout redirect", async () => {
-    upgradePersonalSubscriptionClientMock.mockResolvedValue({
+    upgradePersonalSubscriptionMock.mockResolvedValue({
       data: { mode: "complete" },
       ok: true,
     });

--- a/apps/web/src/components/billing/balance-billing-portal-link.tsx
+++ b/apps/web/src/components/billing/balance-billing-portal-link.tsx
@@ -8,9 +8,9 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { CommonErrorCode } from "@/lib/actions";
 import {
-  openOrganizationBillingPortalClient,
-  openPersonalBillingPortalClient,
-} from "@/lib/auth/subscription.client";
+  openOrganizationBillingPortal,
+  openPersonalBillingPortal,
+} from "@/lib/actions/subscription";
 
 interface BalanceBillingPortalLinkProps {
   baseReturnPath?: string;
@@ -56,11 +56,11 @@ export function BalanceBillingPortalLink({
     try {
       const resolvedReturnPath = resolveReturnPath();
       const result = organizationId
-        ? await openOrganizationBillingPortalClient({
+        ? await openOrganizationBillingPortal({
             organizationId,
             returnPath: resolvedReturnPath,
           })
-        : await openPersonalBillingPortalClient({
+        : await openPersonalBillingPortal({
             returnPath: resolvedReturnPath,
           });
 

--- a/apps/web/src/components/billing/organization-subscription-section.tsx
+++ b/apps/web/src/components/billing/organization-subscription-section.tsx
@@ -11,8 +11,10 @@ import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { CommonErrorCode } from "@/lib/actions/errors";
 import { OrganizationErrorCode } from "@/lib/actions/errors/error-codes";
-import { updateOrganizationSubscriptionSeats } from "@/lib/actions/subscription";
-import { upgradeOrganizationSubscriptionClient } from "@/lib/auth/subscription.client";
+import {
+  updateOrganizationSubscriptionSeats,
+  upgradeOrganizationSubscription,
+} from "@/lib/actions/subscription";
 import {
   OrganizationSeatSettingsFields,
   resolveMinimumOrganizationSeats,
@@ -180,7 +182,7 @@ export function OrganizationSubscriptionSection({
           return;
         }
 
-        const result = await upgradeOrganizationSubscriptionClient({
+        const result = await upgradeOrganizationSubscription({
           organizationId,
           plan: planName,
           returnPath,

--- a/apps/web/src/components/billing/personal-subscription-section.tsx
+++ b/apps/web/src/components/billing/personal-subscription-section.tsx
@@ -10,7 +10,7 @@ import { useFormatter, useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { CommonErrorCode } from "@/lib/actions/errors";
-import { upgradePersonalSubscriptionClient } from "@/lib/auth/subscription.client";
+import { upgradePersonalSubscription } from "@/lib/actions/subscription";
 
 import { SubscriptionFreePlanRow } from "./subscription-free-plan-row";
 import { SubscriptionPlanCard } from "./subscription-plan-card";
@@ -85,7 +85,7 @@ export function PersonalSubscriptionSection({
   async function handlePlanAction(plan: PaidSubscriptionPlanName) {
     setPendingPlan(plan);
     try {
-      const result = await upgradePersonalSubscriptionClient({
+      const result = await upgradePersonalSubscription({
         plan,
         returnPath,
       });

--- a/apps/web/src/lib/actions/subscription/action.ts
+++ b/apps/web/src/lib/actions/subscription/action.ts
@@ -1,18 +1,75 @@
 "use server";
 
 import { OrganizationSubscriptionExclusivityError } from "@sokosumi/database/helpers";
+import type { PaidSubscriptionPlanName } from "@sokosumi/utils";
 import * as z from "zod";
 import {
   type ActionError,
   betterAuthApiErrorSchema,
   CommonErrorCode,
 } from "@/lib/actions/errors";
+import type { SubscriptionChangeResult } from "@/lib/auth/subscription.server";
+import {
+  openOrganizationBillingPortalServer,
+  openPersonalBillingPortalServer,
+  upgradeOrganizationSubscriptionServer,
+  upgradePersonalSubscriptionServer,
+} from "@/lib/auth/subscription.server";
 import { organizationSubscriptionService } from "@/lib/services";
 import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
 } from "@/middleware/auth-middleware";
+
+export type { SubscriptionChangeResult } from "@/lib/auth/subscription.server";
+
+export async function upgradePersonalSubscription({
+  plan,
+  returnPath,
+}: {
+  plan: PaidSubscriptionPlanName;
+  returnPath?: string;
+}): Promise<Result<SubscriptionChangeResult, ActionError>> {
+  return upgradePersonalSubscriptionServer({ plan, returnPath });
+}
+
+export async function upgradeOrganizationSubscription({
+  organizationId,
+  plan,
+  returnPath,
+  seats,
+}: {
+  organizationId: string;
+  plan: PaidSubscriptionPlanName;
+  returnPath: string;
+  seats: number;
+}): Promise<Result<SubscriptionChangeResult, ActionError>> {
+  return upgradeOrganizationSubscriptionServer({
+    organizationId,
+    plan,
+    returnPath,
+    seats,
+  });
+}
+
+export async function openPersonalBillingPortal({
+  returnPath,
+}: {
+  returnPath?: string;
+}): Promise<Result<{ url: string }, ActionError>> {
+  return openPersonalBillingPortalServer({ returnPath });
+}
+
+export async function openOrganizationBillingPortal({
+  organizationId,
+  returnPath,
+}: {
+  organizationId: string;
+  returnPath: string;
+}): Promise<Result<{ url: string }, ActionError>> {
+  return openOrganizationBillingPortalServer({ organizationId, returnPath });
+}
 
 const updateOrganizationSubscriptionSeatsSchema = z.object({
   organizationId: z.string().min(1),

--- a/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
   getAbsoluteAuthRedirectUrl,
+  getAbsoluteRedirectUrlForOrigin,
   getAuthOAuthRedirect,
   normalizeAuthReturnUrl,
   waitForAuthSession,
@@ -174,6 +175,29 @@ describe("getAbsoluteAuthRedirectUrl", () => {
     vi.stubGlobal("window", undefined);
 
     expect(getAbsoluteAuthRedirectUrl("//evil.com", "/chat")).toBe("/chat");
+  });
+});
+
+describe("getAbsoluteRedirectUrlForOrigin", () => {
+  it("anchors a safe relative path to the provided origin", () => {
+    expect(
+      getAbsoluteRedirectUrlForOrigin(
+        "https://preprod.sokosumi.com",
+        "/billing?tab=subscription&status=success",
+      ),
+    ).toBe(
+      "https://preprod.sokosumi.com/billing?tab=subscription&status=success",
+    );
+  });
+
+  it("rejects external returnUrl values", () => {
+    expect(
+      getAbsoluteRedirectUrlForOrigin(
+        "https://preprod.sokosumi.com",
+        "https://evil.example/attack",
+        "/billing",
+      ),
+    ).toBe("https://preprod.sokosumi.com/billing");
   });
 });
 

--- a/apps/web/src/lib/auth/__tests__/subscription.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/subscription.server.test.ts
@@ -3,36 +3,49 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const subscriptionUpgradeMock = vi.fn();
 const subscriptionBillingPortalMock = vi.fn();
 const clearSubscriptionOnboardingGateSessionCookieMock = vi.fn();
+const headersMock = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  headers: (...args: unknown[]) => headersMock(...args),
+}));
 
 vi.mock("@/lib/actions/onboarding", () => ({
   clearSubscriptionOnboardingGateSessionCookie:
     clearSubscriptionOnboardingGateSessionCookieMock,
 }));
 
-vi.mock("@/lib/auth/auth.client", () => ({
-  subscription: {
-    billingPortal: (...args: unknown[]) =>
-      subscriptionBillingPortalMock(...args),
-    upgrade: (...args: unknown[]) => subscriptionUpgradeMock(...args),
-  },
+vi.mock("@/lib/auth/auth.server.client", () => ({
+  getAuthServerClient: () => ({
+    subscription: {
+      billingPortal: (...args: unknown[]) =>
+        subscriptionBillingPortalMock(...args),
+      upgrade: (...args: unknown[]) => subscriptionUpgradeMock(...args),
+    },
+  }),
+  resolveWebRequestOrigin: () => "https://preprod.sokosumi.com",
 }));
 
-describe("subscription client", () => {
+describe("subscription.server", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    headersMock.mockResolvedValue(
+      new Headers({ origin: "https://preprod.sokosumi.com" }),
+    );
   });
 
-  it("returns checkout url from authClient.subscription.upgrade for personal plans", async () => {
+  it("returns checkout url from Core auth subscription.upgrade for personal plans", async () => {
     subscriptionUpgradeMock.mockResolvedValue({
       data: { url: "https://checkout.stripe.com/session/test" },
       error: null,
     });
 
-    const { upgradePersonalSubscriptionClient } = await import(
-      "../subscription.client"
+    const { upgradePersonalSubscriptionServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await upgradePersonalSubscriptionClient({
+    const result = await upgradePersonalSubscriptionServer({
       plan: "starter",
     });
 
@@ -44,19 +57,21 @@ describe("subscription client", () => {
       ok: true,
     });
     expect(subscriptionUpgradeMock).toHaveBeenCalledWith({
-      cancelUrl: "/billing?tab=subscription&status=cancel",
+      cancelUrl:
+        "https://preprod.sokosumi.com/billing?tab=subscription&status=cancel",
       customerType: "user",
       disableRedirect: true,
       plan: "starter",
-      returnUrl: "/billing?tab=subscription",
-      successUrl: "/billing?tab=subscription&status=success",
+      returnUrl: "https://preprod.sokosumi.com/billing?tab=subscription",
+      successUrl:
+        "https://preprod.sokosumi.com/billing?tab=subscription&status=success",
     });
     expect(
       clearSubscriptionOnboardingGateSessionCookieMock,
     ).toHaveBeenCalledTimes(1);
   });
 
-  it("maps authClient upgrade errors by status without leaking the raw message", async () => {
+  it("maps auth client upgrade errors by status without leaking the raw message", async () => {
     subscriptionUpgradeMock.mockResolvedValue({
       data: null,
       error: {
@@ -66,30 +81,26 @@ describe("subscription client", () => {
       },
     });
 
-    const { upgradePersonalSubscriptionClient } = await import(
-      "../subscription.client"
+    const { upgradePersonalSubscriptionServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await upgradePersonalSubscriptionClient({
+    const result = await upgradePersonalSubscriptionServer({
       plan: "pro",
     });
 
-    // The raw Stripe / Better Auth message is never forwarded; the status is
-    // mapped to a CommonErrorCode the UI localizes.
     expect(result).toEqual({
       error: {
         code: "BAD_INPUT",
       },
       ok: false,
     });
-    // A failed checkout must not clear the onboarding gate, otherwise the gate
-    // is permanently suppressed without the user completing checkout.
     expect(
       clearSubscriptionOnboardingGateSessionCookieMock,
     ).not.toHaveBeenCalled();
   });
 
-  it("maps a 401 authClient error to UNAUTHENTICATED so the login affordance fires", async () => {
+  it("maps a 401 auth client error to UNAUTHENTICATED so the login affordance fires", async () => {
     subscriptionUpgradeMock.mockResolvedValue({
       data: null,
       error: {
@@ -99,11 +110,11 @@ describe("subscription client", () => {
       },
     });
 
-    const { upgradePersonalSubscriptionClient } = await import(
-      "../subscription.client"
+    const { upgradePersonalSubscriptionServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await upgradePersonalSubscriptionClient({
+    const result = await upgradePersonalSubscriptionServer({
       plan: "pro",
     });
 
@@ -125,19 +136,17 @@ describe("subscription client", () => {
       },
     });
 
-    const { upgradeOrganizationSubscriptionClient } = await import(
-      "../subscription.client"
+    const { upgradeOrganizationSubscriptionServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await upgradeOrganizationSubscriptionClient({
+    const result = await upgradeOrganizationSubscriptionServer({
       organizationId: "org-1",
       plan: "pro",
       returnPath: "/organizations/acme",
       seats: 7,
     });
 
-    // The app-defined enterprise code is preserved (no raw message) so the org
-    // section can render a localized explanation.
     expect(result).toEqual({
       error: {
         code: "ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE",
@@ -149,17 +158,17 @@ describe("subscription client", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("returns billing portal url from authClient.subscription.billingPortal", async () => {
+  it("returns billing portal url from Core auth subscription.billingPortal", async () => {
     subscriptionBillingPortalMock.mockResolvedValue({
       data: { url: "https://billing.stripe.com/session/test" },
       error: null,
     });
 
-    const { openPersonalBillingPortalClient } = await import(
-      "../subscription.client"
+    const { openPersonalBillingPortalServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await openPersonalBillingPortalClient({
+    const result = await openPersonalBillingPortalServer({
       returnPath: "/billing?tab=coupon",
     });
 
@@ -170,7 +179,7 @@ describe("subscription client", () => {
     expect(subscriptionBillingPortalMock).toHaveBeenCalledWith({
       customerType: "user",
       disableRedirect: true,
-      returnUrl: "/billing?tab=coupon",
+      returnUrl: "https://preprod.sokosumi.com/billing?tab=coupon",
     });
     expect(
       clearSubscriptionOnboardingGateSessionCookieMock,
@@ -183,11 +192,11 @@ describe("subscription client", () => {
       error: null,
     });
 
-    const { upgradeOrganizationSubscriptionClient } = await import(
-      "../subscription.client"
+    const { upgradeOrganizationSubscriptionServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await upgradeOrganizationSubscriptionClient({
+    const result = await upgradeOrganizationSubscriptionServer({
       organizationId: "org-1",
       plan: "pro",
       returnPath: "/organizations/acme",
@@ -202,14 +211,16 @@ describe("subscription client", () => {
       ok: true,
     });
     expect(subscriptionUpgradeMock).toHaveBeenCalledWith({
-      cancelUrl: "/organizations/acme?status=cancel",
+      cancelUrl:
+        "https://preprod.sokosumi.com/organizations/acme?status=cancel",
       customerType: "organization",
       disableRedirect: true,
       plan: "pro",
       referenceId: "org-1",
-      returnUrl: "/organizations/acme",
+      returnUrl: "https://preprod.sokosumi.com/organizations/acme",
       seats: 7,
-      successUrl: "/organizations/acme?status=success",
+      successUrl:
+        "https://preprod.sokosumi.com/organizations/acme?status=success",
     });
     expect(
       clearSubscriptionOnboardingGateSessionCookieMock,
@@ -222,11 +233,11 @@ describe("subscription client", () => {
       error: null,
     });
 
-    const { openOrganizationBillingPortalClient } = await import(
-      "../subscription.client"
+    const { openOrganizationBillingPortalServer } = await import(
+      "../subscription.server"
     );
 
-    const result = await openOrganizationBillingPortalClient({
+    const result = await openOrganizationBillingPortalServer({
       organizationId: "org-1",
       returnPath: "/organizations/acme",
     });
@@ -239,7 +250,7 @@ describe("subscription client", () => {
       customerType: "organization",
       disableRedirect: true,
       referenceId: "org-1",
-      returnUrl: "/organizations/acme",
+      returnUrl: "https://preprod.sokosumi.com/organizations/acme",
     });
   });
 });

--- a/apps/web/src/lib/auth/__tests__/subscription.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/subscription.server.test.ts
@@ -4,6 +4,9 @@ const subscriptionUpgradeMock = vi.fn();
 const subscriptionBillingPortalMock = vi.fn();
 const clearSubscriptionOnboardingGateSessionCookieMock = vi.fn();
 const headersMock = vi.fn();
+const resolveWebRequestOriginMock = vi.fn(
+  () => "https://preprod.sokosumi.com" as string | undefined,
+);
 
 vi.mock("server-only", () => ({}));
 
@@ -24,12 +27,13 @@ vi.mock("@/lib/auth/auth.server.client", () => ({
       upgrade: (...args: unknown[]) => subscriptionUpgradeMock(...args),
     },
   }),
-  resolveWebRequestOrigin: () => "https://preprod.sokosumi.com",
+  resolveWebRequestOrigin: () => resolveWebRequestOriginMock(),
 }));
 
 describe("subscription.server", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveWebRequestOriginMock.mockReturnValue("https://preprod.sokosumi.com");
     headersMock.mockResolvedValue(
       new Headers({ origin: "https://preprod.sokosumi.com" }),
     );
@@ -252,5 +256,48 @@ describe("subscription.server", () => {
       referenceId: "org-1",
       returnUrl: "https://preprod.sokosumi.com/organizations/acme",
     });
+  });
+
+  it("fails an upgrade with INTERNAL_SERVER_ERROR when the request origin is unavailable", async () => {
+    resolveWebRequestOriginMock.mockReturnValue(undefined);
+
+    const { upgradePersonalSubscriptionServer } = await import(
+      "../subscription.server"
+    );
+
+    const result = await upgradePersonalSubscriptionServer({
+      plan: "starter",
+    });
+
+    expect(result).toEqual({
+      error: {
+        code: "INTERNAL_SERVER_ERROR",
+      },
+      ok: false,
+    });
+    expect(subscriptionUpgradeMock).not.toHaveBeenCalled();
+    expect(
+      clearSubscriptionOnboardingGateSessionCookieMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("fails a billing-portal open with INTERNAL_SERVER_ERROR when the request origin is unavailable", async () => {
+    resolveWebRequestOriginMock.mockReturnValue(undefined);
+
+    const { openPersonalBillingPortalServer } = await import(
+      "../subscription.server"
+    );
+
+    const result = await openPersonalBillingPortalServer({
+      returnPath: "/billing?tab=coupon",
+    });
+
+    expect(result).toEqual({
+      error: {
+        code: "INTERNAL_SERVER_ERROR",
+      },
+      ok: false,
+    });
+    expect(subscriptionBillingPortalMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auth/auth.server.client.ts
+++ b/apps/web/src/lib/auth/auth.server.client.ts
@@ -24,7 +24,9 @@ export function getCoreAuthBaseUrl(): string {
  * to the web app's own host — app.sokosumi.com, *.preview.sokosumi.com, or
  * localhost — which Core lists in its trusted origins.
  */
-function resolveCallerOrigin(requestHeaders: Headers): string | undefined {
+export function resolveWebRequestOrigin(
+  requestHeaders: Headers,
+): string | undefined {
   const explicitOrigin = requestHeaders.get("origin");
   if (explicitOrigin) {
     return explicitOrigin;
@@ -60,7 +62,7 @@ export async function fetchCoreAuth(
   // Origin ("Missing or null Origin"). Server-to-server fetches carry no
   // browser Origin, so forward the caller's origin explicitly.
   if (!mergedHeaders.has("origin")) {
-    const origin = resolveCallerOrigin(requestHeaders);
+    const origin = resolveWebRequestOrigin(requestHeaders);
     if (origin) {
       mergedHeaders.set("origin", origin);
     }

--- a/apps/web/src/lib/auth/auth.utils.ts
+++ b/apps/web/src/lib/auth/auth.utils.ts
@@ -160,18 +160,49 @@ function sanitizeAuthRedirectPath(
  * so `/chat` becomes `https://api.preprod…/chat` instead of the web app.
  * Falls back to a relative path when `window` is unavailable (SSR).
  */
+export function sanitizeAuthRedirectPathForOrigin(
+  returnUrl: string | undefined,
+  origin: string,
+  fallback: string = "/",
+): string {
+  if (!returnUrl) {
+    return fallback;
+  }
+
+  try {
+    const parsedUrl = new URL(returnUrl, origin);
+    return parsedUrl.origin === origin ? returnUrl : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function getAbsoluteRedirectUrlForOrigin(
+  origin: string,
+  returnUrl: string | undefined,
+  fallback: string = "/",
+): string {
+  const safePath = sanitizeAuthRedirectPathForOrigin(
+    returnUrl,
+    origin,
+    fallback,
+  );
+  return new URL(safePath, origin).href;
+}
+
 export function getAbsoluteAuthRedirectUrl(
   returnUrl: string | undefined,
   fallback: string = "/",
 ): string {
-  const safePath = sanitizeAuthRedirectPath(returnUrl, fallback);
-
-  // No origin to anchor to during SSR; return the sanitized relative path.
   if (typeof window === "undefined") {
-    return safePath;
+    return sanitizeAuthRedirectPath(returnUrl, fallback);
   }
 
-  return new URL(safePath, window.location.origin).href;
+  return getAbsoluteRedirectUrlForOrigin(
+    window.location.origin,
+    returnUrl,
+    fallback,
+  );
 }
 
 /**

--- a/apps/web/src/lib/auth/subscription.server.ts
+++ b/apps/web/src/lib/auth/subscription.server.ts
@@ -1,11 +1,15 @@
-"use client";
+import "server-only";
 
 import type { PaidSubscriptionPlanName } from "@sokosumi/utils";
-
+import { headers } from "next/headers";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { OrganizationErrorCode } from "@/lib/actions/errors/error-codes";
 import { clearSubscriptionOnboardingGateSessionCookie } from "@/lib/actions/onboarding";
-import { subscription } from "@/lib/auth/auth.client";
+import {
+  getAuthServerClient,
+  resolveWebRequestOrigin,
+} from "@/lib/auth/auth.server.client";
+import { getAbsoluteRedirectUrlForOrigin } from "@/lib/auth/auth.utils";
 import { buildSubscriptionStatusPath } from "@/lib/stripe/subscription-redirect-urls";
 import { Err, Ok, type Result } from "@/lib/ts-res";
 
@@ -20,16 +24,8 @@ interface BetterAuthClientError {
 }
 
 function mapAuthClientError(error: BetterAuthClientError): ActionError {
-  // Surface the real error for debugging (browser console) without leaking it
-  // into the UI — these errors come straight from Stripe / Better Auth and
-  // their messages may expose internal details.
   console.error("[subscription] auth client error", error);
 
-  // App-defined codes are safe to pass through so the UI can localize them
-  // (e.g. the enterprise-contract exclusivity error thrown by
-  // authorizeReference). Everything else routes on the HTTP status, with no
-  // raw message forwarded; a 401 maps to UNAUTHENTICATED so the "log in"
-  // affordance fires.
   if (
     error.code ===
     OrganizationErrorCode.ORGANIZATION_ENTERPRISE_CONTRACT_EXCLUSIVE
@@ -59,7 +55,41 @@ function resolveUpgradeResult(
   return Ok({ mode: "redirect", url: data.url });
 }
 
-export async function upgradePersonalSubscriptionClient({
+async function resolveSubscriptionRedirectUrls(returnPath: string): Promise<
+  Result<
+    {
+      cancelUrl: string;
+      returnUrl: string;
+      successUrl: string;
+    },
+    ActionError
+  >
+> {
+  const requestHeaders = await headers();
+  const origin = resolveWebRequestOrigin(requestHeaders);
+
+  if (!origin) {
+    return Err({
+      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+    });
+  }
+
+  return Ok({
+    cancelUrl: getAbsoluteRedirectUrlForOrigin(
+      origin,
+      buildSubscriptionStatusPath(returnPath, "cancel"),
+      returnPath,
+    ),
+    returnUrl: getAbsoluteRedirectUrlForOrigin(origin, returnPath, returnPath),
+    successUrl: getAbsoluteRedirectUrlForOrigin(
+      origin,
+      buildSubscriptionStatusPath(returnPath, "success"),
+      returnPath,
+    ),
+  });
+}
+
+export async function upgradePersonalSubscriptionServer({
   plan,
   returnPath,
 }: {
@@ -67,13 +97,21 @@ export async function upgradePersonalSubscriptionClient({
   returnPath?: string;
 }): Promise<Result<SubscriptionChangeResult, ActionError>> {
   const resolvedReturnPath = returnPath ?? "/billing?tab=subscription";
+  const redirectUrlsResult =
+    await resolveSubscriptionRedirectUrls(resolvedReturnPath);
 
-  const result = await subscription.upgrade({
+  if (!redirectUrlsResult.ok) {
+    return Err(redirectUrlsResult.error);
+  }
+
+  const redirectUrls = redirectUrlsResult.data;
+
+  const result = await getAuthServerClient().subscription.upgrade({
     plan,
     customerType: "user",
-    successUrl: buildSubscriptionStatusPath(resolvedReturnPath, "success"),
-    cancelUrl: buildSubscriptionStatusPath(resolvedReturnPath, "cancel"),
-    returnUrl: resolvedReturnPath,
+    successUrl: redirectUrls.successUrl,
+    cancelUrl: redirectUrls.cancelUrl,
+    returnUrl: redirectUrls.returnUrl,
     disableRedirect: true,
   });
 
@@ -81,23 +119,27 @@ export async function upgradePersonalSubscriptionClient({
     return Err(mapAuthClientError(result.error));
   }
 
-  // Clear the onboarding gate only after the checkout call succeeds — clearing
-  // it before would permanently suppress the gate if the upgrade call failed.
   await clearSubscriptionOnboardingGateSessionCookie();
 
   return resolveUpgradeResult(result.data);
 }
 
-export async function openPersonalBillingPortalClient({
+export async function openPersonalBillingPortalServer({
   returnPath,
 }: {
   returnPath?: string;
 }): Promise<Result<{ url: string }, ActionError>> {
   const resolvedReturnPath = returnPath ?? "/billing?tab=subscription";
+  const redirectUrlsResult =
+    await resolveSubscriptionRedirectUrls(resolvedReturnPath);
 
-  const result = await subscription.billingPortal({
+  if (!redirectUrlsResult.ok) {
+    return Err(redirectUrlsResult.error);
+  }
+
+  const result = await getAuthServerClient().subscription.billingPortal({
     customerType: "user",
-    returnUrl: resolvedReturnPath,
+    returnUrl: redirectUrlsResult.data.returnUrl,
     disableRedirect: true,
   });
 
@@ -114,7 +156,7 @@ export async function openPersonalBillingPortalClient({
   return Ok({ url: result.data.url });
 }
 
-export async function upgradeOrganizationSubscriptionClient({
+export async function upgradeOrganizationSubscriptionServer({
   organizationId,
   plan,
   returnPath,
@@ -125,14 +167,22 @@ export async function upgradeOrganizationSubscriptionClient({
   returnPath: string;
   seats: number;
 }): Promise<Result<SubscriptionChangeResult, ActionError>> {
-  const result = await subscription.upgrade({
+  const redirectUrlsResult = await resolveSubscriptionRedirectUrls(returnPath);
+
+  if (!redirectUrlsResult.ok) {
+    return Err(redirectUrlsResult.error);
+  }
+
+  const redirectUrls = redirectUrlsResult.data;
+
+  const result = await getAuthServerClient().subscription.upgrade({
     plan,
     customerType: "organization",
     referenceId: organizationId,
     seats,
-    successUrl: buildSubscriptionStatusPath(returnPath, "success"),
-    cancelUrl: buildSubscriptionStatusPath(returnPath, "cancel"),
-    returnUrl: returnPath,
+    successUrl: redirectUrls.successUrl,
+    cancelUrl: redirectUrls.cancelUrl,
+    returnUrl: redirectUrls.returnUrl,
     disableRedirect: true,
   });
 
@@ -140,24 +190,28 @@ export async function upgradeOrganizationSubscriptionClient({
     return Err(mapAuthClientError(result.error));
   }
 
-  // Clear the onboarding gate only after the checkout call succeeds — clearing
-  // it before would permanently suppress the gate if the upgrade call failed.
   await clearSubscriptionOnboardingGateSessionCookie();
 
   return resolveUpgradeResult(result.data);
 }
 
-export async function openOrganizationBillingPortalClient({
+export async function openOrganizationBillingPortalServer({
   organizationId,
   returnPath,
 }: {
   organizationId: string;
   returnPath: string;
 }): Promise<Result<{ url: string }, ActionError>> {
-  const result = await subscription.billingPortal({
+  const redirectUrlsResult = await resolveSubscriptionRedirectUrls(returnPath);
+
+  if (!redirectUrlsResult.ok) {
+    return Err(redirectUrlsResult.error);
+  }
+
+  const result = await getAuthServerClient().subscription.billingPortal({
     customerType: "organization",
     referenceId: organizationId,
-    returnUrl: returnPath,
+    returnUrl: redirectUrlsResult.data.returnUrl,
     disableRedirect: true,
   });
 

--- a/apps/web/src/lib/auth/subscription.server.ts
+++ b/apps/web/src/lib/auth/subscription.server.ts
@@ -17,6 +17,11 @@ export type SubscriptionChangeResult =
   | { mode: "complete" }
   | { mode: "redirect"; url: string };
 
+// A known-safe internal landing page used when the caller's returnPath is
+// rejected by the origin sanitizer. Passing returnPath as its own fallback
+// would re-admit an off-origin value, so anchor to a constant instead.
+const SAFE_REDIRECT_FALLBACK = "/billing?tab=subscription";
+
 interface BetterAuthClientError {
   code?: string;
   message?: string;
@@ -78,13 +83,17 @@ async function resolveSubscriptionRedirectUrls(returnPath: string): Promise<
     cancelUrl: getAbsoluteRedirectUrlForOrigin(
       origin,
       buildSubscriptionStatusPath(returnPath, "cancel"),
-      returnPath,
+      SAFE_REDIRECT_FALLBACK,
     ),
-    returnUrl: getAbsoluteRedirectUrlForOrigin(origin, returnPath, returnPath),
+    returnUrl: getAbsoluteRedirectUrlForOrigin(
+      origin,
+      returnPath,
+      SAFE_REDIRECT_FALLBACK,
+    ),
     successUrl: getAbsoluteRedirectUrlForOrigin(
       origin,
       buildSubscriptionStatusPath(returnPath, "success"),
-      returnPath,
+      SAFE_REDIRECT_FALLBACK,
     ),
   });
 }


### PR DESCRIPTION
## Summary

- Moves subscription upgrade and Stripe billing-portal initiation off the browser `authClient` onto server actions that call Core Better Auth via `getAuthServerClient()`.
- Builds absolute `successUrl`, `cancelUrl`, and `returnUrl` from the incoming web request `Origin`, so post-checkout redirects land on `preprod.sokosumi.com` (not `api.preprod…`).
- Removes `subscription.client.ts`; billing UI now calls `@/lib/actions/subscription`.

## Test plan

- [x] `pnpm --filter web test src/lib/auth/__tests__/subscription.server.test.ts`
- [x] `pnpm --filter web test src/lib/actions/subscription`
- [x] `pnpm --filter web check`
- [ ] On preprod: personal subscription checkout returns to `/billing?tab=subscription&status=success`
- [ ] On preprod: onboarding subscription checkout returns to `/tasks?onboarding_subscription=1&status=success`
- [ ] On preprod: billing portal return lands on the correct web tab/path


Made with [Cursor](https://cursor.com)