### PR TITLE
refactor(core): use ai sdk v7 instructions in openrouter client

### DIFF
--- a/apps/core/src/clients/openrouter.client.test.ts
+++ b/apps/core/src/clients/openrouter.client.test.ts
@@ -51,6 +51,7 @@ describe("openrouter.client", () => {
     expect(call.prompt).toBe("First message: Hello world");
     expect(call.temperature).toBe(0.5);
     expect(call.maxOutputTokens).toBe(40);
+    expect(call.abortSignal).toBeInstanceOf(AbortSignal);
     expect(call.model).toBe("mock-haiku-model");
     expect(call).not.toHaveProperty("system");
   });

--- a/apps/core/src/clients/openrouter.client.test.ts
+++ b/apps/core/src/clients/openrouter.client.test.ts
@@ -55,4 +55,29 @@ describe("openrouter.client", () => {
     expect(call.model).toBe("mock-haiku-model");
     expect(call).not.toHaveProperty("system");
   });
+
+  it("truncates generated chat titles to 50 characters", async () => {
+    generateTextMock.mockResolvedValue({ text: "A".repeat(60) });
+
+    const { openrouterClient } = await import("./openrouter.client");
+
+    const title = await openrouterClient.generateChatTitle("hello");
+
+    expect(title).toBe("A".repeat(50));
+    expect(generateTextMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns null without calling generateText when OpenRouter is not configured", async () => {
+    vi.doMock("@/config/env", () => ({
+      getEnv: () => ({}),
+    }));
+
+    const { openrouterClient } = await import("./openrouter.client");
+
+    await expect(
+      openrouterClient.generateChatTitle("hello"),
+    ).resolves.toBeNull();
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(createOpenRouterMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/clients/openrouter.client.test.ts
+++ b/apps/core/src/clients/openrouter.client.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { generateTextMock, openRouterModelMock, createOpenRouterMock } =
-  vi.hoisted(() => ({
-    generateTextMock: vi.fn(),
-    openRouterModelMock: vi.fn(),
-    createOpenRouterMock: vi.fn(),
-  }));
+const {
+  generateTextMock,
+  openRouterModelMock,
+  createOpenRouterMock,
+  getEnvMock,
+} = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+  openRouterModelMock: vi.fn(),
+  createOpenRouterMock: vi.fn(),
+  getEnvMock: vi.fn(),
+}));
 
 vi.mock("ai", () => ({
   generateText: generateTextMock,
@@ -16,9 +21,7 @@ vi.mock("@openrouter/ai-sdk-provider", () => ({
 }));
 
 vi.mock("@/config/env", () => ({
-  getEnv: () => ({
-    OPENROUTER_DEFAULT_API_KEY: "sk-or-test-openrouter-key",
-  }),
+  getEnv: getEnvMock,
 }));
 
 describe("openrouter.client", () => {
@@ -27,6 +30,9 @@ describe("openrouter.client", () => {
     vi.clearAllMocks();
     openRouterModelMock.mockReturnValue("mock-haiku-model");
     createOpenRouterMock.mockReturnValue(openRouterModelMock);
+    getEnvMock.mockReturnValue({
+      OPENROUTER_DEFAULT_API_KEY: "sk-or-test-openrouter-key",
+    });
     generateTextMock.mockResolvedValue({ text: "Generated chat title" });
   });
 
@@ -68,9 +74,7 @@ describe("openrouter.client", () => {
   });
 
   it("returns null without calling generateText when OpenRouter is not configured", async () => {
-    vi.doMock("@/config/env", () => ({
-      getEnv: () => ({}),
-    }));
+    getEnvMock.mockReturnValue({});
 
     const { openrouterClient } = await import("./openrouter.client");
 

--- a/apps/core/src/clients/openrouter.client.test.ts
+++ b/apps/core/src/clients/openrouter.client.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { generateTextMock, openRouterModelMock, createOpenRouterMock } =
+  vi.hoisted(() => ({
+    generateTextMock: vi.fn(),
+    openRouterModelMock: vi.fn(),
+    createOpenRouterMock: vi.fn(),
+  }));
+
+vi.mock("ai", () => ({
+  generateText: generateTextMock,
+}));
+
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: createOpenRouterMock,
+}));
+
+vi.mock("@/config/env", () => ({
+  getEnv: () => ({
+    OPENROUTER_DEFAULT_API_KEY: "sk-or-test-openrouter-key",
+  }),
+}));
+
+describe("openrouter.client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    openRouterModelMock.mockReturnValue("mock-haiku-model");
+    createOpenRouterMock.mockReturnValue(openRouterModelMock);
+    generateTextMock.mockResolvedValue({ text: "Generated chat title" });
+  });
+
+  it("calls generateText with instructions (not deprecated system) for chat titles", async () => {
+    const { openrouterClient } = await import("./openrouter.client");
+
+    const title = await openrouterClient.generateChatTitle("  Hello world  ");
+
+    expect(title).toBe("Generated chat title");
+    expect(createOpenRouterMock).toHaveBeenCalledWith({
+      apiKey: "sk-or-test-openrouter-key",
+    });
+    expect(openRouterModelMock).toHaveBeenCalledWith(
+      "anthropic/claude-haiku-4.5",
+    );
+    expect(generateTextMock).toHaveBeenCalledOnce();
+
+    const call = generateTextMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call.instructions).toEqual(
+      expect.stringContaining("Generate a very short chat title"),
+    );
+    expect(call.prompt).toBe("First message: Hello world");
+    expect(call.temperature).toBe(0.5);
+    expect(call.maxOutputTokens).toBe(40);
+    expect(call.model).toBe("mock-haiku-model");
+    expect(call).not.toHaveProperty("system");
+  });
+});

--- a/apps/core/src/clients/openrouter.client.ts
+++ b/apps/core/src/clients/openrouter.client.ts
@@ -55,7 +55,7 @@ export const openrouterClient = (() => {
         .map(([key, value]) => `${key} => ${JSON.stringify(value)}`)
         .join(", ");
 
-      const systemPrompt = `Generate a descriptive agent summary following these rules:
+      const instructions = `Generate a descriptive agent summary following these rules:
         - Length: 90-110 characters (including spaces and punctuation)
         - Language: Match the input
         - Format: Single sentence, no agent name
@@ -67,7 +67,7 @@ export const openrouterClient = (() => {
         const { text } = await generateText({
           abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
           model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          system: systemPrompt,
+          instructions,
           prompt: userPrompt,
           temperature: 0.9,
           maxOutputTokens: 80,
@@ -85,7 +85,7 @@ export const openrouterClient = (() => {
         return null;
       }
 
-      const systemPrompt = `Generate a concise task name following these rules:
+      const instructions = `Generate a concise task name following these rules:
         - Length: 30-60 characters (including spaces and punctuation)
         - Language: Match the input
         - Format: Single sentence
@@ -98,7 +98,7 @@ export const openrouterClient = (() => {
         const { text } = await generateText({
           abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
           model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          system: systemPrompt,
+          instructions,
           prompt: userPrompt,
           temperature: 0.9,
           maxOutputTokens: 40,
@@ -121,7 +121,7 @@ export const openrouterClient = (() => {
         return null;
       }
 
-      const systemPrompt = `Generate a very short chat title from the user's first message. Rules:
+      const instructions = `Generate a very short chat title from the user's first message. Rules:
         - Maximum 50 characters (including spaces and punctuation)
         - Language: Match the input
         - Format: Single phrase or sentence fragment, no quotes
@@ -132,7 +132,7 @@ export const openrouterClient = (() => {
       try {
         const { text } = await generateText({
           model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          system: systemPrompt,
+          instructions,
           prompt: userPrompt,
           temperature: 0.5,
           maxOutputTokens: 40,
@@ -155,7 +155,7 @@ export const openrouterClient = (() => {
         return null;
       }
 
-      const systemPrompt = `You are a summary generator. Output ONLY the summary text—no questions, no explanations, no preamble.
+      const instructions = `You are a summary generator. Output ONLY the summary text—no questions, no explanations, no preamble.
 
         Task: Write a one-sentence agent summary (11-14 words maximum).
         
@@ -178,7 +178,7 @@ export const openrouterClient = (() => {
         const { text } = await generateText({
           abortSignal: options?.abortSignal,
           model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          system: systemPrompt,
+          instructions,
           prompt: userPrompt,
           temperature: 0.3,
         });

--- a/apps/core/src/clients/openrouter.client.ts
+++ b/apps/core/src/clients/openrouter.client.ts
@@ -1,8 +1,7 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { getModelIdentifier } from "@sokosumi/chat";
 import { generateText } from "ai";
 
-import { getBetterAuthPublicBaseUrl, getEnv } from "@/config/env";
+import { getEnv } from "@/config/env";
 
 export type AgentInfo = {
   name: string;
@@ -17,23 +16,41 @@ interface OpenRouterRequestOptions {
 // request so a slow or hung OpenRouter call aborts and falls back to a
 // non-LLM name instead of blocking the create request indefinitely.
 const NAME_GENERATION_TIMEOUT_MS = 10_000;
+const OPENROUTER_HAIKU_MODEL = "anthropic/claude-haiku-4.5";
 
-const RESPONSES_API_EVENTS = {
-  OUTPUT_TEXT_DELTA: "response.output_text.delta",
-  COMPLETED: "response.completed",
-} as const;
+interface GenerateOpenRouterTextOptions {
+  instructions: string;
+  prompt: string;
+  temperature: number;
+  maxOutputTokens?: number;
+  abortSignal?: AbortSignal;
+  failureLogLabel: string;
+}
 
-const SSE_DONE_MARKER = "[DONE]";
-const SSE_DATA_PREFIX = "data: ";
+async function generateOpenRouterText(
+  openrouter: NonNullable<ReturnType<typeof createOpenRouter>>,
+  options: GenerateOpenRouterTextOptions,
+): Promise<string | null> {
+  try {
+    const { text } = await generateText({
+      ...(options.abortSignal !== undefined
+        ? { abortSignal: options.abortSignal }
+        : {}),
+      model: openrouter(OPENROUTER_HAIKU_MODEL),
+      instructions: options.instructions,
+      prompt: options.prompt,
+      temperature: options.temperature,
+      ...(options.maxOutputTokens !== undefined
+        ? { maxOutputTokens: options.maxOutputTokens }
+        : {}),
+    });
 
-const UI_MESSAGE_EVENTS = {
-  START: "start",
-  TEXT_START: "text-start",
-  TEXT_DELTA: "text-delta",
-  TEXT_END: "text-end",
-  FINISH: "finish",
-  ERROR: "error",
-} as const;
+    return text || null;
+  } catch (error) {
+    console.error(`OpenRouter ${options.failureLogLabel} failed:`, error);
+    return null;
+  }
+}
 
 export const openrouterClient = (() => {
   const defaultApiKey = getEnv().OPENROUTER_DEFAULT_API_KEY;
@@ -63,21 +80,14 @@ export const openrouterClient = (() => {
       `;
       const userPrompt = `Agent: ${agent.name} ${agent.description ? ` - ${agent.description}` : ""}\nInput: ${inputSummary}`;
 
-      try {
-        const { text } = await generateText({
-          abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
-          model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          instructions,
-          prompt: userPrompt,
-          temperature: 0.9,
-          maxOutputTokens: 80,
-        });
-
-        return text || null;
-      } catch (error) {
-        console.error("OpenRouter job name generation failed:", error);
-        return null;
-      }
+      return generateOpenRouterText(defaultOpenrouter, {
+        abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
+        instructions,
+        prompt: userPrompt,
+        temperature: 0.9,
+        maxOutputTokens: 80,
+        failureLogLabel: "job name generation",
+      });
     },
 
     async generateTaskName(description: string): Promise<string | null> {
@@ -94,21 +104,14 @@ export const openrouterClient = (() => {
       `;
       const userPrompt = `Task Description: ${description}`;
 
-      try {
-        const { text } = await generateText({
-          abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
-          model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          instructions,
-          prompt: userPrompt,
-          temperature: 0.9,
-          maxOutputTokens: 40,
-        });
-
-        return text || null;
-      } catch (error) {
-        console.error("OpenRouter task name generation failed:", error);
-        return null;
-      }
+      return generateOpenRouterText(defaultOpenrouter, {
+        abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
+        instructions,
+        prompt: userPrompt,
+        temperature: 0.9,
+        maxOutputTokens: 40,
+        failureLogLabel: "task name generation",
+      });
     },
 
     async generateChatTitle(firstPrompt: string): Promise<string | null> {
@@ -129,22 +132,20 @@ export const openrouterClient = (() => {
       `;
       const userPrompt = `First message: ${trimmed}`;
 
-      try {
-        const { text } = await generateText({
-          model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          instructions,
-          prompt: userPrompt,
-          temperature: 0.5,
-          maxOutputTokens: 40,
-        });
+      const text = await generateOpenRouterText(defaultOpenrouter, {
+        instructions,
+        prompt: userPrompt,
+        temperature: 0.5,
+        maxOutputTokens: 40,
+        failureLogLabel: "chat title generation",
+      });
 
-        if (!text) return null;
-        const title = text.trim().slice(0, 50);
-        return title || null;
-      } catch (error) {
-        console.error("OpenRouter chat title generation failed:", error);
+      if (!text) {
         return null;
       }
+
+      const title = text.trim().slice(0, 50);
+      return title || null;
     },
 
     async generateAgentSummary(
@@ -174,232 +175,13 @@ export const openrouterClient = (() => {
 
       const userPrompt = `Agent Description: ${description}`;
 
-      try {
-        const { text } = await generateText({
-          abortSignal: options?.abortSignal,
-          model: defaultOpenrouter("anthropic/claude-haiku-4.5"),
-          instructions,
-          prompt: userPrompt,
-          temperature: 0.3,
-        });
-
-        return text || null;
-      } catch (error) {
-        console.error("OpenRouter agent summary generation failed:", error);
-        return null;
-      }
-    },
-
-    async streamChatResponse(messages: unknown[], modelId: string | null) {
-      const chatApiKey = getEnv().OPENROUTER_CHAT_API_KEY;
-      if (!chatApiKey) {
-        throw new Error("OpenRouter chat API key not configured");
-      }
-
-      const modelIdentifier = getModelIdentifier(modelId);
-      const responsesInput = messages.map((msg: unknown) => {
-        const m = msg as { role: string; content: string };
-        return {
-          type: "message",
-          role: m.role,
-          content: [
-            {
-              type: "input_text",
-              text: m.content,
-            },
-          ],
-        };
-      });
-
-      const requestBody = {
-        model: modelIdentifier,
-        input: responsesInput,
-        stream: true,
-        max_output_tokens: 4096,
-      };
-      const response = await fetch("https://openrouter.ai/api/v1/responses", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${chatApiKey}`,
-          "Content-Type": "application/json",
-          "HTTP-Referer": getBetterAuthPublicBaseUrl(),
-          "X-Title": "Sokosumi",
-        },
-        body: JSON.stringify(requestBody),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => "Unknown error");
-        throw new Error(
-          `OpenRouter Responses API error: ${response.status} ${errorText}`,
-        );
-      }
-
-      if (!response.body) {
-        throw new Error("No response body from OpenRouter Responses API");
-      }
-
-      const stream = createUIMessageStream(response.body);
-
-      return new Response(stream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-          "x-vercel-ai-ui-message-stream": "v1",
-        },
+      return generateOpenRouterText(defaultOpenrouter, {
+        abortSignal: options?.abortSignal,
+        instructions,
+        prompt: userPrompt,
+        temperature: 0.3,
+        failureLogLabel: "agent summary generation",
       });
     },
   };
 })();
-
-function createUIMessageStream(
-  body: ReadableStream<Uint8Array>,
-): ReadableStream<Uint8Array> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  const messageId = "response-message";
-
-  let buffer = "";
-  let textStarted = false;
-  let streamClosed = false;
-  let cancelled = false;
-
-  function closeStream(controller: ReadableStreamDefaultController) {
-    if (streamClosed) return;
-    streamClosed = true;
-
-    if (textStarted) {
-      const endEvent = { type: UI_MESSAGE_EVENTS.TEXT_END, id: messageId };
-      controller.enqueue(
-        encoder.encode(`data: ${JSON.stringify(endEvent)}\n\n`),
-      );
-    }
-
-    const finishEvent = { type: UI_MESSAGE_EVENTS.FINISH };
-    controller.enqueue(
-      encoder.encode(`data: ${JSON.stringify(finishEvent)}\n\n`),
-    );
-    controller.enqueue(encoder.encode(`data: ${SSE_DONE_MARKER}\n\n`));
-    controller.close();
-  }
-
-  function handleTextDelta(
-    delta: string,
-    controller: ReadableStreamDefaultController,
-  ) {
-    if (streamClosed) return;
-
-    if (!textStarted) {
-      const startEvent = {
-        type: UI_MESSAGE_EVENTS.TEXT_START,
-        id: messageId,
-      };
-      controller.enqueue(
-        encoder.encode(`data: ${JSON.stringify(startEvent)}\n\n`),
-      );
-      textStarted = true;
-    }
-
-    const deltaEvent = {
-      type: UI_MESSAGE_EVENTS.TEXT_DELTA,
-      delta,
-      id: messageId,
-    };
-    controller.enqueue(
-      encoder.encode(`data: ${JSON.stringify(deltaEvent)}\n\n`),
-    );
-  }
-
-  function processSSELine(
-    data: string,
-    controller: ReadableStreamDefaultController,
-  ): boolean {
-    if (data === SSE_DONE_MARKER) {
-      closeStream(controller);
-      return true;
-    }
-
-    try {
-      const chunk = JSON.parse(data) as { type: string; delta?: string };
-
-      if (
-        chunk.type === RESPONSES_API_EVENTS.OUTPUT_TEXT_DELTA &&
-        chunk.delta &&
-        typeof chunk.delta === "string"
-      ) {
-        handleTextDelta(chunk.delta, controller);
-        return false;
-      }
-
-      if (chunk.type === RESPONSES_API_EVENTS.COMPLETED) {
-        closeStream(controller);
-        return true;
-      }
-    } catch (parseError) {
-      console.warn("Failed to parse Responses API chunk:", parseError);
-    }
-
-    return false;
-  }
-
-  return new ReadableStream({
-    async start(controller) {
-      const startEvent = { type: UI_MESSAGE_EVENTS.START };
-      controller.enqueue(
-        encoder.encode(`data: ${JSON.stringify(startEvent)}\n\n`),
-      );
-
-      try {
-        while (!streamClosed) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
-
-          for (const line of lines) {
-            if (!line.trim() || line.startsWith(":")) continue;
-
-            if (line.startsWith(SSE_DATA_PREFIX)) {
-              const data = line.slice(SSE_DATA_PREFIX.length);
-              const shouldStop = processSSELine(data, controller);
-              if (shouldStop) return;
-            }
-          }
-        }
-
-        if (!streamClosed) {
-          closeStream(controller);
-        }
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        if (!streamClosed) {
-          streamClosed = true;
-          const errorEvent = {
-            type: UI_MESSAGE_EVENTS.ERROR,
-            errorText: errorMessage,
-          };
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`),
-          );
-          controller.close();
-        }
-
-        throw error;
-      }
-    },
-    cancel(reason) {
-      cancelled = true;
-      return reader.cancel(reason);
-    },
-  });
-}

--- a/apps/core/src/clients/openrouter.client.ts
+++ b/apps/core/src/clients/openrouter.client.ts
@@ -28,7 +28,7 @@ interface GenerateOpenRouterTextOptions {
 }
 
 async function generateOpenRouterText(
-  openrouter: NonNullable<ReturnType<typeof createOpenRouter>>,
+  openrouter: ReturnType<typeof createOpenRouter>,
   options: GenerateOpenRouterTextOptions,
 ): Promise<string | null> {
   try {

--- a/apps/core/src/clients/openrouter.client.ts
+++ b/apps/core/src/clients/openrouter.client.ts
@@ -72,11 +72,11 @@ export const openrouterClient = (() => {
         .map(([key, value]) => `${key} => ${JSON.stringify(value)}`)
         .join(", ");
 
-      const instructions = `Generate a descriptive agent summary following these rules:
+      const instructions = `Generate a short job name following these rules:
         - Length: 90-110 characters (including spaces and punctuation)
         - Language: Match the input
         - Format: Single sentence, no agent name
-        - Output: Summary only, no other text
+        - Output: Job name only, no other text
       `;
       const userPrompt = `Agent: ${agent.name} ${agent.description ? ` - ${agent.description}` : ""}\nInput: ${inputSummary}`;
 

--- a/apps/core/src/clients/openrouter.client.ts
+++ b/apps/core/src/clients/openrouter.client.ts
@@ -133,6 +133,7 @@ export const openrouterClient = (() => {
       const userPrompt = `First message: ${trimmed}`;
 
       const text = await generateOpenRouterText(defaultOpenrouter, {
+        abortSignal: AbortSignal.timeout(NAME_GENERATION_TIMEOUT_MS),
         instructions,
         prompt: userPrompt,
         temperature: 0.5,

--- a/docs/superpowers/specs/2026-06-19-remove-openrouter-from-web-design.md
+++ b/docs/superpowers/specs/2026-06-19-remove-openrouter-from-web-design.md
@@ -31,9 +31,10 @@ data access and LLM secrets; shared pure helpers live in `@sokosumi/utils`.
   **only** for these two name generators. Its raw `openrouter` provider export
   is unused. `@openrouter/ai-sdk-provider` is imported in web at exactly this
   one file.
-- Core `clients/openrouter.client.ts` already has `generateJobName`,
-  `generateChatTitle`, `generateAgentSummary`, `streamChatResponse` — but **no
-  `generateTaskName`**. It is null-safe (returns `null` when the key is unset).
+- Core `clients/openrouter.client.ts` has `generateJobName`, `generateTaskName`,
+  `generateChatTitle`, and `generateAgentSummary`. Chat streaming uses
+  `@sokosumi/ai-provider` (not this client). It is null-safe (returns `null`
+  when the key is unset).
 - There is **one** task-create route: `apps/core/src/routes/v1/tasks/post.ts`.
   `projects/[id]/tasks/post.ts` only *assigns* an existing task to a project.
 - `removeDesignMdAttachmentLinks` (web `lib/utils/task-attachments.ts`) is a


### PR DESCRIPTION
## Summary

- Replace deprecated `system` with `instructions` on all OpenRouter `generateText` calls (AI SDK v7 follow-up to #3266)
- Extract shared `generateOpenRouterText` helper for the four Haiku naming/summary call sites
- Remove unused `streamChatResponse` and `createUIMessageStream` dead code (~220 lines; chat streaming lives in `@sokosumi/ai-provider` + Core `streamText`)
- Add `AbortSignal.timeout` to `generateChatTitle` (matches other name generators)
- Fix `generateJobName` instructions copy (job name, not agent summary)
- Expand `openrouter.client.test.ts`: `instructions` vs deprecated `system`, 50-char title truncation, null when API key unset, and isolated env mock setup
- Update OpenRouter design doc to drop removed `streamChatResponse` and note current client surface

## Test plan

- [x] `pnpm --filter core typecheck`
- [x] `pnpm --filter core test src/clients/openrouter.client.test.ts`
- [x] `pnpm --filter core test src/helpers/task-name.test.ts src/services/agent-sync.service.test.ts`