### PR TITLE
fix(web): fix sidebar submenu focus and internal link navigation

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const goBackMock = vi.fn();
+const openSubmenuMock = vi.fn();
+const pushMock = vi.fn();
+const setOpenMobileMock = vi.fn();
+const showLogoutModalMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/components/modals/global-modals-context", () => ({
+  useGlobalModalsContext: () => ({
+    showLogoutModal: showLogoutModalMock,
+  }),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarMenu: ({ children }: { children: React.ReactNode }) => (
+    <ul>{children}</ul>
+  ),
+  SidebarMenuButton: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  SidebarMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
+  useSidebar: () => ({
+    isMobile: true,
+    setOpenMobile: setOpenMobileMock,
+  }),
+}));
+
+vi.mock("@/app/components/sidebar/components/sidebar-submenu", () => ({
+  useSidebarSubmenu: () => ({
+    goBack: goBackMock,
+    openSubmenu: openSubmenuMock,
+  }),
+}));
+
+import { SettingsSubmenuContent } from "@/app/components/sidebar/components/settings-submenu-content";
+
+describe("SettingsSubmenuContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates without closing the submenu", () => {
+    render(
+      <SettingsSubmenuContent
+        sessionUser={{
+          id: "user-1",
+          email: "user@example.com",
+          name: "User",
+          image: null,
+        }}
+        members={[]}
+        activeOrganizationId={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "account" }));
+
+    expect(goBackMock).not.toHaveBeenCalled();
+    expect(pushMock).toHaveBeenCalledWith("/account");
+    expect(setOpenMobileMock).toHaveBeenCalledWith(false);
+  });
+
+  it("closes the submenu when logging out", () => {
+    render(
+      <SettingsSubmenuContent
+        sessionUser={{
+          id: "user-1",
+          email: "user@example.com",
+          name: "User",
+          image: null,
+        }}
+        members={[]}
+        activeOrganizationId={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "logout" }));
+
+    expect(goBackMock).toHaveBeenCalled();
+    expect(setOpenMobileMock).toHaveBeenCalledWith(false);
+    expect(showLogoutModalMock).toHaveBeenCalledWith("user@example.com");
+  });
+});

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx
@@ -1,5 +1,19 @@
+import type { SessionUser } from "@sokosumi/utils";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sessionUser: SessionUser = {
+  id: "user-1",
+  email: "user@example.com",
+  name: "User",
+  image: null,
+  emailVerified: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  termsAccepted: true,
+  marketingOptIn: false,
+  onboardingCompleted: true,
+};
 
 const goBackMock = vi.fn();
 const openSubmenuMock = vi.fn();
@@ -70,12 +84,7 @@ describe("SettingsSubmenuContent", () => {
   it("navigates without closing the submenu", () => {
     render(
       <SettingsSubmenuContent
-        sessionUser={{
-          id: "user-1",
-          email: "user@example.com",
-          name: "User",
-          image: null,
-        }}
+        sessionUser={sessionUser}
         members={[]}
         activeOrganizationId={null}
       />,
@@ -91,12 +100,7 @@ describe("SettingsSubmenuContent", () => {
   it("closes the submenu when logging out", () => {
     render(
       <SettingsSubmenuContent
-        sessionUser={{
-          id: "user-1",
-          email: "user@example.com",
-          name: "User",
-          image: null,
-        }}
+        sessionUser={sessionUser}
         members={[]}
         activeOrganizationId={null}
       />,

--- a/apps/web/src/app/(app)/components/sidebar/components/settings-submenu-content.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/settings-submenu-content.tsx
@@ -44,20 +44,20 @@ export function SettingsSubmenuContent({
     members,
   });
 
-  function closeSubmenuAndSheet() {
-    goBack();
+  function closeMobileSheet() {
     if (isMobile) {
       setOpenMobile(false);
     }
   }
 
   function handleNavigate(path: string) {
-    closeSubmenuAndSheet();
+    closeMobileSheet();
     router.push(path);
   }
 
   function handleLogout() {
-    closeSubmenuAndSheet();
+    goBack();
+    closeMobileSheet();
     showLogoutModal(sessionUser.email);
   }
 

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-submenu.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-submenu.tsx
@@ -169,7 +169,7 @@ export function SidebarSubmenu({
   );
 
   useEffect(() => {
-    if (!activeId) {
+    if (!activeId || trackDepth !== depth) {
       return;
     }
 
@@ -180,7 +180,7 @@ export function SidebarSubmenu({
     return () => {
       cancelAnimationFrame(frame);
     };
-  }, [activeId]);
+  }, [activeId, depth, trackDepth]);
 
   useEffect(() => {
     if (depth > trackDepth) {


### PR DESCRIPTION
## Summary
- Move submenu panel focus until `trackDepth` matches the active depth, so keyboard focus lands on the visible panel instead of inert content.
- Keep the settings submenu open when navigating to internal account links; only close the mobile sheet and still reset on logout.

## Test plan
- [x] `pnpm --filter web test src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx`
- [ ] Open Settings submenu on desktop, tab through items — focus stays on the visible panel
- [ ] Open Settings → Help/Legal, confirm focus moves to the nested panel
- [ ] Click Account/Billing/Connections — page navigates and submenu stays open on desktop
- [ ] On mobile, internal link closes the sheet but reopening sidebar shows Settings submenu again
- [ ] Logout still returns to the main menu


Made with [Cursor](https://cursor.com)