### PR TITLE
fix(vercel): filter web and core installs to required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Other available scripts:
 
 - **Staging:** All changes merged to `main` are auto-deployed to staging.
 - **Production:** Maintainers create a GitHub Release (semantic versioning, e.g., `v1.0.0`) to trigger production deployment.
-- **Database migrations:** The Core Vercel build (`pnpm vercel-build`) runs `prisma migrate deploy` **after** a successful app build and before the deployment activates (Production and Preview). With the Vercel Neon integration, each Preview gets its own database branch; Preview builds require `DATABASE_URL_UNPOOLED` so migrate cannot silently target a shared/production URL. Migrate prefers `DATABASE_URL_UNPOOLED`, otherwise `DATABASE_URL`. Web does not run migrations. See [apps/core/README.md](./apps/core/README.md#deployment-vercel) for the Neon checklist.
+- **Database migrations:** The Core Vercel build (`pnpm vercel-build`) runs `prisma migrate deploy` **after** a successful app build and before the deployment activates (Production and Preview). With the Vercel Neon integration, each Preview gets its own database branch; Preview builds require `DATABASE_URL_UNPOOLED` so migrate cannot silently target a shared/production URL. Migrate prefers `DATABASE_URL_UNPOOLED`, otherwise `DATABASE_URL`. Web does not run migrations and its Vercel install is filtered (`pnpm install --filter web...`) so `@sokosumi/database` is not installed or built. See [apps/core/README.md](./apps/core/README.md#deployment-vercel) for the Neon checklist.
 
 ## Contributing
 

--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -263,7 +263,10 @@ pnpm approve-builds @sentry/profiling-node
 
 ## Deployment (Vercel)
 
-Core’s [`vercel.json`](./vercel.json) sets `buildCommand` to `pnpm vercel-build`, which:
+Core’s [`vercel.json`](./vercel.json) sets:
+
+- `installCommand` to `pnpm install --filter @sokosumi/core...` so only Core and its workspace deps (including `@sokosumi/database`) are installed — not the web app or unrelated packages
+- `buildCommand` to `pnpm vercel-build`, which:
 
 1. Runs `pnpm run build` (workspace deps + `tsup`)
 2. On success, runs `prisma migrate deploy` using `DATABASE_URL_UNPOOLED` (from the Vercel Neon integration) or `DATABASE_URL`
@@ -271,7 +274,7 @@ Core’s [`vercel.json`](./vercel.json) sets `buildCommand` to `pnpm vercel-buil
 
 **Order is intentional:** migrate runs only after a successful app build so a compile failure never touches the database. Schema still applies before Vercel activates the new deployment once migrate succeeds (unlike some Neon samples that migrate first).
 
-No manual DB URL setup for migrate when the Neon integration is connected — it injects pooled and unpooled URLs for Production and each Preview branch. Preview builds **require** `DATABASE_URL_UNPOOLED` (`prisma.config.ts` fails closed for any Prisma CLI command) so a misconfigured Preview cannot fall back to a shared/production `DATABASE_URL`.
+No manual DB URL setup for migrate when the Neon integration is connected — it injects pooled and unpooled URLs for Production and each Preview branch. Preview builds **require** `DATABASE_URL_UNPOOLED` for DB-mutating Prisma CLI commands (`migrate …`, `db …`) so a misconfigured Preview cannot fall back to a shared/production `DATABASE_URL`. `prisma generate` (package prepare) does not need it.
 
 ### Neon / migrate checklist
 

--- a/apps/core/vercel.json
+++ b/apps/core/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --filter @sokosumi/core...",
   "buildCommand": "pnpm vercel-build",
   "functions": {
     "dist/index.js": {

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -91,6 +91,10 @@ Run tests using Vitest with the `happy-dom` browser-like environment:
 pnpm test
 ```
 
+### Deployment (Vercel)
+
+[`vercel.json`](./vercel.json) sets `installCommand` to `pnpm install --filter web...` so only the web app and its workspace deps (`@sokosumi/chat`, `@sokosumi/email`, `@sokosumi/masumi`, `@sokosumi/net`, `@sokosumi/utils`) are installed. `@sokosumi/database` is not a dependency and is not built on web deploys — no Neon/`DATABASE_URL*` vars are required.
+
 ### Database setup
 
 The web app does not connect to Postgres directly. Bootstrap the database from the repo root (`pnpm prisma:migrate:dev`, `pnpm prisma:generate`) and configure `apps/core/.env` — see the root `AGENTS.md` setup section.

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --filter web...",
   "relatedProjects": [
     "prj_CSgdc8zCRyR5ZT1LH8VkDJBJTtff",
     "prj_GrqmJbIxWe0I6aYiZHZC2hiJYLiH"

--- a/packages/database/AGENTS.md
+++ b/packages/database/AGENTS.md
@@ -147,7 +147,7 @@ export const userRepository = {
 - Create migrations with `pnpm prisma:migrate:dev`
 - Migration files are in `prisma/migrations/`
 - Use descriptive migration names
-- **Vercel (Core):** After a successful Core app build, `pnpm vercel-build` runs `prisma migrate deploy` against that deployment’s database (Production and Preview). Order is build-then-migrate (do not migrate if the app fails to compile). Prisma CLI prefers `DATABASE_URL_UNPOOLED` (injected by the Vercel Neon integration), then `DATABASE_URL`. `prisma.config.ts` runs `checkMigrateDeployEnv` on every CLI load: Preview without `DATABASE_URL_UNPOOLED` fails closed (including raw `prisma migrate deploy`); other Vercel envs warn if unpooled is missing. Keep migrations backward-compatible with the previous Core release for the brief window before the new deployment activates.
+- **Vercel (Core):** After a successful Core app build, `pnpm vercel-build` runs `prisma migrate deploy` against that deployment’s database (Production and Preview). Order is build-then-migrate (do not migrate if the app fails to compile). Prisma CLI prefers `DATABASE_URL_UNPOOLED` (injected by the Vercel Neon integration), then `DATABASE_URL`. `prisma.config.ts` runs `checkMigrateDeployEnv` only for DB-mutating CLI commands (`migrate …`, `db …`): Preview without `DATABASE_URL_UNPOOLED` fails closed (including raw `prisma migrate deploy`); other Vercel envs warn if unpooled is missing. `prisma generate` (this package’s prepare) skips the preflight. Web Vercel installs use `pnpm install --filter web...` and never install this package. Keep migrations backward-compatible with the previous Core release for the brief window before the new deployment activates.
 
 ## Package-Specific Commands
 

--- a/packages/database/prisma.config.ts
+++ b/packages/database/prisma.config.ts
@@ -2,16 +2,23 @@ import "dotenv/config";
 
 import type { PrismaConfig } from "prisma/config";
 
-import { checkMigrateDeployEnv } from "./src/helpers/migrate-deploy-preflight.js";
+import {
+  checkMigrateDeployEnv,
+  isDbMutatingPrismaCommand,
+} from "./src/helpers/migrate-deploy-preflight.js";
 
-// Runs for any Prisma CLI command that loads this config (migrate, generate, …).
-// Preview without DATABASE_URL_UNPOOLED fails closed so a raw
-// `prisma migrate deploy` cannot fall back to a shared/production DATABASE_URL.
-const preflight = checkMigrateDeployEnv({
-  VERCEL: process.env.VERCEL,
-  VERCEL_ENV: process.env.VERCEL_ENV,
-  DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
-});
+// Preflight only DB-mutating CLI commands (`migrate …`, `db …`): Preview
+// without DATABASE_URL_UNPOOLED fails closed so a raw `prisma migrate deploy`
+// cannot fall back to a shared/production DATABASE_URL. No-DB commands like
+// `prisma generate` (this package's prepare script) skip it: they have
+// nothing to guard and must not fail installs/builds.
+const preflight = isDbMutatingPrismaCommand(process.argv)
+  ? checkMigrateDeployEnv({
+      VERCEL: process.env.VERCEL,
+      VERCEL_ENV: process.env.VERCEL_ENV,
+      DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
+    })
+  : { ok: true as const, messages: [] };
 
 for (const message of preflight.messages) {
   const prefix =

--- a/packages/database/src/helpers/migrate-deploy-preflight.test.ts
+++ b/packages/database/src/helpers/migrate-deploy-preflight.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from "vitest";
 
-import { checkMigrateDeployEnv } from "./migrate-deploy-preflight.js";
+import {
+  checkMigrateDeployEnv,
+  isDbMutatingPrismaCommand,
+} from "./migrate-deploy-preflight.js";
+
+describe("isDbMutatingPrismaCommand", () => {
+  it.each([
+    ["migrate deploy", ["node", "/x/prisma", "migrate", "deploy"]],
+    ["migrate dev", ["node", "/x/prisma", "migrate", "dev"]],
+    ["db push", ["node", "/x/prisma", "db", "push"]],
+    ["db execute", ["node", "/x/prisma", "db", "execute", "--file", "x.sql"]],
+  ])("is true for %s", (_label: string, argv: string[]) => {
+    expect(isDbMutatingPrismaCommand(argv)).toBe(true);
+  });
+
+  it.each([
+    ["generate", ["node", "/x/prisma", "generate"]],
+    ["validate", ["node", "/x/prisma", "validate"]],
+    ["format", ["node", "/x/prisma", "format"]],
+    ["version", ["node", "/x/prisma", "version"]],
+  ])("is false for %s", (_label: string, argv: string[]) => {
+    expect(isDbMutatingPrismaCommand(argv)).toBe(false);
+  });
+});
 
 describe("checkMigrateDeployEnv", () => {
   it("is a no-op outside Vercel", () => {

--- a/packages/database/src/helpers/migrate-deploy-preflight.ts
+++ b/packages/database/src/helpers/migrate-deploy-preflight.ts
@@ -1,10 +1,13 @@
 /**
  * Guardrails for Prisma CLI on Vercel (loaded via `prisma.config.ts`).
  *
- * Applies to any command that loads the Prisma config (migrate, generate, …),
- * not only the package `prisma:migrate:deploy` script — so a raw
- * `prisma migrate deploy` on Preview is gated the same way.
+ * Scoped to DB-MUTATING commands only (`prisma migrate …`, `prisma db …`) —
+ * including a raw `prisma migrate deploy`, which loads this config the same
+ * way as the package script. Commands that never touch a database
+ * (`prisma generate`, run by this package's prepare script during workspace
+ * install) are exempt: they have nothing to guard and must not fail builds.
  *
+ * For mutating commands:
  * - Preview without DATABASE_URL_UNPOOLED: fail closed (avoids migrating a
  *   shared / production DB when Neon preview branching is misconfigured).
  * - Other Vercel envs without DATABASE_URL_UNPOOLED: warn (Neon DDL via the
@@ -16,6 +19,16 @@ export interface MigrateDeployPreflightEnv {
   VERCEL?: string;
   VERCEL_ENV?: string;
   DATABASE_URL_UNPOOLED?: string;
+}
+
+/**
+ * True when the Prisma CLI invocation (its argv) is a command that can write
+ * to the database: `migrate` (deploy/dev/reset/resolve/…) or `db`
+ * (push/execute/seed). Read-only/no-DB commands like `generate`, `validate`,
+ * or `format` return false and skip the preflight entirely.
+ */
+export function isDbMutatingPrismaCommand(argv: readonly string[]): boolean {
+  return argv.some((arg) => arg === "migrate" || arg === "db");
 }
 
 export type PreflightMessageLevel = "error" | "warn";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Web mainnet Vercel builds were installing the full monorepo, which ran `@sokosumi/database`’s `prepare` (`prisma generate` + build) even though web does not depend on that package and has no Neon/`DATABASE_URL*` env vars.

## Changes

- **Web** `vercel.json`: `installCommand` → `pnpm install --filter web...` (chat, email, masumi, net, utils only — no database / ai-provider)
- **Core** `vercel.json`: `installCommand` → `pnpm install --filter @sokosumi/core...` (includes database and other Core deps; still runs migrate via `vercel-build`)
- **Defense in depth:** Prisma Preview `DATABASE_URL_UNPOOLED` preflight now runs only for DB-mutating CLI commands (`migrate …`, `db …`), not `prisma generate`

## Verification

- Confirmed filter graphs with `pnpm m ls --filter web...` / `--filter @sokosumi/core...`
- `pnpm --filter @sokosumi/database test src/helpers/migrate-deploy-preflight.test.ts` (14 passed)
- Pre-commit `pnpm check` + `pnpm typecheck` green

## Deploy note

After merge, confirm web install logs show a scoped workspace install (no `@sokosumi/database` prepare). Core should still install/build database and run `prisma migrate deploy`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-262085b9-da9f-434d-bfc5-4d7bbd1a1a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-262085b9-da9f-434d-bfc5-4d7bbd1a1a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

