### PR TITLE
fix(ai-provider): forward AI SDK v7 tagged file parts to Responses API

### DIFF
--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -213,6 +213,127 @@ describe("promptToResponsesInput", () => {
     ]);
   });
 
+  it("maps AI SDK v7 tagged url file parts to input_file file_url", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Please review." },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+            data: {
+              type: "url",
+              url: new URL(
+                "https://storage.example.com/containers/blobs/abc123.pdf",
+              ),
+            },
+          },
+          {
+            type: "file",
+            mediaType:
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            filename: "notes.docx",
+            data: {
+              type: "url",
+              url: new URL(
+                "https://storage.example.com/containers/blobs/notes.docx",
+              ),
+            },
+          },
+        ],
+      },
+    ] as Parameters<typeof promptToResponsesInput>[0]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Please review." },
+          {
+            type: "input_file",
+            file_url: "https://storage.example.com/containers/blobs/abc123.pdf",
+            filename: "brief.pdf",
+          },
+          {
+            type: "input_file",
+            file_url: "https://storage.example.com/containers/blobs/notes.docx",
+            filename: "notes.docx",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("maps AI SDK v7 tagged data and image url file parts", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: {
+              type: "url",
+              url: new URL("https://example.com/image.png"),
+            },
+          },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "brief.pdf",
+            data: {
+              type: "data",
+              data: "JVBERi0xLjcK",
+            },
+          },
+        ],
+      },
+    ] as Parameters<typeof promptToResponsesInput>[0]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_image",
+            image_url: "https://example.com/image.png",
+            detail: "auto",
+          },
+          {
+            type: "input_file",
+            file_data: "data:application/pdf;base64,JVBERi0xLjcK",
+            filename: "brief.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("throws for AI SDK v7 provider file references", () => {
+    expect(() =>
+      promptToResponsesInput([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "application/pdf",
+              filename: "brief.pdf",
+              data: {
+                type: "reference",
+                reference: { openai: "file-abc" },
+              },
+            },
+          ],
+        },
+      ] as Parameters<typeof promptToResponsesInput>[0]),
+    ).toThrowError(/provider file references/i);
+  });
+
   it("throws for non-base64 file data urls that cannot be mapped safely", () => {
     expect(() =>
       promptToResponsesInput([

--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -313,6 +313,51 @@ describe("promptToResponsesInput", () => {
     ]);
   });
 
+  it("maps top-level image mediaType segment to input_image", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "image",
+            data: {
+              type: "url",
+              url: new URL("https://example.com/photo.jpg"),
+            },
+          },
+          {
+            type: "file",
+            mediaType: "image/*",
+            data: {
+              type: "url",
+              url: new URL("https://example.com/wild.webp"),
+            },
+          },
+        ],
+      },
+    ] as Parameters<typeof promptToResponsesInput>[0]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_image",
+            image_url: "https://example.com/photo.jpg",
+            detail: "auto",
+          },
+          {
+            type: "input_image",
+            image_url: "https://example.com/wild.webp",
+            detail: "auto",
+          },
+        ],
+      },
+    ]);
+  });
+
   it("throws for AI SDK v7 provider file references", () => {
     expect(() =>
       promptToResponsesInput([

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -3,6 +3,7 @@ import {
   type LanguageModelV3FilePart,
   type LanguageModelV3Prompt,
   type SharedV3Warning,
+  type SharedV4FileData,
 } from "@ai-sdk/provider";
 
 interface OpenRouterResponsesInputTextItem {
@@ -22,6 +23,15 @@ interface OpenRouterResponsesInputFileItem {
   file_url?: string;
   filename?: string;
 }
+
+/**
+ * AI SDK 7 wraps LanguageModelV3 providers as V4 and passes tagged
+ * `SharedV4FileData` (`{ type: "url" | "data" | ... }`) into `doStream`.
+ * Legacy V3 prompts still use bare `Uint8Array | string | URL`.
+ */
+type FilePartData = LanguageModelV3FilePart["data"] | SharedV4FileData;
+
+type UnwrappedFileData = Uint8Array | string | URL;
 
 export type OpenRouterResponsesInputMessage = {
   type: "message";
@@ -53,7 +63,13 @@ export function buildResponsesApiWarnings(
             "File parts on assistant messages are forwarded to the Responses input. Confirm your model endpoint accepts multimodal assistant turns.",
         });
       }
-      const url = toUrlString(part.data);
+      let url: string | null = null;
+      try {
+        url = toUrlString(unwrapFilePartData(part));
+      } catch {
+        // Unsupported tagged shapes (e.g. provider references) are errors at
+        // map time; skip URL compatibility warnings here.
+      }
       if (
         url !== null &&
         !url.startsWith("data:") &&
@@ -199,7 +215,8 @@ function filePartToResponsesContent(
     };
   }
 
-  const url = toUrlString(part.data);
+  const data = unwrapFilePartData(part);
+  const url = toUrlString(data);
   if (url !== null && !url.startsWith("data:")) {
     return {
       type: "input_file",
@@ -210,13 +227,14 @@ function filePartToResponsesContent(
 
   return {
     type: "input_file",
-    file_data: toResponsesInputFileData(part),
+    file_data: toResponsesInputFileData(part, data),
     filename: part.filename,
   };
 }
 
 function toImageUrl(part: LanguageModelV3FilePart): string {
-  const url = toUrlString(part.data);
+  const data = unwrapFilePartData(part);
+  const url = toUrlString(data);
 
   if (url !== null) {
     if (url.startsWith("data:") || isWebUrl(url)) {
@@ -228,7 +246,7 @@ function toImageUrl(part: LanguageModelV3FilePart): string {
     );
   }
 
-  return toDataUrl(part);
+  return toDataUrl(part, data);
 }
 
 /**
@@ -237,13 +255,16 @@ function toImageUrl(part: LanguageModelV3FilePart): string {
  * (`data:application/pdf;base64,...`), not raw base64 — see OpenRouter PDF docs
  * and OpenAI file-input guides.
  */
-function toResponsesInputFileData(part: LanguageModelV3FilePart): string {
-  if (part.data instanceof Uint8Array) {
-    return `data:${part.mediaType};base64,${Buffer.from(part.data).toString("base64")}`;
+function toResponsesInputFileData(
+  part: LanguageModelV3FilePart,
+  data: UnwrappedFileData,
+): string {
+  if (data instanceof Uint8Array) {
+    return `data:${part.mediaType};base64,${Buffer.from(data).toString("base64")}`;
   }
 
-  if (part.data instanceof URL) {
-    const url = part.data.toString();
+  if (data instanceof URL) {
+    const url = data.toString();
     if (url.startsWith("data:")) {
       extractBase64DataFromDataUrl(url, part);
       return url;
@@ -254,27 +275,68 @@ function toResponsesInputFileData(part: LanguageModelV3FilePart): string {
     );
   }
 
-  if (typeof part.data === "string") {
-    if (isWebUrl(part.data)) {
+  if (typeof data === "string") {
+    if (isWebUrl(data)) {
       throw invalidFilePartError(
         part,
         "URL-based file parts must be sent as file_url.",
       );
     }
-    if (part.data.startsWith("data:")) {
-      extractBase64DataFromDataUrl(part.data, part);
-      return part.data;
+    if (data.startsWith("data:")) {
+      extractBase64DataFromDataUrl(data, part);
+      return data;
     }
-    return `data:${part.mediaType};base64,${part.data}`;
+    return `data:${part.mediaType};base64,${data}`;
   }
 
   throw invalidFilePartError(
     part,
-    `Unsupported file data type "${typeof part.data}".`,
+    `Unsupported file data type "${typeof data}".`,
   );
 }
 
-function toUrlString(data: LanguageModelV3FilePart["data"]): string | null {
+function isTaggedFileData(value: unknown): value is SharedV4FileData {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const type = (value as { type?: unknown }).type;
+  return (
+    type === "data" || type === "url" || type === "reference" || type === "text"
+  );
+}
+
+/**
+ * Normalize AI SDK v7 tagged file data and legacy V3 bare payloads to
+ * `Uint8Array | string | URL` for Responses API mapping.
+ */
+function unwrapFilePartData(part: LanguageModelV3FilePart): UnwrappedFileData {
+  const data = part.data as FilePartData;
+
+  if (!isTaggedFileData(data)) {
+    return data;
+  }
+
+  switch (data.type) {
+    case "url":
+      return data.url;
+    case "data":
+      return data.data;
+    case "text":
+      return new TextEncoder().encode(data.text);
+    case "reference":
+      throw invalidFilePartError(
+        part,
+        "Provider file references are not supported; pass a URL or inline file data.",
+      );
+    default: {
+      const _exhaustive: never = data;
+      void _exhaustive;
+      throw invalidFilePartError(part, "Unsupported tagged file data variant.");
+    }
+  }
+}
+
+function toUrlString(data: UnwrappedFileData): string | null {
   if (data instanceof URL) {
     return data.toString();
   }
@@ -294,28 +356,31 @@ function isWebUrl(value: string): boolean {
   return value.startsWith("http://") || value.startsWith("https://");
 }
 
-function toDataUrl(part: LanguageModelV3FilePart): string {
-  if (part.data instanceof Uint8Array) {
-    return `data:${part.mediaType};base64,${Buffer.from(part.data).toString("base64")}`;
+function toDataUrl(
+  part: LanguageModelV3FilePart,
+  data: UnwrappedFileData,
+): string {
+  if (data instanceof Uint8Array) {
+    return `data:${part.mediaType};base64,${Buffer.from(data).toString("base64")}`;
   }
 
-  if (typeof part.data === "string") {
-    if (part.data.startsWith("data:")) {
-      return part.data;
+  if (typeof data === "string") {
+    if (data.startsWith("data:")) {
+      return data;
     }
-    if (isWebUrl(part.data)) {
-      return part.data;
+    if (isWebUrl(data)) {
+      return data;
     }
-    return `data:${part.mediaType};base64,${part.data}`;
+    return `data:${part.mediaType};base64,${data}`;
   }
 
-  if (part.data instanceof URL) {
-    return part.data.toString();
+  if (data instanceof URL) {
+    return data.toString();
   }
 
   throw invalidFilePartError(
     part,
-    `Unsupported image data type "${typeof part.data}".`,
+    `Unsupported image data type "${typeof data}".`,
   );
 }
 

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -74,7 +74,7 @@ export function buildResponsesApiWarnings(
         url !== null &&
         !url.startsWith("data:") &&
         !isWebUrl(url) &&
-        !part.mediaType.startsWith("image/")
+        !isImageMediaType(part.mediaType)
       ) {
         warnings.push({
           type: "compatibility",
@@ -207,7 +207,7 @@ export function promptToResponsesInput(
 function filePartToResponsesContent(
   part: LanguageModelV3FilePart,
 ): OpenRouterResponsesInputImageItem | OpenRouterResponsesInputFileItem {
-  if (part.mediaType.startsWith("image/")) {
+  if (isImageMediaType(part.mediaType)) {
     return {
       type: "input_image",
       image_url: toImageUrl(part),
@@ -303,6 +303,20 @@ function isTaggedFileData(value: unknown): value is SharedV4FileData {
   return (
     type === "data" || type === "url" || type === "reference" || type === "text"
   );
+}
+
+/**
+ * AI SDK 7 allows top-level media segments (`"image"`) as well as full IANA
+ * types (`"image/png"`) and wildcards (`"image/*"`).
+ */
+function isImageMediaType(mediaType: string): boolean {
+  const normalized = mediaType.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return false;
+  }
+  const slash = normalized.indexOf("/");
+  const topLevel = slash === -1 ? normalized : normalized.slice(0, slash);
+  return topLevel === "image";
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chat attachments (PDF/DOCX) stopped reaching Coworker `/v1/responses` as `input_file` with `file_url` after the AI SDK v7 upgrade on **2026-07-06** (`e93bc149`).

AI SDK 7 wraps our `LanguageModelV3` Sokosumi provider as V4 and passes tagged `SharedV4FileData` (`{ type: "url", url }` / `{ type: "data", data }`) into `doStream`. Our Responses mapper only understood legacy bare `URL | string | Uint8Array`, so file parts failed to map and coworker only saw `input_text`.

## Fix

- Unwrap AI SDK v7 tagged file payloads in `packages/ai-provider/src/prompt/to-responses-input.ts`
- Keep legacy V3 bare payloads working
- Reject unsupported provider file references with a clear error
- Treat top-level `mediaType: "image"` / `"image/*"` as `input_image` (AI SDK 7 allows bare top-level segments)
- Add regression tests for tagged `url` / `data` parts (PDF + DOCX), references, and top-level image mediaType

## AI SDK v7 audit (other breaks)

Checked against the official v6→v7 migration guide and our call sites:

| Change | Status |
| --- | --- |
| Tagged file `data` + removed `image` part type | **Fixed** (this PR) |
| System messages in `messages` rejected by default | Already handled (`allowSystemInMessages: true` in upgrade) |
| OpenRouter client `system` → `instructions` | Already handled (`c89de926`) |
| `onFinish` → `onEnd` | Deprecated alias still works; no runtime break |
| `toUIMessageStreamResponse` helpers | Deprecated alias still works; no runtime break |
| `usage.cachedInputTokens` / `reasoningTokens` removed | Not used in our code |
| `finishEvent.reasoning` / `.text` | Still populated from `finalStep` in onEnd event |
| `@openrouter/ai-sdk-provider` | Peer `ai@^7`; already V4-native |
| Bare `mediaType: "image"` | **Fixed** in this PR |

**Not a runtime break (follow-up / debt):** our Sokosumi language model still declares `specificationVersion: "v3"` and relies on AI SDK’s V4 proxy. Longer-term, migrating the provider to native `LanguageModelV4` would avoid future V4-only prompt/stream mismatches.

## Verification

- `pnpm --filter @sokosumi/ai-provider test` — pass
- `pnpm --filter @sokosumi/ai-provider typecheck` — clean
- `biome check` on touched files — clean

## Notes

Pre-commit full-repo `pnpm typecheck` currently fails on unrelated web `.next/dev/types/validator.ts` modal layout errors; not introduced by this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37a48e31-57b8-460b-8d87-8f4ffc148b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37a48e31-57b8-460b-8d87-8f4ffc148b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

