### PR TITLE
fix(web): show coworker and model avatars in history search modal

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/history-search-dialog.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/history-search-dialog.test.tsx
@@ -2,8 +2,9 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getHistoryMock, pushMock } = vi.hoisted(() => ({
+const { getHistoryMock, getCoworkersMock, pushMock } = vi.hoisted(() => ({
   getHistoryMock: vi.fn(),
+  getCoworkersMock: vi.fn(),
   pushMock: vi.fn(),
 }));
 
@@ -16,6 +17,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/clients/core.browser.client", () => ({
   coreClient: {
     getHistory: getHistoryMock,
+    getCoworkers: getCoworkersMock,
   },
 }));
 
@@ -24,7 +26,15 @@ vi.mock("@/components/agents/agent-icon", () => ({
 }));
 
 vi.mock("@/components/chat/chat-model-icon", () => ({
-  ChatModelIcon: () => <span data-testid="chat-model-icon" />,
+  ChatModelIcon: ({
+    modelId,
+    modelName,
+  }: {
+    modelId: string;
+    modelName?: string;
+  }) => (
+    <span data-testid="chat-model-icon">{`${modelId}:${modelName ?? ""}`}</span>
+  ),
 }));
 
 vi.mock("@/app/tasks/components/task-status-badge", () => ({
@@ -81,6 +91,16 @@ describe("HistorySearchDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    getCoworkersMock.mockResolvedValue({
+      data: [
+        {
+          id: "coworker-1",
+          slug: "elena",
+          name: "Elena",
+          image: "https://example.com/elena.webp",
+        },
+      ],
+    });
     getHistoryMock.mockImplementation(async ({ q }: { q?: string } = {}) => ({
       data:
         q === "new"
@@ -180,6 +200,54 @@ describe("HistorySearchDialog", () => {
 
     await waitFor(() => {
       expect(screen.getByText("New query result")).toBeInTheDocument();
+    });
+  });
+
+  it("loads coworkers when the dialog opens", async () => {
+    render(
+      <HistorySearchDialog
+        open
+        onOpenChange={vi.fn()}
+        activeOrganizationId={null}
+        labels={labels}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getCoworkersMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("renders resolved model icons for conversation history items", async () => {
+    getHistoryMock.mockResolvedValue({
+      data: [
+        {
+          id: "conversation-1",
+          kind: "conversation",
+          title: "Are you there?",
+          status: "active",
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          archivedAt: null,
+          description: null,
+          credits: null,
+          bucketSlug: "grok-4-1-fast",
+        },
+      ],
+    });
+
+    render(
+      <HistorySearchDialog
+        open
+        onOpenChange={vi.fn()}
+        activeOrganizationId={null}
+        labels={labels}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-model-icon")).toHaveTextContent(
+        "grok-4-1-fast:Grok 4.1 Fast",
+      );
     });
   });
 });

--- a/apps/web/src/app/(app)/components/__tests__/history-search-dialog.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/history-search-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -216,6 +216,88 @@ describe("HistorySearchDialog", () => {
     await waitFor(() => {
       expect(getCoworkersMock).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("excludes UI-restricted coworkers from bucket icon resolution", async () => {
+    getCoworkersMock.mockResolvedValue({
+      data: [
+        {
+          id: "coworker-hermes",
+          slug: "hermes",
+          name: "Hermes",
+          image: "https://example.com/hermes.webp",
+        },
+        {
+          id: "coworker-elena",
+          slug: "elena",
+          name: "Elena",
+          image: "https://example.com/elena.webp",
+        },
+      ],
+    });
+    getHistoryMock.mockResolvedValue({
+      data: [
+        {
+          id: "conversation-hermes",
+          kind: "conversation",
+          title: "Hermes chat",
+          status: "active",
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          archivedAt: null,
+          description: null,
+          credits: null,
+          bucketSlug: "hermes",
+        },
+        {
+          id: "conversation-elena",
+          kind: "conversation",
+          title: "Elena chat",
+          status: "active",
+          updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+          archivedAt: null,
+          description: null,
+          credits: null,
+          bucketSlug: "elena",
+        },
+      ],
+    });
+
+    render(
+      <HistorySearchDialog
+        open
+        onOpenChange={vi.fn()}
+        activeOrganizationId={null}
+        labels={labels}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Elena chat")).toBeInTheDocument();
+    });
+
+    const hermesItem = screen
+      .getByText("Hermes chat")
+      .closest('[data-slot="command-item"]');
+    const elenaItem = screen
+      .getByText("Elena chat")
+      .closest('[data-slot="command-item"]');
+
+    expect(hermesItem).not.toBeNull();
+    expect(elenaItem).not.toBeNull();
+
+    expect(
+      within(hermesItem as HTMLElement).getByTestId("chat-model-icon"),
+    ).toHaveTextContent(":Conversation");
+    expect(
+      (hermesItem as HTMLElement).querySelector('[data-slot="avatar"]'),
+    ).toBeNull();
+
+    expect(
+      (elenaItem as HTMLElement).querySelector('[data-slot="avatar"]'),
+    ).not.toBeNull();
+    expect(
+      within(elenaItem as HTMLElement).queryByTestId("chat-model-icon"),
+    ).toBeNull();
   });
 
   it("renders resolved model icons for conversation history items", async () => {

--- a/apps/web/src/app/(app)/components/history-search-dialog.tsx
+++ b/apps/web/src/app/(app)/components/history-search-dialog.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
-import { ListTodo } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { ConversationStatusBadge } from "@/app/history/components/conversation-status-badge";
 import { getHistoryItemHref } from "@/app/history/components/history-list-item";
+import { HistoryTypeIcon } from "@/app/history/components/history-type-icon";
 import { getDefaultHistoryScope } from "@/app/history/utils/history-filters";
+import {
+  buildHistoryBucketLookupsFromItems,
+  type CoworkerBucketSource,
+  createEmptyHistoryBucketLookups,
+  type HistoryBucketLookups,
+} from "@/app/history/utils/history-row-subtitle";
 import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
-import { AgentIcon } from "@/components/agents/agent-icon";
-import { ChatModelIcon } from "@/components/chat/chat-model-icon";
 import { JobStatusBadge } from "@/components/jobs/job-status-badge";
 import {
   CommandDialog,
@@ -59,10 +63,20 @@ export function HistorySearchDialog({
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [coworkers, setCoworkers] = useState<CoworkerBucketSource[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const requestIdRef = useRef(0);
   const router = useRouter();
+
+  const loadCoworkers = useEffectEvent(async () => {
+    try {
+      const response = await coreClient.getCoworkers();
+      setCoworkers(response.data);
+    } catch {
+      setCoworkers([]);
+    }
+  });
 
   const loadHistory = useEffectEvent(async (searchQuery: string) => {
     const requestId = ++requestIdRef.current;
@@ -104,14 +118,29 @@ export function HistorySearchDialog({
   useEffect(() => {
     if (!open) return;
 
+    void loadCoworkers();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
     void loadHistory(debouncedQuery);
   }, [activeOrganizationId, debouncedQuery, open]);
+
+  const bucketLookups = useMemo(
+    () =>
+      history.length > 0
+        ? buildHistoryBucketLookupsFromItems(history, coworkers)
+        : createEmptyHistoryBucketLookups(),
+    [coworkers, history],
+  );
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
       setQuery("");
       setDebouncedQuery("");
       setHistory([]);
+      setCoworkers([]);
       setError(null);
       setIsLoading(false);
       requestIdRef.current += 1;
@@ -166,7 +195,11 @@ export function HistorySearchDialog({
                 value={`${item.title} ${item.id}`}
                 onSelect={() => handleSelect(item)}
               >
-                <HistoryItemIcon item={item} labels={labels} />
+                <HistoryTypeIcon
+                  item={item}
+                  labels={labels}
+                  bucketLookups={bucketLookups}
+                />
                 <span className="truncate">{item.title}</span>
                 <HistoryItemStatus item={item} labels={labels} />
               </CommandItem>
@@ -175,39 +208,6 @@ export function HistorySearchDialog({
         ) : null}
       </CommandList>
     </CommandDialog>
-  );
-}
-
-function HistoryItemIcon({
-  item,
-  labels,
-}: {
-  item: HistoryItem;
-  labels: HistorySearchDialogLabels;
-}) {
-  if (item.kind === "task") {
-    return <ListTodo className="size-4" aria-hidden />;
-  }
-
-  if (item.kind === "job") {
-    return (
-      <AgentIcon
-        agent={{
-          name: item.agentName ?? item.title,
-          icon: item.agentIcon ?? null,
-        }}
-        className="size-4"
-      />
-    );
-  }
-
-  return (
-    <ChatModelIcon
-      modelId=""
-      modelName={labels.kind.conversation}
-      className="size-4"
-      size={16}
-    />
   );
 }
 

--- a/apps/web/src/app/(app)/components/history-search-dialog.tsx
+++ b/apps/web/src/app/(app)/components/history-search-dialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/command";
 import { coreClient } from "@/lib/clients/core.browser.client";
 import type { HistoryItem } from "@/lib/clients/generated/core/types.gen";
+import { filterCoworkersForUiListing } from "@/lib/coworkers/ui-restricted-slugs";
 
 const HISTORY_SEARCH_PAGE_SIZE = 50;
 const SEARCH_STATUS_BADGE_CLASSNAME = "ml-auto shrink-0";
@@ -71,7 +72,7 @@ export function HistorySearchDialog({
   const loadCoworkers = useEffectEvent(async () => {
     try {
       const response = await coreClient.getCoworkers();
-      setCoworkers(response.data);
+      setCoworkers(filterCoworkersForUiListing(response.data ?? []));
     } catch {
       setCoworkers([]);
     }

--- a/apps/web/src/app/(app)/components/history-search-dialog.tsx
+++ b/apps/web/src/app/(app)/components/history-search-dialog.tsx
@@ -11,7 +11,6 @@ import {
   buildHistoryBucketLookupsFromItems,
   type CoworkerBucketSource,
   createEmptyHistoryBucketLookups,
-  type HistoryBucketLookups,
 } from "@/app/history/utils/history-row-subtitle";
 import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
 import { JobStatusBadge } from "@/components/jobs/job-status-badge";

--- a/apps/web/src/app/(app)/history/components/history-list-item.tsx
+++ b/apps/web/src/app/(app)/history/components/history-list-item.tsx
@@ -1,22 +1,19 @@
 "use client";
 
 import { SokosumiJobStatus, TaskStatus } from "@sokosumi/utils";
-import { ListTodo } from "lucide-react";
 import Link from "next/link";
 import {
   CHAT_APP_ROUTE_PREFIX,
   FALLBACK_BUCKET_SEGMENT,
 } from "@/app/chat-ui/utils/chat-route-base";
 import { ConversationStatusBadge } from "@/app/history/components/conversation-status-badge";
+import { HistoryTypeIcon } from "@/app/history/components/history-type-icon";
 import {
   getHistoryRowSubtitle,
   type HistoryBucketLookups,
 } from "@/app/history/utils/history-row-subtitle";
 import { TaskStatusBadge } from "@/app/tasks/components/task-status-badge";
-import { AgentIcon } from "@/components/agents/agent-icon";
-import { ChatModelIcon } from "@/components/chat/chat-model-icon";
 import { JobStatusBadge } from "@/components/jobs/job-status-badge";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { HistoryItem } from "@/lib/services/history.service";
 import { cn } from "@/lib/utils";
 import { formatCreditsForDisplay } from "@/lib/utils/credits";
@@ -175,84 +172,6 @@ function HistoryTypeColumn({
         {labels.kind[item.kind]}
       </span>
     </div>
-  );
-}
-
-function HistoryTypeIcon({
-  item,
-  labels,
-  bucketLookups,
-}: {
-  item: HistoryItem;
-  labels: HistoryListItemLabels;
-  bucketLookups: HistoryBucketLookups;
-}) {
-  if (item.kind === "task") {
-    return <ListTodo className="size-4" />;
-  }
-
-  if (item.kind === "job") {
-    return (
-      <AgentIcon
-        agent={{
-          name: item.agentName ?? item.title,
-          icon: item.agentIcon ?? null,
-        }}
-        className="size-4"
-      />
-    );
-  }
-
-  const bucketIcon = item.bucketSlug
-    ? bucketLookups.bucketIconBySlug[item.bucketSlug]
-    : undefined;
-
-  return (
-    <HistoryConversationIcon
-      bucketIcon={bucketIcon}
-      fallbackLabel={labels.kind.conversation}
-    />
-  );
-}
-
-function HistoryConversationIcon({
-  bucketIcon,
-  fallbackLabel,
-}: {
-  bucketIcon: HistoryBucketLookups["bucketIconBySlug"][string] | undefined;
-  fallbackLabel: string;
-}) {
-  if (bucketIcon?.kind === "model") {
-    return (
-      <ChatModelIcon
-        modelId={bucketIcon.modelId}
-        modelName={bucketIcon.modelName}
-        className="size-4"
-        size={16}
-      />
-    );
-  }
-
-  if (bucketIcon?.kind === "coworker") {
-    return (
-      <Avatar className="size-4">
-        {bucketIcon.imageUrl ? (
-          <AvatarImage src={bucketIcon.imageUrl} alt={bucketIcon.name} />
-        ) : null}
-        <AvatarFallback className="bg-primary text-primary-foreground text-[8px]">
-          {bucketIcon.name.charAt(0).toUpperCase()}
-        </AvatarFallback>
-      </Avatar>
-    );
-  }
-
-  return (
-    <ChatModelIcon
-      modelId=""
-      modelName={fallbackLabel}
-      className="size-4"
-      size={16}
-    />
   );
 }
 

--- a/apps/web/src/app/(app)/history/components/history-type-icon.tsx
+++ b/apps/web/src/app/(app)/history/components/history-type-icon.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { ListTodo } from "lucide-react";
+
+import type { HistoryBucketLookups } from "@/app/history/utils/history-row-subtitle";
+import { AgentIcon } from "@/components/agents/agent-icon";
+import { ChatModelIcon } from "@/components/chat/chat-model-icon";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { HistoryItem } from "@/lib/services/history.service";
+
+interface HistoryTypeIconLabels {
+  kind: {
+    task: string;
+    job: string;
+    conversation: string;
+  };
+}
+
+interface HistoryTypeIconProps {
+  item: HistoryItem;
+  bucketLookups: HistoryBucketLookups;
+  labels: HistoryTypeIconLabels;
+  className?: string;
+}
+
+export function HistoryTypeIcon({
+  item,
+  bucketLookups,
+  labels,
+  className = "size-4",
+}: HistoryTypeIconProps) {
+  if (item.kind === "task") {
+    return <ListTodo className={className} aria-hidden />;
+  }
+
+  if (item.kind === "job") {
+    return (
+      <AgentIcon
+        agent={{
+          name: item.agentName ?? item.title,
+          icon: item.agentIcon ?? null,
+        }}
+        className={className}
+      />
+    );
+  }
+
+  const bucketIcon = item.bucketSlug
+    ? bucketLookups.bucketIconBySlug[item.bucketSlug]
+    : undefined;
+
+  return (
+    <HistoryConversationIcon
+      bucketIcon={bucketIcon}
+      fallbackLabel={labels.kind.conversation}
+      className={className}
+    />
+  );
+}
+
+function HistoryConversationIcon({
+  bucketIcon,
+  fallbackLabel,
+  className,
+}: {
+  bucketIcon: HistoryBucketLookups["bucketIconBySlug"][string] | undefined;
+  fallbackLabel: string;
+  className: string;
+}) {
+  if (bucketIcon?.kind === "model") {
+    return (
+      <ChatModelIcon
+        modelId={bucketIcon.modelId}
+        modelName={bucketIcon.modelName}
+        className={className}
+        size={16}
+      />
+    );
+  }
+
+  if (bucketIcon?.kind === "coworker") {
+    return (
+      <Avatar className={className}>
+        {bucketIcon.imageUrl ? (
+          <AvatarImage src={bucketIcon.imageUrl} alt={bucketIcon.name} />
+        ) : null}
+        <AvatarFallback className="bg-primary text-primary-foreground text-[8px]">
+          {bucketIcon.name.charAt(0).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+    );
+  }
+
+  return (
+    <ChatModelIcon
+      modelId=""
+      modelName={fallbackLabel}
+      className={className}
+      size={16}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/history/utils/__tests__/history-row-subtitle.test.ts
+++ b/apps/web/src/app/(app)/history/utils/__tests__/history-row-subtitle.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBucketLookupFromCoworkers } from "@/app/history/utils/history-row-subtitle";
+
+describe("buildBucketLookupFromCoworkers", () => {
+  it("resolves coworker bucket icons and model bucket icons", () => {
+    const result = buildBucketLookupFromCoworkers(
+      ["hannah", "gpt-5-4"],
+      [
+        {
+          id: "coworker-1",
+          slug: "hannah",
+          name: "Hannah",
+          image: "https://example.com/hannah.webp",
+        },
+      ],
+    );
+
+    expect(result.bucketIconBySlug.hannah).toEqual({
+      kind: "coworker",
+      name: "Hannah",
+      imageUrl: "https://example.com/hannah.webp",
+    });
+    expect(result.bucketIconBySlug["gpt-5-4"]).toEqual({
+      kind: "model",
+      modelId: "gpt-5-4",
+      modelName: "GPT-5.4",
+    });
+  });
+});

--- a/apps/web/src/app/(app)/history/utils/__tests__/history-row-subtitle.test.ts
+++ b/apps/web/src/app/(app)/history/utils/__tests__/history-row-subtitle.test.ts
@@ -8,7 +8,6 @@ describe("buildBucketLookupFromCoworkers", () => {
       ["hannah", "gpt-5-4"],
       [
         {
-          id: "coworker-1",
           slug: "hannah",
           name: "Hannah",
           image: "https://example.com/hannah.webp",

--- a/apps/web/src/app/(app)/history/utils/history-row-subtitle.server.ts
+++ b/apps/web/src/app/(app)/history/utils/history-row-subtitle.server.ts
@@ -1,107 +1,24 @@
 import "server-only";
 
-import { CHAT_MODELS } from "@sokosumi/chat";
-
-import { slugify } from "@/app/chat/utils/bucket-slug";
 import {
+  buildBucketLookupFromCoworkers,
   createEmptyHistoryBucketLookups,
-  type HistoryBucketIconPreview,
+  getUniqueBucketSlugsFromHistory,
   type HistoryBucketLookups,
 } from "@/app/history/utils/history-row-subtitle";
-import { getCoworkerImage } from "@/app/tasks/utils/coworker-image";
 import { coworkerService } from "@/lib/services/coworker.service";
 import type { HistoryItem } from "@/lib/services/history.service";
 
 export async function buildHistoryBucketLookups(
   history: HistoryItem[],
 ): Promise<HistoryBucketLookups> {
-  const bucketSlugs = getUniqueBucketSlugs(history);
+  const bucketSlugs = getUniqueBucketSlugsFromHistory(history);
 
   if (bucketSlugs.length === 0) {
     return createEmptyHistoryBucketLookups();
   }
 
-  return buildBucketLookup(bucketSlugs);
-}
-
-function getUniqueBucketSlugs(history: HistoryItem[]): string[] {
-  return [
-    ...new Set(
-      history.flatMap((item) =>
-        item.kind === "conversation" && item.bucketSlug
-          ? [item.bucketSlug]
-          : [],
-      ),
-    ),
-  ];
-}
-
-async function buildBucketLookup(
-  bucketSlugs: string[],
-): Promise<HistoryBucketLookups> {
   const coworkers = await coworkerService.listCoworkers().catch(() => []);
-  const coworkerBySlug = new Map<
-    string,
-    { name: string; imageUrl: string | null }
-  >();
 
-  for (const coworker of coworkers) {
-    const preview = {
-      name: coworker.name,
-      imageUrl: getCoworkerImage(coworker),
-    };
-    coworkerBySlug.set(slugify(coworker.slug), preview);
-    coworkerBySlug.set(slugify(coworker.name), preview);
-  }
-
-  const modelBySlug = new Map(
-    CHAT_MODELS.flatMap((model) => [
-      [slugify(model.name), model],
-      [slugify(model.id), model],
-    ]),
-  );
-
-  const bucketDisplayNameBySlug: Record<string, string> = {};
-  const bucketIconBySlug: Record<string, HistoryBucketIconPreview> = {};
-
-  for (const bucketSlug of bucketSlugs) {
-    const normalizedSlug = slugify(bucketSlug);
-    const coworker = coworkerBySlug.get(normalizedSlug);
-
-    if (coworker) {
-      bucketDisplayNameBySlug[bucketSlug] = coworker.name;
-      bucketIconBySlug[bucketSlug] = {
-        kind: "coworker",
-        name: coworker.name,
-        imageUrl: coworker.imageUrl,
-      };
-      continue;
-    }
-
-    const model = modelBySlug.get(normalizedSlug);
-    if (model) {
-      bucketDisplayNameBySlug[bucketSlug] = model.name;
-      bucketIconBySlug[bucketSlug] = {
-        kind: "model",
-        modelId: model.id,
-        modelName: model.name,
-      };
-      continue;
-    }
-
-    bucketDisplayNameBySlug[bucketSlug] = humanizeSlug(bucketSlug);
-  }
-
-  return {
-    bucketDisplayNameBySlug,
-    bucketIconBySlug,
-  };
-}
-
-function humanizeSlug(slug: string): string {
-  return slug
-    .split("-")
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toLocaleUpperCase() + part.slice(1))
-    .join(" ");
+  return buildBucketLookupFromCoworkers(bucketSlugs, coworkers);
 }

--- a/apps/web/src/app/(app)/history/utils/history-row-subtitle.ts
+++ b/apps/web/src/app/(app)/history/utils/history-row-subtitle.ts
@@ -1,4 +1,14 @@
+import { CHAT_MODELS } from "@sokosumi/chat";
+
+import { slugify } from "@/app/chat/utils/bucket-slug";
+import { getCoworkerImage } from "@/app/tasks/utils/coworker-image";
 import type { HistoryItem } from "@/lib/services/history.service";
+
+export interface CoworkerBucketSource {
+  slug: string;
+  name: string;
+  image?: string | null;
+}
 
 export type HistoryBucketIconPreview =
   | { kind: "model"; modelId: string; modelName: string }
@@ -18,6 +28,103 @@ export function createEmptyHistoryBucketLookups(): HistoryBucketLookups {
     bucketDisplayNameBySlug: {},
     bucketIconBySlug: {},
   };
+}
+
+export function getUniqueBucketSlugsFromHistory(
+  history: HistoryItem[],
+): string[] {
+  return [
+    ...new Set(
+      history.flatMap((item) =>
+        item.kind === "conversation" && item.bucketSlug
+          ? [item.bucketSlug]
+          : [],
+      ),
+    ),
+  ];
+}
+
+export function buildBucketLookupFromCoworkers(
+  bucketSlugs: string[],
+  coworkers: CoworkerBucketSource[],
+): HistoryBucketLookups {
+  const coworkerBySlug = new Map<
+    string,
+    { name: string; imageUrl: string | null }
+  >();
+
+  for (const coworker of coworkers) {
+    const preview = {
+      name: coworker.name,
+      imageUrl: getCoworkerImage(coworker),
+    };
+    coworkerBySlug.set(slugify(coworker.slug), preview);
+    coworkerBySlug.set(slugify(coworker.name), preview);
+  }
+
+  const modelBySlug = new Map(
+    CHAT_MODELS.flatMap((model) => [
+      [slugify(model.name), model],
+      [slugify(model.id), model],
+    ]),
+  );
+
+  const bucketDisplayNameBySlug: Record<string, string> = {};
+  const bucketIconBySlug: Record<string, HistoryBucketIconPreview> = {};
+
+  for (const bucketSlug of bucketSlugs) {
+    const normalizedSlug = slugify(bucketSlug);
+    const coworker = coworkerBySlug.get(normalizedSlug);
+
+    if (coworker) {
+      bucketDisplayNameBySlug[bucketSlug] = coworker.name;
+      bucketIconBySlug[bucketSlug] = {
+        kind: "coworker",
+        name: coworker.name,
+        imageUrl: coworker.imageUrl,
+      };
+      continue;
+    }
+
+    const model = modelBySlug.get(normalizedSlug);
+    if (model) {
+      bucketDisplayNameBySlug[bucketSlug] = model.name;
+      bucketIconBySlug[bucketSlug] = {
+        kind: "model",
+        modelId: model.id,
+        modelName: model.name,
+      };
+      continue;
+    }
+
+    bucketDisplayNameBySlug[bucketSlug] = humanizeSlug(bucketSlug);
+  }
+
+  return {
+    bucketDisplayNameBySlug,
+    bucketIconBySlug,
+  };
+}
+
+export function buildHistoryBucketLookupsFromItems(
+  history: HistoryItem[],
+  coworkers: CoworkerBucketSource[],
+): HistoryBucketLookups {
+  const bucketSlugs = getUniqueBucketSlugsFromHistory(history);
+
+  if (bucketSlugs.length === 0) {
+    return createEmptyHistoryBucketLookups();
+  }
+
+  return buildBucketLookupFromCoworkers(bucketSlugs, coworkers);
+}
+
+function humanizeSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toLocaleUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 export function mergeHistoryBucketLookups(


### PR DESCRIPTION
## Summary
- Reuse shared bucket lookup logic so the history search modal resolves coworker avatars and model icons from conversation `bucketSlug` values.
- Extract `HistoryTypeIcon` for both the history list and search modal to keep icon rendering consistent.

## Test plan
- [x] `pnpm --filter web test src/app/(app)/components/__tests__/history-search-dialog.test.tsx`
- [x] `pnpm --filter web test src/app/(app)/history/utils/__tests__/history-row-subtitle.test.ts`
- [x] `pnpm --filter web test src/app/(app)/history/utils/__tests__/history-row-subtitle.server.test.ts`
- [x] `pnpm --filter web test src/app/(app)/history/__tests__/history-list-item.test.tsx`
- [ ] Open the history search modal and confirm coworker chats show avatars and model chats show model icons


Made with [Cursor](https://cursor.com)