### PR TITLE
fix(core): use assigneeId in coworker me/events query

### DIFF
--- a/apps/core/src/routes/v1/coworkers/me/events/get.test.ts
+++ b/apps/core/src/routes/v1/coworkers/me/events/get.test.ts
@@ -72,7 +72,7 @@ describe("GET /coworkers/me/events", () => {
       expect.objectContaining({
         where: {
           task: {
-            coworkerId: "cow_123",
+            assigneeId: "cow_123",
             status: { not: "DRAFT" },
           },
         },

--- a/apps/core/src/routes/v1/coworkers/me/events/get.ts
+++ b/apps/core/src/routes/v1/coworkers/me/events/get.ts
@@ -75,7 +75,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const where = {
       task: {
-        coworkerId: authContext.coworkerId,
+        assigneeId: authContext.coworkerId,
         status: { not: TaskStatus.DRAFT },
       },
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GET /v1/coworkers/me/events` was still filtering tasks with `task.coworkerId` after the Task role rename (#3330). Prisma rejects that field (`Unknown argument coworkerId`), so coworker event lists 500 in production ([SOKOSUMI-CORE-2K](https://masumi.sentry.io/issues/SOKOSUMI-CORE-2K)).

## Fix

Filter by `task.assigneeId` (the renamed Task assignee FK). Update the unit test expectation to match.

## Verification

- `pnpm --filter @sokosumi/core test src/routes/v1/coworkers/me/events/get.test.ts`
- Pre-commit: `pnpm check` + `pnpm typecheck`

Fixes SOKOSUMI-CORE-2K
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87d07087-cd2f-40b7-a8a2-e08c261e50da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87d07087-cd2f-40b7-a8a2-e08c261e50da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

