### PR TITLE
fix(core): add vercel cron for task-schedules sync

### DIFF
--- a/apps/core/vercel.json
+++ b/apps/core/vercel.json
@@ -41,6 +41,10 @@
     {
       "path": "/sync/jobs",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/sync/task-schedules",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register `/sync/task-schedules` in `apps/core/vercel.json` so Vercel cron invokes the task schedule sync on production.
- Uses the same every-minute schedule as `/sync/jobs`.

## Test plan
- [ ] Deploy Core to Vercel and confirm **Settings → Cron Jobs** lists `/sync/task-schedules`.
- [ ] Verify scheduled tasks promote/clone after the cron runs.


Made with [Cursor](https://cursor.com)