### PR TITLE
refactor(web): extract shared UserProfileAvatar component

### DIFF
--- a/apps/web/src/app/(app)/history/components/history-meta.tsx
+++ b/apps/web/src/app/(app)/history/components/history-meta.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
-import { User } from "lucide-react";
-
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { UserProfileAvatar } from "@/components/user/user-profile-avatar";
 import type { HistoryItem } from "@/lib/services/history.service";
 import { cn } from "@/lib/utils";
 
@@ -51,35 +43,13 @@ export function HistoryOwnerAvatar({
     return null;
   }
 
-  const image = owner.image ? resolveIpfsOrHttpUrl(owner.image) : null;
-  const ownerName = owner.name.trim();
-
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className={cn("inline-flex", className)}>
-          <Avatar className="size-5 ring-background shrink-0 ring-2">
-            {image ? (
-              <AvatarImage
-                src={image}
-                alt={ownerName || "User"}
-                className="object-cover"
-                onError={(event) => {
-                  event.currentTarget.style.display = "none";
-                }}
-              />
-            ) : null}
-            <AvatarFallback className="bg-muted text-[10px] font-medium">
-              {ownerName.slice(0, 1).toUpperCase() || (
-                <User className="size-3" aria-hidden />
-              )}
-            </AvatarFallback>
-          </Avatar>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" sideOffset={6}>
-        {ownerName}
-      </TooltipContent>
-    </Tooltip>
+    <UserProfileAvatar
+      name={owner.name}
+      image={owner.image}
+      size="sm"
+      showTooltip
+      className={className}
+    />
   );
 }

--- a/apps/web/src/app/(app)/tasks/components/task-meta.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-meta.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
-import { Calendar, MessageSquare, User, UserCog } from "lucide-react";
+import { Calendar, MessageSquare, UserCog } from "lucide-react";
 
 import { getCoworkerImage } from "@/app/tasks/utils/coworker-image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -10,6 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UserProfileAvatar } from "@/components/user/user-profile-avatar";
 import type { TaskWithCoworker } from "@/lib/types/task";
 import { useLocalizedDateTime } from "@/lib/utils/datetime.client";
 
@@ -46,38 +46,6 @@ function CoworkerAvatar({
       <AvatarFallback className="bg-muted text-[10px] font-medium">
         {coworker?.name?.slice(0, 1).toUpperCase() ?? (
           <UserCog className="size-3" aria-hidden />
-        )}
-      </AvatarFallback>
-    </Avatar>
-  );
-}
-
-function OwnerAvatar({
-  owner,
-  size = "sm",
-}: {
-  owner: TaskWithCoworker["user"];
-  size?: "sm" | "md";
-}) {
-  const image = owner.image ? resolveIpfsOrHttpUrl(owner.image) : null;
-  const sizeClass = size === "sm" ? "size-5" : "size-6";
-  const ownerName = owner.name.trim();
-
-  return (
-    <Avatar className={`${sizeClass} ring-background shrink-0 ring-2`}>
-      {image ? (
-        <AvatarImage
-          src={image}
-          alt={ownerName || "User"}
-          className="object-cover"
-          onError={(event) => {
-            event.currentTarget.style.display = "none";
-          }}
-        />
-      ) : null}
-      <AvatarFallback className="bg-muted text-[10px] font-medium">
-        {ownerName.slice(0, 1).toUpperCase() || (
-          <User className="size-3" aria-hidden />
         )}
       </AvatarFallback>
     </Avatar>
@@ -141,7 +109,7 @@ export function TaskMetaDetails({
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="z-20 inline-flex">
-              <OwnerAvatar owner={owner} />
+              <UserProfileAvatar name={owner.name} image={owner.image} />
             </span>
           </TooltipTrigger>
           <TooltipContent side="top" sideOffset={6}>

--- a/apps/web/src/components/user/user-profile-avatar.tsx
+++ b/apps/web/src/components/user/user-profile-avatar.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
+import { User } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+export interface UserProfileAvatarProps {
+  name: string;
+  image?: string | null;
+  size?: "sm" | "md";
+  showTooltip?: boolean;
+  className?: string;
+}
+
+export function UserProfileAvatar({
+  name,
+  image,
+  size = "sm",
+  showTooltip = false,
+  className,
+}: UserProfileAvatarProps) {
+  const resolvedImage = image ? resolveIpfsOrHttpUrl(image) : null;
+  const sizeClass = size === "sm" ? "size-5" : "size-6";
+  const userName = name.trim();
+
+  const avatarContent = (
+    <span className={cn("inline-flex", className)}>
+      <Avatar className={cn(sizeClass, "ring-background shrink-0 ring-2")}>
+        {resolvedImage ? (
+          <AvatarImage
+            src={resolvedImage}
+            alt={userName || "User"}
+            className="object-cover"
+            onError={(event) => {
+              event.currentTarget.style.display = "none";
+            }}
+          />
+        ) : null}
+        <AvatarFallback className="bg-muted text-[10px] font-medium">
+          {userName.slice(0, 1).toUpperCase() || (
+            <User className="size-3" aria-hidden />
+          )}
+        </AvatarFallback>
+      </Avatar>
+    </span>
+  );
+
+  if (!showTooltip) {
+    return avatarContent;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{avatarContent}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {userName}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts duplicate owner avatar implementations from history and task meta into a shared `UserProfileAvatar` component.

## Changes

- **Created** `UserProfileAvatar` at `apps/web/src/components/user/user-profile-avatar.tsx` with props:
  - `name: string` (required)
  - `image?: string | null`
  - `size?: "sm" | "md"` (default `"sm"`)
  - `showTooltip?: boolean` (default `false`)
  - `className?: string`

- **Migrated** `HistoryOwnerAvatar` to thin wrapper with:
  - Null guard (`if (!owner) return null`)
  - `showTooltip: true` to preserve existing tooltip behavior
  - Call sites unchanged

- **Migrated** task meta's `OwnerAvatar` to direct `UserProfileAvatar` usage:
  - Removed private `OwnerAvatar` implementation
  - Tooltip remains at call site (matches current UX)

## Implementation Details

- Reuses exact styling from both implementations:
  - `ring-2 ring-background` for avatar border
  - `size-5` for sm, `size-6` for md
  - `bg-muted text-[10px] font-medium` for fallback
  - Initials: first letter uppercase or `User` icon
  - `onError` hides broken images (`display: "none"`)
  
- Uses existing patterns:
  - `resolveIpfsOrHttpUrl` from `@sokosumi/utils`
  - shadcn `Avatar`, `AvatarImage`, `AvatarFallback`
  - `Tooltip` components from shadcn/ui

## Verification

- ✅ `pnpm web:check` - Biome linting passed
- ✅ `pnpm web:test` - All 1427 tests passed
- ✅ `pnpm tsc --noEmit` - TypeScript type checking passed

## Related

Closes SOK-602
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-602](https://linear.app/masumi/issue/SOK-602/refactorweb-extract-shared-userprofileavatar-component)

<div><a href="https://cursor.com/agents/bc-cca1546a-abf8-4754-a30d-9cff8a605683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cca1546a-abf8-4754-a30d-9cff8a605683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

