### PR TITLE
fix(tasks): show horizontal scroll on kanban board overflow

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/drag-scroll-container.tsx
+++ b/apps/web/src/app/(app)/tasks/components/drag-scroll-container.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useDragToScroll } from "@/hooks/use-drag-to-scroll";
+import { cn } from "@/lib/utils";
+
+interface DragScrollContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function DragScrollContainer({
+  children,
+  className,
+}: DragScrollContainerProps) {
+  const scrollRef = useDragToScroll<HTMLDivElement>();
+
+  return (
+    <div
+      ref={scrollRef}
+      className={cn(
+        "cursor-grab data-[drag-scrolling=true]:cursor-grabbing data-[drag-scrolling=true]:select-none",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
+++ b/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
@@ -46,7 +46,7 @@ export function KanbanBoard({
   statusLabels,
 }: KanbanBoardProps) {
   return (
-    <div className="-mx-2 flex h-full min-h-[calc(100svh-8.5rem)] flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4">
+    <div className="-mx-2 flex h-full min-h-0 w-full min-w-0 flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/80 [&::-webkit-scrollbar-track]:bg-transparent">
       {columns.map((column, index) => {
         const columnTasks = tasks
           .filter((task) => task.columnId === column.id)
@@ -112,7 +112,7 @@ export function KanbanBoard({
           <DroppableColumn
             key={column.id}
             id={column.id}
-            className="flex h-full min-h-0 flex-1"
+            className="flex h-full min-h-0 shrink-0 flex-1"
           >
             {columnContent}
           </DroppableColumn>

--- a/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
+++ b/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/types/task";
 
 import { AddTaskButton } from "./add-task-button";
+import { DragScrollContainer } from "./drag-scroll-container";
 import { KanbanColumn } from "./kanban-column";
 import { TaskCard } from "./task-card";
 import {
@@ -46,7 +47,7 @@ export function KanbanBoard({
   statusLabels,
 }: KanbanBoardProps) {
   return (
-    <div className="-mx-2 flex h-full min-h-0 w-full min-w-0 flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/80 [&::-webkit-scrollbar-track]:bg-transparent">
+    <DragScrollContainer className="-mx-2 flex h-full min-h-0 w-full min-w-0 flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/80 [&::-webkit-scrollbar-track]:bg-transparent">
       {columns.map((column, index) => {
         const columnTasks = tasks
           .filter((task) => task.columnId === column.id)
@@ -120,6 +121,6 @@ export function KanbanBoard({
           columnContent
         );
       })}
-    </div>
+    </DragScrollContainer>
   );
 }

--- a/apps/web/src/app/(app)/tasks/components/kanban-column.tsx
+++ b/apps/web/src/app/(app)/tasks/components/kanban-column.tsx
@@ -26,7 +26,7 @@ export function KanbanColumn({
   return (
     <section
       className={cn(
-        "flex h-full min-h-0 min-w-[260px] flex-1 flex-col rounded-xl transition-colors sm:min-w-[280px] lg:min-w-[350px]",
+        "flex h-full min-h-0 min-w-[260px] shrink-0 flex-1 flex-col rounded-xl transition-colors sm:min-w-[280px] lg:min-w-[350px]",
         "bg-muted/30 border border-transparent",
         isEmpty && "border-muted-foreground/20 border-dashed bg-transparent",
       )}

--- a/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
@@ -100,7 +100,12 @@ export function DraggableTask({ id, columnId, children }: DraggableTaskProps) {
   };
 
   return (
-    <div ref={setNodeRef} style={style} onClickCapture={handleClickCapture}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-dnd-draggable=""
+      onClickCapture={handleClickCapture}
+    >
       {children({ attributes, listeners, isDragging })}
     </div>
   );

--- a/apps/web/src/app/(app)/tasks/components/tasks-loading-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-loading-view.tsx
@@ -69,9 +69,7 @@ export function TasksLoadingView({ viewMode, labels }: TasksLoadingViewProps) {
         <div className="flex min-h-0 flex-1 flex-col gap-4">
           <div
             className={cn(
-              resolvedViewMode === "board"
-                ? "flex min-h-0 flex-1 overflow-hidden"
-                : "",
+              resolvedViewMode === "board" ? "flex min-h-0 min-w-0 flex-1" : "",
             )}
           >
             {resolvedViewMode === "board" ? (
@@ -88,14 +86,14 @@ export function TasksLoadingView({ viewMode, labels }: TasksLoadingViewProps) {
 
 function TasksBoardLoading({ labels }: { labels: TasksLoadingLabels }) {
   return (
-    <div className="-mx-2 flex h-full min-h-[calc(100svh-8.5rem)] flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4">
+    <div className="-mx-2 flex h-full min-h-0 w-full min-w-0 flex-1 items-stretch gap-3 overflow-x-auto overflow-y-hidden px-2 pb-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/80 [&::-webkit-scrollbar-track]:bg-transparent">
       {KANBAN_COLUMNS.map((column, index) => {
         const isFirstColumn = index === 0;
 
         return (
           <section
             key={column.id}
-            className="bg-muted/30 flex h-full min-h-0 min-w-[260px] flex-1 flex-col rounded-xl border border-transparent transition-colors sm:min-w-[280px] lg:min-w-[350px]"
+            className="bg-muted/30 flex h-full min-h-0 min-w-[260px] shrink-0 flex-1 flex-col rounded-xl border border-transparent transition-colors sm:min-w-[280px] lg:min-w-[350px]"
           >
             <div className="sticky top-0 z-10 px-3 pt-3 pb-2">
               <ColumnHeader

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -997,7 +997,7 @@ export function TasksView({
         <div className="flex min-h-0 flex-1 flex-col gap-4">
           <div
             className={cn(
-              viewMode === "board" ? "flex min-h-0 flex-1 overflow-hidden" : "",
+              viewMode === "board" ? "flex min-h-0 min-w-0 flex-1" : "",
             )}
           >
             {isMounted ? (

--- a/apps/web/src/hooks/use-drag-to-scroll.ts
+++ b/apps/web/src/hooks/use-drag-to-scroll.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const DRAG_THRESHOLD_PX = 5;
+
+const INTERACTIVE_SELECTOR =
+  'button, a, input, textarea, select, label, [role="button"], [contenteditable="true"]';
+
+function isScrollDragBlocked(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return true;
+  return Boolean(
+    target.closest(
+      `${INTERACTIVE_SELECTOR}, [data-dnd-draggable], [data-no-drag-scroll]`,
+    ),
+  );
+}
+
+export function useDragToScroll<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const pointerStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    scrollLeft: number;
+    isScrolling: boolean;
+  } | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    function clearScrollingStyles() {
+      element.removeAttribute("data-drag-scrolling");
+    }
+
+    function resetPointerState() {
+      pointerStateRef.current = null;
+      clearScrollingStyles();
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (event.button !== 0) return;
+      if (event.pointerType === "touch") return;
+      if (isScrollDragBlocked(event.target)) return;
+
+      pointerStateRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        scrollLeft: element.scrollLeft,
+        isScrolling: false,
+      };
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+      const state = pointerStateRef.current;
+      if (!state || event.pointerId !== state.pointerId) return;
+
+      const deltaX = event.clientX - state.startX;
+      const deltaY = event.clientY - state.startY;
+
+      if (!state.isScrolling) {
+        if (
+          Math.abs(deltaX) < DRAG_THRESHOLD_PX &&
+          Math.abs(deltaY) < DRAG_THRESHOLD_PX
+        ) {
+          return;
+        }
+
+        if (Math.abs(deltaY) >= Math.abs(deltaX)) {
+          resetPointerState();
+          return;
+        }
+
+        state.isScrolling = true;
+        element.setPointerCapture(event.pointerId);
+        element.setAttribute("data-drag-scrolling", "true");
+      }
+
+      event.preventDefault();
+      element.scrollLeft = state.scrollLeft - deltaX;
+    }
+
+    function handlePointerEnd(event: PointerEvent) {
+      const state = pointerStateRef.current;
+      if (!state || event.pointerId !== state.pointerId) return;
+
+      if (state.isScrolling) {
+        element.releasePointerCapture(event.pointerId);
+      }
+
+      resetPointerState();
+    }
+
+    element.addEventListener("pointerdown", handlePointerDown);
+    element.addEventListener("pointermove", handlePointerMove);
+    element.addEventListener("pointerup", handlePointerEnd);
+    element.addEventListener("pointercancel", handlePointerEnd);
+
+    return () => {
+      element.removeEventListener("pointerdown", handlePointerDown);
+      element.removeEventListener("pointermove", handlePointerMove);
+      element.removeEventListener("pointerup", handlePointerEnd);
+      element.removeEventListener("pointercancel", handlePointerEnd);
+      resetPointerState();
+    };
+  }, []);
+
+  return ref;
+}

--- a/apps/web/src/hooks/use-drag-to-scroll.ts
+++ b/apps/web/src/hooks/use-drag-to-scroll.ts
@@ -27,19 +27,21 @@ export function useDragToScroll<T extends HTMLElement>() {
   } | null>(null);
 
   useEffect(() => {
-    const element = ref.current;
-    if (!element) return;
+    const maybeContainer = ref.current;
+    if (!maybeContainer) return;
 
-    function clearScrollingStyles() {
-      element.removeAttribute("data-drag-scrolling");
-    }
+    const scrollContainer: T = maybeContainer;
 
-    function resetPointerState() {
+    const clearScrollingStyles = () => {
+      scrollContainer.removeAttribute("data-drag-scrolling");
+    };
+
+    const resetPointerState = () => {
       pointerStateRef.current = null;
       clearScrollingStyles();
-    }
+    };
 
-    function handlePointerDown(event: PointerEvent) {
+    const handlePointerDown = (event: PointerEvent) => {
       if (event.button !== 0) return;
       if (event.pointerType === "touch") return;
       if (isScrollDragBlocked(event.target)) return;
@@ -48,18 +50,18 @@ export function useDragToScroll<T extends HTMLElement>() {
         pointerId: event.pointerId,
         startX: event.clientX,
         startY: event.clientY,
-        scrollLeft: element.scrollLeft,
+        scrollLeft: scrollContainer.scrollLeft,
         isScrolling: false,
       };
-    }
+    };
 
-    function handlePointerMove(event: PointerEvent) {
+    const handlePointerMove = (event: PointerEvent) => {
       const state = pointerStateRef.current;
       if (!state || event.pointerId !== state.pointerId) return;
 
       if (event.buttons === 0) {
         if (state.isScrolling) {
-          element.releasePointerCapture(event.pointerId);
+          scrollContainer.releasePointerCapture(event.pointerId);
         }
         resetPointerState();
         return;
@@ -82,35 +84,35 @@ export function useDragToScroll<T extends HTMLElement>() {
         }
 
         state.isScrolling = true;
-        element.setPointerCapture(event.pointerId);
-        element.setAttribute("data-drag-scrolling", "true");
+        scrollContainer.setPointerCapture(event.pointerId);
+        scrollContainer.setAttribute("data-drag-scrolling", "true");
       }
 
       event.preventDefault();
-      element.scrollLeft = state.scrollLeft - deltaX;
-    }
+      scrollContainer.scrollLeft = state.scrollLeft - deltaX;
+    };
 
-    function handlePointerEnd(event: PointerEvent) {
+    const handlePointerEnd = (event: PointerEvent) => {
       const state = pointerStateRef.current;
       if (!state || event.pointerId !== state.pointerId) return;
 
       if (state.isScrolling) {
-        element.releasePointerCapture(event.pointerId);
+        scrollContainer.releasePointerCapture(event.pointerId);
       }
 
       resetPointerState();
-    }
+    };
 
-    element.addEventListener("pointerdown", handlePointerDown);
-    element.addEventListener("pointermove", handlePointerMove);
-    element.addEventListener("pointerup", handlePointerEnd);
-    element.addEventListener("pointercancel", handlePointerEnd);
+    scrollContainer.addEventListener("pointerdown", handlePointerDown);
+    scrollContainer.addEventListener("pointermove", handlePointerMove);
+    scrollContainer.addEventListener("pointerup", handlePointerEnd);
+    scrollContainer.addEventListener("pointercancel", handlePointerEnd);
 
     return () => {
-      element.removeEventListener("pointerdown", handlePointerDown);
-      element.removeEventListener("pointermove", handlePointerMove);
-      element.removeEventListener("pointerup", handlePointerEnd);
-      element.removeEventListener("pointercancel", handlePointerEnd);
+      scrollContainer.removeEventListener("pointerdown", handlePointerDown);
+      scrollContainer.removeEventListener("pointermove", handlePointerMove);
+      scrollContainer.removeEventListener("pointerup", handlePointerEnd);
+      scrollContainer.removeEventListener("pointercancel", handlePointerEnd);
       resetPointerState();
     };
   }, []);

--- a/apps/web/src/hooks/use-drag-to-scroll.ts
+++ b/apps/web/src/hooks/use-drag-to-scroll.ts
@@ -57,6 +57,14 @@ export function useDragToScroll<T extends HTMLElement>() {
       const state = pointerStateRef.current;
       if (!state || event.pointerId !== state.pointerId) return;
 
+      if (event.buttons === 0) {
+        if (state.isScrolling) {
+          element.releasePointerCapture(event.pointerId);
+        }
+        resetPointerState();
+        return;
+      }
+
       const deltaX = event.clientX - state.startX;
       const deltaY = event.clientY - state.startY;
 


### PR DESCRIPTION
## Summary
- Fix kanban board horizontal scroll when columns exceed viewport width by constraining the scroll container with `min-w-0` and removing parent `overflow-hidden` clipping.
- Prevent columns from shrinking below their minimum width with `shrink-0`.
- Add thin scrollbar styling so the horizontal scrollbar is visible when overflow occurs.

## Test plan
- [ ] Open Tasks board view on a narrow viewport (or with all 6 columns visible).
- [ ] Confirm a horizontal scrollbar appears at the bottom of the board.
- [ ] Confirm sideways scroll works via scrollbar, trackpad, and shift+wheel.
- [ ] Confirm columns still expand to fill space when fewer columns fit on screen.
- [ ] Confirm vertical scroll within columns still works.


Made with [Cursor](https://cursor.com)