### PR TITLE
fix(web): hide unread dot while bell reminder shows

### DIFF
--- a/apps/web/src/app/(app)/components/header/header-notification-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-notification-avatar.client.tsx
@@ -139,7 +139,7 @@ export function HeaderNotificationAvatar({
               />
             </div>
           </div>
-          {unreadCount > 0 ? (
+          {unreadCount > 0 && !showBell ? (
             <span
               className="bg-primary absolute right-0 top-0 size-2 animate-pulse rounded-full ring-2 ring-background"
               aria-hidden


### PR DESCRIPTION
## Summary

- Hides the unread notification dot while the header bell reminder animation is active
- Restores the intended behavior from the bell polish work in #3235

## Test plan

- [ ] With unread notifications, confirm the pulsing dot shows on the workspace avatar by default
- [ ] Wait for (or trigger) the bell reminder animation and confirm the dot is hidden while the bell is visible
- [ ] After the animation ends, confirm the dot returns
- [ ] Confirm the dot still hides when all notifications are read


Made with [Cursor](https://cursor.com)