### PR TITLE
docs: migrate documentation links to DevHub

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/account-menu-config.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/account-menu-config.tsx
@@ -43,7 +43,7 @@ export interface AccountNavItem {
 
 export const HELP_LINKS: HelpLinkItem[] = [
   {
-    url: "https://docs.sokosumi.com/documentation",
+    url: "https://www.masumi.network/dev/sokosumi/documentation",
     translationKey: "documentation",
     icon: BookOpen,
   },

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar.client.tsx
@@ -207,7 +207,7 @@ export default function UserAvatarClient({
                 onClick={() => {
                   closeMenu();
                   handleOpenExternalLink(
-                    "https://docs.sokosumi.com/documentation",
+                    "https://www.masumi.network/dev/sokosumi/documentation",
                   );
                 }}
               >

--- a/apps/web/src/app/(app)/connections/components/api-keys/api-keys-header.tsx
+++ b/apps/web/src/app/(app)/connections/components/api-keys/api-keys-header.tsx
@@ -21,7 +21,7 @@ export function ApiKeysHeader({ onCreateClick }: ApiKeysHeaderProps) {
             <div>{t("description")}</div>
             <div>
               <Link
-                href="https://docs.sokosumi.com/api-reference"
+                href="https://www.masumi.network/dev/sokosumi/api-reference"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:text-primary/80 inline-flex items-center gap-1 text-sm underline underline-offset-4"

--- a/apps/web/src/app/(app)/connections/components/mcp-active-key-view.tsx
+++ b/apps/web/src/app/(app)/connections/components/mcp-active-key-view.tsx
@@ -16,7 +16,7 @@ export function McpActiveKeyView() {
       <McpUrlDisplay url={getMcpUrl()} />
       <div className="text-muted-foreground text-sm">
         <Link
-          href="https://docs.sokosumi.com/mcp"
+          href="https://www.masumi.network/dev/sokosumi/mcp"
           target="_blank"
           rel="noopener noreferrer"
           className="text-primary hover:text-primary/80 inline-flex items-center gap-1 underline underline-offset-4"

--- a/apps/web/src/components/agents/agent-verified-badge.tsx
+++ b/apps/web/src/components/agents/agent-verified-badge.tsx
@@ -38,7 +38,7 @@ function AgentVerifiedBadge({ className }: AgentVerifiedBadgeProps) {
         <p>
           {t("tooltip")}{" "}
           <Link
-            href="https://docs.masumi.network/core-concepts/identity"
+            href="https://www.masumi.network/dev/masumi/core-concepts/identity"
             target="_blank"
             rel="noreferrer noopener"
             className="underline"

--- a/apps/web/src/components/jobs/job-details/refund-request.tsx
+++ b/apps/web/src/components/jobs/job-details/refund-request.tsx
@@ -365,7 +365,7 @@ export default function RequestRefundButton({
                       {t("confirmDescription")}
                       <span className="mt-2 block">
                         <a
-                          href="https://docs.masumi.network/core-concepts/refunds-and-disputes"
+                          href="https://www.masumi.network/dev/masumi/core-concepts/refunds-and-disputes"
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-primary flex items-center gap-1 hover:underline"

--- a/apps/web/src/config/site.ts
+++ b/apps/web/src/config/site.ts
@@ -6,7 +6,7 @@ export const siteConfig = {
     twitter: "https://twitter.com/sokosumi",
     github: "https://github.com/masumi-network/sokosumi",
     decisionLoggingDocs:
-      "https://docs.masumi.network/core-concepts/decision-logging",
+      "https://www.masumi.network/dev/masumi/core-concepts/decision-logging",
     jobTransactionMainnet: "https://cardanoscan.io/transaction/",
     jobTransactionPreprod: "https://preprod.cardanoscan.io/transaction/",
   },

--- a/packages/masumi/AGENTS.md
+++ b/packages/masumi/AGENTS.md
@@ -252,5 +252,5 @@ pnpm masumi:test
 ## References
 
 - [Root AGENTS.md](../../AGENTS.md) - Comprehensive monorepo guidelines
-- [Masumi Protocol Documentation](https://docs.masumi.network/)
+- [Masumi Protocol Documentation](https://www.masumi.network/dev/masumi/)
 - [Zod Documentation](https://zod.dev/)


### PR DESCRIPTION
## Summary

- replace legacy Masumi and Sokosumi documentation hosts with the canonical DevHub
- preserve route-specific destinations and map moved pages to their current live routes
- keep intentional compatibility references out of this repository change

## Impact

Documentation links now send users and agents to `https://www.masumi.network/dev` instead of retired documentation hosts.

## Validation

- `git diff --check`
- all 42 distinct migrated DevHub URLs returned HTTP 2xx/3xx
- the DevHub documentation audit passed for 304 local routes