### PR TITLE
chore(agents): update model versions for Tech Lead and Reviewer in Sapphire documentation

### DIFF
--- a/.cursor/skills/_team-sapphire/AGENTS.md
+++ b/.cursor/skills/_team-sapphire/AGENTS.md
@@ -18,9 +18,9 @@ Single-issue squad: Investigator → Tech Lead → Coder(s) → Reviewer.
 
 | Role | File | Model |
 |------|------|-------|
-| Tech Lead | `.cursor/agents/sapphire-tech-lead.md` | `claude-opus-4-8` |
+| Tech Lead | `.cursor/agents/sapphire-tech-lead.md` | `grok-4.5` |
 | Coder | `.cursor/agents/sapphire-coder.md` | `composer-2.5` |
-| Reviewer | `.cursor/agents/sapphire-reviewer.md` | `gpt-5.5-medium` |
+| Reviewer | `.cursor/agents/sapphire-reviewer.md` | `grok-4.5` |
 
 Investigator uses the orchestrator model — no subagent override.
 

--- a/.cursor/skills/_team-sapphire/CURSOR-AUTOMATION.md
+++ b/.cursor/skills/_team-sapphire/CURSOR-AUTOMATION.md
@@ -43,7 +43,7 @@ Documented for teams that **stop using `_task` MCP delegate entirely** and accep
 | Trigger | Linear — Delegate assigned → `Cursor` |
 | Filter | Team SOK; description contains `## Sapphire status` |
 | Tools | Linear MCP, GitHub MCP — computer use is built into Cloud Agents |
-| Instructions | Read repo `.cursor/skills/_team-sapphire/SKILL.md`. Run full squad on this issue. Single issue only. **Role models:** Tech Lead `claude-opus-4-8`, Coder `composer-2.5`, Reviewer `gpt-5.5-medium` (see `.cursor/agents/sapphire-*.md`). **Mandatory:** `PHASE-GATE.md` — post phase comment + update status table after each phase; run exit gate before finishing. Reviewer: PR artifacts per `VISUAL-CAPTURE.md`. |
+| Instructions | Read repo `.cursor/skills/_team-sapphire/SKILL.md`. Run full squad on this issue. Single issue only. **Role models:** Tech Lead, Coder, Reviewer (see `.cursor/agents/sapphire-*.md`). **Mandatory:** `PHASE-GATE.md` — post phase comment + update status table after each phase; run exit gate before finishing. Reviewer: PR artifacts per `VISUAL-CAPTURE.md`. |
 
 Filter on `## Sapphire status`, **not** `[repo=…]` alone.
 

--- a/.cursor/skills/_team-sapphire/SKILL.md
+++ b/.cursor/skills/_team-sapphire/SKILL.md
@@ -53,11 +53,11 @@ Resume runs: pick start phase with **artifact-aware resume** (below) — not sta
 
 Investigator runs on the **orchestrator model** (no override). Phases 2–4 delegate to subagents — use `/sapphire-tech-lead`, `/sapphire-coder`, `/sapphire-reviewer` or Task with the same `model` slug.
 
-| Role | Subagent | Model |
-|------|----------|-------|
-| Tech Lead | `sapphire-tech-lead` | `claude-opus-4-8` |
-| Coder(s) | `sapphire-coder` | `composer-2.5` |
-| Reviewer | `sapphire-reviewer` | `gpt-5.5-medium` |
+| Role | Subagent |
+|------|----------|
+| Tech Lead | `sapphire-tech-lead` |
+| Coder(s) | `sapphire-coder` |
+| Reviewer | `sapphire-reviewer` |
 
 Subagent definitions: `.cursor/agents/sapphire-*.md`. When launching Task subagents for coders, always pass `model: composer-2.5`.
 
@@ -105,7 +105,7 @@ See `WORKFLOW.md`. Role details: `INVESTIGATOR.md`, `TECH-LEAD.md`, `CODER.md`, 
 
 ### Phase 2 — Tech Lead
 
-1. Delegate to **`sapphire-tech-lead`** (`model: claude-opus-4-8`) with Requirement (Linear) + Investigation (**session**).
+1. Delegate to **`sapphire-tech-lead`** with Requirement (Linear) + Investigation (**session**).
 2. Receive final spec per `SPEC-TEMPLATE.md` and `SUBAGENT-RUBRIC.md`.
 3. Keep the spec markdown **in session** — pass the full text to Coder and Reviewer. Do **not** merge `## Spec` into the Linear description.
 4. **Gate (blocking):** `save_comment` → `**Sapphire · Tech Lead complete**` (coder count, order, 3–5 bullets). Then `save_issue` → Tech Lead row `done`. Do **not** open Phase 3 until both succeed.


### PR DESCRIPTION
## Summary
- Point Team Sapphire Tech Lead and Reviewer role models to `grok-4.5` in `AGENTS.md`
- Drop duplicated model slugs from `SKILL.md` and Cursor automation instructions so role models live in `.cursor/agents/sapphire-*.md`
- Keep Coder on `composer-2.5` (still required when launching Task coder subagents)

## Key changes
- `.cursor/skills/_team-sapphire/AGENTS.md` — Tech Lead / Reviewer → `grok-4.5`
- `.cursor/skills/_team-sapphire/SKILL.md` — role table is subagent-only; Phase 2 no longer hardcodes a Tech Lead model override
- `.cursor/skills/_team-sapphire/CURSOR-AUTOMATION.md` — automation prompt references agent defs instead of inline model list

## Test plan
- [ ] Confirm `.cursor/agents/sapphire-tech-lead.md` and `sapphire-reviewer.md` match the intended models
- [ ] Spot-check Sapphire skill load order still documents Coder `composer-2.5` requirement
- [ ] No app/runtime verification needed (docs-only)


Made with [Cursor](https://cursor.com)