### PR TITLE
docs(agents): add maintainability cursor rule

### DIFF
--- a/.cursor/rules/maintainability.mdc
+++ b/.cursor/rules/maintainability.mdc
@@ -1,0 +1,37 @@
+---
+description: "Prioritize long-term maintainability over short-term wins"
+alwaysApply: true
+---
+
+## Maintainability first
+
+**Maintainability is a very high priority.** Prefer solutions that stay clear, consistent, and easy to change over options that only save time on this PR.
+
+When two approaches both work, choose the one that:
+
+- Matches existing patterns in the touched area
+- Names things for what they mean today (not legacy behavior)
+- Leaves no dead parameters, branches, or comments behind
+- Can be understood by the next reader without tribal knowledge
+
+### Prefer over short-term wins
+
+| Short-term win | Maintainable choice |
+| -------------- | ------------------- |
+| Reuse a positional arg slot for a new meaning | Named options object or explicit parameter |
+| Copy-paste to ship faster | Shared helper or package when logic is duplicated |
+| Leave a stub, TODO, or partial removal “for later” | Finish the removal or scope the PR honestly |
+| One-off hack around architecture | Fix at the right layer (Core, shared package, schema) |
+| Skip renaming because diff is bigger | Rename when the old name is now misleading |
+
+### When a shortcut is acceptable
+
+- **Explicit user request** for the smallest possible change
+- **Documented follow-up** with a tracked issue when a hotfix truly cannot wait
+- **Scope boundary** — do not expand a bugfix into a refactor unless maintainability of the touched code clearly requires it
+
+### In reviews and implementation
+
+- Ask: “Will this confuse someone in six months?”
+- Clean up misleading API surfaces in the same change when you touch them
+- If you remove a feature, remove its types, routes, UI, migrations, and tests — not just the happy path

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,7 @@ docs(readme): update setup instructions
 
 ### Code Changes
 
+- **Prioritize maintainability** over short-term wins — see [maintainability](.cursor/rules/maintainability.mdc)
 - Prefer editing existing files over creating new ones
 - Use semantic search to understand codebase before making changes
 - Follow the three-layer architecture pattern
@@ -319,6 +320,7 @@ Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). Se
 
 ## Additional Rules
 
+- [Maintainability](.cursor/rules/maintainability.mdc) – long-term clarity and consistency over short-term wins
 - [Linting](.cursor/rules/lint.mdc)
 - [Pinned dependencies](.cursor/rules/pinned-dependencies.mdc) – exact versions in `package.json`, no semver ranges on registry packages
 - [Result Type with neverthrow](.cursor/rules/neverthrow.mdc)


### PR DESCRIPTION
## Summary

- Adds an always-on Cursor rule (`.cursor/rules/maintainability.mdc`) that prioritizes long-term maintainability over short-term wins
- Links the rule from root `AGENTS.md` under Code Changes and Additional Rules

## Test plan

- [ ] Rule loads in Cursor (alwaysApply)
- [ ] `AGENTS.md` links resolve to `.cursor/rules/maintainability.mdc`


Made with [Cursor](https://cursor.com)