### PR TITLE
refactor(ai-provider): migrate language model to LanguageModelV4

### DIFF
--- a/packages/ai-provider/src/create-sokosumi.ts
+++ b/packages/ai-provider/src/create-sokosumi.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModelV4 } from "@ai-sdk/provider";
 
 import {
   createSokosumiLanguageModel,
@@ -22,7 +22,7 @@ export function createSokosumi(
 }
 
 export function isSokosumiLanguageModel(
-  model: LanguageModelV3,
+  model: LanguageModelV4,
 ): model is SokosumiLanguageModel {
   return model.provider === "sokosumi";
 }

--- a/packages/ai-provider/src/index.ts
+++ b/packages/ai-provider/src/index.ts
@@ -20,10 +20,10 @@ export {
 export type { SokosumiLanguageModel } from "./sokosumi-language-model.js";
 export { createSokosumiLanguageModel } from "./sokosumi-language-model.js";
 export {
-  createResponsesSseToV3Stream,
+  createResponsesSseToV4Stream,
   emptyUsage,
   finishStop,
-} from "./stream/responses-sse-to-v3-stream.js";
+} from "./stream/responses-sse-to-v4-stream.js";
 export type {
   CreateSokosumiOptions,
   SokosumiProviderCallOptions,

--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -411,6 +411,17 @@ describe("promptToResponsesInput", () => {
             filename: "legacy.pdf",
             data: "https://storage.example.com/legacy.pdf",
           },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "bytes.pdf",
+            data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+          },
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new URL("https://example.com/bare-url.png"),
+          },
         ],
       },
     ] as unknown as LanguageModelV4Prompt;
@@ -424,6 +435,49 @@ describe("promptToResponsesInput", () => {
             type: "input_file",
             file_url: "https://storage.example.com/legacy.pdf",
             filename: "legacy.pdf",
+          },
+          {
+            type: "input_file",
+            file_data: "data:application/pdf;base64,JVBERg==",
+            filename: "bytes.pdf",
+          },
+          {
+            type: "input_image",
+            image_url: "https://example.com/bare-url.png",
+            detail: "auto",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("maps tagged text file parts to inline file_data", () => {
+    const input = promptToResponsesInput([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            data: {
+              type: "text",
+              text: "hello",
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_file",
+            file_data: `data:text/plain;base64,${Buffer.from("hello").toString("base64")}`,
+            filename: "notes.txt",
           },
         ],
       },
@@ -539,6 +593,83 @@ describe("buildResponsesApiWarnings", () => {
           w.type === "compatibility" && w.feature === "assistant file parts",
       ),
     ).toHaveLength(1);
+  });
+
+  it("warns for ignored V4 assistant and tool part types", () => {
+    const warnings = buildResponsesApiWarnings([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "ok" },
+          { type: "reasoning", text: "hidden chain" },
+          {
+            type: "custom",
+            kind: "openai.something",
+          },
+          {
+            type: "reasoning-file",
+            mediaType: "image/png",
+            data: {
+              type: "url",
+              url: new URL("https://example.com/r.png"),
+            },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "search",
+            input: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "c1",
+            toolName: "search",
+            output: { type: "text", value: "done" },
+          },
+          {
+            type: "tool-approval-response",
+            approvalId: "a1",
+            approved: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "unsupported",
+          feature: "assistant reasoning parts",
+        }),
+        expect.objectContaining({
+          type: "unsupported",
+          feature: "assistant custom parts",
+        }),
+        expect.objectContaining({
+          type: "unsupported",
+          feature: "assistant reasoning-file parts",
+        }),
+        expect.objectContaining({
+          type: "unsupported",
+          feature: "assistant tool-call parts",
+        }),
+        expect.objectContaining({
+          type: "unsupported",
+          feature: "tool tool-approval-response parts",
+        }),
+      ]),
+    );
+    expect(
+      warnings.some(
+        (w) =>
+          w.type === "unsupported" && w.feature === "tool tool-result parts",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/ai-provider/src/prompt/to-responses-input.test.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.test.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV4Prompt } from "@ai-sdk/provider";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -77,13 +78,19 @@ describe("promptToResponsesInput", () => {
           {
             type: "file",
             mediaType: "image/png",
-            data: new URL("https://example.com/image.png"),
+            data: {
+              type: "url",
+              url: new URL("https://example.com/image.png"),
+            },
           },
           {
             type: "file",
             mediaType: "application/pdf",
             filename: "brief.pdf",
-            data: "JVBERi0xLjcK",
+            data: {
+              type: "data",
+              data: "JVBERi0xLjcK",
+            },
           },
         ],
       },
@@ -119,13 +126,19 @@ describe("promptToResponsesInput", () => {
             type: "file",
             mediaType: "application/octet-stream",
             filename: "blob.bin",
-            data: "data:;base64,SGVsbG8=",
+            data: {
+              type: "data",
+              data: "data:;base64,SGVsbG8=",
+            },
           },
           {
             type: "file",
             mediaType: "application/pdf",
             filename: "from-url.pdf",
-            data: new URL("data:;base64,JVBERi0xLjcK"),
+            data: {
+              type: "url",
+              url: new URL("data:;base64,JVBERi0xLjcK"),
+            },
           },
         ],
       },
@@ -160,7 +173,12 @@ describe("promptToResponsesInput", () => {
             type: "file",
             mediaType: "application/pdf",
             filename: "brief.pdf",
-            data: "https://storage.example.com/containers/blobs/abc123.pdf",
+            data: {
+              type: "url",
+              url: new URL(
+                "https://storage.example.com/containers/blobs/abc123.pdf",
+              ),
+            },
           },
         ],
       },
@@ -190,9 +208,12 @@ describe("promptToResponsesInput", () => {
             type: "file",
             mediaType: "application/pdf",
             filename: "brief.pdf",
-            data: new URL(
-              "https://storage.example.com/containers/blobs/abc123.pdf",
-            ),
+            data: {
+              type: "url",
+              url: new URL(
+                "https://storage.example.com/containers/blobs/abc123.pdf",
+              ),
+            },
           },
         ],
       },
@@ -244,7 +265,7 @@ describe("promptToResponsesInput", () => {
           },
         ],
       },
-    ] as Parameters<typeof promptToResponsesInput>[0]);
+    ]);
 
     expect(input).toEqual([
       {
@@ -291,7 +312,7 @@ describe("promptToResponsesInput", () => {
           },
         ],
       },
-    ] as Parameters<typeof promptToResponsesInput>[0]);
+    ]);
 
     expect(input).toEqual([
       {
@@ -336,7 +357,7 @@ describe("promptToResponsesInput", () => {
           },
         ],
       },
-    ] as Parameters<typeof promptToResponsesInput>[0]);
+    ]);
 
     expect(input).toEqual([
       {
@@ -375,8 +396,38 @@ describe("promptToResponsesInput", () => {
             },
           ],
         },
-      ] as Parameters<typeof promptToResponsesInput>[0]),
+      ]),
     ).toThrowError(/provider file references/i);
+  });
+
+  it("still unwraps legacy bare file payloads at runtime", () => {
+    const prompt = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "legacy.pdf",
+            data: "https://storage.example.com/legacy.pdf",
+          },
+        ],
+      },
+    ] as unknown as LanguageModelV4Prompt;
+
+    expect(promptToResponsesInput(prompt)).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_file",
+            file_url: "https://storage.example.com/legacy.pdf",
+            filename: "legacy.pdf",
+          },
+        ],
+      },
+    ]);
   });
 
   it("throws for non-base64 file data urls that cannot be mapped safely", () => {
@@ -389,7 +440,10 @@ describe("promptToResponsesInput", () => {
               type: "file",
               mediaType: "application/pdf",
               filename: "brief.pdf",
-              data: "data:application/pdf,plain-text",
+              data: {
+                type: "data",
+                data: "data:application/pdf,plain-text",
+              },
             },
           ],
         },
@@ -406,7 +460,10 @@ describe("promptToResponsesInput", () => {
             {
               type: "file",
               mediaType: "image/png",
-              data: "file:///tmp/x.png",
+              data: {
+                type: "url",
+                url: new URL("file:///tmp/x.png"),
+              },
             },
           ],
         },
@@ -426,7 +483,10 @@ describe("buildResponsesApiWarnings", () => {
             type: "file",
             mediaType: "application/pdf",
             filename: "x.pdf",
-            data: new URL("file:///tmp/x.pdf"),
+            data: {
+              type: "url",
+              url: new URL("file:///tmp/x.pdf"),
+            },
           },
         ],
       },
@@ -456,12 +516,18 @@ describe("buildResponsesApiWarnings", () => {
           {
             type: "file",
             mediaType: "application/pdf",
-            data: "JVBERi0xLjcK",
+            data: {
+              type: "data",
+              data: "JVBERi0xLjcK",
+            },
           },
           {
             type: "file",
             mediaType: "application/pdf",
-            data: "JVBERi0xLjcK",
+            data: {
+              type: "data",
+              data: "JVBERi0xLjcK",
+            },
           },
         ],
       },
@@ -527,7 +593,10 @@ describe("lastTurnToResponsesInput", () => {
           {
             type: "file",
             mediaType: "image/png",
-            data: new URL("https://example.com/image.png"),
+            data: {
+              type: "url",
+              url: new URL("https://example.com/image.png"),
+            },
           },
         ],
       },

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -42,15 +42,41 @@ export type OpenRouterResponsesInputMessage = {
   >;
 };
 
+const MAPPED_USER_ASSISTANT_PART_TYPES = new Set(["text", "file"]);
+
 export function buildResponsesApiWarnings(
   prompt: LanguageModelV4Prompt,
 ): SharedV4Warning[] {
   const warnings: SharedV4Warning[] = [];
   for (const message of prompt) {
+    if (message.role === "tool") {
+      for (const part of message.content) {
+        if (part.type === "tool-result") {
+          continue;
+        }
+        warnings.push({
+          type: "unsupported",
+          feature: `tool ${part.type} parts`,
+          details:
+            "Only tool-result parts on tool messages are forwarded to the Responses input; other tool parts are dropped.",
+        });
+      }
+      continue;
+    }
+
     if (message.role !== "user" && message.role !== "assistant") {
       continue;
     }
     for (const part of message.content) {
+      if (!MAPPED_USER_ASSISTANT_PART_TYPES.has(part.type)) {
+        warnings.push({
+          type: "unsupported",
+          feature: `${message.role} ${part.type} parts`,
+          details:
+            "Only text and file parts are forwarded to the Responses input; this part type is dropped.",
+        });
+        continue;
+      }
       if (part.type !== "file") {
         continue;
       }

--- a/packages/ai-provider/src/prompt/to-responses-input.ts
+++ b/packages/ai-provider/src/prompt/to-responses-input.ts
@@ -1,9 +1,9 @@
 import {
   InvalidPromptError,
-  type LanguageModelV3FilePart,
-  type LanguageModelV3Prompt,
-  type SharedV3Warning,
+  type LanguageModelV4FilePart,
+  type LanguageModelV4Prompt,
   type SharedV4FileData,
+  type SharedV4Warning,
 } from "@ai-sdk/provider";
 
 interface OpenRouterResponsesInputTextItem {
@@ -25,11 +25,10 @@ interface OpenRouterResponsesInputFileItem {
 }
 
 /**
- * AI SDK 7 wraps LanguageModelV3 providers as V4 and passes tagged
- * `SharedV4FileData` (`{ type: "url" | "data" | ... }`) into `doStream`.
- * Legacy V3 prompts still use bare `Uint8Array | string | URL`.
+ * LanguageModelV4 file parts use tagged `SharedV4FileData`. Also accept legacy
+ * bare `Uint8Array | string | URL` at runtime for defensive compatibility.
  */
-type FilePartData = LanguageModelV3FilePart["data"] | SharedV4FileData;
+type FilePartData = SharedV4FileData | Uint8Array | string | URL;
 
 type UnwrappedFileData = Uint8Array | string | URL;
 
@@ -44,9 +43,9 @@ export type OpenRouterResponsesInputMessage = {
 };
 
 export function buildResponsesApiWarnings(
-  prompt: LanguageModelV3Prompt,
-): SharedV3Warning[] {
-  const warnings: SharedV3Warning[] = [];
+  prompt: LanguageModelV4Prompt,
+): SharedV4Warning[] {
+  const warnings: SharedV4Warning[] = [];
   for (const message of prompt) {
     if (message.role !== "user" && message.role !== "assistant") {
       continue;
@@ -87,14 +86,16 @@ export function buildResponsesApiWarnings(
   return dedupeWarnings(warnings);
 }
 
-function dedupeWarnings(warnings: SharedV3Warning[]): SharedV3Warning[] {
+function dedupeWarnings(warnings: SharedV4Warning[]): SharedV4Warning[] {
   const seen = new Set<string>();
-  const out: SharedV3Warning[] = [];
+  const out: SharedV4Warning[] = [];
   for (const w of warnings) {
     const key =
       w.type === "other"
         ? `other:${w.message}`
-        : `${w.type}:${w.feature}:${w.details ?? ""}`;
+        : w.type === "deprecated"
+          ? `deprecated:${w.setting}:${w.message}`
+          : `${w.type}:${w.feature}:${w.details ?? ""}`;
     if (seen.has(key)) {
       continue;
     }
@@ -106,8 +107,8 @@ function dedupeWarnings(warnings: SharedV3Warning[]): SharedV3Warning[] {
 
 function userAssistantContent(
   message:
-    | Extract<LanguageModelV3Prompt[number], { role: "user" }>
-    | Extract<LanguageModelV3Prompt[number], { role: "assistant" }>,
+    | Extract<LanguageModelV4Prompt[number], { role: "user" }>
+    | Extract<LanguageModelV4Prompt[number], { role: "assistant" }>,
 ): OpenRouterResponsesInputMessage["content"] {
   const content: OpenRouterResponsesInputMessage["content"] = [];
   let textRun = "";
@@ -136,7 +137,7 @@ function userAssistantContent(
 }
 
 function toolMessageText(
-  message: Extract<LanguageModelV3Prompt[number], { role: "tool" }>,
+  message: Extract<LanguageModelV4Prompt[number], { role: "tool" }>,
 ): string {
   const lines: string[] = [];
   for (const part of message.content) {
@@ -150,7 +151,7 @@ function toolMessageText(
 }
 
 export function promptToResponsesInput(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): OpenRouterResponsesInputMessage[] {
   const input: OpenRouterResponsesInputMessage[] = [];
   for (const message of prompt) {
@@ -205,7 +206,7 @@ export function promptToResponsesInput(
 }
 
 function filePartToResponsesContent(
-  part: LanguageModelV3FilePart,
+  part: LanguageModelV4FilePart,
 ): OpenRouterResponsesInputImageItem | OpenRouterResponsesInputFileItem {
   if (isImageMediaType(part.mediaType)) {
     return {
@@ -232,7 +233,7 @@ function filePartToResponsesContent(
   };
 }
 
-function toImageUrl(part: LanguageModelV3FilePart): string {
+function toImageUrl(part: LanguageModelV4FilePart): string {
   const data = unwrapFilePartData(part);
   const url = toUrlString(data);
 
@@ -256,7 +257,7 @@ function toImageUrl(part: LanguageModelV3FilePart): string {
  * and OpenAI file-input guides.
  */
 function toResponsesInputFileData(
-  part: LanguageModelV3FilePart,
+  part: LanguageModelV4FilePart,
   data: UnwrappedFileData,
 ): string {
   if (data instanceof Uint8Array) {
@@ -320,10 +321,10 @@ function isImageMediaType(mediaType: string): boolean {
 }
 
 /**
- * Normalize AI SDK v7 tagged file data and legacy V3 bare payloads to
+ * Unwrap LanguageModelV4 tagged file data (and legacy bare payloads) to
  * `Uint8Array | string | URL` for Responses API mapping.
  */
-function unwrapFilePartData(part: LanguageModelV3FilePart): UnwrappedFileData {
+function unwrapFilePartData(part: LanguageModelV4FilePart): UnwrappedFileData {
   const data = part.data as FilePartData;
 
   if (!isTaggedFileData(data)) {
@@ -371,7 +372,7 @@ function isWebUrl(value: string): boolean {
 }
 
 function toDataUrl(
-  part: LanguageModelV3FilePart,
+  part: LanguageModelV4FilePart,
   data: UnwrappedFileData,
 ): string {
   if (data instanceof Uint8Array) {
@@ -400,7 +401,7 @@ function toDataUrl(
 
 function extractBase64DataFromDataUrl(
   value: string,
-  part: LanguageModelV3FilePart,
+  part: LanguageModelV4FilePart,
 ): string {
   // RFC 2397: mediatype may be empty (`data:;base64,...` is valid).
   const match = /^data:[^;,]*(?:;[^;,=]+=[^;,]+)*(;base64)?,(.*)$/i.exec(value);
@@ -416,7 +417,7 @@ function extractBase64DataFromDataUrl(
 }
 
 function invalidFilePartError(
-  part: LanguageModelV3FilePart,
+  part: LanguageModelV4FilePart,
   reason: string,
 ): InvalidPromptError {
   return new InvalidPromptError({
@@ -426,7 +427,7 @@ function invalidFilePartError(
 }
 
 export function lastTurnToResponsesInput(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): OpenRouterResponsesInputMessage[] {
   let start = -1;
   for (let i = prompt.length - 1; i >= 0; i--) {

--- a/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.coworker-retry.test.ts
@@ -5,7 +5,7 @@ import { COWORKER_AGENT_ERROR_SNIPPET } from "./coworker-agent-error.js";
 import { createSokosumiLanguageModel } from "./sokosumi-language-model.js";
 
 async function collectStreamText(
-  stream: ReadableStream<import("@ai-sdk/provider").LanguageModelV3StreamPart>,
+  stream: ReadableStream<import("@ai-sdk/provider").LanguageModelV4StreamPart>,
 ): Promise<string> {
   const reader = stream.getReader();
   let text = "";

--- a/packages/ai-provider/src/sokosumi-language-model.supported-urls.test.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.supported-urls.test.ts
@@ -4,6 +4,13 @@ import { describe, expect, it } from "vitest";
 import { createSokosumiLanguageModel } from "./sokosumi-language-model.js";
 
 describe("SokosumiLanguageModel supportedUrls", () => {
+  it("exposes LanguageModelV4 specificationVersion", () => {
+    const model = createSokosumiLanguageModel("openai/gpt-5.4", {
+      openRouterApiKey: "sk-or-test",
+    });
+    expect(model.specificationVersion).toBe("v4");
+  });
+
   it("passes through public file and image URLs without SDK pre-downloads", async () => {
     const model = createSokosumiLanguageModel("openai/gpt-5.4", {
       openRouterApiKey: "sk-or-test",

--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -2,12 +2,12 @@ import {
   APICallError,
   EmptyResponseBodyError,
   InvalidPromptError,
-  type LanguageModelV3,
-  type LanguageModelV3CallOptions,
-  type LanguageModelV3Content,
-  type LanguageModelV3GenerateResult,
-  type LanguageModelV3StreamResult,
-  type SharedV3Warning,
+  type LanguageModelV4,
+  type LanguageModelV4CallOptions,
+  type LanguageModelV4Content,
+  type LanguageModelV4GenerateResult,
+  type LanguageModelV4StreamResult,
+  type SharedV4Warning,
 } from "@ai-sdk/provider";
 import { getModelIdentifier } from "@sokosumi/chat";
 import { MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS } from "./coworker-agent-error.js";
@@ -19,10 +19,10 @@ import {
 } from "./prompt/to-responses-input.js";
 import { createCommitGateStream } from "./stream/commit-gate-stream.js";
 import {
-  createResponsesSseToV3Stream,
+  createResponsesSseToV4Stream,
   emptyUsage,
   finishStop,
-} from "./stream/responses-sse-to-v3-stream.js";
+} from "./stream/responses-sse-to-v4-stream.js";
 import type { CreateSokosumiOptions } from "./types.js";
 
 const OPENROUTER_RESPONSES_URL = "https://openrouter.ai/api/v1/responses";
@@ -32,7 +32,7 @@ const SOKOSUMI_SUPPORTED_URL_PATTERNS: Record<string, RegExp[]> = {
   "*": [/^https?:\/\//i, /^data:/i],
 };
 
-export type SokosumiLanguageModel = LanguageModelV3 & {
+export type SokosumiLanguageModel = LanguageModelV4 & {
   readonly provider: "sokosumi";
 };
 
@@ -49,14 +49,14 @@ export function createSokosumiLanguageModel(
 ): SokosumiLanguageModel {
   const modelIdForLanguageModel = resolveModelIdForLanguageModel(modelId);
   async function doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const streamResult = await doStream(options);
     const reader = streamResult.stream.getReader();
-    const content: LanguageModelV3Content[] = [];
+    const content: LanguageModelV4Content[] = [];
     let textBuffer = "";
     let reasoningBuffer = "";
-    let warnings: SharedV3Warning[] = [];
+    let warnings: SharedV4Warning[] = [];
     let finishReason = finishStop();
     let usage = emptyUsage();
 
@@ -115,8 +115,8 @@ export function createSokosumiLanguageModel(
   }
 
   async function doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const sokosumiOpts = parseSokosumiProviderOptions(
       options.providerOptions as Record<string, unknown> | undefined,
     );
@@ -171,7 +171,7 @@ export function createSokosumiLanguageModel(
   }
 
   return {
-    specificationVersion: "v3",
+    specificationVersion: "v4",
     provider: "sokosumi",
     modelId: modelIdForLanguageModel,
     supportedUrls: SOKOSUMI_SUPPORTED_URL_PATTERNS,
@@ -184,10 +184,10 @@ async function streamOpenRouter(
   modelId: string | null,
   config: CreateSokosumiOptions,
   responsesInput: ReturnType<typeof promptToResponsesInput>,
-  promptWarnings: SharedV3Warning[],
+  promptWarnings: SharedV4Warning[],
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
-  options: LanguageModelV3CallOptions,
-): Promise<LanguageModelV3StreamResult> {
+  options: LanguageModelV4CallOptions,
+): Promise<LanguageModelV4StreamResult> {
   const apiKey = config.openRouterApiKey?.trim();
   if (!apiKey) {
     throw new InvalidPromptError({
@@ -261,7 +261,7 @@ async function streamOpenRouter(
   }
 
   return {
-    stream: createResponsesSseToV3Stream(response.body, {
+    stream: createResponsesSseToV4Stream(response.body, {
       warnings: promptWarnings,
       onResponseStarted: sokosumiOpts.onResponseStarted,
       onResponseCompleted: sokosumiOpts.onResponseCompleted,
@@ -277,11 +277,11 @@ async function streamOpenRouter(
 }
 
 async function streamCoworkerWithRetry(
-  promptWarnings: SharedV3Warning[],
+  promptWarnings: SharedV4Warning[],
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
-  options: LanguageModelV3CallOptions,
+  options: LanguageModelV4CallOptions,
   attempt = 0,
-): Promise<LanguageModelV3StreamResult> {
+): Promise<LanguageModelV4StreamResult> {
   const inConversationMode = Boolean(
     sokosumiOpts.providerConversationId?.trim(),
   );
@@ -314,10 +314,10 @@ async function streamCoworkerWithRetry(
 }
 
 async function streamCoworker(
-  promptWarnings: SharedV3Warning[],
+  promptWarnings: SharedV4Warning[],
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
-  options: LanguageModelV3CallOptions,
-): Promise<LanguageModelV3StreamResult> {
+  options: LanguageModelV4CallOptions,
+): Promise<LanguageModelV4StreamResult> {
   const providerConvId = sokosumiOpts.providerConversationId?.trim() ?? null;
   const previousResponseId = sokosumiOpts.previousResponseId?.trim() ?? null;
 
@@ -461,7 +461,7 @@ async function streamCoworker(
   }
 
   return {
-    stream: createResponsesSseToV3Stream(response.body, {
+    stream: createResponsesSseToV4Stream(response.body, {
       warnings: promptWarnings,
       onResponseStarted: sokosumiOpts.onResponseStarted,
       onResponseCompleted: sokosumiOpts.onResponseCompleted,

--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -5,12 +5,12 @@ import { createCommitGateStream } from "./commit-gate-stream.js";
 
 function partsStream(
   parts: Array<{ type: "text-delta"; delta: string } | { type: "finish" }>,
-): ReadableStream<import("@ai-sdk/provider").LanguageModelV3StreamPart> {
+): ReadableStream<import("@ai-sdk/provider").LanguageModelV4StreamPart> {
   return new ReadableStream({
     start(controller) {
       for (const part of parts) {
         controller.enqueue(
-          part as import("@ai-sdk/provider").LanguageModelV3StreamPart,
+          part as import("@ai-sdk/provider").LanguageModelV4StreamPart,
         );
       }
       controller.close();
@@ -19,7 +19,7 @@ function partsStream(
 }
 
 async function collectText(
-  stream: ReadableStream<import("@ai-sdk/provider").LanguageModelV3StreamPart>,
+  stream: ReadableStream<import("@ai-sdk/provider").LanguageModelV4StreamPart>,
 ): Promise<string> {
   const reader = stream.getReader();
   let text = "";

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 
 import {
   COWORKER_AGENT_ERROR_SNIPPET,
@@ -10,7 +10,7 @@ export type CommitGateRetryReason = "agent-error" | "short-tail";
 export interface CommitGateOptions {
   onRetryNeeded: (
     reason: CommitGateRetryReason,
-  ) => Promise<ReadableStream<LanguageModelV3StreamPart> | null>;
+  ) => Promise<ReadableStream<LanguageModelV4StreamPart> | null>;
   minGoodChars?: number;
 }
 
@@ -30,8 +30,8 @@ function coworkerStreamTextLooksSuspiciouslyShort(
 }
 
 async function pipeStreamToController(
-  source: ReadableStream<LanguageModelV3StreamPart>,
-  controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
+  source: ReadableStream<LanguageModelV4StreamPart>,
+  controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
 ): Promise<void> {
   const reader = source.getReader();
   try {
@@ -55,16 +55,16 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
 }
 
 export function createCommitGateStream(
-  sourceStream: ReadableStream<LanguageModelV3StreamPart>,
+  sourceStream: ReadableStream<LanguageModelV4StreamPart>,
   options: CommitGateOptions,
-): ReadableStream<LanguageModelV3StreamPart> {
+): ReadableStream<LanguageModelV4StreamPart> {
   const minGoodChars =
     options.minGoodChars ?? MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS;
   const sourceReader = sourceStream.getReader();
 
-  return new ReadableStream<LanguageModelV3StreamPart>({
+  return new ReadableStream<LanguageModelV4StreamPart>({
     async start(controller) {
-      const buffer: LanguageModelV3StreamPart[] = [];
+      const buffer: LanguageModelV4StreamPart[] = [];
       let textSoFar = "";
       let committed = false;
 

--- a/packages/ai-provider/src/stream/responses-sse-to-v4-stream.test.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v4-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createResponsesSseToV3Stream } from "./responses-sse-to-v3-stream.js";
+import { createResponsesSseToV4Stream } from "./responses-sse-to-v4-stream.js";
 
 function encodeSse(lines: string[]): ReadableStream<Uint8Array> {
   const text = lines.join("\n") + "\n\n";
@@ -13,7 +13,7 @@ function encodeSse(lines: string[]): ReadableStream<Uint8Array> {
 }
 
 async function collectStreamTextAndReasoning(
-  stream: ReturnType<typeof createResponsesSseToV3Stream>,
+  stream: ReturnType<typeof createResponsesSseToV4Stream>,
 ): Promise<{ text: string; reasoning: Record<string, string> }> {
   const reader = stream.getReader();
   let text = "";
@@ -36,13 +36,13 @@ async function collectStreamTextAndReasoning(
 }
 
 function createImageGenerationStream(body: ReadableStream<Uint8Array>) {
-  return createResponsesSseToV3Stream(body, {
+  return createResponsesSseToV4Stream(body, {
     warnings: [],
     stripReactImageGenerationEnvelope: true,
   });
 }
 
-describe("createResponsesSseToV3Stream", () => {
+describe("createResponsesSseToV4Stream", () => {
   it("does not emit synthetic prelude reasoning (avoids UIMessage start/end mismatch)", async () => {
     const body = encodeSse([
       "event: response.created",
@@ -53,7 +53,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     const reasoningIds = new Set<string>();
     while (true) {
@@ -80,7 +80,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let sawMetadata = false;
     while (true) {
@@ -112,7 +112,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     const parts: { type: string; id?: string }[] = [];
     while (true) {
@@ -155,7 +155,7 @@ describe("createResponsesSseToV3Stream", () => {
     ]);
 
     const { reasoning } = await collectStreamTextAndReasoning(
-      createResponsesSseToV3Stream(body, { warnings: [] }),
+      createResponsesSseToV4Stream(body, { warnings: [] }),
     );
 
     expect(reasoning.rs_delta).toBe("I will inspect the request.");
@@ -173,7 +173,7 @@ describe("createResponsesSseToV3Stream", () => {
     ]);
 
     const { reasoning } = await collectStreamTextAndReasoning(
-      createResponsesSseToV3Stream(body, { warnings: [] }),
+      createResponsesSseToV4Stream(body, { warnings: [] }),
     );
 
     expect(reasoning.rs_done).toBe("I checked the structured summary.");
@@ -191,7 +191,7 @@ describe("createResponsesSseToV3Stream", () => {
     ]);
 
     const { reasoning } = await collectStreamTextAndReasoning(
-      createResponsesSseToV3Stream(body, { warnings: [] }),
+      createResponsesSseToV4Stream(body, { warnings: [] }),
     );
 
     expect(reasoning.rs_shape).toBe("I created the final answer.");
@@ -213,7 +213,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, {
+    const stream = createResponsesSseToV4Stream(body, {
       warnings: [],
       onResponseCompleted: async (id) => {
         expect(id).toBe("resp_gate");
@@ -266,7 +266,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, {
+    const stream = createResponsesSseToV4Stream(body, {
       warnings: [],
       onResponseStarted: async () => {
         order.push("started-begin");
@@ -322,7 +322,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, {
+    const stream = createResponsesSseToV4Stream(body, {
       warnings: [],
       onResponseCompleted: async (id) => {
         completedIds.push(id);
@@ -357,7 +357,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {
@@ -399,7 +399,7 @@ describe("createResponsesSseToV3Stream", () => {
     ]);
 
     const result = await collectStreamTextAndReasoning(
-      createResponsesSseToV3Stream(body, { warnings: [] }),
+      createResponsesSseToV4Stream(body, { warnings: [] }),
     );
 
     expect(result.text).toBe(text);
@@ -753,7 +753,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {
@@ -782,7 +782,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {
@@ -817,7 +817,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {
@@ -855,7 +855,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {
@@ -885,7 +885,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {
@@ -916,7 +916,7 @@ describe("createResponsesSseToV3Stream", () => {
       "data: [DONE]",
     ]);
 
-    const stream = createResponsesSseToV3Stream(body, { warnings: [] });
+    const stream = createResponsesSseToV4Stream(body, { warnings: [] });
     const reader = stream.getReader();
     let text = "";
     while (true) {

--- a/packages/ai-provider/src/stream/responses-sse-to-v4-stream.ts
+++ b/packages/ai-provider/src/stream/responses-sse-to-v4-stream.ts
@@ -1,8 +1,8 @@
 import type {
-  LanguageModelV3FinishReason,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-  SharedV3Warning,
+  LanguageModelV4FinishReason,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+  SharedV4Warning,
 } from "@ai-sdk/provider";
 
 import {
@@ -20,7 +20,7 @@ const MAX_REACT_ENVELOPE_BUFFER_CHARS = 16_384;
 const DATA_IMAGE_URL_REGEX =
   /^data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml);base64,/i;
 
-export function emptyUsage(): LanguageModelV3Usage {
+export function emptyUsage(): LanguageModelV4Usage {
   return {
     inputTokens: {
       total: undefined,
@@ -36,12 +36,12 @@ export function emptyUsage(): LanguageModelV3Usage {
   };
 }
 
-export function finishStop(): LanguageModelV3FinishReason {
+export function finishStop(): LanguageModelV4FinishReason {
   return { unified: "stop", raw: undefined };
 }
 
-export interface ResponsesSseToV3Options {
-  warnings: SharedV3Warning[];
+export interface ResponsesSseToV4Options {
+  warnings: SharedV4Warning[];
   onResponseStarted?: (responseId: string) => void | Promise<void>;
   onResponseCompleted?: (responseId: string) => void | Promise<void>;
   stripReactImageGenerationEnvelope?: boolean;
@@ -172,10 +172,10 @@ function extractReasoningTextFromItem(item: unknown): string {
     .join("");
 }
 
-export function createResponsesSseToV3Stream(
+export function createResponsesSseToV4Stream(
   body: ReadableStream<Uint8Array>,
-  options: ResponsesSseToV3Options,
-): ReadableStream<LanguageModelV3StreamPart> {
+  options: ResponsesSseToV4Options,
+): ReadableStream<LanguageModelV4StreamPart> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   const {
@@ -185,7 +185,7 @@ export function createResponsesSseToV3Stream(
     stripReactImageGenerationEnvelope = false,
   } = options;
 
-  return new ReadableStream<LanguageModelV3StreamPart>({
+  return new ReadableStream<LanguageModelV4StreamPart>({
     async start(controller) {
       controller.enqueue({ type: "stream-start", warnings });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3349. `@sokosumi/ai-provider` now implements `LanguageModelV4` natively (`specificationVersion: "v4"`) instead of relying on AI SDK 7’s V3→V4 compatibility wrapper.

- `SokosumiLanguageModel` / `isSokosumiLanguageModel` use `LanguageModelV4`
- Prompt mapper uses `LanguageModelV4Prompt` / `SharedV4FileData` (legacy bare payloads still unwrapped at runtime)
- SSE stream helper renamed to `createResponsesSseToV4Stream`
- Warnings use `SharedV4Warning` (incl. `deprecated` dedupe)
- Emits `unsupported` warnings for dropped assistant/tool part types (`reasoning`, `custom`, `reasoning-file`, `tool-call`, `tool-approval-response`, …)

## Why

After the tagged-file fix, staying on a fake V3 surface still forced the SDK proxy path. Native V4 matches what AI SDK 7 actually calls.

## Test plan

- [x] `pnpm --filter @sokosumi/ai-provider test` (73 tests)
- [x] `pnpm --filter @sokosumi/ai-provider typecheck`
- [x] `pnpm --filter @sokosumi/ai-provider check`
- [x] `pnpm --filter core typecheck`
- [x] Assert `specificationVersion === "v4"`
- [x] Legacy bare unwrap + tagged `{ type: "text" }` coverage
- [x] Clean rebuild leaves no stale `responses-sse-to-v3-stream` in `dist`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37a48e31-57b8-460b-8d87-8f4ffc148b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37a48e31-57b8-460b-8d87-8f4ffc148b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

