### PR TITLE
chore(web): drop stale SOK-594 note from core-dto types

### DIFF
--- a/apps/web/src/lib/types/core-dto.ts
+++ b/apps/web/src/lib/types/core-dto.ts
@@ -26,9 +26,9 @@ export type OrganizationWithLimitedInfo = Pick<
 
 export type OrganizationMembershipSelf = Pick<MemberRecord, "id" | "role">;
 
-/** Core API enum unions — prefer generated const maps for runtime values
- * (`TaskStatus.RUNNING` from `@/lib/clients/generated/core`). Utils maps remain
- * until SOK-594 finishes the web migration. */
+/** Core API enum unions derived from generated entity fields.
+ * Prefer generated const maps for runtime values
+ * (`TaskStatus.RUNNING` from `@/lib/clients/generated/core`). */
 export type TaskStatus = Task["status"];
 export type SokosumiJobStatus = JobSummary["status"];
 export type JobType = Job["jobType"];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the Core DTO roadmap leftover. All eight phase sub-issues are already Done. This PR only removes a stale comment in `apps/web/src/lib/types/core-dto.ts` that still said utils enum maps remain until the web runtime enum migration finished.

## Verification

- No `@sokosumi/database` imports in web app code
- Domain enum runtime values in web come from `@/lib/clients/generated/core` (only the allowlisted drift test imports `SokosumiJobStatus` from utils)
- `pnpm --filter web test src/lib/clients/__tests__/core-enums-drift.test.ts` — 14 passed
- `pnpm check` + `pnpm typecheck` via pre-commit

## Phase PRs (already merged)

#3217, #3309, #3313, #3315, #3320, #3321, #3324, #3325
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-588](https://linear.app/masumi/issue/SOK-588/web-fully-rely-on-core-dtos-roadmap)

<div><a href="https://cursor.com/agents/bc-43eba2e2-9c34-4bce-a9f5-ea9435b5ab33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43eba2e2-9c34-4bce-a9f5-ea9435b5ab33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

