### PR TITLE
docs(coworker): add vendor workspace grants API guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,8 @@ Hybrid mapping: native Linear statuses for needs-triage (Triage) and wontfix (Ca
 
 Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). See [`docs/agents/domain.md`](./docs/agents/domain.md).
 
+**Coworker integrators:** [`docs/coworker/vendor-workspace-grants-api.md`](./docs/coworker/vendor-workspace-grants-api.md) — vendor workspace grants, `GRANT_PENDING`, Core API error kinds.
+
 ## Additional Rules
 
 - [Maintainability](.cursor/rules/maintainability.mdc) – long-term clarity and consistency over short-term wins

--- a/apps/core/AGENTS.md
+++ b/apps/core/AGENTS.md
@@ -686,6 +686,20 @@ Environment variables required by Vitest (or by code under test) must be set in 
 - [Data Access](.cursor/rules/data-access.mdc) – direct Prisma, no repository pattern
 - [Responses](.cursor/rules/responses.mdc)
 
+## Coworker integrators
+
+Vendor workspace grants gate coworker access beyond assignee/vendor-sibling
+baseline. **`GRANT_PENDING`** parks delegated creates until a human approves.
+
+**Read first:** [`docs/coworker/vendor-workspace-grants-api.md`](../../docs/coworker/vendor-workspace-grants-api.md)
+
+Key implementation files:
+
+- `src/helpers/vendor-grants.ts` — grant request, unpark, error kinds
+- `src/helpers/access-control.ts` — coworker read/collaboration/comment gates
+- `src/routes/v1/tasks/*` — list, create, mutations
+- `src/schemas/task.schema.ts` — OpenAPI task fields (`grantResumeStatus`, `pendingVendorGrantId`)
+
 ## References
 
 - [Root AGENTS.md](../../AGENTS.md) - Comprehensive monorepo guidelines

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -686,7 +686,6 @@ describe("requireTaskCommentAccess", () => {
       userId: "user_delegate",
       organizationId: "org_123",
     });
-    const foreignVendorId = "01960001-0002-7001-8001-000000000002";
 
     vi.mocked(tx.coworker.findFirst).mockResolvedValue({
       id: "cow_123",

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -605,9 +605,7 @@ describe("requireTaskCommentAccess", () => {
       slug: "ops-agent",
       baseURL: null,
     } as never);
-    vi.mocked(tx.task.findFirst)
-      .mockResolvedValueOnce(siblingTask as never)
-      .mockResolvedValueOnce(siblingTask as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce(siblingTask as never);
 
     const vars: EnvVariables["Variables"] = {
       isAuthenticated: true,
@@ -671,9 +669,7 @@ describe("requireTaskCommentAccess", () => {
       slug: "ops-agent",
       baseURL: null,
     } as never);
-    vi.mocked(tx.task.findFirst)
-      .mockResolvedValueOnce(siblingTask as never)
-      .mockResolvedValueOnce(siblingTask as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce(siblingTask as never);
 
     const vars: EnvVariables["Variables"] = {
       isAuthenticated: true,
@@ -704,14 +700,6 @@ describe("requireTaskCommentAccess", () => {
         coworkerId: "cow_foreign",
         status: TaskStatus.READY,
         pendingVendorGrantId: null,
-      } as never)
-      .mockResolvedValueOnce({
-        id: "tsk_123",
-        coworkerId: "cow_foreign",
-        status: TaskStatus.READY,
-        workspaceId,
-        coworker: { vendorId: foreignVendorId },
-        workspace: { organizationId: "org_123" },
       } as never);
     vi.mocked(tx.workspace.findUnique).mockResolvedValue({
       organizationId: "org_123",
@@ -773,7 +761,6 @@ describe("requireTaskCommentAccess", () => {
     } as never);
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(foreignTask as never)
       .mockResolvedValueOnce(foreignTask as never);
     getWorkspaceGrantMock.mockResolvedValue({
       id: "workspace-grant",
@@ -816,9 +803,7 @@ describe("requireTaskCommentAccess", () => {
       slug: "ops-agent",
       baseURL: null,
     } as never);
-    vi.mocked(tx.task.findFirst)
-      .mockResolvedValueOnce(siblingTask as never)
-      .mockResolvedValueOnce(siblingTask as never);
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce(siblingTask as never);
 
     const vars: EnvVariables["Variables"] = {
       isAuthenticated: true,

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -28,7 +28,6 @@ import { forbidden, notFound } from "./error";
 import { resolveMemberOrganizationById } from "./organization";
 import {
   getWorkspaceGrant,
-  isBaselineCoworkerTaskAccess,
   requestWorkspaceGrantCommitted,
   requireTaskNotParked,
   throwGrantAccessError,
@@ -476,49 +475,6 @@ export async function requireTaskCommentAccess(
 
   const task = await requireCoworkerTaskRead(coworker, taskId, workspaceId, tx);
   requireTaskNotParked(task);
-
-  const taskMeta = await tx.task.findFirst({
-    where: { id: task.id },
-    select: {
-      coworkerId: true,
-      status: true,
-      workspaceId: true,
-      coworker: { select: { vendorId: true } },
-    },
-  });
-
-  if (!taskMeta) {
-    throw notFound("Task not found");
-  }
-
-  if (
-    isBaselineCoworkerTaskAccess({
-      actorCoworkerId: coworker.coworkerId,
-      actorVendorId: coworker.vendorId,
-      task: taskMeta,
-    })
-  ) {
-    return task;
-  }
-
-  if (!workspaceId) {
-    throwGrantAccessError(null);
-  }
-
-  const grant = await getWorkspaceGrant(
-    {
-      vendorId: coworker.vendorId,
-      workspaceId,
-    },
-    tx,
-  );
-
-  await requireGrantedWorkspaceAccessOrRequest({
-    vendorId: coworker.vendorId,
-    workspaceId,
-    requestedByUserId: coworker.context?.userId ?? null,
-    grant,
-  });
 
   return task;
 }

--- a/apps/core/src/helpers/task.ts
+++ b/apps/core/src/helpers/task.ts
@@ -279,6 +279,8 @@ function mapTaskSummary(task: TaskListItemWithIncludes | TaskWithIncludes) {
     name: task.name,
     description: task.description,
     status: task.status,
+    // Grant parking fields are intentional API surface while GRANT_PENDING so
+    // coworkers and web can correlate the task with the blocking vendor grant.
     grantResumeStatus:
       task.status === TaskStatus.GRANT_PENDING
         ? (task.grantResumeStatus ?? null)

--- a/apps/core/src/helpers/vendor-grants.ts
+++ b/apps/core/src/helpers/vendor-grants.ts
@@ -235,23 +235,6 @@ export async function requestWorkspaceGrantCommitted(params: {
   );
 }
 
-export async function lockAndGetVendorGrantById(
-  grantId: string,
-  tx: Prisma.TransactionClient,
-): Promise<VendorGrant> {
-  await lockVendorGrantById(grantId, tx);
-
-  const grant = await tx.vendorGrant.findUnique({
-    where: { id: grantId },
-  });
-
-  if (!grant) {
-    throw notFound("Vendor grant not found");
-  }
-
-  return grant;
-}
-
 export async function notifyWorkspaceApproversOfPendingGrant(
   params: {
     vendorId: string;

--- a/apps/core/src/routes/v1/tasks/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/post.test.ts
@@ -11,7 +11,6 @@ import mountPostTask, { createTaskRequestSchema } from "./post";
 
 const {
   generateTaskNameMock,
-  getWorkspaceGrantMock,
   mapTaskMock,
   notifyWorkspaceApproversOfPendingGrantMock,
   projectFindFirstMock,
@@ -22,7 +21,6 @@ const {
   workspaceFindUniqueMock,
 } = vi.hoisted(() => ({
   generateTaskNameMock: vi.fn(),
-  getWorkspaceGrantMock: vi.fn(),
   mapTaskMock: vi.fn(),
   notifyWorkspaceApproversOfPendingGrantMock: vi.fn(),
   projectFindFirstMock: vi.fn(),
@@ -106,7 +104,6 @@ vi.mock("@/helpers/vendor-grants", async (importOriginal) => {
 
   return {
     ...actual,
-    getWorkspaceGrant: getWorkspaceGrantMock,
     requestWorkspaceGrant: requestWorkspaceGrantMock,
     notifyWorkspaceApproversOfPendingGrant:
       notifyWorkspaceApproversOfPendingGrantMock,
@@ -506,7 +503,6 @@ describe("POST /tasks delegated coworker create grant", () => {
   });
 
   it("parks create with pendingVendorGrantId when workspace access is missing", async () => {
-    getWorkspaceGrantMock.mockResolvedValue(null);
     mockWorkspaceGrantInTransaction(VendorGrantStatus.PENDING, true);
     notifyWorkspaceApproversOfPendingGrantMock.mockResolvedValue(undefined);
 
@@ -593,7 +589,6 @@ describe("POST /tasks delegated coworker create grant", () => {
   });
 
   it("creates unparked when requestWorkspaceGrant already returns GRANTED", async () => {
-    getWorkspaceGrantMock.mockResolvedValue(null);
     mockWorkspaceGrantInTransaction(VendorGrantStatus.GRANTED, false);
 
     const response = await createDelegatedCoworkerApp().request(
@@ -710,7 +705,6 @@ describe("POST /tasks delegated coworker create grant", () => {
 
   it("parks create in personal workspaces when workspace grant is missing", async () => {
     workspaceFindUniqueMock.mockResolvedValue({ organizationId: null });
-    getWorkspaceGrantMock.mockResolvedValue(null);
     mockWorkspaceGrantInTransaction(VendorGrantStatus.PENDING, true);
     notifyWorkspaceApproversOfPendingGrantMock.mockResolvedValue(undefined);
 

--- a/apps/core/src/schemas/task.schema.ts
+++ b/apps/core/src/schemas/task.schema.ts
@@ -78,12 +78,12 @@ const taskBaseSchema = z.object({
   }),
   grantResumeStatus: z.enum(["DRAFT", "READY"]).nullable().openapi({
     description:
-      "Target status after vendor workspace grant approval. Set only while status is GRANT_PENDING.",
+      "Target status after vendor workspace grant approval. Exposed on the task API only while status is GRANT_PENDING; null otherwise.",
     example: null,
   }),
   pendingVendorGrantId: z.string().uuid().nullable().openapi({
     description:
-      "Vendor grant blocking this task. Set only while status is GRANT_PENDING.",
+      "Vendor grant blocking this task. Exposed on the task API only while status is GRANT_PENDING so integrators can correlate the parked task with the grant; null otherwise.",
     example: null,
   }),
   metadata: z.string().nullable().openapi({

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -1207,7 +1207,7 @@ export const TaskSchema = {
                 'READY',
                 null
             ],
-            description: 'Target status after vendor workspace grant approval. Set only while status is GRANT_PENDING.',
+            description: 'Target status after vendor workspace grant approval. Exposed on the task API only while status is GRANT_PENDING; null otherwise.',
             example: null
         },
         pendingVendorGrantId: {
@@ -1216,7 +1216,7 @@ export const TaskSchema = {
                 'null'
             ],
             format: 'uuid',
-            description: 'Vendor grant blocking this task. Set only while status is GRANT_PENDING.',
+            description: 'Vendor grant blocking this task. Exposed on the task API only while status is GRANT_PENDING so integrators can correlate the parked task with the grant; null otherwise.',
             example: null
         },
         metadata: {
@@ -9572,7 +9572,7 @@ export const TaskListItemSchema = {
                 'READY',
                 null
             ],
-            description: 'Target status after vendor workspace grant approval. Set only while status is GRANT_PENDING.',
+            description: 'Target status after vendor workspace grant approval. Exposed on the task API only while status is GRANT_PENDING; null otherwise.',
             example: null
         },
         pendingVendorGrantId: {
@@ -9581,7 +9581,7 @@ export const TaskListItemSchema = {
                 'null'
             ],
             format: 'uuid',
-            description: 'Vendor grant blocking this task. Set only while status is GRANT_PENDING.',
+            description: 'Vendor grant blocking this task. Exposed on the task API only while status is GRANT_PENDING so integrators can correlate the parked task with the grant; null otherwise.',
             example: null
         },
         metadata: {

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -281,11 +281,11 @@ export type Task = {
      */
     status: 'DRAFT' | 'QUEUED' | 'READY' | 'GRANT_PENDING' | 'INPUT_REQUIRED' | 'APPROVAL_REQUIRED' | 'AUTHENTICATION_REQUIRED' | 'OUT_OF_CREDITS' | 'CREDITS_TOPPED_UP' | 'RUNNING' | 'AWAITING_EXTERNAL' | 'COMPLETED' | 'FAILED' | 'CANCEL_REQUESTED' | 'CANCELED';
     /**
-     * Target status after vendor workspace grant approval. Set only while status is GRANT_PENDING.
+     * Target status after vendor workspace grant approval. Exposed on the task API only while status is GRANT_PENDING; null otherwise.
      */
     grantResumeStatus: 'DRAFT' | 'READY' | null;
     /**
-     * Vendor grant blocking this task. Set only while status is GRANT_PENDING.
+     * Vendor grant blocking this task. Exposed on the task API only while status is GRANT_PENDING so integrators can correlate the parked task with the grant; null otherwise.
      */
     pendingVendorGrantId: string | null;
     /**
@@ -2630,11 +2630,11 @@ export type TaskListItem = {
      */
     status: 'DRAFT' | 'QUEUED' | 'READY' | 'GRANT_PENDING' | 'INPUT_REQUIRED' | 'APPROVAL_REQUIRED' | 'AUTHENTICATION_REQUIRED' | 'OUT_OF_CREDITS' | 'CREDITS_TOPPED_UP' | 'RUNNING' | 'AWAITING_EXTERNAL' | 'COMPLETED' | 'FAILED' | 'CANCEL_REQUESTED' | 'CANCELED';
     /**
-     * Target status after vendor workspace grant approval. Set only while status is GRANT_PENDING.
+     * Target status after vendor workspace grant approval. Exposed on the task API only while status is GRANT_PENDING; null otherwise.
      */
     grantResumeStatus: 'DRAFT' | 'READY' | null;
     /**
-     * Vendor grant blocking this task. Set only while status is GRANT_PENDING.
+     * Vendor grant blocking this task. Exposed on the task API only while status is GRANT_PENDING so integrators can correlate the parked task with the grant; null otherwise.
      */
     pendingVendorGrantId: string | null;
     /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,22 @@
 
 This directory contains documentation for the Sokosumi monorepo.
 
-## Future Structure
+## Coworker integrators
+
+- [`coworker/vendor-workspace-grants-api.md`](./coworker/vendor-workspace-grants-api.md) — Core API behavior for vendor workspace grants (`GRANT_PENDING`, delegated create, 403 kinds)
+- [`coworker-metadata.md`](./coworker-metadata.md) — Marketplace profile and Ready-To-Run offers JSON
+
+## Agent tooling
+
+- [`agents/issue-tracker.md`](./agents/issue-tracker.md)
+- [`agents/triage-labels.md`](./agents/triage-labels.md)
+- [`agents/domain.md`](./agents/domain.md)
+
+## Future structure
 
 Planned documentation includes:
-- `architecture/` - Architecture decision records and diagrams
-- `api/` - API documentation
-- `guides/` - Development guides and tutorials
+
+- `architecture/` — Architecture decision records and diagrams
+- `api/` — Additional API documentation
+- `guides/` — Development guides and tutorials
 

--- a/docs/coworker/vendor-workspace-grants-api.md
+++ b/docs/coworker/vendor-workspace-grants-api.md
@@ -38,8 +38,8 @@ read vs create permissions).
 | `grantResumeStatus` | `DRAFT` \| `READY` \| `null` | `status === GRANT_PENDING` | Target status after approval; `null` when not parked |
 | `pendingVendorGrantId` | uuid \| `null` | `status === GRANT_PENDING` | **Exposed on the task API** so integrators can correlate the parked task with the blocking grant. Cleared when not parked. |
 
-Both `grantResumeStatus` and `pendingVendorGrantId` are **omitted from the
-serialized task** (returned as `null`) once the task leaves `GRANT_PENDING`.
+Both `grantResumeStatus` and `pendingVendorGrantId` are returned as **`null`**
+when the task is not parked (not omitted from the JSON payload).
 
 **Design decision:** these fields are **intentionally exposed on the Core task
 API** while parked (not DB-only). Coworker integrators and the web app use
@@ -86,8 +86,12 @@ and the task is **not DRAFT**.
 **Delegated create** and workspace-scoped list/read require:
 
 - Coworker API token (`actor: coworker`)
-- User context headers (delegated session — e.g. `X-User-Id`, organization context)
-- Active **workspace** header (same as other workspace-scoped task routes)
+- Delegation context headers:
+  - **`X-Context-User-Id`** (required for delegated flows)
+  - **`X-Context-Organization-Id`** (optional; when set, user must be a member)
+- Workspace-scoped routes resolve the active workspace from that user/org context
+  (see Core OpenAPI global parameters in `apps/core/src/routes/v1/index.ts` and
+  `apps/core/src/middleware/coworker-context.ts`)
 
 **Grant admin routes** (`/v1/organizations/{id}/vendor-grants/*`,
 `/v1/users/{id}/vendor-grants/*`) return **403** for coworker auth. Only humans

--- a/docs/coworker/vendor-workspace-grants-api.md
+++ b/docs/coworker/vendor-workspace-grants-api.md
@@ -1,0 +1,161 @@
+# Coworker API: vendor workspace grants
+
+Guide for **coworker integrators** calling the Sokosumi Core API (`apps/core`). Humans
+manage grants via org/user vendor-grant routes; coworkers interact with grants
+implicitly through task and job endpoints.
+
+- **Source of truth (behavior):** `apps/core/src/helpers/access-control.ts`,
+  `apps/core/src/helpers/vendor-grants.ts`, `apps/core/src/routes/v1/tasks/*`
+- **Source of truth (OpenAPI shape):** `apps/core/src/schemas/task.schema.ts`
+- **Shipped in:** PR [#3300](https://github.com/masumi-network/sokosumi/pull/3300)
+  (`feat(vendor-grants)`)
+
+---
+
+## Permission model
+
+One **workspace** grant per `(vendorId, workspaceId)`:
+
+| Grant status | Coworker effect |
+| --- | --- |
+| **None / PENDING** | Baseline task access only (see below). Out-of-scope read/comment → upsert **PENDING** grant, return **403** `grant_required`. Delegated create → task parked as **`GRANT_PENDING`**. |
+| **GRANTED** | Read, list, comment, and create across the whole workspace (all non-DRAFT tasks). |
+| **DENIED / REVOKED** | **403** `grant_denied` / `grant_revoked`. Terminal — Core does not auto-reopen. |
+
+Read, list, comment, and create are **all-or-nothing** when granted (no separate
+read vs create permissions).
+
+**Serviceplan:** new and backfilled workspaces auto-GRANT the Serviceplan vendor
+(`slug: serviceplan`), so coworkers usually skip PENDING for those workspaces.
+
+---
+
+## Task API fields
+
+| Field | Type | When set | Purpose |
+| --- | --- | --- | --- |
+| `status` | enum | always | New value **`GRANT_PENDING`** while waiting on workspace grant approval |
+| `grantResumeStatus` | `DRAFT` \| `READY` \| `null` | `status === GRANT_PENDING` | Target status after approval; `null` when not parked |
+| `pendingVendorGrantId` | uuid \| `null` | `status === GRANT_PENDING` | **Exposed on the task API** so integrators can correlate the parked task with the blocking grant. Cleared when not parked. |
+
+Both `grantResumeStatus` and `pendingVendorGrantId` are **omitted from the
+serialized task** (returned as `null`) once the task leaves `GRANT_PENDING`.
+
+**Design decision:** these fields are **intentionally exposed on the Core task
+API** while parked (not DB-only). Coworker integrators and the web app use
+`pendingVendorGrantId` to correlate a blocked task with its vendor grant; hiding
+it would force extra lookups without improving security (grant admin remains
+human-only).
+
+On approve/unpark, if `grantResumeStatus` is missing (legacy row), Core defaults
+to **`READY`**.
+
+**OpenAPI:** descriptions live in `apps/core/src/schemas/task.schema.ts` and
+propagate to the generated web client via `pnpm --filter web generate:core:snapshot`.
+
+---
+
+## Access tiers
+
+| Tier | Read single task | List `GET /v1/tasks` | `POST /v1/tasks` (delegated) | Comment |
+| --- | --- | --- | --- | --- |
+| **Baseline** | Assignee + same-vendor sibling (non-DRAFT) | Same OR filter | Parks as **`GRANT_PENDING`** if no **GRANTED** grant | Baseline tasks only |
+| **PENDING** grant | **403** `grant_required` (grant row upserted) | Still baseline-only | **201** + `GRANT_PENDING` + `pendingVendorGrantId` | **403** on out-of-scope |
+| **GRANTED** grant | Any non-DRAFT task in workspace | All non-DRAFT workspace tasks | Create at requested `DRAFT`/`READY` | Any readable non-parked task |
+
+**Unchanged:**
+
+- **`tasks` capability** required on all task/job routes.
+- **DRAFT** tasks invisible to coworkers (404 / excluded from list).
+- **Bare coworker auth** (no user context headers): no delegated create; list uses
+  baseline filter only.
+
+### Baseline access
+
+A coworker has baseline access when:
+
+- They are the **assignee** (`task.coworkerId`), or
+- The assignee is another coworker from the **same vendor** (vendor sibling),
+
+and the task is **not DRAFT**.
+
+---
+
+## Authentication
+
+**Delegated create** and workspace-scoped list/read require:
+
+- Coworker API token (`actor: coworker`)
+- User context headers (delegated session — e.g. `X-User-Id`, organization context)
+- Active **workspace** header (same as other workspace-scoped task routes)
+
+**Grant admin routes** (`/v1/organizations/{id}/vendor-grants/*`,
+`/v1/users/{id}/vendor-grants/*`) return **403** for coworker auth. Only humans
+approve, deny, or revoke.
+
+---
+
+## Delegated create (`POST /v1/tasks`)
+
+Applies when auth is coworker **with** user context. Session-only user create is
+unchanged (no grant gate).
+
+1. Single transaction: validate project → `requestWorkspaceGrant` → insert task.
+2. **`GRANTED`** → create at `body.status` (`DRAFT` or `READY`).
+3. **`PENDING`** → `status: GRANT_PENDING`, `grantResumeStatus` ← `body.status`,
+   `pendingVendorGrantId` ← grant id; approvers notified post-commit (best-effort).
+4. **`DENIED` / `REVOKED`** → **403**, no task row.
+
+After human **approve**: task unparks to `grantResumeStatus` (null → `READY`).
+After **deny/revoke** on the create grant: parked task → **`CANCELED`**.
+
+---
+
+## Endpoint reference (coworker-facing)
+
+| Method | Route | Behavior |
+| --- | --- | --- |
+| GET | `/v1/tasks` | With **GRANTED** grant, list all non-DRAFT tasks in workspace. `status=DRAFT` filter → **400**. |
+| GET | `/v1/tasks/{id}` | Baseline unchanged. Out-of-scope: upsert PENDING grant, **403** unless **GRANTED**. Same gate for task events, links, jobs list. |
+| POST | `/v1/tasks` | Delegated create flow above. |
+| POST | `/v1/tasks/{id}/events` | **`GRANT_PENDING`** → **403** `task_parked`. |
+| POST | `/v1/tasks/{id}/jobs` | Parent **`GRANT_PENDING`** → **403** `task_parked`. |
+| PATCH | `/v1/tasks/{id}` (+ schedule, etc.) | Collaborators cannot mutate parked tasks. |
+| GET | `/v1/jobs/{id}` | Sibling read uses workspace grant gate; writes blocked if parent task parked. |
+
+---
+
+## Error responses (`403`)
+
+All use the standard Core error envelope. Relevant `error.kind` values:
+
+| `kind` | When | `extensions` |
+| --- | --- | --- |
+| `grant_required` | Workspace access needed; PENDING grant created or already waiting | `permission: "workspace"` |
+| `grant_denied` | Grant denied; will not auto-reopen | `permission: "workspace"` |
+| `grant_revoked` | Grant revoked | `permission: "workspace"` |
+| `task_parked` | Task is **`GRANT_PENDING`** — mutations, comments, jobs frozen | — |
+
+Integrators should handle `grant_required` by surfacing approval UX to the human
+and polling task/coworker events until the grant resolves or the task unparks.
+
+---
+
+## Events and polling
+
+- Parked create emits an initial task event with status **`GRANT_PENDING`**.
+- Grant approve/deny/revoke and unpark/cancel side-effects appear on
+  **`GET /v1/coworkers/me/events`** (same polling model as other task lifecycle
+  events).
+
+Use `pendingVendorGrantId` on the task (while parked) if you need to show which
+grant is blocking progress; resolve grant details via human-facing settings UI or
+wait for unpark/cancel events.
+
+---
+
+## Related docs
+
+- [Coworker metadata](./../coworker-metadata.md) — marketplace profile and offers JSON
+- [Core AGENTS.md](../../apps/core/AGENTS.md) — route patterns and auth
+- PR [#3300](https://github.com/masumi-network/sokosumi/pull/3300) — full feature summary and test plan

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1271,7 +1271,7 @@ model Task {
   workspace   Workspace @relation(fields: [workspaceId], references: [id])
 
   pendingVendorGrantId String?      @db.Uuid
-  /// Cleared when the grant row is deleted (onDelete: SetNull).
+  /// Cleared when the grant row is deleted (onDelete: SetNull). Exposed on the Core task API while status is GRANT_PENDING.
   pendingVendorGrant   VendorGrant? @relation(fields: [pendingVendorGrantId], references: [id], onDelete: SetNull)
 
   /// Target status after vendor workspace grant approval. Only set while status is GRANT_PENDING.


### PR DESCRIPTION
## Summary

- Adds in-repo coworker integrator guide for vendor workspace grants (`GRANT_PENDING`, delegated create, 403 kinds)
- Aligns OpenAPI/Prisma/mapper docs with intentional exposure of `pendingVendorGrantId` and `grantResumeStatus` while tasks are parked
- Low-risk maintainability: removes unused `lockAndGetVendorGrantById`, drops stale `getWorkspaceGrant` mocks in task create tests, deduplicates coworker comment grant checks via `requireCoworkerTaskRead`

## Commits

1. `docs(coworker): add vendor workspace grants API guide`
2. `docs(core): clarify grant parking fields on task API`
3. `refactor(vendor-grants): remove dead helper and simplify comment access`

## Test plan

- [x] `pnpm --filter core test src/helpers/access-control.test.ts src/helpers/vendor-grants.test.ts src/routes/v1/tasks/post.test.ts`
- [ ] `pnpm --filter core test` (optional full core suite)


Made with [Cursor](https://cursor.com)