### PR TITLE
feat(admin): preview recipient billing on invoice form

### DIFF
--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.test.ts
@@ -8,8 +8,12 @@ import { errorHandler } from "@/helpers/error-handler.js";
 import { defaultValidationHook, type OpenAPIHonoWithAuth } from "@/lib/hono";
 import type { AuthenticationContext, AuthVariables } from "@/middleware/auth";
 
-const { getOrganizationBillingDetailsMock } = vi.hoisted(() => ({
+const {
+  getOrganizationBillingDetailsMock,
+  getOrganizationBillingDetailsByIdMock,
+} = vi.hoisted(() => ({
   getOrganizationBillingDetailsMock: vi.fn(),
+  getOrganizationBillingDetailsByIdMock: vi.fn(),
 }));
 
 vi.mock("@/middleware/auth", () => ({
@@ -21,12 +25,15 @@ vi.mock("@/middleware/auth", () => ({
     }
     return { source: "session" as const, ...authContext };
   },
+  hasAdminRole: (role: string | null | undefined) => role === "admin",
 }));
 
 vi.mock("@/services/stripe-customer-billing.service", () => ({
   stripeCustomerBillingService: {
     getOrganizationBillingDetails: (...args: unknown[]) =>
       getOrganizationBillingDetailsMock(...args),
+    getOrganizationBillingDetailsById: (...args: unknown[]) =>
+      getOrganizationBillingDetailsByIdMock(...args),
   },
 }));
 
@@ -127,6 +134,28 @@ describe("GET /organizations/{id}/billing-details", () => {
       "org_123",
       "user_123",
     );
+  });
+
+  it("returns billing details for a platform admin without org membership", async () => {
+    const adminAuthContext: AuthenticationContext = {
+      actor: "user",
+      userId: "admin_123",
+      organizationId: null,
+      role: "admin",
+    };
+    getOrganizationBillingDetailsByIdMock.mockResolvedValue(billingDetails);
+
+    const response = await createApp(adminAuthContext).request(
+      "http://localhost/org_123/billing-details",
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual(billingDetails);
+    expect(getOrganizationBillingDetailsByIdMock).toHaveBeenCalledWith(
+      "org_123",
+    );
+    expect(getOrganizationBillingDetailsMock).not.toHaveBeenCalled();
   });
 
   it("returns empty billing details when no stripe customer is provisioned", async () => {

--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
@@ -55,8 +55,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    // Platform-admin bypass is session-only: admin invoice UI uses Better Auth
-    // sessions, not API keys. Org members still use membership checks below.
+    // Platform admins with user auth (session or API key) can read org billing
+    // without membership. Org members still use membership checks below.
     const isPlatformAdmin =
       userContext.source === "session" && hasAdminRole(userContext.role);
 

--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
@@ -3,7 +3,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
+import { hasAdminRole, requireUserContext } from "@/middleware/auth";
 import { stripeCustomerBillingDetailsSchema } from "@/schemas/stripe.schema";
 import { stripeCustomerBillingService } from "@/services/stripe-customer-billing.service";
 
@@ -55,11 +55,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
-    const billingDetails =
-      await stripeCustomerBillingService.getOrganizationBillingDetails(
-        id,
-        userContext.userId,
-      );
+    const isPlatformAdmin =
+      userContext.source === "session" && hasAdminRole(userContext.role);
+
+    const billingDetails = isPlatformAdmin
+      ? await stripeCustomerBillingService.getOrganizationBillingDetailsById(id)
+      : await stripeCustomerBillingService.getOrganizationBillingDetails(
+          id,
+          userContext.userId,
+        );
 
     return ok(c, stripeCustomerBillingDetailsSchema.parse(billingDetails));
   });

--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
@@ -19,7 +19,7 @@ const route = createRoute({
   method: "get",
   path: "/{id}/billing-details",
   description:
-    "Get billing address and tax IDs stored on the organization's Stripe customer. Organization owners and admins only.",
+    "Get billing address and tax IDs stored on the organization's Stripe customer. Organization owners and admins, or platform admins with a session, may access this route.",
   tags: ["Organizations"],
   request: {
     params,
@@ -55,6 +55,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
+    // Platform-admin bypass is session-only: admin invoice UI uses Better Auth
+    // sessions, not API keys. Org members still use membership checks below.
     const isPlatformAdmin =
       userContext.source === "session" && hasAdminRole(userContext.role);
 

--- a/apps/core/src/services/__tests__/stripe-customer-billing.service.test.ts
+++ b/apps/core/src/services/__tests__/stripe-customer-billing.service.test.ts
@@ -158,7 +158,9 @@ describe("stripeCustomerBillingService", () => {
     vi.mocked(prisma.organization.findUnique).mockResolvedValue(null);
 
     await expect(
-      stripeCustomerBillingService.getOrganizationBillingDetailsById("org_missing"),
+      stripeCustomerBillingService.getOrganizationBillingDetailsById(
+        "org_missing",
+      ),
     ).rejects.toThrow("Organization not found");
   });
 
@@ -175,6 +177,8 @@ describe("stripeCustomerBillingService", () => {
       where: { id: "org_1" },
       select: { stripeCustomerId: true },
     });
-    expect(retrieveCustomerBillingDetailsMock).toHaveBeenCalledWith("cus_org_1");
+    expect(retrieveCustomerBillingDetailsMock).toHaveBeenCalledWith(
+      "cus_org_1",
+    );
   });
 });

--- a/apps/core/src/services/__tests__/stripe-customer-billing.service.test.ts
+++ b/apps/core/src/services/__tests__/stripe-customer-billing.service.test.ts
@@ -24,6 +24,9 @@ vi.mock("@/lib/db/prisma", () => ({
     user: {
       findUnique: vi.fn(),
     },
+    organization: {
+      findUnique: vi.fn(),
+    },
   },
 }));
 
@@ -134,5 +137,44 @@ describe("stripeCustomerBillingService", () => {
     expect(retrieveCustomerBillingDetailsMock).toHaveBeenCalledWith(
       "cus_org_1",
     );
+  });
+
+  it("returns empty billing details when organization has no stripe customer", async () => {
+    vi.mocked(prisma.organization.findUnique).mockResolvedValue({
+      stripeCustomerId: null,
+    } as never);
+
+    await expect(
+      stripeCustomerBillingService.getOrganizationBillingDetailsById("org_1"),
+    ).resolves.toEqual({
+      stripeCustomerId: null,
+      email: null,
+      address: null,
+      taxIds: [],
+    });
+  });
+
+  it("throws when organization is not found", async () => {
+    vi.mocked(prisma.organization.findUnique).mockResolvedValue(null);
+
+    await expect(
+      stripeCustomerBillingService.getOrganizationBillingDetailsById("org_missing"),
+    ).rejects.toThrow("Organization not found");
+  });
+
+  it("returns stripe billing details for an organization by id", async () => {
+    vi.mocked(prisma.organization.findUnique).mockResolvedValue({
+      stripeCustomerId: "cus_org_1",
+    } as never);
+
+    await expect(
+      stripeCustomerBillingService.getOrganizationBillingDetailsById("org_1"),
+    ).resolves.toEqual(billingDetails);
+
+    expect(prisma.organization.findUnique).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      select: { stripeCustomerId: true },
+    });
+    expect(retrieveCustomerBillingDetailsMock).toHaveBeenCalledWith("cus_org_1");
   });
 });

--- a/apps/core/src/services/invoice-admin.service.test.ts
+++ b/apps/core/src/services/invoice-admin.service.test.ts
@@ -19,6 +19,22 @@ const handleInvoicePaidEventMock = vi.fn();
 const creditBucketFindFirstMock = vi.fn();
 const organizationUpdateMock = vi.fn();
 const userUpdateMock = vi.fn();
+const getUserBillingDetailsMock = vi.fn();
+const getOrganizationBillingDetailsByIdMock = vi.fn();
+
+const completeBillingDetails = {
+  stripeCustomerId: "cus_test",
+  email: "billing@example.com",
+  address: {
+    line1: "123 Main St",
+    line2: null,
+    city: "Berlin",
+    state: null,
+    postalCode: "10115",
+    country: "DE",
+  },
+  taxIds: [],
+};
 
 const buildUserInvoiceCreditReferenceIdMock = vi.fn();
 const buildOrganizationInvoiceCreditReferenceIdMock = vi.fn();
@@ -81,6 +97,15 @@ vi.mock("@/services/stripe-invoice-credit.service", () => ({
     handleInvoicePaidEventMock(...args),
 }));
 
+vi.mock("@/services/stripe-customer-billing.service", () => ({
+  stripeCustomerBillingService: {
+    getUserBillingDetails: (...args: unknown[]) =>
+      getUserBillingDetailsMock(...args),
+    getOrganizationBillingDetailsById: (...args: unknown[]) =>
+      getOrganizationBillingDetailsByIdMock(...args),
+  },
+}));
+
 import {
   InvoiceValidationError,
   invoiceAdminService,
@@ -101,6 +126,10 @@ describe("invoiceAdminService.createInvoice", () => {
       status: "open",
     });
     getAccountIdMock.mockResolvedValue("acct_1");
+    getUserBillingDetailsMock.mockResolvedValue(completeBillingDetails);
+    getOrganizationBillingDetailsByIdMock.mockResolvedValue(
+      completeBillingDetails,
+    );
   });
 
   it("invoices the organization's Stripe customer for an organization target", async () => {
@@ -258,6 +287,34 @@ describe("invoiceAdminService.createInvoice", () => {
         priceId: null,
       }),
     ).rejects.toThrow("Expiry must be a positive integer of at most 3650 days");
+  });
+
+  it("rejects when the recipient has no billing address with country", async () => {
+    getOrganizationWithRelationsByIdMock.mockResolvedValue({
+      id: "org_1",
+      name: "Acme",
+      slug: "acme",
+      stripeCustomerId: "cus_org",
+      metadata: null,
+    });
+    getOrganizationBillingDetailsByIdMock.mockResolvedValue({
+      stripeCustomerId: "cus_org",
+      email: null,
+      address: null,
+      taxIds: [],
+    });
+
+    await expect(
+      invoiceAdminService.createInvoice({
+        target: { targetType: "organization", targetId: "org_1" },
+        credits: 10,
+        ttlDays: null,
+        priceId: null,
+      }),
+    ).rejects.toThrow(
+      "Recipient billing address with country is required for invoicing",
+    );
+    expect(createAdminInvoiceMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/core/src/services/invoice-admin.service.test.ts
+++ b/apps/core/src/services/invoice-admin.service.test.ts
@@ -316,6 +316,33 @@ describe("invoiceAdminService.createInvoice", () => {
     );
     expect(createAdminInvoiceMock).not.toHaveBeenCalled();
   });
+
+  it("rejects a user target when billing address has no country", async () => {
+    getUserByIdMock.mockResolvedValue({
+      id: "user_1",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      stripeCustomerId: "cus_user",
+    });
+    getUserBillingDetailsMock.mockResolvedValue({
+      stripeCustomerId: "cus_user",
+      email: "ada@example.com",
+      address: null,
+      taxIds: [],
+    });
+
+    await expect(
+      invoiceAdminService.createInvoice({
+        target: { targetType: "user", targetId: "user_1" },
+        credits: 10,
+        ttlDays: null,
+        priceId: null,
+      }),
+    ).rejects.toThrow(
+      "Recipient billing address with country is required for invoicing",
+    );
+    expect(createAdminInvoiceMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("invoiceAdminService.listInvoices", () => {

--- a/apps/core/src/services/invoice-admin.service.ts
+++ b/apps/core/src/services/invoice-admin.service.ts
@@ -557,20 +557,20 @@ export const invoiceAdminService = (() => {
         }
       }
 
-      // These are independent reads (target lookup, price lookup, Stripe
-      // account id) — run them concurrently rather than serially.
-      const [target, price, accountId] = await Promise.all([
+      // Target lookup, price lookup, Stripe account id, and billing details are
+      // independent reads — run them concurrently rather than serially.
+      const [target, price, accountId, billingDetails] = await Promise.all([
         resolveTarget(params.target),
         resolvePrice(params.priceId),
         stripeClient.getAccountId(),
-      ]);
-
-      const billingDetails =
         params.target.targetType === "user"
-          ? await stripeCustomerBillingService.getUserBillingDetails(target.id)
-          : await stripeCustomerBillingService.getOrganizationBillingDetailsById(
-              target.id,
-            );
+          ? stripeCustomerBillingService.getUserBillingDetails(
+              params.target.targetId,
+            )
+          : stripeCustomerBillingService.getOrganizationBillingDetailsById(
+              params.target.targetId,
+            ),
+      ]);
 
       if (!hasStripeBillingAddressWithCountry(billingDetails.address)) {
         throw new InvoiceValidationError(

--- a/apps/core/src/services/invoice-admin.service.ts
+++ b/apps/core/src/services/invoice-admin.service.ts
@@ -6,11 +6,13 @@ import {
   organizationRepository,
   userRepository,
 } from "@sokosumi/database/repositories";
+import { hasStripeBillingAddressWithCountry } from "@sokosumi/utils";
 import type Stripe from "stripe";
 
 import { stripeClient } from "@/clients/stripe.client";
 import { MAX_ADMIN_CREDIT_TTL_DAYS } from "@/lib/admin-credit-grant";
 import prisma from "@/lib/db/prisma";
+import { stripeCustomerBillingService } from "@/services/stripe-customer-billing.service";
 import { handleInvoicePaidEvent } from "@/services/stripe-invoice-credit.service";
 
 /**
@@ -562,6 +564,19 @@ export const invoiceAdminService = (() => {
         resolvePrice(params.priceId),
         stripeClient.getAccountId(),
       ]);
+
+      const billingDetails =
+        params.target.targetType === "user"
+          ? await stripeCustomerBillingService.getUserBillingDetails(target.id)
+          : await stripeCustomerBillingService.getOrganizationBillingDetailsById(
+              target.id,
+            );
+
+      if (!hasStripeBillingAddressWithCountry(billingDetails.address)) {
+        throw new InvoiceValidationError(
+          "Recipient billing address with country is required for invoicing",
+        );
+      }
 
       const invoice = await stripeClient.createAdminInvoice({
         customerId: target.stripeCustomerId,

--- a/apps/core/src/services/stripe-customer-billing.service.ts
+++ b/apps/core/src/services/stripe-customer-billing.service.ts
@@ -50,4 +50,17 @@ export const stripeCustomerBillingService = {
 
     return await getBillingDetailsForCustomer(organization.stripeCustomerId);
   },
+
+  async getOrganizationBillingDetailsById(organizationId: string) {
+    const organization = await prisma.organization.findUnique({
+      where: { id: organizationId },
+      select: { stripeCustomerId: true },
+    });
+
+    if (!organization) {
+      throw notFound("Organization not found");
+    }
+
+    return await getBillingDetailsForCustomer(organization.stripeCustomerId);
+  },
 };

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2855,7 +2855,30 @@
           "createError": "Rechnung konnte nicht erstellt werden",
           "pricePlaceholder": "Preis auswählen",
           "priceHelper": "Preis pro Credit für den Rechnungsbetrag.",
-          "priceRequired": "Wählen Sie einen Preis aus"
+          "priceRequired": "Wählen Sie einen Preis aus",
+          "billingLoadErrorTitle": "Rechnungsdaten konnten nicht geladen werden",
+          "billingLoadError": "Rechnungsdaten des Empfängers konnten nicht geladen werden",
+          "billingIncomplete": "Rechnungsadresse mit Land ist erforderlich",
+          "billingIncompleteTitle": "Rechnungsdaten unvollständig",
+          "billingIncompleteUser": "Dieser Benutzer muss in den Kontoeinstellungen eine Rechnungsadresse mit Land hinterlegen, bevor Sie eine Rechnung erstellen können.",
+          "billingIncompleteOrganization": "Diese Organisation muss in den Organisationseinstellungen eine Rechnungsadresse mit Land hinterlegen, bevor Sie eine Rechnung erstellen können.",
+          "BillingDetails": {
+            "title": "Rechnungsinformationen",
+            "description": "Rechnungsadresse und Steuerdaten des Stripe-Kunden des Empfängers.",
+            "addressLabel": "Rechnungsadresse",
+            "taxIdLabel": "USt-IdNr. / Steuernummer",
+            "taxIdVerification": "Verifizierungsstatus: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Verifiziert",
+              "pending": "Ausstehend",
+              "unverified": "Nicht verifiziert",
+              "unavailable": "Nicht verfügbar",
+              "verification_failed": "Verifizierung fehlgeschlagen"
+            },
+            "invoiceEmailLabel": "Rechnungs-E-Mail",
+            "invoiceEmailEmpty": "Keine Rechnungs-E-Mail hinterlegt",
+            "empty": "Keine Rechnungsadresse hinterlegt"
+          }
         },
         "Result": {
           "heading": "Rechnung",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2860,7 +2860,6 @@
           "billingLoadError": "Rechnungsdaten des Empfängers konnten nicht geladen werden",
           "billingRefresh": "Aktualisieren",
           "billingIncomplete": "Rechnungsadresse mit Land ist erforderlich",
-          "billingIncompleteTitle": "Rechnungsdaten unvollständig",
           "billingIncompleteUser": "Dieser Benutzer muss in den Kontoeinstellungen eine Rechnungsadresse mit Land hinterlegen, bevor Sie eine Rechnung erstellen können.",
           "billingIncompleteOrganization": "Diese Organisation muss in den Organisationseinstellungen eine Rechnungsadresse mit Land hinterlegen, bevor Sie eine Rechnung erstellen können.",
           "BillingDetails": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2858,6 +2858,7 @@
           "priceRequired": "Wählen Sie einen Preis aus",
           "billingLoadErrorTitle": "Rechnungsdaten konnten nicht geladen werden",
           "billingLoadError": "Rechnungsdaten des Empfängers konnten nicht geladen werden",
+          "billingRefresh": "Aktualisieren",
           "billingIncomplete": "Rechnungsadresse mit Land ist erforderlich",
           "billingIncompleteTitle": "Rechnungsdaten unvollständig",
           "billingIncompleteUser": "Dieser Benutzer muss in den Kontoeinstellungen eine Rechnungsadresse mit Land hinterlegen, bevor Sie eine Rechnung erstellen können.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2827,6 +2827,7 @@
           "priceRequired": "Select a price",
           "billingLoadErrorTitle": "Could not load billing details",
           "billingLoadError": "Failed to load recipient billing details",
+          "billingRefresh": "Refresh",
           "billingIncomplete": "Recipient billing address with country is required",
           "billingIncompleteTitle": "Billing details incomplete",
           "billingIncompleteUser": "This user must add a billing address with country in their account settings before you can create an invoice.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2829,7 +2829,6 @@
           "billingLoadError": "Failed to load recipient billing details",
           "billingRefresh": "Refresh",
           "billingIncomplete": "Recipient billing address with country is required",
-          "billingIncompleteTitle": "Billing details incomplete",
           "billingIncompleteUser": "This user must add a billing address with country in their account settings before you can create an invoice.",
           "billingIncompleteOrganization": "This organization must add a billing address with country in its organization settings before you can create an invoice.",
           "BillingDetails": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2824,7 +2824,30 @@
           "createSuccess": "Invoice created",
           "createError": "Failed to create invoice",
           "pricePlaceholder": "Select a price",
-          "priceRequired": "Select a price"
+          "priceRequired": "Select a price",
+          "billingLoadErrorTitle": "Could not load billing details",
+          "billingLoadError": "Failed to load recipient billing details",
+          "billingIncomplete": "Recipient billing address with country is required",
+          "billingIncompleteTitle": "Billing details incomplete",
+          "billingIncompleteUser": "This user must add a billing address with country in their account settings before you can create an invoice.",
+          "billingIncompleteOrganization": "This organization must add a billing address with country in its organization settings before you can create an invoice.",
+          "BillingDetails": {
+            "title": "Billing information",
+            "description": "Billing address and tax details stored on the recipient's Stripe customer.",
+            "addressLabel": "Billing address",
+            "taxIdLabel": "VAT / tax ID",
+            "taxIdVerification": "Verification status: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Verified",
+              "pending": "Pending",
+              "unverified": "Unverified",
+              "unavailable": "Unavailable",
+              "verification_failed": "Verification failed"
+            },
+            "invoiceEmailLabel": "Invoice email",
+            "invoiceEmailEmpty": "No invoice email on file",
+            "empty": "No billing address on file"
+          }
         },
         "Result": {
           "heading": "Invoice",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2858,6 +2858,7 @@
           "priceRequired": "Selecciona un precio",
           "billingLoadErrorTitle": "No se pudieron cargar los datos de facturación",
           "billingLoadError": "No se pudieron cargar los datos de facturación del destinatario",
+          "billingRefresh": "Actualizar",
           "billingIncomplete": "Se requiere una dirección de facturación con país",
           "billingIncompleteTitle": "Datos de facturación incompletos",
           "billingIncompleteUser": "Este usuario debe añadir una dirección de facturación con país en la configuración de su cuenta antes de que puedas crear una factura.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2855,7 +2855,30 @@
           "createError": "No se pudo crear la factura",
           "pricePlaceholder": "Selecciona un precio",
           "priceHelper": "Precio por crédito utilizado para el importe de la factura.",
-          "priceRequired": "Selecciona un precio"
+          "priceRequired": "Selecciona un precio",
+          "billingLoadErrorTitle": "No se pudieron cargar los datos de facturación",
+          "billingLoadError": "No se pudieron cargar los datos de facturación del destinatario",
+          "billingIncomplete": "Se requiere una dirección de facturación con país",
+          "billingIncompleteTitle": "Datos de facturación incompletos",
+          "billingIncompleteUser": "Este usuario debe añadir una dirección de facturación con país en la configuración de su cuenta antes de que puedas crear una factura.",
+          "billingIncompleteOrganization": "Esta organización debe añadir una dirección de facturación con país en la configuración de la organización antes de que puedas crear una factura.",
+          "BillingDetails": {
+            "title": "Información de facturación",
+            "description": "Dirección de facturación y datos fiscales almacenados en el cliente de Stripe del destinatario.",
+            "addressLabel": "Dirección de facturación",
+            "taxIdLabel": "IVA / ID fiscal",
+            "taxIdVerification": "Estado de verificación: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Verificado",
+              "pending": "Pendiente",
+              "unverified": "No verificado",
+              "unavailable": "No disponible",
+              "verification_failed": "Verificación fallida"
+            },
+            "invoiceEmailLabel": "Correo de facturación",
+            "invoiceEmailEmpty": "No hay correo de facturación registrado",
+            "empty": "No hay dirección de facturación registrada"
+          }
         },
         "Result": {
           "heading": "Factura",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2860,7 +2860,6 @@
           "billingLoadError": "No se pudieron cargar los datos de facturación del destinatario",
           "billingRefresh": "Actualizar",
           "billingIncomplete": "Se requiere una dirección de facturación con país",
-          "billingIncompleteTitle": "Datos de facturación incompletos",
           "billingIncompleteUser": "Este usuario debe añadir una dirección de facturación con país en la configuración de su cuenta antes de que puedas crear una factura.",
           "billingIncompleteOrganization": "Esta organización debe añadir una dirección de facturación con país en la configuración de la organización antes de que puedas crear una factura.",
           "BillingDetails": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2891,7 +2891,6 @@
           "billingLoadError": "Impossible de charger les informations de facturation du destinataire",
           "billingRefresh": "Actualiser",
           "billingIncomplete": "Une adresse de facturation avec pays est requise",
-          "billingIncompleteTitle": "Informations de facturation incomplètes",
           "billingIncompleteUser": "Cet utilisateur doit ajouter une adresse de facturation avec pays dans les paramètres de son compte avant que vous puissiez créer une facture.",
           "billingIncompleteOrganization": "Cette organisation doit ajouter une adresse de facturation avec pays dans les paramètres de l'organisation avant que vous puissiez créer une facture.",
           "BillingDetails": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2886,7 +2886,30 @@
           "createError": "Échec de la création de la facture",
           "pricePlaceholder": "Sélectionner un prix",
           "priceHelper": "Prix par crédit utilisé pour le montant de la facture.",
-          "priceRequired": "Sélectionnez un prix"
+          "priceRequired": "Sélectionnez un prix",
+          "billingLoadErrorTitle": "Impossible de charger les informations de facturation",
+          "billingLoadError": "Impossible de charger les informations de facturation du destinataire",
+          "billingIncomplete": "Une adresse de facturation avec pays est requise",
+          "billingIncompleteTitle": "Informations de facturation incomplètes",
+          "billingIncompleteUser": "Cet utilisateur doit ajouter une adresse de facturation avec pays dans les paramètres de son compte avant que vous puissiez créer une facture.",
+          "billingIncompleteOrganization": "Cette organisation doit ajouter une adresse de facturation avec pays dans les paramètres de l'organisation avant que vous puissiez créer une facture.",
+          "BillingDetails": {
+            "title": "Informations de facturation",
+            "description": "Adresse de facturation et informations fiscales enregistrées sur le client Stripe du destinataire.",
+            "addressLabel": "Adresse de facturation",
+            "taxIdLabel": "TVA / identifiant fiscal",
+            "taxIdVerification": "Statut de vérification : {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Vérifié",
+              "pending": "En attente",
+              "unverified": "Non vérifié",
+              "unavailable": "Indisponible",
+              "verification_failed": "Échec de la vérification"
+            },
+            "invoiceEmailLabel": "E-mail de facturation",
+            "invoiceEmailEmpty": "Aucun e-mail de facturation enregistré",
+            "empty": "Aucune adresse de facturation enregistrée"
+          }
         },
         "Result": {
           "heading": "Facture",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2889,6 +2889,7 @@
           "priceRequired": "Sélectionnez un prix",
           "billingLoadErrorTitle": "Impossible de charger les informations de facturation",
           "billingLoadError": "Impossible de charger les informations de facturation du destinataire",
+          "billingRefresh": "Actualiser",
           "billingIncomplete": "Une adresse de facturation avec pays est requise",
           "billingIncompleteTitle": "Informations de facturation incomplètes",
           "billingIncompleteUser": "Cet utilisateur doit ajouter une adresse de facturation avec pays dans les paramètres de son compte avant que vous puissiez créer une facture.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2889,6 +2889,7 @@
           "priceRequired": "Seleziona un prezzo",
           "billingLoadErrorTitle": "Impossibile caricare i dati di fatturazione",
           "billingLoadError": "Impossibile caricare i dati di fatturazione del destinatario",
+          "billingRefresh": "Aggiorna",
           "billingIncomplete": "È richiesto un indirizzo di fatturazione con paese",
           "billingIncompleteTitle": "Dati di fatturazione incompleti",
           "billingIncompleteUser": "Questo utente deve aggiungere un indirizzo di fatturazione con paese nelle impostazioni dell'account prima che tu possa creare una fattura.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2886,7 +2886,30 @@
           "createError": "Creazione della fattura non riuscita",
           "pricePlaceholder": "Seleziona un prezzo",
           "priceHelper": "Prezzo per credito utilizzato per l'importo della fattura.",
-          "priceRequired": "Seleziona un prezzo"
+          "priceRequired": "Seleziona un prezzo",
+          "billingLoadErrorTitle": "Impossibile caricare i dati di fatturazione",
+          "billingLoadError": "Impossibile caricare i dati di fatturazione del destinatario",
+          "billingIncomplete": "È richiesto un indirizzo di fatturazione con paese",
+          "billingIncompleteTitle": "Dati di fatturazione incompleti",
+          "billingIncompleteUser": "Questo utente deve aggiungere un indirizzo di fatturazione con paese nelle impostazioni dell'account prima che tu possa creare una fattura.",
+          "billingIncompleteOrganization": "Questa organizzazione deve aggiungere un indirizzo di fatturazione con paese nelle impostazioni dell'organizzazione prima che tu possa creare una fattura.",
+          "BillingDetails": {
+            "title": "Informazioni di fatturazione",
+            "description": "Indirizzo di fatturazione e dati fiscali memorizzati sul cliente Stripe del destinatario.",
+            "addressLabel": "Indirizzo di fatturazione",
+            "taxIdLabel": "IVA / codice fiscale",
+            "taxIdVerification": "Stato di verifica: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Verificato",
+              "pending": "In attesa",
+              "unverified": "Non verificato",
+              "unavailable": "Non disponibile",
+              "verification_failed": "Verifica non riuscita"
+            },
+            "invoiceEmailLabel": "E-mail di fatturazione",
+            "invoiceEmailEmpty": "Nessuna e-mail di fatturazione registrata",
+            "empty": "Nessun indirizzo di fatturazione registrato"
+          }
         },
         "Result": {
           "heading": "Fattura",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2891,7 +2891,6 @@
           "billingLoadError": "Impossibile caricare i dati di fatturazione del destinatario",
           "billingRefresh": "Aggiorna",
           "billingIncomplete": "È richiesto un indirizzo di fatturazione con paese",
-          "billingIncompleteTitle": "Dati di fatturazione incompleti",
           "billingIncompleteUser": "Questo utente deve aggiungere un indirizzo di fatturazione con paese nelle impostazioni dell'account prima che tu possa creare una fattura.",
           "billingIncompleteOrganization": "Questa organizzazione deve aggiungere un indirizzo di fatturazione con paese nelle impostazioni dell'organizzazione prima che tu possa creare una fattura.",
           "BillingDetails": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2886,7 +2886,30 @@
           "createError": "請求書の作成に失敗しました",
           "pricePlaceholder": "価格を選択",
           "priceHelper": "請求金額に使用するクレジットあたりの価格。",
-          "priceRequired": "価格を選択してください"
+          "priceRequired": "価格を選択してください",
+          "billingLoadErrorTitle": "請求情報を読み込めませんでした",
+          "billingLoadError": "受取人の請求情報を読み込めませんでした",
+          "billingIncomplete": "国を含む請求先住所が必要です",
+          "billingIncompleteTitle": "請求情報が不完全です",
+          "billingIncompleteUser": "請求書を作成する前に、このユーザーはアカウント設定で国を含む請求先住所を追加する必要があります。",
+          "billingIncompleteOrganization": "請求書を作成する前に、この組織は組織設定で国を含む請求先住所を追加する必要があります。",
+          "BillingDetails": {
+            "title": "請求情報",
+            "description": "受取人の Stripe 顧客に保存されている請求先住所と税務情報。",
+            "addressLabel": "請求先住所",
+            "taxIdLabel": "VAT / 税 ID",
+            "taxIdVerification": "確認ステータス: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "確認済み",
+              "pending": "保留中",
+              "unverified": "未確認",
+              "unavailable": "利用不可",
+              "verification_failed": "確認に失敗"
+            },
+            "invoiceEmailLabel": "請求書メール",
+            "invoiceEmailEmpty": "請求書メールが登録されていません",
+            "empty": "請求先住所が登録されていません"
+          }
         },
         "Result": {
           "heading": "請求書",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2891,7 +2891,6 @@
           "billingLoadError": "受取人の請求情報を読み込めませんでした",
           "billingRefresh": "更新",
           "billingIncomplete": "国を含む請求先住所が必要です",
-          "billingIncompleteTitle": "請求情報が不完全です",
           "billingIncompleteUser": "請求書を作成する前に、このユーザーはアカウント設定で国を含む請求先住所を追加する必要があります。",
           "billingIncompleteOrganization": "請求書を作成する前に、この組織は組織設定で国を含む請求先住所を追加する必要があります。",
           "BillingDetails": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2889,6 +2889,7 @@
           "priceRequired": "価格を選択してください",
           "billingLoadErrorTitle": "請求情報を読み込めませんでした",
           "billingLoadError": "受取人の請求情報を読み込めませんでした",
+          "billingRefresh": "更新",
           "billingIncomplete": "国を含む請求先住所が必要です",
           "billingIncompleteTitle": "請求情報が不完全です",
           "billingIncompleteUser": "請求書を作成する前に、このユーザーはアカウント設定で国を含む請求先住所を追加する必要があります。",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2889,6 +2889,7 @@
           "priceRequired": "Selecione um preço",
           "billingLoadErrorTitle": "Não foi possível carregar os dados de faturamento",
           "billingLoadError": "Não foi possível carregar os dados de faturamento do destinatário",
+          "billingRefresh": "Atualizar",
           "billingIncomplete": "É necessário um endereço de faturamento com país",
           "billingIncompleteTitle": "Dados de faturamento incompletos",
           "billingIncompleteUser": "Este usuário precisa adicionar um endereço de faturamento com país nas configurações da conta antes que você possa criar uma fatura.",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2891,7 +2891,6 @@
           "billingLoadError": "Não foi possível carregar os dados de faturamento do destinatário",
           "billingRefresh": "Atualizar",
           "billingIncomplete": "É necessário um endereço de faturamento com país",
-          "billingIncompleteTitle": "Dados de faturamento incompletos",
           "billingIncompleteUser": "Este usuário precisa adicionar um endereço de faturamento com país nas configurações da conta antes que você possa criar uma fatura.",
           "billingIncompleteOrganization": "Esta organização precisa adicionar um endereço de faturamento com país nas configurações da organização antes que você possa criar uma fatura.",
           "BillingDetails": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2886,7 +2886,30 @@
           "createError": "Falha ao criar a fatura",
           "pricePlaceholder": "Selecione um preço",
           "priceHelper": "Preço por crédito usado para o valor da fatura.",
-          "priceRequired": "Selecione um preço"
+          "priceRequired": "Selecione um preço",
+          "billingLoadErrorTitle": "Não foi possível carregar os dados de faturamento",
+          "billingLoadError": "Não foi possível carregar os dados de faturamento do destinatário",
+          "billingIncomplete": "É necessário um endereço de faturamento com país",
+          "billingIncompleteTitle": "Dados de faturamento incompletos",
+          "billingIncompleteUser": "Este usuário precisa adicionar um endereço de faturamento com país nas configurações da conta antes que você possa criar uma fatura.",
+          "billingIncompleteOrganization": "Esta organização precisa adicionar um endereço de faturamento com país nas configurações da organização antes que você possa criar uma fatura.",
+          "BillingDetails": {
+            "title": "Informações de faturamento",
+            "description": "Endereço de faturamento e dados fiscais armazenados no cliente Stripe do destinatário.",
+            "addressLabel": "Endereço de faturamento",
+            "taxIdLabel": "IVA / ID fiscal",
+            "taxIdVerification": "Status de verificação: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Verificado",
+              "pending": "Pendente",
+              "unverified": "Não verificado",
+              "unavailable": "Indisponível",
+              "verification_failed": "Falha na verificação"
+            },
+            "invoiceEmailLabel": "E-mail de faturamento",
+            "invoiceEmailEmpty": "Nenhum e-mail de faturamento cadastrado",
+            "empty": "Nenhum endereço de faturamento cadastrado"
+          }
         },
         "Result": {
           "heading": "Fatura",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2889,6 +2889,7 @@
           "priceRequired": "Selecione um preço",
           "billingLoadErrorTitle": "Não foi possível carregar os dados de faturação",
           "billingLoadError": "Não foi possível carregar os dados de faturação do destinatário",
+          "billingRefresh": "Atualizar",
           "billingIncomplete": "É necessária uma morada de faturação com país",
           "billingIncompleteTitle": "Dados de faturação incompletos",
           "billingIncompleteUser": "Este utilizador tem de adicionar uma morada de faturação com país nas definições da conta antes de poder criar uma fatura.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2886,7 +2886,30 @@
           "createError": "Falha ao criar a fatura",
           "pricePlaceholder": "Selecione um preço",
           "priceHelper": "Preço por crédito usado para o valor da fatura.",
-          "priceRequired": "Selecione um preço"
+          "priceRequired": "Selecione um preço",
+          "billingLoadErrorTitle": "Não foi possível carregar os dados de faturação",
+          "billingLoadError": "Não foi possível carregar os dados de faturação do destinatário",
+          "billingIncomplete": "É necessária uma morada de faturação com país",
+          "billingIncompleteTitle": "Dados de faturação incompletos",
+          "billingIncompleteUser": "Este utilizador tem de adicionar uma morada de faturação com país nas definições da conta antes de poder criar uma fatura.",
+          "billingIncompleteOrganization": "Esta organização tem de adicionar uma morada de faturação com país nas definições da organização antes de poder criar uma fatura.",
+          "BillingDetails": {
+            "title": "Informações de faturação",
+            "description": "Morada de faturação e dados fiscais guardados no cliente Stripe do destinatário.",
+            "addressLabel": "Morada de faturação",
+            "taxIdLabel": "IVA / NIF",
+            "taxIdVerification": "Estado de verificação: {status}",
+            "taxIdVerificationStatus": {
+              "verified": "Verificado",
+              "pending": "Pendente",
+              "unverified": "Não verificado",
+              "unavailable": "Indisponível",
+              "verification_failed": "Verificação falhou"
+            },
+            "invoiceEmailLabel": "E-mail de faturação",
+            "invoiceEmailEmpty": "Sem e-mail de faturação registado",
+            "empty": "Sem morada de faturação registada"
+          }
         },
         "Result": {
           "heading": "Fatura",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2891,7 +2891,6 @@
           "billingLoadError": "Não foi possível carregar os dados de faturação do destinatário",
           "billingRefresh": "Atualizar",
           "billingIncomplete": "É necessária uma morada de faturação com país",
-          "billingIncompleteTitle": "Dados de faturação incompletos",
           "billingIncompleteUser": "Este utilizador tem de adicionar uma morada de faturação com país nas definições da conta antes de poder criar uma fatura.",
           "billingIncompleteOrganization": "Esta organização tem de adicionar uma morada de faturação com país nas definições da organização antes de poder criar uma fatura.",
           "BillingDetails": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2891,7 +2891,6 @@
           "billingLoadError": "无法加载收件人的账单信息",
           "billingRefresh": "刷新",
           "billingIncomplete": "需要包含国家的账单地址",
-          "billingIncompleteTitle": "账单信息不完整",
           "billingIncompleteUser": "创建发票前，该用户必须在其账户设置中添加包含国家的账单地址。",
           "billingIncompleteOrganization": "创建发票前，该组织必须在其组织设置中添加包含国家的账单地址。",
           "BillingDetails": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2889,6 +2889,7 @@
           "priceRequired": "请选择价格",
           "billingLoadErrorTitle": "无法加载账单信息",
           "billingLoadError": "无法加载收件人的账单信息",
+          "billingRefresh": "刷新",
           "billingIncomplete": "需要包含国家的账单地址",
           "billingIncompleteTitle": "账单信息不完整",
           "billingIncompleteUser": "创建发票前，该用户必须在其账户设置中添加包含国家的账单地址。",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2886,7 +2886,30 @@
           "createError": "创建发票失败",
           "pricePlaceholder": "选择价格",
           "priceHelper": "用于发票金额的每积分价格。",
-          "priceRequired": "请选择价格"
+          "priceRequired": "请选择价格",
+          "billingLoadErrorTitle": "无法加载账单信息",
+          "billingLoadError": "无法加载收件人的账单信息",
+          "billingIncomplete": "需要包含国家的账单地址",
+          "billingIncompleteTitle": "账单信息不完整",
+          "billingIncompleteUser": "创建发票前，该用户必须在其账户设置中添加包含国家的账单地址。",
+          "billingIncompleteOrganization": "创建发票前，该组织必须在其组织设置中添加包含国家的账单地址。",
+          "BillingDetails": {
+            "title": "账单信息",
+            "description": "存储在收件人 Stripe 客户上的账单地址和税务信息。",
+            "addressLabel": "账单地址",
+            "taxIdLabel": "增值税 / 税号",
+            "taxIdVerification": "验证状态：{status}",
+            "taxIdVerificationStatus": {
+              "verified": "已验证",
+              "pending": "待处理",
+              "unverified": "未验证",
+              "unavailable": "不可用",
+              "verification_failed": "验证失败"
+            },
+            "invoiceEmailLabel": "发票邮箱",
+            "invoiceEmailEmpty": "未设置发票邮箱",
+            "empty": "未设置账单地址"
+          }
         },
         "Result": {
           "heading": "发票",

--- a/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
+++ b/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
@@ -1,0 +1,308 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InvoiceForm } from "@/components/admin/invoices/invoice-form";
+import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
+import type { CreditPriceOption } from "@/lib/services/invoice-admin.service";
+
+const getBillingMock = vi.fn();
+const createInvoiceMock = vi.fn();
+const mockRouterPush = vi.fn();
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const prices: CreditPriceOption[] = [
+  {
+    id: "price_1",
+    amountPerCredit: 100,
+    currency: "usd",
+    nickname: null,
+  },
+];
+
+const completeBillingDetails: StripeCustomerBillingDetails = {
+  stripeCustomerId: "cus_complete",
+  email: "billing@example.com",
+  address: {
+    line1: "123 Main St",
+    line2: null,
+    city: "Berlin",
+    state: null,
+    postalCode: "10115",
+    country: "DE",
+  },
+  taxIds: [],
+};
+
+const incompleteBillingDetails: StripeCustomerBillingDetails = {
+  stripeCustomerId: "cus_incomplete",
+  email: null,
+  address: null,
+  taxIds: [],
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations:
+    (namespace: string) => (key: string, values?: Record<string, unknown>) => {
+      if (
+        namespace === "App.Admin.Invoices" &&
+        key === "Form.BillingDetails.title"
+      ) {
+        return "Billing information";
+      }
+      if (
+        namespace === "App.Admin.Invoices" &&
+        key === "Form.BillingDetails.description"
+      ) {
+        return "Recipient billing description";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "addressLabel"
+      ) {
+        return "Billing address";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "empty"
+      ) {
+        return "No billing address";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "invoiceEmailLabel"
+      ) {
+        return "Invoice email";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "invoiceEmailEmpty"
+      ) {
+        return "No invoice email";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "taxIdLabel"
+      ) {
+        return "VAT / tax ID";
+      }
+      if (key === "Form.billingIncompleteOrganization") {
+        return "Organization billing incomplete";
+      }
+      if (key === "Form.billingLoadErrorTitle") {
+        return "Billing load failed";
+      }
+      if (key === "Form.submit") {
+        return "Create invoice";
+      }
+      if (key === "Form.submitting") {
+        return "Creating…";
+      }
+      if (values && "status" in values) {
+        return `${key}:${values.status}`;
+      }
+      return `${namespace}.${key}`;
+    },
+  useFormatter: () => ({
+    number: (value: number) => String(value),
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/actions/invoice-admin/action", () => ({
+  getAdminRecipientBillingDetailsAction: (...args: unknown[]) =>
+    getBillingMock(...args),
+  createAdminInvoiceAction: (...args: unknown[]) => createInvoiceMock(...args),
+}));
+
+vi.mock("@/lib/actions/admin-search/client", () => ({
+  searchOrganizationsClient: vi.fn(),
+  searchUsersClient: vi.fn(),
+}));
+
+vi.mock("@/components/admin/async-search-combobox", () => ({
+  buildComboboxLabels: () => ({
+    placeholder: "placeholder",
+    searchPlaceholder: "search",
+    loading: "loading",
+    empty: "empty",
+    error: "error",
+    idle: "idle",
+    clear: "clear",
+  }),
+  AsyncSearchCombobox: ({
+    onChange,
+  }: {
+    onChange: (
+      value: { id: string; name: string; slug: string } | null,
+    ) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="select-org-1"
+        onClick={() => onChange({ id: "org_1", name: "Acme", slug: "acme" })}
+      >
+        Select Acme
+      </button>
+      <button
+        type="button"
+        data-testid="select-org-2"
+        onClick={() => onChange({ id: "org_2", name: "Beta", slug: "beta" })}
+      >
+        Select Beta
+      </button>
+    </div>
+  ),
+}));
+
+describe("InvoiceForm billing preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBillingMock.mockResolvedValue({
+      ok: true,
+      data: completeBillingDetails,
+    });
+  });
+
+  it("shows billing description and preview after selecting a recipient", async () => {
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+
+    expect(
+      await screen.findByText("Recipient billing description"),
+    ).toBeVisible();
+    expect(await screen.findByText(/123 Main St/)).toBeVisible();
+    expect(getBillingMock).toHaveBeenCalledWith({
+      targetType: "organization",
+      targetId: "org_1",
+    });
+  });
+
+  it("disables submit when billing address has no country", async () => {
+    getBillingMock.mockResolvedValue({
+      ok: true,
+      data: incompleteBillingDetails,
+    });
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+
+    expect(
+      await screen.findByText("Organization billing incomplete"),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Create invoice" }),
+    ).toBeDisabled();
+  });
+
+  it("enables submit when billing is complete and credits are entered", async () => {
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+    await screen.findByText(/123 Main St/);
+    await user.type(screen.getByRole("spinbutton", { name: /credits/i }), "10");
+
+    expect(
+      screen.getByRole("button", { name: "Create invoice" }),
+    ).toBeEnabled();
+  });
+
+  it("shows a billing load error when the fetch action fails", async () => {
+    getBillingMock.mockResolvedValue({
+      ok: false,
+      error: { message: "Stripe unavailable" },
+    });
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+
+    expect(await screen.findByText("Stripe unavailable")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Create invoice" }),
+    ).toBeDisabled();
+  });
+
+  it("ignores stale billing responses when the recipient changes quickly", async () => {
+    const firstLoad = createDeferred<{
+      ok: true;
+      data: StripeCustomerBillingDetails;
+    }>();
+    const secondLoad = createDeferred<{
+      ok: true;
+      data: StripeCustomerBillingDetails;
+    }>();
+
+    getBillingMock
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise);
+
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+    await user.click(screen.getByTestId("select-org-2"));
+
+    secondLoad.resolve({
+      ok: true,
+      data: {
+        ...completeBillingDetails,
+        address: {
+          line1: "Beta Street 2",
+          line2: null,
+          city: "Hamburg",
+          state: null,
+          postalCode: "20095",
+          country: "DE",
+        },
+      },
+    });
+
+    expect(await screen.findByText(/Beta Street 2/)).toBeVisible();
+
+    firstLoad.resolve({
+      ok: true,
+      data: {
+        ...completeBillingDetails,
+        address: {
+          line1: "Stale Acme Street 1",
+          line2: null,
+          city: "Berlin",
+          state: null,
+          postalCode: "10115",
+          country: "DE",
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Stale Acme Street 1/)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Beta Street 2/)).toBeVisible();
+  });
+});

--- a/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
+++ b/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
@@ -252,6 +252,18 @@ describe("InvoiceForm billing preview", () => {
     ).toBeDisabled();
   });
 
+  it("disables submit when billing is complete but credits are empty", async () => {
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+    await screen.findByText(/123 Main St/);
+
+    expect(
+      screen.getByRole("button", { name: "Create invoice" }),
+    ).toBeDisabled();
+  });
+
   it("enables submit when billing is complete and credits are entered", async () => {
     const user = userEvent.setup();
     render(<InvoiceForm prices={prices} />);
@@ -367,7 +379,7 @@ describe("InvoiceForm billing preview", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Create invoice" }),
-    ).toBeEnabled();
+    ).toBeDisabled();
   });
 
   it("loads billing for a user target when the user tab is selected", async () => {

--- a/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
+++ b/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
@@ -106,6 +106,9 @@ vi.mock("next-intl", () => ({
       if (key === "Form.billingLoadErrorTitle") {
         return "Billing load failed";
       }
+      if (key === "Form.billingRefresh") {
+        return "Refresh";
+      }
       if (key === "Form.submit") {
         return "Create invoice";
       }
@@ -304,5 +307,36 @@ describe("InvoiceForm billing preview", () => {
       expect(screen.queryByText(/Stale Acme Street 1/)).not.toBeInTheDocument();
     });
     expect(screen.getByText(/Beta Street 2/)).toBeVisible();
+  });
+
+  it("reloads billing when refresh is clicked", async () => {
+    getBillingMock
+      .mockResolvedValueOnce({
+        ok: true,
+        data: incompleteBillingDetails,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: completeBillingDetails,
+      });
+
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByTestId("select-org-1"));
+    expect(
+      await screen.findByText("Organization billing incomplete"),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(await screen.findByText(/123 Main St/)).toBeVisible();
+    expect(getBillingMock).toHaveBeenCalledTimes(2);
+    expect(
+      screen.queryByText("Organization billing incomplete"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create invoice" }),
+    ).toBeEnabled();
   });
 });

--- a/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
+++ b/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
@@ -103,6 +103,12 @@ vi.mock("next-intl", () => ({
       if (key === "Form.billingIncompleteOrganization") {
         return "Organization billing incomplete";
       }
+      if (key === "Form.billingIncompleteUser") {
+        return "User billing incomplete";
+      }
+      if (key === "Form.Tabs.user") {
+        return "User";
+      }
       if (key === "Form.billingLoadErrorTitle") {
         return "Billing load failed";
       }
@@ -139,8 +145,8 @@ vi.mock("@/lib/actions/invoice-admin/action", () => ({
 }));
 
 vi.mock("@/lib/actions/admin-search/client", () => ({
-  searchOrganizationsClient: vi.fn(),
-  searchUsersClient: vi.fn(),
+  searchOrganizationsClient: { __type: "organization" },
+  searchUsersClient: { __type: "user" },
 }));
 
 vi.mock("@/components/admin/async-search-combobox", () => ({
@@ -155,28 +161,52 @@ vi.mock("@/components/admin/async-search-combobox", () => ({
   }),
   AsyncSearchCombobox: ({
     onChange,
+    search,
   }: {
     onChange: (
-      value: { id: string; name: string; slug: string } | null,
+      value: {
+        id: string;
+        name: string;
+        slug?: string;
+        email?: string;
+      } | null,
     ) => void;
-  }) => (
-    <div>
-      <button
-        type="button"
-        data-testid="select-org-1"
-        onClick={() => onChange({ id: "org_1", name: "Acme", slug: "acme" })}
-      >
-        Select Acme
-      </button>
-      <button
-        type="button"
-        data-testid="select-org-2"
-        onClick={() => onChange({ id: "org_2", name: "Beta", slug: "beta" })}
-      >
-        Select Beta
-      </button>
-    </div>
-  ),
+    search: { __type?: string };
+  }) =>
+    search.__type === "user" ? (
+      <div>
+        <button
+          type="button"
+          data-testid="select-user-1"
+          onClick={() =>
+            onChange({
+              id: "user_1",
+              name: "Ada Lovelace",
+              email: "ada@example.com",
+            })
+          }
+        >
+          Select Ada
+        </button>
+      </div>
+    ) : (
+      <div>
+        <button
+          type="button"
+          data-testid="select-org-1"
+          onClick={() => onChange({ id: "org_1", name: "Acme", slug: "acme" })}
+        >
+          Select Acme
+        </button>
+        <button
+          type="button"
+          data-testid="select-org-2"
+          onClick={() => onChange({ id: "org_2", name: "Beta", slug: "beta" })}
+        >
+          Select Beta
+        </button>
+      </div>
+    ),
 }));
 
 describe("InvoiceForm billing preview", () => {
@@ -338,5 +368,19 @@ describe("InvoiceForm billing preview", () => {
     expect(
       screen.getByRole("button", { name: "Create invoice" }),
     ).toBeEnabled();
+  });
+
+  it("loads billing for a user target when the user tab is selected", async () => {
+    const user = userEvent.setup();
+    render(<InvoiceForm prices={prices} />);
+
+    await user.click(screen.getByRole("tab", { name: "User" }));
+    await user.click(screen.getByTestId("select-user-1"));
+
+    expect(await screen.findByText(/123 Main St/)).toBeVisible();
+    expect(getBillingMock).toHaveBeenCalledWith({
+      targetType: "user",
+      targetId: "user_1",
+    });
   });
 });

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -4,7 +4,7 @@ import { hasStripeBillingAddressWithCountry } from "@sokosumi/utils";
 import { AlertCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -88,6 +88,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
     useState<StripeCustomerBillingDetails | null>(null);
   const [isBillingLoading, setIsBillingLoading] = useState(false);
   const [billingLoadError, setBillingLoadError] = useState<string | null>(null);
+  const billingLoadIdRef = useRef(0);
 
   const orgLabels = buildComboboxLabels(tOrg);
   const userLabels = buildComboboxLabels(tUser);
@@ -114,6 +115,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
     nextTargetType: InvoiceTargetType,
     targetId: string,
   ) {
+    const loadId = ++billingLoadIdRef.current;
     setIsBillingLoading(true);
     setBillingLoadError(null);
     setBillingDetails(null);
@@ -123,13 +125,18 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
         targetType: nextTargetType,
         targetId,
       });
+      if (loadId !== billingLoadIdRef.current) {
+        return;
+      }
       if (!result.ok) {
         setBillingLoadError(result.error.message ?? t("Form.billingLoadError"));
         return;
       }
       setBillingDetails(result.data);
     } finally {
-      setIsBillingLoading(false);
+      if (loadId === billingLoadIdRef.current) {
+        setIsBillingLoading(false);
+      }
     }
   }
 
@@ -271,9 +278,14 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
           aria-labelledby="invoice-recipient-billing"
           className="bg-muted/30 space-y-4 rounded-lg border p-4"
         >
-          <h3 className="text-sm font-medium" id="invoice-recipient-billing">
-            {t("Form.BillingDetails.title")}
-          </h3>
+          <div className="space-y-1">
+            <h3 className="text-sm font-medium" id="invoice-recipient-billing">
+              {t("Form.BillingDetails.title")}
+            </h3>
+            <p className="text-muted-foreground text-sm">
+              {t("Form.BillingDetails.description")}
+            </p>
+          </div>
 
           {isBillingLoading ? (
             <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { hasStripeBillingAddressWithCountry } from "@sokosumi/utils";
+import { AlertCircle, MapPin } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
 import { type FormEvent, useState } from "react";
@@ -9,6 +11,8 @@ import {
   AsyncSearchCombobox,
   buildComboboxLabels,
 } from "@/components/admin/async-search-combobox";
+import { StripeBillingInformationContent } from "@/components/billing/stripe-billing-information-content";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,12 +24,17 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   searchOrganizationsClient,
   searchUsersClient,
 } from "@/lib/actions/admin-search/client";
-import { createAdminInvoiceAction } from "@/lib/actions/invoice-admin/action";
+import {
+  createAdminInvoiceAction,
+  getAdminRecipientBillingDetailsAction,
+} from "@/lib/actions/invoice-admin/action";
+import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
 import type { AdminOrganizationOption } from "@/lib/services/admin-organization.service";
 import type { AdminUserOption } from "@/lib/services/admin-user.service";
 import type {
@@ -62,8 +71,6 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
   const router = useRouter();
   const formatter = useFormatter();
   const defaultPriceId = prices[0]?.id ?? "";
-  // Pad every price to the same number of decimals so the values line up in
-  // the dropdown (combined with tabular-nums on render).
   const priceFractionDigits = Math.max(
     2,
     ...prices.map((price) => countDecimals(price.amountPerCredit) + 2),
@@ -79,9 +86,84 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
   const [expiryDaysInput, setExpiryDaysInput] = useState("");
   const [priceId, setPriceId] = useState(defaultPriceId);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [billingDetails, setBillingDetails] =
+    useState<StripeCustomerBillingDetails | null>(null);
+  const [isBillingLoading, setIsBillingLoading] = useState(false);
+  const [billingLoadError, setBillingLoadError] = useState<string | null>(null);
 
   const orgLabels = buildComboboxLabels(tOrg);
   const userLabels = buildComboboxLabels(tUser);
+
+  const selectedTargetId =
+    targetType === "user" ? selectedUser?.id : selectedOrg?.id;
+  const hasCompleteBilling =
+    billingDetails !== null &&
+    hasStripeBillingAddressWithCountry(billingDetails.address);
+  const canCreateInvoice =
+    Boolean(selectedTargetId) &&
+    !isBillingLoading &&
+    billingLoadError === null &&
+    hasCompleteBilling &&
+    !isSubmitting;
+
+  function clearBillingState() {
+    setBillingDetails(null);
+    setBillingLoadError(null);
+    setIsBillingLoading(false);
+  }
+
+  async function loadRecipientBillingDetails(
+    nextTargetType: InvoiceTargetType,
+    targetId: string,
+  ) {
+    setIsBillingLoading(true);
+    setBillingLoadError(null);
+    setBillingDetails(null);
+
+    try {
+      const result = await getAdminRecipientBillingDetailsAction({
+        targetType: nextTargetType,
+        targetId,
+      });
+      if (!result.ok) {
+        setBillingLoadError(result.error.message ?? t("Form.billingLoadError"));
+        return;
+      }
+      setBillingDetails(result.data);
+    } finally {
+      setIsBillingLoading(false);
+    }
+  }
+
+  function handleTargetTypeChange(value: string) {
+    const nextTargetType = value as InvoiceTargetType;
+    setTargetType(nextTargetType);
+    clearBillingState();
+
+    const targetId =
+      nextTargetType === "user" ? selectedUser?.id : selectedOrg?.id;
+    if (targetId) {
+      void loadRecipientBillingDetails(nextTargetType, targetId);
+    }
+  }
+
+  function handleOrganizationChange(org: AdminOrganizationOption | null) {
+    setSelectedOrg(org);
+    if (!org) {
+      clearBillingState();
+      return;
+    }
+    void loadRecipientBillingDetails("organization", org.id);
+  }
+
+  function handleUserChange(user: AdminUserOption | null) {
+    setSelectedUser(user);
+    if (!user) {
+      clearBillingState();
+      return;
+    }
+    void loadRecipientBillingDetails("user", user.id);
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -89,6 +171,11 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
     const targetId = targetType === "user" ? selectedUser?.id : selectedOrg?.id;
     if (!targetId) {
       toast.error(t("Form.targetRequired"));
+      return;
+    }
+
+    if (!hasCompleteBilling) {
+      toast.error(t("Form.billingIncomplete"));
       return;
     }
 
@@ -124,7 +211,6 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
         return;
       }
       toast.success(t("Form.createSuccess"));
-      // The invoice detail page doubles as the post-creation summary view.
       router.push(`/admin/invoices/${result.data.invoiceId}`);
     } finally {
       setIsSubmitting(false);
@@ -135,10 +221,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="space-y-2">
         <Label htmlFor="target">{t("Form.Fields.target")}</Label>
-        <Tabs
-          value={targetType}
-          onValueChange={(value) => setTargetType(value as InvoiceTargetType)}
-        >
+        <Tabs value={targetType} onValueChange={handleTargetTypeChange}>
           <TabsList>
             <TabsTrigger value="organization">
               {t("Form.Tabs.organization")}
@@ -150,7 +233,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
           <AsyncSearchCombobox<AdminOrganizationOption>
             id="target"
             value={selectedOrg}
-            onChange={setSelectedOrg}
+            onChange={handleOrganizationChange}
             search={searchOrganizationsClient}
             getKey={(org) => org.id}
             getTriggerLabel={(org) => org.name}
@@ -168,7 +251,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
           <AsyncSearchCombobox<AdminUserOption>
             id="target"
             value={selectedUser}
-            onChange={setSelectedUser}
+            onChange={handleUserChange}
             search={searchUsersClient}
             getKey={(user) => user.id}
             getTriggerLabel={(user) => user.name}
@@ -184,6 +267,56 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
           />
         )}
       </div>
+
+      {selectedTargetId ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <MapPin className="size-5" />
+            <div className="space-y-0.5">
+              <p className="font-medium">{t("Form.BillingDetails.title")}</p>
+              <p className="text-muted-foreground text-sm">
+                {t("Form.BillingDetails.description")}
+              </p>
+            </div>
+          </div>
+
+          {isBillingLoading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+          ) : null}
+
+          {!isBillingLoading && billingLoadError ? (
+            <Alert variant="destructive">
+              <AlertCircle />
+              <AlertTitle>{t("Form.billingLoadErrorTitle")}</AlertTitle>
+              <AlertDescription>{billingLoadError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {!isBillingLoading && !billingLoadError && billingDetails ? (
+            <div className="space-y-3">
+              <StripeBillingInformationContent
+                billingDetails={billingDetails}
+                translationNamespace="App.Admin.Invoices.Form.BillingDetails"
+              />
+              {!hasCompleteBilling ? (
+                <Alert variant="destructive">
+                  <AlertCircle />
+                  <AlertTitle>{t("Form.billingIncompleteTitle")}</AlertTitle>
+                  <AlertDescription>
+                    {targetType === "organization"
+                      ? t("Form.billingIncompleteOrganization")
+                      : t("Form.billingIncompleteUser")}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <Separator />
 
@@ -250,7 +383,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
 
       <Separator />
 
-      <Button type="submit" disabled={isSubmitting}>
+      <Button type="submit" disabled={!canCreateInvoice}>
         {isSubmitting ? t("Form.submitting") : t("Form.submit")}
       </Button>
     </form>

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { hasStripeBillingAddressWithCountry } from "@sokosumi/utils";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
 import { type FormEvent, useRef, useState } from "react";
@@ -114,11 +114,14 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
   async function loadRecipientBillingDetails(
     nextTargetType: InvoiceTargetType,
     targetId: string,
+    options?: { preserveExisting?: boolean },
   ) {
     const loadId = ++billingLoadIdRef.current;
     setIsBillingLoading(true);
     setBillingLoadError(null);
-    setBillingDetails(null);
+    if (!options?.preserveExisting) {
+      setBillingDetails(null);
+    }
 
     try {
       const result = await getAdminRecipientBillingDetailsAction({
@@ -168,6 +171,15 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
       return;
     }
     void loadRecipientBillingDetails("user", user.id);
+  }
+
+  function handleRefreshBilling() {
+    if (!selectedTargetId) {
+      return;
+    }
+    void loadRecipientBillingDetails(targetType, selectedTargetId, {
+      preserveExisting: true,
+    });
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -278,13 +290,31 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
           aria-labelledby="invoice-recipient-billing"
           className="bg-muted/30 space-y-4 rounded-lg border p-4"
         >
-          <div className="space-y-1">
-            <h3 className="text-sm font-medium" id="invoice-recipient-billing">
-              {t("Form.BillingDetails.title")}
-            </h3>
-            <p className="text-muted-foreground text-sm">
-              {t("Form.BillingDetails.description")}
-            </p>
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <h3
+                className="text-sm font-medium"
+                id="invoice-recipient-billing"
+              >
+                {t("Form.BillingDetails.title")}
+              </h3>
+              <p className="text-muted-foreground text-sm">
+                {t("Form.BillingDetails.description")}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleRefreshBilling}
+              disabled={isBillingLoading}
+              aria-label={t("Form.billingRefresh")}
+            >
+              <RefreshCw
+                className={`size-4 ${isBillingLoading ? "animate-spin" : ""}`}
+              />
+              {t("Form.billingRefresh")}
+            </Button>
           </div>
 
           {isBillingLoading ? (

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -98,11 +98,13 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
   const hasCompleteBilling =
     billingDetails !== null &&
     hasStripeBillingAddressWithCountry(billingDetails.address);
+  const hasValidCredits = parseOptionalPositiveInteger(creditsInput) !== null;
   const canCreateInvoice =
     Boolean(selectedTargetId) &&
     !isBillingLoading &&
     billingLoadError === null &&
     hasCompleteBilling &&
+    hasValidCredits &&
     !isSubmitting;
 
   function clearBillingState() {

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { hasStripeBillingAddressWithCountry } from "@sokosumi/utils";
-import { AlertCircle, MapPin } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
 import { type FormEvent, useState } from "react";
@@ -12,7 +12,6 @@ import {
   buildComboboxLabels,
 } from "@/components/admin/async-search-combobox";
 import { StripeBillingInformationContent } from "@/components/billing/stripe-billing-information-content";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,7 +22,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -218,8 +216,8 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="space-y-2">
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <div className="space-y-3">
         <Label htmlFor="target">{t("Form.Fields.target")}</Label>
         <Tabs value={targetType} onValueChange={handleTargetTypeChange}>
           <TabsList>
@@ -269,123 +267,119 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
       </div>
 
       {selectedTargetId ? (
-        <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <MapPin className="size-5" />
-            <div className="space-y-0.5">
-              <p className="font-medium">{t("Form.BillingDetails.title")}</p>
-              <p className="text-muted-foreground text-sm">
-                {t("Form.BillingDetails.description")}
-              </p>
-            </div>
-          </div>
+        <section
+          aria-labelledby="invoice-recipient-billing"
+          className="bg-muted/30 space-y-4 rounded-lg border p-4"
+        >
+          <h3 className="text-sm font-medium" id="invoice-recipient-billing">
+            {t("Form.BillingDetails.title")}
+          </h3>
 
           {isBillingLoading ? (
-            <div className="space-y-3">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-16 w-full" />
-              <Skeleton className="h-4 w-48" />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Skeleton className="h-14 w-full" />
+              <Skeleton className="h-14 w-full" />
             </div>
           ) : null}
 
           {!isBillingLoading && billingLoadError ? (
-            <Alert variant="destructive">
-              <AlertCircle />
-              <AlertTitle>{t("Form.billingLoadErrorTitle")}</AlertTitle>
-              <AlertDescription>{billingLoadError}</AlertDescription>
-            </Alert>
+            <p className="text-destructive flex items-start gap-2 text-sm">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <span>
+                <span className="font-medium">
+                  {t("Form.billingLoadErrorTitle")}.{" "}
+                </span>
+                {billingLoadError}
+              </span>
+            </p>
           ) : null}
 
           {!isBillingLoading && !billingLoadError && billingDetails ? (
-            <div className="space-y-3">
+            <>
               <StripeBillingInformationContent
                 billingDetails={billingDetails}
                 translationNamespace="App.Admin.Invoices.Form.BillingDetails"
               />
               {!hasCompleteBilling ? (
-                <Alert variant="destructive">
-                  <AlertCircle />
-                  <AlertTitle>{t("Form.billingIncompleteTitle")}</AlertTitle>
-                  <AlertDescription>
-                    {targetType === "organization"
-                      ? t("Form.billingIncompleteOrganization")
-                      : t("Form.billingIncompleteUser")}
-                  </AlertDescription>
-                </Alert>
+                <p className="text-destructive border-t pt-3 text-sm">
+                  {targetType === "organization"
+                    ? t("Form.billingIncompleteOrganization")
+                    : t("Form.billingIncompleteUser")}
+                </p>
               ) : null}
-            </div>
+            </>
           ) : null}
-        </div>
+        </section>
       ) : null}
 
-      <Separator />
-
-      <div className="space-y-2">
-        <Label htmlFor="price">{t("Form.Fields.price")}</Label>
-        <Select value={priceId} onValueChange={setPriceId}>
-          <SelectTrigger id="price" className="w-full">
-            <SelectValue placeholder={t("Form.pricePlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            {prices.map((price) => (
-              <SelectItem key={price.id} value={price.id}>
-                <span className="tabular-nums">
-                  {formatter.number(price.amountPerCredit / 100, {
-                    style: "currency",
-                    currency: price.currency.toUpperCase(),
-                    minimumFractionDigits: priceFractionDigits,
-                    maximumFractionDigits: priceFractionDigits,
-                  })}
-                </span>
-                {price.nickname ? (
-                  <span className="text-muted-foreground">
-                    {price.nickname}
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="price">{t("Form.Fields.price")}</Label>
+          <Select value={priceId} onValueChange={setPriceId}>
+            <SelectTrigger id="price" className="w-full">
+              <SelectValue placeholder={t("Form.pricePlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {prices.map((price) => (
+                <SelectItem key={price.id} value={price.id}>
+                  <span className="tabular-nums">
+                    {formatter.number(price.amountPerCredit / 100, {
+                      style: "currency",
+                      currency: price.currency.toUpperCase(),
+                      minimumFractionDigits: priceFractionDigits,
+                      maximumFractionDigits: priceFractionDigits,
+                    })}
                   </span>
-                ) : null}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+                  {price.nickname ? (
+                    <span className="text-muted-foreground">
+                      {price.nickname}
+                    </span>
+                  ) : null}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="credits">{t("Form.Fields.credits")}</Label>
+            <Input
+              id="credits"
+              type="number"
+              min={1}
+              step={1}
+              value={creditsInput}
+              onChange={(event) => setCreditsInput(event.target.value)}
+              required
+            />
+            <p className="text-muted-foreground text-xs">
+              {t("Form.creditsHelper")}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="expiryDays">{t("Form.Fields.expiryDays")}</Label>
+            <Input
+              id="expiryDays"
+              type="number"
+              min={1}
+              step={1}
+              value={expiryDaysInput}
+              onChange={(event) => setExpiryDaysInput(event.target.value)}
+              placeholder={t("Form.expiryPlaceholder")}
+            />
+            <p className="text-muted-foreground text-xs">
+              {t("Form.expiryHelper")}
+            </p>
+          </div>
+        </div>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor="credits">{t("Form.Fields.credits")}</Label>
-          <Input
-            id="credits"
-            type="number"
-            min={1}
-            step={1}
-            value={creditsInput}
-            onChange={(event) => setCreditsInput(event.target.value)}
-            required
-          />
-          <p className="text-muted-foreground text-xs">
-            {t("Form.creditsHelper")}
-          </p>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="expiryDays">{t("Form.Fields.expiryDays")}</Label>
-          <Input
-            id="expiryDays"
-            type="number"
-            min={1}
-            step={1}
-            value={expiryDaysInput}
-            onChange={(event) => setExpiryDaysInput(event.target.value)}
-            placeholder={t("Form.expiryPlaceholder")}
-          />
-          <p className="text-muted-foreground text-xs">
-            {t("Form.expiryHelper")}
-          </p>
-        </div>
+      <div className="flex justify-end border-t pt-6">
+        <Button type="submit" disabled={!canCreateInvoice}>
+          {isSubmitting ? t("Form.submitting") : t("Form.submit")}
+        </Button>
       </div>
-
-      <Separator />
-
-      <Button type="submit" disabled={!canCreateInvoice}>
-        {isSubmitting ? t("Form.submitting") : t("Form.submit")}
-      </Button>
     </form>
   );
 }

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -106,6 +106,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
     !isSubmitting;
 
   function clearBillingState() {
+    billingLoadIdRef.current += 1;
     setBillingDetails(null);
     setBillingLoadError(null);
     setIsBillingLoading(false);

--- a/apps/web/src/components/billing/stripe-billing-information-card.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-card.tsx
@@ -1,6 +1,7 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
+import { StripeBillingInformationFields } from "@/components/billing/stripe-billing-information-fields";
 import {
   Card,
   CardContent,
@@ -8,12 +9,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { buildStripeBillingInformationFieldsProps } from "@/lib/billing/build-stripe-billing-information-fields-props";
 import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
 
-import {
-  StripeBillingInformationContent,
-  type StripeBillingInformationTranslationNamespace,
-} from "./stripe-billing-information-content";
+export type StripeBillingInformationTranslationNamespace =
+  | "App.Account.BillingDetails"
+  | "App.Organizations.OrganizationDetail.BillingDetails";
 
 export interface StripeBillingInformationCardProps {
   billingDetails: StripeCustomerBillingDetails;
@@ -26,7 +27,10 @@ export async function StripeBillingInformationCard({
   portalLink,
   translationNamespace,
 }: StripeBillingInformationCardProps) {
-  const t = await getTranslations(translationNamespace);
+  const [t, locale] = await Promise.all([
+    getTranslations(translationNamespace),
+    getLocale(),
+  ]);
 
   return (
     <Card>
@@ -35,10 +39,13 @@ export async function StripeBillingInformationCard({
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent>
-        <StripeBillingInformationContent
-          billingDetails={billingDetails}
+        <StripeBillingInformationFields
+          {...buildStripeBillingInformationFieldsProps(
+            billingDetails,
+            t,
+            locale,
+          )}
           portalLink={portalLink}
-          translationNamespace={translationNamespace}
         />
       </CardContent>
     </Card>

--- a/apps/web/src/components/billing/stripe-billing-information-card.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-card.tsx
@@ -1,4 +1,3 @@
-import { MapPin } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
@@ -32,10 +31,7 @@ export async function StripeBillingInformationCard({
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center gap-2">
-          <MapPin className="size-5" />
-          <CardTitle>{t("title")}</CardTitle>
-        </div>
+        <CardTitle>{t("title")}</CardTitle>
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent>

--- a/apps/web/src/components/billing/stripe-billing-information-card.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-card.tsx
@@ -1,7 +1,10 @@
 import { getLocale, getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
-import { StripeBillingInformationFields } from "@/components/billing/stripe-billing-information-fields";
+import {
+  StripeBillingInformationFields,
+  type StripeBillingInformationTranslationNamespace,
+} from "@/components/billing/stripe-billing-information-fields";
 import {
   Card,
   CardContent,
@@ -11,10 +14,6 @@ import {
 } from "@/components/ui/card";
 import { buildStripeBillingInformationFieldsProps } from "@/lib/billing/build-stripe-billing-information-fields-props";
 import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
-
-export type StripeBillingInformationTranslationNamespace =
-  | "App.Account.BillingDetails"
-  | "App.Organizations.OrganizationDetail.BillingDetails";
 
 export interface StripeBillingInformationCardProps {
   billingDetails: StripeCustomerBillingDetails;

--- a/apps/web/src/components/billing/stripe-billing-information-card.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-card.tsx
@@ -1,5 +1,5 @@
 import { MapPin } from "lucide-react";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
 import {
@@ -9,16 +9,17 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { formatStripeBillingAddress } from "@/lib/billing/format-stripe-billing-address";
-import { formatStripeTaxIdVerificationStatus } from "@/lib/billing/format-stripe-tax-id-verification-status";
 import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
+
+import {
+  StripeBillingInformationContent,
+  type StripeBillingInformationTranslationNamespace,
+} from "./stripe-billing-information-content";
 
 export interface StripeBillingInformationCardProps {
   billingDetails: StripeCustomerBillingDetails;
   portalLink?: ReactNode;
-  translationNamespace:
-    | "App.Account.BillingDetails"
-    | "App.Organizations.OrganizationDetail.BillingDetails";
+  translationNamespace: StripeBillingInformationTranslationNamespace;
 }
 
 export async function StripeBillingInformationCard({
@@ -27,10 +28,6 @@ export async function StripeBillingInformationCard({
   translationNamespace,
 }: StripeBillingInformationCardProps) {
   const t = await getTranslations(translationNamespace);
-  const locale = await getLocale();
-  const formattedAddress = billingDetails.address
-    ? formatStripeBillingAddress(billingDetails.address, locale)
-    : null;
 
   return (
     <Card>
@@ -41,49 +38,12 @@ export async function StripeBillingInformationCard({
         </div>
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-6">
-        <div className="space-y-1">
-          <p className="text-muted-foreground text-sm">{t("addressLabel")}</p>
-          {formattedAddress ? (
-            <p className="text-sm whitespace-pre-line">{formattedAddress}</p>
-          ) : (
-            <p className="text-muted-foreground text-sm">{t("empty")}</p>
-          )}
-        </div>
-
-        {billingDetails.taxIds.length > 0 ? (
-          <div className="space-y-3">
-            <p className="text-muted-foreground text-sm">{t("taxIdLabel")}</p>
-            {billingDetails.taxIds.map((taxId) => (
-              <div key={taxId.id} className="space-y-1 text-sm">
-                <p>{taxId.value}</p>
-                {taxId.verificationStatus ? (
-                  <p className="text-muted-foreground text-xs">
-                    {formatStripeTaxIdVerificationStatus(
-                      t,
-                      taxId.verificationStatus,
-                    )}
-                  </p>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        ) : null}
-
-        <div className="space-y-1">
-          <p className="text-muted-foreground text-sm">
-            {t("invoiceEmailLabel")}
-          </p>
-          <p className="text-sm">
-            {billingDetails.email ?? (
-              <span className="text-muted-foreground">
-                {t("invoiceEmailEmpty")}
-              </span>
-            )}
-          </p>
-        </div>
-
-        {portalLink ? <div className="border-t pt-2">{portalLink}</div> : null}
+      <CardContent>
+        <StripeBillingInformationContent
+          billingDetails={billingDetails}
+          portalLink={portalLink}
+          translationNamespace={translationNamespace}
+        />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/billing/stripe-billing-information-content.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-content.tsx
@@ -29,50 +29,64 @@ export function StripeBillingInformationContent({
     ? formatStripeBillingAddress(billingDetails.address, locale)
     : null;
 
-  return (
-    <div className="space-y-6">
-      <div className="space-y-1">
-        <p className="text-muted-foreground text-sm">{t("addressLabel")}</p>
-        {formattedAddress ? (
-          <p className="text-sm whitespace-pre-line">{formattedAddress}</p>
-        ) : (
-          <p className="text-muted-foreground text-sm">{t("empty")}</p>
+  const addressField = (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {t("addressLabel")}
+      </p>
+      {formattedAddress ? (
+        <p className="text-sm whitespace-pre-line">{formattedAddress}</p>
+      ) : (
+        <p className="text-muted-foreground text-sm">{t("empty")}</p>
+      )}
+    </div>
+  );
+
+  const taxIdField =
+    billingDetails.taxIds.length > 0 ? (
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {t("taxIdLabel")}
+        </p>
+        {billingDetails.taxIds.map((taxId) => (
+          <div key={taxId.id} className="space-y-0.5 text-sm">
+            <p>{taxId.value}</p>
+            {taxId.verificationStatus ? (
+              <p className="text-muted-foreground text-xs">
+                {formatStripeTaxIdVerificationStatus(
+                  t,
+                  taxId.verificationStatus,
+                )}
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    ) : null;
+
+  const emailField = (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {t("invoiceEmailLabel")}
+      </p>
+      <p className="text-sm">
+        {billingDetails.email ?? (
+          <span className="text-muted-foreground">
+            {t("invoiceEmailEmpty")}
+          </span>
         )}
+      </p>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {addressField}
+        {emailField}
       </div>
-
-      {billingDetails.taxIds.length > 0 ? (
-        <div className="space-y-3">
-          <p className="text-muted-foreground text-sm">{t("taxIdLabel")}</p>
-          {billingDetails.taxIds.map((taxId) => (
-            <div key={taxId.id} className="space-y-1 text-sm">
-              <p>{taxId.value}</p>
-              {taxId.verificationStatus ? (
-                <p className="text-muted-foreground text-xs">
-                  {formatStripeTaxIdVerificationStatus(
-                    t,
-                    taxId.verificationStatus,
-                  )}
-                </p>
-              ) : null}
-            </div>
-          ))}
-        </div>
-      ) : null}
-
-      <div className="space-y-1">
-        <p className="text-muted-foreground text-sm">
-          {t("invoiceEmailLabel")}
-        </p>
-        <p className="text-sm">
-          {billingDetails.email ?? (
-            <span className="text-muted-foreground">
-              {t("invoiceEmailEmpty")}
-            </span>
-          )}
-        </p>
-      </div>
-
-      {portalLink ? <div className="border-t pt-2">{portalLink}</div> : null}
+      {taxIdField}
+      {portalLink ? <div className="border-t pt-3">{portalLink}</div> : null}
     </div>
   );
 }

--- a/apps/web/src/components/billing/stripe-billing-information-content.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-content.tsx
@@ -3,14 +3,12 @@
 import { useLocale, useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
-import { StripeBillingInformationFields } from "@/components/billing/stripe-billing-information-fields";
+import {
+  StripeBillingInformationFields,
+  type StripeBillingInformationTranslationNamespace,
+} from "@/components/billing/stripe-billing-information-fields";
 import { buildStripeBillingInformationFieldsProps } from "@/lib/billing/build-stripe-billing-information-fields-props";
 import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
-
-export type StripeBillingInformationTranslationNamespace =
-  | "App.Account.BillingDetails"
-  | "App.Organizations.OrganizationDetail.BillingDetails"
-  | "App.Admin.Invoices.Form.BillingDetails";
 
 export interface StripeBillingInformationContentProps {
   billingDetails: StripeCustomerBillingDetails;

--- a/apps/web/src/components/billing/stripe-billing-information-content.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-content.tsx
@@ -3,8 +3,8 @@
 import { useLocale, useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
-import { formatStripeBillingAddress } from "@/lib/billing/format-stripe-billing-address";
-import { formatStripeTaxIdVerificationStatus } from "@/lib/billing/format-stripe-tax-id-verification-status";
+import { StripeBillingInformationFields } from "@/components/billing/stripe-billing-information-fields";
+import { buildStripeBillingInformationFieldsProps } from "@/lib/billing/build-stripe-billing-information-fields-props";
 import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
 
 export type StripeBillingInformationTranslationNamespace =
@@ -25,68 +25,11 @@ export function StripeBillingInformationContent({
 }: StripeBillingInformationContentProps) {
   const t = useTranslations(translationNamespace);
   const locale = useLocale();
-  const formattedAddress = billingDetails.address
-    ? formatStripeBillingAddress(billingDetails.address, locale)
-    : null;
-
-  const addressField = (
-    <div className="space-y-1">
-      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-        {t("addressLabel")}
-      </p>
-      {formattedAddress ? (
-        <p className="text-sm whitespace-pre-line">{formattedAddress}</p>
-      ) : (
-        <p className="text-muted-foreground text-sm">{t("empty")}</p>
-      )}
-    </div>
-  );
-
-  const taxIdField =
-    billingDetails.taxIds.length > 0 ? (
-      <div className="space-y-2">
-        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-          {t("taxIdLabel")}
-        </p>
-        {billingDetails.taxIds.map((taxId) => (
-          <div key={taxId.id} className="space-y-0.5 text-sm">
-            <p>{taxId.value}</p>
-            {taxId.verificationStatus ? (
-              <p className="text-muted-foreground text-xs">
-                {formatStripeTaxIdVerificationStatus(
-                  t,
-                  taxId.verificationStatus,
-                )}
-              </p>
-            ) : null}
-          </div>
-        ))}
-      </div>
-    ) : null;
-
-  const emailField = (
-    <div className="space-y-1">
-      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-        {t("invoiceEmailLabel")}
-      </p>
-      <p className="text-sm">
-        {billingDetails.email ?? (
-          <span className="text-muted-foreground">
-            {t("invoiceEmailEmpty")}
-          </span>
-        )}
-      </p>
-    </div>
-  );
 
   return (
-    <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-2">
-        {addressField}
-        {emailField}
-      </div>
-      {taxIdField}
-      {portalLink ? <div className="border-t pt-3">{portalLink}</div> : null}
-    </div>
+    <StripeBillingInformationFields
+      {...buildStripeBillingInformationFieldsProps(billingDetails, t, locale)}
+      portalLink={portalLink}
+    />
   );
 }

--- a/apps/web/src/components/billing/stripe-billing-information-content.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-content.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+import { formatStripeBillingAddress } from "@/lib/billing/format-stripe-billing-address";
+import { formatStripeTaxIdVerificationStatus } from "@/lib/billing/format-stripe-tax-id-verification-status";
+import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
+
+export type StripeBillingInformationTranslationNamespace =
+  | "App.Account.BillingDetails"
+  | "App.Organizations.OrganizationDetail.BillingDetails"
+  | "App.Admin.Invoices.Form.BillingDetails";
+
+export interface StripeBillingInformationContentProps {
+  billingDetails: StripeCustomerBillingDetails;
+  portalLink?: ReactNode;
+  translationNamespace: StripeBillingInformationTranslationNamespace;
+}
+
+export function StripeBillingInformationContent({
+  billingDetails,
+  portalLink,
+  translationNamespace,
+}: StripeBillingInformationContentProps) {
+  const t = useTranslations(translationNamespace);
+  const locale = useLocale();
+  const formattedAddress = billingDetails.address
+    ? formatStripeBillingAddress(billingDetails.address, locale)
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <p className="text-muted-foreground text-sm">{t("addressLabel")}</p>
+        {formattedAddress ? (
+          <p className="text-sm whitespace-pre-line">{formattedAddress}</p>
+        ) : (
+          <p className="text-muted-foreground text-sm">{t("empty")}</p>
+        )}
+      </div>
+
+      {billingDetails.taxIds.length > 0 ? (
+        <div className="space-y-3">
+          <p className="text-muted-foreground text-sm">{t("taxIdLabel")}</p>
+          {billingDetails.taxIds.map((taxId) => (
+            <div key={taxId.id} className="space-y-1 text-sm">
+              <p>{taxId.value}</p>
+              {taxId.verificationStatus ? (
+                <p className="text-muted-foreground text-xs">
+                  {formatStripeTaxIdVerificationStatus(
+                    t,
+                    taxId.verificationStatus,
+                  )}
+                </p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="space-y-1">
+        <p className="text-muted-foreground text-sm">
+          {t("invoiceEmailLabel")}
+        </p>
+        <p className="text-sm">
+          {billingDetails.email ?? (
+            <span className="text-muted-foreground">
+              {t("invoiceEmailEmpty")}
+            </span>
+          )}
+        </p>
+      </div>
+
+      {portalLink ? <div className="border-t pt-2">{portalLink}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/stripe-billing-information-fields.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-fields.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+
+import type { StripeBillingInformationFieldsContent } from "@/lib/billing/build-stripe-billing-information-fields-props";
+
+export interface StripeBillingInformationFieldsProps
+  extends StripeBillingInformationFieldsContent {
+  portalLink?: ReactNode;
+}
+
+export function StripeBillingInformationFields({
+  addressLabel,
+  formattedAddress,
+  emptyAddressText,
+  invoiceEmailLabel,
+  invoiceEmail,
+  invoiceEmailEmpty,
+  taxIdLabel,
+  taxIds,
+  portalLink,
+}: StripeBillingInformationFieldsProps) {
+  const addressField = (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {addressLabel}
+      </p>
+      {formattedAddress ? (
+        <p className="text-sm whitespace-pre-line">{formattedAddress}</p>
+      ) : (
+        <p className="text-muted-foreground text-sm">{emptyAddressText}</p>
+      )}
+    </div>
+  );
+
+  const taxIdField =
+    taxIds.length > 0 ? (
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {taxIdLabel}
+        </p>
+        {taxIds.map((taxId) => (
+          <div key={taxId.id} className="space-y-0.5 text-sm">
+            <p>{taxId.value}</p>
+            {taxId.verificationStatusText ? (
+              <p className="text-muted-foreground text-xs">
+                {taxId.verificationStatusText}
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    ) : null;
+
+  const emailField = (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {invoiceEmailLabel}
+      </p>
+      <p className="text-sm">
+        {invoiceEmail ?? (
+          <span className="text-muted-foreground">{invoiceEmailEmpty}</span>
+        )}
+      </p>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {addressField}
+        {emailField}
+      </div>
+      {taxIdField}
+      {portalLink ? <div className="border-t pt-3">{portalLink}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/stripe-billing-information-fields.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-fields.tsx
@@ -2,6 +2,11 @@ import type { ReactNode } from "react";
 
 import type { StripeBillingInformationFieldsContent } from "@/lib/billing/build-stripe-billing-information-fields-props";
 
+export type StripeBillingInformationTranslationNamespace =
+  | "App.Account.BillingDetails"
+  | "App.Organizations.OrganizationDetail.BillingDetails"
+  | "App.Admin.Invoices.Form.BillingDetails";
+
 export interface StripeBillingInformationFieldsProps
   extends StripeBillingInformationFieldsContent {
   portalLink?: ReactNode;

--- a/apps/web/src/lib/actions/invoice-admin/action.ts
+++ b/apps/web/src/lib/actions/invoice-admin/action.ts
@@ -7,6 +7,7 @@ import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
 import { CoreApiRequestError } from "@/lib/clients/core.shared";
+import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
 import {
   type InvoiceListItem,
   type InvoiceStatusFilter,
@@ -140,6 +141,27 @@ export const markAdminInvoicePaidAction = withSession<
     const summary = await invoiceAdminService.markInvoicePaid(invoiceId);
     revalidatePath("/admin/invoices");
     return Ok(summary);
+  } catch (error) {
+    return Err(mapError(error));
+  }
+});
+
+interface GetAdminRecipientBillingDetailsParameters
+  extends AuthenticatedRequest {
+  targetType: InvoiceTargetType;
+  targetId: string;
+}
+
+export const getAdminRecipientBillingDetailsAction = withSession<
+  GetAdminRecipientBillingDetailsParameters,
+  Result<StripeCustomerBillingDetails, ActionError>
+>(async ({ session, targetType, targetId }) => {
+  try {
+    assertAdminSession(session);
+    const billingDetails = await invoiceAdminService.getRecipientBillingDetails(
+      { targetType, targetId },
+    );
+    return Ok(billingDetails);
   } catch (error) {
     return Err(mapError(error));
   }

--- a/apps/web/src/lib/billing/build-stripe-billing-information-fields-props.ts
+++ b/apps/web/src/lib/billing/build-stripe-billing-information-fields-props.ts
@@ -4,7 +4,7 @@ import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core"
 
 type BillingDetailsTranslator = (
   key: string,
-  values?: Record<string, unknown>,
+  values?: Record<string, string | number | Date>,
 ) => string;
 
 export interface StripeBillingInformationTaxIdField {

--- a/apps/web/src/lib/billing/build-stripe-billing-information-fields-props.ts
+++ b/apps/web/src/lib/billing/build-stripe-billing-information-fields-props.ts
@@ -1,0 +1,50 @@
+import { formatStripeBillingAddress } from "@/lib/billing/format-stripe-billing-address";
+import { formatStripeTaxIdVerificationStatus } from "@/lib/billing/format-stripe-tax-id-verification-status";
+import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
+
+type BillingDetailsTranslator = (
+  key: string,
+  values?: Record<string, unknown>,
+) => string;
+
+export interface StripeBillingInformationTaxIdField {
+  id: string;
+  value: string;
+  verificationStatusText: string | null;
+}
+
+export interface StripeBillingInformationFieldsContent {
+  addressLabel: string;
+  formattedAddress: string | null;
+  emptyAddressText: string;
+  invoiceEmailLabel: string;
+  invoiceEmail: string | null;
+  invoiceEmailEmpty: string;
+  taxIdLabel: string;
+  taxIds: StripeBillingInformationTaxIdField[];
+}
+
+export function buildStripeBillingInformationFieldsProps(
+  billingDetails: StripeCustomerBillingDetails,
+  t: BillingDetailsTranslator,
+  locale: string,
+): StripeBillingInformationFieldsContent {
+  return {
+    addressLabel: t("addressLabel"),
+    formattedAddress: billingDetails.address
+      ? formatStripeBillingAddress(billingDetails.address, locale)
+      : null,
+    emptyAddressText: t("empty"),
+    invoiceEmailLabel: t("invoiceEmailLabel"),
+    invoiceEmail: billingDetails.email,
+    invoiceEmailEmpty: t("invoiceEmailEmpty"),
+    taxIdLabel: t("taxIdLabel"),
+    taxIds: billingDetails.taxIds.map((taxId) => ({
+      id: taxId.id,
+      value: taxId.value,
+      verificationStatusText: taxId.verificationStatus
+        ? formatStripeTaxIdVerificationStatus(t, taxId.verificationStatus)
+        : null,
+    })),
+  };
+}

--- a/apps/web/src/lib/billing/format-stripe-tax-id-verification-status.ts
+++ b/apps/web/src/lib/billing/format-stripe-tax-id-verification-status.ts
@@ -8,7 +8,7 @@ const STRIPE_TAX_ID_VERIFICATION_STATUS_KEYS = {
 
 type BillingDetailsTranslator = (
   key: string,
-  values?: { status?: string },
+  values?: Record<string, string | number | Date>,
 ) => string;
 
 export function formatStripeTaxIdVerificationStatus(

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -1372,6 +1372,19 @@ export function createCoreClient(getClient: GetClient) {
     );
   }
 
+  async function getUserBillingDetails(userId: string) {
+    return executeOperation(
+      getClient,
+      (client) =>
+        coreGetUsersByIdBillingDetails({
+          client,
+          path: { id: userId },
+          cache: "no-store",
+        }),
+      "Failed to fetch user billing details",
+    );
+  }
+
   /**
    * Revokes the current user's OAuth consent: Core deletes the consent,
    * revokes the client's refresh tokens, and deletes its access tokens in a
@@ -2799,6 +2812,7 @@ export function createCoreClient(getClient: GetClient) {
     createMyStripeCustomer,
     createOrganizationStripeCustomer,
     getMyBillingDetails,
+    getUserBillingDetails,
     getMyStripeCustomer,
     getOrganizationActiveSubscription,
     getOrganizationBillingDetails,

--- a/apps/web/src/lib/services/invoice-admin.service.ts
+++ b/apps/web/src/lib/services/invoice-admin.service.ts
@@ -4,6 +4,7 @@ import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 
 import { coreClient } from "@/lib/clients/core.client";
 import { CoreApiRequestError } from "@/lib/clients/core.shared";
+import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
 
 export type InvoiceTargetType = "user" | "organization";
 
@@ -174,6 +175,16 @@ export const invoiceAdminService = {
     const response = await coreClient
       .markAdminInvoicePaid(invoiceId)
       .catch(mapCoreError);
+    return response.data;
+  },
+
+  async getRecipientBillingDetails(
+    target: InvoiceTarget,
+  ): Promise<StripeCustomerBillingDetails> {
+    const response =
+      target.targetType === "user"
+        ? await coreClient.getUserBillingDetails(target.targetId)
+        : await coreClient.getOrganizationBillingDetails(target.targetId);
     return response.data;
   },
 };

--- a/packages/utils/src/__tests__/stripe-billing-address.test.ts
+++ b/packages/utils/src/__tests__/stripe-billing-address.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { hasStripeBillingAddressWithCountry } from "../stripe-billing-address";
+
+describe("hasStripeBillingAddressWithCountry", () => {
+  it("returns false when address is null or undefined", () => {
+    expect(hasStripeBillingAddressWithCountry(null)).toBe(false);
+    expect(hasStripeBillingAddressWithCountry(undefined)).toBe(false);
+  });
+
+  it("returns false when country is empty or whitespace", () => {
+    expect(hasStripeBillingAddressWithCountry({ country: "" })).toBe(false);
+    expect(hasStripeBillingAddressWithCountry({ country: "   " })).toBe(false);
+  });
+
+  it("returns true when country is set", () => {
+    expect(hasStripeBillingAddressWithCountry({ country: "DE" })).toBe(true);
+    expect(hasStripeBillingAddressWithCountry({ country: " US " })).toBe(true);
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -166,6 +166,10 @@ export {
 } from "./organization-metadata.js";
 export { SokosumiJobStatus } from "./sokosumi-job-status.js";
 export {
+  hasStripeBillingAddressWithCountry,
+  type StripeBillingAddressLike,
+} from "./stripe-billing-address.js";
+export {
   getTaskCannotArchiveMessage,
   isTaskArchivableStatus,
   TASK_ARCHIVABLE_STATUSES,

--- a/packages/utils/src/stripe-billing-address.ts
+++ b/packages/utils/src/stripe-billing-address.ts
@@ -1,0 +1,9 @@
+export interface StripeBillingAddressLike {
+  country: string;
+}
+
+export function hasStripeBillingAddressWithCountry(
+  address: StripeBillingAddressLike | null | undefined,
+): boolean {
+  return (address?.country?.trim().length ?? 0) > 0;
+}


### PR DESCRIPTION
## Summary

- Show recipient Stripe billing details on `/admin/invoices/new` when a user or organization is selected.
- Disable **Create invoice** until the recipient has a billing address with country on file (tax ID optional), preventing Stripe automatic tax failures at finalize time.
- Add server-side validation in Core before invoice creation and allow platform admins to read organization billing details without membership.
- Unify billing layout across account, organization, and admin invoice surfaces with a shared compact two-column grid.
- Split billing display into a server-safe fields component so account/org cards stay RSC without extra client hydration.
- Guard the admin billing preview against stale responses when recipients are switched quickly.
- Add a **Refresh** control on the invoice form so admins can reload billing after updating it in Stripe.
- Fetch recipient billing details in parallel with target resolution during Core `createInvoice`.

## Changes

**`packages/utils`**
- `hasStripeBillingAddressWithCountry()` helper + unit tests

**`apps/core`**
- Platform admin org billing read bypass (session-only)
- `createAdminInvoice` validates billing address country
- Parallel billing fetch in `createInvoice`
- Route and service tests, including user-target validation

**`apps/web`**
- Recipient billing fetch via Core API + server action
- Invoice form preview panel with disabled submit, refresh button, and compact error states
- Shared `StripeBillingInformationFields` + props builder
- Invoice form tests (preview, incomplete billing, load error, stale-response race, refresh)

## Test plan

- [x] `pnpm --filter utils test src/__tests__/stripe-billing-address.test.ts`
- [x] `pnpm --filter core test src/services/invoice-admin.service.test.ts src/routes/v1/organizations/[id]/billing-details/get.test.ts`
- [x] `pnpm --filter web test src/components/admin/invoices/__tests__/invoice-form.test.tsx`
- [x] `pnpm --filter web check`
- [x] `pnpm --filter core check`
- [ ] Manual: open `/admin/invoices/new`, select recipient with and without billing address; confirm preview, disabled submit, and successful create only when country is set
- [ ] Manual: switch recipients quickly and confirm billing preview matches the latest selection
- [ ] Manual: update billing in Stripe, click **Refresh** on the invoice form, and confirm preview updates without re-selecting the recipient
- [ ] Manual: confirm account and organization billing pages use the same compact layout