### PR TITLE
fix(core): enable automatic tax for Stripe transactions

### DIFF
--- a/apps/core/src/clients/stripe.client.test.ts
+++ b/apps/core/src/clients/stripe.client.test.ts
@@ -11,6 +11,7 @@ const {
   stripeInvoicesFinalizeMock,
   stripePricesListMock,
   stripeProductsRetrieveMock,
+  stripeSubscriptionsUpdateMock,
 } = vi.hoisted(() => ({
   stripeConstructorMock: vi.fn(),
   stripeCheckoutSessionsCreateMock: vi.fn(),
@@ -22,6 +23,7 @@ const {
   stripeInvoicesFinalizeMock: vi.fn(),
   stripePricesListMock: vi.fn(),
   stripeProductsRetrieveMock: vi.fn(),
+  stripeSubscriptionsUpdateMock: vi.fn(),
 }));
 
 vi.mock("stripe", () => ({
@@ -59,6 +61,10 @@ vi.mock("stripe", () => ({
       create: (...args: unknown[]) => stripeInvoicesCreateMock(...args),
       finalizeInvoice: (...args: unknown[]) =>
         stripeInvoicesFinalizeMock(...args),
+    };
+
+    subscriptions = {
+      update: (...args: unknown[]) => stripeSubscriptionsUpdateMock(...args),
     };
 
     constructor(secretKey: string, options?: unknown) {
@@ -271,6 +277,7 @@ describe("stripeClient", () => {
 
     expect(stripeInvoicesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        automatic_tax: { enabled: true },
         metadata: expect.objectContaining({
           coupon_id: "coupon_1",
           price_id: "price_credits",
@@ -301,6 +308,29 @@ describe("stripeClient", () => {
         }),
       }),
       expect.anything(),
+    );
+  });
+
+  it("enables automatic tax when updating subscription item quantity", async () => {
+    stripeSubscriptionsUpdateMock.mockResolvedValue({ id: "sub_1" });
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.updateSubscriptionItemQuantity("sub_1", "si_1", 3);
+
+    expect(stripeSubscriptionsUpdateMock).toHaveBeenCalledWith(
+      "sub_1",
+      expect.objectContaining({
+        automatic_tax: { enabled: true },
+        items: [
+          {
+            id: "si_1",
+            quantity: 3,
+          },
+        ],
+        payment_behavior: "error_if_incomplete",
+        proration_behavior: "always_invoice",
+      }),
+      undefined,
     );
   });
 
@@ -378,6 +408,7 @@ describe("stripeClient", () => {
 
     expect(stripeCheckoutSessionsCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        automatic_tax: { enabled: true },
         success_url:
           "https://app.sokosumi.test/billing?tab=credits&session_id={CHECKOUT_SESSION_ID}",
         cancel_url: "https://app.sokosumi.test/billing?tab=credits&cancel=true",
@@ -447,7 +478,14 @@ describe("stripeClient.createAdminInvoice", () => {
     // (it would compute against €0); it belongs on the product-priced line item
     // so a product-scoped coupon applies.
     expect(stripeInvoicesCreateMock).toHaveBeenCalledWith(
-      expect.not.objectContaining({ discounts: expect.anything() }),
+      expect.objectContaining({
+        automatic_tax: { enabled: true },
+      }),
+    );
+    expect(stripeInvoicesCreateMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        discounts: expect.anything(),
+      }),
     );
     expect(stripeInvoiceItemsCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -272,6 +272,7 @@ export const stripeClient = {
     return await stripe.subscriptions.update(
       subscriptionId,
       {
+        automatic_tax: { enabled: true },
         items: [
           {
             id: itemId,
@@ -421,6 +422,7 @@ export const stripeClient = {
         pending_invoice_items_behavior: "include",
         collection_method: "charge_automatically",
         auto_advance: true,
+        automatic_tax: { enabled: true },
         metadata: {
           coupon_id: couponId,
           price_id: price.id,
@@ -629,6 +631,7 @@ export const stripeClient = {
         address: "auto",
         name: "auto",
       },
+      automatic_tax: { enabled: true },
       metadata: sessionMetadata,
       invoice_creation: {
         enabled: true,
@@ -795,6 +798,7 @@ export const stripeClient = {
       collection_method: "send_invoice",
       days_until_due: params.daysUntilDue ?? 30,
       auto_advance: false,
+      automatic_tax: { enabled: true },
       metadata,
     });
 

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -531,6 +531,9 @@ describe("core auth config", () => {
           subscription: {
             getCheckoutSessionParams: () => Promise<{
               params?: {
+                automatic_tax?: {
+                  enabled: boolean;
+                };
                 billing_address_collection?: string;
                 customer_update?: {
                   address?: string;
@@ -552,6 +555,9 @@ describe("core auth config", () => {
 
     expect(sessionParams).toEqual({
       params: {
+        automatic_tax: {
+          enabled: true,
+        },
         billing_address_collection: "required",
         customer_update: {
           address: "auto",

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -687,6 +687,9 @@ export const auth = betterAuth({
         onSubscriptionUpdate: handleStripeBackedSubscriptionLifecycle,
         getCheckoutSessionParams: async () => ({
           params: {
+            automatic_tax: {
+              enabled: true,
+            },
             billing_address_collection: "required",
             customer_update: {
               address: "auto",


### PR DESCRIPTION
## Summary
- Enable `automatic_tax[enabled]` for Stripe Checkout sessions, Stripe invoices, and subscription seat updates that can create prorated invoices.
- Add regression coverage for Core Stripe client request params and Better Auth subscription checkout params.

## Verification
- `pnpm --filter @sokosumi/core test`
- `pnpm --filter @sokosumi/core typecheck`
- `pnpm --filter @sokosumi/core check`

## Notes
- Local startup was verified separately on web `http://localhost:3003` and Core `http://localhost:3001` because port `3000` was already occupied by another local Docusaurus process.