### PR TITLE
fix(hermes): clear pending connections and stale mirror on purge

### DIFF
--- a/apps/core/src/routes/v1/hermes/index.test.ts
+++ b/apps/core/src/routes/v1/hermes/index.test.ts
@@ -1103,7 +1103,11 @@ describe("Hermes route contracts", () => {
     expect(prismaTransactionMock).toHaveBeenCalledWith([
       expect.any(Promise),
       expect.any(Promise),
+      expect.any(Promise),
     ]);
+    expect(hermesPendingConnectionDeleteManyMock).toHaveBeenCalledWith({
+      where: { userId: "user_gone" },
+    });
   });
 
   it("persists a re-picked orb seed via PATCH /me/instance", async () => {
@@ -1366,7 +1370,14 @@ describe("Hermes route contracts", () => {
     expect(response.status).toBe(200);
     expect(body).toHaveProperty("data.ok", true);
     expect(destroyInstance).toHaveBeenCalledWith("user_123");
-    expect(prismaTransactionMock).toHaveBeenCalled();
+    expect(prismaTransactionMock).toHaveBeenCalledWith([
+      expect.any(Promise),
+      expect.any(Promise),
+      expect.any(Promise),
+    ]);
+    expect(hermesPendingConnectionDeleteManyMock).toHaveBeenCalledWith({
+      where: { userId: "user_123" },
+    });
   });
 
   it("returns 503 and reports to Sentry when orchestrator destroy succeeds but DB cleanup fails", async () => {
@@ -1825,6 +1836,31 @@ describe("Hermes route contracts", () => {
       "user_123",
       expect.any(Object),
     );
+    // Idempotent re-provision of a live instance must not wipe chat.
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("clears leftover local mirror when provisioning after orch has no instance", async () => {
+    resolveActiveSubscriptionMock.mockResolvedValue({ plan: "starter" });
+    vi.mocked(getInstance)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(instanceWithPendingConfirmation());
+
+    const response = await createApp().request("/me/instance", {
+      method: "POST",
+      headers: { Authorization: "Bearer test_api_key" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(prismaTransactionMock).toHaveBeenCalledWith([
+      expect.any(Promise),
+      expect.any(Promise),
+      expect.any(Promise),
+    ]);
+    expect(hermesPendingConnectionDeleteManyMock).toHaveBeenCalledWith({
+      where: { userId: "user_123" },
+    });
+    expect(hermesInstanceUpsertMock).toHaveBeenCalled();
   });
 
   it("provisions when a member organization carries the paid plan", async () => {

--- a/apps/core/src/routes/v1/hermes/index.ts
+++ b/apps/core/src/routes/v1/hermes/index.ts
@@ -618,6 +618,20 @@ async function upsertHermesInstanceForUser(
   });
 }
 
+/**
+ * Wipe Sokosumi's per-user Hermes mirror: chat history, instance metadata
+ * (name / orb / poll cursors), and any in-flight integration OAuth claims.
+ * Used by user destroy, orchestrator purge, and fresh provision after an
+ * orch-side teardown that left zombie rows behind. Idempotent.
+ */
+async function clearHermesLocalMirror(userId: string): Promise<void> {
+  await prisma.$transaction([
+    prisma.hermesMessage.deleteMany({ where: { userId } }),
+    prisma.hermesPendingConnection.deleteMany({ where: { userId } }),
+    prisma.hermesInstance.deleteMany({ where: { userId } }),
+  ]);
+}
+
 interface HermesInstanceMeta {
   assistantName: string | null;
   avatarSeed: string | null;
@@ -1178,7 +1192,7 @@ const purgeInstanceStateRoute = withGlobalHeaderParameters(
     method: "post",
     path: "/instances/{userId}/purge",
     description:
-      "Orchestrator-only: delete Sokosumi's local mirror state (chat history + instance metadata) for a user whose orchestrator-side instance was destroyed. Idempotent — purging a user with no local state is a no-op. Authenticated with an orchestrator API key (orch_); user sessions and coworker keys are rejected.",
+      "Orchestrator-only: delete Sokosumi's local mirror state (chat history, instance metadata, and pending integration OAuth claims) for a user whose orchestrator-side instance was destroyed. Idempotent — purging a user with no local state is a no-op. Authenticated with an orchestrator API key (orch_); user sessions and coworker keys are rejected.",
     tags: TAGS,
     request: {
       params: z.object({
@@ -2133,6 +2147,19 @@ app.openapi(provisionInstanceRoute, async (c) => {
   });
 
   try {
+    // `provisionInstance` is idempotent — re-POSTing for a live orch
+    // instance must NOT wipe chat. Only clear the local mirror when the
+    // orchestrator currently has no instance (fresh activate, or
+    // re-activate after an orch-side destroy that left zombie rows).
+    // On a pre-check blip, assume an instance exists so we never delete
+    // live history by accident.
+    let hadOrchestratorInstance = true;
+    try {
+      hadOrchestratorInstance = (await getInstance(userContext.userId)) != null;
+    } catch {
+      hadOrchestratorInstance = true;
+    }
+
     await provisionInstance(userContext.userId, {
       name: user?.name,
       email: user?.email,
@@ -2144,6 +2171,15 @@ app.openapi(provisionInstanceRoute, async (c) => {
       throw serviceUnavailable(
         "Provision call succeeded but the assistant instance is not visible yet.",
       );
+    }
+
+    if (!hadOrchestratorInstance) {
+      await clearHermesLocalMirror(userContext.userId).catch((error) => {
+        Sentry.captureException(error, {
+          tags: { context: "hermes_provision_clear_stale_mirror" },
+          extra: { userId: userContext.userId },
+        });
+      });
     }
 
     await upsertHermesInstanceForUser(userContext.userId).catch((error) => {
@@ -2210,14 +2246,7 @@ app.openapi(destroyInstanceRoute, async (c) => {
   }
 
   try {
-    await prisma.$transaction([
-      prisma.hermesMessage.deleteMany({
-        where: { userId: userContext.userId },
-      }),
-      prisma.hermesInstance.deleteMany({
-        where: { userId: userContext.userId },
-      }),
-    ]);
+    await clearHermesLocalMirror(userContext.userId);
   } catch (error) {
     Sentry.captureException(error, {
       tags: { context: "hermes_destroy_db_cleanup" },
@@ -2241,10 +2270,7 @@ app.openapi(purgeInstanceStateRoute, async (c) => {
   const { userId } = c.req.valid("param");
 
   try {
-    await prisma.$transaction([
-      prisma.hermesMessage.deleteMany({ where: { userId } }),
-      prisma.hermesInstance.deleteMany({ where: { userId } }),
-    ]);
+    await clearHermesLocalMirror(userId);
   } catch (error) {
     Sentry.captureException(error, {
       tags: { context: "hermes_purge_instance_state" },

--- a/apps/web/src/app/(app)/personal-assistant/README.md
+++ b/apps/web/src/app/(app)/personal-assistant/README.md
@@ -273,8 +273,10 @@ Useful for design iteration.
 ### Resetting an instance
 
 `DELETE /v1/instances/:userId` on the orchestrator (mirror also clears
-`hermesInstance` + `hermesMessage` in our DB via the destroy route). For a
-hard local-only reset, drop those rows directly.
+`hermesInstance` + `hermesMessage` + `hermesPendingConnection` in our DB via
+the destroy route). Orchestrator-side deletes must also
+`POST /v1/hermes/instances/{userId}/purge`. For a hard local-only reset, drop
+those rows directly.
 
 ---
 

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -676,7 +676,7 @@ export const postHermesMeInstance = <ThrowOnError extends boolean = false>(optio
 });
 
 /**
- * Orchestrator-only: delete Sokosumi's local mirror state (chat history + instance metadata) for a user whose orchestrator-side instance was destroyed. Idempotent — purging a user with no local state is a no-op. Authenticated with an orchestrator API key (orch_); user sessions and coworker keys are rejected.
+ * Orchestrator-only: delete Sokosumi's local mirror state (chat history, instance metadata, and pending integration OAuth claims) for a user whose orchestrator-side instance was destroyed. Idempotent — purging a user with no local state is a no-op. Authenticated with an orchestrator API key (orch_); user sessions and coworker keys are rejected.
  */
 export const postHermesInstancesByUserIdPurge = <ThrowOnError extends boolean = false>(options: Options<PostHermesInstancesByUserIdPurgeData, ThrowOnError>): RequestResult<PostHermesInstancesByUserIdPurgeResponses, PostHermesInstancesByUserIdPurgeErrors, ThrowOnError> => (options.client ?? client).post<PostHermesInstancesByUserIdPurgeResponses, PostHermesInstancesByUserIdPurgeErrors, ThrowOnError>({
     responseTransformer: postHermesInstancesByUserIdPurgeResponseTransformer,

--- a/docs/orchestrator/hermes-orchestrator-actor.md
+++ b/docs/orchestrator/hermes-orchestrator-actor.md
@@ -38,7 +38,8 @@ route), matching coworker usage.
 ## Instance lifecycle: purging Sokosumi's local mirror
 
 Sokosumi keeps a local mirror of each Hermes instance (chat history in
-`hermesMessage`, display metadata + poll cursors in `hermesInstance`). This
+`hermesMessage`, display metadata + poll cursors in `hermesInstance`, and
+short-lived integration OAuth claims in `hermesPendingConnection`). This
 mirror is **never auto-deleted** from polling signals — a spurious
 `instance_not_found` must not wipe user data. When the orchestrator destroys
 an instance outside Sokosumi's own `DELETE /v1/hermes/me/instance` flow, it
@@ -51,7 +52,12 @@ Authorization: Bearer orch_…
 
 Orchestrator keys only (user sessions and coworker keys get 403). No body,
 no context headers. Idempotent: purging a user with no local state is a
-no-op, and retrying after a 500 is safe.
+no-op, and retrying after a 500 is safe. Purge deletes messages, instance
+metadata, and pending connection claims together.
+
+Fresh user activate (`POST /v1/hermes/me/instance`) also clears any leftover
+local mirror when the orchestrator currently has no instance — so re-activating
+after an orch-side destroy that missed purge does not resurrect old chat.
 
 ## Migration note
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes review finding **10** (zombie local mirror / incomplete purge) for the personal assistant redesign (#3250).

- **Destroy + orch purge** now clear `hermesPendingConnection` together with `hermesMessage` and `hermesInstance` via a shared `clearHermesLocalMirror` helper.
- **Fresh provision** (when the orchestrator currently has no instance) clears leftover local rows before upserting, so re-activate after an orch-side destroy that missed purge does not resurrect old chat / OAuth claims.
- Idempotent re-POST while an orch instance already exists does **not** wipe history.
- Docs / OpenAPI description updated; Core client snapshot regenerated.

Still intentional: GET `hasInstance: false` does **not** auto-delete (avoids wiping on a bad `instance_not_found`). Orch must call purge promptly for the idle zombie window.

## Test plan

- [x] `pnpm --filter core test src/routes/v1/hermes/index.test.ts` (58 passed)
- [x] Pre-commit `pnpm check` + typecheck
- [ ] Merge into #3250 after review

Stacked on `claude/stoic-dijkstra-8c3b35` (PA redesign).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c769916a-8ea4-4983-8c00-fb2154975850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

