### PR TITLE
chore(ci): remove unused Stripe publishable key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ env:
   SOKOSUMI_API_URL: "https://api.sokosumi.com"
   PAYMENT_API_KEY: "ci-payment-api-key"
   REGISTRY_API_KEY: "ci-registry-api-key"
-  STRIPE_PUBLISHABLE_KEY: "pk_test_ci_build_placeholder"
   STRIPE_SECRET_KEY: "sk_test_ci_build_placeholder"
   STRIPE_WEBHOOK_SECRET: "whsec_ci_build_placeholder"
   STRIPE_WELCOME_COUPON: "ci-stripe-welcome-coupon"


### PR DESCRIPTION
## Summary
- Remove the unused `STRIPE_PUBLISHABLE_KEY` placeholder from the build workflow.
- Confirm no tracked code imports Stripe.js or reads a Stripe publishable key.

## Test plan
- [x] Search repo for `STRIPE_PUBLISHABLE_KEY`, `loadStripe`, `@stripe/stripe-js`, and `stripe-js`
- [x] Removed local ignored `apps/web/.env` publishable-key entry as cleanup, not part of this PR


Made with [Cursor](https://cursor.com)