### PR TITLE
fix(hermes): persist confirmation audit when pending snapshot is missing

### DIFF
--- a/apps/core/src/routes/v1/hermes/index.test.ts
+++ b/apps/core/src/routes/v1/hermes/index.test.ts
@@ -1702,7 +1702,7 @@ describe("Hermes route contracts", () => {
     });
   });
 
-  it("does not persist a confirmation card when the orchestrator reports already_resolved", async () => {
+  it("persists an audit card when the orchestrator reports already_resolved", async () => {
     vi.mocked(getInstance).mockResolvedValue(instanceWithPendingConfirmation());
     approveConfirmationMock.mockResolvedValue({
       status: "already_resolved",
@@ -1719,10 +1719,19 @@ describe("Hermes route contracts", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(hermesMessageUpsertMock).not.toHaveBeenCalled();
+    expect(hermesMessageUpsertMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = hermesMessageUpsertMock.mock.calls[0]![0] as {
+      create: { content: string };
+    };
+    expect(JSON.parse(upsertArgs.create.content)).toMatchObject({
+      confirmationId: "conf_1",
+      status: "already_resolved",
+      organizationId: "org_nmkr",
+      organizationName: "NMKR",
+    });
   });
 
-  it("still approves (without persisting a card) when the pre-resolve snapshot fetch fails", async () => {
+  it("still approves without persisting when snapshot fails and no client fallback is sent", async () => {
     vi.mocked(getInstance).mockRejectedValue(
       new HermesOrchestratorError(503, { title: "edge restart" }),
     );
@@ -1742,6 +1751,128 @@ describe("Hermes route contracts", () => {
       undefined,
     );
     expect(hermesMessageUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it("persists from the client confirmation fallback when the orch snapshot is missing", async () => {
+    vi.mocked(getInstance).mockResolvedValue({
+      ...instanceWithPendingConfirmation(),
+      pendingConfirmations: [],
+    });
+
+    const clientConfirmation = {
+      id: "conf_1",
+      toolName: "sokosumi_create_task",
+      summary: "Create task 'Weekly report' and assign it to Alex.",
+      createdAt: "2026-07-17T12:00:00.000Z",
+      referencedCoworkers: [],
+      referencedOrganizations: [],
+      organizationId: "org_nmkr",
+      organizationName: "NMKR",
+    };
+
+    const response = await createApp().request(
+      "/me/instance/confirmations/conf_1/approve",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test_api_key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ confirmation: clientConfirmation }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(hermesMessageUpsertMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = hermesMessageUpsertMock.mock.calls[0]![0] as {
+      create: { content: string };
+    };
+    expect(JSON.parse(upsertArgs.create.content)).toMatchObject({
+      confirmationId: "conf_1",
+      toolName: "sokosumi_create_task",
+      status: "approved",
+      organizationId: "org_nmkr",
+      organizationName: "NMKR",
+    });
+  });
+
+  it("ignores a client confirmation whose id does not match the path param", async () => {
+    vi.mocked(getInstance).mockResolvedValue({
+      ...instanceWithPendingConfirmation(),
+      pendingConfirmations: [],
+    });
+
+    const response = await createApp().request(
+      "/me/instance/confirmations/conf_1/approve",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test_api_key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          confirmation: {
+            id: "conf_other",
+            toolName: "sokosumi_create_task",
+            summary: "Wrong id",
+            createdAt: "2026-07-17T12:00:00.000Z",
+            referencedCoworkers: [],
+            referencedOrganizations: [],
+            organizationId: null,
+            organizationName: null,
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(hermesMessageUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it("persists already_resolved from client fallback when orch pending list is empty", async () => {
+    vi.mocked(getInstance).mockResolvedValue({
+      ...instanceWithPendingConfirmation(),
+      pendingConfirmations: [],
+    });
+    approveConfirmationMock.mockResolvedValue({
+      status: "already_resolved",
+      result: null,
+      error: null,
+    });
+
+    const response = await createApp().request(
+      "/me/instance/confirmations/conf_1/approve",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test_api_key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          confirmation: {
+            id: "conf_1",
+            toolName: "sokosumi_create_job",
+            summary: "Run job for weekly report.",
+            createdAt: "2026-07-17T12:00:00.000Z",
+            referencedCoworkers: [],
+            referencedOrganizations: [],
+            organizationId: null,
+            organizationName: null,
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(hermesMessageUpsertMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = hermesMessageUpsertMock.mock.calls[0]![0] as {
+      create: { content: string };
+    };
+    expect(JSON.parse(upsertArgs.create.content)).toMatchObject({
+      confirmationId: "conf_1",
+      status: "already_resolved",
+      toolName: "sokosumi_create_job",
+    });
   });
 
   it("blocks provisioning without paid coverage and never calls the orchestrator", async () => {

--- a/apps/core/src/routes/v1/hermes/index.ts
+++ b/apps/core/src/routes/v1/hermes/index.ts
@@ -773,7 +773,7 @@ const HERMES_CONFIRMATION_CARD_KIND = "confirmation_card";
 async function persistHermesConfirmationCard(args: {
   userId: string;
   confirmation: HermesPendingConfirmation;
-  status: "approved" | "rejected";
+  status: "approved" | "rejected" | "already_resolved";
   /** Final workspace the tool call ran in (override, else Hermes' proposal).
    * `null` = personal scope. */
   organizationId: string | null;
@@ -823,9 +823,9 @@ async function persistHermesConfirmationCard(args: {
 
 /**
  * Best-effort snapshot of a pending confirmation just before it is resolved
- * — the orchestrator drops it from `pendingConfirmations` on resolve, and
- * this is the only source for the persisted audit card. Returns null (and
- * skips persistence) on any failure rather than blocking the resolve.
+ * — the orchestrator drops it from `pendingConfirmations` on resolve.
+ * Returns null on miss/failure; callers may fall back to a client-supplied
+ * display snapshot so the audit card still lands in message history.
  */
 async function snapshotPendingConfirmation(
   userId: string,
@@ -840,6 +840,21 @@ async function snapshotPendingConfirmation(
   } catch {
     return null;
   }
+}
+
+/**
+ * Prefer the orchestrator pending-list snapshot; fall back to the client's
+ * display copy when the list already dropped the row. Client `id` must match
+ * the path param — mismatched payloads are ignored (display-only trust).
+ */
+function resolveConfirmationForAudit(
+  confirmationId: string,
+  orchSnapshot: HermesPendingConfirmation | null,
+  clientSnapshot: HermesPendingConfirmation | undefined,
+): HermesPendingConfirmation | null {
+  if (orchSnapshot) return orchSnapshot;
+  if (clientSnapshot?.id === confirmationId) return clientSnapshot;
+  return null;
 }
 
 /**
@@ -2565,6 +2580,11 @@ app.openapi(approveConfirmationRoute, async (c) => {
     userContext.userId,
     confirmationId,
   );
+  const auditConfirmation = resolveConfirmationForAudit(
+    confirmationId,
+    pendingSnapshot,
+    body.confirmation,
+  );
 
   try {
     const result = await approveConfirmation(
@@ -2572,22 +2592,29 @@ app.openapi(approveConfirmationRoute, async (c) => {
       confirmationId,
       overrides,
     );
-    // Persist the audit card only for a resolve this request actually
-    // performed — "already_resolved" means an earlier request (which
-    // persisted its own card) got there first.
-    if (result.status === "approved" && pendingSnapshot) {
+    // Persist a durable audit card whenever this gate leaves pending.
+    // Prefer orch snapshot; fall back to the client's display copy when
+    // the pending list already dropped the row. `already_resolved` also
+    // writes (idempotent upsert) so a race that skipped the first writer's
+    // persist still leaves a trail.
+    if (
+      (result.status === "approved" || result.status === "already_resolved") &&
+      auditConfirmation
+    ) {
       const overrodeOrganization =
-        overrides !== undefined && "organizationId" in overrides;
+        result.status === "approved" &&
+        overrides !== undefined &&
+        "organizationId" in overrides;
       await persistHermesConfirmationCard({
         userId: userContext.userId,
-        confirmation: pendingSnapshot,
-        status: "approved",
+        confirmation: auditConfirmation,
+        status: result.status,
         organizationId: overrodeOrganization
           ? (overrides?.organizationId ?? null)
-          : pendingSnapshot.organizationId,
+          : auditConfirmation.organizationId,
         organizationName: overrodeOrganization
           ? overrideOrganizationName
-          : pendingSnapshot.organizationName,
+          : auditConfirmation.organizationName,
       });
     }
     return ok(c, hermesConfirmationResolveResponseSchema.parse(result));
@@ -2609,6 +2636,11 @@ app.openapi(rejectConfirmationRoute, async (c) => {
     userContext.userId,
     confirmationId,
   );
+  const auditConfirmation = resolveConfirmationForAudit(
+    confirmationId,
+    pendingSnapshot,
+    body.confirmation,
+  );
 
   try {
     const result = await rejectConfirmation(
@@ -2616,13 +2648,16 @@ app.openapi(rejectConfirmationRoute, async (c) => {
       confirmationId,
       body.reason,
     );
-    if (result.status === "rejected" && pendingSnapshot) {
+    if (
+      (result.status === "rejected" || result.status === "already_resolved") &&
+      auditConfirmation
+    ) {
       await persistHermesConfirmationCard({
         userId: userContext.userId,
-        confirmation: pendingSnapshot,
-        status: "rejected",
-        organizationId: pendingSnapshot.organizationId,
-        organizationName: pendingSnapshot.organizationName,
+        confirmation: auditConfirmation,
+        status: result.status,
+        organizationId: auditConfirmation.organizationId,
+        organizationName: auditConfirmation.organizationName,
       });
     }
     return ok(c, hermesConfirmationResolveResponseSchema.parse(result));

--- a/apps/core/src/schemas/hermes.schema.ts
+++ b/apps/core/src/schemas/hermes.schema.ts
@@ -206,6 +206,12 @@ export const hermesConfirmationResolveResponseSchema = z
 export const hermesRejectConfirmationRequestSchema = z
   .object({
     reason: z.string().min(1).max(500).optional(),
+    /**
+     * Display-only fallback for the audit card when the orchestrator's
+     * pending list no longer contains this confirmation (race / lag).
+     * `id` must match the path param or Core ignores it.
+     */
+    confirmation: hermesPendingConfirmationSchema.optional(),
   })
   .openapi("HermesRejectConfirmationRequest");
 
@@ -214,6 +220,8 @@ export const hermesRejectConfirmationRequestSchema = z
  * queued tool args before executing. `organizationId` is nullable so
  * personal scope can clear stale queued org args. Omit the whole
  * `overrides` block to keep the tool args exactly as Hermes proposed.
+ *
+ * `confirmation` is a display-only audit fallback (same rules as reject).
  */
 export const hermesApproveConfirmationRequestSchema = z
   .object({
@@ -222,6 +230,7 @@ export const hermesApproveConfirmationRequestSchema = z
         organizationId: z.string().min(1).nullable().optional(),
       })
       .optional(),
+    confirmation: hermesPendingConfirmationSchema.optional(),
   })
   .openapi("HermesApproveConfirmationRequest");
 

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state.tsx
@@ -2330,9 +2330,10 @@ function ConfirmationCard({
       workspaceOverride
         ? {
             confirmationId: confirmation.id,
+            confirmation,
             ...workspaceOverride,
           }
-        : { confirmationId: confirmation.id },
+        : { confirmationId: confirmation.id, confirmation },
     );
     setBusy(null);
     if (!result.ok) {
@@ -2398,6 +2399,7 @@ function ConfirmationCard({
       : undefined;
     const result = await rejectHermesConfirmationAction({
       confirmationId: confirmation.id,
+      confirmation,
     });
     setBusy(null);
     if (!result.ok) {

--- a/apps/web/src/lib/actions/hermes/__tests__/confirmation-action.test.ts
+++ b/apps/web/src/lib/actions/hermes/__tests__/confirmation-action.test.ts
@@ -53,6 +53,17 @@ vi.mock("@/lib/clients/core.client", () => ({
 
 import { approveHermesConfirmationAction } from "@/lib/actions/hermes";
 
+const SAMPLE_CONFIRMATION = {
+  id: "conf_1",
+  toolName: "sokosumi_create_task",
+  summary: "Create task 'Weekly report'.",
+  createdAt: "2026-07-17T12:00:00.000Z",
+  referencedCoworkers: [],
+  referencedOrganizations: [],
+  organizationId: "org-1" as string | null,
+  organizationName: "Org One" as string | null,
+};
+
 describe("approveHermesConfirmationAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,11 +80,16 @@ describe("approveHermesConfirmationAction", () => {
     const result = await approveHermesConfirmationAction({
       confirmationId: "conf_1",
       organizationId: "org-1",
+      confirmation: SAMPLE_CONFIRMATION,
     });
 
     expect(result.ok).toBe(true);
     expect(approveHermesConfirmationMock).toHaveBeenCalledWith("conf_1", {
       overrides: { organizationId: "org-1" },
+      confirmation: {
+        ...SAMPLE_CONFIRMATION,
+        createdAt: new Date(SAMPLE_CONFIRMATION.createdAt),
+      },
     });
   });
 
@@ -81,11 +97,16 @@ describe("approveHermesConfirmationAction", () => {
     const result = await approveHermesConfirmationAction({
       confirmationId: "conf_1",
       organizationId: null,
+      confirmation: SAMPLE_CONFIRMATION,
     });
 
     expect(result.ok).toBe(true);
     expect(approveHermesConfirmationMock).toHaveBeenCalledWith("conf_1", {
       overrides: { organizationId: null },
+      confirmation: {
+        ...SAMPLE_CONFIRMATION,
+        createdAt: new Date(SAMPLE_CONFIRMATION.createdAt),
+      },
     });
   });
 
@@ -99,5 +120,20 @@ describe("approveHermesConfirmationAction", () => {
       "conf_1",
       undefined,
     );
+  });
+
+  it("forwards the confirmation audit snapshot without overrides", async () => {
+    const result = await approveHermesConfirmationAction({
+      confirmationId: "conf_1",
+      confirmation: SAMPLE_CONFIRMATION,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(approveHermesConfirmationMock).toHaveBeenCalledWith("conf_1", {
+      confirmation: {
+        ...SAMPLE_CONFIRMATION,
+        createdAt: new Date(SAMPLE_CONFIRMATION.createdAt),
+      },
+    });
   });
 });

--- a/apps/web/src/lib/actions/hermes/action.ts
+++ b/apps/web/src/lib/actions/hermes/action.ts
@@ -11,8 +11,10 @@ import {
 } from "@/lib/clients/core.client";
 import type { HermesInstance } from "@/lib/clients/generated/core";
 import type {
+  HermesApproveConfirmationRequest,
   HermesGetInstanceNone,
   HermesGetInstanceSome,
+  HermesRejectConfirmationRequest,
 } from "@/lib/clients/generated/core/types.gen";
 import { hasPaidPlanCoverage } from "@/lib/hermes/paid-plan-coverage";
 import type {
@@ -638,6 +640,28 @@ export const toggleHermesScheduleAction = withSession<
 
 interface ResolveConfirmationArgs extends AuthenticatedRequest {
   confirmationId: string;
+  /**
+   * Display snapshot of the pending card the user acted on. Core uses this
+   * as a fallback when the orchestrator's pending list already dropped the
+   * row, so the audit message still persists.
+   */
+  confirmation?: HermesPendingConfirmation;
+}
+
+/** Map web ISO confirmation → Core request shape (`createdAt` as Date). */
+function toCoreConfirmationSnapshot(
+  confirmation: HermesPendingConfirmation,
+): NonNullable<HermesApproveConfirmationRequest["confirmation"]> {
+  return {
+    id: confirmation.id,
+    toolName: confirmation.toolName,
+    summary: confirmation.summary,
+    createdAt: new Date(confirmation.createdAt),
+    referencedCoworkers: confirmation.referencedCoworkers,
+    referencedOrganizations: confirmation.referencedOrganizations,
+    organizationId: confirmation.organizationId,
+    organizationName: confirmation.organizationName,
+  };
 }
 
 function mapConfirmationResolveResult(raw: {
@@ -673,17 +697,18 @@ export const approveHermesConfirmationAction = withSession<
   Result<HermesConfirmationResolveResult, ActionError>
 >(async (args) => {
   try {
-    const body =
-      "organizationId" in args
-        ? {
-            overrides: {
-              organizationId: args.organizationId ?? null,
-            },
-          }
-        : undefined;
+    const body: HermesApproveConfirmationRequest = {};
+    if ("organizationId" in args) {
+      body.overrides = {
+        organizationId: args.organizationId ?? null,
+      };
+    }
+    if (args.confirmation) {
+      body.confirmation = toCoreConfirmationSnapshot(args.confirmation);
+    }
     const response = await coreClient.approveHermesConfirmation(
       args.confirmationId,
-      body,
+      Object.keys(body).length > 0 ? body : undefined,
     );
     return Ok(mapConfirmationResolveResult(response.data));
   } catch (error) {
@@ -698,11 +723,18 @@ interface RejectConfirmationArgs extends ResolveConfirmationArgs {
 export const rejectHermesConfirmationAction = withSession<
   RejectConfirmationArgs,
   Result<HermesConfirmationResolveResult, ActionError>
->(async ({ confirmationId, reason }) => {
+>(async ({ confirmationId, reason, confirmation }) => {
   try {
-    const response = await coreClient.rejectHermesConfirmation(confirmationId, {
+    const body: HermesRejectConfirmationRequest = {
       reason: reason && reason.trim().length > 0 ? reason.trim() : undefined,
-    });
+    };
+    if (confirmation) {
+      body.confirmation = toCoreConfirmationSnapshot(confirmation);
+    }
+    const response = await coreClient.rejectHermesConfirmation(
+      confirmationId,
+      body,
+    );
     return Ok(mapConfirmationResolveResult(response.data));
   } catch (error) {
     return Err(toActionError(error));

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -5666,6 +5666,9 @@ export const HermesApproveConfirmationRequestSchema = {
                     minLength: 1
                 }
             }
+        },
+        confirmation: {
+            $ref: '#/components/schemas/HermesPendingConfirmation'
         }
     }
 } as const;
@@ -5677,6 +5680,9 @@ export const HermesRejectConfirmationRequestSchema = {
             type: 'string',
             minLength: 1,
             maxLength: 500
+        },
+        confirmation: {
+            $ref: '#/components/schemas/HermesPendingConfirmation'
         }
     }
 } as const;

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1650,10 +1650,12 @@ export type HermesApproveConfirmationRequest = {
     overrides?: {
         organizationId?: string | null;
     };
+    confirmation?: HermesPendingConfirmation;
 };
 
 export type HermesRejectConfirmationRequest = {
     reason?: string;
+    confirmation?: HermesPendingConfirmation;
 };
 
 export type HermesInitiateIntegrationResponse = {

--- a/apps/web/src/lib/hermes/__tests__/confirmation-card-message.test.ts
+++ b/apps/web/src/lib/hermes/__tests__/confirmation-card-message.test.ts
@@ -77,6 +77,17 @@ describe("parseConfirmationCardMessage", () => {
     ]);
   });
 
+  it("parses an already_resolved audit card", () => {
+    const parsed = parseConfirmationCardMessage(
+      JSON.stringify({ ...VALID_CARD, status: "already_resolved" }),
+    );
+
+    expect(parsed?.resolution).toEqual({
+      status: "already_resolved",
+      organizationId: "org_nmkr",
+    });
+  });
+
   it.each([
     ["not json at all", "plain text"],
     ["a JSON scalar", JSON.stringify("hello")],
@@ -87,7 +98,7 @@ describe("parseConfirmationCardMessage", () => {
     ["empty toolName", JSON.stringify({ ...VALID_CARD, toolName: "" })],
     [
       "an unexpected status",
-      JSON.stringify({ ...VALID_CARD, status: "already_resolved" }),
+      JSON.stringify({ ...VALID_CARD, status: "pending" }),
     ],
   ])("returns null for %s", (_label, content) => {
     expect(parseConfirmationCardMessage(content)).toBeNull();

--- a/apps/web/src/lib/hermes/confirmation-card-message.ts
+++ b/apps/web/src/lib/hermes/confirmation-card-message.ts
@@ -15,7 +15,7 @@ export const HERMES_CONFIRMATION_CARD_KIND = "confirmation_card";
 export interface PersistedConfirmationCard {
   confirmation: HermesPendingConfirmation;
   resolution: {
-    status: "approved" | "rejected";
+    status: "approved" | "rejected" | "already_resolved";
     organizationId: string | null;
   };
 }
@@ -82,7 +82,13 @@ export function parseConfirmationCardMessage(
   }
   if (typeof toolName !== "string" || toolName.length === 0) return null;
   if (typeof summary !== "string") return null;
-  if (status !== "approved" && status !== "rejected") return null;
+  if (
+    status !== "approved" &&
+    status !== "rejected" &&
+    status !== "already_resolved"
+  ) {
+    return null;
+  }
 
   return {
     confirmation: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes confirmation cards vanishing from chat history when the orchestrator pending list is already empty (race / lag) or when orch returns `already_resolved`.

### Core
- Approve/reject accept optional `confirmation` display snapshot
- Prefer orch pending snapshot; fall back to client when `id` matches path param
- Persist idempotent audit cards for `approved`, `rejected`, and `already_resolved`

### Web
- Confirmation card always sends its snapshot on approve/reject
- Parser accepts `already_resolved` so reloads still show the audit trail
- Regenerated Core client types

Stacks onto #3250.

## Test plan
- [x] Core hermes route tests (60 green)
- [x] Web confirmation action + card-message tests
- [x] `pnpm check && pnpm typecheck`
- [ ] Manual: approve with lagging pending list → card still in history after reload
- [ ] Manual: double-tab already_resolved → audit card still present

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

