### PR TITLE
feat(web): show active-filter dot on taskboard Filters button

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-view-filters.tsx
@@ -7,6 +7,7 @@ import { useCallback, useMemo } from "react";
 import {
   buildTasksFiltersSearchParams,
   getTasksFiltersFromSearchParams,
+  hasActiveTasksFilters,
   type ProjectFilterOption,
   type TasksFilters,
 } from "@/app/tasks/utils/tasks-filters";
@@ -54,6 +55,11 @@ export function TasksViewFilters({
         projectOptions,
       ),
     [activeOrganizationId, coworkerOptions, projectOptions, searchParams],
+  );
+
+  const showActiveIndicator = useMemo(
+    () => hasActiveTasksFilters(filters, activeOrganizationId),
+    [activeOrganizationId, filters],
   );
 
   const handleFilterChange = useCallback(
@@ -190,6 +196,7 @@ export function TasksViewFilters({
       searchPlaceholder={labels.searchPlaceholder}
       emptyResultsLabel={labels.emptyResults}
       sections={sections}
+      showActiveIndicator={showActiveIndicator}
     />
   );
 }

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -6,6 +6,7 @@ import {
   getDefaultTasksScope,
   getTasksFiltersFromSearchParams,
   getTasksFiltersResetKey,
+  hasActiveTasksFilters,
   isTaskDraggableForViewFilters,
   isTaskOwnerEditable,
   parseTasksFilters,
@@ -284,6 +285,63 @@ describe("tasks-filters", () => {
         null,
       ),
     ).toBe(true);
+  });
+
+  describe("hasActiveTasksFilters", () => {
+    const defaultFilters = {
+      scope: "owned" as const,
+      coworkerId: null,
+      status: null,
+      projectId: null,
+    };
+
+    it("shows the indicator for org boards with owned scope (default)", () => {
+      expect(hasActiveTasksFilters(defaultFilters, "org-1")).toBe(true);
+    });
+
+    it("shows the indicator for org boards with workspace scope", () => {
+      expect(
+        hasActiveTasksFilters(
+          { ...defaultFilters, scope: "workspace" },
+          "org-1",
+        ),
+      ).toBe(true);
+    });
+
+    it("shows the indicator for org boards with all-default owned scope", () => {
+      expect(hasActiveTasksFilters(defaultFilters, "org-1")).toBe(true);
+    });
+
+    it("hides the indicator for personal boards with owned scope only", () => {
+      expect(hasActiveTasksFilters(defaultFilters, null)).toBe(false);
+    });
+
+    it("shows the indicator for personal boards with status filter", () => {
+      expect(
+        hasActiveTasksFilters(
+          { ...defaultFilters, status: TaskStatus.READY },
+          null,
+        ),
+      ).toBe(true);
+    });
+
+    it("shows the indicator for personal boards with coworker filter", () => {
+      expect(
+        hasActiveTasksFilters(
+          { ...defaultFilters, coworkerId: "coworker-1" },
+          null,
+        ),
+      ).toBe(true);
+    });
+
+    it("shows the indicator for personal boards with project filter", () => {
+      expect(
+        hasActiveTasksFilters(
+          { ...defaultFilters, projectId: PROJECT_ID },
+          null,
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("isTaskDraggableForViewFilters", () => {

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/tasks-filters.test.ts
@@ -308,10 +308,6 @@ describe("tasks-filters", () => {
       ).toBe(true);
     });
 
-    it("shows the indicator for org boards with all-default owned scope", () => {
-      expect(hasActiveTasksFilters(defaultFilters, "org-1")).toBe(true);
-    });
-
     it("hides the indicator for personal boards with owned scope only", () => {
       expect(hasActiveTasksFilters(defaultFilters, null)).toBe(false);
     });

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -229,6 +229,25 @@ export function getTasksFiltersResetKey(
   return `${activeOrganizationId ?? "personal"}:${filters.scope}:${filters.coworkerId ?? "all"}:${filters.status ?? "all"}:${filters.projectId ?? "all"}`;
 }
 
+export function hasActiveTasksFilters(
+  filters: TasksFilters,
+  activeOrganizationId: string | null,
+): boolean {
+  const hasNonScopeFilter = Boolean(
+    filters.coworkerId || filters.status || filters.projectId,
+  );
+
+  if (activeOrganizationId !== null) {
+    return (
+      filters.scope === "owned" ||
+      filters.scope === "workspace" ||
+      hasNonScopeFilter
+    );
+  }
+
+  return hasNonScopeFilter;
+}
+
 export function isTaskOwnerEditable(
   task: Pick<TaskWithCoworker, "userId">,
   userId: string | null | undefined,

--- a/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
+++ b/apps/web/src/app/(app)/tasks/utils/tasks-filters.ts
@@ -229,6 +229,18 @@ export function getTasksFiltersResetKey(
   return `${activeOrganizationId ?? "personal"}:${filters.scope}:${filters.coworkerId ?? "all"}:${filters.status ?? "all"}:${filters.projectId ?? "all"}`;
 }
 
+/**
+ * Determines whether to show the active filter indicator dot.
+ *
+ * Business logic:
+ * - Organization boards: Show the dot when `scope` is "owned" or "workspace",
+ *   even though "owned" is the default. This signals the board is filtered
+ *   (either "My Tasks" or "All workspace tasks") as opposed to a hypothetical
+ *   unfiltered view. Also show when coworkerId, status, or projectId is set.
+ * - Personal boards: Show the dot only when a non-default filter is applied
+ *   (coworkerId, status, or projectId). The default "owned" scope alone does
+ *   not show the dot, as there's no workspace context to distinguish from.
+ */
 export function hasActiveTasksFilters(
   filters: TasksFilters,
   activeOrganizationId: string | null,

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -47,6 +47,7 @@ interface FilterDropdownMenuProps {
   searchPlaceholder: string;
   emptyResultsLabel: string;
   sections: FilterDropdownMenuSection[];
+  showActiveIndicator?: boolean;
 }
 
 const ALL_FILTER_VALUE = "__all__";
@@ -56,6 +57,7 @@ export function FilterDropdownMenu({
   searchPlaceholder,
   emptyResultsLabel,
   sections,
+  showActiveIndicator = false,
 }: FilterDropdownMenuProps) {
   const [open, setOpen] = useState(false);
 
@@ -66,9 +68,15 @@ export function FilterDropdownMenu({
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2">
+        <Button variant="outline" size="sm" className="relative gap-2">
           <ListFilter className="size-4" aria-hidden />
           <span className="hidden sm:inline">{buttonLabel}</span>
+          {showActiveIndicator ? (
+            <span
+              aria-hidden
+              className="absolute top-1 right-1 size-1.5 rounded-full bg-primary ring-2 ring-background"
+            />
+          ) : null}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a small primary-colored dot to the taskboard Filters button when filters are active, providing visual feedback that the board is in a filtered state.

**Changes:**
- Added `hasActiveTasksFilters` helper function with org vs personal logic
- Modified `FilterDropdownMenu` to accept `showActiveIndicator` prop
- Updated `TasksViewFilters` to compute and pass indicator state
- Added comprehensive unit tests
- Added JSDoc documentation explaining business logic

**Filter indicator rules:**
- **Organization boards:** Show when scope is "owned" or "workspace" (even though "owned" is default), or when any coworkerId/status/projectId filter is active
- **Personal boards:** Show only when coworkerId/status/projectId is set (not for default "owned" scope)

Closes SOK-615
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-615](https://linear.app/masumi/issue/SOK-615/featweb-show-active-filter-dot-on-taskboard-filters-button)

<div><a href="https://cursor.com/agents/bc-9fa1bae3-cf26-4636-a6ed-45813bd82d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fa1bae3-cf26-4636-a6ed-45813bd82d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

