### PR TITLE
feat(core): add unified Stripe webhook behind USE_UNIFIED_STRIPE_WEBHOOK

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -64,8 +64,14 @@ STRIPE_SUPPORT_COUPON="<stripe-support-coupon>"
 STRIPE_WEBHOOK_SECRET="<stripe-webhook-secret>"
 
 # Signing secret for Better Auth Stripe plugin (POST /auth/stripe/webhook).
-# Separate Stripe Dashboard endpoint while testing Core auth cutover.
+# Used while USE_UNIFIED_STRIPE_WEBHOOK=false (split endpoints).
 STRIPE_BA_WEBHOOK_SECRET="<stripe-better-auth-webhook-secret>"
+
+# When true, Stripe Dashboard should send all events to POST /auth/stripe/webhook
+# only (use STRIPE_WEBHOOK_SECRET). Billing events are handled from auth onEvent;
+# POST /webhooks/stripe returns 410. Flip together with web
+# NEXT_PUBLIC_USE_CORE_AUTH_CLIENT=true.
+USE_UNIFIED_STRIPE_WEBHOOK="false"
 LOCK_TIMEOUT="120000"
 LOCK_TIMEOUT_BUFFER="25000"
 INSTANCE_ID="<instance-id>"

--- a/apps/core/scripts/write-openapi-for-web.mts
+++ b/apps/core/scripts/write-openapi-for-web.mts
@@ -37,6 +37,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_SUPPORT_COUPON: "coupon_support_test",
   STRIPE_WEBHOOK_SECRET: "whsec_test_example",
   STRIPE_BA_WEBHOOK_SECRET: "whsec_ba_test_example",
+  USE_UNIFIED_STRIPE_WEBHOOK: "false",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",
   INSTANCE_ID: "test-instance-id",

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -122,6 +122,14 @@ const envSchema = z.object({
   // Signing secret for Better Auth Stripe plugin (POST /auth/stripe/webhook).
   STRIPE_BA_WEBHOOK_SECRET: z.string().min(1),
 
+  // When true, Stripe Dashboard should send all events to POST /auth/stripe/webhook
+  // only (STRIPE_WEBHOOK_SECRET). Billing events are handled from auth onEvent and
+  // POST /webhooks/stripe is disabled. Flip with web NEXT_PUBLIC_USE_CORE_AUTH_CLIENT.
+  USE_UNIFIED_STRIPE_WEBHOOK: z
+    .string()
+    .default("false")
+    .transform((val: string) => val.trim().toLowerCase() === "true"),
+
   // Sync lock configuration
   LOCK_TIMEOUT: z.coerce
     .number()

--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -125,10 +125,7 @@ const envSchema = z.object({
   // When true, Stripe Dashboard should send all events to POST /auth/stripe/webhook
   // only (STRIPE_WEBHOOK_SECRET). Billing events are handled from auth onEvent and
   // POST /webhooks/stripe is disabled. Flip with web NEXT_PUBLIC_USE_CORE_AUTH_CLIENT.
-  USE_UNIFIED_STRIPE_WEBHOOK: z
-    .string()
-    .default("false")
-    .transform((val: string) => val.trim().toLowerCase() === "true"),
+  USE_UNIFIED_STRIPE_WEBHOOK: z.stringbool().default(false),
 
   // Sync lock configuration
   LOCK_TIMEOUT: z.coerce

--- a/apps/core/src/lib/__tests__/stripe-auth-webhook-on-event.test.ts
+++ b/apps/core/src/lib/__tests__/stripe-auth-webhook-on-event.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handleEventMock = vi.fn();
+const handleSubscriptionDeletedEventMock = vi.fn();
+const captureExceptionMock = vi.fn();
+
+vi.mock("@sentry/node", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock("@/services/stripe-webhook.service", () => ({
+  stripeWebhookService: {
+    handleEvent: (...args: unknown[]) => handleEventMock(...args),
+  },
+}));
+
+vi.mock("@/services/stripe-backed-subscription.service", () => ({
+  handleSubscriptionDeletedEvent: (...args: unknown[]) =>
+    handleSubscriptionDeletedEventMock(...args),
+}));
+
+import {
+  handleStripeAuthWebhookOnEvent,
+  isBillingStripeEventType,
+  resolveStripeAuthWebhookSecret,
+} from "../stripe-auth-webhook-on-event";
+
+describe("resolveStripeAuthWebhookSecret", () => {
+  it("uses the Better Auth secret while split endpoints are enabled", () => {
+    expect(
+      resolveStripeAuthWebhookSecret({
+        useUnifiedStripeWebhook: false,
+        stripeWebhookSecret: "whsec_billing",
+        stripeBetterAuthWebhookSecret: "whsec_ba",
+      }),
+    ).toBe("whsec_ba");
+  });
+
+  it("uses the billing secret when unified webhooks are enabled", () => {
+    expect(
+      resolveStripeAuthWebhookSecret({
+        useUnifiedStripeWebhook: true,
+        stripeWebhookSecret: "whsec_billing",
+        stripeBetterAuthWebhookSecret: "whsec_ba",
+      }),
+    ).toBe("whsec_billing");
+  });
+});
+
+describe("isBillingStripeEventType", () => {
+  it.each([
+    "invoice.paid",
+    "customer.created",
+    "customer.updated",
+  ] as const)("returns true for %s", (eventType) => {
+    expect(isBillingStripeEventType(eventType)).toBe(true);
+  });
+
+  it("returns false for subscription lifecycle events", () => {
+    expect(isBillingStripeEventType("customer.subscription.deleted")).toBe(
+      false,
+    );
+  });
+});
+
+describe("handleStripeAuthWebhookOnEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleEventMock.mockResolvedValue(undefined);
+    handleSubscriptionDeletedEventMock.mockResolvedValue(undefined);
+  });
+
+  it("routes billing events through stripeWebhookService when unified", async () => {
+    const event = {
+      id: "evt_invoice",
+      type: "invoice.paid",
+      data: { object: { id: "in_123" } },
+    } as never;
+
+    await handleStripeAuthWebhookOnEvent(event, {
+      useUnifiedStripeWebhook: true,
+    });
+
+    expect(handleEventMock).toHaveBeenCalledWith(event);
+    expect(handleSubscriptionDeletedEventMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores billing events when unified mode is disabled", async () => {
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+
+    try {
+      await handleStripeAuthWebhookOnEvent(
+        {
+          id: "evt_invoice",
+          type: "invoice.paid",
+          data: { object: { id: "in_123" } },
+        } as never,
+        { useUnifiedStripeWebhook: false },
+      );
+
+      expect(handleEventMock).not.toHaveBeenCalled();
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
+        "Unhandled Stripe event type: invoice.paid",
+      );
+    } finally {
+      consoleInfoSpy.mockRestore();
+    }
+  });
+
+  it("handles customer.subscription.deleted regardless of unified mode", async () => {
+    const subscription = { id: "sub_123", customer: "cus_123" };
+
+    await handleStripeAuthWebhookOnEvent(
+      {
+        id: "evt_sub_deleted",
+        type: "customer.subscription.deleted",
+        data: { object: subscription },
+      } as never,
+      { useUnifiedStripeWebhook: false },
+    );
+
+    expect(handleSubscriptionDeletedEventMock).toHaveBeenCalledWith(
+      subscription,
+    );
+    expect(handleEventMock).not.toHaveBeenCalled();
+  });
+
+  it("reports subscription delete handler failures to Sentry", async () => {
+    const failure = new Error("delete failed");
+    handleSubscriptionDeletedEventMock.mockRejectedValue(failure);
+
+    await expect(
+      handleStripeAuthWebhookOnEvent(
+        {
+          id: "evt_sub_deleted",
+          type: "customer.subscription.deleted",
+          data: { object: { id: "sub_123", customer: "cus_123" } },
+        } as never,
+        { useUnifiedStripeWebhook: true },
+      ),
+    ).rejects.toThrow("delete failed");
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          stripeEventType: "customer.subscription.deleted",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -114,6 +114,7 @@ function getDefaultEnv() {
     STRIPE_SECRET_KEY: "sk_test_123",
     STRIPE_WEBHOOK_SECRET: "whsec_test_123",
     STRIPE_BA_WEBHOOK_SECRET: "whsec_ba_test_123",
+    USE_UNIFIED_STRIPE_WEBHOOK: false,
     VERCEL_ENV: undefined,
     VERCEL_GIT_COMMIT_REF: "",
   };
@@ -563,6 +564,21 @@ describe("core auth config", () => {
         },
       },
     });
+  });
+
+  it("uses STRIPE_WEBHOOK_SECRET for the auth stripe webhook when unified mode is enabled", async () => {
+    getEnvMock.mockReturnValue({
+      ...getDefaultEnv(),
+      USE_UNIFIED_STRIPE_WEBHOOK: true,
+    });
+
+    await import("./auth");
+
+    expect(stripePluginMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripeWebhookSecret: "whsec_test_123",
+      }),
+    );
   });
 
   it("handles customer.subscription.deleted via the Stripe webhook handlers", async () => {

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -54,14 +54,15 @@ import {
 import { uploadProfileImage } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
 import {
+  handleStripeAuthWebhookOnEvent,
+  resolveStripeAuthWebhookSecret,
+} from "@/lib/stripe-auth-webhook-on-event";
+import {
   ensureCanAcceptOrganizationInvitation,
   syncLocalFreeSeatsAndCreditsForCurrentMembers,
 } from "@/services/organization-subscription-auth.service";
 import { resolveActiveOrganizationIdForSession } from "@/services/preferred-organization.service";
-import {
-  handleSubscriptionDeletedEvent,
-  reconcileActiveStripeBackedSubscription,
-} from "@/services/stripe-backed-subscription.service";
+import { reconcileActiveStripeBackedSubscription } from "@/services/stripe-backed-subscription.service";
 import {
   handleUserUpdateStripeEmailSync,
   prepareStripeEmailSyncForUserUpdate,
@@ -685,12 +686,16 @@ export const auth = betterAuth({
     oAuthProxy({
       productionURL: getBetterAuthProductionUrl(),
     }),
-    // Subscription/checkout webhooks use a separate Stripe Dashboard endpoint
-    // (POST /auth/stripe/webhook, STRIPE_BA_WEBHOOK_SECRET) — same split as web
-    // today vs Core billing (POST /webhooks/stripe). Consolidate after cutover.
+    // Better Auth Stripe plugin webhook (POST /auth/stripe/webhook). When
+    // USE_UNIFIED_STRIPE_WEBHOOK is true, point the Stripe Dashboard here only
+    // and use STRIPE_WEBHOOK_SECRET; billing events are handled from onEvent.
     stripe({
       stripeClient: stripeInstance,
-      stripeWebhookSecret: env.STRIPE_BA_WEBHOOK_SECRET,
+      stripeWebhookSecret: resolveStripeAuthWebhookSecret({
+        useUnifiedStripeWebhook: env.USE_UNIFIED_STRIPE_WEBHOOK,
+        stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
+        stripeBetterAuthWebhookSecret: env.STRIPE_BA_WEBHOOK_SECRET,
+      }),
       createCustomerOnSignUp: false,
       subscription: {
         enabled: true,
@@ -742,35 +747,9 @@ export const auth = betterAuth({
         enabled: true,
       },
       onEvent: async (event) => {
-        switch (event.type) {
-          case "customer.subscription.deleted": {
-            const subscription = event.data.object as Stripe.Subscription;
-            try {
-              await handleSubscriptionDeletedEvent(subscription);
-            } catch (error) {
-              Sentry.captureException(error, {
-                tags: {
-                  stripeEventType: "customer.subscription.deleted",
-                  stripeSubscriptionId: subscription.id,
-                },
-                extra: {
-                  customer:
-                    typeof subscription.customer === "string"
-                      ? subscription.customer
-                      : subscription.customer.id,
-                  eventId: event.id,
-                  subscription: subscription.id,
-                },
-              });
-              throw error;
-            }
-            break;
-          }
-          default: {
-            console.info(`Unhandled Stripe event type: ${event.type}`);
-            break;
-          }
-        }
+        await handleStripeAuthWebhookOnEvent(event, {
+          useUnifiedStripeWebhook: env.USE_UNIFIED_STRIPE_WEBHOOK,
+        });
       },
     }),
   ],

--- a/apps/core/src/lib/stripe-auth-webhook-on-event.ts
+++ b/apps/core/src/lib/stripe-auth-webhook-on-event.ts
@@ -1,0 +1,60 @@
+import * as Sentry from "@sentry/node";
+import type Stripe from "stripe";
+
+import { handleSubscriptionDeletedEvent } from "@/services/stripe-backed-subscription.service";
+import { stripeWebhookService } from "@/services/stripe-webhook.service";
+
+export const BILLING_STRIPE_EVENT_TYPES: ReadonlySet<Stripe.Event.Type> =
+  new Set(["invoice.paid", "customer.created", "customer.updated"]);
+
+export function isBillingStripeEventType(
+  eventType: Stripe.Event.Type,
+): boolean {
+  return BILLING_STRIPE_EVENT_TYPES.has(eventType);
+}
+
+export async function handleStripeAuthWebhookOnEvent(
+  event: Stripe.Event,
+  options: { useUnifiedStripeWebhook: boolean },
+): Promise<void> {
+  if (options.useUnifiedStripeWebhook && isBillingStripeEventType(event.type)) {
+    await stripeWebhookService.handleEvent(event);
+    return;
+  }
+
+  if (event.type === "customer.subscription.deleted") {
+    const subscription = event.data.object;
+    try {
+      await handleSubscriptionDeletedEvent(subscription);
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          stripeEventType: "customer.subscription.deleted",
+          stripeSubscriptionId: subscription.id,
+        },
+        extra: {
+          customer:
+            typeof subscription.customer === "string"
+              ? subscription.customer
+              : subscription.customer.id,
+          eventId: event.id,
+          subscription: subscription.id,
+        },
+      });
+      throw error;
+    }
+    return;
+  }
+
+  console.info(`Unhandled Stripe event type: ${event.type}`);
+}
+
+export function resolveStripeAuthWebhookSecret(options: {
+  useUnifiedStripeWebhook: boolean;
+  stripeWebhookSecret: string;
+  stripeBetterAuthWebhookSecret: string;
+}): string {
+  return options.useUnifiedStripeWebhook
+    ? options.stripeWebhookSecret
+    : options.stripeBetterAuthWebhookSecret;
+}

--- a/apps/core/src/routes/webhooks/index.test.ts
+++ b/apps/core/src/routes/webhooks/index.test.ts
@@ -1,9 +1,16 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { constructWebhookEventMock, handleEventMock } = vi.hoisted(() => ({
-  constructWebhookEventMock: vi.fn(),
-  handleEventMock: vi.fn(),
+const { constructWebhookEventMock, getEnvMock, handleEventMock } = vi.hoisted(
+  () => ({
+    constructWebhookEventMock: vi.fn(),
+    getEnvMock: vi.fn(),
+    handleEventMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/config/env", () => ({
+  getEnv: () => getEnvMock(),
 }));
 
 vi.mock("@/clients/stripe.client", () => ({
@@ -40,6 +47,7 @@ function postStripeWebhook(
 describe("POST /webhooks/stripe", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getEnvMock.mockReturnValue({ USE_UNIFIED_STRIPE_WEBHOOK: false });
     constructWebhookEventMock.mockResolvedValue({
       id: "evt_123",
       type: "customer.updated",
@@ -104,6 +112,17 @@ describe("POST /webhooks/stripe", () => {
     expect(handleEventMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: "evt_123", type: "customer.updated" }),
     );
+  });
+
+  it("returns 410 when unified stripe webhooks are enabled", async () => {
+    getEnvMock.mockReturnValue({ USE_UNIFIED_STRIPE_WEBHOOK: true });
+    const app = await createApp();
+
+    const response = await postStripeWebhook(app, { signature: "t=1,v1=abc" });
+
+    expect(response.status).toBe(410);
+    expect(constructWebhookEventMock).not.toHaveBeenCalled();
+    expect(handleEventMock).not.toHaveBeenCalled();
   });
 
   it("returns 500 when the handler fails so Stripe retries", async () => {

--- a/apps/core/src/routes/webhooks/stripe/post.ts
+++ b/apps/core/src/routes/webhooks/stripe/post.ts
@@ -2,10 +2,21 @@ import type { Hono } from "hono";
 import type Stripe from "stripe";
 
 import { stripeClient } from "@/clients/stripe.client";
+import { getEnv } from "@/config/env";
 import { stripeWebhookService } from "@/services/stripe-webhook.service";
 
 export default function mount(app: Hono) {
   app.post("/stripe", async (c) => {
+    if (getEnv().USE_UNIFIED_STRIPE_WEBHOOK) {
+      return c.json(
+        {
+          message:
+            "POST /webhooks/stripe is disabled when USE_UNIFIED_STRIPE_WEBHOOK is enabled. Send billing events to POST /auth/stripe/webhook instead.",
+        },
+        410,
+      );
+    }
+
     const signature = c.req.header("stripe-signature");
     if (!signature) {
       return c.json({ message: "Missing stripe-signature header" }, 400);

--- a/apps/core/src/test/setup.ts
+++ b/apps/core/src/test/setup.ts
@@ -30,6 +30,7 @@ const envDefaults: Record<string, string> = {
   STRIPE_SUPPORT_COUPON: "coupon_support_test",
   STRIPE_WEBHOOK_SECRET: "whsec_test_example",
   STRIPE_BA_WEBHOOK_SECRET: "whsec_ba_test_example",
+  USE_UNIFIED_STRIPE_WEBHOOK: "false",
   LOCK_TIMEOUT: "900000",
   LOCK_TIMEOUT_BUFFER: "25000",
   INSTANCE_ID: "test-instance-id",


### PR DESCRIPTION
## Summary

- Adds `USE_UNIFIED_STRIPE_WEBHOOK` (Core server flag, default `false`) to consolidate Stripe delivery on Better Auth `POST /auth/stripe/webhook`.
- When enabled: BA plugin verifies with `STRIPE_WEBHOOK_SECRET`; billing events (`invoice.paid`, `customer.created`, `customer.updated`) run in `onEvent` via `stripeWebhookService`; legacy `POST /webhooks/stripe` returns **410**.
- When disabled: current split remains (BA uses `STRIPE_BA_WEBHOOK_SECRET`; billing on `/webhooks/stripe`).

Flip together with web `NEXT_PUBLIC_USE_CORE_AUTH_CLIENT=true` and point the Stripe Dashboard webhook URL to Core `/auth/stripe/webhook`.

## Test plan

- [x] `pnpm --filter core test src/lib/__tests__/stripe-auth-webhook-on-event.test.ts src/lib/auth.test.ts src/routes/webhooks/index.test.ts`
- [ ] Preprod: enable `USE_UNIFIED_STRIPE_WEBHOOK` on Core + `NEXT_PUBLIC_USE_CORE_AUTH_CLIENT` on web; confirm single webhook delivery
- [ ] Verify `customer.subscription.deleted` still reconciles local subscription rows
- [ ] Verify `/webhooks/stripe` returns 410 when unified flag is on


Made with [Cursor](https://cursor.com)