### PR TITLE
fix(hermes): gate personal assistant use behind paid plan

### DIFF
--- a/apps/core/src/routes/v1/hermes/index.test.ts
+++ b/apps/core/src/routes/v1/hermes/index.test.ts
@@ -307,7 +307,9 @@ describe("Hermes route contracts", () => {
     memberFindFirstMock.mockResolvedValue(null);
     memberFindManyMock.mockResolvedValue([]);
     enterpriseContractFindFirstMock.mockResolvedValue(null);
-    resolveActiveSubscriptionMock.mockResolvedValue(null);
+    // Default to paid coverage so use-path tests exercise business logic,
+    // not the subscription gate. Unpaid cases set this back to null.
+    resolveActiveSubscriptionMock.mockResolvedValue({ plan: "starter" });
     resolveOrganizationBillingPlanMock.mockResolvedValue({
       mode: "self_serve",
       plan: "free",
@@ -1743,6 +1745,8 @@ describe("Hermes route contracts", () => {
   });
 
   it("blocks provisioning without paid coverage and never calls the orchestrator", async () => {
+    resolveActiveSubscriptionMock.mockResolvedValue(null);
+
     const response = await createApp().request("/me/instance", {
       method: "POST",
       headers: { Authorization: "Bearer test_api_key" },
@@ -1751,9 +1755,60 @@ describe("Hermes route contracts", () => {
 
     expect(response.status).toBe(403);
     expect(body.message).toBe(
-      "A paid subscription is required to activate the personal assistant.",
+      "A paid subscription is required to use the personal assistant.",
     );
     expect(provisionInstance).not.toHaveBeenCalled();
+  });
+
+  it("blocks chat without paid coverage and never calls the orchestrator", async () => {
+    resolveActiveSubscriptionMock.mockResolvedValue(null);
+    vi.mocked(getInstance).mockResolvedValue({
+      ...instanceWithPendingConfirmation(),
+      status: "running",
+      pendingConfirmations: [],
+    });
+
+    const response = await createApp().request("/chat", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test_api_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ content: "hello" }),
+    });
+    const body = await parseJson(response);
+
+    expect(response.status).toBe(403);
+    expect(body.message).toBe(
+      "A paid subscription is required to use the personal assistant.",
+    );
+    expect(proxyChatCompletionsMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks onboarding without paid coverage", async () => {
+    resolveActiveSubscriptionMock.mockResolvedValue(null);
+
+    const response = await createApp().request("/me/instance/onboard", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test_api_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        assistantName: "Ada",
+        avatarSeed: "seed_1",
+        researchDepth: "deep",
+        autonomyLevel: "medium",
+        personality: { tone: 50, detail: 50, style: 50 },
+      }),
+    });
+    const body = await parseJson(response);
+
+    expect(response.status).toBe(403);
+    expect(body.message).toBe(
+      "A paid subscription is required to use the personal assistant.",
+    );
+    expect(startInstanceOnboardingMock).not.toHaveBeenCalled();
   });
 
   it("provisions when the user has an active paid personal subscription", async () => {
@@ -1773,6 +1828,7 @@ describe("Hermes route contracts", () => {
   });
 
   it("provisions when a member organization carries the paid plan", async () => {
+    resolveActiveSubscriptionMock.mockResolvedValue(null);
     memberFindManyMock.mockResolvedValue([{ organizationId: "org_paid" }]);
     resolveOrganizationBillingPlanMock.mockResolvedValue({
       mode: "self_serve",

--- a/apps/core/src/routes/v1/hermes/index.ts
+++ b/apps/core/src/routes/v1/hermes/index.ts
@@ -1551,10 +1551,13 @@ const finalizeIntegrationRoute = withGlobalHeaderParameters(
 
 const app = new OpenAPIHonoWithAuth();
 
-// Access posture: the personal assistant is available to all authenticated
-// users; the gate that matters is the paid-plan check on provisioning.
+// Access posture: viewing is open to authenticated users; activating and
+// using (chat, onboard, settings mutations, skills) require paid coverage
+// (or admin). Destroy / purge / GET reads stay ungated so cancelled users
+// can still see history and tear down.
 app.openapi(postChatRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const body = c.req.valid("json");
   const userContent = typeof body.content === "string" ? body.content : "";
   const trimmed = userContent.trim();
@@ -1820,6 +1823,7 @@ export async function captureFromStream(
  */
 app.post("/chat/stream", async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
 
   const rawJson = await c.req.json().catch(() => null);
   const parsed = hermesChatRequestSchema.safeParse(rawJson);
@@ -2100,19 +2104,29 @@ async function userHasPaidPlanCoverage(userId: string): Promise<boolean> {
   return false;
 }
 
+/**
+ * Enforce paid coverage for activating and using the personal assistant.
+ * Admins are exempt. Reads (GET instance / messages / unread) stay open so
+ * the UI can still show history and the subscription wall; destroy stays
+ * open so cancelled users can tear the instance down.
+ */
+async function requirePaidPlanCoverage(userContext: {
+  userId: string;
+  role: string | null | undefined;
+}): Promise<void> {
+  if (hasAdminRole(userContext.role)) return;
+  if (await userHasPaidPlanCoverage(userContext.userId)) return;
+  throw forbidden(
+    "A paid subscription is required to use the personal assistant.",
+  );
+}
+
 app.openapi(provisionInstanceRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
   // Paid-plan gate, mirroring the web action's check (which alone is
   // bypassable by calling this route directly with an API key). Admins are
   // exempt so the team can operate test instances without billing.
-  if (
-    !hasAdminRole(userContext.role) &&
-    !(await userHasPaidPlanCoverage(userContext.userId))
-  ) {
-    throw forbidden(
-      "A paid subscription is required to activate the personal assistant.",
-    );
-  }
+  await requirePaidPlanCoverage(userContext);
   const user = await prisma.user.findUnique({
     where: { id: userContext.userId },
     select: { name: true, email: true },
@@ -2150,6 +2164,7 @@ app.openapi(provisionInstanceRoute, async (c) => {
 
 app.openapi(updateInstanceRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const body = c.req.valid("json");
 
   try {
@@ -2361,6 +2376,7 @@ app.openapi(markInboxSeenRoute, async (c) => {
 
 app.openapi(setSecretRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const body = c.req.valid("json");
 
   if (!isValidSecretKey(body.key)) {
@@ -2391,6 +2407,7 @@ app.openapi(setSecretRoute, async (c) => {
 
 app.openapi(startOnboardingRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const body = c.req.valid("json");
 
   // Pull name/email from the DB if the client didn't provide them, so the
@@ -2481,6 +2498,7 @@ app.openapi(listSchedulesRoute, async (c) => {
 
 app.openapi(patchScheduleRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { scheduleId } = c.req.valid("param");
   const body = c.req.valid("json");
 
@@ -2506,6 +2524,7 @@ app.openapi(patchScheduleRoute, async (c) => {
 
 app.openapi(approveConfirmationRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { confirmationId } = c.req.valid("param");
   // Body is optional on this route — when the client posts no payload Hono
   // returns `undefined` and we treat it as the no-overrides case (Hermes'
@@ -2582,6 +2601,7 @@ app.openapi(approveConfirmationRoute, async (c) => {
 
 app.openapi(rejectConfirmationRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { confirmationId } = c.req.valid("param");
   const body = c.req.valid("json");
 
@@ -2623,6 +2643,7 @@ app.openapi(rejectConfirmationRoute, async (c) => {
 
 app.openapi(disconnectIntegrationRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { provider } = c.req.valid("param");
 
   // Mirror the dual-provider behaviour of finalize: Outlook's mail + calendar
@@ -2674,6 +2695,7 @@ function pairedOrchestratorProviders(
 
 app.openapi(initiateIntegrationRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { provider, mode } = c.req.valid("json");
   const toolkit = composioToolkitForProvider(provider);
   const callbackUrl = `${getWebAppBaseUrl()}/composio/callback`;
@@ -2829,6 +2851,7 @@ async function clearPendingConnection(connectionId: string): Promise<void> {
 
 app.openapi(finalizeIntegrationRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { provider, connectionId, mode } = c.req.valid("json");
   const toolkit = composioToolkitForProvider(provider);
 
@@ -3310,6 +3333,7 @@ app.openapi(preinstalledSkillsRoute, async (c) => {
 
 app.openapi(installSkillRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { source, slug } = c.req.valid("json");
 
   let input: HermesInstallSkillInput;
@@ -3355,6 +3379,7 @@ app.openapi(installSkillRoute, async (c) => {
 
 app.openapi(removeSkillRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
+  await requirePaidPlanCoverage(userContext);
   const { slug } = c.req.valid("param");
   try {
     await removeInstalledSkill(userContext.userId, slug);

--- a/apps/web/src/app/(app)/personal-assistant/README.md
+++ b/apps/web/src/app/(app)/personal-assistant/README.md
@@ -230,7 +230,10 @@ project channel if you don't have them yet. Never commit them.
 
 ### Enabling the feature
 
-The route is open to all authenticated users; activation is gated by a paid plan (or admin role) on the Core provision endpoint.
+The route is open to all authenticated users; activating **and using**
+(chat, onboard, settings mutations, skills, confirmations) are gated by a
+paid plan (or admin role) on the Core endpoints. Viewing history and
+destroying an instance stay open so cancelled users can tear down.
 Locally it's enabled for users in `HERMES_BETA_ALLOWLIST`, or for everyone
 when `HERMES_BETA_ALL_USERS=true`.
 

--- a/apps/web/src/app/(app)/personal-assistant/components/autonomy-panel.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/autonomy-panel.tsx
@@ -34,6 +34,8 @@ interface AutonomyPanelProps {
   onAutonomyChanged?: (next: HermesAutonomyLevel) => void;
   /** Re-pull the instance so the parent's autonomy badge stays fresh. */
   onRefreshInstance?: () => void | Promise<void>;
+  hasActiveSubscription?: boolean;
+  onRequireSubscription?: () => void;
 }
 
 /**
@@ -49,6 +51,8 @@ export default function AutonomyPanel({
   autonomyLevel,
   onAutonomyChanged,
   onRefreshInstance,
+  hasActiveSubscription = true,
+  onRequireSubscription,
 }: AutonomyPanelProps) {
   const t = useTranslations("App.Hermes.Settings");
   const tPanel = useTranslations("App.Hermes.AutonomyPanel");
@@ -69,6 +73,12 @@ export default function AutonomyPanel({
       setAutonomy(next);
 
       if (previewMode) return;
+
+      if (!hasActiveSubscription) {
+        setAutonomy(previous);
+        onRequireSubscription?.();
+        return;
+      }
 
       setAutonomySaving(true);
       // Piggyback the browser-detected IANA timezone every time the user
@@ -98,7 +108,15 @@ export default function AutonomyPanel({
       // resync the selector from the stale `autonomyLevel` prop.
       void onRefreshInstance?.();
     },
-    [autonomy, previewMode, onAutonomyChanged, onRefreshInstance, t],
+    [
+      autonomy,
+      previewMode,
+      hasActiveSubscription,
+      onRequireSubscription,
+      onAutonomyChanged,
+      onRefreshInstance,
+      t,
+    ],
   );
 
   const [schedules, setSchedules] = useState<HermesSchedule[]>([]);
@@ -158,6 +176,8 @@ export default function AutonomyPanel({
           <SchedulesSection
             schedules={schedules}
             loading={schedulesLoading}
+            hasActiveSubscription={hasActiveSubscription}
+            onRequireSubscription={onRequireSubscription}
             onScheduleUpdated={(updated) =>
               setSchedules((prev) =>
                 prev.map((s) => (s.id === updated.id ? updated : s)),
@@ -176,10 +196,14 @@ function SchedulesSection({
   schedules,
   loading,
   onScheduleUpdated,
+  hasActiveSubscription = true,
+  onRequireSubscription,
 }: {
   schedules: HermesSchedule[];
   loading: boolean;
   onScheduleUpdated: (next: HermesSchedule) => void;
+  hasActiveSubscription?: boolean;
+  onRequireSubscription?: () => void;
 }) {
   const t = useTranslations("App.Hermes.Settings");
   const onScheduleChange = onScheduleUpdated;
@@ -204,7 +228,13 @@ function SchedulesSection({
       ) : (
         <ul className="border-border/60 divide-border/60 divide-y overflow-hidden rounded-xl border">
           {schedules.map((s) => (
-            <ScheduleRow key={s.id} schedule={s} onChange={onScheduleChange} />
+            <ScheduleRow
+              key={s.id}
+              schedule={s}
+              onChange={onScheduleChange}
+              hasActiveSubscription={hasActiveSubscription}
+              onRequireSubscription={onRequireSubscription}
+            />
           ))}
         </ul>
       )}
@@ -226,15 +256,23 @@ function SchedulesSection({
 function ScheduleRow({
   schedule,
   onChange,
+  hasActiveSubscription = true,
+  onRequireSubscription,
 }: {
   schedule: HermesSchedule;
   onChange: (next: HermesSchedule) => void;
+  hasActiveSubscription?: boolean;
+  onRequireSubscription?: () => void;
 }) {
   const t = useTranslations("App.Hermes.Settings");
   const [toggling, setToggling] = useState(false);
 
   const handleToggle = async () => {
     if (toggling) return;
+    if (!hasActiveSubscription) {
+      onRequireSubscription?.();
+      return;
+    }
     setToggling(true);
     const result = await toggleHermesScheduleAction({
       scheduleId: schedule.id,

--- a/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
@@ -55,8 +55,9 @@ interface HermesExperienceProps {
   organizations?: HermesOrganizationOption[];
   /** Active org from the user's session; pre-selected in the dropdown. */
   activeOrganizationId?: string | null;
-  /** Whether the user (or their active org) has a paid subscription.
-   * Activating the assistant is gated on this — viewing the page is not. */
+  /** Whether the user (or a member org) has paid-plan coverage.
+   * Activating and using the assistant are gated on this — viewing
+   * history / the landing page is not. */
   hasActiveSubscription?: boolean;
   /** The 3 paid plans, shown as links on the subscription wall. Empty if
    * the catalog couldn't be loaded — the wall still works without them. */
@@ -228,9 +229,19 @@ export default function HermesExperience({
   const [committedSeed, setCommittedSeed] = useState<string | null | undefined>(
     undefined,
   );
-  /** The subscription wall — shown instead of activating when a free-plan
-   * user hits the CTA. Viewing EmptyState itself is never gated. */
+  /** The subscription wall — shown instead of activating / using when a
+   * free-plan user hits a paid CTA. Viewing EmptyState / history is
+   * never gated. */
   const [subscriptionWallOpen, setSubscriptionWallOpen] = useState(false);
+
+  const subscriptionWall = (
+    <SubscriptionRequiredDialog
+      open={subscriptionWallOpen}
+      onOpenChange={setSubscriptionWallOpen}
+      plans={subscriptionWallPlans}
+      activeOrganizationId={activeOrganizationId}
+    />
+  );
 
   // Anchors the elapsed-time displays (and, for provisioning, the 15-minute
   // timeout deadline) to persisted start times — recomputed only when we
@@ -533,6 +544,10 @@ export default function HermesExperience({
       autonomyLevel: HermesAutonomyLevel;
       personality: HermesPersonality;
     }) => {
+      if (!hasActiveSubscription) {
+        setSubscriptionWallOpen(true);
+        return;
+      }
       // Show their actual orb choice on the provisioning / progress screens
       // immediately, without waiting for the instance to round-trip it.
       setCommittedSeed(options.avatarSeed);
@@ -572,7 +587,7 @@ export default function HermesExperience({
         setIsStartingOnboarding(false);
       }
     },
-    [previewMode, t],
+    [previewMode, t, hasActiveSubscription],
   );
 
   // Base seed for the generative orb avatar — the user id makes every user's
@@ -597,12 +612,7 @@ export default function HermesExperience({
     return (
       <>
         <EmptyState onActivate={handleActivate} />
-        <SubscriptionRequiredDialog
-          open={subscriptionWallOpen}
-          onOpenChange={setSubscriptionWallOpen}
-          plans={subscriptionWallPlans}
-          activeOrganizationId={activeOrganizationId}
-        />
+        {subscriptionWall}
       </>
     );
   }
@@ -616,15 +626,18 @@ export default function HermesExperience({
   }
   if (uiState === "infrastructure_ready") {
     return (
-      <OnboardingScreen
-        defaultName={userName ?? ""}
-        defaultEmail={userEmail ?? ""}
-        orbBaseSeed={orbBaseSeed}
-        integrations={instance?.integrations ?? []}
-        previewMode={previewMode}
-        isStarting={isStartingOnboarding}
-        onContinue={(opts) => void handleStartOnboarding(opts)}
-      />
+      <>
+        <OnboardingScreen
+          defaultName={userName ?? ""}
+          defaultEmail={userEmail ?? ""}
+          orbBaseSeed={orbBaseSeed}
+          integrations={instance?.integrations ?? []}
+          previewMode={previewMode}
+          isStarting={isStartingOnboarding}
+          onContinue={(opts) => void handleStartOnboarding(opts)}
+        />
+        {subscriptionWall}
+      </>
     );
   }
   if (uiState === "onboarding") {
@@ -654,18 +667,23 @@ export default function HermesExperience({
     );
   }
   return (
-    <RunningState
-      userName={userName ?? null}
-      userImageUrl={userImageUrl ?? null}
-      avatarSeed={effectiveOrbSeed}
-      orbBaseSeed={orbBaseSeed}
-      instance={instance}
-      previewMode={previewMode}
-      initialMessages={initialMessages}
-      organizations={effectiveOrganizations}
-      activeOrganizationId={effectiveActiveOrgId}
-      onDestroy={handleDestroy}
-      onRefresh={() => refetchHermes({ background: true })}
-    />
+    <>
+      <RunningState
+        userName={userName ?? null}
+        userImageUrl={userImageUrl ?? null}
+        avatarSeed={effectiveOrbSeed}
+        orbBaseSeed={orbBaseSeed}
+        instance={instance}
+        previewMode={previewMode}
+        initialMessages={initialMessages}
+        organizations={effectiveOrganizations}
+        activeOrganizationId={effectiveActiveOrgId}
+        hasActiveSubscription={hasActiveSubscription}
+        onRequireSubscription={() => setSubscriptionWallOpen(true)}
+        onDestroy={handleDestroy}
+        onRefresh={() => refetchHermes({ background: true })}
+      />
+      {subscriptionWall}
+    </>
   );
 }

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state.tsx
@@ -135,6 +135,10 @@ interface RunningStateProps {
   organizations?: HermesOrganizationOption[];
   /** Active org from the session — pre-selected in the dropdown. */
   activeOrganizationId?: string | null;
+  /** Paid coverage for chat / confirmations / settings mutations. */
+  hasActiveSubscription?: boolean;
+  /** Opens the subscription wall when an unpaid user tries to use PA. */
+  onRequireSubscription?: () => void;
   onDestroy: () => Promise<void> | void;
   /** Re-pull the instance from the orchestrator. SettingsPanel calls this
    * after mutations so the integrations chip / autonomy badge don't drift. */
@@ -246,6 +250,8 @@ export default function RunningState({
   initialMessages,
   organizations = [],
   activeOrganizationId = null,
+  hasActiveSubscription = true,
+  onRequireSubscription,
   onDestroy,
   onRefresh,
 }: RunningStateProps) {
@@ -445,6 +451,11 @@ export default function RunningState({
       const trimmed = content.trim();
       const hasFiles = files.length > 0;
       if ((!trimmed && !hasFiles) || isReplying) return;
+
+      if (!previewMode && !hasActiveSubscription) {
+        onRequireSubscription?.();
+        return;
+      }
 
       const now = Date.now();
       const fileNote = hasFiles
@@ -779,7 +790,17 @@ export default function RunningState({
         }
       })();
     },
-    [files, isReplying, messages, mockReplies, onRefresh, previewMode, t],
+    [
+      files,
+      hasActiveSubscription,
+      isReplying,
+      messages,
+      mockReplies,
+      onRefresh,
+      onRequireSubscription,
+      previewMode,
+      t,
+    ],
   );
 
   const stop = useCallback(() => {
@@ -984,6 +1005,8 @@ export default function RunningState({
                         organizations={organizations}
                         activeOrganizationId={activeOrganizationId}
                         resolution={item.entry.resolution}
+                        hasActiveSubscription={hasActiveSubscription}
+                        onRequireSubscription={onRequireSubscription}
                         onResolved={() => {}}
                       />
                     ),
@@ -1008,6 +1031,8 @@ export default function RunningState({
                       organizations={organizations}
                       activeOrganizationId={activeOrganizationId}
                       resolution={null}
+                      hasActiveSubscription={hasActiveSubscription}
+                      onRequireSubscription={onRequireSubscription}
                       onResolved={(id, resolution, resolvedConfirmation) => {
                         // Anchor the card just past the newest thing on screen
                         // at this moment — after the message that raised the
@@ -1127,6 +1152,8 @@ export default function RunningState({
             assistantName={instance?.assistantName ?? null}
             avatarSeed={instance?.avatarSeed ?? null}
             orbBaseSeed={orbBaseSeed}
+            hasActiveSubscription={hasActiveSubscription}
+            onRequireSubscription={onRequireSubscription}
             onDestroy={onDestroy}
             onRefreshInstance={onRefresh}
           />
@@ -1135,6 +1162,8 @@ export default function RunningState({
             onOpenChange={setAutonomyOpen}
             previewMode={previewMode}
             autonomyLevel={instance?.autonomyLevel ?? "medium"}
+            hasActiveSubscription={hasActiveSubscription}
+            onRequireSubscription={onRequireSubscription}
             onRefreshInstance={onRefresh}
           />
         </div>
@@ -2196,6 +2225,8 @@ function ConfirmationCard({
   organizations,
   activeOrganizationId,
   resolution,
+  hasActiveSubscription = true,
+  onRequireSubscription,
 }: {
   confirmation: HermesPendingConfirmation;
   onResolved: (
@@ -2207,6 +2238,8 @@ function ConfirmationCard({
   activeOrganizationId: string | null;
   /** Non-null means the user already resolved this card; render read-only. */
   resolution: ConfirmationResolution | null;
+  hasActiveSubscription?: boolean;
+  onRequireSubscription?: () => void;
 }) {
   const t = useTranslations("App.Hermes.Running.confirmation");
   const [busy, setBusy] = useState<"approving" | "rejecting" | null>(null);
@@ -2263,6 +2296,10 @@ function ConfirmationCard({
 
   const handleApprove = async () => {
     if (busy || isResolved) return;
+    if (!hasActiveSubscription) {
+      onRequireSubscription?.();
+      return;
+    }
     setBusy("approving");
     // The workspace dropdown shows a local default that may NOT match the
     // workspace Hermes proposed in its tool call. Only send an organization
@@ -2348,6 +2385,10 @@ function ConfirmationCard({
 
   const handleReject = async () => {
     if (busy || isResolved) return;
+    if (!hasActiveSubscription) {
+      onRequireSubscription?.();
+      return;
+    }
     setBusy("rejecting");
     const resolutionOrgId = showOrgPicker
       ? buildCurrentConfirmationApproveOrganizationOverride(

--- a/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
@@ -70,6 +70,9 @@ interface SettingsPanelProps {
    * local overlay for snappy UI, but the chip / autonomy badge upstream
    * read from parent state. */
   onRefreshInstance?: () => void | Promise<void>;
+  /** Paid coverage for settings mutations (rename, connect, skills…). */
+  hasActiveSubscription?: boolean;
+  onRequireSubscription?: () => void;
 }
 
 // Composio's `outlook` toolkit covers mail + calendar in a single connection,
@@ -114,6 +117,8 @@ export default function SettingsPanel({
   lastInboxRefreshAt,
   onDestroy,
   onRefreshInstance,
+  hasActiveSubscription = true,
+  onRequireSubscription,
 }: SettingsPanelProps) {
   const t = useTranslations("App.Hermes.Settings");
   const tProviders = useTranslations("App.Hermes.Onboarding.providers");
@@ -139,6 +144,11 @@ export default function SettingsPanel({
       return;
     }
 
+    if (!hasActiveSubscription) {
+      onRequireSubscription?.();
+      return;
+    }
+
     setNameSaving(true);
     const result = await updateHermesInstanceAction({ assistantName: trimmed });
     setNameSaving(false);
@@ -149,7 +159,15 @@ export default function SettingsPanel({
     }
     toast.success(t("nameSavedToast"));
     void onRefreshInstance?.();
-  }, [nameDraft, assistantName, previewMode, onRefreshInstance, t]);
+  }, [
+    nameDraft,
+    assistantName,
+    previewMode,
+    hasActiveSubscription,
+    onRequireSubscription,
+    onRefreshInstance,
+    t,
+  ]);
   const tOnboarding = useTranslations("App.Hermes.Onboarding");
   const orbSeeds = useMemo(() => orbCandidateSeeds(orbBaseSeed), [orbBaseSeed]);
   // Optimistic local orb choice, resynced from the server prop — same
@@ -172,6 +190,12 @@ export default function SettingsPanel({
         return;
       }
 
+      if (!hasActiveSubscription) {
+        setOrbDraft(previous);
+        onRequireSubscription?.();
+        return;
+      }
+
       setOrbSaving(true);
       const result = await updateHermesInstanceAction({ avatarSeed: seed });
       setOrbSaving(false);
@@ -184,7 +208,15 @@ export default function SettingsPanel({
       toast.success(t("lookSavedToast"));
       void onRefreshInstance?.();
     },
-    [orbDraft, orbSaving, previewMode, onRefreshInstance, t],
+    [
+      orbDraft,
+      orbSaving,
+      previewMode,
+      hasActiveSubscription,
+      onRequireSubscription,
+      onRefreshInstance,
+      t,
+    ],
   );
 
   const [overlay, setOverlay] = useState<
@@ -217,6 +249,11 @@ export default function SettingsPanel({
 
   const runConnect = useCallback(
     async (provider: HermesIntegrationProvider, mode: "read" | "write") => {
+      if (!previewMode && !hasActiveSubscription) {
+        onRequireSubscription?.();
+        return;
+      }
+
       setOverlay((prev) => ({ ...prev, [provider]: "connecting" }));
 
       if (previewMode) {
@@ -245,19 +282,33 @@ export default function SettingsPanel({
       // for the next background refresh tick.
       void onRefreshInstance?.();
     },
-    [previewMode, composioOAuth, onRefreshInstance, tOAuth],
+    [
+      previewMode,
+      hasActiveSubscription,
+      onRequireSubscription,
+      composioOAuth,
+      onRefreshInstance,
+      tOAuth,
+    ],
   );
 
   const handleDisconnect = useCallback(
     async (provider: HermesIntegrationProvider) => {
       const previous = effectiveStatus(provider);
-      setOverlay((prev) => ({ ...prev, [provider]: "connecting" }));
 
       if (previewMode) {
+        setOverlay((prev) => ({ ...prev, [provider]: "connecting" }));
         await new Promise((r) => setTimeout(r, 500));
         setOverlay((prev) => ({ ...prev, [provider]: "disconnected" }));
         return;
       }
+
+      if (!hasActiveSubscription) {
+        onRequireSubscription?.();
+        return;
+      }
+
+      setOverlay((prev) => ({ ...prev, [provider]: "connecting" }));
 
       const result = await disconnectHermesIntegrationAction({ provider });
       if (!result.ok) {
@@ -268,7 +319,14 @@ export default function SettingsPanel({
       setOverlay((prev) => ({ ...prev, [provider]: "disconnected" }));
       void onRefreshInstance?.();
     },
-    [previewMode, effectiveStatus, onRefreshInstance],
+    [
+      previewMode,
+      hasActiveSubscription,
+      onRequireSubscription,
+      effectiveStatus,
+      onRefreshInstance,
+      tOAuth,
+    ],
   );
 
   const handleDestroy = () => {
@@ -419,7 +477,13 @@ export default function SettingsPanel({
             </PanelSection>
 
             {/* ── Skills (skills.sh marketplace) ───────────────── */}
-            {!previewMode ? <SkillsMarketplace variant="settings" /> : null}
+            {!previewMode ? (
+              <SkillsMarketplace
+                variant="settings"
+                hasActiveSubscription={hasActiveSubscription}
+                onRequireSubscription={onRequireSubscription}
+              />
+            ) : null}
 
             {/* ── Memory refresh (informational, compact) ─────── */}
             <SyncStatusSection

--- a/apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
@@ -49,6 +49,8 @@ import type {
 interface SkillsMarketplaceProps {
   /** Onboarding hides the header + search; settings shows the full browser. */
   variant?: "settings" | "onboarding";
+  hasActiveSubscription?: boolean;
+  onRequireSubscription?: () => void;
 }
 
 type ConfirmTarget = { item: SkillCatalogItem; risk: string | null };
@@ -61,6 +63,8 @@ const MAX_ONBOARDING = 16;
 
 export default function SkillsMarketplace({
   variant = "settings",
+  hasActiveSubscription = true,
+  onRequireSubscription,
 }: SkillsMarketplaceProps) {
   const t = useTranslations("App.Hermes.Skills");
 
@@ -171,6 +175,10 @@ export default function SkillsMarketplace({
 
   const doInstall = useCallback(
     async (item: SkillCatalogItem) => {
+      if (!hasActiveSubscription) {
+        onRequireSubscription?.();
+        return;
+      }
       setBusy(item.skillId);
       const res = await installSkillAction({
         source: item.source,
@@ -188,7 +196,7 @@ export default function SkillsMarketplace({
         toast.success(t("addedToast", { name: item.name }));
       }
     },
-    [markInstalled, t],
+    [hasActiveSubscription, markInstalled, onRequireSubscription, t],
   );
 
   const handleAdd = useCallback(
@@ -228,6 +236,10 @@ export default function SkillsMarketplace({
 
   const handleRemove = useCallback(
     async (skill: InstalledSkill) => {
+      if (!hasActiveSubscription) {
+        onRequireSubscription?.();
+        return;
+      }
       setBusy(skill.skillId);
       const res = await removeSkillAction({ slug: skill.slug });
       setBusy(null);
@@ -238,7 +250,7 @@ export default function SkillsMarketplace({
       setInstalled((prev) => prev.filter((s) => s.slug !== skill.slug));
       toast.success(t("removedToast", { name: skill.name }));
     },
-    [t],
+    [hasActiveSubscription, onRequireSubscription, t],
   );
 
   return (

--- a/apps/web/src/app/(app)/personal-assistant/page.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/page.tsx
@@ -60,13 +60,12 @@ export default async function HermesPage() {
     slug: m.organization.slug,
   }));
 
-  // Activating the assistant requires a paid plan — viewing the page (the
-  // landing content, the pitch) stays open to everyone. Fail closed: if the
-  // coverage lookups error we can't confirm a subscription, so treat the user
-  // as unsubscribed here. This is only the UX-level gate; provisionHermesAction
-  // re-checks server-side, which is the real enforcement. Admins skip the
-  // wall entirely (same admin-role check used to bypass restrictions
-  // elsewhere) so the team can set up and test instances without billing.
+  // Activating and using the assistant requires a paid plan — viewing the
+  // page (landing content, chat history) stays open to everyone. Fail closed:
+  // if the coverage lookups error we can't confirm a subscription, so treat
+  // the user as unsubscribed here. This is only the UX-level gate; Core
+  // re-checks on provision / chat / mutations. Admins skip the wall
+  // entirely so the team can set up and test instances without billing.
   // Coverage = personal Stripe plan OR any member org's billing plan
   // (enterprise contract or paid self-serve) — same rule as Core.
   const [hasCoverage, catalogResultRaw] = await Promise.all([


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Paid gate now covers **using** the personal assistant, not only activating it.

### Core
- `requirePaidPlanCoverage` on chat, chat/stream, onboard, settings mutations, confirmations, integrations, and skills install/remove
- Reads (GET instance/messages/unread), destroy, and purge stay open so cancelled users can view history and tear down
- Tests: default paid coverage for use-path cases; explicit 403 cases for chat + onboard without paid

### Web
- Subscription wall opens when unpaid users try to chat, onboard, approve/reject, or change settings/skills/autonomy
- History viewing still works without a paid plan

Stacks onto #3250 (`claude/stoic-dijkstra-8c3b35`).

## Test plan
- [x] `pnpm --filter core test src/routes/v1/hermes/index.test.ts` (57 green)
- [x] `pnpm check && pnpm typecheck` (pre-commit)
- [ ] Manual: unpaid user with existing instance can open PA, see history, send opens wall
- [ ] Manual: paid user chat/onboard still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

