### PR TITLE
feat(core): add catalog endpoint listing all agents and coworkers

### DIFF
--- a/apps/core/src/routes/v1/catalog/get.test.ts
+++ b/apps/core/src/routes/v1/catalog/get.test.ts
@@ -1,0 +1,218 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatZodErrorMessage, unprocessableEntity } from "@/helpers/error";
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import type { AuthVariables } from "@/middleware/auth";
+
+import mountGetCatalog from "./get";
+
+const {
+  agentFindManyMock,
+  buildAgentSummariesMock,
+  buildAvailableAgentWhereClauseMock,
+  getAgentAuthorImageMock,
+  getCreditCostsOrThrowMock,
+  coworkerFindManyMock,
+  prismaTransactionMock,
+} = vi.hoisted(() => ({
+  agentFindManyMock: vi.fn(),
+  buildAgentSummariesMock: vi.fn(),
+  buildAvailableAgentWhereClauseMock: vi.fn(),
+  getAgentAuthorImageMock: vi.fn(),
+  getCreditCostsOrThrowMock: vi.fn(),
+  coworkerFindManyMock: vi.fn(),
+  prismaTransactionMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/agent", () => ({
+  buildAvailableAgentWhereClause: buildAvailableAgentWhereClauseMock,
+  getCreditCostsOrThrow: getCreditCostsOrThrowMock,
+  getAgentAuthorImage: getAgentAuthorImageMock,
+}));
+
+vi.mock("@/helpers/agent-summary", () => ({
+  buildAgentSummaries: buildAgentSummariesMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: prismaTransactionMock,
+    coworker: {
+      findMany: coworkerFindManyMock,
+    },
+  },
+}));
+
+const agentRow = {
+  id: "agent_123",
+  tags: [{ name: "research" }, { name: "analysis" }],
+  overrideTags: [],
+  exampleOutput: [
+    {
+      name: "Sample",
+      mimeType: "image/png",
+      url: "https://example.com/output.png",
+    },
+  ],
+  overrideExampleOutput: [],
+};
+
+const agentSummary = {
+  id: "agent_123",
+  createdAt: new Date("2026-03-17T10:00:00.000Z"),
+  updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+  name: "Research Assistant",
+  image: null,
+  icon: null,
+  credits: 100,
+  summary: "A short summary",
+  description: "Finds information",
+  metrics: {
+    executions: { count: 2, averageTime: 120 },
+    ratings: { total: 3, average: 4.5 },
+  },
+  author: {
+    name: "Jane Doe",
+    image: null,
+    organization: "Sokosumi",
+    email: "jane@example.com",
+    other: null,
+  },
+  legal: { privacyPolicy: null, terms: null, dpa: null, other: null },
+  categories: [],
+  riskClassification: "MINIMAL",
+};
+
+const coworkerRow = {
+  id: "cow_123",
+  createdAt: new Date("2026-03-17T10:00:00.000Z"),
+  updatedAt: new Date("2026-03-17T10:00:00.000Z"),
+  archivedAt: null,
+  isWhitelisted: true,
+  priority: 10,
+  slug: "ops-agent",
+  name: "Ops Agent",
+  caption: null,
+  company: null,
+  companyLogo: null,
+  url: null,
+  baseURL: null,
+  description: "Ops helper",
+  capabilities: ["chat", "tasks"],
+  image: null,
+  metadata: null,
+};
+
+function createApp() {
+  const app = new OpenAPIHono<{
+    Variables: AuthVariables;
+  }>({
+    defaultHook: (result) => {
+      if (!result.success && result.error) {
+        throw unprocessableEntity(formatZodErrorMessage(result.error));
+      }
+    },
+  });
+
+  app.use("*", async (c, next) => {
+    c.set("requestId", "test-req-id");
+    c.set("isAuthenticated", true);
+    c.set("authContext", {
+      actor: "user",
+      userId: "user_123",
+      organizationId: null,
+      role: "user",
+    });
+    return await next();
+  });
+
+  mountGetCatalog(app as unknown as OpenAPIHonoWithAuth);
+  return app;
+}
+
+describe("GET /catalog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    buildAvailableAgentWhereClauseMock.mockReturnValue({ isAvailable: true });
+    getCreditCostsOrThrowMock.mockResolvedValue([]);
+    getAgentAuthorImageMock.mockReturnValue(null);
+    agentFindManyMock.mockResolvedValue([agentRow]);
+    buildAgentSummariesMock.mockResolvedValue([agentSummary]);
+    coworkerFindManyMock.mockResolvedValue([coworkerRow]);
+    prismaTransactionMock.mockImplementation(async (callback) =>
+      callback({ agent: { findMany: agentFindManyMock } }),
+    );
+  });
+
+  it("returns all agents with detail metadata and coworkers in one response", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.agents).toHaveLength(1);
+    expect(body.data.agents[0]).toMatchObject({
+      id: "agent_123",
+      name: "Research Assistant",
+      riskClassification: "MINIMAL",
+      tags: ["research", "analysis"],
+    });
+    expect(body.data.agents[0].exampleOutputs[0]).toMatchObject({
+      name: "Sample",
+      mimeType: "image/png",
+      url: "https://example.com/output.png",
+    });
+    expect(body.data.coworkers).toHaveLength(1);
+    expect(body.data.coworkers[0]).toMatchObject({
+      id: "cow_123",
+      slug: "ops-agent",
+      capabilities: ["chat", "tasks"],
+    });
+  });
+
+  it("defaults coworkers to the whitelisted scope", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/");
+
+    expect(response.status).toBe(200);
+    expect(coworkerFindManyMock).toHaveBeenCalledWith({
+      where: { archivedAt: null, isWhitelisted: true },
+      orderBy: [{ priority: "desc" }, { slug: "asc" }],
+    });
+  });
+
+  it("returns all active coworkers when coworkerScope=all", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/?coworkerScope=all");
+
+    expect(response.status).toBe(200);
+    expect(coworkerFindManyMock).toHaveBeenCalledWith({
+      where: { archivedAt: null },
+      orderBy: [{ priority: "desc" }, { slug: "asc" }],
+    });
+  });
+
+  it("returns archived coworkers when coworkerScope=archived", async () => {
+    const app = createApp();
+    const response = await app.request(
+      "http://localhost/?coworkerScope=archived",
+    );
+
+    expect(response.status).toBe(200);
+    expect(coworkerFindManyMock).toHaveBeenCalledWith({
+      where: { archivedAt: { not: null } },
+      orderBy: [{ priority: "desc" }, { slug: "asc" }],
+    });
+  });
+
+  it("rejects an invalid coworkerScope value", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/?coworkerScope=bogus");
+
+    expect(response.status).toBe(422);
+    expect(coworkerFindManyMock).not.toHaveBeenCalled();
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/routes/v1/catalog/get.ts
+++ b/apps/core/src/routes/v1/catalog/get.ts
@@ -1,0 +1,97 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+import {
+  buildAvailableAgentWhereClause,
+  getCreditCostsOrThrow,
+} from "@/helpers/agent";
+import { buildAgentSummaries } from "@/helpers/agent-summary";
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import {
+  type OpenAPIHonoWithAuth,
+  withGlobalHeaderParameters,
+} from "@/lib/hono";
+import {
+  getAgentExampleOutputsFromAgent,
+  getAgentTagsFromAgent,
+} from "@/schemas/agent.schema";
+import { catalogSchema } from "@/schemas/catalog.schema";
+import { agentDetailInclude, agentOrderBy } from "@/types/agent";
+
+const querySchema = z.object({
+  coworkerScope: z
+    .enum(["all", "whitelisted", "archived"])
+    .optional()
+    .default("whitelisted")
+    .openapi({
+      param: { name: "coworkerScope", in: "query" },
+      description:
+        "Coworker visibility scope. Defaults to 'whitelisted'. Use 'all' to include all active coworkers or 'archived' to include archived coworkers.",
+      example: "all",
+    }),
+});
+
+const route = withGlobalHeaderParameters(
+  createRoute({
+    method: "get",
+    path: "/",
+    description:
+      "List all available agents and coworkers with their metadata in a single response.",
+    tags: ["Catalog"],
+    request: {
+      query: querySchema,
+    },
+    responses: {
+      200: jsonSuccessResponse(
+        catalogSchema,
+        "Retrieve all agents and coworkers",
+      ),
+      401: jsonErrorResponse("Unauthorized"),
+      422: jsonErrorResponse("Unprocessable Entity"),
+    },
+  }),
+);
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    const { coworkerScope } = c.req.valid("query");
+
+    const coworkerWhere =
+      coworkerScope === "archived"
+        ? { archivedAt: { not: null } }
+        : {
+            archivedAt: null,
+            ...(coworkerScope === "whitelisted" ? { isWhitelisted: true } : {}),
+          };
+
+    const [agents, coworkers] = await Promise.all([
+      prisma.$transaction(async (tx) => {
+        const creditCosts = await getCreditCostsOrThrow(tx);
+        const rows = await tx.agent.findMany({
+          where: buildAvailableAgentWhereClause(creditCosts),
+          orderBy: [...agentOrderBy, { id: "desc" }],
+          include: agentDetailInclude,
+        });
+
+        const rowsById = new Map(rows.map((row) => [row.id, row]));
+        const summaries = await buildAgentSummaries(rows, creditCosts, tx);
+
+        return summaries.map((summary) => {
+          const row = rowsById.get(summary.id);
+          return {
+            ...summary,
+            tags: row ? getAgentTagsFromAgent(row) : [],
+            exampleOutputs: row ? getAgentExampleOutputsFromAgent(row) : [],
+          };
+        });
+      }),
+      prisma.coworker.findMany({
+        where: coworkerWhere,
+        orderBy: [{ priority: "desc" }, { slug: "asc" }],
+      }),
+    ]);
+
+    return ok(c, catalogSchema.parse({ agents, coworkers }));
+  });
+}

--- a/apps/core/src/routes/v1/catalog/index.test.ts
+++ b/apps/core/src/routes/v1/catalog/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import catalogRouter from "./index";
+
+describe("catalog routes OpenAPI contract", () => {
+  const doc = catalogRouter.getOpenAPI31Document({
+    openapi: "3.1.0",
+    info: {
+      title: "Catalog API",
+      version: "1.0.0",
+    },
+  });
+
+  it("exposes a single GET / endpoint", () => {
+    const paths = Object.keys(doc.paths ?? {});
+    expect(paths).toEqual(["/"]);
+  });
+
+  it("documents the coworkerScope query parameter and validation failure", () => {
+    const operation = doc.paths?.["/"]?.get;
+    const parameterNames = (operation?.parameters ?? []).map((parameter) =>
+      "name" in parameter ? parameter.name : null,
+    );
+
+    expect(parameterNames).toContain("coworkerScope");
+    expect(operation?.responses).toHaveProperty("422");
+  });
+
+  it("documents the Catalog schema with agents and coworkers", () => {
+    const components = doc.components?.schemas as
+      | Record<string, { properties?: Record<string, unknown> }>
+      | undefined;
+
+    expect(components?.Catalog?.properties?.agents).toBeDefined();
+    expect(components?.Catalog?.properties?.coworkers).toBeDefined();
+  });
+});

--- a/apps/core/src/routes/v1/catalog/index.ts
+++ b/apps/core/src/routes/v1/catalog/index.ts
@@ -1,0 +1,11 @@
+import { OpenAPIHonoWithAuth } from "@/lib/hono";
+
+import mountGetCatalog from "./get.js";
+
+const app = new OpenAPIHonoWithAuth({
+  includeWorkspaceContext: true,
+});
+
+mountGetCatalog(app);
+
+export default app;

--- a/apps/core/src/routes/v1/index.test.ts
+++ b/apps/core/src/routes/v1/index.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/config/env.js", () => ({
 
 vi.mock("./admin/index.js", () => ({ default: new Hono() }));
 vi.mock("./agents/index.js", () => ({ default: new Hono() }));
+vi.mock("./catalog/index.js", () => ({ default: new Hono() }));
 vi.mock("./categories/index.js", () => ({ default: new Hono() }));
 vi.mock("./chat/index.js", () => ({ default: new Hono() }));
 vi.mock("./checkout/index.js", () => ({ default: new Hono() }));

--- a/apps/core/src/routes/v1/index.ts
+++ b/apps/core/src/routes/v1/index.ts
@@ -6,6 +6,7 @@ import { resolveCorsAllowOrigin } from "@/config/cors-allow-origin.js";
 
 import adminRouter from "./admin/index.js";
 import agentsRouter from "./agents/index.js";
+import catalogRouter from "./catalog/index.js";
 import categoriesRouter from "./categories/index.js";
 import chatRouter from "./chat/index.js";
 import checkoutRouter from "./checkout/index.js";
@@ -112,6 +113,7 @@ app.doc31("/openapi.json", {
 // Mount Routes
 app.route("/admin", adminRouter);
 app.route("/agents", agentsRouter);
+app.route("/catalog", catalogRouter);
 app.route("/categories", categoriesRouter);
 app.route("/chat", chatRouter);
 app.route("/checkout", checkoutRouter);

--- a/apps/core/src/schemas/catalog.schema.ts
+++ b/apps/core/src/schemas/catalog.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "@hono/zod-openapi";
+
+import { agentDetailSchema } from "@/schemas/agent.schema";
+import { coworkerSchema } from "@/schemas/coworker.schema";
+
+export const catalogSchema = z
+  .object({
+    agents: z.array(agentDetailSchema).openapi({
+      description: "All available agents with their full metadata.",
+    }),
+    coworkers: z.array(coworkerSchema).openapi({
+      description: "Coworkers with their full metadata.",
+    }),
+  })
+  .openapi("Catalog");
+
+export type Catalog = z.infer<typeof catalogSchema>;


### PR DESCRIPTION
## What & why

Adds a single endpoint to fetch the entire catalog — every available agent **and** every coworker, with full metadata — in one request. Previously a client had to paginate `GET /v1/agents` and separately call `GET /v1/coworkers`. This is a convenience aggregation for callers that just want "everything, easily."

## Endpoint

`GET /v1/catalog` (authenticated)

Response shape:

```jsonc
{
  "data": {
    "agents": [ /* AgentDetail[] */ ],
    "coworkers": [ /* Coworker[] */ ]
  },
  "meta": { "timestamp": "...", "requestId": "..." }
}
```

- **agents** — all available agents (same availability filter as `GET /v1/agents`), returned with the **full detail** metadata: credits, execution + rating metrics, author, legal, categories, `riskClassification`, `tags`, and `exampleOutputs`. Not paginated — the whole set comes back in one call.
- **coworkers** — coworkers with their full metadata (profile, offers, channels, capabilities, …).

### Query params

| Param | Values | Default | Effect |
| --- | --- | --- | --- |
| `coworkerScope` | `whitelisted` \| `all` \| `archived` | `whitelisted` | Coworker visibility, mirroring `GET /v1/coworkers`. Default matches the existing public listing; pass `all` to include non-whitelisted active coworkers. |

## Implementation notes

- Reuses `buildAgentSummaries` (credits + **batched** metrics — no per-agent query fan-out) and the existing `getAgentTagsFromAgent` / `getAgentExampleOutputsFromAgent` helpers to extend each summary into the full `agentDetailSchema` shape. No new data-access logic.
- Agents and coworkers are queried concurrently (`Promise.all`); agent reads run inside a single `prisma.$transaction`.
- New `catalogSchema` composes the existing `agentDetailSchema` + `coworkerSchema`, so the OpenAPI contract stays in sync with the dedicated endpoints.
- Mounted in `apps/core/src/routes/v1/index.ts`; the `v1` router test mocks the new sub-router consistent with the existing pattern.

## Verification

- `pnpm --filter core typecheck` ✅
- `pnpm exec biome check` on changed files ✅
- `pnpm --filter core test src/routes/v1/catalog src/routes/v1/index.test.ts` ✅ (9 tests)
  - handler returns agents with full detail metadata (tags, example outputs, risk classification) + coworkers in one response
  - `coworkerScope` default / `all` / `archived` produce the correct Prisma `where` clauses
  - invalid `coworkerScope` → 422
  - OpenAPI contract exposes a single `GET /` with the `Catalog` schema and documents `coworkerScope` + 422
- Booted the Core dev server locally: `/catalog` appears in `/v1/openapi.json` with the `Catalog` schema (agents + coworkers), and unauthenticated `GET /v1/catalog` returns 401 (auth-protected, as expected). The authenticated 200 path is covered by the unit tests; it was not exercised against a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)