### PR TITLE
feat(web): add spreadsheet offer output type and normalize file extensions

### DIFF
--- a/apps/core/src/schemas/coworker.schema.test.ts
+++ b/apps/core/src/schemas/coworker.schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { coworkerSchema } from "./coworker.schema";
+import { coworkerOfferSchema, coworkerSchema } from "./coworker.schema";
 
 describe("coworkerSchema", () => {
   it("parses coworker profile metadata fields", () => {
@@ -135,5 +135,62 @@ describe("coworkerSchema", () => {
         baseURL: null,
       });
     }).toThrow();
+  });
+});
+
+describe("coworkerOfferSchema output types", () => {
+  function parseType(type: string): string | undefined {
+    return coworkerOfferSchema.parse({
+      title: "Title",
+      prompt: "Prompt",
+      outputs: [{ type, url: "https://example.com/file" }],
+    }).outputs?.[0].type;
+  }
+
+  it("normalizes common file extensions to canonical kinds", () => {
+    expect(parseType("docx")).toBe("doc");
+    expect(parseType("pptx")).toBe("slides");
+    expect(parseType("xlsx")).toBe("sheet");
+    expect(parseType("xls")).toBe("sheet");
+    expect(parseType("csv")).toBe("sheet");
+    expect(parseType("png")).toBe("image");
+  });
+
+  it("passes canonical kinds through unchanged", () => {
+    for (const kind of [
+      "pdf",
+      "image",
+      "slides",
+      "doc",
+      "sheet",
+      "text",
+      "html",
+    ]) {
+      expect(parseType(kind)).toBe(kind);
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseType("XLSX")).toBe("sheet");
+    expect(parseType("PDF")).toBe("pdf");
+  });
+
+  it("rejects unknown output types", () => {
+    expect(() => parseType("zip")).toThrow();
+  });
+
+  it("accepts and normalizes multiple outputs", () => {
+    const result = coworkerOfferSchema.parse({
+      title: "Title",
+      prompt: "Prompt",
+      outputs: [
+        { type: "docx", url: "https://example.com/a.docx", label: "Brief" },
+        { type: "xlsx", url: "https://example.com/b.xlsx", label: "Data" },
+      ],
+    });
+    expect(result.outputs?.map((output) => output.type)).toEqual([
+      "doc",
+      "sheet",
+    ]);
   });
 });

--- a/apps/core/src/schemas/coworker.schema.ts
+++ b/apps/core/src/schemas/coworker.schema.ts
@@ -33,6 +33,51 @@ export const coworkerProfileSchema = z
   })
   .openapi("CoworkerProfile");
 
+// Canonical, semantic output kinds. Files are described by what they are, not
+// by extension, so the UI can pick the right icon/preview.
+const OUTPUT_TYPES = [
+  "pdf",
+  "image",
+  "slides",
+  "doc",
+  "sheet",
+  "text",
+  "html",
+] as const;
+
+// Common file extensions / spellings → canonical kind, so a hand-filled offer
+// can use the natural extension (e.g. "xlsx", "docx", "pptx", "png") instead of
+// the abstract name and still validate. Unknown strings pass through unchanged
+// and are then rejected by the enum.
+const OUTPUT_TYPE_ALIASES: Record<string, (typeof OUTPUT_TYPES)[number]> = {
+  doc: "doc",
+  docx: "doc",
+  slides: "slides",
+  ppt: "slides",
+  pptx: "slides",
+  sheet: "sheet",
+  xls: "sheet",
+  xlsx: "sheet",
+  csv: "sheet",
+  pdf: "pdf",
+  image: "image",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  svg: "image",
+  text: "text",
+  md: "text",
+  markdown: "text",
+  html: "html",
+  htm: "html",
+};
+function normalizeOutputType(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  return OUTPUT_TYPE_ALIASES[value.toLowerCase()] ?? value;
+}
+
 export const coworkerOfferSchema = z
   .object({
     title: z.string().openapi({ example: "Competitive analysis" }),
@@ -53,8 +98,10 @@ export const coworkerOfferSchema = z
       .array(
         z.object({
           type: z
-            .enum(["pdf", "image", "slides", "doc", "text", "html"])
+            .preprocess(normalizeOutputType, z.enum(OUTPUT_TYPES))
             .openapi({
+              description:
+                "Output kind. Common file extensions are accepted and normalized (e.g. docx→doc, pptx→slides, xlsx/xls/csv→sheet, png/jpg→image).",
               example: "pdf",
             }),
           url: z.string().optional().openapi({
@@ -74,7 +121,7 @@ export const coworkerOfferSchema = z
       .optional()
       .openapi({
         description:
-          "Example outputs the offer produces — text and/or files (PDF, slides, image).",
+          "Example outputs the offer produces — text and/or files (PDF, document, slides, spreadsheet, image, html). Multiple outputs render as switchable tabs in the preview.",
       }),
   })
   .openapi("CoworkerOffer");

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3607,6 +3607,7 @@
           "pdf": "PDF",
           "slides": "Slides",
           "doc": "Document",
+          "sheet": "Spreadsheet",
           "text": "Text",
           "image": "Image",
           "html": "Web"

--- a/apps/web/src/components/agents/offer-card.tsx
+++ b/apps/web/src/components/agents/offer-card.tsx
@@ -69,8 +69,26 @@ const OFFICE_FILE = /\.(pptx?|docx?|xlsx?)(\?|#|$)/i;
 export function isOfficeFile(url: string): boolean {
   return OFFICE_FILE.test(url);
 }
-export function officeViewerUrl(url: string): string {
-  return `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(url)}`;
+// Office document kinds — these must go through the Office viewer regardless of
+// the URL's extension, otherwise the browser downloads them instead of showing them.
+const OFFICE_EXT: Partial<Record<OutputKind, string>> = {
+  doc: "docx",
+  slides: "pptx",
+  sheet: "xlsx",
+};
+export function isOfficeType(type: OutputKind): boolean {
+  return type in OFFICE_EXT;
+}
+export function officeViewerUrl(url: string, type?: OutputKind): string {
+  // The Office viewer identifies the format from the URL's file extension.
+  // Extensionless URLs (e.g. IPFS hashes) need a filename hint or the viewer
+  // can't open them — append one derived from the output type.
+  let src = url;
+  if (!isOfficeFile(url)) {
+    const ext = (type && OFFICE_EXT[type]) ?? "docx";
+    src = `${url}${url.includes("?") ? "&" : "?"}filename=file.${ext}`;
+  }
+  return `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(src)}`;
 }
 
 export function OutputTypeIcon({
@@ -496,10 +514,13 @@ export function OfferEmbed({
     );
   }
   if (url) {
-    // Hide the browser's native PDF chrome (toolbar / thumbnail rail) for a clean preview.
-    const src = isOfficeFile(url)
-      ? officeViewerUrl(url)
-      : `${url}#toolbar=0&navpanes=0&scrollbar=0&view=FitH`;
+    // Office documents must use the viewer (the browser would download them);
+    // route by the declared type so extensionless URLs still embed. PDFs render
+    // natively — hide the browser's PDF chrome (toolbar / thumbnail rail).
+    const src =
+      isOfficeType(type) || isOfficeFile(url)
+        ? officeViewerUrl(url, type)
+        : `${url}#toolbar=0&navpanes=0&scrollbar=0&view=FitH`;
     return (
       <iframe src={src} title={title} className="bg-muted/40 h-full w-full" />
     );

--- a/apps/web/src/components/agents/offer-card.tsx
+++ b/apps/web/src/components/agents/offer-card.tsx
@@ -16,6 +16,7 @@ import {
   PenLine,
   Play,
   Presentation,
+  Table,
   Users,
 } from "lucide-react";
 import { type ReactNode, useState } from "react";
@@ -38,6 +39,7 @@ const OUTPUT_ICON: Record<OutputKind, typeof FileText> = {
   pdf: FileText,
   doc: FileText,
   slides: Presentation,
+  sheet: Table,
   image: ImageIcon,
   text: AlignLeft,
   html: AppWindow,
@@ -48,6 +50,7 @@ const DEFAULT_OUTPUT_LABEL: Record<OutputKind, string> = {
   pdf: "PDF",
   doc: "Doc",
   slides: "Slides",
+  sheet: "Sheet",
   image: "Image",
   text: "Text",
   html: "Web",
@@ -84,6 +87,7 @@ export function OutputTypeIcon({
 type MockKind =
   | "slides"
   | "page"
+  | "sheet"
   | "image"
   | "text"
   | "chart"
@@ -167,12 +171,19 @@ function mockKind(offer: CoworkerOffer): MockKind {
   const primary = offerOutputs(offer)[0];
   if (primary.type === "image" && primary.url) return "image";
   if (primary.type === "slides") return "slides";
+  if (primary.type === "sheet") return "sheet";
   if (primary.type === "html") return "web";
   if ((primary.type === "pdf" || primary.type === "doc") && primary.url) {
     return "page";
   }
   return CATEGORY_MOCK[offer.category ?? ""] ?? "text";
 }
+
+// Stable keys for the decorative 4×4 spreadsheet grid (avoids array-index keys).
+const SHEET_CELLS = Array.from(
+  { length: 16 },
+  (_cell, index) => `r${Math.floor(index / 4)}c${index % 4}`,
+);
 
 /** Stylized skeleton of the output — decorative, no fabricated content. One element
  * carries the category accent so the preview is color-cued without becoming a wash. */
@@ -304,6 +315,23 @@ function OfferMock({
             <div className={cn("h-6 w-full rounded", accent)} />
             <div className="bg-muted-foreground/20 h-1.5 w-2/3 rounded" />
             <div className="bg-muted-foreground/20 h-1.5 w-1/2 rounded" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+  if (kind === "sheet") {
+    return (
+      <div className="flex h-full items-center justify-center p-5">
+        <div className="ring-border w-full max-w-[82%] overflow-hidden rounded-md bg-card shadow-sm ring-1">
+          <div className={cn("h-2 w-full", accent)} />
+          <div className="grid grid-cols-4">
+            {SHEET_CELLS.map((cell) => (
+              <div
+                key={cell}
+                className="border-border/60 h-3.5 border-r border-b last:border-r-0"
+              />
+            ))}
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -8803,9 +8803,11 @@ export const CoworkerOfferSchema = {
                             'image',
                             'slides',
                             'doc',
+                            'sheet',
                             'text',
                             'html'
                         ],
+                        description: 'Output kind. Common file extensions are accepted and normalized (e.g. docx→doc, pptx→slides, xlsx/xls/csv→sheet, png/jpg→image).',
                         example: 'pdf'
                     },
                     url: {
@@ -8826,7 +8828,7 @@ export const CoworkerOfferSchema = {
                     'type'
                 ]
             },
-            description: 'Example outputs the offer produces — text and/or files (PDF, slides, image).'
+            description: 'Example outputs the offer produces — text and/or files (PDF, document, slides, spreadsheet, image, html). Multiple outputs render as switchable tabs in the preview.'
         }
     },
     required: [

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -2447,10 +2447,13 @@ export type CoworkerOffer = {
     description?: string;
     deliverable?: string;
     /**
-     * Example outputs the offer produces — text and/or files (PDF, slides, image).
+     * Example outputs the offer produces — text and/or files (PDF, document, slides, spreadsheet, image, html). Multiple outputs render as switchable tabs in the preview.
      */
     outputs?: Array<{
-        type: 'pdf' | 'image' | 'slides' | 'doc' | 'text' | 'html';
+        /**
+         * Output kind. Common file extensions are accepted and normalized (e.g. docx→doc, pptx→slides, xlsx/xls/csv→sheet, png/jpg→image).
+         */
+        type: 'pdf' | 'image' | 'slides' | 'doc' | 'sheet' | 'text' | 'html';
         url?: string;
         label?: string;
         /**

--- a/docs/coworker-metadata.md
+++ b/docs/coworker-metadata.md
@@ -190,23 +190,30 @@ and the default tab.
 | `text` | rendered **Markdown** | `text` |
 | `html` | **sandboxed iframe** (scripts run) | `url` or `text` |
 
-### File extensions are normalized
+### Always use the canonical `type` value
 
-You can use the natural file extension as the `type` — it's mapped to the
-canonical kind automatically (case-insensitive):
+The `type` MUST be one of these exact values:
 
-| You write | Becomes |
+> `pdf` · `image` · `slides` · `doc` · `sheet` · `text` · `html`
+
+**Do NOT use file extensions** (`docx`, `pptx`, `xlsx`, `png`, …) as the `type`.
+Map your file to the canonical kind instead:
+
+| Your file | Use `type` |
 | --- | --- |
-| `docx`, `doc` | `doc` |
-| `pptx`, `ppt`, `slides` | `slides` |
-| `xlsx`, `xls`, `csv`, `sheet` | `sheet` |
-| `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `image` | `image` |
-| `md`, `markdown`, `text` | `text` |
-| `htm`, `html` | `html` |
-| `pdf` | `pdf` |
+| Word (`.docx`) | `doc` |
+| PowerPoint (`.pptx`) | `slides` |
+| Excel / CSV (`.xlsx` / `.csv`) | `sheet` |
+| Image (`.png` / `.jpg` / …) | `image` |
+| PDF | `pdf` |
+| Markdown / plain text | `text` |
+| Web page / interactive HTML | `html` |
 
-Anything else (e.g. `zip`) is **rejected** — and an invalid type breaks the
-coworker list, so stick to the table above.
+> ⚠️ Extensions like `docx`/`xlsx`/`pptx` are accepted **only as a fallback on the
+> latest deployment** (normalized to `doc`/`sheet`/`slides`). On an older
+> deployment they are **rejected**, and an invalid `type` **breaks the entire
+> coworker list** (the page won't load). The canonical names are always correct,
+> so use them. Any value outside the canonical list (e.g. `zip`) is rejected.
 
 ### `url` vs `text`
 
@@ -295,9 +302,9 @@ hosts are fine).
       "description": "Research high-converting landing pages and produce a designer-ready brief.",
       "deliverable": "Conversion-focused landing page brief.",
       "outputs": [
-        { "type": "docx", "url": "https://host/brief.docx",  "label": "Landing Page Brief" },
-        { "type": "xlsx", "url": "https://host/research.xlsx", "label": "Consumer Research" },
-        { "type": "xlsx", "url": "https://host/seo.xlsx",      "label": "SEO Intelligence" }
+        { "type": "doc",   "url": "https://host/brief.docx",    "label": "Landing Page Brief" },
+        { "type": "sheet", "url": "https://host/research.xlsx", "label": "Consumer Research" },
+        { "type": "sheet", "url": "https://host/seo.xlsx",      "label": "SEO Intelligence" }
       ]
     }
   ]
@@ -306,7 +313,8 @@ hosts are fine).
 
 The second offer has three outputs → the preview shows three tabs
 ("Landing Page Brief", "Consumer Research", "SEO Intelligence"), with the brief
-shown first. The `docx`/`xlsx` types are normalized to `doc`/`sheet`.
+shown first. Note the canonical types: a Word file is `doc` and a spreadsheet is
+`sheet` — never `docx`/`xlsx`.
 
 ### An interactive HTML output
 
@@ -343,15 +351,26 @@ shown first. The `docx`/`xlsx` types are normalized to `doc`/`sheet`.
 - **`channels` is required** (it can be `{}`, but the key must exist).
 - Per offer, only **`title` + `prompt`** are required.
 - **Invalid data breaks the whole coworker list**, not just one card — most
-  commonly an unsupported `type`. Stick to the types/extensions table.
+  commonly an unsupported `type`. Use only the canonical type values.
+- **Use canonical types, never file extensions** — `doc` not `docx`, `slides`
+  not `pptx`, `sheet` not `xlsx`.
 - **Hosted files must be public** and (for `html`) embeddable in an iframe.
 - **`email`/`whatsapp` are plain strings** — not Markdown links.
 - `outputs` has no "folder" concept — list each file as its own entry.
 
-### Deployment / compatibility
+### Deployment / compatibility (read this)
 
-`sheet` and `html`, and the file-extension normalization, require the code that
-adds them to be **deployed**. On an older deployment the allowed types are only
-`pdf | image | slides | doc | text`, and using a newer type there will break the
-page. When in doubt, confirm the target environment is up to date before using
-`sheet` / `html` / extension aliases.
+Not every type is live everywhere yet. Pick by where you're editing:
+
+| Type | Availability |
+| --- | --- |
+| `pdf`, `image`, `slides`, `doc`, `text` | **Safe everywhere** |
+| `html` | Needs a recent deployment |
+| `sheet` | Newest — needs the latest deployment |
+| extension aliases (`docx`, `xlsx`, `pptx`, …) | Latest only — **avoid; use canonical types** |
+
+Using a type the target environment doesn't have yet is rejected and **breaks the
+whole page**. On the **current mainnet** the safe set is
+`pdf · image · slides · doc · text · html`. If unsure, confirm the environment is
+up to date (or use `pdf`, which works everywhere) before using `sheet`. Never use
+extension aliases.

--- a/docs/coworker-metadata.md
+++ b/docs/coworker-metadata.md
@@ -1,0 +1,331 @@
+# Coworker Metadata
+
+How to structure the `metadata` for a coworker so it shows up correctly in the
+agents marketplace and the New Task picker — the public **profile** (model /
+hosting / capabilities) and the **Ready-To-Run Tasks** (offers) with their
+example-output previews.
+
+- **Source of truth:** `apps/core/src/schemas/coworker.schema.ts`
+  (`coworkerMetadataSchema`). This document mirrors that schema; if they ever
+  disagree, the schema wins.
+- **Where it lives:** the `Coworker.metadata` column (a JSON column). Editing
+  metadata is pure data — **no migration** is needed.
+- **How it's validated:** every coworker the API returns is parsed against the
+  schema. **Invalid metadata on a single coworker makes the coworker list fail
+  to load** — so keep it valid.
+
+---
+
+## Quick start (minimal valid metadata)
+
+```json
+{
+  "channels": { "email": "agent@example.com" }
+}
+```
+
+`channels` is the only required key. Everything else (`profile`, `offers`) is
+optional and only enriches the UI.
+
+---
+
+## Top-level structure
+
+```jsonc
+{
+  "channels": { ... },   // REQUIRED — contact channels
+  "profile":  { ... },   // optional — public profile shown when picking a coworker
+  "offers":   [ ... ]    // optional — the "Ready-To-Run Tasks"
+}
+```
+
+| Key | Required | Type | Purpose |
+| --- | --- | --- | --- |
+| `channels` | ✅ | object (string → string) | Contact channels keyed by provider |
+| `profile` | — | object | Model / hosting / capabilities / examples |
+| `offers` | — | array | Pre-filled task offers (cards + previews) |
+
+---
+
+## `channels`
+
+A map of provider id → value. Keys are free-form; common ones are `email` and
+`whatsapp`.
+
+```json
+"channels": {
+  "email": "hannah@example.com",
+  "whatsapp": "+49 151 0000000"
+}
+```
+
+> ⚠️ Values are plain strings. Use a bare address — **not** a Markdown link.
+> ✅ `"email": "hannah@example.com"`
+> ❌ `"email": "[hannah@example.com](mailto:hannah@example.com)"`
+
+---
+
+## `profile`
+
+Shown in the agent selection UI. All fields optional.
+
+```json
+"profile": {
+  "llm": ["GPT-4o", "Claude 3.5 Sonnet"],
+  "hosting": "EU · Frankfurt",
+  "capabilities": ["Market Research", "Copywriting"],
+  "examples": ["Plan a multi-channel campaign"]
+}
+```
+
+| Field | Type | Renders as |
+| --- | --- | --- |
+| `llm` | string[] | Model chips, each with an auto-detected brand icon |
+| `hosting` | string | A chip with an auto-detected region flag |
+| `capabilities` | string[] | Capability tags |
+| `examples` | string[] | Example prompts |
+
+### Model icons are automatic
+
+You write the model name as a string; the icon is matched by a keyword in it
+(case-insensitive, first match wins). The **text you write is what's shown** —
+write it nicely (`"Claude 3.5 Sonnet"`), the icon is derived.
+
+| If the string contains… | Icon |
+| --- | --- |
+| `gpt`, `chatgpt`, `openai`, `dall-e`, `sora` | OpenAI |
+| `claude`, `anthropic` | Claude |
+| `mistral`, `mixtral`, `codestral` | Mistral |
+| `gemini`, `gemma`, `bard`, `palm`, `google` | Gemini |
+| `llama`, `meta` | Llama / Meta |
+| `deepseek` | DeepSeek |
+| `grok`, `xai` | Grok / xAI |
+| `qwen`, `tongyi`, `alibaba` | Qwen |
+| `cohere`, `command-r` | Cohere Command R |
+| `perplexity`, `sonar`, `pplx` | Perplexity |
+| `amazon`, `bedrock`, `titan` | Amazon Titan |
+| `phi`, `copilot`, `microsoft` | Microsoft |
+
+No match → the chip shows just the text (no icon). To add a provider, extend
+`BRAND_RULES` in `apps/web/src/components/agents/tag-icon.tsx`.
+
+`hosting` resolves to a **region flag** when a known region is recognized
+(e.g. `"EU · Frankfurt"` → 🇪🇺), otherwise text only.
+
+---
+
+## `offers` (Ready-To-Run Tasks)
+
+Each entry is one task card. Only `title` and `prompt` are required.
+
+```jsonc
+{
+  "title":       "Competitive analysis",        // REQUIRED — card title
+  "prompt":      "Run a competitive analysis…",  // REQUIRED — prefilled into the editor
+  "category":    "Research",                     // optional — theming (see below)
+  "description": "A sourced, side-by-side…",      // optional — shown on the card + preview
+  "deliverable": "A 2–3 page PDF brief…",         // optional — "Deliverable" box in the preview
+  "outputs":     [ ... ]                          // optional — example preview(s)
+}
+```
+
+| Field | Required | Type | Purpose |
+| --- | --- | --- | --- |
+| `title` | ✅ | string | Card title |
+| `prompt` | ✅ | string | Pre-filled into the task editor when picked |
+| `category` | — | string | Drives icon / accent color / placeholder mock |
+| `description` | — | string | Short blurb on the card and in the preview |
+| `deliverable` | — | string | "What you get" line in the preview |
+| `outputs` | — | array | Example outputs shown in the preview |
+
+### `category`
+
+Known categories get a themed icon, accent color, and placeholder mock. Spell
+them exactly. Any other string still works but renders **neutral** (generic icon,
+muted color).
+
+| `category` | Icon | Accent | Placeholder mock |
+| --- | --- | --- | --- |
+| `Research` | bar chart | chart-1 | bar-chart skeleton |
+| `Planning` | checklist | chart-4 | checklist |
+| `Coordination` | people | chart-5 | checklist |
+| `Engineering` | code | chart-3 | code block |
+| `Presentations` | slides | chart-2 | slide |
+| `Prototyping` | boxes | chart-1 | wireframe |
+| `Writing` | pen | chart-3 | text lines |
+| `Social` | clapperboard | chart-2 | video frame |
+
+The placeholder mock is only shown when there's no real file output (i.e. a
+`text` output or no `outputs`). With a real file, the thumbnail reflects the file
+instead; the category still sets the accent color and the chip.
+
+---
+
+## `outputs` — example previews
+
+`outputs` is an **array**. Each entry is one file/item. **Multiple outputs render
+as switchable tabs** in the preview; the **first** output is the card thumbnail
+and the default tab.
+
+```jsonc
+{ "type": "pdf", "url": "https://…/file.pdf", "label": "Competitive brief" }
+```
+
+| Field | Required | Type | Purpose |
+| --- | --- | --- | --- |
+| `type` | ✅ | enum (see below) | What kind of output it is |
+| `url` | — | string | Link to a hosted file |
+| `text` | — | string | Inline content (Markdown for `text`, HTML for `html`) |
+| `label` | — | string | Tab / chip name (defaults to the type) |
+
+### Output types
+
+| `type` | Renders as | Provide |
+| --- | --- | --- |
+| `pdf` | inline PDF viewer | `url` |
+| `image` | image | `url` |
+| `slides` | presentation (Office viewer) | `url` (pptx) |
+| `doc` | document (Office viewer) | `url` (docx) |
+| `sheet` | spreadsheet (Office viewer) | `url` (xlsx/csv) |
+| `text` | rendered **Markdown** | `text` |
+| `html` | **sandboxed iframe** (scripts run) | `url` or `text` |
+
+### File extensions are normalized
+
+You can use the natural file extension as the `type` — it's mapped to the
+canonical kind automatically (case-insensitive):
+
+| You write | Becomes |
+| --- | --- |
+| `docx`, `doc` | `doc` |
+| `pptx`, `ppt`, `slides` | `slides` |
+| `xlsx`, `xls`, `csv`, `sheet` | `sheet` |
+| `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `image` | `image` |
+| `md`, `markdown`, `text` | `text` |
+| `htm`, `html` | `html` |
+| `pdf` | `pdf` |
+
+Anything else (e.g. `zip`) is **rejected** — and an invalid type breaks the
+coworker list, so stick to the table above.
+
+### `url` vs `text`
+
+- **`url`** — a hosted file. Must be **publicly reachable**. Office files
+  (`doc`/`slides`/`sheet`) render through the Microsoft Office viewer.
+- **`text`** — inline content with no hosting:
+  - `type: "text"` → Markdown.
+  - `type: "html"` → a full HTML document.
+
+### `html` outputs
+
+Rendered in a **sandboxed iframe** (`sandbox="allow-scripts"`, no same-origin),
+so interactive pages (e.g. a Three.js/WebGL hero) run but stay isolated from the
+app.
+
+```jsonc
+// hosted (recommended)
+{ "type": "html", "url": "https://…/index.html", "label": "Live demo" }
+
+// inline (whole document as a string)
+{ "type": "html", "text": "<!DOCTYPE html><html>…</html>", "label": "Live demo" }
+```
+
+Caveats: a hosted page must allow being embedded in an iframe (no
+`X-Frame-Options: DENY` / restrictive `frame-ancestors` — most static / IPFS
+hosts are fine).
+
+---
+
+## Full examples
+
+### A complete coworker
+
+```json
+{
+  "channels": {
+    "email": "hannah@example.com",
+    "whatsapp": "+49 151 0000000"
+  },
+  "profile": {
+    "llm": ["Claude 3.5 Sonnet", "Mistral Large"],
+    "hosting": "EU · Frankfurt",
+    "capabilities": ["Market Research", "Competitive Analysis", "Consumer Insights"]
+  },
+  "offers": [
+    {
+      "title": "Competitive & Market Analysis",
+      "prompt": "Run a competitive and market analysis for [COMPANY] ([WEBSITE]).",
+      "category": "Research",
+      "description": "Benchmark competitors, market trends and digital positioning.",
+      "deliverable": "Decision-ready market intelligence report.",
+      "outputs": [
+        { "type": "pdf", "url": "https://host/competitive-analysis.pdf", "label": "Report" }
+      ]
+    },
+    {
+      "title": "Landing Page Research & Brief",
+      "prompt": "Research and brief a campaign landing page for [COMPANY].",
+      "category": "Writing",
+      "description": "Research high-converting landing pages and produce a designer-ready brief.",
+      "deliverable": "Conversion-focused landing page brief.",
+      "outputs": [
+        { "type": "docx", "url": "https://host/brief.docx",  "label": "Landing Page Brief" },
+        { "type": "xlsx", "url": "https://host/research.xlsx", "label": "Consumer Research" },
+        { "type": "xlsx", "url": "https://host/seo.xlsx",      "label": "SEO Intelligence" }
+      ]
+    }
+  ]
+}
+```
+
+The second offer has three outputs → the preview shows three tabs
+("Landing Page Brief", "Consumer Research", "SEO Intelligence"), with the brief
+shown first. The `docx`/`xlsx` types are normalized to `doc`/`sheet`.
+
+### An interactive HTML output
+
+```json
+{
+  "title": "Interactive 3D hero",
+  "prompt": "Design an interactive 3D hero section for our landing page.",
+  "category": "Prototyping",
+  "description": "A self-contained, animated WebGL hero — ready to drop in.",
+  "deliverable": "A single self-contained index.html with a Three.js hero.",
+  "outputs": [
+    { "type": "html", "url": "https://host/hero-3d/index.html", "label": "Live 3D hero" }
+  ]
+}
+```
+
+### An inline Markdown sample (no hosting)
+
+```json
+{
+  "title": "Project plan",
+  "prompt": "Turn my goal into a sequenced project plan.",
+  "category": "Planning",
+  "outputs": [
+    { "type": "text", "text": "## Project plan\n\n- Milestone 1 — …\n- Milestone 2 — …", "label": "Sample plan" }
+  ]
+}
+```
+
+---
+
+## Validation rules & gotchas
+
+- **`channels` is required** (it can be `{}`, but the key must exist).
+- Per offer, only **`title` + `prompt`** are required.
+- **Invalid data breaks the whole coworker list**, not just one card — most
+  commonly an unsupported `type`. Stick to the types/extensions table.
+- **Hosted files must be public** and (for `html`) embeddable in an iframe.
+- **`email`/`whatsapp` are plain strings** — not Markdown links.
+- `outputs` has no "folder" concept — list each file as its own entry.
+
+### Deployment / compatibility
+
+`sheet` and `html`, and the file-extension normalization, require the code that
+adds them to be **deployed**. On an older deployment the allowed types are only
+`pdf | image | slides | doc | text`, and using a newer type there will break the
+page. When in doubt, confirm the target environment is up to date before using
+`sheet` / `html` / extension aliases.

--- a/docs/coworker-metadata.md
+++ b/docs/coworker-metadata.md
@@ -210,11 +210,37 @@ coworker list, so stick to the table above.
 
 ### `url` vs `text`
 
-- **`url`** — a hosted file. Must be **publicly reachable**. Office files
-  (`doc`/`slides`/`sheet`) render through the Microsoft Office viewer.
+- **`url`** — a hosted file. Must be **publicly reachable**.
 - **`text`** — inline content with no hosting:
   - `type: "text"` → Markdown.
   - `type: "html"` → a full HTML document.
+
+### Everything previews inline — never a download
+
+The preview should always render in-app; it should never trigger a file
+download. How each kind renders:
+
+- `pdf`, `image` → rendered natively by the browser.
+- `html` → sandboxed iframe (see below).
+- `text` → Markdown.
+- `doc`, `slides`, `sheet` → the **Microsoft Office viewer** (browsers can't
+  display Office formats natively).
+
+### Office documents (`doc` / `slides` / `sheet`)
+
+Browsers cannot render Word/PowerPoint/Excel inline, so these go through the
+Office viewer. Two things to know:
+
+- The file must be **publicly reachable** (the viewer fetches it server-side).
+- The viewer identifies the format from the URL. **Extensionless URLs (e.g. IPFS
+  hashes) are handled automatically** — the app routes by the declared `type` and
+  appends a filename hint — so a plain `{ "type": "doc", "url": "https://…/<cid>" }`
+  works. (On older deployments without this handling, an extensionless Office URL
+  would download; use the canonical `type` and, if needed, a URL ending in the
+  real extension.)
+- **Prefer PDF for document deliverables when you can.** PDFs render natively —
+  faster, more reliable, and not dependent on a third-party viewer. Reach for
+  `doc`/`slides`/`sheet` only when the Office file itself is the deliverable.
 
 ### `html` outputs
 


### PR DESCRIPTION
## What

Follow-up to #3243 (merged). Makes offer outputs robust for hand-filled metadata, adds spreadsheet support, fixes Office files downloading, and documents the format.

### 1. `sheet` output type + forgiving extensions
- New `sheet` kind (xlsx/csv) — Office viewer, Table icon, spreadsheet-grid card mock.
- The Core offer schema normalizes natural file extensions to canonical kinds (`docx→doc`, `pptx→slides`, `xlsx/xls/csv→sheet`, `png/jpg→image`, `md→text`, `htm→html`). Unknown values are still rejected. Generated client surface stays clean: `'pdf' | 'image' | 'slides' | 'doc' | 'sheet' | 'text' | 'html'`.

### 2. Office files render inline instead of downloading
Previously a file only went to the Office viewer if its **URL ended in** `.docx/.pptx/.xlsx`. Extensionless URLs (e.g. IPFS hashes) bypassed the viewer, hit a raw iframe, and the browser **downloaded** them. Now `doc`/`slides`/`sheet` route to the viewer by their declared **type**, with a filename hint appended so extensionless URLs embed.

### 3. Docs
`docs/coworker-metadata.md` — full reference for `channels` / `profile` / `offers`, output types, extension normalization, the "always inline, never download" behavior, Office-file guidance (prefer PDF for documents), html, multi-output tabs, with examples and gotchas.

## Notes
- No DB migration (offers live in the existing `Coworker.metadata` JSON column).
- Minor known limitation: a `.csv` URL gets a generic preview rather than a grid.
- Office viewer fetches files server-side, so they must be publicly reachable; for document deliverables, PDF is the most reliable inline format.

## Verification
- `pnpm typecheck` (all packages) ✅
- Full suites: **web 1482 passed**, **core 1639 passed** ✅ (incl. 5 new schema-normalization tests)
- Biome clean; multi-agent audit of the output-type change → GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)
