### PR TITLE
chore: add Neon integration test PR marker

### DIFF
--- a/docs/neon-integration-test.md
+++ b/docs/neon-integration-test.md
@@ -1,0 +1,4 @@
+# Neon Integration Test
+
+This file exists only to create a test pull request that verifies the Neon
+integration wiring for this repository.


### PR DESCRIPTION
## Summary
- Adds a small docs-only marker file to create a test pull request.
- Intended to verify the Neon integration is wired for repository PR workflows.

## Test plan
- Not run; docs-only test PR.


Made with [Cursor](https://cursor.com)