### PR TITLE
fix(hermes): do not auto-retry onboard start on transient errors

### DIFF
--- a/apps/core/src/clients/hermes-orchestrator.client.test.ts
+++ b/apps/core/src/clients/hermes-orchestrator.client.test.ts
@@ -235,39 +235,28 @@ describe("hermes-orchestrator.client", () => {
     );
   });
 
-  it("wraps a raw fetch failure as a HermesOrchestratorError instead of letting it propagate opaque", async () => {
-    vi.useFakeTimers();
-    try {
-      fetchMock.mockRejectedValue(new TypeError("fetch failed"));
+  it("wraps a raw fetch failure on onboard as HermesOrchestratorError without retrying", async () => {
+    fetchMock.mockRejectedValue(new TypeError("fetch failed"));
 
-      const { startInstanceOnboarding, HermesOrchestratorError } = await import(
-        "./hermes-orchestrator.client"
-      );
+    const { startInstanceOnboarding, HermesOrchestratorError } = await import(
+      "./hermes-orchestrator.client"
+    );
 
-      const resultPromise = startInstanceOnboarding("user_network_blip", {
+    await expect(
+      startInstanceOnboarding("user_network_blip", {
         researchDepth: "deep",
-      });
-      // Attach the rejection assertion before advancing timers, so the
-      // eventual rejection is never briefly "unhandled" mid-await.
-      const expectation = expect(resultPromise).rejects.toSatisfy(
-        (error: unknown) => {
-          expect(error).toBeInstanceOf(HermesOrchestratorError);
-          expect(
-            (error as InstanceType<typeof HermesOrchestratorError>).httpStatus,
-          ).toBe(503);
-          expect((error as Error).message).toContain("fetch failed");
-          return true;
-        },
-      );
-      // Every attempt fails, so this exhausts the full retry budget before
-      // rejecting — advance through all of it rather than the real ~30s.
-      await vi.runAllTimersAsync();
-      await expectation;
-      // 1 initial attempt + 4 retries.
-      expect(fetchMock).toHaveBeenCalledTimes(5);
-    } finally {
-      vi.useRealTimers();
-    }
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(HermesOrchestratorError);
+      expect(
+        (error as InstanceType<typeof HermesOrchestratorError>).httpStatus,
+      ).toBe(503);
+      expect((error as Error).message).toContain("fetch failed");
+      return true;
+    });
+    // Onboard is single-shot — no orchFetchWithRetry — so the user can click
+    // Continue again without a silent second research/boot kickoff.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("retries provisionInstance on a transient 503 from the orchestrator edge, then succeeds", async () => {

--- a/apps/core/src/clients/hermes-orchestrator.client.ts
+++ b/apps/core/src/clients/hermes-orchestrator.client.ts
@@ -377,13 +377,14 @@ const ORCH_RETRY_BASE_DELAY_MS = 2000;
  * (2s/4s/8s/16s — ~30s total) before giving up. The orchestrator runs as a
  * single Railway replica, so every deploy has a brief window where its edge
  * returns 502/503/504 for in-flight requests — without a retry, a
- * synchronous user-initiated action (provision, patch, onboard) that lands
- * in that window surfaces as a hard failure even though the orchestrator is
- * healthy moments later.
+ * synchronous user-initiated action (provision, patch) that lands in that
+ * window surfaces as a hard failure even though the orchestrator is healthy
+ * moments later.
  *
- * Scoped to those synchronous setup calls only — NOT used for polling reads
- * (which just retry on the next poll tick) or chat completions (retrying a
- * POST with side effects on a transient status is unsafe).
+ * Scoped to provision + patch only — NOT used for polling reads (which just
+ * retry on the next poll tick), chat completions, or onboard (retrying a
+ * POST that starts research/boot can double side effects; the UI lets the
+ * user click Continue again instead).
  */
 async function orchFetchWithRetry(
   path: string,
@@ -1197,6 +1198,10 @@ export interface StartOnboardingInput {
  * POST /v1/instances/:userId/onboard
  * Fired when the user clicks "Let's go" on the onboarding screen. Flips
  * status to `onboarding`, runs boot + research, then flips to `ready`.
+ *
+ * Single-shot (no orchFetchWithRetry): onboard starts research/boot, so a
+ * gateway 503 after the orch accepted the request must not re-POST. Failures
+ * surface to the wizard; the user can click Continue again.
  */
 export async function startInstanceOnboarding(
   userId: string,
@@ -1214,7 +1219,7 @@ export async function startInstanceOnboarding(
   if (input.researchDepth) body.researchDepth = input.researchDepth;
   if (input.personality) body.personality = input.personality;
 
-  const res = await orchFetchWithRetry(
+  const res = await orchFetch(
     `/v1/instances/${encodeURIComponent(userId)}/onboard`,
     {
       method: "POST",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stop auto-retrying `POST …/onboard` on 502/503/504.

Onboard starts research/boot. A gateway blip after orch already accepted the request plus a retry could kick that off twice. Fail once; the setup wizard already lets the user click Continue again.

Provision + patch keep `orchFetchWithRetry` (deploy-window resilience without the same research double-start risk).

Stacks onto #3250.

## Test plan
- [x] `pnpm --filter core test src/clients/hermes-orchestrator.client.test.ts`
- [x] `pnpm check && pnpm typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

