### PR TITLE
chore(deps): upgrade ai sdk to v7 for web, core, and ai-provider

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -58,7 +58,7 @@
     "@vercel/oidc": "3.8.0",
     "@vercel/related-projects": "1.1.0",
     "ably": "2.23.0",
-    "ai": "6.0.219",
+    "ai": "7.0.15",
     "better-auth": "1.6.23",
     "cron-parser": "5.6.1",
     "dotenv": "17.4.2",

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -984,6 +984,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       const result = streamText({
         model: getSokosumiProvider()(selectedModel),
         messages: modelMessages,
+        // Chat persists and replays `role: "system"` turns (coworker context, etc.).
+        allowSystemInMessages: true,
         maxRetries: 0,
         providerOptions: {
           sokosumi: sokosumiProviderOptions,

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -984,7 +984,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       const result = streamText({
         model: getSokosumiProvider()(selectedModel),
         messages: modelMessages,
-        // Chat persists and replays `role: "system"` turns (coworker context, etc.).
         allowSystemInMessages: true,
         maxRetries: 0,
         providerOptions: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "generate:core:snapshot": "pnpm --filter @sokosumi/core run write-openapi-snapshot-for-web && openapi-ts -f openapi-ts.core.config.ts -i openapi-core.snapshot.json"
   },
   "dependencies": {
-    "@ai-sdk/react": "3.0.221",
+    "@ai-sdk/react": "4.0.16",
     "@better-auth/api-key": "1.6.23",
     "@better-auth/i18n": "1.6.23",
     "@better-auth/oauth-provider": "1.6.23",
@@ -53,7 +53,7 @@
     "@vercel/related-projects": "1.1.0",
     "@vercel/speed-insights": "2.0.0",
     "ably": "2.23.0",
-    "ai": "6.0.219",
+    "ai": "7.0.15",
     "babel-plugin-react-compiler": "1.0.0",
     "better-auth": "1.6.23",
     "class-variance-authority": "0.7.1",

--- a/packages/ai-provider/package.json
+++ b/packages/ai-provider/package.json
@@ -34,12 +34,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ai-sdk/provider": "3.0.13",
+    "@ai-sdk/provider": "4.0.2",
     "@sokosumi/chat": "workspace:*",
     "@sokosumi/utils": "workspace:*"
   },
   "devDependencies": {
-    "@ai-sdk/provider-utils": "4.0.35",
+    "@ai-sdk/provider-utils": "5.0.5",
     "@types/node": "24.13.2",
     "typescript": "6.0.3",
     "vitest": "4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 1.4.0(hono@4.12.27)(zod@4.4.3)
       '@openrouter/ai-sdk-provider':
         specifier: 2.10.0
-        version: 2.10.0(ai@6.0.219(zod@4.4.3))(zod@4.4.3)
+        version: 2.10.0(ai@7.0.15(zod@4.4.3))(zod@4.4.3)
       '@scalar/hono-api-reference':
         specifier: 0.11.8
         version: 0.11.8(hono@4.12.27)
@@ -115,8 +115,8 @@ importers:
         specifier: 2.23.0
         version: 2.23.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ai:
-        specifier: 6.0.219
-        version: 6.0.219(zod@4.4.3)
+        specifier: 7.0.15
+        version: 7.0.15(zod@4.4.3)
       better-auth:
         specifier: 1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(happy-dom@20.10.6)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)))(vue@3.5.34(typescript@6.0.3))
@@ -176,8 +176,8 @@ importers:
   apps/web:
     dependencies:
       '@ai-sdk/react':
-        specifier: 3.0.221
-        version: 3.0.221(react@19.2.7)(zod@4.4.3)
+        specifier: 4.0.16
+        version: 4.0.16(react@19.2.7)(zod@4.4.3)
       '@better-auth/api-key':
         specifier: 1.6.23
         version: 1.6.23(5aef44478d59104ceff01f95d8862db1)
@@ -263,8 +263,8 @@ importers:
         specifier: 2.23.0
         version: 2.23.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ai:
-        specifier: 6.0.219
-        version: 6.0.219(zod@4.4.3)
+        specifier: 7.0.15
+        version: 7.0.15(zod@4.4.3)
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
@@ -486,8 +486,8 @@ importers:
   packages/ai-provider:
     dependencies:
       '@ai-sdk/provider':
-        specifier: 3.0.13
-        version: 3.0.13
+        specifier: 4.0.2
+        version: 4.0.2
       '@sokosumi/chat':
         specifier: workspace:*
         version: link:../chat
@@ -496,8 +496,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@ai-sdk/provider-utils':
-        specifier: 4.0.35
-        version: 4.0.35(zod@4.4.3)
+        specifier: 5.0.5
+        version: 5.0.5(zod@4.4.3)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -677,25 +677,31 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ai-sdk/gateway@3.0.143':
-    resolution: {integrity: sha512-RCH60KsUaNiZkI/fBuyau4yvYrVBIEgAcN+Ain94QpL1kVm28GduQzFKfGffAiJU2We0ZrmN4BHkoCZzACK96Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.12':
+    resolution: {integrity: sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.35':
-    resolution: {integrity: sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/mcp@2.0.7':
+    resolution: {integrity: sha512-DX1v5M/R4RD2yi1KSH2ERLKcb6h2qJF0DKt0PGTTpNJNK+meXMmouwSRZS8Y+JocbyHk7U9p6PgqVmKU/e5XhQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.13':
-    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.5':
+    resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: 4.4.3
 
-  '@ai-sdk/react@3.0.221':
-    resolution: {integrity: sha512-5Zd+rF0YbjOqre0NEzdNE+FvNPrEuqfHm4KGxw9ovbAHv0ut/7sgYIn2kzr6ekvXHNqWz0HEmi+zYOXOZCJxJw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.2':
+    resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.16':
+    resolution: {integrity: sha512-VpJhn9ob7EC9g2Wn5m/FCCu8h6Uj4tE7u8BunK0kNo5kJasEl/f3oHV7f3r4tNtq4zW5wu0EjGs5sKkShErGew==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
@@ -4695,6 +4701,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -4752,9 +4761,9 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  ai@6.0.219:
-    resolution: {integrity: sha512-rtTDz99Rc9HsstSJ7YdO8DX7DQwS442N2vQ5jOopXDdo4qfkLrtIRpORdztFMOZxX/XjBzHRlvqF6eMg3cpyLA==}
-    engines: {node: '>=18'}
+  ai@7.0.15:
+    resolution: {integrity: sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: 4.4.3
 
@@ -7390,6 +7399,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -8978,28 +8991,38 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/gateway@3.0.143(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.12(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 4.0.35(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.35(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.7(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.13':
+  '@ai-sdk/provider@4.0.2':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.221(react@19.2.7)(zod@4.4.3)':
+  '@ai-sdk/react@4.0.16(react@19.2.7)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.35(zod@4.4.3)
-      ai: 6.0.219(zod@4.4.3)
+      '@ai-sdk/mcp': 2.0.7(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      ai: 7.0.15(zod@4.4.3)
       react: 19.2.7
       swr: 2.4.1(react@19.2.7)
       throttleit: 2.1.0
@@ -10174,9 +10197,9 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
-  '@openrouter/ai-sdk-provider@2.10.0(ai@6.0.219(zod@4.4.3))(zod@4.4.3)':
+  '@openrouter/ai-sdk-provider@2.10.0(ai@7.0.15(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      ai: 6.0.219(zod@4.4.3)
+      ai: 7.0.15(zod@4.4.3)
       zod: 4.4.3
 
   '@opentelemetry/api-logs@0.214.0':
@@ -13329,6 +13352,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@workflow/serde@4.1.0': {}
+
   '@xmldom/xmldom@0.8.13':
     optional: true
 
@@ -13391,12 +13416,11 @@ snapshots:
       screenfull: 5.2.0
       tslib: 2.8.1
 
-  ai@6.0.219(zod@4.4.3):
+  ai@7.0.15(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.143(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 4.0.35(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.12(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.20.0):
@@ -16405,6 +16429,8 @@ snapshots:
   picospinner@3.0.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Bump `ai` from 6.0.219 to 7.0.15 in `apps/core` and `apps/web`
- Bump `@ai-sdk/react` from 3.0.221 to 4.0.16 in `apps/web`
- Bump `@ai-sdk/provider` from 3.0.13 to 4.0.2 and `@ai-sdk/provider-utils` from 4.0.35 to 5.0.5 in `packages/ai-provider`
- Set `allowSystemInMessages: true` on Core `streamText` because AI SDK v7 rejects `role: "system"` messages in `messages` by default, while Sokosumi chat persists and replays system turns

## Migration notes

No other code changes were required. Typecheck and tests pass across `ai-provider`, `core`, and `web`. `generateText` call sites already use the `system` option (recommended in v7). Deprecated APIs like `ToolCallOptions`, `fullStream`, and `onStepFinish` are not used in this repo.

## Test plan

- [x] `pnpm --filter @sokosumi/ai-provider typecheck && test`
- [x] `pnpm --filter core typecheck && test`
- [x] `pnpm --filter web typecheck && test`
- [ ] Smoke-test chat streaming (model + coworker) in preview, including a conversation with a persisted system message if available


Made with [Cursor](https://cursor.com)