### PR TITLE
chore(cursor): enable shared workspace plugins

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,16 @@
+{
+  "plugins": {
+    "caveman/caveman": {
+      "enabled": true
+    },
+    "superpowers": {
+      "enabled": true
+    },
+    "cavekit-marketplace/ck": {
+      "enabled": true
+    },
+    "docs-canvas": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.cursor/settings.json` to enable shared workspace plugins: caveman, superpowers, cavekit, and docs-canvas.
- Gives the team the same Cursor plugin defaults in this repo.

## Test plan
- [ ] Open the repo in Cursor and confirm the listed plugins show as enabled for the workspace
- [ ] Confirm no app/runtime behavior changes (settings-only)


Made with [Cursor](https://cursor.com)