### PR TITLE
fix(web): wire register form Terms and Privacy links to main menu legal URLs

### DIFF
--- a/apps/web/src/app/(app)/components/header/user-account-menu-items.tsx
+++ b/apps/web/src/app/(app)/components/header/user-account-menu-items.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
+import { LEGAL_URLS } from "@/lib/constants/legal-urls";
 
 interface HelpLinkItem {
   url: string;
@@ -65,27 +66,27 @@ const HELP_LINKS: HelpLinkItem[] = [
 
 const LEGAL_LINKS: LegalLinkItem[] = [
   {
-    url: "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
+    url: LEGAL_URLS.SERVICEPLAN_AI_COWORKER,
     translationKey: "serviceplanAiCoworker",
     icon: Bot,
   },
   {
-    url: "https://www.sokosumi.com/terms-of-service",
+    url: LEGAL_URLS.TERMS_OF_SERVICE,
     translationKey: "termsOfService",
     icon: ScrollText,
   },
   {
-    url: "https://www.sokosumi.com/privacy-policy",
+    url: LEGAL_URLS.PRIVACY_POLICY,
     translationKey: "privacyPolicy",
     icon: Shield,
   },
   {
-    url: "https://www.sokosumi.com/imprint",
+    url: LEGAL_URLS.IMPRINT,
     translationKey: "imprint",
     icon: Landmark,
   },
   {
-    url: "https://www.sokosumi.com/acceptable-use",
+    url: LEGAL_URLS.ACCEPTABLE_USE,
     translationKey: "acceptableUse",
     icon: ListChecks,
   },

--- a/apps/web/src/app/(auth)/components/form/form-fields.tsx
+++ b/apps/web/src/app/(auth)/components/form/form-fields.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { LEGAL_URLS } from "@/lib/constants/legal-urls";
 import type { FormData } from "@/lib/form";
 
 import { PasswordInput } from "./password-input";
@@ -104,11 +105,19 @@ function FormInput<T extends FieldValues>({
         className="flex flex-wrap items-center gap-1"
       >
         <span>{iAgreeToText}</span>
-        <Link target="_blank" href="/terms-of-service" className="underline">
+        <Link
+          target="_blank"
+          href={LEGAL_URLS.TERMS_OF_SERVICE}
+          className="underline"
+        >
           {termsOfServiceText}
         </Link>
         <span>{andText}</span>
-        <Link target="_blank" href="/privacy-policy" className="underline">
+        <Link
+          target="_blank"
+          href={LEGAL_URLS.PRIVACY_POLICY}
+          className="underline"
+        >
           {privacyPolicyText}
         </Link>
       </Label>

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -7,6 +7,7 @@ import { getTranslations } from "next-intl/server";
 
 import { SokosumiLogo, ThemedLogo } from "@/components/masumi-logos";
 import { getSession } from "@/lib/auth/auth.server";
+import { LEGAL_URLS } from "@/lib/constants/legal-urls";
 import { getDefaultAuthenticatedLandingPath } from "@/lib/utils/landing-path";
 
 import AuthBackground from "./components/auth-background";
@@ -67,7 +68,7 @@ function AuthLayoutFooter() {
   return (
     <div className="flex flex-wrap items-center justify-center gap-2 text-center sm:gap-4">
       <Link
-        href="https://www.sokosumi.com/terms-of-service"
+        href={LEGAL_URLS.TERMS_OF_SERVICE}
         target="_blank"
         rel="noopener noreferrer"
         className="text-sm hover:text-gray-300"
@@ -75,7 +76,7 @@ function AuthLayoutFooter() {
         {t("termsOfServices")}
       </Link>
       <Link
-        href="https://www.sokosumi.com/privacy-policy"
+        href={LEGAL_URLS.PRIVACY_POLICY}
         target="_blank"
         rel="noopener noreferrer"
         className="text-sm hover:text-gray-300"
@@ -83,7 +84,7 @@ function AuthLayoutFooter() {
         {t("privacyPolicy")}
       </Link>
       <Link
-        href="https://www.sokosumi.com/imprint"
+        href={LEGAL_URLS.IMPRINT}
         target="_blank"
         rel="noopener noreferrer"
         className="text-sm hover:text-gray-300"
@@ -91,7 +92,7 @@ function AuthLayoutFooter() {
         {t("imprint")}
       </Link>
       <Link
-        href="https://www.sokosumi.com/acceptable-use"
+        href={LEGAL_URLS.ACCEPTABLE_USE}
         target="_blank"
         rel="noopener noreferrer"
         className="text-sm hover:text-gray-300"

--- a/apps/web/src/lib/constants/legal-urls.ts
+++ b/apps/web/src/lib/constants/legal-urls.ts
@@ -1,0 +1,8 @@
+export const LEGAL_URLS = {
+  TERMS_OF_SERVICE: "https://www.sokosumi.com/terms-of-service",
+  PRIVACY_POLICY: "https://www.sokosumi.com/privacy-policy",
+  IMPRINT: "https://www.sokosumi.com/imprint",
+  ACCEPTABLE_USE: "https://www.sokosumi.com/acceptable-use",
+  SERVICEPLAN_AI_COWORKER:
+    "https://www.house-of-communication.com/de/en/brands/plan-net/landingpages/agentic-services/legal-ai-coworkers.html",
+} as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken Terms of Service and Privacy Policy links on the register page. The links now point to the correct external URLs (`https://www.sokosumi.com/...`) instead of relative paths.

## Changes

- Created shared `LEGAL_URLS` constant in `apps/web/src/lib/constants/legal-urls.ts` containing all legal page URLs
- Updated register form links to use correct external URLs from the shared constant
- Refactored user account menu and auth layout footer to use the same shared constant for consistency

## Verification

- ✅ Links on register page now point to `https://www.sokosumi.com/terms-of-service` and `https://www.sokosumi.com/privacy-policy`
- ✅ Links open in new tab as before (existing `target="_blank"` preserved)
- ✅ All legal URLs centralized in one constant, making future updates easier
- ✅ Biome linting and formatting checks passed

## Related Issue

Closes SOK-610
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-610](https://linear.app/masumi/issue/SOK-610/fixweb-wire-register-form-terms-and-privacy-links-to-main-menu-legal)

<div><a href="https://cursor.com/agents/bc-0bd0d72e-5f86-4727-9ab2-6f1fa417dbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bd0d72e-5f86-4727-9ab2-6f1fa417dbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

