### PR TITLE
docs(agents): add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,3 +335,29 @@ Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). Se
 - [Next.js App Router](https://nextjs.org/docs/app)
 - [Shadcn UI](https://ui.shadcn.com/)
 - [Tailwind CSS](https://tailwindcss.com/)
+
+## Cursor Cloud specific instructions
+
+These notes cover non-obvious, durable facts about running this repo in the Cursor Cloud VM. The update script only runs `pnpm install`; everything below (Node 24, PostgreSQL, `.env` files, applied migrations) is baked into the VM snapshot and persists across runs.
+
+### Runtime versions
+
+- **Node 24 is the required runtime** (`engines: 24.x`, root `.nvmrc` = `lts/krypton`). The base image's `/exec-daemon/node` is Node 22 and is early in `PATH`, so Node 24 (installed via nvm) is symlinked into `/usr/local/cargo/bin` (which is first in `PATH`) as `node`/`npm`/`npx`/`corepack`/`pnpm`. This makes `node -v` = 24 and `pnpm -v` = 11.10.0 in **every** shell (login or not). If a future run somehow sees Node 22, recreate those symlinks from `~/.nvm/versions/node/v24*/bin`.
+
+### Database (local PostgreSQL, not Neon)
+
+- The dev DB is a **local PostgreSQL 16 cluster** (installed via apt). It is **not started on boot** — start it with `sudo pg_ctlcluster 16 main start` (check with `pg_lsclusters`). DB `core`, role `sokosumi` / password `sokosumi`, on `localhost:5432`.
+- **Gotcha — injected `DATABASE_URL`:** the platform injects a stale/invalid Neon `DATABASE_URL` env var (`...neon.tech...`, `neondb_owner` auth fails). `dotenv` does **not** override an already-set env var, so it would shadow `apps/core/.env`. A `~/.bashrc` line exports the local `DATABASE_URL`, which wins in **login/interactive** shells. Therefore **run the dev servers in a login shell** (tmux started with `bash -l`, or `bash -lc "…"`). If you see `Authentication failed against the database server, the provided database credentials for (not available)` or a `neon.tech` host, the injected var leaked into a non-login shell — prefix the command with the local `DATABASE_URL` or use a login shell.
+- Schema is already applied. After pulling schema changes, run `pnpm prisma:generate` then `pnpm prisma:migrate:deploy` (needs `DATABASE_URL`; use a login shell). To inspect: `PGPASSWORD=sokosumi psql -h localhost -U sokosumi -d core`.
+
+### `.env` files (gitignored, snapshot-persisted)
+
+`apps/core/.env` and `apps/web/.env` were created from `.env.example` with local fixes so the apps boot past their Zod env validation. Non-obvious edits: DB host `sokosumi`→`localhost`; `POSTMARK_FROM_EMAIL` and `HERMES_ORCH_BASE_URL` set to valid dummy values; invalid placeholders removed (`COMPOSIO_API_KEY`, `AGENT_HIRED_WEBHOOK`); `BETTER_AUTH_COOKIE_DOMAIN` disabled so session cookies work on `localhost`; web `APP_SIGNING_SECRET` set equal to Core `BETTER_AUTH_SECRET` (required to match).
+
+### Running & known local gotchas
+
+- Start services (login shell): `pnpm core:dev` → Core API on `:8787` (Swagger at `/`, OpenAPI at `/v1/openapi.json`); `pnpm web:dev` → web on `:3000`. `pnpm dev` runs everything. Standard scripts/ports are in the Commands table above and each app's `AGENTS.md`.
+- **Auth for a test account:** email/password signup works with no email verification and auto sign-in (`/signup`). Google/Microsoft OAuth and magic-link email do **not** work (placeholder credentials). Use email/password.
+- **Agents catalog is empty and 500s by default:** `GET /v1/agents` and `/v1/categories` throw `Failed to get credit information for agents` until the `credit_cost` table has rows (seeded in real envs via the admin `POST /v1/credit-costs` endpoint / `/admin` UI). This breaks the Agents marketplace and the Chat/Tasks landing pages until seeded — it is missing data, not a broken build.
+- **Realtime (Ably) is unconfigured:** `POST /api/ably/auth` returns 500 (`No key specified`) and chat pages surface a "Something went wrong" modal, because `ABLY_SUBSCRIBE_ONLY_KEY` / Core `ABLY_PUBLISH_ONLY_KEY` are placeholders. Optional; unrelated to setup.
+- Lint (`pnpm lint`), tests (`pnpm test`), and type checks do **not** need the DB or the servers running.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the Sokosumi monorepo and documents the durable, non-obvious startup caveats for future cloud agents.

The only committed change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. All environment state (Node 24, PostgreSQL 16, `.env` files, applied migrations) lives in the VM snapshot; the startup update script is just `pnpm install`.

### What was set up

- **Node 24** (repo requires `24.x`; base image ships Node 22). Installed via nvm and symlinked into `/usr/local/cargo/bin` so `node`/`pnpm` resolve to v24 in every shell.
- **PostgreSQL 16** (local): role `sokosumi`, db `core`; schema applied via `pnpm prisma:migrate:deploy` (61 tables).
- **`.env` files** for `apps/core` and `apps/web` from `.env.example`, with local fixes so both apps pass Zod env validation and cookies work on `localhost`.
- Documented that the platform-injected `DATABASE_URL` (Neon) is a stale/invalid placeholder; a `~/.bashrc` override points dev servers (run in a login shell) at local Postgres.

### Verification

- ✅ `pnpm lint` (Biome, 2236 files, no errors)
- ✅ `pnpm test` — all suites pass (web 1631, core 1725, database 222, masumi 134, ai-provider 65, utils 167, email 18, net 13)
- ✅ `pnpm core:dev` (`:8787`) and `pnpm web:dev` (`:3000`) run; DB-backed API returns 200s
- ✅ Hello-world: created an account via `/signup` (email/password), auto sign-in, reached the authenticated app; user + personal workspace + 3000-credit signup bonus written to Postgres

### Known local gotchas (documented in AGENTS.md, not setup failures)

- Agents catalog (`/v1/agents`, `/v1/categories`) returns 500 until the `credit_cost` table is seeded (admin `POST /v1/credit-costs`) — missing data, not a broken build.
- Ably realtime (`/api/ably/auth`) 500s with placeholder keys, surfacing a "Something went wrong" modal on chat/tasks pages. Optional.

<a href="https://cursor.com/agents/bc-771b90d5-0439-42c5-a6be-d3a6833bd3b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsokosumi_signup_hello_world.mp4"><img src="https://cursor.com/artifacts/c/art-a0baf432-09a3-4722-9d44-a2f399954e3c" alt="sokosumi_signup_hello_world.mp4" /></a>

![Signup form](https://cursor.com/artifacts/c/art-bc6edb64-2d29-4250-89ab-20ac3de07bb1)
![Authenticated chat dashboard (Ada Lovelace)](https://cursor.com/artifacts/c/art-cbb42b1e-64fd-4645-9dcc-6c061bd0f0ba)
![Authenticated Account settings page](https://cursor.com/artifacts/c/art-555495e6-0b9f-4709-b04e-b76f5c9a3954)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-771b90d5-0439-42c5-a6be-d3a6833bd3b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-771b90d5-0439-42c5-a6be-d3a6833bd3b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

