### PR TITLE
feat(web): gate the personal assistant behind an nmkr.io beta whitelist

### DIFF
--- a/apps/core/src/routes/v1/hermes/index.ts
+++ b/apps/core/src/routes/v1/hermes/index.ts
@@ -1615,10 +1615,12 @@ const finalizeIntegrationRoute = withGlobalHeaderParameters(
 
 const app = new OpenAPIHonoWithAuth();
 
-// Access posture: viewing is open to authenticated users; activating and
-// using (chat, onboard, settings mutations, skills) require paid coverage
-// (or admin). Destroy / purge / GET reads stay ungated so cancelled users
-// can still see history and tear down.
+// Access posture: web navigation/page access is beta-gated to whitelisted
+// email domains (apps/web hermes beta-access); the Core API itself stays
+// available to authenticated users. Activating and using (chat, onboard,
+// settings mutations, skills) require paid coverage (or admin). Destroy /
+// purge / GET reads stay ungated so cancelled users can still see history
+// and tear down.
 app.openapi(postChatRoute, async (c) => {
   const userContext = requireUserAuthContext(c.var.authContext);
   await requirePaidPlanCoverage(userContext);

--- a/apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
@@ -35,9 +35,10 @@ interface AssistantNavState {
 /**
  * Polls the lightweight unread-count endpoint, which also carries the chosen
  * orb seed — so the sidebar shows the user's orb (and reacts after they pick
- * one) without a heavier instance fetch.
+ * one) without a heavier instance fetch. Never polls while the beta gate
+ * hides the nav item.
  */
-function useAssistantNavState(): AssistantNavState {
+function useAssistantNavState(enabled: boolean): AssistantNavState {
   const [state, setState] = useState<AssistantNavState>({
     count: 0,
     avatarSeed: null,
@@ -46,6 +47,7 @@ function useAssistantNavState(): AssistantNavState {
   });
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
 
     const tick = async () => {
@@ -79,7 +81,7 @@ function useAssistantNavState(): AssistantNavState {
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener(HERMES_NAV_REFRESH_EVENT, onNavRefresh);
     };
-  }, []);
+  }, [enabled]);
 
   return state;
 }
@@ -88,9 +90,14 @@ function useAssistantNavState(): AssistantNavState {
  * The Personal Assistant — a normal nav item at the very top of the sidebar,
  * set apart from "New" by a divider (rendered in the sidebar composition). Its
  * live orb carries its identity, and the label becomes the assistant's chosen
- * name once it has one.
+ * name once it has one. Hidden entirely while the Hermes beta gate excludes
+ * the user (see `isHermesBetaAccessEmail`).
  */
-export default function PersonalAssistantNav() {
+export default function PersonalAssistantNav({
+  enabled,
+}: {
+  enabled: boolean;
+}) {
   const t = useTranslations("App.Sidebar.Content.MenuItems");
   const pathname = usePathname();
   const {
@@ -98,7 +105,9 @@ export default function PersonalAssistantNav() {
     avatarSeed,
     assistantName,
     hasInstance,
-  } = useAssistantNavState();
+  } = useAssistantNavState(enabled);
+
+  if (!enabled) return null;
 
   const href = "/personal-assistant";
   const isActive = pathname === href || pathname.startsWith(`${href}/`);

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -11,6 +11,7 @@ import {
   SidebarHeader,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
+import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 import { userService } from "@/lib/services";
 import { resolvePlanSecondaryLabel } from "@/lib/utils/plan-label";
 
@@ -44,6 +45,9 @@ export default async function Sidebar({
 }: SidebarProps) {
   const tCredit = await getTranslations("App.Header.Credit");
   const tPlan = await getTranslations("App.Header.Plan");
+  // Hermes beta gate: the Personal Assistant entry only renders for
+  // whitelisted email domains; /personal-assistant itself 404s in its layout.
+  const hermesMenuEnabled = isHermesBetaAccessEmail(session.user.email);
   const currentPlan = creditsData?.subscription?.plan ?? "free";
   const planForLabel = creditsData === null ? null : currentPlan;
   const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
@@ -81,8 +85,8 @@ export default async function Sidebar({
             activeOrganizationId={activeOrganizationId}
             planLabel={planLabel}
           >
-            <PersonalAssistantNav />
-            <SidebarSeparator className="mx-0" />
+            <PersonalAssistantNav enabled={hermesMenuEnabled} />
+            {hermesMenuEnabled ? <SidebarSeparator className="mx-0" /> : null}
             <NewChatTaskActions />
             <SidebarSeparator className="mx-0 mt-2" />
             <MenuItems />

--- a/apps/web/src/app/(app)/personal-assistant/README.md
+++ b/apps/web/src/app/(app)/personal-assistant/README.md
@@ -235,7 +235,10 @@ project channel if you don't have them yet. Never commit them.
 
 ### Enabling the feature
 
-The route is open to all authenticated users; activating **and using**
+Web access is gated by the Hermes beta whitelist
+(`apps/web/src/lib/hermes/beta-access.ts`): only `nmkr.io` emails see the
+sidebar entry, and `/personal-assistant` 404s for everyone else via this
+route's `layout.tsx`. On top of that, activating **and using**
 (chat, onboard, settings mutations, skills, confirmations) are gated by a
 paid plan (or admin role) on the Core endpoints. Viewing history and
 destroying an instance stay open so cancelled users can tear down.
@@ -288,7 +291,7 @@ those rows directly.
 ```
 apps/web/src/app/(app)/personal-assistant/
 ├── README.md                            ← you are here
-├── layout.tsx                           ← FullscreenEffect wrapper
+├── layout.tsx                           ← beta whitelist gate + FullscreenEffect
 ├── page.tsx                             ← session pass-through, renders HermesExperience
 └── components/
     ├── hermes-experience.tsx            ← state machine + polling

--- a/apps/web/src/app/(app)/personal-assistant/layout.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/layout.tsx
@@ -1,4 +1,8 @@
+import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
+
+import { getSession } from "@/lib/auth/auth.server";
+import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 
 import FullscreenEffect from "./components/fullscreen-effect";
 
@@ -6,7 +10,14 @@ interface HermesLayoutProps {
   children: ReactNode;
 }
 
-export default function HermesLayout({ children }: HermesLayoutProps) {
+export default async function HermesLayout({ children }: HermesLayoutProps) {
+  // Hermes beta gate: outside the whitelisted email domains the whole route
+  // does not exist — same 404 a made-up path would get, so nothing leaks.
+  const session = await getSession();
+  if (!isHermesBetaAccessEmail(session?.user.email)) {
+    notFound();
+  }
+
   // We DON'T use `data-agent-fullbleed` here even though it nicely zeros
   // main's p-4 padding. That helper also sets `overflow: visible` on
   // main + every ancestor up to the app shell, which delegates scrolling

--- a/apps/web/src/lib/hermes/__tests__/beta-access.test.ts
+++ b/apps/web/src/lib/hermes/__tests__/beta-access.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
+
+describe("isHermesBetaAccessEmail", () => {
+  it.each(["a@nmkr.io", "A@NMKR.IO", "patrick@nmkr.io"])(
+    "allows nmkr.io email %s",
+    (email) => {
+      expect(isHermesBetaAccessEmail(email)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["a subdomain", "a@sub.nmkr.io"],
+    ["a lookalike domain", "a@nmkr.io.evil.com"],
+    ["another company", "someone@house-of-communication.com"],
+    ["a plain gmail", "someone@gmail.com"],
+    ["not an email", "not-an-email"],
+    ["empty string", ""],
+  ])("denies %s", (_label, email) => {
+    expect(isHermesBetaAccessEmail(email)).toBe(false);
+  });
+
+  it("denies null and undefined", () => {
+    expect(isHermesBetaAccessEmail(null)).toBe(false);
+    expect(isHermesBetaAccessEmail(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/hermes/beta-access.ts
+++ b/apps/web/src/lib/hermes/beta-access.ts
@@ -1,0 +1,21 @@
+import { getEmailDomain } from "@/lib/utils";
+
+/**
+ * Email domains allowed to use the Hermes beta (sidebar entry + page).
+ * Everyone else gets a 404 on /personal-assistant and no nav item —
+ * activation itself additionally stays behind the Core paid-plan gate.
+ */
+export const HERMES_BETA_EMAIL_DOMAINS = ["nmkr.io"] as const;
+
+const HERMES_BETA_EMAIL_DOMAIN_SET = new Set<string>(HERMES_BETA_EMAIL_DOMAINS);
+
+export function isHermesBetaAccessEmail(
+  email: string | null | undefined,
+): boolean {
+  if (!email) {
+    return false;
+  }
+
+  const domain = getEmailDomain(email);
+  return domain !== null && HERMES_BETA_EMAIL_DOMAIN_SET.has(domain);
+}


### PR DESCRIPTION
## What

Brings the Hermes beta whitelist back, as a pure **domain gate**: everyone with an `@nmkr.io` email has access to the Personal Assistant — no one else.

- `apps/web/src/lib/hermes/beta-access.ts` is restored with `HERMES_BETA_EMAIL_DOMAINS = ["nmkr.io"]` only — the four individually allowlisted external emails from the old whitelist are **not** carried over.
- **Sidebar**: the Personal Assistant nav card (and its divider) only renders for whitelisted users; the unread/identity poll never fires for excluded users.
- **Route**: `/personal-assistant` 404s for non-whitelisted users via the route layout — indistinguishable from a page that doesn't exist.
- Unlike the old implementation this does not reintroduce the `flags` SDK layer; the gate reads the session directly (matching is case-insensitive, exact domain only — subdomains and lookalikes are rejected, covered by tests).
- Core API posture matches the previous beta: endpoints stay session-authenticated, with the existing paid-plan gate on activation/use.

## Testing

- `pnpm check`, `pnpm --filter web typecheck` clean
- `pnpm --filter web test`: 294 files, 1787 passed / 1 skipped (includes new `beta-access.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)