### PR TITLE
feat(web): add mark all as read to notification popover

### DIFF
--- a/apps/web/src/app/(app)/components/header/notification-dropdown-content.tsx
+++ b/apps/web/src/app/(app)/components/header/notification-dropdown-content.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { toast } from "sonner";
 import { AccountNoticeRow } from "@/app/components/account-notice-row";
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
 import { Button } from "@/components/ui/button";
@@ -31,8 +33,16 @@ export function NotificationDropdownContent({
   const { handleSelectWorkspace } = useWorkspaceSwitcher();
   const activeOrganizationId = session?.session.activeOrganizationId ?? null;
   const { notice } = useAccountNotice();
-  const { notifications, markRead, isLoading, hasFetchError, refetch } =
-    useNotifications();
+  const {
+    notifications,
+    unreadCount,
+    markRead,
+    markAllRead,
+    isLoading,
+    hasFetchError,
+    refetch,
+  } = useNotifications();
+  const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
 
   const handleNotificationClick = async (notificationId: string) => {
     const notification = notifications.find((n) => n.id === notificationId);
@@ -54,6 +64,19 @@ export function NotificationDropdownContent({
       tDetail,
     );
     onClose();
+  };
+
+  const handleMarkAllRead = async () => {
+    if (isMarkingAllRead || unreadCount === 0) return;
+
+    setIsMarkingAllRead(true);
+    try {
+      await markAllRead();
+    } catch {
+      toast.error(t("markAllReadError"));
+    } finally {
+      setIsMarkingAllRead(false);
+    }
   };
 
   const handleSeeMoreClick = () => {
@@ -118,7 +141,24 @@ export function NotificationDropdownContent({
   return (
     <>
       {accountNoticeSection}
-      <DropdownMenuLabel>{t("title")}</DropdownMenuLabel>
+      <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+        <DropdownMenuLabel className="p-0">{t("title")}</DropdownMenuLabel>
+        {unreadCount > 0 ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground h-auto px-2 py-1 text-xs font-normal"
+            onPointerDown={(event) => {
+              event.preventDefault();
+            }}
+            onClick={() => void handleMarkAllRead()}
+            disabled={isMarkingAllRead}
+          >
+            {isMarkingAllRead ? t("loading") : t("markAllRead")}
+          </Button>
+        ) : null}
+      </div>
       <DropdownMenuSeparator />
       <div className="max-h-96 overflow-y-auto">
         {notifications.map((notification) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Mark all as read** action to the header notifications popover.

The full `/notifications` page and Core API already supported this; the dropdown only marked items read one-by-one. The popover now reuses `useNotifications().markAllRead` and the existing `Components.NotificationCenter.markAllRead` copy.

## Changes

- Header row in `notification-dropdown-content.tsx`: title on the left, **Mark all as read** on the right when `unreadCount > 0`
- Loading disabled state + error toast (same pattern as the notifications page)
- Keeps the menu open so unread styling clears in place

## Verification

- `pnpm check` / precommit typecheck passed
- Manual: open the bell popover with unread items → click **Mark all as read** → badge clears and row unread styles drop
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afc7fa29-e506-4089-8d3b-5fc6add970b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afc7fa29-e506-4089-8d3b-5fc6add970b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

