### PR TITLE
feat(web): move queued tasks to backlog and drop scheduled column

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "Backlog",
-        "scheduled": "Geplant",
         "todo": "Offen",
         "inProgress": "In Bearbeitung",
         "inputRequired": "Input erforderlich",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1422,7 +1422,6 @@
       },
       "Columns": {
         "backlog": "Backlog",
-        "scheduled": "Scheduled",
         "todo": "Todo",
         "inProgress": "In Progress",
         "inputRequired": "Input Required",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "Pendiente",
-        "scheduled": "Programado",
         "todo": "Por hacer",
         "inProgress": "En proceso",
         "inputRequired": "Input requerido",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "Backlog",
-        "scheduled": "Planifié",
         "todo": "À faire",
         "inProgress": "En cours",
         "inputRequired": "Saisie requise",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "Backlog",
-        "scheduled": "Programmato",
         "todo": "Da fare",
         "inProgress": "In corso",
         "inputRequired": "Input richiesto",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "バックログ",
-        "scheduled": "予定済み",
         "todo": "未着手",
         "inProgress": "進行中",
         "inputRequired": "入力が必要",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "Backlog",
-        "scheduled": "Agendado",
         "todo": "A fazer",
         "inProgress": "Em andamento",
         "inputRequired": "Entrada necessária",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "Backlog",
-        "scheduled": "Agendado",
         "todo": "A fazer",
         "inProgress": "Em progresso",
         "inputRequired": "Input necessário",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1411,7 +1411,6 @@
       },
       "Columns": {
         "backlog": "待规划",
-        "scheduled": "已排期",
         "todo": "待办",
         "inProgress": "进行中",
         "inputRequired": "需要输入",

--- a/apps/web/src/app/(app)/tasks/(root)/loading.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/loading.tsx
@@ -20,7 +20,6 @@ export default async function TasksRootLoading() {
 
   const columnLabels: Record<KanbanColumnId, string> = {
     backlog: tColumns("backlog"),
-    scheduled: tColumns("scheduled"),
     todo: tColumns("todo"),
     "in-progress": tColumns("inProgress"),
     "input-required": tColumns("inputRequired"),

--- a/apps/web/src/app/(app)/tasks/(root)/page.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/page.tsx
@@ -209,7 +209,6 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
 
   const columnLabels: Record<KanbanColumnId, string> = {
     backlog: tColumns("backlog"),
-    scheduled: tColumns("scheduled"),
     todo: tColumns("todo"),
     "in-progress": tColumns("inProgress"),
     "input-required": tColumns("inputRequired"),

--- a/apps/web/src/app/(app)/tasks/components/__tests__/jobs-list-view.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/jobs-list-view.test.tsx
@@ -50,7 +50,6 @@ const labels = {
 
 const columnLabels: Record<KanbanColumnId, string> = {
   backlog: "Backlog",
-  scheduled: "Scheduled",
   todo: "Todo",
   "in-progress": "In Progress",
   "input-required": "Input Required",

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-dnd.test.ts
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-dnd.test.ts
@@ -10,10 +10,6 @@ describe("task-dnd", () => {
       expect(isDnDDragColumn("todo")).toBe(true);
     });
 
-    it("disallows scheduled until schedule-on-drop is implemented", () => {
-      expect(isDnDDragColumn("scheduled")).toBe(false);
-    });
-
     it("disallows other columns as drag sources", () => {
       expect(isDnDDragColumn("in-progress")).toBe(false);
       expect(isDnDDragColumn("done")).toBe(false);
@@ -26,10 +22,6 @@ describe("task-dnd", () => {
       expect(isDnDDropColumn("todo")).toBe(true);
     });
 
-    it("disallows scheduled until schedule-on-drop is implemented", () => {
-      expect(isDnDDropColumn("scheduled")).toBe(false);
-    });
-
     it("disallows other columns as drop targets", () => {
       expect(isDnDDropColumn("in-progress")).toBe(false);
       expect(isDnDDropColumn("done")).toBe(false);
@@ -37,11 +29,7 @@ describe("task-dnd", () => {
   });
 
   describe("statusForColumn", () => {
-    it("maps scheduled to QUEUED", () => {
-      expect(statusForColumn("scheduled")).toBe(TaskStatus.QUEUED);
-    });
-
-    it("maps todo to READY so scheduled QUEUED tasks can move to ready", () => {
+    it("maps todo to READY", () => {
       expect(statusForColumn("todo")).toBe(TaskStatus.READY);
     });
 

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-dnd.test.ts
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-dnd.test.ts
@@ -1,7 +1,12 @@
 import { TaskStatus } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
-import { isDnDDragColumn, isDnDDropColumn, statusForColumn } from "../task-dnd";
+import {
+  isDnDDragColumn,
+  isDnDDropColumn,
+  isTaskDnDDraggable,
+  statusForColumn,
+} from "../task-dnd";
 
 describe("task-dnd", () => {
   describe("isDnDDragColumn", () => {
@@ -39,6 +44,42 @@ describe("task-dnd", () => {
 
     it("returns null for non-dnd columns", () => {
       expect(statusForColumn("in-progress")).toBeNull();
+    });
+  });
+
+  describe("isTaskDnDDraggable", () => {
+    const scheduledMetadata = JSON.stringify({
+      schedule: { mode: "daily", timezone: "UTC" },
+    });
+
+    it("allows draft backlog tasks", () => {
+      expect(
+        isTaskDnDDraggable({
+          status: TaskStatus.DRAFT,
+          metadata: null,
+          nextRunAt: null,
+        }),
+      ).toBe(true);
+    });
+
+    it("disallows scheduled queued backlog tasks", () => {
+      expect(
+        isTaskDnDDraggable({
+          status: TaskStatus.QUEUED,
+          metadata: scheduledMetadata,
+          nextRunAt: "2026-06-25T09:00:00.000Z",
+        }),
+      ).toBe(false);
+    });
+
+    it("allows queued tasks without an active schedule", () => {
+      expect(
+        isTaskDnDDraggable({
+          status: TaskStatus.QUEUED,
+          metadata: null,
+          nextRunAt: null,
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
@@ -513,6 +513,83 @@ describe("TaskForm", () => {
     expect(onSuccess).toHaveBeenCalledWith("task-1");
   });
 
+  it("disables Mark as Ready in edit mode when the task has a schedule", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskForm
+        variant="modal"
+        mode="edit"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        taskId="task-1"
+        initialValues={{
+          name: "Task name",
+          description: "Initial description",
+          coworkerId: "coworker-1",
+          status: TaskStatus.DRAFT,
+          metadata: JSON.stringify({
+            version: 1,
+            mode: "once",
+            scheduledAt: "2026-06-26T09:00:00.000Z",
+            runAt: "2026-06-26T09:00:00.000Z",
+          }),
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const markAsReadyButton = screen.getByRole("button", {
+      name: "Mark as Ready",
+    });
+    expect(markAsReadyButton).toBeDisabled();
+
+    await user.click(markAsReadyButton);
+    expect(
+      screen.getByRole("button", { name: "Mark as Ready" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables Mark as Ready after adding a schedule while editing", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskForm
+        variant="modal"
+        mode="edit"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        taskId="task-1"
+        initialValues={{
+          name: "Task name",
+          description: "Initial description",
+          coworkerId: "coworker-1",
+          status: TaskStatus.DRAFT,
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Mark as Ready" }),
+    ).not.toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Set schedule" }));
+    await user.click(screen.getByRole("button", { name: "save" }));
+
+    const markAsReadyButton = screen.getByRole("button", {
+      name: "Mark as Ready",
+    });
+    expect(markAsReadyButton).toBeDisabled();
+
+    await user.click(markAsReadyButton);
+    expect(
+      screen.getByRole("button", { name: "Mark as Ready" }),
+    ).toBeInTheDocument();
+  });
+
   it("toggles status in edit modal and keeps the toggled status on save", async () => {
     const user = userEvent.setup();
     const updateTaskMock = vi.mocked(updateTask);

--- a/apps/web/src/app/(app)/tasks/components/jobs-list-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/jobs-list-view.tsx
@@ -97,7 +97,6 @@ export function JobsListView({
   const groupedJobs = useMemo(() => {
     const initial: Record<KanbanColumnId, TasksViewJob[]> = {
       backlog: [],
-      scheduled: [],
       todo: [],
       "in-progress": [],
       "input-required": [],

--- a/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
+++ b/apps/web/src/app/(app)/tasks/components/kanban-board.tsx
@@ -1,7 +1,4 @@
-import {
-  compareScheduledTasksAsc,
-  compareTasksDesc,
-} from "@/app/tasks/utils/task-sort";
+import { compareTasksDesc } from "@/app/tasks/utils/task-sort";
 import type { TaskStatus } from "@/lib/types/core-dto";
 import {
   COLUMN_STATUS_COLORS,
@@ -51,11 +48,7 @@ export function KanbanBoard({
       {columns.map((column, index) => {
         const columnTasks = tasks
           .filter((task) => task.columnId === column.id)
-          .sort(
-            column.id === "scheduled"
-              ? compareScheduledTasksAsc
-              : compareTasksDesc,
-          );
+          .sort(compareTasksDesc);
         const isFirstColumn = index === 0;
         const isDraggableColumn = isDragEnabled && isDnDDragColumn(column.id);
         const isDropTargetColumn = isDragEnabled && isDnDDropColumn(column.id);

--- a/apps/web/src/app/(app)/tasks/components/task-card.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-card.tsx
@@ -1,3 +1,5 @@
+import { TaskStatus } from "@sokosumi/utils";
+
 import { TaskScheduleDisplay } from "@/components/task-schedule-display";
 import type { TaskStatus as TaskStatusType } from "@/lib/types/core-dto";
 import type { TaskWithCoworker } from "@/lib/types/task";
@@ -69,7 +71,8 @@ export function TaskCard({
               </div>
             ) : null}
 
-            {hasActiveSchedule(
+            {task.status === TaskStatus.QUEUED &&
+            hasActiveSchedule(
               task.metadata,
               task.nextRunAt ? new Date(task.nextRunAt) : null,
             ) ? (

--- a/apps/web/src/app/(app)/tasks/components/task-card.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-card.tsx
@@ -2,6 +2,7 @@ import { TaskScheduleDisplay } from "@/components/task-schedule-display";
 import type { TaskStatus as TaskStatusType } from "@/lib/types/core-dto";
 import type { TaskWithCoworker } from "@/lib/types/task";
 import { cn } from "@/lib/utils";
+import { hasActiveSchedule } from "@/lib/utils/task-schedule";
 import { TaskDetailLink } from "./task-detail-link";
 import type { DragHandleProps } from "./task-dnd";
 import { TaskMetaDetails } from "./task-meta";
@@ -68,7 +69,10 @@ export function TaskCard({
               </div>
             ) : null}
 
-            {task.columnId === "scheduled" ? (
+            {hasActiveSchedule(
+              task.metadata,
+              task.nextRunAt ? new Date(task.nextRunAt) : null,
+            ) ? (
               <TaskScheduleDisplay
                 variant="card"
                 metadata={task.metadata}

--- a/apps/web/src/app/(app)/tasks/components/task-created-celebration.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-created-celebration.tsx
@@ -4,10 +4,15 @@ import { ArrowRight, Check, Clock } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { Button } from "@/components/ui/button";
-import { COLUMN_STATUS_COLORS, type KanbanColumnId } from "@/lib/types/task";
+import { COLUMN_STATUS_COLORS } from "@/lib/types/task";
 import { cn } from "@/lib/utils";
 
 type CelebrationTaskStatus = "DRAFT" | "QUEUED" | "READY";
+
+type CelebrationColumnId = "backlog" | "todo" | "celebration-scheduled";
+
+/** Matches removed kanban `scheduled` column dot color for unchanged celebration UI. */
+const CELEBRATION_SCHEDULED_DOT = "bg-primary";
 
 interface TaskCreatedCelebrationProps {
   name: string;
@@ -26,10 +31,10 @@ interface TaskCreatedCelebrationProps {
 
 // A 3-column slice of the real kanban board (matching its column dot colors).
 // A DRAFT task lands in "Backlog", READY in "To Do", QUEUED in "Scheduled".
-const COLUMNS: Array<{ id: KanbanColumnId; dot: string }> = [
+const COLUMNS: Array<{ id: CelebrationColumnId; dot: string }> = [
   { id: "backlog", dot: COLUMN_STATUS_COLORS.backlog },
   { id: "todo", dot: COLUMN_STATUS_COLORS.todo },
-  { id: "scheduled", dot: COLUMN_STATUS_COLORS.scheduled },
+  { id: "celebration-scheduled", dot: CELEBRATION_SCHEDULED_DOT },
 ];
 
 const STATUS_COLUMN_INDEX: Record<CelebrationTaskStatus, number> = {
@@ -52,7 +57,7 @@ const STATUS_CARD_STYLES: Record<
   },
   QUEUED: {
     badge: "bg-primary/10 text-primary",
-    dot: COLUMN_STATUS_COLORS.scheduled,
+    dot: CELEBRATION_SCHEDULED_DOT,
   },
 };
 

--- a/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
@@ -13,10 +13,10 @@ import { type CSSProperties, type ReactNode, useRef } from "react";
 import type { KanbanColumnId } from "@/lib/types/task";
 import { cn } from "@/lib/utils";
 
-/** Columns whose tasks can be dragged. Scheduled is view-only until schedule-on-drop ships. */
+/** Columns whose tasks can be dragged. */
 const DND_DRAG_COLUMNS = new Set<KanbanColumnId>(["backlog", "todo"]);
 
-/** Columns that accept drops. Scheduled is view-only until schedule-on-drop ships. */
+/** Columns that accept drops. */
 const DND_DROP_COLUMNS = new Set<KanbanColumnId>(["backlog", "todo"]);
 
 export interface DragHandleProps {
@@ -49,8 +49,6 @@ export function statusForColumn(columnId: KanbanColumnId): TaskStatus | null {
   switch (columnId) {
     case "backlog":
       return TaskStatus.DRAFT;
-    case "scheduled":
-      return TaskStatus.QUEUED;
     case "todo":
       return TaskStatus.READY;
     default:

--- a/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
@@ -10,8 +10,9 @@ import {
 import { TaskStatus } from "@sokosumi/utils";
 import { type CSSProperties, type ReactNode, useRef } from "react";
 
-import type { KanbanColumnId } from "@/lib/types/task";
+import type { KanbanColumnId, TaskWithCoworker } from "@/lib/types/task";
 import { cn } from "@/lib/utils";
+import { hasActiveSchedule } from "@/lib/utils/task-schedule";
 
 /** Columns whose tasks can be dragged. */
 const DND_DRAG_COLUMNS = new Set<KanbanColumnId>(["backlog", "todo"]);
@@ -54,6 +55,20 @@ export function statusForColumn(columnId: KanbanColumnId): TaskStatus | null {
     default:
       return null;
   }
+}
+
+/** Scheduled backlog tasks must not be dragged; status changes require clearing the schedule first. */
+export function isTaskDnDDraggable(
+  task: Pick<TaskWithCoworker, "status" | "metadata" | "nextRunAt">,
+): boolean {
+  if (task.status !== TaskStatus.QUEUED) {
+    return true;
+  }
+
+  return !hasActiveSchedule(
+    task.metadata,
+    task.nextRunAt ? new Date(task.nextRunAt) : null,
+  );
 }
 
 export function DraggableTask({ id, columnId, children }: DraggableTaskProps) {

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -357,10 +357,22 @@ export function TaskForm({
   const canUseSubmitShortcut = showTaskStep && !isSaveDisabled;
   const taskStepTitle = labels.taskStepTitle ?? "What should {name} do?";
   const shouldShowEditToggle = mode === "edit";
+  const canMarkAsReady = !hasSchedule;
   const statusToggleLabel =
     status === TaskStatus.DRAFT
       ? (labels.markAsReady ?? labels.statusReady)
       : (labels.revertToDraft ?? labels.statusDraft);
+  const isStatusToggleDisabled =
+    isSubmitting || (status === TaskStatus.DRAFT && !canMarkAsReady);
+
+  function handleStatusToggle() {
+    setStatus((current) => {
+      if (current === TaskStatus.DRAFT) {
+        return canMarkAsReady ? TaskStatus.READY : current;
+      }
+      return TaskStatus.DRAFT;
+    });
+  }
 
   const handleSave = useCallback(
     async (overrideStatus?: TaskStatus) => {
@@ -1023,14 +1035,8 @@ export function TaskForm({
                       type="button"
                       variant="outline"
                       className="min-w-28"
-                      onClick={() =>
-                        setStatus((current) =>
-                          current === TaskStatus.DRAFT
-                            ? TaskStatus.READY
-                            : TaskStatus.DRAFT,
-                        )
-                      }
-                      disabled={isSubmitting}
+                      onClick={handleStatusToggle}
+                      disabled={isStatusToggleDisabled}
                     >
                       {statusToggleLabel}
                     </Button>

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -4,7 +4,6 @@ import { TaskStatus } from "@sokosumi/utils";
 import {
   ArrowLeft,
   CalendarClock,
-  Clock,
   Command,
   CornerDownLeft,
   Loader2,
@@ -45,6 +44,7 @@ import { getDefaultTimezone } from "@/lib/schedules/timezones";
 import type { CoworkerOption } from "@/lib/types/coworker";
 import type { TaskScheduleSelection } from "@/lib/types/task-schedule";
 import { cn } from "@/lib/utils";
+import { getScheduleIcon } from "@/lib/utils/schedule-icon";
 import {
   createDesignMdDismissedState,
   ensureDesignMdInDescription,
@@ -303,6 +303,11 @@ export function TaskForm({
   const isNameRequired = mode === "edit";
   const isUploadingAttachments = uploadingAttachmentsCount > 0;
   const hasSchedule = scheduleSelection.mode !== "none";
+  const ScheduleFooterIcon = hasSchedule
+    ? getScheduleIcon(
+        scheduleSelection.mode === "recurring" ? "recurring" : "once",
+      )
+    : null;
   const scheduleLabel = useMemo(
     () =>
       formatTaskScheduleSelectionLabel(
@@ -936,9 +941,9 @@ export function TaskForm({
                 : "flex flex-col items-stretch justify-between gap-3 border-t px-6 py-6 sm:flex-row sm:items-center md:px-8"
             }
           >
-            {hasSchedule && scheduleLabel ? (
+            {hasSchedule && scheduleLabel && ScheduleFooterIcon ? (
               <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
-                <Clock className="size-4 shrink-0" aria-hidden />
+                <ScheduleFooterIcon className="size-4 shrink-0" aria-hidden />
                 <span className="truncate">{scheduleLabel}</span>
               </div>
             ) : null}

--- a/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view.tsx
@@ -83,7 +83,12 @@ import { JobsListView } from "./jobs-list-view";
 import { JobsViewFilters } from "./jobs-view-filters";
 import { KanbanBoard } from "./kanban-board";
 import { TaskCard } from "./task-card";
-import { isDnDDragColumn, isDnDDropColumn, statusForColumn } from "./task-dnd";
+import {
+  isDnDDragColumn,
+  isDnDDropColumn,
+  isTaskDnDDraggable,
+  statusForColumn,
+} from "./task-dnd";
 import type { TaskFormInitialDesignMdAttachment } from "./task-form";
 import { TaskListItem } from "./task-list-item";
 import { TaskListView } from "./task-list-view";
@@ -593,6 +598,7 @@ export function TasksView({
     const draggedTask = itemsRef.current.find((task) => task.id === activeId);
     if (
       !draggedTask ||
+      !isTaskDnDDraggable(draggedTask) ||
       !isTaskDraggableForViewFilters(
         draggedTask,
         userId,
@@ -1015,6 +1021,7 @@ export function TasksView({
                     compact={density === "compact"}
                     statusLabels={labels.filters.statusOptions}
                     canDragTask={(task) =>
+                      isTaskDnDDraggable(task) &&
                       isTaskDraggableForViewFilters(
                         task,
                         userId,
@@ -1037,6 +1044,7 @@ export function TasksView({
                     compact={density === "compact"}
                     statusLabels={labels.filters.statusOptions}
                     canDragTask={(task) =>
+                      isTaskDnDDraggable(task) &&
                       isTaskDraggableForViewFilters(
                         task,
                         userId,

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-sort.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-sort.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { TaskWithCoworker } from "@/lib/types/task";
 
-import { compareScheduledTasksAsc, compareTasksDesc } from "../task-sort";
+import { compareTasksDesc } from "../task-sort";
 
 function buildTask(
   overrides: Partial<TaskWithCoworker> & Pick<TaskWithCoworker, "id">,
@@ -17,50 +17,13 @@ function buildTask(
     updatedAt: "2026-06-01T12:00:00.000Z",
     jobsCount: 0,
     commentsCount: 0,
-    columnId: "scheduled",
+    columnId: "backlog",
     events: [],
     agents: [],
     coworker: null,
     ...overrides,
   };
 }
-
-describe("compareScheduledTasksAsc", () => {
-  it("orders tasks by soonest nextRunAt first", () => {
-    const tasks = [
-      buildTask({
-        id: "later",
-        nextRunAt: "2026-06-10T09:00:00.000Z",
-      }),
-      buildTask({
-        id: "sooner",
-        nextRunAt: "2026-06-08T09:00:00.000Z",
-      }),
-      buildTask({
-        id: "middle",
-        nextRunAt: "2026-06-09T09:00:00.000Z",
-      }),
-    ];
-
-    expect(
-      [...tasks].sort(compareScheduledTasksAsc).map((task) => task.id),
-    ).toEqual(["sooner", "middle", "later"]);
-  });
-
-  it("places tasks without nextRunAt after scheduled tasks", () => {
-    const tasks = [
-      buildTask({ id: "missing", nextRunAt: null }),
-      buildTask({
-        id: "scheduled",
-        nextRunAt: "2026-06-08T09:00:00.000Z",
-      }),
-    ];
-
-    expect(
-      [...tasks].sort(compareScheduledTasksAsc).map((task) => task.id),
-    ).toEqual(["scheduled", "missing"]);
-  });
-});
 
 describe("compareTasksDesc", () => {
   it("orders tasks by updatedAt descending", () => {

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts
@@ -112,7 +112,7 @@ describe("getTasksColumnPage", () => {
     expect(page.tasks.map((task) => task.id)).toEqual(["task-2"]);
     expect(page.nextCursor).toBeNull();
     expect(listTasksMock).toHaveBeenCalledWith({
-      status: [TaskStatus.DRAFT],
+      status: [TaskStatus.DRAFT, TaskStatus.QUEUED],
       scope: "owned",
       coworkerId: undefined,
       projectId: undefined,
@@ -121,7 +121,7 @@ describe("getTasksColumnPage", () => {
     });
   });
 
-  it("queries scheduled column statuses in one request", async () => {
+  it("queries backlog column statuses in one request", async () => {
     listTasksMock.mockResolvedValue({
       tasks: [
         buildTask({
@@ -129,12 +129,17 @@ describe("getTasksColumnPage", () => {
           status: TaskStatus.QUEUED,
           updatedAt: "2026-03-02T02:00:00.000Z",
         }),
+        buildTask({
+          id: "task-draft",
+          status: TaskStatus.DRAFT,
+          updatedAt: "2026-03-02T01:00:00.000Z",
+        }),
       ],
       pagination: { nextCursor: null },
     });
 
     const page = await getTasksColumnPage({
-      columnId: "scheduled",
+      columnId: "backlog",
       cursor: null,
       limit: 10,
       scope: "owned",
@@ -145,15 +150,17 @@ describe("getTasksColumnPage", () => {
       agentsById: new Map(),
     });
 
-    expect(page.tasks.map((task) => task.id)).toEqual(["task-queued"]);
+    expect(page.tasks.map((task) => task.id)).toEqual([
+      "task-queued",
+      "task-draft",
+    ]);
     expect(listTasksMock).toHaveBeenCalledWith({
-      status: [TaskStatus.QUEUED],
+      status: [TaskStatus.DRAFT, TaskStatus.QUEUED],
       scope: "owned",
       coworkerId: undefined,
       projectId: undefined,
       cursor: null,
       limit: 10,
-      sort: "nextRunAt",
     });
   });
 

--- a/apps/web/src/app/(app)/tasks/utils/task-sort.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-sort.ts
@@ -13,24 +13,3 @@ export function compareTasksDesc(
   if (updatedAtDiff !== 0) return updatedAtDiff;
   return b.id.localeCompare(a.id);
 }
-
-/**
- * Scheduled column: soonest nextRunAt first. Tasks without nextRunAt sort last.
- */
-export function compareScheduledTasksAsc(
-  a: TaskWithCoworker,
-  b: TaskWithCoworker,
-): number {
-  const aNextRunAt = a.nextRunAt ? new Date(a.nextRunAt).getTime() : null;
-  const bNextRunAt = b.nextRunAt ? new Date(b.nextRunAt).getTime() : null;
-
-  if (aNextRunAt == null && bNextRunAt == null) {
-    return compareTasksDesc(a, b);
-  }
-  if (aNextRunAt == null) return 1;
-  if (bNextRunAt == null) return -1;
-
-  const nextRunDiff = aNextRunAt - bNextRunAt;
-  if (nextRunDiff !== 0) return nextRunDiff;
-  return a.id.localeCompare(b.id);
-}

--- a/apps/web/src/app/(app)/tasks/utils/tasks-column-page.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-column-page.ts
@@ -57,7 +57,6 @@ export async function getTasksColumnPage({
     projectId: projectId ?? undefined,
     cursor,
     limit,
-    ...(columnId === "scheduled" ? { sort: "nextRunAt" as const } : {}),
   });
   const tasks = result.tasks.map((task) =>
     mapTaskToTaskWithCoworker(task, coworkersById, agentsById),

--- a/apps/web/src/components/task-schedule-display.tsx
+++ b/apps/web/src/components/task-schedule-display.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Clock } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 
 import {
@@ -8,6 +7,7 @@ import {
   formatScheduleTitle,
 } from "@/components/schedules/format";
 import { cn } from "@/lib/utils";
+import { getScheduleIcon } from "@/lib/utils/schedule-icon";
 import { parseTaskScheduleMetadata } from "@/lib/utils/task-schedule";
 
 interface TaskScheduleDisplayProps {
@@ -72,11 +72,15 @@ export function TaskScheduleDisplay({
     : null;
 
   if (variant === "card") {
+    const ScheduleIcon = scheduleMetadata
+      ? getScheduleIcon(scheduleMetadata.mode)
+      : null;
+
     return (
       <div className={cn("flex items-center justify-between gap-2", className)}>
-        {scheduleLabel ? (
+        {scheduleLabel && ScheduleIcon ? (
           <p className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">
-            <Clock className="size-3.5 shrink-0" aria-hidden />
+            <ScheduleIcon className="size-3.5 shrink-0" aria-hidden />
             <span className="truncate">{scheduleLabel}</span>
           </p>
         ) : null}

--- a/apps/web/src/lib/actions/task/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/task/__tests__/action.test.ts
@@ -1,6 +1,8 @@
 import { TaskLinkType, TaskStatus } from "@sokosumi/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Task } from "@/lib/clients/generated/core";
+
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
@@ -88,8 +90,13 @@ function buildTaskLink(
 }
 
 function buildTask(
-  overrides?: Partial<{ id: string; name: string; status: TaskStatus }>,
-) {
+  overrides?: Partial<
+    Pick<Task, "id" | "name" | "description" | "coworkerId" | "status"> & {
+      metadata: string | null;
+      nextRunAt: Date | null;
+    }
+  >,
+): Task {
   return {
     id: "task-created",
     name: "Generated task name",
@@ -97,7 +104,7 @@ function buildTask(
     coworkerId: null,
     status: TaskStatus.READY,
     ...overrides,
-  } as never;
+  } as Task;
 }
 
 describe("task link actions", () => {
@@ -602,14 +609,14 @@ describe("setTaskStatusFromDrag", () => {
   });
 
   it("clears the schedule before moving a scheduled queued task to ready", async () => {
-    taskServiceMock.getTaskById.mockResolvedValue({
-      ...buildTask({
+    taskServiceMock.getTaskById.mockResolvedValue(
+      buildTask({
         id: "task-1",
         status: TaskStatus.QUEUED,
+        metadata: scheduledMetadata,
+        nextRunAt: new Date("2026-06-25T09:00:00.000Z"),
       }),
-      metadata: scheduledMetadata,
-      nextRunAt: new Date("2026-06-25T09:00:00.000Z"),
-    });
+    );
     taskScheduleServiceMock.clearSchedule.mockResolvedValue({
       id: "task-1",
       status: TaskStatus.DRAFT,
@@ -631,14 +638,14 @@ describe("setTaskStatusFromDrag", () => {
   });
 
   it("clears the schedule without re-queuing when reverting a scheduled queued task to draft", async () => {
-    taskServiceMock.getTaskById.mockResolvedValue({
-      ...buildTask({
+    taskServiceMock.getTaskById.mockResolvedValue(
+      buildTask({
         id: "task-1",
         status: TaskStatus.QUEUED,
+        metadata: scheduledMetadata,
+        nextRunAt: new Date("2026-06-25T09:00:00.000Z"),
       }),
-      metadata: scheduledMetadata,
-      nextRunAt: new Date("2026-06-25T09:00:00.000Z"),
-    });
+    );
     taskScheduleServiceMock.clearSchedule.mockResolvedValue({
       id: "task-1",
       status: TaskStatus.DRAFT,

--- a/apps/web/src/lib/actions/task/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/task/__tests__/action.test.ts
@@ -33,6 +33,7 @@ const taskServiceMock = {
   deleteTask: vi.fn(),
   patchTask: vi.fn(),
   createTaskEvent: vi.fn(),
+  getTaskById: vi.fn(),
 };
 const taskScheduleServiceMock = {
   clearSchedule: vi.fn(),
@@ -109,6 +110,7 @@ describe("task link actions", () => {
     taskServiceMock.deleteTask.mockReset();
     taskServiceMock.patchTask.mockReset();
     taskServiceMock.createTaskEvent.mockReset();
+    taskServiceMock.getTaskById.mockReset();
     taskScheduleServiceMock.clearSchedule.mockReset();
     taskScheduleServiceMock.setSchedule.mockReset();
     taskServiceMock.patchTask.mockResolvedValue({});
@@ -556,6 +558,97 @@ describe("updateTask schedule status", () => {
       hadSchedule: true,
       originalSchedule: recurringSchedule,
       schedule: recurringSchedule,
+    });
+
+    expect(taskScheduleServiceMock.clearSchedule).toHaveBeenCalledWith(
+      "task-1",
+    );
+    expect(taskServiceMock.createTaskEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("setTaskStatusFromDrag", () => {
+  const scheduledMetadata = JSON.stringify({
+    schedule: { mode: "daily", timezone: "UTC" },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskServiceMock.getTaskById.mockReset();
+    taskServiceMock.createTaskEvent.mockReset();
+    taskScheduleServiceMock.clearSchedule.mockReset();
+    taskServiceMock.createTaskEvent.mockResolvedValue({});
+  });
+
+  it("creates a status event for a simple draft to ready move", async () => {
+    taskServiceMock.getTaskById.mockResolvedValue(
+      buildTask({
+        id: "task-1",
+        status: TaskStatus.DRAFT,
+      }),
+    );
+
+    const { setTaskStatusFromDrag } = await import("../action");
+
+    await setTaskStatusFromDrag({
+      taskId: "task-1",
+      desiredStatus: TaskStatus.READY,
+    });
+
+    expect(taskScheduleServiceMock.clearSchedule).not.toHaveBeenCalled();
+    expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith("task-1", {
+      status: TaskStatus.READY,
+    });
+  });
+
+  it("clears the schedule before moving a scheduled queued task to ready", async () => {
+    taskServiceMock.getTaskById.mockResolvedValue({
+      ...buildTask({
+        id: "task-1",
+        status: TaskStatus.QUEUED,
+      }),
+      metadata: scheduledMetadata,
+      nextRunAt: new Date("2026-06-25T09:00:00.000Z"),
+    });
+    taskScheduleServiceMock.clearSchedule.mockResolvedValue({
+      id: "task-1",
+      status: TaskStatus.DRAFT,
+    });
+
+    const { setTaskStatusFromDrag } = await import("../action");
+
+    await setTaskStatusFromDrag({
+      taskId: "task-1",
+      desiredStatus: TaskStatus.READY,
+    });
+
+    expect(taskScheduleServiceMock.clearSchedule).toHaveBeenCalledWith(
+      "task-1",
+    );
+    expect(taskServiceMock.createTaskEvent).toHaveBeenCalledWith("task-1", {
+      status: TaskStatus.READY,
+    });
+  });
+
+  it("clears the schedule without re-queuing when reverting a scheduled queued task to draft", async () => {
+    taskServiceMock.getTaskById.mockResolvedValue({
+      ...buildTask({
+        id: "task-1",
+        status: TaskStatus.QUEUED,
+      }),
+      metadata: scheduledMetadata,
+      nextRunAt: new Date("2026-06-25T09:00:00.000Z"),
+    });
+    taskScheduleServiceMock.clearSchedule.mockResolvedValue({
+      id: "task-1",
+      status: TaskStatus.DRAFT,
+    });
+
+    const { setTaskStatusFromDrag } = await import("../action");
+
+    await setTaskStatusFromDrag({
+      taskId: "task-1",
+      desiredStatus: TaskStatus.DRAFT,
     });
 
     expect(taskScheduleServiceMock.clearSchedule).toHaveBeenCalledWith(

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -15,6 +15,7 @@ import { taskScheduleService } from "@/lib/services/task-schedule.service";
 import type { TaskScheduleSelection } from "@/lib/types/task-schedule";
 import { normalizeOptionalProjectId } from "@/lib/utils/project";
 import {
+  hasActiveSchedule,
   hasTaskScheduleChanged,
   selectionToApiBody,
 } from "@/lib/utils/task-schedule";
@@ -489,9 +490,29 @@ export const setTaskStatusFromDrag = withSession<
   { taskId: string }
 >(async ({ taskId, desiredStatus }) => {
   try {
-    await taskService.createTaskEvent(taskId, {
-      status: desiredStatus,
-    });
+    const task = await taskService.getTaskById(taskId);
+    if (!task) {
+      throw new Error("Task not found");
+    }
+
+    const currentStatus = task.status as TaskStatus;
+    let statusAfterSchedule = currentStatus;
+
+    const shouldClearSchedule =
+      currentStatus === TaskStatus.QUEUED &&
+      desiredStatus !== TaskStatus.QUEUED &&
+      hasActiveSchedule(task.metadata, task.nextRunAt);
+
+    if (shouldClearSchedule) {
+      const clearedTask = await taskScheduleService.clearSchedule(taskId);
+      statusAfterSchedule = clearedTask.status as TaskStatus;
+    }
+
+    if (desiredStatus !== statusAfterSchedule) {
+      await taskService.createTaskEvent(taskId, {
+        status: desiredStatus,
+      });
+    }
 
     revalidatePath("/tasks");
     revalidatePath(`/tasks/${taskId}`);

--- a/apps/web/src/lib/types/__tests__/task.test.ts
+++ b/apps/web/src/lib/types/__tests__/task.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from "vitest";
 import { KANBAN_COLUMNS } from "@/lib/types/task";
 
 describe("KANBAN_COLUMNS", () => {
-  it("orders scheduled after todo so backlog↔todo drag does not cross scheduled", () => {
+  it("orders backlog before todo so backlog↔todo drag columns are adjacent", () => {
     const columnIds = KANBAN_COLUMNS.map((column) => column.id);
-    const scheduledIndex = columnIds.indexOf("scheduled");
+    const backlogIndex = columnIds.indexOf("backlog");
     const todoIndex = columnIds.indexOf("todo");
 
-    expect(scheduledIndex).toBeGreaterThan(-1);
+    expect(backlogIndex).toBeGreaterThan(-1);
     expect(todoIndex).toBeGreaterThan(-1);
-    expect(todoIndex).toBeLessThan(scheduledIndex);
+    expect(backlogIndex).toBeLessThan(todoIndex);
+    expect(todoIndex - backlogIndex).toBe(1);
   });
 });

--- a/apps/web/src/lib/types/task.ts
+++ b/apps/web/src/lib/types/task.ts
@@ -11,7 +11,6 @@ export type { TaskEvent };
 export type KanbanColumnId =
   | "backlog"
   | "todo"
-  | "scheduled"
   | "in-progress"
   | "input-required"
   | "done";
@@ -45,7 +44,6 @@ export interface KanbanColumnDefinition {
 export const KANBAN_COLUMNS: KanbanColumnDefinition[] = [
   { id: "backlog", translationKey: "App.Tasks.Columns.backlog" },
   { id: "todo", translationKey: "App.Tasks.Columns.todo" },
-  { id: "scheduled", translationKey: "App.Tasks.Columns.scheduled" },
   { id: "in-progress", translationKey: "App.Tasks.Columns.inProgress" },
   { id: "input-required", translationKey: "App.Tasks.Columns.inputRequired" },
   { id: "done", translationKey: "App.Tasks.Columns.done" },
@@ -53,7 +51,6 @@ export const KANBAN_COLUMNS: KanbanColumnDefinition[] = [
 
 export const COLUMN_STATUS_COLORS: Record<KanbanColumnId, string> = {
   backlog: "bg-muted-foreground",
-  scheduled: "bg-primary",
   todo: "bg-blue-500",
   "in-progress": "bg-amber-500",
   "input-required": "bg-orange-500",

--- a/apps/web/src/lib/utils/__tests__/task-transformer.test.ts
+++ b/apps/web/src/lib/utils/__tests__/task-transformer.test.ts
@@ -43,12 +43,12 @@ function buildTask(
 }
 
 describe("mapTaskToTaskWithCoworker", () => {
-  it("maps queued tasks to scheduled column", () => {
+  it("maps queued tasks to backlog column", () => {
     const task = buildTask(TaskStatus.QUEUED);
 
     const mapped = mapTaskToTaskWithCoworker(task, new Map(), new Map());
 
-    expect(mapped.columnId).toBe("scheduled");
+    expect(mapped.columnId).toBe("backlog");
   });
 
   it("maps canceled tasks to done column", () => {

--- a/apps/web/src/lib/utils/schedule-icon.ts
+++ b/apps/web/src/lib/utils/schedule-icon.ts
@@ -1,0 +1,6 @@
+import type { LucideIcon } from "lucide-react";
+import { CalendarSync, Clock } from "lucide-react";
+
+export function getScheduleIcon(mode: "once" | "recurring"): LucideIcon {
+  return mode === "recurring" ? CalendarSync : Clock;
+}

--- a/apps/web/src/lib/utils/task-column.ts
+++ b/apps/web/src/lib/utils/task-column.ts
@@ -4,8 +4,7 @@ import type { KanbanColumnId } from "@/lib/types/task";
 
 /** Single source of truth for task status → kanban column. Used by getTasksColumnPage and mapTaskToTaskWithCoworker. */
 export const COLUMN_TASK_STATUSES: Record<KanbanColumnId, TaskStatus[]> = {
-  backlog: [TaskStatus.DRAFT],
-  scheduled: [TaskStatus.QUEUED],
+  backlog: [TaskStatus.DRAFT, TaskStatus.QUEUED],
   todo: [TaskStatus.READY, TaskStatus.CREDITS_TOPPED_UP],
   "in-progress": [
     TaskStatus.RUNNING,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements SOK-614.

## Changes

### Column mapping
- Maps `QUEUED` tasks from Scheduled column → Backlog column
- Backlog now holds both `DRAFT` and `QUEUED` tasks
- Removes `scheduled` from `KanbanColumnId` union, `KANBAN_COLUMNS` array, and `COLUMN_STATUS_COLORS`

### Schedule label icons
- Adds `getScheduleIcon(mode)` helper to differentiate icons by schedule type
- Recurring schedules show `CalendarSync` icon
- One-time schedules show `Clock` icon
- Applied to task card schedule display and task-form footer label

### Ripple updates
- Updates task card visibility check: uses `hasActiveSchedule(metadata, nextRunAt)` instead of `columnId === "scheduled"`
- Removes `scheduled` sort branch from kanban-board
- Removes dead `compareScheduledTasksAsc` and `sort: "nextRunAt"` special case
- Removes `scheduled` case from `statusForColumn` in task-dnd
- Updates page/loading column label maps
- Type-decouples celebration (preserves render, no animation change)

### i18n cleanup
- Removes `App.Tasks.Columns.scheduled` key from all 9 locale files

### Tests
- Updates affected tests for new column mapping
- All web:check, web:test passing

## Out of scope
- Post-create celebration still shows 3-slice "Scheduled" animation (known cosmetic gap, no rework per requirement)
- No changes to Core/API task status semantics or schedule persistence
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-614](https://linear.app/masumi/issue/SOK-614/improveweb-move-queued-tasks-to-backlog-and-drop-scheduled-column)

<div><a href="https://cursor.com/agents/bc-ffcef3d2-ea48-43e8-a466-5b3e3aac6bb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffcef3d2-ea48-43e8-a466-5b3e3aac6bb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

