### PR TITLE
fix(web): handle slim task list responses without events arrays

### DIFF
--- a/apps/web/src/lib/clients/__tests__/core.client.test.ts
+++ b/apps/web/src/lib/clients/__tests__/core.client.test.ts
@@ -14,6 +14,7 @@ const getConversationsMock = vi.fn();
 const getAgentsByIdInputSchemaMock = vi.fn();
 const getShareByTokenMock = vi.fn();
 const getHistoryMock = vi.fn();
+const getTasksMock = vi.fn();
 const getTasksByIdMock = vi.fn();
 const getUsersByIdNoticesPendingMock = vi.fn();
 const postUsersByIdNoticesByNoticeIdAcknowledgeMock = vi.fn();
@@ -53,6 +54,7 @@ vi.mock("@/lib/clients/generated/core", () => ({
   getAgentsByIdInputSchema: getAgentsByIdInputSchemaMock,
   getConversations: getConversationsMock,
   getHistory: getHistoryMock,
+  getTasks: getTasksMock,
   getShareByToken: getShareByTokenMock,
   getTasksById: getTasksByIdMock,
   getUsersByIdNoticesPending: getUsersByIdNoticesPendingMock,
@@ -683,6 +685,83 @@ describe("core.client", () => {
     );
     expect(response.meta?.timestamp).toEqual(
       new Date("2026-02-19T12:00:00.000Z"),
+    );
+  });
+
+  it("normalizes slim task list items without events or jobs arrays", async () => {
+    getTasksMock.mockImplementation(
+      async (options: {
+        responseTransformer?: (data: unknown) => Promise<unknown>;
+      }) => {
+        const rawResponse = {
+          data: [
+            {
+              id: "task_1",
+              createdAt: "2026-07-13T10:00:00.000Z",
+              updatedAt: "2026-07-13T10:05:00.000Z",
+              userId: "user_1",
+              user: { id: "user_1", name: "Ada", image: null },
+              organizationId: null,
+              organization: null,
+              projectId: null,
+              coworkerId: null,
+              coworker: null,
+              name: "Review onboarding",
+              description: null,
+              status: "READY",
+              metadata: null,
+              nextRunAt: null,
+              jobsCount: 2,
+              commentsCount: 4,
+              workspace: {
+                id: "ws_1",
+                organizationId: null,
+                organization: null,
+              },
+            },
+          ],
+          meta: {
+            requestId: "req_123",
+            timestamp: "2026-07-13T10:00:00.000Z",
+            pagination: {
+              cursor: null,
+              limit: 20,
+              total: 1,
+              nextCursor: null,
+            },
+          },
+        };
+
+        return {
+          data: options.responseTransformer
+            ? await options.responseTransformer(rawResponse)
+            : rawResponse,
+          response: new Response("{}", { status: 200 }),
+        };
+      },
+    );
+
+    const { coreClient } = await import("../core.client");
+    const response = await coreClient.getTasks({ limit: 20 });
+
+    expect(getTasksMock).toHaveBeenCalledWith({
+      cache: "no-store",
+      client: mockClient,
+      query: { limit: 20 },
+      responseTransformer: expect.any(Function),
+    });
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0]?.createdAt).toEqual(
+      new Date("2026-07-13T10:00:00.000Z"),
+    );
+    expect(response.data[0]).toMatchObject({
+      jobsCount: 2,
+      commentsCount: 4,
+    });
+    expect(response.data[0]).not.toHaveProperty("events");
+    expect(response.data[0]).not.toHaveProperty("jobs");
+    expect(response.meta?.timestamp).toEqual(
+      new Date("2026-07-13T10:00:00.000Z"),
     );
   });
 

--- a/apps/web/src/lib/clients/__tests__/task-share-transformer.test.ts
+++ b/apps/web/src/lib/clients/__tests__/task-share-transformer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAdminTaskResponseTransformer,
   getTasksByIdResponseTransformer,
+  getTasksResponseTransformer,
 } from "@/lib/clients/generated/core/transformers.gen";
 
 /**
@@ -14,6 +15,30 @@ import {
  * "Cannot read properties of null (reading 'createdAt')". The unit/service
  * tests mock the client and never run the transformer, so this covers the gap.
  */
+function buildTaskListItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "tsk_1",
+    createdAt: "2026-03-25T10:00:00.000Z",
+    updatedAt: "2026-03-25T10:00:00.000Z",
+    userId: "user_1",
+    user: { id: "user_1", name: "Ada", image: null },
+    organizationId: null,
+    organization: null,
+    projectId: null,
+    coworkerId: null,
+    coworker: null,
+    name: "Task",
+    description: null,
+    status: "READY",
+    metadata: null,
+    nextRunAt: null,
+    jobsCount: 1,
+    commentsCount: 2,
+    workspace: { id: "ws_1", organizationId: null, organization: null },
+    ...overrides,
+  };
+}
+
 function buildTask(overrides: Record<string, unknown> = {}) {
   return {
     id: "tsk_1",
@@ -45,6 +70,22 @@ const meta = {
 };
 
 describe("task response transformers with a null share", () => {
+  it("getTasksResponseTransformer does not throw for slim list items", async () => {
+    const result = await getTasksResponseTransformer({
+      data: [buildTaskListItem()],
+      meta: { ...meta },
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.createdAt).toBeInstanceOf(Date);
+    expect(result.data[0]).toMatchObject({
+      jobsCount: 1,
+      commentsCount: 2,
+    });
+    expect(result.data[0]).not.toHaveProperty("events");
+    expect(result.data[0]).not.toHaveProperty("jobs");
+  });
+
   it("getTasksByIdResponseTransformer does not throw and converts dates", async () => {
     const result = await getTasksByIdResponseTransformer({
       data: buildTask(),

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -271,6 +271,23 @@ function transformHistoryResponseEnvelope(data: any) {
   return data;
 }
 
+function transformTaskListResponseEnvelope(data: any) {
+  data.data = (data.data ?? []).map((item: any) => {
+    item.createdAt = toDate(item.createdAt);
+    item.updatedAt = toDate(item.updatedAt);
+    if (item.nextRunAt) {
+      item.nextRunAt = toDate(item.nextRunAt);
+    }
+
+    return item;
+  });
+  if (data.meta?.timestamp) {
+    data.meta.timestamp = toDate(data.meta.timestamp);
+  }
+
+  return data;
+}
+
 function transformTaskResponseEnvelope(data: any) {
   const task = data.data;
 
@@ -562,6 +579,8 @@ export function createCoreClient(getClient: GetClient) {
           client,
           query,
           cache: "no-store",
+          responseTransformer: async (data) =>
+            transformTaskListResponseEnvelope(data),
         }),
       "Failed to fetch tasks",
     );

--- a/apps/web/src/lib/services/__tests__/task.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/task.service.test.ts
@@ -98,6 +98,33 @@ describe("task.service", () => {
     });
   });
 
+  it("returns an empty task list when core data is missing", async () => {
+    coreClientMock.getTasks.mockResolvedValue({
+      data: undefined,
+      meta: {
+        pagination: {
+          cursor: null,
+          limit: 20,
+          total: 0,
+          nextCursor: null,
+        },
+      },
+    });
+
+    const { taskService } = await import("../task.service");
+    const result = await taskService.listTasks({ limit: 20 });
+
+    expect(result).toEqual({
+      tasks: [],
+      pagination: {
+        cursor: null,
+        limit: 20,
+        total: 0,
+        nextCursor: null,
+      },
+    });
+  });
+
   it("passes through multiple statuses for the core client", async () => {
     coreClientMock.getTasks.mockResolvedValue({
       data: [buildTask()],

--- a/apps/web/src/lib/services/task.service.ts
+++ b/apps/web/src/lib/services/task.service.ts
@@ -77,7 +77,7 @@ export const taskService = (() => {
     });
 
     return {
-      tasks: result.data,
+      tasks: result.data ?? [],
       pagination: result.meta?.pagination ?? null,
     };
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOKOSUMI-Q4](https://masumi.sentry.io/issues/SOKOSUMI-Q4): `/tasks` crashed with `Cannot read properties of undefined (reading 'map')` when the web app parsed task list responses from Core.

## Root cause

`perf(core): slim task list queries (#3292)` changed `GET /tasks` list items to return `jobsCount` / `commentsCount` instead of `events` / `jobs` arrays. Production briefly had Core on the new shape while web still used the generated transformer that unconditionally called `data.events.map(...)` and `data.jobs.map(...)`, throwing when those fields were absent.

## Fix

- Route `coreClient.getTasks` through a hand-written `transformTaskListResponseEnvelope` that only normalizes dates on slim list items (same pattern as history/task detail envelopes).
- Default missing `result.data` to `[]` in `taskService.listTasks` as a defensive fallback.
- Add regression tests for slim list payloads in the Core client transport and generated transformer.

## Verification

- `pnpm --filter web test src/lib/clients/__tests__/core.client.test.ts`
- `pnpm --filter web test src/lib/clients/__tests__/task-share-transformer.test.ts`
- `pnpm --filter web test src/lib/services/__tests__/task.service.test.ts`
- `pnpm --filter web test src/app/(app)/tasks/utils/__tests__/tasks-column-page.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90088ef7-4313-4ef0-92ff-fc1612f41901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90088ef7-4313-4ef0-92ff-fc1612f41901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

