### PR TITLE
feat(chat): make welcome try-asking prompts look actionable

### DIFF
--- a/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
+++ b/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
@@ -2,6 +2,7 @@
 
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
+import { ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type Dispatch, type SetStateAction, useMemo } from "react";
 import {
@@ -179,14 +180,16 @@ export default function WelcomeScreen({
                       type="button"
                       onClick={() => handleSuggestionClick(text)}
                       className={cn(
-                        "border-border/60 bg-muted/30 w-full rounded-xl border px-4 py-3 text-left text-sm",
-                        "hover:border-border hover:bg-muted/50 transition-colors",
+                        "group border-border/60 bg-muted/30 w-full rounded-xl border px-4 py-3 text-left text-sm",
+                        "hover:border-primary hover:bg-muted/50 hover:shadow-sm transition-colors cursor-pointer",
                         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+                        "flex items-center justify-between gap-3",
                       )}
                     >
                       <span className="text-muted-foreground leading-snug">
                         {text}
                       </span>
+                      <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
                     </button>
                   </li>
                 ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes welcome screen "Try asking" suggestion cards visually read as tappable actions with primary-colored borders, pointer cursor, and iOS-style chevron on hover.

## Changes

- Add `ChevronRight` icon from lucide-react
- Use `group` + `group-hover:` pattern for coordinated hover states
- Change hover border from `border` to `primary` color
- Add subtle shadow on hover (`hover:shadow-sm`)
- Add chevron icon with slide animation (`group-hover:translate-x-0.5`)
- Maintain existing stagger animation and focus-visible accessibility styles

## Testing

Manual verification in light and dark mode:
1. Navigate to http://localhost:3000/chat (authenticated)
2. Verify suggestion cards appear below "Try asking" label
3. Hover each card → border turns primary, chevron slides right + darkens, cursor is pointer
4. Click card → prompt sends (existing behavior preserved)
5. Test keyboard focus → focus ring visible and consistent

## Related

Closes SOK-585
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-585](https://linear.app/masumi/issue/SOK-585/improvechat-make-welcome-try-asking-prompts-look-actionable)

<div><a href="https://cursor.com/agents/bc-917d8097-4056-462d-9059-af5a6204fb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-917d8097-4056-462d-9059-af5a6204fb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

