### PR TITLE
fix(web): correct credit usage hover text in light mode

### DIFF
--- a/apps/web/src/app/(app)/components/credit-usage.tsx
+++ b/apps/web/src/app/(app)/components/credit-usage.tsx
@@ -319,7 +319,7 @@ export default function CreditUsage({
             aria-label={triggerLabel}
             className="group hover:bg-sidebar-accent focus-visible:ring-sidebar-ring data-[state=open]:bg-sidebar-accent w-full min-w-28 cursor-pointer space-y-1 rounded-md px-2 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
           >
-            <div className="text-muted-foreground group-hover:text-primary-foreground dark:group-hover:text-primary-foreground group-data-[state=open]:text-primary-foreground flex w-full items-center gap-1.5 text-xs font-semibold">
+            <div className="text-muted-foreground group-hover:text-sidebar-accent-foreground group-data-[state=open]:text-sidebar-accent-foreground flex w-full items-center gap-1.5 text-xs font-semibold">
               {isLowCredits ? (
                 <AlertTriangle className="size-3.5 shrink-0" aria-hidden />
               ) : null}


### PR DESCRIPTION
## Summary

- Fix unreadable credit usage text on hover/open in the sidebar footer on light mode
- Use `text-sidebar-accent-foreground` instead of `text-primary-foreground` to match other sidebar items

## Test plan

- [x] `pnpm --filter web test src/app/(app)/components/__tests__/credit-usage.test.tsx`
- [ ] Hover credit usage widget in sidebar footer on light mode — text stays readable
- [ ] Open credit usage popover on light mode — text stays readable
- [ ] Verify dark mode hover/open still looks correct


Made with [Cursor](https://cursor.com)