### PR TITLE
fix(web): preserve first newline in markdown editor serialize

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx
@@ -417,4 +417,57 @@ describe("MarkdownEditor", () => {
     expect(savedMarkdown).toBe("test\ntest\ntest\n");
     expect(savedMarkdown).not.toContain("testtest");
   });
+
+  it("preserves br-based line breaks when saving", async () => {
+    const onChange = vi.fn();
+
+    render(<MarkdownEditor value="" onChange={onChange} />);
+
+    const editor = screen.getByRole("textbox");
+    editor.innerHTML = "line1<br>line2<br>line3";
+    fireEvent.input(editor);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const savedMarkdown = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(savedMarkdown).toBe("line1\nline2\nline3");
+  });
+
+  it("keeps a heading on a new line after bare preceding text", async () => {
+    const onChange = vi.fn();
+
+    render(<MarkdownEditor value="" onChange={onChange} />);
+
+    const editor = screen.getByRole("textbox");
+    editor.innerHTML = "text<h2>heading</h2>";
+    fireEvent.input(editor);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const savedMarkdown = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(savedMarkdown).toBe("text\n## heading\n");
+    expect(savedMarkdown).not.toContain("text##");
+  });
+
+  it("keeps a blockquote on a new line after bare preceding text", async () => {
+    const onChange = vi.fn();
+
+    render(<MarkdownEditor value="" onChange={onChange} />);
+
+    const editor = screen.getByRole("textbox");
+    editor.innerHTML = "text<blockquote>quote</blockquote>";
+    fireEvent.input(editor);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const savedMarkdown = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(savedMarkdown).toBe("text\nquote\n");
+    expect(savedMarkdown).not.toContain("textquote");
+  });
 });

--- a/apps/web/src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx
@@ -379,4 +379,42 @@ describe("MarkdownEditor", () => {
     const savedMarkdown = onChange.mock.calls.at(-1)?.[0] as string;
     expect(savedMarkdown).toContain("```\nline 1\nline 2\n```\n");
   });
+
+  it("preserves the first newline for Chrome contentEditable div lines", async () => {
+    const onChange = vi.fn();
+
+    render(<MarkdownEditor value="" onChange={onChange} />);
+
+    const editor = screen.getByRole("textbox");
+    // Chrome Enter after the first line leaves bare text, then wraps later
+    // lines in <div> — without a separator the first break becomes "testtest".
+    editor.innerHTML = "test<div>test</div><div>test</div>";
+    fireEvent.input(editor);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const savedMarkdown = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(savedMarkdown).toBe("test\ntest\ntest\n");
+    expect(savedMarkdown).not.toContain("testtest");
+  });
+
+  it("preserves the first newline for paragraph-wrapped lines", async () => {
+    const onChange = vi.fn();
+
+    render(<MarkdownEditor value="" onChange={onChange} />);
+
+    const editor = screen.getByRole("textbox");
+    editor.innerHTML = "test<p>test</p><p>test</p>";
+    fireEvent.input(editor);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const savedMarkdown = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(savedMarkdown).toBe("test\ntest\ntest\n");
+    expect(savedMarkdown).not.toContain("testtest");
+  });
 });

--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -51,6 +51,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   getBacktickFence,
+  isBlockMarkdownElement,
   normalizeUrl,
 } from "@/lib/utils/markdown-editor-utils";
 import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
@@ -380,28 +381,6 @@ export const MarkdownEditor = forwardRef<
       return `${fenceHeader}\n${codeContent}\n${fence}\n`;
     }
 
-    function isBlockMarkdownElement(
-      childTag: string,
-      childMarkdown: string,
-    ): boolean {
-      // Chrome contentEditable Enter wraps later lines in <div>/<p>. Those
-      // blocks already serialize with a trailing newline, but the preceding
-      // sibling (often a bare text node for the first line) does not — so we
-      // must insert a separator before the block or the first break is lost.
-      return (
-        childTag === "pre" ||
-        childTag === "div" ||
-        childTag === "p" ||
-        childTag === "h1" ||
-        childTag === "h2" ||
-        childTag === "h3" ||
-        childTag === "ul" ||
-        childTag === "ol" ||
-        childTag === "li" ||
-        (childTag === "code" && childMarkdown.startsWith("```"))
-      );
-    }
-
     function appendChildMarkdown(
       acc: string,
       child: Node,
@@ -519,6 +498,7 @@ export const MarkdownEditor = forwardRef<
             return "\n";
           case "div":
           case "p":
+          case "blockquote":
             return content.endsWith("\n") ? content : `${content}\n`;
           default:
             return content;

--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -380,6 +380,28 @@ export const MarkdownEditor = forwardRef<
       return `${fenceHeader}\n${codeContent}\n${fence}\n`;
     }
 
+    function isBlockMarkdownElement(
+      childTag: string,
+      childMarkdown: string,
+    ): boolean {
+      // Chrome contentEditable Enter wraps later lines in <div>/<p>. Those
+      // blocks already serialize with a trailing newline, but the preceding
+      // sibling (often a bare text node for the first line) does not — so we
+      // must insert a separator before the block or the first break is lost.
+      return (
+        childTag === "pre" ||
+        childTag === "div" ||
+        childTag === "p" ||
+        childTag === "h1" ||
+        childTag === "h2" ||
+        childTag === "h3" ||
+        childTag === "ul" ||
+        childTag === "ol" ||
+        childTag === "li" ||
+        (childTag === "code" && childMarkdown.startsWith("```"))
+      );
+    }
+
     function appendChildMarkdown(
       acc: string,
       child: Node,
@@ -392,15 +414,12 @@ export const MarkdownEditor = forwardRef<
 
       const childElement = child as HTMLElement;
       const childTag = childElement.tagName.toLowerCase();
-      const shouldTreatAsBlockCode =
-        childTag === "pre" ||
-        (childTag === "code" && childMarkdown.startsWith("```"));
+      const shouldSeparateAsBlock = isBlockMarkdownElement(
+        childTag,
+        childMarkdown,
+      );
 
-      if (!shouldTreatAsBlockCode) {
-        return acc + childMarkdown;
-      }
-
-      if (acc.length > 0 && !acc.endsWith("\n")) {
+      if (shouldSeparateAsBlock && acc.length > 0 && !acc.endsWith("\n")) {
         return `${acc}\n${childMarkdown}`;
       }
 

--- a/apps/web/src/lib/utils/__tests__/markdown-editor-utils.test.ts
+++ b/apps/web/src/lib/utils/__tests__/markdown-editor-utils.test.ts
@@ -3,6 +3,7 @@ import {
   formatHeading,
   formatInlineCodeSnippet,
   formatMarkdownLink,
+  isBlockMarkdownElement,
 } from "@/lib/utils/markdown-editor-utils";
 
 describe("formatInlineCodeSnippet", () => {
@@ -52,5 +53,29 @@ describe("formatHeading", () => {
 
   it("formats a markdown heading", () => {
     expect(formatHeading("Details")).toBe("\n## Details\n");
+  });
+});
+
+describe("isBlockMarkdownElement", () => {
+  it("treats line-break containers and lists as blocks", () => {
+    expect(isBlockMarkdownElement("div", "line\n")).toBe(true);
+    expect(isBlockMarkdownElement("p", "line\n")).toBe(true);
+    expect(isBlockMarkdownElement("blockquote", "quote\n")).toBe(true);
+    expect(isBlockMarkdownElement("h2", "## heading\n")).toBe(true);
+    expect(isBlockMarkdownElement("ul", "- item\n")).toBe(true);
+    expect(isBlockMarkdownElement("pre", "```\ncode\n```\n")).toBe(true);
+  });
+
+  it("treats fenced code as a block but not inline code", () => {
+    expect(isBlockMarkdownElement("code", "```\ncode\n```\n")).toBe(true);
+    expect(isBlockMarkdownElement("code", "`inline`")).toBe(false);
+  });
+
+  it("does not treat br or inline tags as blocks", () => {
+    expect(isBlockMarkdownElement("br", "\n")).toBe(false);
+    expect(isBlockMarkdownElement("strong", "**bold**")).toBe(false);
+    expect(isBlockMarkdownElement("a", "[label](https://example.com)")).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/src/lib/utils/markdown-editor-utils.ts
+++ b/apps/web/src/lib/utils/markdown-editor-utils.ts
@@ -2,6 +2,33 @@ const DEFAULT_CODE_TEXT = "code";
 const DEFAULT_LINK_TEXT = "link";
 const DEFAULT_HEADING_TEXT = "Heading";
 
+/**
+ * Tags whose html→markdown serializer emits a trailing newline (or a fenced
+ * code block). When these follow bare text — Chrome contentEditable's first
+ * line pattern — prepend `\n` so the first break is not glued away.
+ *
+ * Keep in sync with `processNode` cases in `markdown-editor.tsx` that append
+ * `\n` (`div`/`p`/`blockquote`/headings/lists/`pre`/fenced `code`).
+ */
+export function isBlockMarkdownElement(
+  childTag: string,
+  childMarkdown: string,
+): boolean {
+  return (
+    childTag === "pre" ||
+    childTag === "div" ||
+    childTag === "p" ||
+    childTag === "blockquote" ||
+    childTag === "h1" ||
+    childTag === "h2" ||
+    childTag === "h3" ||
+    childTag === "ul" ||
+    childTag === "ol" ||
+    childTag === "li" ||
+    (childTag === "code" && childMarkdown.startsWith("```"))
+  );
+}
+
 function getNormalizedSelection(
   selectionText: string,
   fallbackText: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chrome `contentEditable` Enter leaves the first line as bare text and wraps later lines in `<div>`/`<p>`. `htmlToMarkdown` only inserted a separator before fenced code blocks, so the first break was glued (`testtest\ntest`).

## Changes

- Treat block elements (`div`, `p`, `blockquote`, headings, lists, fenced `code`/`pre`) as needing a leading `\n` when the accumulator does not already end with one
- Hoist `isBlockMarkdownElement` to `markdown-editor-utils` (kept in sync with `processNode` tags that append `\n`)
- Serialize `blockquote` like other block siblings (trailing newline)
- Regression tests for Chrome `<div>`/`<p>` trees, `<br>` lines, heading/blockquote after bare text, plus unit coverage for the helper

## Verification

- `pnpm --filter web test src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx src/lib/utils/__tests__/markdown-editor-utils.test.ts` (31 passed)
- Pre-commit: `pnpm check` + `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-332f5a10-8c6a-4162-aab3-075d2ac6fd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-332f5a10-8c6a-4162-aab3-075d2ac6fd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

