### PR TITLE
chore(deps): bump pnpm to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokosumi",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.6.0",
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "dev": "pnpm -r dev",
     "web:dev": "pnpm --filter web dev",


### PR DESCRIPTION
## Summary

Bumps the workspace `packageManager` pin from `pnpm@11.6.0` to `pnpm@11.7.0`. This is the only pnpm version pin in the repo; CI and corepack read it directly, and the `engines` fields pin only Node.

## Verification

- `corepack pnpm@11.7.0 install --frozen-lockfile` — passed; lockfile unchanged, no regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)