### PR TITLE
feat(admin): show stripe customer id in invoice billing details

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2886,6 +2886,8 @@
             },
             "invoiceEmailLabel": "Rechnungs-E-Mail",
             "invoiceEmailEmpty": "Keine Rechnungs-E-Mail hinterlegt",
+            "stripeCustomerIdLabel": "Stripe-Kunden-ID",
+            "stripeCustomerIdEmpty": "Kein Stripe-Kunde hinterlegt",
             "empty": "Keine Rechnungsadresse hinterlegt"
           }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2853,6 +2853,8 @@
             },
             "invoiceEmailLabel": "Invoice email",
             "invoiceEmailEmpty": "No invoice email on file",
+            "stripeCustomerIdLabel": "Stripe customer ID",
+            "stripeCustomerIdEmpty": "No Stripe customer on file",
             "empty": "No billing address on file"
           }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2886,6 +2886,8 @@
             },
             "invoiceEmailLabel": "Correo de facturación",
             "invoiceEmailEmpty": "No hay correo de facturación registrado",
+            "stripeCustomerIdLabel": "ID de cliente de Stripe",
+            "stripeCustomerIdEmpty": "No hay cliente de Stripe registrado",
             "empty": "No hay dirección de facturación registrada"
           }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2917,6 +2917,8 @@
             },
             "invoiceEmailLabel": "E-mail de facturation",
             "invoiceEmailEmpty": "Aucun e-mail de facturation enregistré",
+            "stripeCustomerIdLabel": "ID client Stripe",
+            "stripeCustomerIdEmpty": "Aucun client Stripe enregistré",
             "empty": "Aucune adresse de facturation enregistrée"
           }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2917,6 +2917,8 @@
             },
             "invoiceEmailLabel": "E-mail di fatturazione",
             "invoiceEmailEmpty": "Nessuna e-mail di fatturazione registrata",
+            "stripeCustomerIdLabel": "ID cliente Stripe",
+            "stripeCustomerIdEmpty": "Nessun cliente Stripe registrato",
             "empty": "Nessun indirizzo di fatturazione registrato"
           }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2917,6 +2917,8 @@
             },
             "invoiceEmailLabel": "請求書メール",
             "invoiceEmailEmpty": "請求書メールが登録されていません",
+            "stripeCustomerIdLabel": "Stripe 顧客 ID",
+            "stripeCustomerIdEmpty": "Stripe顧客が登録されていません",
             "empty": "請求先住所が登録されていません"
           }
         },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2917,6 +2917,8 @@
             },
             "invoiceEmailLabel": "E-mail de faturamento",
             "invoiceEmailEmpty": "Nenhum e-mail de faturamento cadastrado",
+            "stripeCustomerIdLabel": "ID do cliente Stripe",
+            "stripeCustomerIdEmpty": "Nenhum cliente Stripe cadastrado",
             "empty": "Nenhum endereço de faturamento cadastrado"
           }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2917,6 +2917,8 @@
             },
             "invoiceEmailLabel": "E-mail de faturação",
             "invoiceEmailEmpty": "Sem e-mail de faturação registado",
+            "stripeCustomerIdLabel": "ID de cliente Stripe",
+            "stripeCustomerIdEmpty": "Nenhum cliente Stripe registado",
             "empty": "Sem morada de faturação registada"
           }
         },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2917,6 +2917,8 @@
             },
             "invoiceEmailLabel": "发票邮箱",
             "invoiceEmailEmpty": "未设置发票邮箱",
+            "stripeCustomerIdLabel": "Stripe 客户 ID",
+            "stripeCustomerIdEmpty": "暂无 Stripe 客户",
             "empty": "未设置账单地址"
           }
         },

--- a/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
+++ b/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
@@ -96,6 +96,18 @@ vi.mock("next-intl", () => ({
       }
       if (
         namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "stripeCustomerIdLabel"
+      ) {
+        return "Stripe customer ID";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
+        key === "stripeCustomerIdEmpty"
+      ) {
+        return "No Stripe customer";
+      }
+      if (
+        namespace === "App.Admin.Invoices.Form.BillingDetails" &&
         key === "taxIdLabel"
       ) {
         return "VAT / tax ID";
@@ -136,6 +148,10 @@ vi.mock("sonner", () => ({
     error: vi.fn(),
     success: vi.fn(),
   },
+}));
+
+vi.mock("@/components/copyable-value", () => ({
+  CopyableValue: ({ value }: { value: string }) => <span>{value}</span>,
 }));
 
 vi.mock("@/lib/actions/invoice-admin/action", () => ({
@@ -228,6 +244,7 @@ describe("InvoiceForm billing preview", () => {
       await screen.findByText("Recipient billing description"),
     ).toBeVisible();
     expect(await screen.findByText(/123 Main St/)).toBeVisible();
+    expect(await screen.findByText("cus_complete")).toBeVisible();
     expect(getBillingMock).toHaveBeenCalledWith({
       targetType: "organization",
       targetId: "org_1",

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -343,6 +343,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
             <>
               <StripeBillingInformationContent
                 billingDetails={billingDetails}
+                showStripeCustomerId
                 translationNamespace="App.Admin.Invoices.Form.BillingDetails"
               />
               {!hasCompleteBilling ? (

--- a/apps/web/src/components/billing/stripe-billing-information-content.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-content.tsx
@@ -13,12 +13,14 @@ import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core"
 export interface StripeBillingInformationContentProps {
   billingDetails: StripeCustomerBillingDetails;
   portalLink?: ReactNode;
+  showStripeCustomerId?: boolean;
   translationNamespace: StripeBillingInformationTranslationNamespace;
 }
 
 export function StripeBillingInformationContent({
   billingDetails,
   portalLink,
+  showStripeCustomerId = false,
   translationNamespace,
 }: StripeBillingInformationContentProps) {
   const t = useTranslations(translationNamespace);
@@ -26,7 +28,9 @@ export function StripeBillingInformationContent({
 
   return (
     <StripeBillingInformationFields
-      {...buildStripeBillingInformationFieldsProps(billingDetails, t, locale)}
+      {...buildStripeBillingInformationFieldsProps(billingDetails, t, locale, {
+        showStripeCustomerId,
+      })}
       portalLink={portalLink}
     />
   );

--- a/apps/web/src/components/billing/stripe-billing-information-fields.tsx
+++ b/apps/web/src/components/billing/stripe-billing-information-fields.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { CopyableValue } from "@/components/copyable-value";
 import type { StripeBillingInformationFieldsContent } from "@/lib/billing/build-stripe-billing-information-fields-props";
 
 export type StripeBillingInformationTranslationNamespace =
@@ -19,6 +20,9 @@ export function StripeBillingInformationFields({
   invoiceEmailLabel,
   invoiceEmail,
   invoiceEmailEmpty,
+  stripeCustomerIdLabel,
+  stripeCustomerId,
+  stripeCustomerIdEmpty,
   taxIdLabel,
   taxIds,
   portalLink,
@@ -68,9 +72,32 @@ export function StripeBillingInformationFields({
     </div>
   );
 
+  const stripeCustomerIdField =
+    stripeCustomerIdLabel !== undefined ? (
+      <div className="space-y-1">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {stripeCustomerIdLabel}
+        </p>
+        {stripeCustomerId ? (
+          <CopyableValue
+            copiedFeedback
+            presentation="inline-code"
+            value={stripeCustomerId}
+            buttonClassName="size-7"
+            codeClassName="text-sm"
+          />
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            {stripeCustomerIdEmpty}
+          </p>
+        )}
+      </div>
+    ) : null;
+
   return (
     <div className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-2">
+        {stripeCustomerIdField}
         {addressField}
         {emailField}
       </div>

--- a/apps/web/src/lib/billing/build-stripe-billing-information-fields-props.ts
+++ b/apps/web/src/lib/billing/build-stripe-billing-information-fields-props.ts
@@ -20,16 +20,24 @@ export interface StripeBillingInformationFieldsContent {
   invoiceEmailLabel: string;
   invoiceEmail: string | null;
   invoiceEmailEmpty: string;
+  stripeCustomerIdLabel?: string;
+  stripeCustomerId?: string | null;
+  stripeCustomerIdEmpty?: string;
   taxIdLabel: string;
   taxIds: StripeBillingInformationTaxIdField[];
+}
+
+export interface BuildStripeBillingInformationFieldsPropsOptions {
+  showStripeCustomerId?: boolean;
 }
 
 export function buildStripeBillingInformationFieldsProps(
   billingDetails: StripeCustomerBillingDetails,
   t: BillingDetailsTranslator,
   locale: string,
+  options?: BuildStripeBillingInformationFieldsPropsOptions,
 ): StripeBillingInformationFieldsContent {
-  return {
+  const content: StripeBillingInformationFieldsContent = {
     addressLabel: t("addressLabel"),
     formattedAddress: billingDetails.address
       ? formatStripeBillingAddress(billingDetails.address, locale)
@@ -47,4 +55,12 @@ export function buildStripeBillingInformationFieldsProps(
         : null,
     })),
   };
+
+  if (options?.showStripeCustomerId) {
+    content.stripeCustomerIdLabel = t("stripeCustomerIdLabel");
+    content.stripeCustomerId = billingDetails.stripeCustomerId;
+    content.stripeCustomerIdEmpty = t("stripeCustomerIdEmpty");
+  }
+
+  return content;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the Stripe customer ID to the **Billing information** section on the admin **New invoice** form. Account and organization billing views are unchanged.

## Changes

- Extended `buildStripeBillingInformationFieldsProps` with an opt-in `showStripeCustomerId` flag
- Rendered the Stripe customer ID (copyable) in `StripeBillingInformationFields` only when that flag is set
- Enabled the field on the admin invoice form via `showStripeCustomerId` on `StripeBillingInformationContent`
- Added admin-only translation keys (`stripeCustomerIdLabel`, `stripeCustomerIdEmpty`) across all locales

## Verification

- `pnpm --filter web test src/components/admin/invoices/__tests__/invoice-form.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35bad242-1b2d-46ba-83bc-7eb6228ae2f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35bad242-1b2d-46ba-83bc-7eb6228ae2f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

