### PR TITLE
feat(core): harden OpenAPI status and role enums

### DIFF
--- a/apps/core/src/schemas/admin.schema.ts
+++ b/apps/core/src/schemas/admin.schema.ts
@@ -3,6 +3,7 @@ import { TaskStatus } from "@sokosumi/utils";
 
 import { LIMITS } from "@/config/constants";
 import { dateTimeSchema } from "@/helpers/datetime";
+import { stripeSubscriptionStatusNullableSchema } from "@/schemas/domain-enums.schema";
 import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
 import { taskSchema } from "@/schemas/task.schema";
 
@@ -88,7 +89,7 @@ export const adminUserOverviewItemSchema = z
       description: "Active subscription plan, if any",
       example: "pro",
     }),
-    subscriptionStatus: z.string().nullable().openapi({ example: "active" }),
+    subscriptionStatus: stripeSubscriptionStatusNullableSchema,
     startedTaskCount: z.number().int().min(0).openapi({
       description: "Number of tasks the user has started (status beyond DRAFT)",
       example: 7,

--- a/apps/core/src/schemas/domain-enums.schema.test.ts
+++ b/apps/core/src/schemas/domain-enums.schema.test.ts
@@ -5,6 +5,7 @@ import {
   INVITATION_DB_STATUS_VALUES,
   invitationStatusSchema,
   MEMBER_ROLE_VALUES,
+  memberRoleNullableSchema,
   memberRoleSchema,
 } from "./domain-enums.schema";
 
@@ -41,23 +42,22 @@ describe("domain enum schemas", () => {
     expect(() => invitationStatusSchema.parse("unknown")).toThrow();
   });
 
-  /**
-   * Phase-1 audit: these schemas still use bare `string` for role/status/kind
-   * because the values are external (Stripe, Better Auth platform role, Hermes)
-   * rather than Sokosumi Postgres enums. Tighten in a follow-up when sources
-   * are catalogued.
-   */
-  it("documents remaining bare string role/status/kind fields outside phase-1 scope", () => {
-    expect([
-      "user.schema.ts: role (platform Better Auth role)",
-      "subscription.schema.ts: status (Stripe subscription status)",
-      "hermes.schema.ts: role, kind (external Hermes API strings)",
-    ]).toMatchInlineSnapshot(`
-      [
-        "user.schema.ts: role (platform Better Auth role)",
-        "subscription.schema.ts: status (Stripe subscription status)",
-        "hermes.schema.ts: role, kind (external Hermes API strings)",
-      ]
-    `);
+  it("memberRoleNullableSchema accepts member roles and null, rejects unknown values", () => {
+    for (const role of MEMBER_ROLE_VALUES) {
+      expect(memberRoleNullableSchema.parse(role)).toBe(role);
+    }
+
+    expect(memberRoleNullableSchema.parse(null)).toBeNull();
+    expect(() => memberRoleNullableSchema.parse("superadmin")).toThrow();
   });
 });
+
+/*
+ * Phase-1 audit (deferred): these schemas still use bare `string` for
+ * role/status/kind because the values are external (Stripe subscription
+ * status, Better Auth platform role, Hermes API) rather than Sokosumi
+ * Postgres enums. Tighten in a follow-up once the sources are catalogued:
+ *   - user.schema.ts: role (platform Better Auth role)
+ *   - subscription.schema.ts: status (Stripe subscription status)
+ *   - hermes.schema.ts: role, kind (external Hermes API strings)
+ */

--- a/apps/core/src/schemas/domain-enums.schema.test.ts
+++ b/apps/core/src/schemas/domain-enums.schema.test.ts
@@ -7,6 +7,9 @@ import {
   MEMBER_ROLE_VALUES,
   memberRoleNullableSchema,
   memberRoleSchema,
+  STRIPE_SUBSCRIPTION_STATUS_VALUES,
+  stripeSubscriptionStatusNullableSchema,
+  stripeSubscriptionStatusSchema,
 } from "./domain-enums.schema";
 
 describe("domain enum schemas", () => {
@@ -50,14 +53,32 @@ describe("domain enum schemas", () => {
     expect(memberRoleNullableSchema.parse(null)).toBeNull();
     expect(() => memberRoleNullableSchema.parse("superadmin")).toThrow();
   });
+
+  it("stripeSubscriptionStatusSchema accepts Stripe statuses and rejects unknown values", () => {
+    for (const status of STRIPE_SUBSCRIPTION_STATUS_VALUES) {
+      expect(stripeSubscriptionStatusSchema.parse(status)).toBe(status);
+    }
+
+    expect(() => stripeSubscriptionStatusSchema.parse("unknown")).toThrow();
+  });
+
+  it("stripeSubscriptionStatusNullableSchema accepts Stripe statuses and null", () => {
+    for (const status of STRIPE_SUBSCRIPTION_STATUS_VALUES) {
+      expect(stripeSubscriptionStatusNullableSchema.parse(status)).toBe(status);
+    }
+
+    expect(stripeSubscriptionStatusNullableSchema.parse(null)).toBeNull();
+    expect(() =>
+      stripeSubscriptionStatusNullableSchema.parse("unknown"),
+    ).toThrow();
+  });
 });
 
 /*
  * Phase-1 audit (deferred): these schemas still use bare `string` for
- * role/status/kind because the values are external (Stripe subscription
- * status, Better Auth platform role, Hermes API) rather than Sokosumi
- * Postgres enums. Tighten in a follow-up once the sources are catalogued:
+ * role/kind because the values are intentionally open-ended rather than
+ * Sokosumi Postgres enums. Tighten in a follow-up only if the source contracts
+ * become closed sets:
  *   - user.schema.ts: role (platform Better Auth role)
- *   - subscription.schema.ts: status (Stripe subscription status)
  *   - hermes.schema.ts: role, kind (external Hermes API strings)
  */

--- a/apps/core/src/schemas/domain-enums.schema.test.ts
+++ b/apps/core/src/schemas/domain-enums.schema.test.ts
@@ -1,0 +1,63 @@
+import { InvitationStatus, MemberRole } from "@sokosumi/database";
+import { describe, expect, it } from "vitest";
+
+import {
+  INVITATION_DB_STATUS_VALUES,
+  invitationStatusSchema,
+  MEMBER_ROLE_VALUES,
+  memberRoleSchema,
+} from "./domain-enums.schema";
+
+describe("domain enum schemas", () => {
+  it("memberRoleSchema values match the database MemberRole enum", () => {
+    expect([...MEMBER_ROLE_VALUES].sort()).toEqual(
+      Object.values(MemberRole).sort(),
+    );
+  });
+
+  it("invitationStatusSchema values match database InvitationStatus (excluding frontend-only expired)", () => {
+    const { EXPIRED: _expired, ...databaseStatuses } = InvitationStatus;
+
+    expect([...INVITATION_DB_STATUS_VALUES].sort()).toEqual(
+      Object.values(databaseStatuses).sort(),
+    );
+    expect(InvitationStatus.EXPIRED).toBe("expired");
+  });
+
+  it("memberRoleSchema accepts all member roles and rejects unknown values", () => {
+    for (const role of MEMBER_ROLE_VALUES) {
+      expect(memberRoleSchema.parse(role)).toBe(role);
+    }
+
+    expect(() => memberRoleSchema.parse("superadmin")).toThrow();
+  });
+
+  it("invitationStatusSchema accepts all database statuses and rejects unknown values", () => {
+    for (const status of INVITATION_DB_STATUS_VALUES) {
+      expect(invitationStatusSchema.parse(status)).toBe(status);
+    }
+
+    expect(() => invitationStatusSchema.parse("expired")).toThrow();
+    expect(() => invitationStatusSchema.parse("unknown")).toThrow();
+  });
+
+  /**
+   * Phase-1 audit: these schemas still use bare `string` for role/status/kind
+   * because the values are external (Stripe, Better Auth platform role, Hermes)
+   * rather than Sokosumi Postgres enums. Tighten in a follow-up when sources
+   * are catalogued.
+   */
+  it("documents remaining bare string role/status/kind fields outside phase-1 scope", () => {
+    expect([
+      "user.schema.ts: role (platform Better Auth role)",
+      "subscription.schema.ts: status (Stripe subscription status)",
+      "hermes.schema.ts: role, kind (external Hermes API strings)",
+    ]).toMatchInlineSnapshot(`
+      [
+        "user.schema.ts: role (platform Better Auth role)",
+        "subscription.schema.ts: status (Stripe subscription status)",
+        "hermes.schema.ts: role, kind (external Hermes API strings)",
+      ]
+    `);
+  });
+});

--- a/apps/core/src/schemas/domain-enums.schema.ts
+++ b/apps/core/src/schemas/domain-enums.schema.ts
@@ -14,9 +14,11 @@ export const memberRoleSchema = z.enum(MEMBER_ROLE_VALUES).openapi({
   description: "Organization member role",
 });
 
-export const memberRoleNullableSchema = memberRoleSchema
-  .nullable()
-  .openapi({ example: MemberRole.MEMBER });
+export const memberRoleNullableSchema = memberRoleSchema.nullable().openapi({
+  example: MemberRole.MEMBER,
+  enum: [...MEMBER_ROLE_VALUES, null],
+  description: "Organization member role",
+});
 
 /** Invitation statuses persisted in Postgres (excludes frontend-only `expired`). */
 export const INVITATION_DB_STATUS_VALUES = [

--- a/apps/core/src/schemas/domain-enums.schema.ts
+++ b/apps/core/src/schemas/domain-enums.schema.ts
@@ -10,10 +10,13 @@ export const MEMBER_ROLE_VALUES = [
 
 export const memberRoleSchema = z.enum(MEMBER_ROLE_VALUES).openapi({
   example: MemberRole.MEMBER,
-  enum: [...MEMBER_ROLE_VALUES],
   description: "Organization member role",
 });
 
+// `enum` is set explicitly here: `z.enum(...).nullable()` emits
+// `type: ["string", "null"]` but keeps the non-null enum, which makes the
+// generated client drop the nullable union. Listing `null` in the enum keeps
+// the OpenAPI artifact and generated type (`... | null`) consistent.
 export const memberRoleNullableSchema = memberRoleSchema.nullable().openapi({
   example: MemberRole.MEMBER,
   enum: [...MEMBER_ROLE_VALUES, null],
@@ -32,6 +35,5 @@ export const invitationStatusSchema = z
   .enum(INVITATION_DB_STATUS_VALUES)
   .openapi({
     example: InvitationStatus.PENDING,
-    enum: [...INVITATION_DB_STATUS_VALUES],
     description: "Invitation lifecycle status stored in the database",
   });

--- a/apps/core/src/schemas/domain-enums.schema.ts
+++ b/apps/core/src/schemas/domain-enums.schema.ts
@@ -1,0 +1,35 @@
+import { z } from "@hono/zod-openapi";
+import { InvitationStatus, MemberRole } from "@sokosumi/database";
+
+/** Stored organization member roles (Postgres string column, not a Prisma enum). */
+export const MEMBER_ROLE_VALUES = [
+  MemberRole.OWNER,
+  MemberRole.ADMIN,
+  MemberRole.MEMBER,
+] as const;
+
+export const memberRoleSchema = z.enum(MEMBER_ROLE_VALUES).openapi({
+  example: MemberRole.MEMBER,
+  enum: [...MEMBER_ROLE_VALUES],
+  description: "Organization member role",
+});
+
+export const memberRoleNullableSchema = memberRoleSchema
+  .nullable()
+  .openapi({ example: MemberRole.MEMBER });
+
+/** Invitation statuses persisted in Postgres (excludes frontend-only `expired`). */
+export const INVITATION_DB_STATUS_VALUES = [
+  InvitationStatus.PENDING,
+  InvitationStatus.ACCEPTED,
+  InvitationStatus.REJECTED,
+  InvitationStatus.CANCELED,
+] as const;
+
+export const invitationStatusSchema = z
+  .enum(INVITATION_DB_STATUS_VALUES)
+  .openapi({
+    example: InvitationStatus.PENDING,
+    enum: [...INVITATION_DB_STATUS_VALUES],
+    description: "Invitation lifecycle status stored in the database",
+  });

--- a/apps/core/src/schemas/domain-enums.schema.ts
+++ b/apps/core/src/schemas/domain-enums.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { InvitationStatus, MemberRole } from "@sokosumi/database";
+import type Stripe from "stripe";
 
 /** Stored organization member roles (Postgres string column, not a Prisma enum). */
 export const MEMBER_ROLE_VALUES = [
@@ -36,4 +37,40 @@ export const invitationStatusSchema = z
   .openapi({
     example: InvitationStatus.PENDING,
     description: "Invitation lifecycle status stored in the database",
+  });
+
+/** Stripe subscription statuses mirrored in our persisted Subscription.status. */
+export const STRIPE_SUBSCRIPTION_STATUS_VALUES = [
+  "active",
+  "canceled",
+  "incomplete",
+  "incomplete_expired",
+  "past_due",
+  "paused",
+  "trialing",
+  "unpaid",
+] as const satisfies readonly Stripe.Subscription.Status[];
+
+type MissingStripeSubscriptionStatus = Exclude<
+  Stripe.Subscription.Status,
+  (typeof STRIPE_SUBSCRIPTION_STATUS_VALUES)[number]
+>;
+
+const _stripeSubscriptionStatusValuesAreExhaustive: Record<
+  MissingStripeSubscriptionStatus,
+  never
+> = {};
+
+export const stripeSubscriptionStatusSchema = z
+  .enum(STRIPE_SUBSCRIPTION_STATUS_VALUES)
+  .openapi({
+    example: "active",
+    description: "Stripe subscription lifecycle status",
+  });
+
+export const stripeSubscriptionStatusNullableSchema =
+  stripeSubscriptionStatusSchema.nullable().openapi({
+    example: "active",
+    enum: [...STRIPE_SUBSCRIPTION_STATUS_VALUES, null],
+    description: "Stripe subscription lifecycle status, or null when absent",
   });

--- a/apps/core/src/schemas/invitation.schema.ts
+++ b/apps/core/src/schemas/invitation.schema.ts
@@ -1,6 +1,10 @@
 import { z } from "@hono/zod-openapi";
 
 import { dateTimeSchema } from "@/helpers/datetime";
+import {
+  invitationStatusSchema,
+  memberRoleNullableSchema,
+} from "@/schemas/domain-enums.schema";
 
 /**
  * Raw pending-invitation fields, mirroring the `Invitation` model. Used by the
@@ -11,8 +15,8 @@ export const pendingInvitationSchema = z
     id: z.string().openapi({ example: "inv_123" }),
     organizationId: z.string().openapi({ example: "org_123" }),
     email: z.string().openapi({ example: "jane@example.com" }),
-    role: z.string().nullable().openapi({ example: "member" }),
-    status: z.string().openapi({ example: "pending" }),
+    role: memberRoleNullableSchema,
+    status: invitationStatusSchema,
     expiresAt: dateTimeSchema,
     inviterId: z.string().openapi({ example: "user_123" }),
     createdAt: dateTimeSchema,

--- a/apps/core/src/schemas/member.schema.ts
+++ b/apps/core/src/schemas/member.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "@hono/zod-openapi";
 
 import { dateTimeSchema } from "@/helpers/datetime";
+import { memberRoleSchema } from "@/schemas/domain-enums.schema";
 import { organizationRecordSchema } from "@/schemas/organization.schema";
 
 const memberUserSchema = z.object({
@@ -17,7 +18,7 @@ export const memberWithUserSchema = z
   .object({
     id: z.string().openapi({ example: "member_123" }),
     organizationId: z.string().openapi({ example: "org_123" }),
-    role: z.string().openapi({ example: "member" }),
+    role: memberRoleSchema,
     seatAssignedAt: dateTimeSchema.nullable(),
     createdAt: dateTimeSchema,
     user: memberUserSchema,
@@ -42,7 +43,7 @@ export const memberRecordSchema = z
     id: z.string().openapi({ example: "member_123" }),
     userId: z.string().openapi({ example: "user_123" }),
     organizationId: z.string().openapi({ example: "org_123" }),
-    role: z.string().openapi({ example: "member" }),
+    role: memberRoleSchema,
     seatAssignedAt: dateTimeSchema.nullable(),
     createdAt: dateTimeSchema,
   })
@@ -60,7 +61,7 @@ export const memberWithOrganizationSchema = z
     id: z.string().openapi({ example: "member_123" }),
     userId: z.string().openapi({ example: "user_123" }),
     organizationId: z.string().openapi({ example: "org_123" }),
-    role: z.string().openapi({ example: "member" }),
+    role: memberRoleSchema,
     seatAssignedAt: dateTimeSchema.nullable(),
     createdAt: dateTimeSchema,
     organization: organizationRecordSchema,

--- a/apps/core/src/schemas/organization.schema.ts
+++ b/apps/core/src/schemas/organization.schema.ts
@@ -2,6 +2,7 @@ import { z } from "@hono/zod-openapi";
 import { sanitizeOrganizationLogoForApi } from "@sokosumi/utils";
 
 import { dateTimeSchema } from "@/helpers/datetime";
+import { memberRoleSchema } from "@/schemas/domain-enums.schema";
 
 const organizationLogoSchema = z.preprocess(
   (logo) => sanitizeOrganizationLogoForApi(logo),
@@ -30,7 +31,7 @@ export type Organization = z.infer<typeof organizationSchema>;
 
 export const organizationWithRoleSchema = organizationSchema
   .extend({
-    role: z.string().openapi({ example: "member" }),
+    role: memberRoleSchema,
   })
   .openapi("Organization");
 

--- a/apps/core/src/schemas/subscription.schema.ts
+++ b/apps/core/src/schemas/subscription.schema.ts
@@ -1,10 +1,11 @@
 import { z } from "@hono/zod-openapi";
 
 import { dateTimeSchema } from "@/helpers/datetime";
+import { stripeSubscriptionStatusSchema } from "@/schemas/domain-enums.schema";
 
 export const subscriptionSchema = z.object({
   plan: z.string().openapi({ example: "starter" }),
-  status: z.string().openapi({ example: "active" }),
+  status: stripeSubscriptionStatusSchema,
   periodStart: dateTimeSchema.nullish(),
   periodEnd: dateTimeSchema.nullish(),
   cancelAtPeriodEnd: z.boolean().nullish().openapi({ example: false }),
@@ -39,7 +40,7 @@ export const activeSubscriptionResponseSchema = z
     subscription: z
       .object({
         plan: z.string().openapi({ example: "starter" }),
-        status: z.string().openapi({ example: "active" }),
+        status: stripeSubscriptionStatusSchema,
         cancelAtPeriodEnd: z.boolean().nullish().openapi({ example: false }),
         periodStart: dateTimeSchema.nullish(),
         periodEnd: dateTimeSchema.nullish(),

--- a/apps/web/src/app/(app)/components/__tests__/user-credits.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/user-credits.test.tsx
@@ -1,7 +1,9 @@
 import type { Session } from "@sokosumi/utils";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import UserCredits from "@/app/components/user-credits";
+import UserCredits, {
+  type UserCreditsData,
+} from "@/app/components/user-credits";
 
 vi.mock("next-intl/server", () => ({
   getTranslations: (namespace: string) =>
@@ -75,7 +77,10 @@ const session = {
   },
 } as unknown as Session;
 
-function createCreditsResponse(plan: string | null, buffer: number) {
+function createCreditsResponse(
+  plan: string | null,
+  buffer: number,
+): { data: { credits: UserCreditsData } } {
   return {
     data: {
       credits: {

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -5674,7 +5674,8 @@ export const PendingInvitationSchema = {
             enum: [
                 'owner',
                 'admin',
-                'member'
+                'member',
+                null
             ],
             example: 'member',
             description: 'Organization member role'

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -101,7 +101,19 @@ export const AdminUserOverviewItemSchema = {
                 'string',
                 'null'
             ],
-            example: 'active'
+            enum: [
+                'active',
+                'canceled',
+                'incomplete',
+                'incomplete_expired',
+                'past_due',
+                'paused',
+                'trialing',
+                'unpaid',
+                null
+            ],
+            example: 'active',
+            description: 'Stripe subscription lifecycle status, or null when absent'
         },
         startedTaskCount: {
             type: 'integer',
@@ -5420,7 +5432,18 @@ export const ActiveSubscriptionResponseSchema = {
                 },
                 status: {
                     type: 'string',
-                    example: 'active'
+                    enum: [
+                        'active',
+                        'canceled',
+                        'incomplete',
+                        'incomplete_expired',
+                        'past_due',
+                        'paused',
+                        'trialing',
+                        'unpaid'
+                    ],
+                    example: 'active',
+                    description: 'Stripe subscription lifecycle status'
                 },
                 cancelAtPeriodEnd: {
                     type: [

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -4859,7 +4859,13 @@ export const MemberWithOrganizationSchema = {
         },
         role: {
             type: 'string',
-            example: 'member'
+            enum: [
+                'owner',
+                'admin',
+                'member'
+            ],
+            example: 'member',
+            description: 'Organization member role'
         },
         seatAssignedAt: {
             type: [
@@ -5007,7 +5013,13 @@ export const OrganizationSchema = {
         },
         role: {
             type: 'string',
-            example: 'member'
+            enum: [
+                'owner',
+                'admin',
+                'member'
+            ],
+            example: 'member',
+            description: 'Organization member role'
         }
     },
     required: [
@@ -5037,7 +5049,13 @@ export const MemberRecordSchema = {
         },
         role: {
             type: 'string',
-            example: 'member'
+            enum: [
+                'owner',
+                'admin',
+                'member'
+            ],
+            example: 'member',
+            description: 'Organization member role'
         },
         seatAssignedAt: {
             type: [
@@ -5526,7 +5544,13 @@ export const MemberSchema = {
         },
         role: {
             type: 'string',
-            example: 'member'
+            enum: [
+                'owner',
+                'admin',
+                'member'
+            ],
+            example: 'member',
+            description: 'Organization member role'
         },
         seatAssignedAt: {
             type: [
@@ -5647,11 +5671,24 @@ export const PendingInvitationSchema = {
                 'string',
                 'null'
             ],
-            example: 'member'
+            enum: [
+                'owner',
+                'admin',
+                'member'
+            ],
+            example: 'member',
+            description: 'Organization member role'
         },
         status: {
             type: 'string',
-            example: 'pending'
+            enum: [
+                'pending',
+                'accepted',
+                'rejected',
+                'canceled'
+            ],
+            example: 'pending',
+            description: 'Invitation lifecycle status stored in the database'
         },
         expiresAt: {
             type: 'string',

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1403,7 +1403,10 @@ export type MemberWithOrganization = {
     id: string;
     userId: string;
     organizationId: string;
-    role: string;
+    /**
+     * Organization member role
+     */
+    role: 'owner' | 'admin' | 'member';
     seatAssignedAt: Date | null;
     createdAt: Date;
     organization: OrganizationRecord;
@@ -1430,14 +1433,20 @@ export type Organization = {
         invoiceEmail?: string | null;
         [key: string]: unknown;
     } | null;
-    role: string;
+    /**
+     * Organization member role
+     */
+    role: 'owner' | 'admin' | 'member';
 };
 
 export type MemberRecord = {
     id: string;
     userId: string;
     organizationId: string;
-    role: string;
+    /**
+     * Organization member role
+     */
+    role: 'owner' | 'admin' | 'member';
     seatAssignedAt: Date | null;
     createdAt: Date;
 };
@@ -1622,7 +1631,10 @@ export type User = {
 export type Member = {
     id: string;
     organizationId: string;
-    role: string;
+    /**
+     * Organization member role
+     */
+    role: 'owner' | 'admin' | 'member';
     seatAssignedAt: Date | null;
     createdAt: Date;
     user: {
@@ -1659,8 +1671,14 @@ export type PendingInvitation = {
     id: string;
     organizationId: string;
     email: string;
-    role: string | null;
-    status: string;
+    /**
+     * Organization member role
+     */
+    role: 'owner' | 'admin' | 'member';
+    /**
+     * Invitation lifecycle status stored in the database
+     */
+    status: 'pending' | 'accepted' | 'rejected' | 'canceled';
     expiresAt: Date;
     inviterId: string;
     createdAt: Date;

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -42,7 +42,10 @@ export type AdminUserOverviewItem = {
      * Active subscription plan, if any
      */
     subscriptionPlan: string | null;
-    subscriptionStatus: string | null;
+    /**
+     * Stripe subscription lifecycle status, or null when absent
+     */
+    subscriptionStatus: 'active' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'paused' | 'trialing' | 'unpaid' | null;
     /**
      * Number of tasks the user has started (status beyond DRAFT)
      */
@@ -1605,7 +1608,10 @@ export type ProvisionedStripeCustomer = {
 export type ActiveSubscriptionResponse = {
     subscription: {
         plan: string;
-        status: string;
+        /**
+         * Stripe subscription lifecycle status
+         */
+        status: 'active' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'paused' | 'trialing' | 'unpaid';
         cancelAtPeriodEnd?: boolean | null;
         periodStart?: Date | null;
         periodEnd?: Date | null;
@@ -9960,7 +9966,10 @@ export type GetUsersByIdCreditsResponses = {
              */
             subscription: {
                 plan: string;
-                status: string;
+                /**
+                 * Stripe subscription lifecycle status
+                 */
+                status: 'active' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'paused' | 'trialing' | 'unpaid';
                 periodStart?: Date | null;
                 periodEnd?: Date | null;
                 cancelAtPeriodEnd?: boolean | null;
@@ -9988,7 +9997,10 @@ export type GetUsersByIdCreditsResponses = {
             credits: {
                 subscription: {
                     plan: string;
-                    status: string;
+                    /**
+                     * Stripe subscription lifecycle status
+                     */
+                    status: 'active' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'paused' | 'trialing' | 'unpaid';
                     periodStart?: Date | null;
                     periodEnd?: Date | null;
                     cancelAtPeriodEnd?: boolean | null;
@@ -10499,7 +10511,10 @@ export type GetUsersByIdOrganizationsByOrganizationIdCreditsResponses = {
              */
             subscription: {
                 plan: string;
-                status: string;
+                /**
+                 * Stripe subscription lifecycle status
+                 */
+                status: 'active' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'paused' | 'trialing' | 'unpaid';
                 periodStart?: Date | null;
                 periodEnd?: Date | null;
                 cancelAtPeriodEnd?: boolean | null;
@@ -10527,7 +10542,10 @@ export type GetUsersByIdOrganizationsByOrganizationIdCreditsResponses = {
             credits: {
                 subscription: {
                     plan: string;
-                    status: string;
+                    /**
+                     * Stripe subscription lifecycle status
+                     */
+                    status: 'active' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'past_due' | 'paused' | 'trialing' | 'unpaid';
                     periodStart?: Date | null;
                     periodEnd?: Date | null;
                     cancelAtPeriodEnd?: boolean | null;

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1674,7 +1674,7 @@ export type PendingInvitation = {
     /**
      * Organization member role
      */
-    role: 'owner' | 'admin' | 'member';
+    role: 'owner' | 'admin' | 'member' | null;
     /**
      * Invitation lifecycle status stored in the database
      */


### PR DESCRIPTION
## Summary

Implements SOK-589 phase 1: tightens Core OpenAPI schemas so web-critical role and status fields use typed enums instead of bare `string`.

## Changes

- Add shared Core enum schemas for member roles, invitation statuses, and Stripe subscription statuses
- Pin `Member`, `MemberRecord`, `MemberWithOrganization`, and `Organization.role` to `owner | admin | member`
- Pin `PendingInvitation.role` to member roles plus `null`
- Pin `PendingInvitation.status` to database values: `pending | accepted | rejected | canceled`
- Pin subscription DTO status fields to Stripe values: `active | canceled | incomplete | incomplete_expired | past_due | paused | trialing | unpaid`
- Add schema tests and a compile-time Stripe status exhaustiveness guard against `Stripe.Subscription.Status`
- Regenerate the web Core client from the OpenAPI snapshot

## Audit

Remaining bare-string role/kind fields are intentionally open-ended:

- `user.schema.ts` `role`: Better Auth platform role can be custom/comma-separated
- `hermes.schema.ts` onboarding `role`: free-text user job title, not an access-control role
- `hermes.schema.ts` message `kind`: orchestrator message kind allows future values

## Verification

- `pnpm --filter core check`
- `pnpm --filter core typecheck`
- `pnpm --filter core test src/schemas/domain-enums.schema.test.ts src/schemas/subscription.schema.test.ts`
- `pnpm --filter web generate:core:snapshot`