### PR TITLE
fix(web): keep provision timeout clock and offer Start over

### DIFF
--- a/apps/web/src/app/(app)/personal-assistant/README.md
+++ b/apps/web/src/app/(app)/personal-assistant/README.md
@@ -59,7 +59,7 @@ The page is a state machine driven off `getHermesInstanceAction`:
 | `infrastructure_ready`  | `OnboardingScreen`    | Machine up, awaiting user. Five-step wizard: **Name → Look + personality → Autonomy → Integrations → Review**.                         |
 | `onboarding`            | `OnboardingProgress`  | `POST /me/instance/onboard` fired. Polls `/onboarding-progress` every second; renders the orchestrator's step list with status icons.  |
 | `ready` / `running`     | `RunningState`        | Chat is open. Integrations chip in top-right routes into Settings.                                                                     |
-| `error`                 | `ErrorState`          | Orchestrator returned an error or instance is in a bad state. Retry button re-fires provision.                                         |
+| `error`                 | `ErrorState`          | Orchestrator error, fetch failure, or client provision timeout. Retry refetches instance status (does not re-fire provision). Start over destroys when status is `error`/`provisioning` or after a provision timeout. |
 
 All states share a `FlowBackground` (animated violet/cyan/amber blobs) and
 the `ProgressPips` macro indicator (`Setup → Personalize → Ready`).

--- a/apps/web/src/app/(app)/personal-assistant/components/__tests__/hermes-experience-phase-clock.test.ts
+++ b/apps/web/src/app/(app)/personal-assistant/components/__tests__/hermes-experience-phase-clock.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  shouldClearSetupPhaseClock,
+  shouldOfferHermesStartOver,
+} from "@/app/personal-assistant/components/hermes-setup-recovery";
+
+describe("shouldClearSetupPhaseClock", () => {
+  it("keeps the clock across error and loading so Retry cannot reset the deadline", () => {
+    expect(shouldClearSetupPhaseClock("error")).toBe(false);
+    expect(shouldClearSetupPhaseClock("loading")).toBe(false);
+  });
+
+  it("clears when leaving for a real phase (success, wizard, or idle)", () => {
+    expect(shouldClearSetupPhaseClock("idle")).toBe(true);
+    expect(shouldClearSetupPhaseClock("provisioning")).toBe(true);
+    expect(shouldClearSetupPhaseClock("infrastructure_ready")).toBe(true);
+    expect(shouldClearSetupPhaseClock("onboarding")).toBe(true);
+    expect(shouldClearSetupPhaseClock("running")).toBe(true);
+  });
+});
+
+describe("shouldOfferHermesStartOver", () => {
+  it("hides Start over in preview or when there is no instance", () => {
+    expect(
+      shouldOfferHermesStartOver({
+        previewMode: true,
+        instanceStatus: "error",
+        isProvisionTimeout: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOfferHermesStartOver({
+        previewMode: false,
+        instanceStatus: null,
+        isProvisionTimeout: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("offers Start over for orch error and stuck provisioning", () => {
+    expect(
+      shouldOfferHermesStartOver({
+        previewMode: false,
+        instanceStatus: "error",
+        isProvisionTimeout: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOfferHermesStartOver({
+        previewMode: false,
+        instanceStatus: "provisioning",
+        isProvisionTimeout: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("offers Start over after a client provision timeout even if status drifted", () => {
+    expect(
+      shouldOfferHermesStartOver({
+        previewMode: false,
+        instanceStatus: "infrastructure_ready",
+        isProvisionTimeout: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/app/(app)/personal-assistant/components/error-state.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/error-state.tsx
@@ -21,10 +21,9 @@ interface ErrorStateProps {
   onRetry: () => void;
   /**
    * When set, the screen offers a confirmed "Start over" that destroys the
-   * stuck instance and returns to the landing page. Wired only when an
-   * instance actually exists in `error` status — an orchestrator-side
-   * failure can leave it stuck there forever, and Retry (a plain refetch)
-   * can never recover from that on its own.
+   * stuck instance and returns to the landing page. Wired for orch `error`,
+   * stuck `provisioning` (incl. client 15m timeout), or an explicit provision
+   * timeout flag — Retry alone (refetch) cannot recover from those.
    */
   onStartOver?: () => Promise<void> | void;
   message?: string;

--- a/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
@@ -7,6 +7,10 @@ import { toast } from "sonner";
 
 import EmptyState from "@/app/personal-assistant/components/empty-state";
 import ErrorState from "@/app/personal-assistant/components/error-state";
+import {
+  shouldClearSetupPhaseClock,
+  shouldOfferHermesStartOver,
+} from "@/app/personal-assistant/components/hermes-setup-recovery";
 import LoadingState from "@/app/personal-assistant/components/loading-state";
 import OnboardingProgress from "@/app/personal-assistant/components/onboarding-progress";
 import OnboardingScreen from "@/app/personal-assistant/components/onboarding-screen";
@@ -216,6 +220,10 @@ export default function HermesExperience({
     HermesPersistedMessage[]
   >([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  /** True when the current error screen is the client-side 15m provision
+   * deadline — drives Start over even though orch status is still
+   * `provisioning`. */
+  const [isProvisionTimeout, setIsProvisionTimeout] = useState(false);
   /** True while `POST /me/instance/onboard` is in flight. Keeps the setup
    * wizard mounted so `OnboardingProgress` does not poll until onboard has
    * actually started. */
@@ -262,13 +270,13 @@ export default function HermesExperience({
     [uiState, userId],
   );
 
-  // Clears each persisted start time once we leave its phase (success or
-  // error) so a future, genuinely new setup attempt doesn't inherit it.
-  // `loading` is exempt: it's the transient mount state BEFORE the instance
-  // fetch discovers which phase we're in — clearing there would wipe the
-  // keys on every reload and defeat the cross-reload persistence entirely.
+  // Clears each persisted start time once we leave its phase for a real
+  // onward/idle transition. Kept across `error` / `loading` so Retry after
+  // a client-side provision timeout reuses the original start (and still
+  // times out) instead of granting a fresh 15 minutes.
   useEffect(() => {
-    if (uiState === "loading") return;
+    if (!shouldClearSetupPhaseClock(uiState)) return;
+    setIsProvisionTimeout(false);
     if (uiState !== "provisioning") clearPhaseStartedAt("provisioning", userId);
     if (uiState !== "onboarding") clearPhaseStartedAt("onboarding", userId);
   }, [uiState, userId]);
@@ -372,6 +380,7 @@ export default function HermesExperience({
       if (cancelled) return;
       if (deadline !== null && Date.now() > deadline) {
         setUiState("error");
+        setIsProvisionTimeout(true);
         setErrorMessage(t("provisionTimeout"));
         return;
       }
@@ -474,6 +483,10 @@ export default function HermesExperience({
       setSubscriptionWallOpen(true);
       return;
     }
+    // Fresh activate — drop any leftover timeout clock from a prior stuck
+    // attempt (normally cleared on idle, but be explicit).
+    clearPhaseStartedAt("provisioning", userId);
+    setIsProvisionTimeout(false);
     setUiState("provisioning");
     setErrorMessage(null);
     const result = await provisionHermesAction({});
@@ -496,11 +509,13 @@ export default function HermesExperience({
     // Immediately reflect server-side status — if it already came back as
     // "running" the polling effect will just no-op.
     setUiState(nextUi);
-  }, [t, hasActiveSubscription]);
+  }, [t, hasActiveSubscription, userId]);
 
   const handleRetry = useCallback(() => {
     if (previewMode) return;
     setErrorMessage(null);
+    // Keep `isProvisionTimeout` so a still-stuck provision can offer Start
+    // over after refetch; cleared when we leave error for a real phase.
     setUiState("loading");
     void refetchHermes();
   }, [previewMode, refetchHermes]);
@@ -518,12 +533,15 @@ export default function HermesExperience({
     }
     setInstance(null);
     setInitialMessages([]);
+    setIsProvisionTimeout(false);
+    clearPhaseStartedAt("provisioning", userId);
+    clearPhaseStartedAt("onboarding", userId);
     // Forget the destroyed assistant's orb choice — the next activation is a
     // fresh identity and must start from the white placeholder, not the old
     // assistant's colour.
     setCommittedSeed(undefined);
     setUiState("idle");
-  }, [previewMode, t]);
+  }, [previewMode, t, userId]);
 
   /**
    * Kicks off the orchestrator's research-intro flow. The progress screen
@@ -655,11 +673,14 @@ export default function HermesExperience({
       <ErrorState
         message={errorMessage ?? undefined}
         onRetry={handleRetry}
-        // Offer the destroy-and-restart escape hatch only when an instance
-        // actually exists and is the thing that's stuck — for transient
-        // fetch failures there is nothing to destroy.
+        // Destroy when orch reports `error`, or when provision is stuck
+        // (client 15m timeout leaves status as `provisioning`).
         onStartOver={
-          !previewMode && instance?.status === "error"
+          shouldOfferHermesStartOver({
+            previewMode,
+            instanceStatus: instance?.status,
+            isProvisionTimeout,
+          })
             ? handleDestroy
             : undefined
         }

--- a/apps/web/src/app/(app)/personal-assistant/components/hermes-setup-recovery.ts
+++ b/apps/web/src/app/(app)/personal-assistant/components/hermes-setup-recovery.ts
@@ -1,0 +1,34 @@
+import type { HermesInstanceStatus } from "@/lib/hermes/types";
+
+export type HermesUiState =
+  | "loading"
+  | "idle"
+  | "provisioning"
+  | "infrastructure_ready"
+  | "onboarding"
+  | "running"
+  | "error";
+
+/**
+ * Setup-phase clocks must survive `error` / `loading` so Retry after a
+ * client-side provision timeout does not write a fresh start and grant
+ * another 15 minutes on the same stuck attempt. Clear only when leaving
+ * for a real phase change (ready / wizard / idle / …).
+ */
+export function shouldClearSetupPhaseClock(uiState: HermesUiState): boolean {
+  return uiState !== "loading" && uiState !== "error";
+}
+
+/** True when ErrorState should offer destroy — orch `error`, or a stuck
+ * provision (client timeout leaves status as `provisioning`). */
+export function shouldOfferHermesStartOver(options: {
+  previewMode: boolean;
+  instanceStatus: HermesInstanceStatus | null | undefined;
+  isProvisionTimeout: boolean;
+}): boolean {
+  if (options.previewMode) return false;
+  if (options.instanceStatus == null) return false;
+  if (options.instanceStatus === "error") return true;
+  if (options.instanceStatus === "provisioning") return true;
+  return options.isProvisionTimeout;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes finding 9 on the personal-assistant provision timeout path.

- Keep the provisioning start time across `error` / `loading` so Retry after the 15m client timeout cannot grant a fresh window on the same stuck attempt
- Offer **Start over** (destroy) when the instance is `error` or still `provisioning`, or when the error is a provision timeout
- Retry remains a refetch only (does not re-fire provision)
- README corrected

Stacks onto #3250.

## Test plan
- [x] Unit tests for `shouldClearSetupPhaseClock` / `shouldOfferHermesStartOver`
- [x] `pnpm check && pnpm typecheck`
- [ ] Manual: force provision timeout → Retry still times out immediately → Start over destroys

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

