### PR TITLE
fix(web): prevent long org names from clipping in Settings sidebar

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-menu-button.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-menu-button.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const openSubmenuMock = vi.fn();
+const setOpenMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/agents",
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarMenuButton: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  SidebarMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
+  useSidebar: () => ({
+    state: "collapsed",
+    setOpen: setOpenMock,
+  }),
+}));
+
+vi.mock("@/app/components/sidebar/components/sidebar-submenu", () => ({
+  SIDEBAR_SUBMENU_SLIDE_DURATION_MS: 200,
+  useSidebarSubmenu: () => ({
+    openSubmenu: openSubmenuMock,
+  }),
+}));
+
+import SettingsMenuButton from "@/app/components/sidebar/components/settings-menu-button.client";
+
+describe("SettingsMenuButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for sidebar expansion before opening settings from collapsed state", () => {
+    render(<SettingsMenuButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+
+    expect(setOpenMock).toHaveBeenCalledWith(true);
+    expect(openSubmenuMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(200);
+
+    expect(openSubmenuMock).toHaveBeenCalledWith("settings");
+  });
+});

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx
@@ -74,7 +74,24 @@ vi.mock("@/app/components/sidebar/components/sidebar-submenu", () => ({
   }),
 }));
 
-import { SettingsSubmenuContent } from "@/app/components/sidebar/components/settings-submenu-content";
+import {
+  SettingsPanelHeader,
+  SettingsSubmenuContent,
+} from "@/app/components/sidebar/components/settings-submenu-content";
+
+describe("SettingsPanelHeader", () => {
+  it("truncates long labels within the panel header", () => {
+    const longLabel =
+      "Enterprise (Very Long Organization Name That Should Not Overflow)";
+
+    render(<SettingsPanelHeader planLabel={longLabel} />);
+
+    const label = screen.getByText(longLabel);
+    expect(label).toHaveClass("truncate");
+    expect(label).toHaveClass("min-w-0");
+    expect(label).toHaveAttribute("title", longLabel);
+  });
+});
 
 describe("SettingsSubmenuContent", () => {
   beforeEach(() => {

--- a/apps/web/src/app/(app)/components/sidebar/components/settings-menu-button.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/settings-menu-button.client.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 
-import { useSidebarSubmenu } from "./sidebar-submenu";
+import {
+  SIDEBAR_SUBMENU_SLIDE_DURATION_MS,
+  useSidebarSubmenu,
+} from "./sidebar-submenu";
 
 function isSettingsRouteActive(pathname: string): boolean {
   return (
@@ -32,6 +35,10 @@ export default function SettingsMenuButton() {
   function handleClick() {
     if (state === "collapsed") {
       setOpen(true);
+      window.setTimeout(() => {
+        openSubmenu("settings");
+      }, SIDEBAR_SUBMENU_SLIDE_DURATION_MS);
+      return;
     }
 
     openSubmenu("settings");

--- a/apps/web/src/app/(app)/components/sidebar/components/settings-submenu-content.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/settings-submenu-content.tsx
@@ -158,5 +158,12 @@ interface SettingsPanelHeaderProps {
 }
 
 export function SettingsPanelHeader({ planLabel }: SettingsPanelHeaderProps) {
-  return <span className="truncate text-sm font-medium">{planLabel}</span>;
+  return (
+    <span
+      className="block min-w-0 w-full truncate text-sm font-medium"
+      title={planLabel}
+    >
+      {planLabel}
+    </span>
+  );
 }

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-nav.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-nav.client.tsx
@@ -117,7 +117,7 @@ function SidebarNavInner({
         id: "help",
         parentId: "settings",
         header: (
-          <span className="truncate text-sm font-medium">
+          <span className="block min-w-0 w-full truncate text-sm font-medium">
             {tUserAvatar("help")}
           </span>
         ),
@@ -134,7 +134,7 @@ function SidebarNavInner({
         id: "legal",
         parentId: "settings",
         header: (
-          <span className="truncate text-sm font-medium">
+          <span className="block min-w-0 w-full truncate text-sm font-medium">
             {tUserAvatar("legal")}
           </span>
         ),

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-submenu.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-submenu.tsx
@@ -44,7 +44,7 @@ interface SidebarSubmenuProps {
 const SLIDE_TRANSITION_CLASS =
   "transition-transform duration-200 ease-out motion-reduce:transition-none";
 const TRACK_PANEL_CLASS = "min-w-0 shrink-0 grow-0 basis-full";
-const SLIDE_DURATION_MS = 200;
+export const SIDEBAR_SUBMENU_SLIDE_DURATION_MS = 200;
 
 function computePanelPath(
   panels: SidebarSubmenuPanel[],
@@ -113,7 +113,7 @@ function SubmenuPanelView({
     <div
       ref={panelRef}
       tabIndex={isActive ? -1 : undefined}
-      className={cn(TRACK_PANEL_CLASS, "outline-hidden")}
+      className={cn(TRACK_PANEL_CLASS, "outline-hidden overflow-hidden")}
       aria-hidden={!isActive}
       {...(!isActive ? { inert: true } : {})}
     >
@@ -124,7 +124,7 @@ function SubmenuPanelView({
         )}
       >
         <SidebarSubmenuBackButton />
-        <div className="min-w-0 flex-1">{panel.header}</div>
+        <div className="min-w-0 flex-1 overflow-hidden">{panel.header}</div>
       </div>
       <div className={cn(!isActive && "pointer-events-none")}>
         {panel.content}
@@ -199,7 +199,7 @@ export function SidebarSubmenu({
 
     const timeout = window.setTimeout(() => {
       setTrackPanels(pathPanels);
-    }, SLIDE_DURATION_MS);
+    }, SIDEBAR_SUBMENU_SLIDE_DURATION_MS);
 
     return () => {
       window.clearTimeout(timeout);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long organization names in the Settings sidebar panel were hard-clipped instead of sliding fully into view.

## Root cause

Two issues stacked:

1. **Header truncation in flex layout** — `SettingsPanelHeader` used `truncate` on an inline `<span>` without width constraints, so long plan/org labels could overflow the panel and get clipped by the slide viewport's `overflow-hidden`.
2. **Competing animations** — Opening Settings from collapsed icon mode expanded the sidebar and slid the submenu at the same time, so the panel could render at icon width during the transition.

## Changes

- Constrain `SettingsPanelHeader` with `block min-w-0 w-full truncate` and expose the full label via `title` for hover/focus.
- Add `overflow-hidden` to submenu panel containers and header wrappers.
- Defer opening the Settings submenu until the sidebar expand animation completes (200ms) when starting from collapsed state.
- Apply the same header truncation pattern to Help/Legal panel headers for consistency.
- Add unit tests for header truncation and deferred submenu open.

## Verification

- `pnpm --filter web test src/app/(app)/components/sidebar/components/__tests__/settings-submenu-content.test.tsx src/app/(app)/components/sidebar/components/__tests__/settings-menu-button.test.tsx`
- `pnpm --filter web check`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-627](https://linear.app/masumi/issue/SOK-627/long-organization-names-dont-fully-slide-over-in-settings)

<div><a href="https://cursor.com/agents/bc-ff28a7c3-1cf0-448d-9bad-4bc0a294fea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff28a7c3-1cf0-448d-9bad-4bc0a294fea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

