### PR TITLE
fix(web): activate org workspace after create and invite accept

### DIFF
--- a/apps/web/src/app/(app)/components/user-avatar/__tests__/workspace-switcher.test.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/__tests__/workspace-switcher.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  activateOrganizationWorkspace,
   getAgentJobsBasePath,
   useWorkspaceSwitcher,
 } from "@/app/components/user-avatar/workspace-switcher";
@@ -57,6 +58,85 @@ describe("workspace switcher", () => {
     vi.mocked(authClient.organization.setActive).mockReset();
     vi.mocked(updatePreferredOrganization).mockReset();
     vi.mocked(toast.success).mockReset();
+  });
+
+  describe("activateOrganizationWorkspace", () => {
+    it("sets the active organization and persists it as preferred", async () => {
+      vi.mocked(authClient.organization.setActive).mockResolvedValueOnce({
+        data: null,
+        error: null,
+      });
+      vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
+        ok: true,
+        data: {
+          organizationId: "org-7",
+        },
+      });
+
+      await activateOrganizationWorkspace("org-7");
+
+      expect(authClient.organization.setActive).toHaveBeenCalledWith({
+        organizationId: "org-7",
+      });
+      expect(updatePreferredOrganization).toHaveBeenCalledWith({
+        organizationId: "org-7",
+      });
+    });
+
+    it("activates the personal workspace when given null", async () => {
+      vi.mocked(authClient.organization.setActive).mockResolvedValueOnce({
+        data: null,
+        error: null,
+      });
+      vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
+        ok: true,
+        data: {
+          organizationId: null,
+        },
+      });
+
+      await activateOrganizationWorkspace(null);
+
+      expect(authClient.organization.setActive).toHaveBeenCalledWith({
+        organizationId: null,
+      });
+      expect(updatePreferredOrganization).toHaveBeenCalledWith({
+        organizationId: null,
+      });
+    });
+
+    it("still resolves when persisting the preferred organization fails", async () => {
+      vi.mocked(authClient.organization.setActive).mockResolvedValueOnce({
+        data: null,
+        error: null,
+      });
+      vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "UNAUTHORIZED",
+        },
+      });
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      await expect(
+        activateOrganizationWorkspace("org-7"),
+      ).resolves.toBeUndefined();
+
+      expect(authClient.organization.setActive).toHaveBeenCalledWith({
+        organizationId: "org-7",
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to persist preferred organization:",
+        {
+          code: "UNAUTHORIZED",
+        },
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
   });
 
   describe("getAgentJobsBasePath", () => {

--- a/apps/web/src/app/(app)/components/user-avatar/workspace-switcher.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/workspace-switcher.tsx
@@ -17,6 +17,29 @@ export function getAgentJobsBasePath(pathname: string): string | null {
   return `/agents/${agentId}/jobs`;
 }
 
+export async function activateOrganizationWorkspace(
+  organizationId: string | null,
+): Promise<void> {
+  await authClient.organization.setActive({
+    organizationId,
+  });
+
+  try {
+    const result = await updatePreferredOrganization({
+      organizationId,
+    });
+
+    if (!result.ok) {
+      console.error(
+        "Failed to persist preferred organization:",
+        result.error,
+      );
+    }
+  } catch (error) {
+    console.error("Failed to persist preferred organization:", error);
+  }
+}
+
 export function useWorkspaceSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
@@ -31,24 +54,7 @@ export function useWorkspaceSwitcher() {
   ) => {
     startTransition(async () => {
       try {
-        await authClient.organization.setActive({
-          organizationId,
-        });
-
-        try {
-          const result = await updatePreferredOrganization({
-            organizationId,
-          });
-
-          if (!result.ok) {
-            console.error(
-              "Failed to persist preferred organization:",
-              result.error,
-            );
-          }
-        } catch (error) {
-          console.error("Failed to persist preferred organization:", error);
-        }
+        await activateOrganizationWorkspace(organizationId);
 
         if (options?.successMessage) {
           toast.success(options.successMessage);

--- a/apps/web/src/app/(app)/components/user-avatar/workspace-switcher.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/workspace-switcher.tsx
@@ -30,10 +30,7 @@ export async function activateOrganizationWorkspace(
     });
 
     if (!result.ok) {
-      console.error(
-        "Failed to persist preferred organization:",
-        result.error,
-      );
+      console.error("Failed to persist preferred organization:", result.error);
     }
   } catch (error) {
     console.error("Failed to persist preferred organization:", error);

--- a/apps/web/src/app/(app)/organizations/[organizationSlug]/components/__tests__/organization-edit-button.test.tsx
+++ b/apps/web/src/app/(app)/organizations/[organizationSlug]/components/__tests__/organization-edit-button.test.tsx
@@ -20,6 +20,14 @@ vi.mock("next/navigation", () => ({
     push: vi.fn(),
     refresh: vi.fn(),
   }),
+  usePathname: () => "/organizations/acme",
+}));
+
+vi.mock("@/app/components/user-avatar/workspace-switcher", () => ({
+  useWorkspaceSwitcher: () => ({
+    isPending: false,
+    handleSelectWorkspace: vi.fn(),
+  }),
 }));
 
 vi.mock("next-intl", () => ({

--- a/apps/web/src/app/(flows)/accept-invitation/[id]/components/invitation-actions.tsx
+++ b/apps/web/src/app/(flows)/accept-invitation/[id]/components/invitation-actions.tsx
@@ -93,9 +93,7 @@ export default function InvitationActions({
       }
     } else {
       try {
-        await activateOrganizationWorkspace(
-          result.data.member.organizationId,
-        );
+        await activateOrganizationWorkspace(result.data.member.organizationId);
       } catch (error) {
         console.error("Failed to switch organization workspace:", error);
       }

--- a/apps/web/src/app/(flows)/accept-invitation/[id]/components/invitation-actions.tsx
+++ b/apps/web/src/app/(flows)/accept-invitation/[id]/components/invitation-actions.tsx
@@ -8,10 +8,10 @@ import { useTranslations } from "next-intl";
 import { useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 
+import { activateOrganizationWorkspace } from "@/app/components/user-avatar/workspace-switcher";
 import { Button } from "@/components/ui/button";
 import { CardFooter } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { updatePreferredOrganization } from "@/lib/actions/organization";
 import { authClient } from "@/lib/auth/auth.client";
 import type { PendingInvitationDetail } from "@/lib/services/organization.service";
 import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
@@ -93,18 +93,11 @@ export default function InvitationActions({
       }
     } else {
       try {
-        const persistenceResult = await updatePreferredOrganization({
-          organizationId: result.data.member.organizationId,
-        });
-
-        if (!persistenceResult.ok) {
-          console.error(
-            "Failed to persist preferred organization:",
-            persistenceResult.error,
-          );
-        }
+        await activateOrganizationWorkspace(
+          result.data.member.organizationId,
+        );
       } catch (error) {
-        console.error("Failed to persist preferred organization:", error);
+        console.error("Failed to switch organization workspace:", error);
       }
 
       toast.success(t("Success.accept"));

--- a/apps/web/src/components/organizations/organization-information/form.tsx
+++ b/apps/web/src/components/organizations/organization-information/form.tsx
@@ -21,6 +21,7 @@ import {
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
+import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
 import { OrganizationLogoUploadField } from "@/components/organizations/organization-logo-upload-field";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,7 +34,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { generateOrganizationSlug } from "@/lib/actions";
-import { updatePreferredOrganization } from "@/lib/actions/organization";
 import { authClient } from "@/lib/auth/auth.client";
 import {
   ORGANIZATION_LOGO_ALLOWED_MIME_TYPES,
@@ -73,6 +73,7 @@ export default function OrganizationInformationForm({
 }: OrganizationInformationFormProps) {
   const t = useTranslations("Components.Organizations.InformationModal.Form");
   const router = useRouter();
+  const { handleSelectWorkspace } = useWorkspaceSwitcher();
   const submitInFlightRef = useRef(false);
   const [pendingLogoFiles, setPendingLogoFiles] = useState<File[]>([]);
   const [isUploadingLogo, setIsUploadingLogo] = useState(false);
@@ -205,23 +206,11 @@ export default function OrganizationInformationForm({
         toast.success(isCreating ? t("Success.create") : t("Success.edit"));
 
         if (isCreating) {
-          try {
-            const persistenceResult = await updatePreferredOrganization({
-              organizationId: result.data.id,
-            });
-
-            if (!persistenceResult.ok) {
-              console.error(
-                "Failed to persist preferred organization:",
-                persistenceResult.error,
-              );
-            }
-          } catch (error) {
-            console.error("Failed to persist preferred organization:", error);
-          }
+          handleSelectWorkspace(result.data.id);
+        } else {
+          router.refresh();
         }
 
-        router.refresh();
         onOpenChange(false);
       }
     } finally {

--- a/apps/web/src/components/organizations/organization-information/form.tsx
+++ b/apps/web/src/components/organizations/organization-information/form.tsx
@@ -206,7 +206,9 @@ export default function OrganizationInformationForm({
         toast.success(isCreating ? t("Success.create") : t("Success.edit"));
 
         if (isCreating) {
-          handleSelectWorkspace(result.data.id);
+          handleSelectWorkspace(result.data.id, {
+            shouldRedirectAgentJobsBasePath: false,
+          });
         } else {
           router.refresh();
         }


### PR DESCRIPTION
## Summary

- After creating an organization, switch the session workspace via `setActive` (not only `updatePreferredOrganization`).
- After accepting an org invitation, do the same before navigating to the organization page.
- Extract `activateOrganizationWorkspace` in `workspace-switcher.tsx` so create, invite accept, and manual switch share one path.

## Test plan

- [x] `pnpm --filter web test src/app/(app)/components/user-avatar/__tests__/workspace-switcher.test.tsx`
- [x] `pnpm --filter web test src/app/(app)/organizations/[organizationSlug]/components/__tests__/`
- [ ] Create org from header switcher → new org shows as active workspace
- [ ] Accept org invite → lands on org page with that workspace active in header


Made with [Cursor](https://cursor.com)