### PR TITLE
chore(sapphire): add bugbot gates and quality rules for team pipeline

### DIFF
--- a/.cursor/agents/sapphire-coder.md
+++ b/.cursor/agents/sapphire-coder.md
@@ -6,12 +6,12 @@ model: composer-2.5
 
 You are a **Team Sapphire Coder** subagent.
 
-Follow `.cursor/skills/_team-sapphire/CODER.md` (**Subagent mode**) and `REVIEWER.md` (**Verification command trust** only).
+Follow `.cursor/skills/_team-sapphire/CODER.md` (**Subagent mode**) and `REVIEWER.md` (**Verification command trust** only). Before handoff, read `BUGBOT-LEARNINGS.md` — orchestrator runs Bugbot (fix High only); you must leave local verification green.
 
 **Inputs:** Your coder block from the **session spec** (inline in the prompt), file ownership table, Linear issue id, and whether you are the **sole coder** or one of **parallel coders** (Multiple coders flow).
 
-**Sole coder:** Implement your scope, run allowlisted verification, open one PR (body references the Linear issue id). Return PR URL, branch name, and draft `**PR handoff**` + `**Sapphire · Coder complete**` comment text.
+**Sole coder:** Implement your scope, run allowlisted verification (exit 0), open one PR (body references the Linear issue id). Return PR URL, branch name, and draft `**PR handoff**` + `**Sapphire · Coder complete**` comment text. **Orchestrator** runs CI watch + Bugbot before Phase 4 — posts `**Bugbot · medium (human review)**` on Linear when mediums exist; note verification commands in handoff.
 
-**Parallel coders (Multiple coders flow):** Implement your scope only, run allowlisted verification for your deliverables, commit on a named branch. **Do not** push or open a PR — the orchestrator merges all coder output into one branch and opens the single PR. Return branch name, changed files, commit message(s), verification results, and a one-line scope summary.
+**Parallel coders (Multiple coders flow):** Implement your scope only, run allowlisted verification for your deliverables (exit 0), commit on a named branch. **Do not** push or open a PR — the orchestrator merges all coder output into one branch, opens the single PR, runs **CI green + Bugbot (0 High)**, then posts Phase 3 gates.
 
 **Do not:** call Linear MCP (`save_comment`, `save_issue`), set issue **In Review** or **Done**, or edit files owned by other coders. The orchestrator merges parallel work, opens the one PR, and posts Phase 3 gates after all coders finish.

--- a/.cursor/agents/sapphire-coder.md
+++ b/.cursor/agents/sapphire-coder.md
@@ -10,7 +10,7 @@ Follow `.cursor/skills/_team-sapphire/CODER.md` (**Subagent mode**) and `REVIEWE
 
 **Inputs:** Your coder block from the **session spec** (inline in the prompt), file ownership table, Linear issue id, and whether you are the **sole coder** or one of **parallel coders** (Multiple coders flow).
 
-**Sole coder:** Implement your scope, run allowlisted verification (exit 0), open one PR (body references the Linear issue id). Return PR URL, branch name, and draft `**PR handoff**` + `**Sapphire · Coder complete**` comment text. **Orchestrator** runs CI watch + Bugbot before Phase 4 — posts `**Bugbot · medium (human review)**` on Linear when mediums exist; note verification commands in handoff.
+**Sole coder:** Implement your scope, run allowlisted verification (exit 0), open one PR (body references the Linear issue id). Return PR URL, branch name, verification summary, and **draft** `**PR handoff**` / `**Sapphire · Coder complete**` text (orchestrator fills CI + Bugbot lines after gates pass). **Do not** run `gh pr checks` or Bugbot — **orchestrator** watches CI green, runs Bugbot (0 High), posts `**Bugbot · medium (human review)**` when needed, then posts Linear gates.
 
 **Parallel coders (Multiple coders flow):** Implement your scope only, run allowlisted verification for your deliverables (exit 0), commit on a named branch. **Do not** push or open a PR — the orchestrator merges all coder output into one branch, opens the single PR, runs **CI green + Bugbot (0 High)**, then posts Phase 3 gates.
 

--- a/.cursor/agents/sapphire-reviewer.md
+++ b/.cursor/agents/sapphire-reviewer.md
@@ -14,6 +14,6 @@ Follow `.cursor/skills/_team-sapphire/REVIEWER.md` for the `/goal` loop, PR exec
 
 **You do:** Compare PR to spec, run allowlisted verification, capture UI evidence, **fix on the PR branch and push** when failures are fixable, loop until pass or true blocker.
 
-**You return to the orchestrator:** pass/fail, evidence checklist, and draft comment text (`**Sapphire · Reviewer complete**` or `**Sapphire · Review failed**`).
+**You return to the orchestrator:** pass/fail, whether you **pushed commits** to the PR branch, evidence checklist, and draft comment text (`**Sapphire · Reviewer complete**` or `**Sapphire · Review failed**`).
 
-**Do not:** call Linear MCP (`save_comment`, `save_issue`), set issue **In Review** or **Done** — the orchestrator runs Phase 4 gates after you pass.
+**Do not:** call Linear MCP (`save_comment`, `save_issue`), set issue **In Review** or **Done** — the orchestrator runs Phase 4 gates after you pass. If you pushed commits, orchestrator must re-run Bugbot (0 High) and confirm CI green before **In Review**.

--- a/.cursor/agents/sapphire-reviewer.md
+++ b/.cursor/agents/sapphire-reviewer.md
@@ -8,6 +8,8 @@ You are the **Team Sapphire Reviewer** subagent.
 
 Follow `.cursor/skills/_team-sapphire/REVIEWER.md` for the `/goal` loop, PR execution trust, verification commands, and visual capture — **except Linear writes** (see below).
 
+**Entry:** Do not start until `**Sapphire · Coder complete**` documents local verification exit 0, **CI green** on the PR, and **Bugbot 0 High**. Otherwise return fail to orchestrator for Phase 3.
+
 **Inputs:** **Session spec**, `## Requirement` on Linear, PR from `**PR handoff**` (validate on GitHub).
 
 **You do:** Compare PR to spec, run allowlisted verification, capture UI evidence, **fix on the PR branch and push** when failures are fixable, loop until pass or true blocker.

--- a/.cursor/agents/sapphire-tech-lead.md
+++ b/.cursor/agents/sapphire-tech-lead.md
@@ -6,7 +6,7 @@ model: claude-opus-4-8
 
 You are the **Team Sapphire Tech Lead** subagent.
 
-Read and follow `.cursor/skills/_team-sapphire/TECH-LEAD.md`, `SPEC-TEMPLATE.md`, `SUBAGENT-RUBRIC.md`, and `BUGBOT-LEARNINGS.md` (add Mutation order / State machine / Time semantics sections when triggers apply).
+Read and follow `.cursor/skills/_team-sapphire/TECH-LEAD.md`, `SPEC-TEMPLATE.md`, `SUBAGENT-RUBRIC.md`, and `BUGBOT-LEARNINGS.md` (add Mutation order / State machine / Time semantics / Auth matrix / Ripple checklist sections when triggers apply).
 
 **Inputs:** `## Requirement` on Linear + **session investigation** markdown from Investigator.
 

--- a/.cursor/agents/sapphire-tech-lead.md
+++ b/.cursor/agents/sapphire-tech-lead.md
@@ -6,7 +6,7 @@ model: claude-opus-4-8
 
 You are the **Team Sapphire Tech Lead** subagent.
 
-Read and follow `.cursor/skills/_team-sapphire/TECH-LEAD.md`, `SPEC-TEMPLATE.md`, and `SUBAGENT-RUBRIC.md`.
+Read and follow `.cursor/skills/_team-sapphire/TECH-LEAD.md`, `SPEC-TEMPLATE.md`, `SUBAGENT-RUBRIC.md`, and `BUGBOT-LEARNINGS.md` (add Mutation order / State machine / Time semantics sections when triggers apply).
 
 **Inputs:** `## Requirement` on Linear + **session investigation** markdown from Investigator.
 

--- a/.cursor/skills/_team-sapphire/AGENTS.md
+++ b/.cursor/skills/_team-sapphire/AGENTS.md
@@ -9,9 +9,10 @@ Single-issue squad: Investigator → Tech Lead → Coder(s) → Reviewer.
 3. Read `WORKFLOW.md`.
 4. Read role file for the current phase: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, or `REVIEWER.md`.
 5. Read `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md` before Tech Lead phase.
-6. Read `LINEAR-MCP.md` before Linear writes.
-7. Read `VISUAL-CAPTURE.md` before Reviewer phase (UI evidence).
-8. Read `CURSOR-AUTOMATION.md` when configuring optional Linear-triggered Cloud Agents.
+6. Read `BUGBOT-LEARNINGS.md` before Coder phase (Pre-Reviewer gates).
+7. Read `LINEAR-MCP.md` before Linear writes.
+8. Read `VISUAL-CAPTURE.md` before Reviewer phase (UI evidence).
+9. Read `CURSOR-AUTOMATION.md` when configuring optional Linear-triggered Cloud Agents.
 
 ## Subagents (role models)
 

--- a/.cursor/skills/_team-sapphire/AGENTS.md
+++ b/.cursor/skills/_team-sapphire/AGENTS.md
@@ -7,9 +7,9 @@ Single-issue squad: Investigator → Tech Lead → Coder(s) → Reviewer.
 1. Read `SKILL.md` — includes **Role models** (Tech Lead, Coder, Reviewer subagents).
 2. Read `PHASE-GATE.md` — blocking Linear writes per phase; exit verification.
 3. Read `WORKFLOW.md`.
-4. Read role file for the current phase: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, or `REVIEWER.md`.
-5. Read `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md` before Tech Lead phase.
-6. Read `BUGBOT-LEARNINGS.md` before Coder phase (Pre-Reviewer gates).
+4. Read `BUGBOT-LEARNINGS.md` before Phase 1 (Investigator R1–R12 trigger flags) and before Coder Pre-Reviewer gates.
+5. Read role file for the current phase: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, or `REVIEWER.md`.
+6. Read `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md` before Tech Lead phase.
 7. Read `LINEAR-MCP.md` before Linear writes.
 8. Read `VISUAL-CAPTURE.md` before Reviewer phase (UI evidence).
 9. Read `CURSOR-AUTOMATION.md` when configuring optional Linear-triggered Cloud Agents.

--- a/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
+++ b/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
@@ -2,7 +2,7 @@
 
 Distilled from high/medium Bugbot findings on `masumi-network/sokosumi` and local review sessions. Use these to prevent regressions before Reviewer runs.
 
-**Mandatory gates (Coder / orchestrator — before Phase 4):** see `CODER.md` **Pre-Reviewer gates** and `PHASE-GATE.md`.
+**Mandatory gates (orchestrator after PR open — before Phase 4):** see `CODER.md` **Pre-Reviewer gates** and `PHASE-GATE.md`.
 
 ## Quality rules (R1–R12)
 
@@ -118,7 +118,23 @@ Apply when the **trigger** matches the work. Investigator flags risks; Tech Lead
 
 ## Mandatory Bugbot (before Reviewer)
 
-Orchestrator runs **one Bugbot review** per PR before Phase 4 (`review-bugbot` skill — `subagent_type: "bugbot"`, `Diff: branch changes`).
+Orchestrator runs **one Bugbot review** per PR before Phase 4 (after the PR exists). Launch a **Task** subagent — do not assume a repo-local skill file:
+
+| Field | Value |
+|-------|-------|
+| `subagent_type` | `bugbot` |
+| `readonly` | `true` |
+| `run_in_background` | `false` |
+| `description` | `Bugbot` |
+
+Prompt (exact shape):
+
+```text
+Full Repository Path: <absolute repository root>
+Diff: branch changes
+```
+
+In Cursor IDE, `/review-bugbot` runs the same flow when the editor skill is installed — either path is valid. If the subagent cannot compute the diff, retry once with `Diff: natural language` and a per-file change description (see `review-bugbot` skill retry rules).
 
 | Severity | Action |
 |----------|--------|

--- a/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
+++ b/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
@@ -139,12 +139,12 @@ In Cursor IDE, `/review-bugbot` runs the same flow when the editor skill is inst
 | Severity | Action |
 |----------|--------|
 | **High** | **Must fix** on the PR branch. Re-run Bugbot until **zero High** findings. |
-| **Medium** | **Do not block** Reviewer. Post a dedicated Linear comment `**Bugbot · medium (human review)**` (see below). Human fixes on merge pass if needed. Fix in PR only if trivial and in scope. |
+| **Medium** | **Do not block** Reviewer. Post `**Bugbot · medium (human review)**` **once** during **Phase gate** (`CODER.md` step 2) — not during the Bugbot run. Human fixes on merge pass if needed. Fix in PR only if trivial and in scope. |
 | **Low** | Optional note; no gate. |
 
-### Medium findings — Linear comment (required when N > 0)
+### Medium findings — Linear comment (Phase gate only)
 
-After Bugbot passes with 0 High, post `save_comment` on the issue:
+Post **once** during **Phase gate** step 2 in `CODER.md` — after `**PR handoff**`, before `**Sapphire · Coder complete**`. Skip when there are no medium findings.
 
 ```markdown
 **Bugbot · medium (human review)**

--- a/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
+++ b/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
@@ -118,7 +118,7 @@ Apply when the **trigger** matches the work. Investigator flags risks; Tech Lead
 
 ## Mandatory Bugbot (before Reviewer)
 
-Orchestrator runs **one Bugbot review** per PR before Phase 4 (after the PR exists). Launch a **Task** subagent — do not assume a repo-local skill file:
+**Gate runner** (orchestrator in squad mode; standalone Coder when invoked alone) runs **one Bugbot review** per PR before Phase 4 (after the PR exists). **Re-run** after Reviewer pushes commits to the PR branch — zero High required before **In Review**. Launch a **Task** subagent — do not assume a repo-local skill file:
 
 | Field | Value |
 |-------|-------|

--- a/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
+++ b/.cursor/skills/_team-sapphire/BUGBOT-LEARNINGS.md
@@ -1,0 +1,168 @@
+# Bugbot learnings (Sapphire quality rules)
+
+Distilled from high/medium Bugbot findings on `masumi-network/sokosumi` and local review sessions. Use these to prevent regressions before Reviewer runs.
+
+**Mandatory gates (Coder / orchestrator — before Phase 4):** see `CODER.md` **Pre-Reviewer gates** and `PHASE-GATE.md`.
+
+## Quality rules (R1–R12)
+
+Apply when the **trigger** matches the work. Investigator flags risks; Tech Lead encodes contracts; Coder implements; Reviewer verifies in `/goal`.
+
+### R1 — Mutation order and atomicity
+
+**Trigger:** Multi-step create/update (form → action → Core), billing + DB, schedule + status.
+
+- **Investigator:** Map mutation order; flag partial-failure (orphan records, billing drift).
+- **Tech Lead:** **Mutation order** table — step, rollback on failure, user-visible error.
+- **Coder:** Dependent writes atomic or compensated; no success if a later step failed.
+- **Reviewer:** Failure-path check in `/goal` (e.g. schedule fails → no stray task).
+
+### R2 — Single source of truth for status
+
+**Trigger:** Status enums, kanban, toggles, drag-and-drop, schedule-driven status.
+
+- **Investigator:** Allowed transitions; independent status writers.
+- **Tech Lead:** **State machine** table — user action → status; derived vs explicit.
+- **Coder:** One resolver for final status; never apply form toggle after API already set status.
+- **Reviewer:** Matrix cases (draft + schedule, clear on QUEUED, toggle after schedule API).
+
+### R3 — Idempotent updates
+
+**Trigger:** PUT/PATCH, schedule saves, notification upserts.
+
+- **Investigator:** Unconditional re-PUT on unrelated edits.
+- **Tech Lead:** When schedule/metadata is touched vs preserved.
+- **Coder:** Skip schedule API when unchanged; preserve `nextRunAt` on metadata-only edits.
+- **Reviewer:** Name-only edit on scheduled task → `nextRunAt` unchanged.
+
+### R4 — Timezone and calendar semantics
+
+**Trigger:** Date pickers, cron, `intervalDays`, `runAt`, recurring end dates.
+
+- **Investigator:** Browser → web → Core; server TZ (often UTC on Vercel).
+- **Tech Lead:** **Time semantics** — IANA TZ for display, parse, persist; cron vs UI label.
+- **Coder:** Parse with schedule TZ; calendar days ≠ cron `*/N` day-of-month.
+- **Reviewer:** Non-UTC boundary in manual checks when spec touches time.
+
+### R5 — Serverless background work
+
+**Trigger:** Notifications, emails, webhooks, post-response capture.
+
+- **Investigator:** `void dispatch` without `waitUntil`; blocking `await` on non-critical path.
+- **Tech Lead:** Side effects — must finish before response vs background (`waitUntil`).
+- **Coder:** Core uses `waitUntil` for fire-and-forget; no bare `void` on serverless paths.
+- **Reviewer:** Spec-listed background effects implemented correctly.
+
+### R6 — UI label ↔ API behavior
+
+**Trigger:** Presets, columns, badges, sort order, warning copy.
+
+- **Investigator:** UI strings vs API/schema meaning.
+- **Tech Lead:** Contract row per preset/column — **UI says** / **API does**.
+- **Coder:** Do not client re-sort in a way that overrides API sort intent.
+- **Reviewer:** Label matches behavior on happy path.
+
+### R7 — Shared client state consistency
+
+**Trigger:** Provider + page + toast + header; realtime + fetch.
+
+- **Investigator:** All surfaces reading/writing same state; race windows.
+- **Tech Lead:** **State ownership** — provider vs page; mark-read, fetch, realtime rules.
+- **Coder:** Consistent nav on mark-read failure; fetch must not stomp realtime.
+- **Reviewer:** Two-surface check (badge + page, or toast + dropdown).
+
+### R8 — i18n key paths and locales
+
+**Trigger:** `useTranslations`, `messages/*.json`, user-visible dates.
+
+- **Investigator:** Namespace path matches component; locale file structure.
+- **Tech Lead:** Translation namespaces in deliverables.
+- **Coder:** Follow `translations` skill; no hardcoded relative times.
+- **Reviewer:** Key path spot-check or non-`en` locale when UI-facing.
+
+### R9 — Mobile and sheet/dialog lifecycle
+
+**Trigger:** Sidebar, `Sheet`, modals, header nav.
+
+- **Investigator:** `sm:` breakpoints; `SheetClose` + dialog state ownership.
+- **Tech Lead:** **Responsive behavior** for &lt; `sm`; modal dismiss during async.
+- **Coder:** No `SheetClose` wrapping stateful dialogs; mobile entry for critical nav.
+- **Reviewer:** Narrow viewport or mobile screenshot when UI spec applies.
+
+### R10 — Auth, workspace, and capability matrix
+
+**Trigger:** New Core routes, coworker API keys, workspace-scoped lists.
+
+- **Investigator:** Router flags (`includeWorkspaceContext`), capabilities, scope params.
+- **Tech Lead:** **Auth matrix** — caller type × endpoint × capability/scope.
+- **Coder:** Match sibling endpoints; parallel fetches handle 404 consistently.
+- **Reviewer:** Wrong-workspace / missing-capability cases when in spec.
+
+### R11 — Enum / status ripple effects
+
+**Trigger:** New status, job status, notification kind.
+
+- **Investigator:** Grep archivable lists, transitions, UI actions, notification mappers, DnD.
+- **Tech Lead:** **Ripple checklist** — validators, UI, archive, notifications, columns.
+- **Coder:** Update all consumers in same PR.
+- **Reviewer:** No stale enum assumptions on touched status.
+
+### R12 — Navigation targets and API response truth
+
+**Trigger:** `href` builders, admin CRUD, POST responses after sync.
+
+- **Investigator:** Routes exist; lightweight vs heavy fetch patterns.
+- **Tech Lead:** Real routes for links; response fields after sync.
+- **Coder:** Response reflects post-sync state; 404 → `notFound()` not error page.
+- **Reviewer:** Click-through on one deep link when notifications/links in scope.
+
+## Mandatory Bugbot (before Reviewer)
+
+Orchestrator runs **one Bugbot review** per PR before Phase 4 (`review-bugbot` skill — `subagent_type: "bugbot"`, `Diff: branch changes`).
+
+| Severity | Action |
+|----------|--------|
+| **High** | **Must fix** on the PR branch. Re-run Bugbot until **zero High** findings. |
+| **Medium** | **Do not block** Reviewer. Post a dedicated Linear comment `**Bugbot · medium (human review)**` (see below). Human fixes on merge pass if needed. Fix in PR only if trivial and in scope. |
+| **Low** | Optional note; no gate. |
+
+### Medium findings — Linear comment (required when N > 0)
+
+After Bugbot passes with 0 High, post `save_comment` on the issue:
+
+```markdown
+**Bugbot · medium (human review)**
+
+For human review on merge — not blocking Reviewer.
+
+| Severity | Location | Finding |
+|----------|----------|---------|
+| Medium | `path:line` | One-line summary |
+```
+
+When there are **no** medium findings, skip this comment; say `**Bugbot medium:** none` in `**Sapphire · Coder complete**`.
+
+Post a short Bugbot summary in `**Sapphire · Coder complete**`:
+
+```markdown
+**Bugbot:** 0 High (re-run after fixes). Medium: N — see `**Bugbot · medium (human review)**` comment (or `none`).
+```
+
+If Bugbot cannot run (subagent failure after retry), **stop before Reviewer** and report the blocker.
+
+## Coder self-check (before Bugbot)
+
+Answer for each triggered rule (R1–R12). Fix obvious gaps before opening or updating the PR.
+
+1. Multi-step writes — order and failure behavior defined and implemented?
+2. Status — one resolver; no stale toggle after schedule/status API?
+3. Updates — no blind re-PUT of unchanged schedule/metadata?
+4. Time — TZ documented and used consistently?
+5. Background — `waitUntil` where needed?
+6. UI labels match API/cron/sort behavior?
+7. Shared client state — races and cross-surface sync handled?
+8. i18n keys under correct namespace in all touched locales?
+9. Mobile/sheet/dialog flows tested mentally?
+10. Auth/workspace/capability aligned with sibling routes?
+11. New enums/status — all consumers updated?
+12. Links and POST responses reflect real routes and post-sync state?

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -14,11 +14,10 @@ When Tech Lead defined one coder block (or no breakdown section):
 
 1. Implement all deliverables in the spec.
 2. Follow repo conventions (`AGENTS.md`, scoped app guides).
-3. Run allowlisted verification before PR.
-4. Open PR — body references Linear issue id (e.g. `SOK-549`).
-5. **Standalone Coder only:** Post `**PR handoff**` on the issue (see below).
-6. **Standalone Coder only:** Post `**Sapphire · Coder complete**`.
-7. **Standalone Coder only:** `save_issue` — Coder row → `done` (issue stays **In Progress**). See **Phase gate (blocking)**.
+3. Complete **Pre-Reviewer gates** (all four steps) — see table below. **Standalone Coder** runs steps 1–4 yourself. **Orchestrator + sole subagent:** subagent runs 1–2; orchestrator runs 3–4.
+4. **Standalone Coder only:** Run **Phase gate (blocking)** (Linear comments + Coder row `done`), then **Exit gate** (`PHASE-GATE.md`). Do **not** post `**PR handoff**` until steps 3–4 of Pre-Reviewer gates pass.
+
+Orchestrator mode: see **Subagent mode** — subagents do not post Linear gates.
 
 ## Subagent mode (`sapphire-coder`)
 
@@ -26,9 +25,10 @@ When the orchestrator delegates to `sapphire-coder`:
 
 ### Sole coder (one block / no breakdown)
 
-1. Implement, verify, and open PR per **Single coder** steps 1–4.
-2. **Do not** call Linear MCP — no `save_comment` or `save_issue`.
-3. Return PR URL, branch, and draft `**PR handoff**` / `**Sapphire · Coder complete**` text to the orchestrator.
+1. Implement and follow repo conventions per **Single coder** steps 1–2.
+2. Complete **Pre-Reviewer gates** steps 1–2 (local verification, open PR).
+3. **Do not** call Linear MCP — no `save_comment` or `save_issue`.
+4. Return PR URL, branch, verification summary, and draft `**PR handoff**` / `**Sapphire · Coder complete**` text to the orchestrator.
 
 The orchestrator runs **Phase gate (blocking)** after you finish — CI watch, Bugbot, then Linear comments.
 
@@ -75,7 +75,7 @@ Each subagent prompt must include:
 ## Handoff to Reviewer
 
 - **Sapphire orchestrator (default):** After Coder complete, continue to Phase 4 (Reviewer) in the **same run** per `SKILL.md` — do not stop early.
-- **Standalone Coder** (user invoked Coder only): Complete **Phase gate (blocking)** below (PR handoff + Coder complete + status row), then **Exit gate** (`PHASE-GATE.md`), then stop; Reviewer runs in a separate session.
+- **Standalone Coder** (user invoked Coder only): Complete **Pre-Reviewer gates**, then **Phase gate (blocking)** (PR handoff + optional medium comment + Coder complete + status row), then **Exit gate** (`PHASE-GATE.md`), then stop; Reviewer runs in a separate session.
 
 ## PR handoff comment
 
@@ -138,12 +138,12 @@ gh pr view <number> --json statusCheckRollup,state
 1. Launch Bugbot on the PR branch vs merge-base.
 2. **Fix every High finding** on the PR branch.
 3. Re-run Bugbot until **zero High** findings.
-4. **Medium:** post dedicated Linear comment (see below) — do not block Reviewer; human fixes on merge pass.
+4. **Medium:** record findings for **Phase gate** step 2 — do **not** post the Linear comment here (post once during Phase gate).
 5. Re-run local verification and confirm CI still green after High fixes.
 
 ### Medium findings — Linear comment
 
-When Bugbot reports one or more **Medium** findings, post `save_comment` **before** `**Sapphire · Coder complete**`:
+Post **once** during **Phase gate** step 2 — **only when** Bugbot reported ≥1 Medium. Do not post during the Bugbot run above.
 
 ```markdown
 **Bugbot · medium (human review)**
@@ -172,7 +172,7 @@ Include in `**Sapphire · Coder complete**`:
 Before Reviewer starts:
 
 1. `save_comment` — `**PR handoff**` (PR URL, branch, one-line summary)
-2. `save_comment` — `**Bugbot · medium (human review)**` — **only when** Bugbot reported ≥1 Medium (table per `BUGBOT-LEARNINGS.md`)
+2. `save_comment` — `**Bugbot · medium (human review)**` — **only when** Bugbot reported ≥1 Medium; **only place** this comment is posted (table below; see also `BUGBOT-LEARNINGS.md`)
 3. `save_comment` — `**Sapphire · Coder complete**` (verification, CI, Bugbot summary)
 4. `save_issue` — Coder row → `done` (issue stays **In Progress**)
 

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -30,7 +30,7 @@ When the orchestrator delegates to `sapphire-coder`:
 2. **Do not** call Linear MCP — no `save_comment` or `save_issue`.
 3. Return PR URL, branch, and draft `**PR handoff**` / `**Sapphire · Coder complete**` text to the orchestrator.
 
-The orchestrator runs **Phase gate (blocking)** after you finish.
+The orchestrator runs **Phase gate (blocking)** after you finish — CI watch, Bugbot, then Linear comments.
 
 ### Parallel coders (Multiple coders flow)
 
@@ -42,7 +42,7 @@ When Tech Lead defined `### Coder A`, `### Coder B`, … and the orchestrator la
 4. Return to the orchestrator: branch name, changed files, commit message(s), verification results, and a one-line scope summary.
 5. **Do not** call Linear MCP. **Do not** edit files owned by other coders.
 
-The orchestrator merges all parallel coder branches onto one integration branch, runs combined verification if needed, opens **one PR** for the issue, then runs **Phase gate (blocking)**.
+The orchestrator merges all parallel coder branches onto one integration branch, opens **one PR**, runs **CI green + Bugbot (0 High)**, then posts Phase 3 gates.
 
 ## Multiple coders (orchestrator)
 
@@ -94,17 +94,32 @@ Map spec **Verification** scope to allowlisted commands in `REVIEWER.md` **Verif
 
 ## Pre-Reviewer gates (blocking)
 
-**Orchestrator** (always) and **sole `sapphire-coder`** (when not parallel) must complete these **after** implementation and **before** `**PR handoff**` / Phase 4. Parallel coders run verification on their branch; the orchestrator runs the full gate set on the merged integration branch before opening the PR.
+Complete in order **before** `**PR handoff**` / Phase 4:
+
+| Step | Gate | Who |
+|------|------|-----|
+| 1 | Local verification (exit 0) | Implementer (subagent or orchestrator) |
+| 2 | Open one PR on GitHub | Sole `sapphire-coder` when not parallel; **orchestrator** after parallel merge |
+| 3 | CI green on the PR | **Orchestrator** (always — including after sole subagent returns) |
+| 4 | Bugbot 0 High | **Orchestrator** (always) |
+
+**Standalone Coder** (user invoked Coder only): you run all four steps yourself.
+
+**Subagent mode:** parallel coders run step 1 on their branch only; sole subagent runs steps 1–2 and returns draft handoff text; **orchestrator** runs steps 3–4 and posts Linear gates.
 
 Read `BUGBOT-LEARNINGS.md` for R1–R12 quality rules and the Coder self-check.
 
 ### 1. Local verification (green)
 
-Run allowlisted `pnpm` commands for the spec scope. **Every command exit 0.** Fix failures on the PR branch; do not hand off with failing local checks.
+Run allowlisted `pnpm` commands for the spec scope. **Every command exit 0.** Fix failures on the branch; do not open the PR or hand off with failing local checks.
 
-### 2. CI green on the PR
+### 2. Open PR
 
-Push the PR branch and confirm **GitHub CI is green** before Reviewer starts:
+Push the branch and open **one PR** per issue (body references Linear issue id). Parallel coders **do not** open a PR — orchestrator merges branches and opens it.
+
+### 3. CI green on the PR
+
+After the PR exists, confirm **GitHub CI is green** before Reviewer starts:
 
 ```bash
 gh pr checks <number> --watch
@@ -116,9 +131,9 @@ gh pr view <number> --json statusCheckRollup,state
 - If CI fails, fix on the PR branch and re-push until green.
 - **Do not** post `**PR handoff**` or start Phase 4 while required checks are failing or pending without watching to completion.
 
-### 3. Mandatory Bugbot (High must be zero)
+### 4. Mandatory Bugbot (High must be zero)
 
-Run Bugbot once on branch changes per `BUGBOT-LEARNINGS.md` **Mandatory Bugbot** (orchestrator uses `review-bugbot` skill).
+**Orchestrator** runs Bugbot once on branch changes per `BUGBOT-LEARNINGS.md` **Mandatory Bugbot** (Task `subagent_type: "bugbot"`, `Diff: branch changes`).
 
 1. Launch Bugbot on the PR branch vs merge-base.
 2. **Fix every High finding** on the PR branch.

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -90,14 +90,75 @@ Each subagent prompt must include:
 
 ## Pre-PR verification
 
-Map spec **Verification** scope to allowlisted commands in `REVIEWER.md` **Verification command trust**. Run the narrowest set covering your deliverables.
+Map spec **Verification** scope to allowlisted commands in `REVIEWER.md` **Verification command trust**. Run the narrowest set covering your deliverables. **All commands must exit 0** before the PR is handed to Reviewer.
+
+## Pre-Reviewer gates (blocking)
+
+**Orchestrator** (always) and **sole `sapphire-coder`** (when not parallel) must complete these **after** implementation and **before** `**PR handoff**` / Phase 4. Parallel coders run verification on their branch; the orchestrator runs the full gate set on the merged integration branch before opening the PR.
+
+Read `BUGBOT-LEARNINGS.md` for R1–R12 quality rules and the Coder self-check.
+
+### 1. Local verification (green)
+
+Run allowlisted `pnpm` commands for the spec scope. **Every command exit 0.** Fix failures on the PR branch; do not hand off with failing local checks.
+
+### 2. CI green on the PR
+
+Push the PR branch and confirm **GitHub CI is green** before Reviewer starts:
+
+```bash
+gh pr checks <number> --watch
+# or
+gh pr view <number> --json statusCheckRollup,state
+```
+
+- All **required** checks must pass (or repo has no required checks and latest workflow runs are success).
+- If CI fails, fix on the PR branch and re-push until green.
+- **Do not** post `**PR handoff**` or start Phase 4 while required checks are failing or pending without watching to completion.
+
+### 3. Mandatory Bugbot (High must be zero)
+
+Run Bugbot once on branch changes per `BUGBOT-LEARNINGS.md` **Mandatory Bugbot** (orchestrator uses `review-bugbot` skill).
+
+1. Launch Bugbot on the PR branch vs merge-base.
+2. **Fix every High finding** on the PR branch.
+3. Re-run Bugbot until **zero High** findings.
+4. **Medium:** post dedicated Linear comment (see below) — do not block Reviewer; human fixes on merge pass.
+5. Re-run local verification and confirm CI still green after High fixes.
+
+### Medium findings — Linear comment
+
+When Bugbot reports one or more **Medium** findings, post `save_comment` **before** `**Sapphire · Coder complete**`:
+
+```markdown
+**Bugbot · medium (human review)**
+
+For human review on merge — not blocking Reviewer.
+
+| Severity | Location | Finding |
+|----------|----------|---------|
+| Medium | `path:line` | One-line summary |
+```
+
+When there are no medium findings, skip this comment.
+
+### Handoff comment additions
+
+Include in `**Sapphire · Coder complete**`:
+
+```markdown
+**Verification:** <commands run, all exit 0>
+**CI:** green on PR #<n> (required checks pass)
+**Bugbot:** 0 High. Medium: <N> — see `**Bugbot · medium (human review)**` comment (or `none`)
+```
 
 ## Phase gate (blocking)
 
 Before Reviewer starts:
 
 1. `save_comment` — `**PR handoff**` (PR URL, branch, one-line summary)
-2. `save_comment` — `**Sapphire · Coder complete**`
-3. `save_issue` — Coder row → `done` (issue stays **In Progress**)
+2. `save_comment` — `**Bugbot · medium (human review)**` — **only when** Bugbot reported ≥1 Medium (table per `BUGBOT-LEARNINGS.md`)
+3. `save_comment` — `**Sapphire · Coder complete**` (verification, CI, Bugbot summary)
+4. `save_issue` — Coder row → `done` (issue stays **In Progress**)
 
-Do **not** run `/goal` or set **In Review** until all three succeed. See `PHASE-GATE.md`.
+Do **not** run `/goal` or set **In Review** until the Phase gate steps succeed **and** **Pre-Reviewer gates** (local verification, CI green, Bugbot 0 High) pass. See `PHASE-GATE.md`.

--- a/.cursor/skills/_team-sapphire/CODER.md
+++ b/.cursor/skills/_team-sapphire/CODER.md
@@ -14,7 +14,7 @@ When Tech Lead defined one coder block (or no breakdown section):
 
 1. Implement all deliverables in the spec.
 2. Follow repo conventions (`AGENTS.md`, scoped app guides).
-3. Complete **Pre-Reviewer gates** (all four steps) — see table below. **Standalone Coder** runs steps 1–4 yourself. **Orchestrator + sole subagent:** subagent runs 1–2; orchestrator runs 3–4.
+3. Complete **Pre-Reviewer gates** (all four steps) — see table below. **Standalone Coder:** you are the gate runner — run steps 1–4 yourself (including CI watch and Bugbot). **Orchestrator + sole subagent:** subagent runs 1–2; orchestrator runs 3–4.
 4. **Standalone Coder only:** Run **Phase gate (blocking)** (Linear comments + Coder row `done`), then **Exit gate** (`PHASE-GATE.md`). Do **not** post `**PR handoff**` until steps 3–4 of Pre-Reviewer gates pass.
 
 Orchestrator mode: see **Subagent mode** — subagents do not post Linear gates.
@@ -42,7 +42,7 @@ When Tech Lead defined `### Coder A`, `### Coder B`, … and the orchestrator la
 4. Return to the orchestrator: branch name, changed files, commit message(s), verification results, and a one-line scope summary.
 5. **Do not** call Linear MCP. **Do not** edit files owned by other coders.
 
-The orchestrator merges all parallel coder branches onto one integration branch, opens **one PR**, runs **CI green + Bugbot (0 High)**, then posts Phase 3 gates.
+The orchestrator merges all parallel coder branches onto one integration branch, runs allowlisted verification on the integration branch (exit 0), opens **one PR**, runs **CI green + Bugbot (0 High)**, then posts Phase 3 gates.
 
 ## Multiple coders (orchestrator)
 
@@ -50,7 +50,7 @@ When Tech Lead defined `### Coder A`, `### Coder B`, …:
 
 1. Respect **Execution order** — sequential coders wait for dependencies.
 2. Launch parallel **`sapphire-coder`** Task subagents (`model: composer-2.5`) for independent coders with disjoint file ownership — each subagent commits on a branch but **does not** open a PR.
-3. After all parallel coders return, merge work on one integration branch and open **one PR** for the issue.
+3. After all parallel coders return, merge work on one integration branch, run allowlisted verification on the integration branch (exit 0), and open **one PR** for the issue.
 4. One PR per issue — do not open multiple PRs for the same SOK unless human asked.
 
 Each subagent prompt must include:
@@ -100,10 +100,10 @@ Complete in order **before** `**PR handoff**` / Phase 4:
 |------|------|-----|
 | 1 | Local verification (exit 0) | Implementer (subagent or orchestrator) |
 | 2 | Open one PR on GitHub | Sole `sapphire-coder` when not parallel; **orchestrator** after parallel merge |
-| 3 | CI green on the PR | **Orchestrator** (always — including after sole subagent returns) |
-| 4 | Bugbot 0 High | **Orchestrator** (always) |
+| 3 | CI green on the PR | **Gate runner** — orchestrator after subagent returns; **standalone Coder** when no orchestrator |
+| 4 | Bugbot 0 High | **Gate runner** — orchestrator after subagent returns; **standalone Coder** when no orchestrator |
 
-**Standalone Coder** (user invoked Coder only): you run all four steps yourself.
+**Standalone Coder** (user invoked Coder only): you are the gate runner — run all four steps yourself (CI watch + mandatory Bugbot per `BUGBOT-LEARNINGS.md`).
 
 **Subagent mode:** parallel coders run step 1 on their branch only; sole subagent runs steps 1–2 and returns draft handoff text; **orchestrator** runs steps 3–4 and posts Linear gates.
 
@@ -133,7 +133,7 @@ gh pr view <number> --json statusCheckRollup,state
 
 ### 4. Mandatory Bugbot (High must be zero)
 
-**Orchestrator** runs Bugbot once on branch changes per `BUGBOT-LEARNINGS.md` **Mandatory Bugbot** (Task `subagent_type: "bugbot"`, `Diff: branch changes`).
+**Gate runner** (orchestrator in squad mode; standalone Coder when invoked alone) runs Bugbot once on branch changes per `BUGBOT-LEARNINGS.md` **Mandatory Bugbot** (Task `subagent_type: "bugbot"`, `Diff: branch changes`).
 
 1. Launch Bugbot on the PR branch vs merge-base.
 2. **Fix every High finding** on the PR branch.

--- a/.cursor/skills/_team-sapphire/INVESTIGATOR.md
+++ b/.cursor/skills/_team-sapphire/INVESTIGATOR.md
@@ -11,6 +11,7 @@ Investigation markdown per the output template below. Keep it **in orchestrator 
 - Search routes, services, schemas, tests, and similar features.
 - Read scoped `AGENTS.md` for touched apps/packages.
 - Note **pitfalls**: auth gaps, web→core boundary, migrations, generated files, i18n keys.
+- When triggers match, flag risks from `BUGBOT-LEARNINGS.md` R1–R12 (mutation order, status machine, timezone, serverless, client state, auth matrix, enum ripples).
 - Point to **similar implementations** with file paths — e.g. "History list pattern in `apps/web/src/...` — consider extracting shared hook."
 - List **open technical questions** for the Tech Lead to resolve in the spec.
 - Link related Linear issues when MCP is available.

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -130,7 +130,7 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | Same session — Tech Lead = `done` + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
-| `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
+| `**Sapphire · Coder complete**` comment + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -130,7 +130,8 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | Same session — Tech Lead = `done` + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
-| `**Sapphire · Coder complete**` comment + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
+| `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
+| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run Pre-Reviewer gates (CI, Bugbot); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -134,7 +134,7 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
 | `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else Phase 3 gate repair); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else **gate repair only**); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
 
 ## Post-run response
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -132,9 +132,9 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
-| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
-| `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else **gate repair only**); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
+| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` + **session spec** in context | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
+| `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before gate repair or Reviewer (Investigator first if investigation missing) |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; if Coder complete invalid → **gate repair only** via step 8; if valid → Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
 
 ## Post-run response
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -14,6 +14,7 @@ Single-issue updates only. No child issues.
 | Issue **state** (`In Progress` → `In Review`) | |
 | Phase summary **comments** | |
 | `**PR handoff**` comment | |
+| `**Bugbot · medium (human review)**` comment (when ≥1 Medium) | |
 
 Investigation and spec pass **in orchestrator session** to Tech Lead → Coder → Reviewer. See `SKILL.md` **Session artifacts**.
 
@@ -86,7 +87,7 @@ Use structured headers for audit trail:
 |-------|----------------|
 | Investigator | `**Sapphire · Investigator complete**` — 3–5 bullets |
 | Tech Lead | `**Sapphire · Tech Lead complete**` — coder count, order, 3–5 bullets |
-| Coder | `**PR handoff**` + `**Sapphire · Coder complete**` |
+| Coder | `**PR handoff**`; optional `**Bugbot · medium (human review)**` when ≥1 Medium; `**Sapphire · Coder complete**` (verification exit 0, CI green, Bugbot summary) |
 | Reviewer pass | `**Sapphire · Reviewer complete**` |
 | Reviewer fail | `**Sapphire · Review failed**` |
 
@@ -133,7 +134,7 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
 | `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else Phase 3 gate repair); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
 
 ## Post-run response
 

--- a/.cursor/skills/_team-sapphire/LINEAR-MCP.md
+++ b/.cursor/skills/_team-sapphire/LINEAR-MCP.md
@@ -131,7 +131,7 @@ Legacy `## Investigation` / `## Spec` on the issue are ignored for skip logic; s
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
-| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run Pre-Reviewer gates (CI, Bugbot); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
+| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -77,6 +77,8 @@ Check **every** status row marked `done` on the issue — including rows from pr
 
 If work is done but gates were skipped:
 
+**Gate-only Coder repair:** When `**PR handoff**` exists but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields, run Pre-Reviewer gates 3–4 (CI green, Bugbot 0 High), then post or update Phase gate comments per `CODER.md`. Do **not** re-implement unless a gate fails.
+
 1. Reconstruct summaries from session artifacts (investigation, spec, PR URL)
 2. Post missing comments in phase order (Investigator → Tech Lead → PR handoff → Coder → Reviewer)
 3. `save_issue` with full merged description — set each completed row → `done`

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -18,7 +18,7 @@ Coder uses **three or four comments** plus status: (1) `save_comment` → `**PR 
 1. Local allowlisted verification — all exit 0 (on branch before PR)
 2. **PR open** on GitHub (sole subagent or orchestrator after parallel merge)
 3. **CI green** on the PR (`gh pr checks` / required checks pass) — **orchestrator** after PR exists
-4. **Bugbot** — orchestrator runs once; **fix all High**; re-run until 0 High; post `**Bugbot · medium (human review)**` Linear comment when ≥1 Medium (human fixes on merge pass)
+4. **Bugbot** — orchestrator runs once; **fix all High**; re-run until 0 High; **record** Medium findings for Phase gate step 2 (do **not** post `**Bugbot · medium (human review)**` during the Bugbot run)
 
 See `CODER.md` and `BUGBOT-LEARNINGS.md`. Do not post `**PR handoff**` or start Reviewer until all four pass.
 

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -15,11 +15,12 @@ Coder uses **three or four comments** plus status: (1) `save_comment` → `**PR 
 
 **Pre-Reviewer gates** (blocking — before step 1 above or before Phase 4):
 
-1. Local allowlisted verification — all exit 0
-2. **CI green** on the PR (`gh pr checks` / required checks pass)
-3. **Bugbot** — run once; **fix all High**; re-run until 0 High; post `**Bugbot · medium (human review)**` Linear comment when ≥1 Medium (human fixes on merge pass)
+1. Local allowlisted verification — all exit 0 (on branch before PR)
+2. **PR open** on GitHub (sole subagent or orchestrator after parallel merge)
+3. **CI green** on the PR (`gh pr checks` / required checks pass) — **orchestrator** after PR exists
+4. **Bugbot** — orchestrator runs once; **fix all High**; re-run until 0 High; post `**Bugbot · medium (human review)**` Linear comment when ≥1 Medium (human fixes on merge pass)
 
-See `CODER.md` and `BUGBOT-LEARNINGS.md`. Do not post `**PR handoff**` or start Reviewer until all three pass.
+See `CODER.md` and `BUGBOT-LEARNINGS.md`. Do not post `**PR handoff**` or start Reviewer until all four pass.
 
 Reviewer adds a state write **after** status table is saved: `save_issue` with `state: "In Review"` only (no `description`).
 
@@ -95,13 +96,13 @@ After each phase, mentally confirm before continuing:
 [ ] Next phase may start
 ```
 
-Coder additionally:
+Coder additionally (in order):
 
 ```
-[ ] Local verification exit 0 (allowlisted pnpm)
+[ ] Local verification exit 0 (allowlisted pnpm) — before PR
 [ ] PR open on GitHub (validated via gh)
-[ ] CI green — required checks pass on PR
-[ ] Bugbot run — 0 High
+[ ] CI green — required checks pass on PR (orchestrator)
+[ ] Bugbot run — 0 High (orchestrator)
 [ ] **Bugbot · medium (human review)** comment posted when ≥1 Medium
 [ ] **PR handoff** comment posted before Coder complete
 [ ] Coder complete lists verification + CI + Bugbot summary (points to medium comment or `none`)

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -63,7 +63,7 @@ Check **every** status row marked `done` on the issue — including rows from pr
 |----------------------|-------------------------|
 | Investigator → `done` | Comment `**Sapphire · Investigator complete**` |
 | Tech Lead → `done` | Comment `**Sapphire · Tech Lead complete**` |
-| Coder → `done` | Comments `**PR handoff**` + `**Sapphire · Coder complete**`; optional `**Bugbot · medium (human review)**` when mediums exist |
+| Coder → `done` | Comments `**PR handoff**` + `**Sapphire · Coder complete**`; `**Bugbot · medium (human review)**` **required** when Coder complete reports Medium > 0 (or Bugbot recorded ≥1 Medium) |
 | Reviewer → `done` | Comment `**Sapphire · Reviewer complete**` + issue state **In Review** |
 
 **Failed exit gate examples:**
@@ -77,10 +77,10 @@ Check **every** status row marked `done` on the issue — including rows from pr
 
 If work is done but gates were skipped:
 
-**Gate-only Coder repair:** When `**PR handoff**` exists but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields, run Pre-Reviewer gates 3–4 (CI green, Bugbot 0 High), then post or update Phase gate comments per `CODER.md`. Do **not** re-implement unless a gate fails.
+**Gate-only Coder repair:** When `**PR handoff**` exists but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields, run all missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High), then post or update Phase gate comments per `CODER.md`. Do **not** re-implement unless a gate fails.
 
 1. Reconstruct summaries from session artifacts (investigation, spec, PR URL)
-2. Post missing comments in phase order (Investigator → Tech Lead → PR handoff → Coder → Reviewer)
+2. Post missing comments in phase order (Investigator → Tech Lead → PR handoff → Bugbot medium when ≥1 Medium → Coder complete → Reviewer)
 3. `save_issue` with full merged description — set each completed row → `done`
 4. If Reviewer pass criteria are met and issue is not **In Review**, `save_issue` with `state: "In Review"` only (no `description`)
 5. Re-run exit gate (comments, all `done` rows, and issue state); only then return to user

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -77,7 +77,7 @@ Check **every** status row marked `done` on the issue — including rows from pr
 
 If work is done but gates were skipped:
 
-**Gate-only Coder repair:** When `**PR handoff**` exists but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields, run all missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High), then post or update Phase gate comments per `CODER.md`. Do **not** re-implement unless a gate fails.
+**Gate repair only:** When `**PR handoff**` exists but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields, run all missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High), then post or update Phase gate comments per `CODER.md`. Do **not** re-implement unless a gate fails.
 
 1. Reconstruct summaries from session artifacts (investigation, spec, PR URL)
 2. Post missing comments in phase order (Investigator → Tech Lead → PR handoff → Bugbot medium when ≥1 Medium → Coder complete → Reviewer)

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -17,8 +17,8 @@ Coder uses **three or four comments** plus status: (1) `save_comment` → `**PR 
 
 1. Local allowlisted verification — all exit 0 (on branch before PR)
 2. **PR open** on GitHub (sole subagent or orchestrator after parallel merge)
-3. **CI green** on the PR (`gh pr checks` / required checks pass) — **orchestrator** after PR exists
-4. **Bugbot** — orchestrator runs once; **fix all High**; re-run until 0 High; **record** Medium findings for Phase gate step 2 (do **not** post `**Bugbot · medium (human review)**` during the Bugbot run)
+3. **CI green** on the PR (`gh pr checks` / required checks pass) — **gate runner** after PR exists (orchestrator in squad mode; standalone Coder when alone)
+4. **Bugbot** — **gate runner** runs once; **fix all High**; re-run until 0 High; **record** Medium findings for Phase gate step 2 (do **not** post `**Bugbot · medium (human review)**` during the Bugbot run). **Re-run** after Reviewer pushes commits before **In Review**.
 
 See `CODER.md` and `BUGBOT-LEARNINGS.md`. Do not post `**PR handoff**` or start Reviewer until all four pass.
 
@@ -103,11 +103,12 @@ Coder additionally (in order):
 ```
 [ ] Local verification exit 0 (allowlisted pnpm) — before PR
 [ ] PR open on GitHub (validated via gh)
-[ ] CI green — required checks pass on PR (orchestrator)
-[ ] Bugbot run — 0 High (orchestrator)
+[ ] CI green — required checks pass on PR (gate runner)
+[ ] Bugbot run — 0 High (gate runner)
+[ ] **PR handoff** comment posted
 [ ] **Bugbot · medium (human review)** comment posted when ≥1 Medium
-[ ] **PR handoff** comment posted before Coder complete
 [ ] Coder complete lists verification + CI + Bugbot summary (points to medium comment or `none`)
+[ ] save_issue — Coder row `done` (issue stays In Progress)
 ```
 
 Reviewer additionally:
@@ -115,6 +116,7 @@ Reviewer additionally:
 ```
 [ ] Coder complete documents verification + CI green + Bugbot 0 High
 [ ] /goal criteria pass
+[ ] Bugbot re-run 0 High + CI green when Reviewer pushed commits
 [ ] Reviewer row done saved before state change
 [ ] save_issue state In Review (description omitted)
 ```

--- a/.cursor/skills/_team-sapphire/PHASE-GATE.md
+++ b/.cursor/skills/_team-sapphire/PHASE-GATE.md
@@ -11,7 +11,15 @@ Every Sapphire phase ends with **mandatory Linear writes**. These are not option
 | 1 | `save_comment` | Phase summary with exact header (see table below) |
 | 2 | `save_issue` | Update `## Sapphire status` row → `done` (status-only merge per `LINEAR-MCP.md`) |
 
-Coder uses **three writes** instead of two: (1) `save_comment` → `**PR handoff**`, (2) `save_comment` → `**Sapphire · Coder complete**`, (3) `save_issue` → Coder row `done`.
+Coder uses **three or four comments** plus status: (1) `save_comment` → `**PR handoff**`, (2) optional `save_comment` → `**Bugbot · medium (human review)**` when Bugbot reported ≥1 Medium, (3) `save_comment` → `**Sapphire · Coder complete**`, (4) `save_issue` → Coder row `done`.
+
+**Pre-Reviewer gates** (blocking — before step 1 above or before Phase 4):
+
+1. Local allowlisted verification — all exit 0
+2. **CI green** on the PR (`gh pr checks` / required checks pass)
+3. **Bugbot** — run once; **fix all High**; re-run until 0 High; post `**Bugbot · medium (human review)**` Linear comment when ≥1 Medium (human fixes on merge pass)
+
+See `CODER.md` and `BUGBOT-LEARNINGS.md`. Do not post `**PR handoff**` or start Reviewer until all three pass.
 
 Reviewer adds a state write **after** status table is saved: `save_issue` with `state: "In Review"` only (no `description`).
 
@@ -21,7 +29,7 @@ Reviewer adds a state write **after** status table is saved: `save_issue` with `
 |-------|---------------------------|------------------------|
 | Investigator | `**Sapphire · Investigator complete**` | Investigator → `done` |
 | Tech Lead | `**Sapphire · Tech Lead complete**` | Tech Lead → `done` |
-| Coder | `**PR handoff**` then `**Sapphire · Coder complete**` | Coder → `done` |
+| Coder | `**PR handoff**`; optional `**Bugbot · medium (human review)**`; `**Sapphire · Coder complete**` | Coder → `done` |
 | Reviewer | `**Sapphire · Reviewer complete**` (or `**Sapphire · Review failed**` while looping) | Reviewer → `done` + `state: "In Review"` on pass |
 
 Comment headers must match **exactly** (including bold markers). Summaries belong in the comment body — not only in the Cloud Agent thread.
@@ -54,7 +62,7 @@ Check **every** status row marked `done` on the issue — including rows from pr
 |----------------------|-------------------------|
 | Investigator → `done` | Comment `**Sapphire · Investigator complete**` |
 | Tech Lead → `done` | Comment `**Sapphire · Tech Lead complete**` |
-| Coder → `done` | Comments `**PR handoff**` + `**Sapphire · Coder complete**` |
+| Coder → `done` | Comments `**PR handoff**` + `**Sapphire · Coder complete**`; optional `**Bugbot · medium (human review)**` when mediums exist |
 | Reviewer → `done` | Comment `**Sapphire · Reviewer complete**` + issue state **In Review** |
 
 **Failed exit gate examples:**
@@ -90,13 +98,19 @@ After each phase, mentally confirm before continuing:
 Coder additionally:
 
 ```
+[ ] Local verification exit 0 (allowlisted pnpm)
 [ ] PR open on GitHub (validated via gh)
+[ ] CI green — required checks pass on PR
+[ ] Bugbot run — 0 High
+[ ] **Bugbot · medium (human review)** comment posted when ≥1 Medium
 [ ] **PR handoff** comment posted before Coder complete
+[ ] Coder complete lists verification + CI + Bugbot summary (points to medium comment or `none`)
 ```
 
 Reviewer additionally:
 
 ```
+[ ] Coder complete documents verification + CI green + Bugbot 0 High
 [ ] /goal criteria pass
 [ ] Reviewer row done saved before state change
 [ ] save_issue state In Review (description omitted)

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -4,6 +4,14 @@
 
 Runs after Coder posts `**PR handoff**`. Same issue — no sub-tasks.
 
+**Entry requirements (blocking):** Reviewer must not start until Coder/orchestrator confirms in `**Sapphire · Coder complete**`:
+
+- Local allowlisted verification — all exit 0
+- **CI green** on the PR (required GitHub checks pass)
+- **Bugbot** — zero **High** findings (medium listed in `**Bugbot · medium (human review)**` Linear comment for human merge pass — not Reviewer scope unless spec requires)
+
+If any gate is missing or failed, return to Coder/orchestrator — do not begin `/goal`.
+
 **Sapphire orchestrator:** Phase 4 runs in the **same session** as Phases 1–3 — do not exit after Coder complete. In a **new session**, do not start Reviewer without **session spec** — rebuild Tech Lead (and Investigator if needed) first per `SKILL.md`.
 
 ## `/goal` loop
@@ -75,9 +83,15 @@ Reject commands with `|`, `&`, `;`, `` ` ``, `$()`, `sudo`, `curl`, `wget`, `rm`
 
 ### Quality gates
 
-- [ ] Lint/check — exit 0
+- [ ] Lint/check — exit 0 (confirmed in Coder complete; re-run if Reviewer fixes code)
 - [ ] Tests — exit 0
 - [ ] Build — exit 0
+- [ ] **CI green** on PR — required GitHub checks pass (`gh pr checks`)
+- [ ] **Bugbot** — 0 High at handoff (re-run Bugbot if Reviewer changes are substantial)
+
+### Bugbot regression (triggered rules)
+
+When the spec touches areas in `BUGBOT-LEARNINGS.md` R1–R12, verify those rules in `/goal` — do not rely on Bugbot alone for medium-risk patterns (timezone, state machine, client state races).
 
 ### Visual (UI changes)
 

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -23,8 +23,9 @@ Prefix work with `/goal`. Do **not** stop after one failed pass when fixes are p
 3. Compare diff to **Contract / behavior**, **Verification**, **Out of scope**.
 4. Run **Verification command trust** only.
 5. Capture screenshot or recording for user-facing changes — see `VISUAL-CAPTURE.md`.
-6. Fix on PR branch, push, rerun until pass or true blocker.
-7. On pass: run **Completion** gate below — `save_comment` → Reviewer complete, `save_issue` → Reviewer row `done`, then `save_issue` → `state: "In Review"` only (`PHASE-GATE.md`).
+6. Fix on PR branch, push, rerun verification until pass or true blocker.
+7. **Post-fix gates (blocking when step 6 pushed commits):** **Orchestrator** (or standalone Reviewer when no orchestrator) re-runs mandatory Bugbot until **0 High** and confirms **CI green** on the PR before **Completion** gate. Subagent returns `pushed: true` so orchestrator knows to re-gate.
+8. On pass: run **Completion** gate below — `save_comment` → Reviewer complete, `save_issue` → Reviewer row `done`, then `save_issue` → `state: "In Review"` only (`PHASE-GATE.md`).
 
 ## PR execution trust
 
@@ -87,7 +88,7 @@ Reject commands with `|`, `&`, `;`, `` ` ``, `$()`, `sudo`, `curl`, `wget`, `rm`
 - [ ] Tests — exit 0
 - [ ] Build — exit 0
 - [ ] **CI green** on PR — required GitHub checks pass (`gh pr checks`)
-- [ ] **Bugbot** — 0 High at handoff (re-run Bugbot if Reviewer changes are substantial)
+- [ ] **Bugbot** — 0 High at handoff; **re-run mandatory Bugbot** (orchestrator) after any Reviewer push before **In Review**
 
 ### Bugbot regression (triggered rules)
 
@@ -125,7 +126,7 @@ When the orchestrator delegates to `sapphire-reviewer`:
 
 1. Follow **`/goal` loop** above — including fix on PR branch, push, and rerun until pass or blocker.
 2. **Do not** call Linear MCP — no `save_comment` or `save_issue`, and do not set **In Review**.
-3. Return pass/fail, evidence checklist, and draft `**Sapphire · Reviewer complete**` or `**Sapphire · Review failed**` text to the orchestrator.
+3. Return pass/fail, whether you **pushed commits** to the PR branch, evidence checklist, and draft `**Sapphire · Reviewer complete**` or `**Sapphire · Review failed**` text to the orchestrator.
 
 The orchestrator runs **Completion** and **Exit gate** after you pass.
 

--- a/.cursor/skills/_team-sapphire/REVIEWER.md
+++ b/.cursor/skills/_team-sapphire/REVIEWER.md
@@ -2,9 +2,9 @@
 
 **Goal:** Compare PR + code to the **session spec**. Loop with **`/goal`** until all criteria pass. Set issue **In Review** on pass.
 
-Runs after Coder posts `**PR handoff**`. Same issue — no sub-tasks.
+Runs after Phase 3 gates complete on the same issue — no sub-tasks. **Do not** start when only `**PR handoff**` exists; wait for `**Sapphire · Coder complete**` and Coder row `done`.
 
-**Entry requirements (blocking):** Reviewer must not start until Coder/orchestrator confirms in `**Sapphire · Coder complete**`:
+**Entry requirements (blocking):** Reviewer must not start until `**Sapphire · Coder complete**` documents:
 
 - Local allowlisted verification — all exit 0
 - **CI green** on the PR (required GitHub checks pass)

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -88,7 +88,7 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
   3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
   5. Run from `target` through all later phases in this session.
-- If `**PR handoff**` + open PR exist and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
+- If `**Sapphire · Coder complete**` comment exists, open PR, and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
 - If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass run **Completion** gate per `REVIEWER.md` (comment → Reviewer row `done` if needed → `state: "In Review"` only), then **Exit gate** per `PHASE-GATE.md`.
 - If **every** status row is `done` and issue is **`In Review`**, run **Exit gate**; on pass, stop — await human merge.
 
@@ -153,7 +153,7 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | Same session — Tech Lead = done + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
-| `**PR handoff**` + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
+| `**Sapphire · Coder complete**` comment + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 | Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -88,7 +88,7 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
   3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
   5. Run from `target` through all later phases in this session.
-- If `**Sapphire · Coder complete**` comment exists, open PR, and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
+- If valid `**Sapphire · Coder complete**` comment exists (documents verification exit 0, CI green, Bugbot 0 High), open PR, and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
 - If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass run **Completion** gate per `REVIEWER.md` (comment → Reviewer row `done` if needed → `state: "In Review"` only), then **Exit gate** per `PHASE-GATE.md`.
 - If **every** status row is `done` and issue is **`In Review`**, run **Exit gate**; on pass, stop — await human merge.
 
@@ -153,7 +153,8 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | Same session — Tech Lead = done + **session spec** in context | Skip Tech Lead unless user asked to re-spec |
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
-| `**Sapphire · Coder complete**` comment + open PR + Coder = `done` + **session spec** in context | Skip Coder; run Reviewer |
+| `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
+| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run Pre-Reviewer gates (CI, Bugbot); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 | Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -82,16 +82,15 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
 - Optional: start phase (`investigator`, `tech-lead`, `coder`, `reviewer`) when resuming a stalled run — still apply **artifact-aware resume** when downstream phases need session investigation or spec (unless user explicitly asked to run that phase only).
 - Load issue with `get_issue`. Read `## Requirement` (or requirement body before Sapphire sections exist).
 - If `## Sapphire status` is **missing**, insert the initial status block per `LINEAR-MCP.md` (full-description merge via `save_issue`) **first** — do not run resume or cleanup rules until the table exists; then start Investigator (or the user’s explicit start phase).
-- If `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone):
+- If `## Sapphire status` is present, compute start phase with **artifact-aware resume** (do not use status table alone). Initialize `mode` = **full** (default).
   1. Set `target` = user start phase if specified, else first row not `done` (Investigator → Tech Lead → Coder → Reviewer).
   2. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`) → run `target`, then **Exit gate**, then stop.
   3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
-  5. Run from `target` through all later phases in this session.
-- If `**PR handoff**` + open PR + Coder = `done` but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields → set `target` to **Phase 3 gate repair** (run Phase 3 steps 4–5 only — do **not** re-implement). Session spec still required (step 3 applies).
-- If valid `**Sapphire · Coder complete**` comment exists (documents verification exit 0, CI green, Bugbot 0 High), open PR, and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
-- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing; confirm valid `**Sapphire · Coder complete**` (else run Phase 3 gate repair); then Phase 4 per `REVIEWER.md` (`/goal`, post-fix Bugbot + CI when Reviewer pushed, **Completion** gate, **Exit gate**).
-- If **every** status row is `done` and issue is **`In Review`**, run **Exit gate**; on pass, stop — await human merge.
+  5. If `**PR handoff**` + open PR + Coder = `done` but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields → set `target` to **Coder**, `mode` to **gate repair only**. Do **not** set `target` to Reviewer.
+  6. If **every** status row is already `done` and issue is **not** `In Review` → run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing; confirm valid `**Sapphire · Coder complete**` (else set `target` to **Coder**, `mode` to **gate repair only**); then Phase 4 per `REVIEWER.md` (`/goal`, post-fix Bugbot + CI when Reviewer pushed, **Completion** gate, **Exit gate**).
+  7. If **every** status row is `done` and issue is **`In Review`** → run **Exit gate**; on pass, stop — await human merge.
+  8. Run from `target` through all later phases in this session. When `mode` = **gate repair only**, Phase 3 uses **gate repair path** (not full implementation path).
 
 ## Workflow
 
@@ -114,13 +113,21 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 ### Phase 3 — Coder(s)
 
-**Gate repair path:** When intake or resume selects **gate repair only** (`**PR handoff**` + open PR, Coder = `done` on Linear, but `**Sapphire · Coder complete**` missing or incomplete), **skip steps 2–3**. Resolve PR from handoff, run missing Pre-Reviewer gates 1–4, then step 5.
+**Gate repair path** (`mode` = **gate repair only**): `**PR handoff**` + open PR + Coder = `done` on Linear, but `**Sapphire · Coder complete**` missing or incomplete. Triggered by intake step 5 or Reviewer cleanup. **Do not** run full-path steps 2–4 below.
 
 1. Read **session spec** (plus session investigation for context). Requirement from Linear when needed.
-2. **Full implementation only** — if Tech Lead defined multiple coders with parallel ownership, launch **parallel** **`sapphire-coder`** Task subagents (`model: composer-2.5`) — one per coder block. Each subagent implements and returns branch/commits; **subagents do not open PRs**. After all return, orchestrator merges onto one integration branch, runs allowlisted verification on the merged branch (exit 0), and opens **one PR**.
-3. **Full implementation only** — if single coder, delegate to **`sapphire-coder`** (`model: composer-2.5`) — subagent implements, runs allowlisted verification (exit 0), opens **one PR**, and returns draft handoff text. **Orchestrator skips** duplicate verification and PR open.
-4. **Pre-Reviewer gates (blocking, after PR exists):** **Gate runner** watches **CI green** on the PR (`gh pr checks`) and runs **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). Subagents do **not** run CI or Bugbot. See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
-5. **Gate (blocking):** After step 4 passes — `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until step 5 succeeds.
+2. Resolve PR from `**PR handoff**` (branch via `gh`).
+3. Run each **missing** Pre-Reviewer gate 1–4 in order (`CODER.md`): local verification exit 0 → PR open (usually already done) → CI green → Bugbot 0 High.
+4. Post or update Phase gate Linear comments per `CODER.md` **Phase gate (blocking)**.
+5. **Continue in this run** — proceed to Phase 4 without stopping.
+
+**Full implementation path** (`mode` = **full**, default):
+
+1. Read **session spec** (plus session investigation for context). Requirement from Linear when needed.
+2. If Tech Lead defined multiple coders with parallel ownership, launch **parallel** **`sapphire-coder`** Task subagents (`model: composer-2.5`) — one per coder block. Each subagent implements and returns branch/commits; **subagents do not open PRs**. After all return, orchestrator merges onto one integration branch, runs allowlisted verification on the merged branch (exit 0), and opens **one PR**.
+3. If single coder, delegate to **`sapphire-coder`** (`model: composer-2.5`) — subagent implements, runs allowlisted verification (exit 0), opens **one PR**, and returns draft handoff text. **Orchestrator skips** duplicate verification and PR open.
+4. **Pre-Reviewer gates 3–4 (blocking, after PR exists):** **Gate runner** watches **CI green** on the PR (`gh pr checks`) and runs **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). Gates 1–2 complete in steps 2–3 (local verification exit 0, then PR open). Subagents do **not** run CI or Bugbot. See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
+5. **Phase gate (blocking):** After step 4 passes — `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until step 5 succeeds.
 6. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
@@ -158,7 +165,7 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
 | `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else Phase 3 gate repair); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else **gate repair only**); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
 | Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |
 
 ## Output

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -138,7 +138,7 @@ Before returning to the user, run **Exit gate** in `PHASE-GATE.md`: `get_issue` 
 ## MCP
 
 - Read `PHASE-GATE.md` before the first phase — gates are blocking.
-- Read `BUGBOT-LEARNINGS.md` before Coder Pre-Reviewer gates (CI + Bugbot).
+- Read `BUGBOT-LEARNINGS.md` before Phase 1 (Investigator R1–R12 flags) and before Coder Pre-Reviewer gates (CI + Bugbot).
 - Read `LINEAR-MCP.md` before any write.
 - Health check before first call — same message as `_task` if `user-linear` is missing.
 - Use `save_issue` for **status table**, **state**, and legacy section cleanup only — not investigation or spec; use `save_comment` for phase markers.
@@ -154,7 +154,7 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
-| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run Pre-Reviewer gates (CI, Bugbot); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
+| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
 | All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
 | Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -117,13 +117,15 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 2. If Tech Lead defined multiple coders with parallel ownership, launch **parallel** **`sapphire-coder`** Task subagents (`model: composer-2.5`) — one per coder block. Each subagent implements and returns branch/commits; **subagents do not open PRs**. After all return, merge onto one integration branch on the orchestrator side.
 3. If single coder, delegate to **`sapphire-coder`** (`model: composer-2.5`) — subagent opens the PR (or returns handoff for you to post gates).
 4. Run allowlisted verification before PR (`REVIEWER.md` **Verification command trust**). For multiple coders, run combined verification on the merged branch.
-5. Open **one PR** (orchestrator always owns the PR when multiple coders ran); PR body must reference the Linear issue id.
-6. **Gate (blocking):** `save_comment` → `**PR handoff**`. Then `save_comment` → `**Sapphire · Coder complete**`. Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until all three succeed.
-7. **Continue in this run** — proceed to Phase 4 without stopping.
+5. **Pre-Reviewer gates (blocking):** Local verification exit 0, **CI green** on the PR, **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
+6. Open **one PR** (orchestrator always owns the PR when multiple coders ran); PR body must reference the Linear issue id.
+7. **Gate (blocking):** `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until gates succeed **and** Pre-Reviewer gates pass.
+8. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
 
-1. Delegate to **`sapphire-reviewer`** (`model: gpt-5.5-medium`) — run `/goal` per `REVIEWER.md` until all criteria pass.
+1. Confirm Coder complete comment documents **local verification exit 0**, **CI green**, and **Bugbot 0 High** — otherwise return to Phase 3.
+2. Delegate to **`sapphire-reviewer`** (`model: gpt-5.5-medium`) — run `/goal` per `REVIEWER.md` until all criteria pass.
 2. For UI specs, capture evidence per `VISUAL-CAPTURE.md` (Cloud: PR artifacts; IDE: screenshots; optional CLI for WebM).
 3. Fix on PR branch when needed; loop.
 4. **Gate (blocking):** On pass — `save_comment` → `**Sapphire · Reviewer complete**` with evidence; `save_issue` → Reviewer row `done` (full description merge); then `save_issue` → `state: "In Review"` only. All four status rows must be `done` before exit.
@@ -136,6 +138,7 @@ Before returning to the user, run **Exit gate** in `PHASE-GATE.md`: `get_issue` 
 ## MCP
 
 - Read `PHASE-GATE.md` before the first phase — gates are blocking.
+- Read `BUGBOT-LEARNINGS.md` before Coder Pre-Reviewer gates (CI + Bugbot).
 - Read `LINEAR-MCP.md` before any write.
 - Health check before first call — same message as `_task` if `user-linear` is missing.
 - Use `save_issue` for **status table**, **state**, and legacy section cleanup only — not investigation or spec; use `save_comment` for phase markers.
@@ -162,6 +165,7 @@ Return issue id/URL, **all phases completed in this run**, PR link (if any), and
 ## Supporting files
 
 - `PHASE-GATE.md` — blocking comment + status writes per phase; exit verification
+- `BUGBOT-LEARNINGS.md` — R1–R12 quality rules; mandatory Bugbot (fix High only)
 - `WORKFLOW.md` — pipeline diagram and status lifecycle
 - `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, `REVIEWER.md` — role contracts
 - `SPEC-TEMPLATE.md` — Tech Lead output shape

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -14,13 +14,13 @@ Run the squad in order on the **same issue** `_task` created (or any SOK issue t
 
 **Do not stop after one phase.** You are the orchestrator — run every remaining phase in **this same agent session** until the pipeline finishes or you hit an unrecoverable blocker.
 
-**Do not batch Linear updates.** Each phase ends with a **blocking gate** before the next phase starts — typically `save_comment` then `save_issue` to mark the row `done` (Coder: `**PR handoff**` comment, then Coder complete comment, then `save_issue`). See `PHASE-GATE.md`. Skipping gates (e.g. only posting a final Reviewer comment while the status table stays `pending`) is a **failed run** — repair before exit.
+**Do not batch Linear updates.** Each phase ends with a **blocking gate** before the next phase starts — typically `save_comment` then `save_issue` to mark the row `done` (Coder: Pre-Reviewer gates pass, then `**PR handoff**`; optional `**Bugbot · medium (human review)**` when ≥1 Medium; `**Sapphire · Coder complete**` with verification, CI, Bugbot summary; then `save_issue`). See `PHASE-GATE.md`. Skipping gates (e.g. only posting a final Reviewer comment while the status table stays `pending`) is a **failed run** — repair before exit.
 
 | After phase completes | Next action |
 |----------------------|-------------|
 | Investigator → `done` | **Immediately** start Phase 2 (Tech Lead) — do not return to the user yet |
 | Tech Lead → `done` | **Immediately** start Phase 3 (Coder) |
-| Coder → `done` + PR open | **Immediately** start Phase 4 (Reviewer) |
+| Coder → `done` + valid `**Sapphire · Coder complete**` (verification exit 0, CI green, Bugbot 0 High) + PR open | **Immediately** start Phase 4 (Reviewer) |
 | Reviewer → `done` | Run **Completion** gate — comment, all status rows `done`, then `state: "In Review"`; then **Exit gate** (`PHASE-GATE.md`); return summary to user |
 
 **Only stop early when:**
@@ -88,8 +88,9 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
   3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
   5. Run from `target` through all later phases in this session.
+- If `**PR handoff**` + open PR + Coder = `done` but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields → set `target` to **Phase 3 gate repair** (run Phase 3 steps 4–5 only — do **not** re-implement). Session spec still required (step 3 applies).
 - If valid `**Sapphire · Coder complete**` comment exists (documents verification exit 0, CI green, Bugbot 0 High), open PR, and Coder = `done`, `target` is normally **Reviewer** — steps 3–4 still apply when session spec or investigation is missing.
-- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing, then verify PR + `/goal`; on pass run **Completion** gate per `REVIEWER.md` (comment → Reviewer row `done` if needed → `state: "In Review"` only), then **Exit gate** per `PHASE-GATE.md`.
+- If **every** status row is already `done` and issue is **not** `In Review`, run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing; confirm valid `**Sapphire · Coder complete**` (else run Phase 3 gate repair); then Phase 4 per `REVIEWER.md` (`/goal`, post-fix Bugbot + CI when Reviewer pushed, **Completion** gate, **Exit gate**).
 - If **every** status row is `done` and issue is **`In Review`**, run **Exit gate**; on pass, stop — await human merge.
 
 ## Workflow
@@ -113,14 +114,14 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 ### Phase 3 — Coder(s)
 
+**Gate repair path:** When intake or resume selects **gate repair only** (`**PR handoff**` + open PR, Coder = `done` on Linear, but `**Sapphire · Coder complete**` missing or incomplete), **skip steps 2–3**. Resolve PR from handoff, run missing Pre-Reviewer gates 1–4, then step 5.
+
 1. Read **session spec** (plus session investigation for context). Requirement from Linear when needed.
-2. If Tech Lead defined multiple coders with parallel ownership, launch **parallel** **`sapphire-coder`** Task subagents (`model: composer-2.5`) — one per coder block. Each subagent implements and returns branch/commits; **subagents do not open PRs**. After all return, merge onto one integration branch on the orchestrator side.
-3. If single coder, delegate to **`sapphire-coder`** (`model: composer-2.5`) — subagent opens the PR (or returns handoff for you to post gates).
-4. Run allowlisted verification before opening the PR (`REVIEWER.md` **Verification command trust**). For multiple coders, run combined verification on the merged branch. **All commands exit 0.**
-5. Open **one PR** — sole `sapphire-coder` subagent opens it when not parallel; **orchestrator** opens it after merging parallel coder branches. PR body must reference the Linear issue id.
-6. **Pre-Reviewer gates (blocking, after PR exists):** **Orchestrator** watches **CI green** on the PR (`gh pr checks`) and runs **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). Sole `sapphire-coder` subagents do **not** run CI or Bugbot — return draft handoff text; orchestrator runs steps 6–7. See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
-7. **Gate (blocking):** After step 6 passes — `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until step 7 succeeds.
-8. **Continue in this run** — proceed to Phase 4 without stopping.
+2. **Full implementation only** — if Tech Lead defined multiple coders with parallel ownership, launch **parallel** **`sapphire-coder`** Task subagents (`model: composer-2.5`) — one per coder block. Each subagent implements and returns branch/commits; **subagents do not open PRs**. After all return, orchestrator merges onto one integration branch, runs allowlisted verification on the merged branch (exit 0), and opens **one PR**.
+3. **Full implementation only** — if single coder, delegate to **`sapphire-coder`** (`model: composer-2.5`) — subagent implements, runs allowlisted verification (exit 0), opens **one PR**, and returns draft handoff text. **Orchestrator skips** duplicate verification and PR open.
+4. **Pre-Reviewer gates (blocking, after PR exists):** **Gate runner** watches **CI green** on the PR (`gh pr checks`) and runs **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). Subagents do **not** run CI or Bugbot. See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
+5. **Gate (blocking):** After step 4 passes — `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until step 5 succeeds.
+6. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
 
@@ -128,8 +129,9 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 2. Delegate to **`sapphire-reviewer`** (`model: gpt-5.5-medium`) — run `/goal` per `REVIEWER.md` until all criteria pass.
 3. For UI specs, capture evidence per `VISUAL-CAPTURE.md` (Cloud: PR artifacts; IDE: screenshots; optional CLI for WebM).
 4. Fix on PR branch when needed; loop.
-5. **Gate (blocking):** On pass — `save_comment` → `**Sapphire · Reviewer complete**` with evidence; `save_issue` → Reviewer row `done` (full description merge); then `save_issue` → `state: "In Review"` only. All four status rows must be `done` before exit.
-6. Do **not** mark issue **Done** — human merges PR.
+5. **Post-fix gates (blocking when Reviewer pushed commits):** Re-run mandatory Bugbot until **0 High** and confirm **CI green** on the PR before Completion gate (`REVIEWER.md` step 7).
+6. **Gate (blocking):** On pass — `save_comment` → `**Sapphire · Reviewer complete**` with evidence; `save_issue` → Reviewer row `done` (full description merge); then `save_issue` → `state: "In Review"` only. All four status rows must be `done` before exit.
+7. Do **not** mark issue **Done** — human merges PR.
 
 ### Exit gate (blocking)
 
@@ -156,7 +158,7 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
 | `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
 | `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing, verify PR + `/goal`; on pass run **Completion** gate then **Exit gate** |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else Phase 3 gate repair); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
 | Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |
 
 ## Output

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -116,20 +116,20 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 1. Read **session spec** (plus session investigation for context). Requirement from Linear when needed.
 2. If Tech Lead defined multiple coders with parallel ownership, launch **parallel** **`sapphire-coder`** Task subagents (`model: composer-2.5`) — one per coder block. Each subagent implements and returns branch/commits; **subagents do not open PRs**. After all return, merge onto one integration branch on the orchestrator side.
 3. If single coder, delegate to **`sapphire-coder`** (`model: composer-2.5`) — subagent opens the PR (or returns handoff for you to post gates).
-4. Run allowlisted verification before PR (`REVIEWER.md` **Verification command trust**). For multiple coders, run combined verification on the merged branch.
-5. **Pre-Reviewer gates (blocking):** Local verification exit 0, **CI green** on the PR, **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
-6. Open **one PR** (orchestrator always owns the PR when multiple coders ran); PR body must reference the Linear issue id.
-7. **Gate (blocking):** `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until gates succeed **and** Pre-Reviewer gates pass.
+4. Run allowlisted verification before opening the PR (`REVIEWER.md` **Verification command trust**). For multiple coders, run combined verification on the merged branch. **All commands exit 0.**
+5. Open **one PR** — sole `sapphire-coder` subagent opens it when not parallel; **orchestrator** opens it after merging parallel coder branches. PR body must reference the Linear issue id.
+6. **Pre-Reviewer gates (blocking, after PR exists):** **Orchestrator** watches **CI green** on the PR (`gh pr checks`) and runs **mandatory Bugbot** with **zero High** findings (fix High on branch; medium acknowledged only). Sole `sapphire-coder` subagents do **not** run CI or Bugbot — return draft handoff text; orchestrator runs steps 6–7. See `CODER.md` **Pre-Reviewer gates** and `BUGBOT-LEARNINGS.md`.
+7. **Gate (blocking):** After step 6 passes — `save_comment` → `**PR handoff**`. If Bugbot reported ≥1 Medium: `save_comment` → `**Bugbot · medium (human review)**` (table for human merge pass). Then `save_comment` → `**Sapphire · Coder complete**` (verification, CI, Bugbot summary). Then `save_issue` → Coder row `done`. Stay **In Progress** — do not set In Review yet. Do **not** open Phase 4 until step 7 succeeds.
 8. **Continue in this run** — proceed to Phase 4 without stopping.
 
 ### Phase 4 — Reviewer
 
 1. Confirm Coder complete comment documents **local verification exit 0**, **CI green**, and **Bugbot 0 High** — otherwise return to Phase 3.
 2. Delegate to **`sapphire-reviewer`** (`model: gpt-5.5-medium`) — run `/goal` per `REVIEWER.md` until all criteria pass.
-2. For UI specs, capture evidence per `VISUAL-CAPTURE.md` (Cloud: PR artifacts; IDE: screenshots; optional CLI for WebM).
-3. Fix on PR branch when needed; loop.
-4. **Gate (blocking):** On pass — `save_comment` → `**Sapphire · Reviewer complete**` with evidence; `save_issue` → Reviewer row `done` (full description merge); then `save_issue` → `state: "In Review"` only. All four status rows must be `done` before exit.
-5. Do **not** mark issue **Done** — human merges PR.
+3. For UI specs, capture evidence per `VISUAL-CAPTURE.md` (Cloud: PR artifacts; IDE: screenshots; optional CLI for WebM).
+4. Fix on PR branch when needed; loop.
+5. **Gate (blocking):** On pass — `save_comment` → `**Sapphire · Reviewer complete**` with evidence; `save_issue` → Reviewer row `done` (full description merge); then `save_issue` → `state: "In Review"` only. All four status rows must be `done` before exit.
+6. Do **not** mark issue **Done** — human merges PR.
 
 ### Exit gate (blocking)
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -87,8 +87,8 @@ When updating Linear, merge **only** `## Requirement`, `## Sapphire status`, and
   2. If user explicitly requested **that phase only** (e.g. `run investigator for SOK-XXX`) → run `target`, then **Exit gate**, then stop.
   3. If `target` is Coder or Reviewer and there is no **session spec** in this run → set `target` to **Tech Lead** (even when Tech Lead = `done` on Linear).
   4. If `target` is Tech Lead or later and there is no **session investigation** in this run → set `target` to **Investigator** (even when Investigator = `done` on Linear).
-  5. If `**PR handoff**` + open PR + Coder = `done` but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields → set `target` to **Coder**, `mode` to **gate repair only**. Do **not** set `target` to Reviewer.
-  6. If **every** status row is already `done` and issue is **not** `In Review` → run **Reviewer cleanup** — rebuild session spec via Tech Lead (and Investigator if needed) when missing; confirm valid `**Sapphire · Coder complete**` (else set `target` to **Coder**, `mode` to **gate repair only**); then Phase 4 per `REVIEWER.md` (`/goal`, post-fix Bugbot + CI when Reviewer pushed, **Completion** gate, **Exit gate**).
+  5. If `target` is **Coder** or **Reviewer**, `**session spec**` is in context, `**PR handoff**` + open PR + Coder = `done`, but `**Sapphire · Coder complete**` is missing or lacks verification / CI / Bugbot fields → set `target` to **Coder**, `mode` to **gate repair only**. Do **not** set `target` to Reviewer. (When **session spec** is missing, steps 3–4 keep `target` on Tech Lead or Investigator — do not enter gate repair.)
+  6. If **every** status row is already `done` and issue is **not** `In Review` → **Reviewer cleanup**: rebuild session spec via Tech Lead (and Investigator if needed) when missing; if `**Sapphire · Coder complete**` is missing or invalid → set `target` to **Coder**, `mode` to **gate repair only**; else set `target` to **Reviewer**. Phase 4 runs only via step 8 when `target` is **Reviewer** and Coder complete is valid (`REVIEWER.md`, post-fix Bugbot + CI when Reviewer pushed, **Completion** gate, **Exit gate**).
   7. If **every** status row is `done` and issue is **`In Review`** → run **Exit gate**; on pass, stop — await human merge.
   8. Run from `target` through all later phases in this session. When `mode` = **gate repair only**, Phase 3 uses **gate repair path** (not full implementation path).
 
@@ -113,7 +113,7 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 ### Phase 3 — Coder(s)
 
-**Gate repair path** (`mode` = **gate repair only**): `**PR handoff**` + open PR + Coder = `done` on Linear, but `**Sapphire · Coder complete**` missing or incomplete. Triggered by intake step 5 or Reviewer cleanup. **Do not** run full-path steps 2–4 below.
+**Gate repair path** (`mode` = **gate repair only**): `**PR handoff**` + open PR + Coder = `done` on Linear, but `**Sapphire · Coder complete**` missing or incomplete. Requires **session spec** in context (intake steps 3–4 run first when missing). Triggered by intake step 5 or Reviewer cleanup. **Do not** run full-path steps 2–4 below.
 
 1. Read **session spec** (plus session investigation for context). Requirement from Linear when needed.
 2. Resolve PR from `**PR handoff**` (branch via `gh`).
@@ -163,9 +163,9 @@ Use `## Sapphire status` for progress on Linear; **session artifacts** decide wh
 | New session — Investigator = `done` on Linear but no **session investigation** | Re-run Investigator before Tech Lead |
 | New session — Tech Lead = `done` on Linear but no **session spec** | Re-run Tech Lead before Coder or Reviewer (Investigator first if investigation missing) |
 | `**Sapphire · Coder complete**` documents verification exit 0, CI green, Bugbot 0 High + open PR + Coder = `done` + **session spec** in context | Skip Coder implementation; run Reviewer |
-| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
-| `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before Reviewer (Investigator first if investigation missing) |
-| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; confirm valid Coder complete (else **gate repair only**); Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
+| `**PR handoff**` + open PR + Coder = `done`, missing or incomplete `**Sapphire · Coder complete**` + **session spec** in context | **Gate repair only** — run missing Pre-Reviewer gates 1–4 (local verification exit 0, CI green, Bugbot 0 High); post/update Phase 3 comments per `CODER.md`; do **not** re-implement unless gates fail |
+| `**PR handoff**` + open PR, no **session spec** (new session) | Re-run Tech Lead before gate repair or Reviewer (Investigator first if investigation missing) |
+| All status rows = `done`, issue not `In Review` | Reviewer cleanup — rebuild session spec when missing; if Coder complete invalid → **gate repair only** via step 8; if valid → Phase 4 + post-fix gates + **Completion** gate + **Exit gate** |
 | Issue `In Review` + Reviewer done | **Exit gate**; on pass, stop — await human merge |
 
 ## Output

--- a/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
+++ b/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
@@ -42,6 +42,26 @@ flowchart TB
 | Auth | … |
 | Errors | … |
 
+(Optional — add when `BUGBOT-LEARNINGS.md` triggers apply.)
+
+## Mutation order
+
+| Step | On failure |
+|------|------------|
+| … | … |
+
+## State machine
+
+| User action | Target status | Notes |
+|-------------|---------------|-------|
+| … | … | derived / explicit |
+
+## Time semantics
+
+- Display TZ: …
+- Parse/persist TZ: …
+- Cron / interval meaning vs UI label: …
+
 ## Key decisions
 
 | Decision | Choice |

--- a/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
+++ b/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
@@ -42,46 +42,6 @@ flowchart TB
 | Auth | … |
 | Errors | … |
 
-(Optional — add when `BUGBOT-LEARNINGS.md` triggers apply: **Mutation order**, **State machine**, **Time semantics**, **Auth matrix**, **Ripple checklist**.)
-
-## Mutation order
-
-| Step | On failure |
-|------|------------|
-| … | … |
-
-## State machine
-
-| User action | Target status | Notes |
-|-------------|---------------|-------|
-| … | … | derived / explicit |
-
-## Time semantics
-
-- Display TZ: …
-- Parse/persist TZ: …
-- Cron / interval meaning vs UI label: …
-
-## Auth matrix
-
-(Include when R10 triggers — new Core routes, coworker API keys, workspace-scoped lists.)
-
-| Caller type | Endpoint | Capability / scope |
-|-------------|----------|-------------------|
-| … | … | … |
-
-## Ripple checklist
-
-(Include when R11 triggers — new status, job status, notification kind.)
-
-| Area | Updated in this PR |
-|------|-------------------|
-| Validators | … |
-| UI | … |
-| Archive | … |
-| Notifications | … |
-| Columns | … |
-
 ## Key decisions
 
 | Decision | Choice |
@@ -126,3 +86,42 @@ Scope hints only — agents map to allowlisted `pnpm` scripts per `REVIEWER.md`.
 - Remove empty optional sections.
 - Keep Data flow, Verification, Out of scope.
 - Spec stays in orchestrator session — not written to Linear.
+- Copy optional sections from **Appendix: optional BUGBOT sections** only when `BUGBOT-LEARNINGS.md` triggers apply (`TECH-LEAD.md`).
+
+## Appendix: optional BUGBOT sections
+
+**Do not** include these in every spec. Copy only the sections whose triggers fired; delete unused appendix blocks before handoff.
+
+### Mutation order (R6)
+
+| Step | On failure |
+|------|------------|
+| … | … |
+
+### State machine (R7)
+
+| User action | Target status | Notes |
+|-------------|---------------|-------|
+| … | … | derived / explicit |
+
+### Time semantics (R8)
+
+- Display TZ: …
+- Parse/persist TZ: …
+- Cron / interval meaning vs UI label: …
+
+### Auth matrix (R10)
+
+| Caller type | Endpoint | Capability / scope |
+|-------------|----------|-------------------|
+| … | … | … |
+
+### Ripple checklist (R11)
+
+| Area | Updated in this PR |
+|------|-------------------|
+| Validators | … |
+| UI | … |
+| Archive | … |
+| Notifications | … |
+| Columns | … |

--- a/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
+++ b/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
@@ -42,7 +42,7 @@ flowchart TB
 | Auth | … |
 | Errors | … |
 
-(Optional — add when `BUGBOT-LEARNINGS.md` triggers apply.)
+(Optional — add when `BUGBOT-LEARNINGS.md` triggers apply: **Mutation order**, **State machine**, **Time semantics**, **Auth matrix**, **Ripple checklist**.)
 
 ## Mutation order
 
@@ -61,6 +61,26 @@ flowchart TB
 - Display TZ: …
 - Parse/persist TZ: …
 - Cron / interval meaning vs UI label: …
+
+## Auth matrix
+
+(Include when R10 triggers — new Core routes, coworker API keys, workspace-scoped lists.)
+
+| Caller type | Endpoint | Capability / scope |
+|-------------|----------|-------------------|
+| … | … | … |
+
+## Ripple checklist
+
+(Include when R11 triggers — new status, job status, notification kind.)
+
+| Area | Updated in this PR |
+|------|-------------------|
+| Validators | … |
+| UI | … |
+| Archive | … |
+| Notifications | … |
+| Columns | … |
 
 ## Key decisions
 

--- a/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
+++ b/.cursor/skills/_team-sapphire/SPEC-TEMPLATE.md
@@ -92,19 +92,19 @@ Scope hints only — agents map to allowlisted `pnpm` scripts per `REVIEWER.md`.
 
 **Do not** include these in every spec. Copy only the sections whose triggers fired; delete unused appendix blocks before handoff.
 
-### Mutation order (R6)
+### Mutation order (R1)
 
 | Step | On failure |
 |------|------------|
 | … | … |
 
-### State machine (R7)
+### State machine (R2)
 
 | User action | Target status | Notes |
 |-------------|---------------|-------|
 | … | … | derived / explicit |
 
-### Time semantics (R8)
+### Time semantics (R4)
 
 - Display TZ: …
 - Parse/persist TZ: …

--- a/.cursor/skills/_team-sapphire/TECH-LEAD.md
+++ b/.cursor/skills/_team-sapphire/TECH-LEAD.md
@@ -18,6 +18,7 @@
 - Resolve open questions from Investigation with concrete choices in **Key decisions**.
 - Include **Data flow** mermaid always.
 - Add **Current state** / **Target architecture** when rubric says so.
+- When `BUGBOT-LEARNINGS.md` triggers apply, add spec sections: **Mutation order**, **State machine**, **Time semantics**, **Auth matrix**, or **Ripple checklist** as needed.
 - Split work into multiple coders only when rubric score ≥ 2 — each block must be paste-ready for `CODER.md`.
 - Add `[repo=masumi-network/sokosumi]` at the top of the session spec.
 - Do not modify `## Requirement` on Linear.

--- a/.cursor/skills/_team-sapphire/WORKFLOW.md
+++ b/.cursor/skills/_team-sapphire/WORKFLOW.md
@@ -13,7 +13,8 @@ flowchart LR
   inv --> lead["Tech Lead\n(session spec)"]
   lead --> code["Coder(s)"]
   code --> pr["Pull request"]
-  pr --> rev["Reviewer\n/goal loop"]
+  pr --> gates["CI green +\nBugbot 0 High"]
+  gates --> rev["Reviewer\n/goal loop"]
   rev -->|pass| review["In Review"]
   review --> human["Human merge → Done"]
 ```
@@ -30,7 +31,7 @@ Resume: use **artifact-aware resume** in `SKILL.md` — status `done` does not s
 |------|--------|----------------|
 | **Investigator** | Pitfalls, patterns, recommendations | **Session** → Tech Lead |
 | **Tech Lead** | Implementable spec, optional coder breakdown | **Session** → Coder, Reviewer |
-| **Coder** | Code + PR + `**PR handoff**` | GitHub + Linear comments |
+| **Coder** | Code + PR + verification + CI + Bugbot + `**PR handoff**` | GitHub + Linear comments |
 | **Reviewer** | Evidence + issue **In Review** | Linear state + comments |
 
 ## Issue description shape (Linear)
@@ -74,5 +75,6 @@ Manual: `Run _team-sapphire for SOK-XXX` in Cursor.
 - Do not write `## Investigation` or `## Spec` to the Linear description.
 - Do not run Coder before **session spec** exists.
 - Do not set **In Review** when the PR opens — Reviewer sets it on pass.
+- Do not start Reviewer until **local verification exit 0**, **CI green**, and **Bugbot 0 High** (`CODER.md`, `BUGBOT-LEARNINGS.md`).
 - Do not mark **Done** before human merge.
 - Do not batch phase comments or status updates at the end — each phase gate must pass before the next phase (`PHASE-GATE.md`).


### PR DESCRIPTION
## Summary
- Add `BUGBOT-LEARNINGS.md` with R1–R12 quality rules distilled from high/medium Bugbot findings
- Require CI green and mandatory Bugbot (fix High only) before Reviewer phase
- Post medium Bugbot findings in a dedicated Linear comment (`**Bugbot · medium (human review)**`) for human merge pass
- Wire gates through SKILL, CODER, REVIEWER, PHASE-GATE, WORKFLOW, and sapphire subagent definitions

## Test plan
- [ ] Verify `_team-sapphire` load order references `BUGBOT-LEARNINGS.md`
- [ ] Confirm Coder phase gate docs list PR handoff → optional medium comment → Coder complete
- [ ] Dry-run a Sapphire issue and confirm orchestrator blocks Reviewer without CI green + Bugbot 0 High


Made with [Cursor](https://cursor.com)