### PR TITLE
fix(dev): start core and web in parallel via pnpm dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "scripts": {
-    "dev": "pnpm -r dev",
+    "dev": "pnpm -r --parallel dev",
     "web:dev": "pnpm --filter web dev",
     "core:dev": "pnpm --filter core dev",
     "build": "pnpm -r build",


### PR DESCRIPTION
## Summary
- Run `pnpm dev` with `--parallel` so Core and Web start together
- Fixes local login/API failures when only Web was starting under `pnpm -r dev`

## Test plan
- [ ] Run `pnpm dev` and confirm both Core (`:8787`) and Web (`:3000`) start
- [ ] Open `/signin` and verify no "Failed to fetch session from Core" error
- [ ] Confirm login works end-to-end


Made with [Cursor](https://cursor.com)