### PR TITLE
feat(admin): add orchestrator display metadata management

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3110,7 +3110,7 @@
           "submitting": "Wird gespeichert…",
           "image": {
             "label": "Bild",
-            "description": "PNG, JPEG, WebP oder GIF bis 2 MB. Uploads und Entfernen werden sofort gespeichert.",
+            "description": "PNG, JPEG, WebP oder GIF bis 2 MB.",
             "upload": "Bild hochladen",
             "replace": "Bild ersetzen",
             "remove": "Bild entfernen",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2885,6 +2885,10 @@
             "title": "Aufgaben",
             "description": "Durchsuchbare Liste aller Aufgaben über Benutzer und Organisationen hinweg."
           },
+          "orchestrators": {
+            "title": "Orchestratoren",
+            "description": "Anzeigemetadaten für First-Party-Orchestratoren bearbeiten."
+          },
           "freeCredits": {
             "title": "Kostenlose Credits",
             "description": "Kostenlose Credits direkt an einen Benutzer oder eine Organisation gewähren, ohne Stripe-Rechnung."
@@ -3084,6 +3088,67 @@
         "TaskDetail": {
           "backToList": "Zurück zu Aufgaben",
           "personalWorkspace": "Persönlicher Workspace"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orchestratoren",
+        "description": "Anzeigemetadaten für First-Party-Orchestratoren verwalten.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# Orchestrator} other {# Orchestratoren}}",
+          "empty": "Keine Orchestratoren gefunden.",
+          "orchestrator": "Orchestrator",
+          "slug": "Slug",
+          "caption": "Untertitel"
+        },
+        "Detail": {
+          "title": "Orchestrator bearbeiten",
+          "backToList": "Zurück zu Orchestratoren"
+        },
+        "EditForm": {
+          "submit": "Änderungen speichern",
+          "submitting": "Wird gespeichert…",
+          "image": {
+            "label": "Bild",
+            "description": "PNG, JPEG, WebP oder GIF bis 2 MB. Wird beim Absenden des Formulars gespeichert.",
+            "upload": "Bild hochladen",
+            "replace": "Bild ersetzen",
+            "remove": "Bild entfernen",
+            "previewAlt": "Vorschau des Orchestrator-Bildes",
+            "fileTooLarge": "Das Bild darf höchstens 2 MB groß sein.",
+            "fileTypeNotAccepted": "Verwende PNG, JPEG, WebP oder GIF.",
+            "maxFilesExceeded": "Lade jeweils nur ein Bild hoch.",
+            "uploadError": "Das ausgewählte Bild konnte nicht verarbeitet werden."
+          },
+          "fields": {
+            "name": {
+              "label": "Name",
+              "description": "Wird überall angezeigt, wo der Orchestrator aufgeführt ist."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Schreibgeschützte Kennung für URLs und APIs."
+            },
+            "caption": {
+              "label": "Untertitel",
+              "description": "Kurze Zeile unter dem Namen. Leer lassen zum Löschen."
+            },
+            "description": {
+              "label": "Beschreibung",
+              "description": "Längerer Text für Detailansichten. Leer lassen zum Löschen."
+            }
+          },
+          "validation": {
+            "nameMinLength": "Der Name muss mindestens {min} Zeichen haben.",
+            "noChanges": "Keine Änderungen zum Speichern."
+          },
+          "success": {
+            "saved": "Orchestrator aktualisiert.",
+            "textSavedImageFailed": "Text gespeichert, aber das Bild konnte nicht aktualisiert werden."
+          },
+          "errors": {
+            "saveFailed": "Orchestrator konnte nicht gespeichert werden.",
+            "notFound": "Orchestrator nicht gefunden."
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3110,7 +3110,7 @@
           "submitting": "Wird gespeichert…",
           "image": {
             "label": "Bild",
-            "description": "PNG, JPEG, WebP oder GIF bis 2 MB. Wird beim Absenden des Formulars gespeichert.",
+            "description": "PNG, JPEG, WebP oder GIF bis 2 MB. Uploads und Entfernen werden sofort gespeichert.",
             "upload": "Bild hochladen",
             "replace": "Bild ersetzen",
             "remove": "Bild entfernen",
@@ -3144,11 +3144,13 @@
           },
           "success": {
             "saved": "Orchestrator aktualisiert.",
-            "textSavedImageFailed": "Text gespeichert, aber das Bild konnte nicht aktualisiert werden."
+            "imageSaved": "Bild gespeichert.",
+            "imageRemoved": "Bild entfernt."
           },
           "errors": {
             "saveFailed": "Orchestrator konnte nicht gespeichert werden.",
-            "notFound": "Orchestrator nicht gefunden."
+            "notFound": "Orchestrator nicht gefunden.",
+            "imageSaveFailed": "Bild konnte nicht aktualisiert werden."
           }
         }
       },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3098,7 +3098,8 @@
           "empty": "Keine Orchestratoren gefunden.",
           "orchestrator": "Orchestrator",
           "slug": "Slug",
-          "caption": "Untertitel"
+          "caption": "Untertitel",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Orchestrator bearbeiten",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3233,7 +3233,7 @@
           "submitting": "Saving…",
           "image": {
             "label": "Image",
-            "description": "PNG, JPEG, WebP, or GIF up to 2 MB. Uploads and removals save immediately.",
+            "description": "PNG, JPEG, WebP, or GIF up to 2 MB.",
             "upload": "Upload image",
             "replace": "Replace image",
             "remove": "Remove image",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3221,7 +3221,8 @@
           "empty": "No orchestrators found.",
           "orchestrator": "Orchestrator",
           "slug": "Slug",
-          "caption": "Caption"
+          "caption": "Caption",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Edit orchestrator",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3090,6 +3090,10 @@
           "tasks": {
             "title": "Tasks",
             "description": "Searchable list of all tasks across users and organizations."
+          },
+          "orchestrators": {
+            "title": "Orchestrators",
+            "description": "Edit display metadata for first-party orchestrators."
           }
         }
       },
@@ -3207,6 +3211,67 @@
         "TaskDetail": {
           "backToList": "Back to tasks",
           "personalWorkspace": "Personal workspace"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orchestrators",
+        "description": "Manage display metadata for first-party orchestrators.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# orchestrator} other {# orchestrators}}",
+          "empty": "No orchestrators found.",
+          "orchestrator": "Orchestrator",
+          "slug": "Slug",
+          "caption": "Caption"
+        },
+        "Detail": {
+          "title": "Edit orchestrator",
+          "backToList": "Back to orchestrators"
+        },
+        "EditForm": {
+          "submit": "Save changes",
+          "submitting": "Saving…",
+          "image": {
+            "label": "Image",
+            "description": "PNG, JPEG, WebP, or GIF up to 2 MB. Saved when you submit the form.",
+            "upload": "Upload image",
+            "replace": "Replace image",
+            "remove": "Remove image",
+            "previewAlt": "Orchestrator image preview",
+            "fileTooLarge": "Image must be 2 MB or smaller.",
+            "fileTypeNotAccepted": "Use PNG, JPEG, WebP, or GIF.",
+            "maxFilesExceeded": "Upload one image at a time.",
+            "uploadError": "Could not process the selected image."
+          },
+          "fields": {
+            "name": {
+              "label": "Name",
+              "description": "Shown wherever the orchestrator is listed."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Read-only identifier used in URLs and APIs."
+            },
+            "caption": {
+              "label": "Caption",
+              "description": "Short line shown under the name. Leave empty to clear."
+            },
+            "description": {
+              "label": "Description",
+              "description": "Longer copy for detail views. Leave empty to clear."
+            }
+          },
+          "validation": {
+            "nameMinLength": "Name must be at least {min} characters.",
+            "noChanges": "No changes to save."
+          },
+          "success": {
+            "saved": "Orchestrator updated.",
+            "textSavedImageFailed": "Text saved, but the image could not be updated."
+          },
+          "errors": {
+            "saveFailed": "Failed to save orchestrator.",
+            "notFound": "Orchestrator not found."
+          }
         }
       }
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3233,7 +3233,7 @@
           "submitting": "Saving…",
           "image": {
             "label": "Image",
-            "description": "PNG, JPEG, WebP, or GIF up to 2 MB. Saved when you submit the form.",
+            "description": "PNG, JPEG, WebP, or GIF up to 2 MB. Uploads and removals save immediately.",
             "upload": "Upload image",
             "replace": "Replace image",
             "remove": "Remove image",
@@ -3267,11 +3267,13 @@
           },
           "success": {
             "saved": "Orchestrator updated.",
-            "textSavedImageFailed": "Text saved, but the image could not be updated."
+            "imageSaved": "Image saved.",
+            "imageRemoved": "Image removed."
           },
           "errors": {
             "saveFailed": "Failed to save orchestrator.",
-            "notFound": "Orchestrator not found."
+            "notFound": "Orchestrator not found.",
+            "imageSaveFailed": "Failed to update image."
           }
         }
       }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3110,7 +3110,7 @@
           "submitting": "Guardando…",
           "image": {
             "label": "Imagen",
-            "description": "PNG, JPEG, WebP o GIF de hasta 2 MB. Las subidas y eliminaciones se guardan al instante.",
+            "description": "PNG, JPEG, WebP o GIF de hasta 2 MB.",
             "upload": "Subir imagen",
             "replace": "Reemplazar imagen",
             "remove": "Eliminar imagen",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2885,6 +2885,10 @@
             "title": "Tareas",
             "description": "Lista de todas las tareas con búsqueda por usuarios y organizaciones."
           },
+          "orchestrators": {
+            "title": "Orquestadores",
+            "description": "Editar metadatos de presentación de orquestadores propios."
+          },
           "freeCredits": {
             "title": "Créditos gratuitos",
             "description": "Otorga créditos gratuitos directamente a un usuario u organización sin factura de Stripe."
@@ -3084,6 +3088,67 @@
         "TaskDetail": {
           "backToList": "Volver a tareas",
           "personalWorkspace": "Espacio de trabajo personal"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orquestadores",
+        "description": "Gestionar metadatos de presentación de orquestadores propios.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# orquestador} other {# orquestadores}}",
+          "empty": "No se encontraron orquestadores.",
+          "orchestrator": "Orquestador",
+          "slug": "Slug",
+          "caption": "Subtítulo"
+        },
+        "Detail": {
+          "title": "Editar orquestador",
+          "backToList": "Volver a orquestadores"
+        },
+        "EditForm": {
+          "submit": "Guardar cambios",
+          "submitting": "Guardando…",
+          "image": {
+            "label": "Imagen",
+            "description": "PNG, JPEG, WebP o GIF de hasta 2 MB. Se guarda al enviar el formulario.",
+            "upload": "Subir imagen",
+            "replace": "Reemplazar imagen",
+            "remove": "Eliminar imagen",
+            "previewAlt": "Vista previa de la imagen del orquestador",
+            "fileTooLarge": "La imagen debe pesar 2 MB o menos.",
+            "fileTypeNotAccepted": "Usa PNG, JPEG, WebP o GIF.",
+            "maxFilesExceeded": "Sube una imagen a la vez.",
+            "uploadError": "No se pudo procesar la imagen seleccionada."
+          },
+          "fields": {
+            "name": {
+              "label": "Nombre",
+              "description": "Se muestra dondequiera que aparezca el orquestador."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Identificador de solo lectura usado en URLs y APIs."
+            },
+            "caption": {
+              "label": "Subtítulo",
+              "description": "Línea breve bajo el nombre. Déjalo vacío para borrarlo."
+            },
+            "description": {
+              "label": "Descripción",
+              "description": "Texto más largo para vistas de detalle. Déjalo vacío para borrarlo."
+            }
+          },
+          "validation": {
+            "nameMinLength": "El nombre debe tener al menos {min} caracteres.",
+            "noChanges": "No hay cambios que guardar."
+          },
+          "success": {
+            "saved": "Orquestador actualizado.",
+            "textSavedImageFailed": "Texto guardado, pero no se pudo actualizar la imagen."
+          },
+          "errors": {
+            "saveFailed": "No se pudo guardar el orquestador.",
+            "notFound": "Orquestador no encontrado."
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3098,7 +3098,8 @@
           "empty": "No se encontraron orquestadores.",
           "orchestrator": "Orquestador",
           "slug": "Slug",
-          "caption": "Subtítulo"
+          "caption": "Subtítulo",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Editar orquestador",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3110,7 +3110,7 @@
           "submitting": "Guardando…",
           "image": {
             "label": "Imagen",
-            "description": "PNG, JPEG, WebP o GIF de hasta 2 MB. Se guarda al enviar el formulario.",
+            "description": "PNG, JPEG, WebP o GIF de hasta 2 MB. Las subidas y eliminaciones se guardan al instante.",
             "upload": "Subir imagen",
             "replace": "Reemplazar imagen",
             "remove": "Eliminar imagen",
@@ -3144,11 +3144,13 @@
           },
           "success": {
             "saved": "Orquestador actualizado.",
-            "textSavedImageFailed": "Texto guardado, pero no se pudo actualizar la imagen."
+            "imageSaved": "Imagen guardada.",
+            "imageRemoved": "Imagen eliminada."
           },
           "errors": {
             "saveFailed": "No se pudo guardar el orquestador.",
-            "notFound": "Orquestador no encontrado."
+            "notFound": "Orquestador no encontrado.",
+            "imageSaveFailed": "No se pudo actualizar la imagen."
           }
         }
       },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3129,7 +3129,8 @@
           "empty": "Aucun orchestrateur trouvé.",
           "orchestrator": "Orchestrateur",
           "slug": "Slug",
-          "caption": "Légende"
+          "caption": "Légende",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Modifier l'orchestrateur",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3141,7 +3141,7 @@
           "submitting": "Enregistrement…",
           "image": {
             "label": "Image",
-            "description": "PNG, JPEG, WebP ou GIF jusqu'à 2 Mo. Enregistrée lors de l'envoi du formulaire.",
+            "description": "PNG, JPEG, WebP ou GIF jusqu’à 2 Mo. Les ajouts et suppressions sont enregistrés immédiatement.",
             "upload": "Téléverser une image",
             "replace": "Remplacer l'image",
             "remove": "Supprimer l'image",
@@ -3175,11 +3175,13 @@
           },
           "success": {
             "saved": "Orchestrateur mis à jour.",
-            "textSavedImageFailed": "Texte enregistré, mais l'image n'a pas pu être mise à jour."
+            "imageSaved": "Image enregistrée.",
+            "imageRemoved": "Image supprimée."
           },
           "errors": {
             "saveFailed": "Impossible d'enregistrer l'orchestrateur.",
-            "notFound": "Orchestrateur introuvable."
+            "notFound": "Orchestrateur introuvable.",
+            "imageSaveFailed": "Échec de la mise à jour de l’image."
           }
         }
       },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2916,6 +2916,10 @@
             "title": "Tâches",
             "description": "Liste consultable de toutes les tâches, tous utilisateurs et organisations confondus."
           },
+          "orchestrators": {
+            "title": "Orchestrateurs",
+            "description": "Modifier les métadonnées d'affichage des orchestrateurs internes."
+          },
           "freeCredits": {
             "title": "Crédits gratuits",
             "description": "Accordez des crédits gratuits directement à un utilisateur ou une organisation sans facture Stripe."
@@ -3115,6 +3119,67 @@
         "TaskDetail": {
           "backToList": "Retour aux tâches",
           "personalWorkspace": "Espace de travail personnel"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orchestrateurs",
+        "description": "Gérer les métadonnées d'affichage des orchestrateurs internes.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# orchestrateur} other {# orchestrateurs}}",
+          "empty": "Aucun orchestrateur trouvé.",
+          "orchestrator": "Orchestrateur",
+          "slug": "Slug",
+          "caption": "Légende"
+        },
+        "Detail": {
+          "title": "Modifier l'orchestrateur",
+          "backToList": "Retour aux orchestrateurs"
+        },
+        "EditForm": {
+          "submit": "Enregistrer les modifications",
+          "submitting": "Enregistrement…",
+          "image": {
+            "label": "Image",
+            "description": "PNG, JPEG, WebP ou GIF jusqu'à 2 Mo. Enregistrée lors de l'envoi du formulaire.",
+            "upload": "Téléverser une image",
+            "replace": "Remplacer l'image",
+            "remove": "Supprimer l'image",
+            "previewAlt": "Aperçu de l'image de l'orchestrateur",
+            "fileTooLarge": "L'image doit faire 2 Mo ou moins.",
+            "fileTypeNotAccepted": "Utilisez PNG, JPEG, WebP ou GIF.",
+            "maxFilesExceeded": "Téléversez une image à la fois.",
+            "uploadError": "Impossible de traiter l'image sélectionnée."
+          },
+          "fields": {
+            "name": {
+              "label": "Nom",
+              "description": "Affiché partout où l'orchestrateur apparaît."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Identifiant en lecture seule utilisé dans les URL et les API."
+            },
+            "caption": {
+              "label": "Légende",
+              "description": "Courte ligne sous le nom. Laissez vide pour effacer."
+            },
+            "description": {
+              "label": "Description",
+              "description": "Texte plus long pour les vues détaillées. Laissez vide pour effacer."
+            }
+          },
+          "validation": {
+            "nameMinLength": "Le nom doit comporter au moins {min} caractères.",
+            "noChanges": "Aucune modification à enregistrer."
+          },
+          "success": {
+            "saved": "Orchestrateur mis à jour.",
+            "textSavedImageFailed": "Texte enregistré, mais l'image n'a pas pu être mise à jour."
+          },
+          "errors": {
+            "saveFailed": "Impossible d'enregistrer l'orchestrateur.",
+            "notFound": "Orchestrateur introuvable."
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3141,7 +3141,7 @@
           "submitting": "Enregistrement…",
           "image": {
             "label": "Image",
-            "description": "PNG, JPEG, WebP ou GIF jusqu’à 2 Mo. Les ajouts et suppressions sont enregistrés immédiatement.",
+            "description": "PNG, JPEG, WebP ou GIF jusqu’à 2 Mo.",
             "upload": "Téléverser une image",
             "replace": "Remplacer l'image",
             "remove": "Supprimer l'image",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3141,7 +3141,7 @@
           "submitting": "Salvataggio…",
           "image": {
             "label": "Immagine",
-            "description": "PNG, JPEG, WebP o GIF fino a 2 MB. Salvata quando invii il modulo.",
+            "description": "PNG, JPEG, WebP o GIF fino a 2 MB. Caricamenti e rimozioni vengono salvati subito.",
             "upload": "Carica immagine",
             "replace": "Sostituisci immagine",
             "remove": "Rimuovi immagine",
@@ -3175,11 +3175,13 @@
           },
           "success": {
             "saved": "Orchestrator aggiornato.",
-            "textSavedImageFailed": "Testo salvato, ma l'immagine non è stata aggiornata."
+            "imageSaved": "Immagine salvata.",
+            "imageRemoved": "Immagine rimossa."
           },
           "errors": {
             "saveFailed": "Impossibile salvare l'orchestrator.",
-            "notFound": "Orchestrator non trovato."
+            "notFound": "Orchestrator non trovato.",
+            "imageSaveFailed": "Impossibile aggiornare l’immagine."
           }
         }
       },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2916,6 +2916,10 @@
             "title": "Attività",
             "description": "Elenco ricercabile di tutte le attività tra utenti e organizzazioni."
           },
+          "orchestrators": {
+            "title": "Orchestrator",
+            "description": "Modifica i metadati di visualizzazione degli orchestrator proprietari."
+          },
           "freeCredits": {
             "title": "Crediti gratuiti",
             "description": "Concedi crediti gratuiti direttamente a un utente o un'organizzazione senza fattura Stripe."
@@ -3115,6 +3119,67 @@
         "TaskDetail": {
           "backToList": "Torna alle attività",
           "personalWorkspace": "Spazio di lavoro personale"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orchestrator",
+        "description": "Gestisci i metadati di visualizzazione degli orchestrator proprietari.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# orchestrator} other {# orchestrator}}",
+          "empty": "Nessun orchestrator trovato.",
+          "orchestrator": "Orchestrator",
+          "slug": "Slug",
+          "caption": "Didascalia"
+        },
+        "Detail": {
+          "title": "Modifica orchestrator",
+          "backToList": "Torna agli orchestrator"
+        },
+        "EditForm": {
+          "submit": "Salva modifiche",
+          "submitting": "Salvataggio…",
+          "image": {
+            "label": "Immagine",
+            "description": "PNG, JPEG, WebP o GIF fino a 2 MB. Salvata quando invii il modulo.",
+            "upload": "Carica immagine",
+            "replace": "Sostituisci immagine",
+            "remove": "Rimuovi immagine",
+            "previewAlt": "Anteprima immagine orchestrator",
+            "fileTooLarge": "L'immagine deve essere di 2 MB o meno.",
+            "fileTypeNotAccepted": "Usa PNG, JPEG, WebP o GIF.",
+            "maxFilesExceeded": "Carica un'immagine alla volta.",
+            "uploadError": "Impossibile elaborare l'immagine selezionata."
+          },
+          "fields": {
+            "name": {
+              "label": "Nome",
+              "description": "Mostrato ovunque compaia l'orchestrator."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Identificatore di sola lettura usato in URL e API."
+            },
+            "caption": {
+              "label": "Didascalia",
+              "description": "Breve riga sotto il nome. Lascia vuoto per cancellare."
+            },
+            "description": {
+              "label": "Descrizione",
+              "description": "Testo più lungo per le viste di dettaglio. Lascia vuoto per cancellare."
+            }
+          },
+          "validation": {
+            "nameMinLength": "Il nome deve avere almeno {min} caratteri.",
+            "noChanges": "Nessuna modifica da salvare."
+          },
+          "success": {
+            "saved": "Orchestrator aggiornato.",
+            "textSavedImageFailed": "Testo salvato, ma l'immagine non è stata aggiornata."
+          },
+          "errors": {
+            "saveFailed": "Impossibile salvare l'orchestrator.",
+            "notFound": "Orchestrator non trovato."
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3141,7 +3141,7 @@
           "submitting": "Salvataggio…",
           "image": {
             "label": "Immagine",
-            "description": "PNG, JPEG, WebP o GIF fino a 2 MB. Caricamenti e rimozioni vengono salvati subito.",
+            "description": "PNG, JPEG, WebP o GIF fino a 2 MB.",
             "upload": "Carica immagine",
             "replace": "Sostituisci immagine",
             "remove": "Rimuovi immagine",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3129,7 +3129,8 @@
           "empty": "Nessun orchestrator trovato.",
           "orchestrator": "Orchestrator",
           "slug": "Slug",
-          "caption": "Didascalia"
+          "caption": "Didascalia",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Modifica orchestrator",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3141,7 +3141,7 @@
           "submitting": "保存中…",
           "image": {
             "label": "画像",
-            "description": "PNG / JPEG / WebP / GIF（最大 2 MB）。アップロードと削除はすぐに保存されます。",
+            "description": "PNG / JPEG / WebP / GIF（最大 2 MB）。",
             "upload": "画像をアップロード",
             "replace": "画像を差し替え",
             "remove": "画像を削除",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3141,7 +3141,7 @@
           "submitting": "保存中…",
           "image": {
             "label": "画像",
-            "description": "PNG、JPEG、WebP、GIF（最大 2 MB）。フォーム送信時に保存されます。",
+            "description": "PNG / JPEG / WebP / GIF（最大 2 MB）。アップロードと削除はすぐに保存されます。",
             "upload": "画像をアップロード",
             "replace": "画像を差し替え",
             "remove": "画像を削除",
@@ -3175,11 +3175,13 @@
           },
           "success": {
             "saved": "オーケストレーターを更新しました。",
-            "textSavedImageFailed": "テキストは保存されましたが、画像を更新できませんでした。"
+            "imageSaved": "画像を保存しました。",
+            "imageRemoved": "画像を削除しました。"
           },
           "errors": {
             "saveFailed": "オーケストレーターを保存できませんでした。",
-            "notFound": "オーケストレーターが見つかりません。"
+            "notFound": "オーケストレーターが見つかりません。",
+            "imageSaveFailed": "画像の更新に失敗しました。"
           }
         }
       },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2916,6 +2916,10 @@
             "title": "タスク",
             "description": "ユーザーや組織を横断してすべてのタスクを検索できる一覧です。"
           },
+          "orchestrators": {
+            "title": "オーケストレーター",
+            "description": "自社オーケストレーターの表示メタデータを編集します。"
+          },
           "freeCredits": {
             "title": "無料クレジット",
             "description": "Stripe の請求書なしで、ユーザーまたは組織に無料クレジットを直接付与します。"
@@ -3115,6 +3119,67 @@
         "TaskDetail": {
           "backToList": "タスク一覧に戻る",
           "personalWorkspace": "個人ワークスペース"
+        }
+      },
+      "Orchestrators": {
+        "title": "オーケストレーター",
+        "description": "自社オーケストレーターの表示メタデータを管理します。",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, other {# 件のオーケストレーター}}",
+          "empty": "オーケストレーターが見つかりません。",
+          "orchestrator": "オーケストレーター",
+          "slug": "スラッグ",
+          "caption": "キャプション"
+        },
+        "Detail": {
+          "title": "オーケストレーターを編集",
+          "backToList": "オーケストレーター一覧に戻る"
+        },
+        "EditForm": {
+          "submit": "変更を保存",
+          "submitting": "保存中…",
+          "image": {
+            "label": "画像",
+            "description": "PNG、JPEG、WebP、GIF（最大 2 MB）。フォーム送信時に保存されます。",
+            "upload": "画像をアップロード",
+            "replace": "画像を差し替え",
+            "remove": "画像を削除",
+            "previewAlt": "オーケストレーター画像のプレビュー",
+            "fileTooLarge": "画像は 2 MB 以下にしてください。",
+            "fileTypeNotAccepted": "PNG、JPEG、WebP、GIF を使用してください。",
+            "maxFilesExceeded": "一度に 1 枚だけアップロードできます。",
+            "uploadError": "選択した画像を処理できませんでした。"
+          },
+          "fields": {
+            "name": {
+              "label": "名前",
+              "description": "オーケストレーターが表示されるすべての場所に使われます。"
+            },
+            "slug": {
+              "label": "スラッグ",
+              "description": "URL や API で使う読み取り専用の識別子です。"
+            },
+            "caption": {
+              "label": "キャプション",
+              "description": "名前の下に表示する短い文言。空にすると削除されます。"
+            },
+            "description": {
+              "label": "説明",
+              "description": "詳細画面向けの長い説明文。空にすると削除されます。"
+            }
+          },
+          "validation": {
+            "nameMinLength": "名前は {min} 文字以上にしてください。",
+            "noChanges": "保存する変更がありません。"
+          },
+          "success": {
+            "saved": "オーケストレーターを更新しました。",
+            "textSavedImageFailed": "テキストは保存されましたが、画像を更新できませんでした。"
+          },
+          "errors": {
+            "saveFailed": "オーケストレーターを保存できませんでした。",
+            "notFound": "オーケストレーターが見つかりません。"
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3129,7 +3129,8 @@
           "empty": "オーケストレーターが見つかりません。",
           "orchestrator": "オーケストレーター",
           "slug": "スラッグ",
-          "caption": "キャプション"
+          "caption": "キャプション",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "オーケストレーターを編集",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -3129,7 +3129,8 @@
           "empty": "Nenhum orquestrador encontrado.",
           "orchestrator": "Orquestrador",
           "slug": "Slug",
-          "caption": "Legenda"
+          "caption": "Legenda",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Editar orquestrador",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -3141,7 +3141,7 @@
           "submitting": "Salvando…",
           "image": {
             "label": "Imagem",
-            "description": "PNG, JPEG, WebP ou GIF de até 2 MB. Salva ao enviar o formulário.",
+            "description": "PNG, JPEG, WebP ou GIF de até 2 MB. Envios e remoções são salvos imediatamente.",
             "upload": "Enviar imagem",
             "replace": "Substituir imagem",
             "remove": "Remover imagem",
@@ -3175,11 +3175,13 @@
           },
           "success": {
             "saved": "Orquestrador atualizado.",
-            "textSavedImageFailed": "Texto salvo, mas a imagem não pôde ser atualizada."
+            "imageSaved": "Imagem salva.",
+            "imageRemoved": "Imagem removida."
           },
           "errors": {
             "saveFailed": "Não foi possível salvar o orquestrador.",
-            "notFound": "Orquestrador não encontrado."
+            "notFound": "Orquestrador não encontrado.",
+            "imageSaveFailed": "Falha ao atualizar a imagem."
           }
         }
       },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2916,6 +2916,10 @@
             "title": "Tarefas",
             "description": "Lista pesquisável de todas as tarefas entre usuários e organizações."
           },
+          "orchestrators": {
+            "title": "Orquestradores",
+            "description": "Editar metadados de exibição de orquestradores próprios."
+          },
           "freeCredits": {
             "title": "Créditos gratuitos",
             "description": "Conceda créditos gratuitos diretamente a um usuário ou organização sem fatura Stripe."
@@ -3115,6 +3119,67 @@
         "TaskDetail": {
           "backToList": "Voltar às tarefas",
           "personalWorkspace": "Espaço de trabalho pessoal"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orquestradores",
+        "description": "Gerenciar metadados de exibição de orquestradores próprios.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# orquestrador} other {# orquestradores}}",
+          "empty": "Nenhum orquestrador encontrado.",
+          "orchestrator": "Orquestrador",
+          "slug": "Slug",
+          "caption": "Legenda"
+        },
+        "Detail": {
+          "title": "Editar orquestrador",
+          "backToList": "Voltar aos orquestradores"
+        },
+        "EditForm": {
+          "submit": "Salvar alterações",
+          "submitting": "Salvando…",
+          "image": {
+            "label": "Imagem",
+            "description": "PNG, JPEG, WebP ou GIF de até 2 MB. Salva ao enviar o formulário.",
+            "upload": "Enviar imagem",
+            "replace": "Substituir imagem",
+            "remove": "Remover imagem",
+            "previewAlt": "Pré-visualização da imagem do orquestrador",
+            "fileTooLarge": "A imagem deve ter 2 MB ou menos.",
+            "fileTypeNotAccepted": "Use PNG, JPEG, WebP ou GIF.",
+            "maxFilesExceeded": "Envie uma imagem por vez.",
+            "uploadError": "Não foi possível processar a imagem selecionada."
+          },
+          "fields": {
+            "name": {
+              "label": "Nome",
+              "description": "Exibido onde o orquestrador for listado."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Identificador somente leitura usado em URLs e APIs."
+            },
+            "caption": {
+              "label": "Legenda",
+              "description": "Linha curta abaixo do nome. Deixe vazio para limpar."
+            },
+            "description": {
+              "label": "Descrição",
+              "description": "Texto mais longo para telas de detalhe. Deixe vazio para limpar."
+            }
+          },
+          "validation": {
+            "nameMinLength": "O nome deve ter pelo menos {min} caracteres.",
+            "noChanges": "Nenhuma alteração para salvar."
+          },
+          "success": {
+            "saved": "Orquestrador atualizado.",
+            "textSavedImageFailed": "Texto salvo, mas a imagem não pôde ser atualizada."
+          },
+          "errors": {
+            "saveFailed": "Não foi possível salvar o orquestrador.",
+            "notFound": "Orquestrador não encontrado."
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -3141,7 +3141,7 @@
           "submitting": "Salvando…",
           "image": {
             "label": "Imagem",
-            "description": "PNG, JPEG, WebP ou GIF de até 2 MB. Envios e remoções são salvos imediatamente.",
+            "description": "PNG, JPEG, WebP ou GIF de até 2 MB.",
             "upload": "Enviar imagem",
             "replace": "Substituir imagem",
             "remove": "Remover imagem",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3129,7 +3129,8 @@
           "empty": "Nenhum orquestrador encontrado.",
           "orchestrator": "Orquestrador",
           "slug": "Slug",
-          "caption": "Legenda"
+          "caption": "Legenda",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "Editar orquestrador",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2916,6 +2916,10 @@
             "title": "Tarefas",
             "description": "Lista pesquisável de todas as tarefas entre utilizadores e organizações."
           },
+          "orchestrators": {
+            "title": "Orquestradores",
+            "description": "Editar metadados de apresentação de orquestradores próprios."
+          },
           "freeCredits": {
             "title": "Créditos gratuitos",
             "description": "Conceda créditos gratuitos diretamente a um utilizador ou organização sem fatura Stripe."
@@ -3115,6 +3119,67 @@
         "TaskDetail": {
           "backToList": "Voltar às tarefas",
           "personalWorkspace": "Espaço de trabalho pessoal"
+        }
+      },
+      "Orchestrators": {
+        "title": "Orquestradores",
+        "description": "Gerir metadados de apresentação de orquestradores próprios.",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, one {# orquestrador} other {# orquestradores}}",
+          "empty": "Nenhum orquestrador encontrado.",
+          "orchestrator": "Orquestrador",
+          "slug": "Slug",
+          "caption": "Legenda"
+        },
+        "Detail": {
+          "title": "Editar orquestrador",
+          "backToList": "Voltar aos orquestradores"
+        },
+        "EditForm": {
+          "submit": "Guardar alterações",
+          "submitting": "A guardar…",
+          "image": {
+            "label": "Imagem",
+            "description": "PNG, JPEG, WebP ou GIF até 2 MB. Guardada ao submeter o formulário.",
+            "upload": "Carregar imagem",
+            "replace": "Substituir imagem",
+            "remove": "Remover imagem",
+            "previewAlt": "Pré-visualização da imagem do orquestrador",
+            "fileTooLarge": "A imagem deve ter 2 MB ou menos.",
+            "fileTypeNotAccepted": "Use PNG, JPEG, WebP ou GIF.",
+            "maxFilesExceeded": "Carregue uma imagem de cada vez.",
+            "uploadError": "Não foi possível processar a imagem selecionada."
+          },
+          "fields": {
+            "name": {
+              "label": "Nome",
+              "description": "Mostrado onde o orquestrador é listado."
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "Identificador só de leitura usado em URLs e APIs."
+            },
+            "caption": {
+              "label": "Legenda",
+              "description": "Linha curta sob o nome. Deixe vazio para limpar."
+            },
+            "description": {
+              "label": "Descrição",
+              "description": "Texto mais longo para vistas de detalhe. Deixe vazio para limpar."
+            }
+          },
+          "validation": {
+            "nameMinLength": "O nome deve ter pelo menos {min} caracteres.",
+            "noChanges": "Sem alterações para guardar."
+          },
+          "success": {
+            "saved": "Orquestrador atualizado.",
+            "textSavedImageFailed": "Texto guardado, mas a imagem não pôde ser atualizada."
+          },
+          "errors": {
+            "saveFailed": "Não foi possível guardar o orquestrador.",
+            "notFound": "Orquestrador não encontrado."
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3141,7 +3141,7 @@
           "submitting": "A guardar…",
           "image": {
             "label": "Imagem",
-            "description": "PNG, JPEG, WebP ou GIF até 2 MB. Envios e remoções são guardados de imediato.",
+            "description": "PNG, JPEG, WebP ou GIF até 2 MB.",
             "upload": "Carregar imagem",
             "replace": "Substituir imagem",
             "remove": "Remover imagem",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3141,7 +3141,7 @@
           "submitting": "A guardar…",
           "image": {
             "label": "Imagem",
-            "description": "PNG, JPEG, WebP ou GIF até 2 MB. Guardada ao submeter o formulário.",
+            "description": "PNG, JPEG, WebP ou GIF até 2 MB. Envios e remoções são guardados de imediato.",
             "upload": "Carregar imagem",
             "replace": "Substituir imagem",
             "remove": "Remover imagem",
@@ -3175,11 +3175,13 @@
           },
           "success": {
             "saved": "Orquestrador atualizado.",
-            "textSavedImageFailed": "Texto guardado, mas a imagem não pôde ser atualizada."
+            "imageSaved": "Imagem guardada.",
+            "imageRemoved": "Imagem removida."
           },
           "errors": {
             "saveFailed": "Não foi possível guardar o orquestrador.",
-            "notFound": "Orquestrador não encontrado."
+            "notFound": "Orquestrador não encontrado.",
+            "imageSaveFailed": "Falha ao atualizar a imagem."
           }
         }
       },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2916,6 +2916,10 @@
             "title": "任务",
             "description": "可跨用户和组织搜索的所有任务列表。"
           },
+          "orchestrators": {
+            "title": "编排器",
+            "description": "编辑自有编排器的展示元数据。"
+          },
           "freeCredits": {
             "title": "免费积分",
             "description": "无需 Stripe 发票，直接向用户或组织发放免费积分。"
@@ -3115,6 +3119,67 @@
         "TaskDetail": {
           "backToList": "返回任务列表",
           "personalWorkspace": "个人工作区"
+        }
+      },
+      "Orchestrators": {
+        "title": "编排器",
+        "description": "管理自有编排器的展示元数据。",
+        "OrchestratorList": {
+          "totalCount": "{count, plural, other {# 个编排器}}",
+          "empty": "未找到编排器。",
+          "orchestrator": "编排器",
+          "slug": "Slug",
+          "caption": "副标题"
+        },
+        "Detail": {
+          "title": "编辑编排器",
+          "backToList": "返回编排器列表"
+        },
+        "EditForm": {
+          "submit": "保存更改",
+          "submitting": "正在保存…",
+          "image": {
+            "label": "图片",
+            "description": "支持 PNG、JPEG、WebP 或 GIF，最大 2 MB。提交表单时保存。",
+            "upload": "上传图片",
+            "replace": "替换图片",
+            "remove": "移除图片",
+            "previewAlt": "编排器图片预览",
+            "fileTooLarge": "图片大小不能超过 2 MB。",
+            "fileTypeNotAccepted": "请使用 PNG、JPEG、WebP 或 GIF。",
+            "maxFilesExceeded": "一次只能上传一张图片。",
+            "uploadError": "无法处理所选图片。"
+          },
+          "fields": {
+            "name": {
+              "label": "名称",
+              "description": "在展示编排器的所有位置显示。"
+            },
+            "slug": {
+              "label": "Slug",
+              "description": "用于 URL 和 API 的只读标识符。"
+            },
+            "caption": {
+              "label": "副标题",
+              "description": "显示在名称下方的简短文字。留空即清除。"
+            },
+            "description": {
+              "label": "描述",
+              "description": "用于详情页的较长文案。留空即清除。"
+            }
+          },
+          "validation": {
+            "nameMinLength": "名称至少需要 {min} 个字符。",
+            "noChanges": "没有可保存的更改。"
+          },
+          "success": {
+            "saved": "编排器已更新。",
+            "textSavedImageFailed": "文本已保存，但图片未能更新。"
+          },
+          "errors": {
+            "saveFailed": "保存编排器失败。",
+            "notFound": "未找到编排器。"
+          }
         }
       },
       "FreeCredits": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -3141,7 +3141,7 @@
           "submitting": "正在保存…",
           "image": {
             "label": "图片",
-            "description": "支持 PNG、JPEG、WebP 或 GIF，最大 2 MB。提交表单时保存。",
+            "description": "PNG、JPEG、WebP 或 GIF，最大 2 MB。上传和删除会立即保存。",
             "upload": "上传图片",
             "replace": "替换图片",
             "remove": "移除图片",
@@ -3175,11 +3175,13 @@
           },
           "success": {
             "saved": "编排器已更新。",
-            "textSavedImageFailed": "文本已保存，但图片未能更新。"
+            "imageSaved": "图片已保存。",
+            "imageRemoved": "图片已删除。"
           },
           "errors": {
             "saveFailed": "保存编排器失败。",
-            "notFound": "未找到编排器。"
+            "notFound": "未找到编排器。",
+            "imageSaveFailed": "更新图片失败。"
           }
         }
       },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -3141,7 +3141,7 @@
           "submitting": "正在保存…",
           "image": {
             "label": "图片",
-            "description": "PNG、JPEG、WebP 或 GIF，最大 2 MB。上传和删除会立即保存。",
+            "description": "PNG、JPEG、WebP 或 GIF，最大 2 MB。",
             "upload": "上传图片",
             "replace": "替换图片",
             "remove": "移除图片",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -3129,7 +3129,8 @@
           "empty": "未找到编排器。",
           "orchestrator": "编排器",
           "slug": "Slug",
-          "caption": "副标题"
+          "caption": "副标题",
+          "emptyCaption": "—"
         },
         "Detail": {
           "title": "编辑编排器",

--- a/apps/web/src/app/(app)/admin/admin-sections.ts
+++ b/apps/web/src/app/(app)/admin/admin-sections.ts
@@ -1,4 +1,5 @@
 import {
+  Bot,
   Building,
   Building2,
   Coins,
@@ -50,5 +51,10 @@ export const ADMIN_SECTIONS: AdminSection[] = [
     key: "tasks",
     href: "/admin/tasks",
     Icon: ListTodo,
+  },
+  {
+    key: "orchestrators",
+    href: "/admin/orchestrators",
+    Icon: Bot,
   },
 ];

--- a/apps/web/src/app/(app)/admin/orchestrators/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/orchestrators/[id]/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { OrchestratorEditForm } from "@/components/admin/orchestrators/orchestrator-edit-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { adminOrchestratorService } from "@/lib/services/admin-orchestrator.service";
+
+export const metadata: Metadata = {
+  title: "Edit orchestrator",
+  description: "Edit orchestrator display metadata",
+};
+
+interface AdminOrchestratorDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function AdminOrchestratorDetailPage({
+  params,
+}: AdminOrchestratorDetailPageProps) {
+  const { id } = await params;
+  const [orchestrator, t] = await Promise.all([
+    adminOrchestratorService.getOrchestrator(id),
+    getTranslations("App.Admin.Orchestrators.Detail"),
+  ]);
+
+  if (!orchestrator) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-full w-full">
+      <div className="mx-auto max-w-3xl space-y-6 px-4 py-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {t("title")}
+            </h1>
+            <p className="text-muted-foreground text-sm">{orchestrator.name}</p>
+          </div>
+          <Button variant="outline" asChild>
+            <Link href="/admin/orchestrators">{t("backToList")}</Link>
+          </Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{orchestrator.slug}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <OrchestratorEditForm orchestrator={orchestrator} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/admin/orchestrators/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/orchestrators/[id]/page.tsx
@@ -50,7 +50,10 @@ export default async function AdminOrchestratorDetailPage({
             <CardTitle>{orchestrator.slug}</CardTitle>
           </CardHeader>
           <CardContent>
-            <OrchestratorEditForm orchestrator={orchestrator} />
+            <OrchestratorEditForm
+              key={orchestrator.id}
+              orchestrator={orchestrator}
+            />
           </CardContent>
         </Card>
       </div>

--- a/apps/web/src/app/(app)/admin/orchestrators/page.tsx
+++ b/apps/web/src/app/(app)/admin/orchestrators/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+import { OrchestratorList } from "@/components/admin/orchestrators/orchestrator-list";
+import { adminOrchestratorService } from "@/lib/services/admin-orchestrator.service";
+
+export const metadata: Metadata = {
+  title: "Orchestrators",
+  description: "Manage orchestrator display metadata",
+};
+
+export default async function AdminOrchestratorsPage() {
+  const t = await getTranslations("App.Admin.Orchestrators");
+  const orchestrators = await adminOrchestratorService.listOrchestrators();
+
+  return (
+    <div className="min-h-full w-full">
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-2">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground text-sm">{t("description")}</p>
+        </div>
+
+        <OrchestratorList orchestrators={orchestrators} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { Bot, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type FormEvent, useState } from "react";
@@ -14,16 +14,17 @@ import { Textarea } from "@/components/ui/textarea";
 import { updateAdminOrchestratorDisplayAction } from "@/lib/actions/admin-orchestrators/action";
 import { CommonErrorCode } from "@/lib/actions/errors";
 import {
+  ADMIN_ORCHESTRATOR_CAPTION_MAX_LENGTH,
+  ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH,
+} from "@/lib/constants/orchestrator-display";
+import {
   ORCHESTRATOR_IMAGE_ACCEPT,
   ORCHESTRATOR_IMAGE_MAX_SIZE_BYTES,
 } from "@/lib/constants/orchestrator-image";
 import type {
+  AdminOrchestratorDisplayPatchBody,
   AdminOrchestratorItem,
-  AdminOrchestratorPatchBody,
 } from "@/lib/services/admin-orchestrator.service";
-
-const MIN_NAME_LENGTH = 3;
-const MAX_CAPTION_LENGTH = 255;
 
 interface OrchestratorEditFormProps {
   orchestrator: AdminOrchestratorItem;
@@ -41,8 +42,8 @@ function buildPatchBody(
     caption: string;
     description: string;
   },
-): AdminOrchestratorPatchBody | undefined {
-  const patchBody: AdminOrchestratorPatchBody = {};
+): AdminOrchestratorDisplayPatchBody | undefined {
+  const patchBody: AdminOrchestratorDisplayPatchBody = {};
 
   const nextName = values.name.trim();
   if (nextName !== orchestrator.name) {
@@ -175,8 +176,12 @@ export function OrchestratorEditForm({
     }
 
     const trimmedName = name.trim();
-    if (trimmedName.length < MIN_NAME_LENGTH) {
-      toast.error(t("validation.nameMinLength", { min: MIN_NAME_LENGTH }));
+    if (trimmedName.length < ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH) {
+      toast.error(
+        t("validation.nameMinLength", {
+          min: ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH,
+        }),
+      );
       return;
     }
 
@@ -224,6 +229,7 @@ export function OrchestratorEditForm({
         <OrganizationLogoUploadField
           accept={ORCHESTRATOR_IMAGE_ACCEPT}
           disabled={isBusy}
+          fallbackIcon={<Bot className="size-8" />}
           isRemoving={isRemovingImage}
           isUploading={isUploadingImage}
           labels={imageLabels}
@@ -279,7 +285,7 @@ export function OrchestratorEditForm({
           onChange={(event) => setCaption(event.target.value)}
           disabled={isBusy}
           autoComplete="off"
-          maxLength={MAX_CAPTION_LENGTH}
+          maxLength={ADMIN_ORCHESTRATOR_CAPTION_MAX_LENGTH}
         />
         <p className="text-muted-foreground text-sm">
           {t("fields.caption.description")}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { OrganizationLogoUploadField } from "@/components/organizations/organization-logo-upload-field";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { updateAdminOrchestratorDisplayAction } from "@/lib/actions/admin-orchestrators/action";
+import { CommonErrorCode } from "@/lib/actions/errors";
+import type {
+  AdminOrchestratorItem,
+  AdminOrchestratorPatchBody,
+} from "@/lib/services/admin-orchestrator.service";
+
+const MIN_NAME_LENGTH = 3;
+
+interface OrchestratorEditFormProps {
+  orchestrator: AdminOrchestratorItem;
+}
+
+function normalizeOptionalText(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function buildPatchBody(
+  orchestrator: AdminOrchestratorItem,
+  values: {
+    name: string;
+    caption: string;
+    description: string;
+  },
+): AdminOrchestratorPatchBody | undefined {
+  const patchBody: AdminOrchestratorPatchBody = {};
+
+  const nextName = values.name.trim();
+  if (nextName !== orchestrator.name) {
+    patchBody.name = nextName;
+  }
+
+  const nextCaption = normalizeOptionalText(values.caption);
+  if (nextCaption !== orchestrator.caption) {
+    patchBody.caption = nextCaption;
+  }
+
+  const nextDescription = normalizeOptionalText(values.description);
+  if (nextDescription !== orchestrator.description) {
+    patchBody.description = nextDescription;
+  }
+
+  return Object.keys(patchBody).length > 0 ? patchBody : undefined;
+}
+
+export function OrchestratorEditForm({
+  orchestrator,
+}: OrchestratorEditFormProps) {
+  const t = useTranslations("App.Admin.Orchestrators.EditForm");
+  const router = useRouter();
+
+  const [name, setName] = useState(orchestrator.name);
+  const [caption, setCaption] = useState(orchestrator.caption ?? "");
+  const [description, setDescription] = useState(
+    orchestrator.description ?? "",
+  );
+  const [imageValue, setImageValue] = useState(orchestrator.image ?? "");
+  const [pendingImageFiles, setPendingImageFiles] = useState<File[]>([]);
+  const [pendingImageFile, setPendingImageFile] = useState<File | null>(null);
+  const [removeImage, setRemoveImage] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const pendingPreviewUrl = useMemo(() => {
+    if (!pendingImageFile) {
+      return null;
+    }
+    return URL.createObjectURL(pendingImageFile);
+  }, [pendingImageFile]);
+
+  useEffect(() => {
+    return () => {
+      if (pendingPreviewUrl) {
+        URL.revokeObjectURL(pendingPreviewUrl);
+      }
+    };
+  }, [pendingPreviewUrl]);
+
+  const displayImageValue = removeImage
+    ? ""
+    : (pendingPreviewUrl ?? imageValue);
+
+  const imageLabels = {
+    fileTooLarge: t("image.fileTooLarge"),
+    fileTypeNotAccepted: t("image.fileTypeNotAccepted"),
+    maxFilesExceeded: t("image.maxFilesExceeded"),
+    previewAlt: t("image.previewAlt"),
+    remove: t("image.remove"),
+    replace: t("image.replace"),
+    upload: t("image.upload"),
+    uploadError: t("image.uploadError"),
+  };
+
+  function handleImageSelect(files: File[]) {
+    const file = files[0];
+    if (!file) {
+      return;
+    }
+
+    setPendingImageFile(file);
+    setPendingImageFiles(files);
+    setRemoveImage(false);
+  }
+
+  function handleRemoveImage() {
+    setPendingImageFile(null);
+    setPendingImageFiles([]);
+    setRemoveImage(true);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    if (trimmedName.length < MIN_NAME_LENGTH) {
+      toast.error(t("validation.nameMinLength", { min: MIN_NAME_LENGTH }));
+      return;
+    }
+
+    const patchBody = buildPatchBody(orchestrator, {
+      name,
+      caption,
+      description,
+    });
+    const imageIntent = removeImage
+      ? "remove"
+      : pendingImageFile
+        ? "upload"
+        : "none";
+
+    if (!patchBody && imageIntent === "none") {
+      toast.error(t("validation.noChanges"));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const result = await updateAdminOrchestratorDisplayAction({
+        id: orchestrator.id,
+        patchBody,
+        imageIntent,
+        imageFile: pendingImageFile ?? undefined,
+      });
+
+      if (!result.ok) {
+        if (result.error.code === CommonErrorCode.NOT_FOUND) {
+          toast.error(t("errors.notFound"));
+          router.push("/admin/orchestrators");
+          return;
+        }
+
+        toast.error(result.error.message ?? t("errors.saveFailed"));
+        return;
+      }
+
+      setName(result.data.orchestrator.name);
+      setCaption(result.data.orchestrator.caption ?? "");
+      setDescription(result.data.orchestrator.description ?? "");
+      setImageValue(result.data.orchestrator.image ?? "");
+      setPendingImageFile(null);
+      setPendingImageFiles([]);
+      setRemoveImage(false);
+
+      if (result.data.imageError) {
+        toast.error(result.data.imageError);
+        toast.message(t("success.textSavedImageFailed"));
+      } else {
+        toast.success(t("success.saved"));
+      }
+
+      router.refresh();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <div className="space-y-2">
+        <Label>{t("image.label")}</Label>
+        <OrganizationLogoUploadField
+          disabled={isSubmitting}
+          isUploading={false}
+          labels={imageLabels}
+          logoValue={displayImageValue}
+          onPendingLogoFilesChange={setPendingImageFiles}
+          onRemove={handleRemoveImage}
+          onUpload={handleImageSelect}
+          pendingLogoFiles={pendingImageFiles}
+          showRemoveButton={Boolean(displayImageValue) || removeImage}
+        />
+        <p className="text-muted-foreground text-sm">
+          {t("image.description")}
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="orchestrator-name">{t("fields.name.label")}</Label>
+          <Input
+            id="orchestrator-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={isSubmitting}
+            autoComplete="off"
+          />
+          <p className="text-muted-foreground text-sm">
+            {t("fields.name.description")}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="orchestrator-slug">{t("fields.slug.label")}</Label>
+          <Input
+            id="orchestrator-slug"
+            value={orchestrator.slug}
+            disabled
+            readOnly
+          />
+          <p className="text-muted-foreground text-sm">
+            {t("fields.slug.description")}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="orchestrator-caption">
+          {t("fields.caption.label")}
+        </Label>
+        <Input
+          id="orchestrator-caption"
+          value={caption}
+          onChange={(event) => setCaption(event.target.value)}
+          disabled={isSubmitting}
+          autoComplete="off"
+        />
+        <p className="text-muted-foreground text-sm">
+          {t("fields.caption.description")}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="orchestrator-description">
+          {t("fields.description.label")}
+        </Label>
+        <Textarea
+          id="orchestrator-description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          disabled={isSubmitting}
+          rows={5}
+        />
+        <p className="text-muted-foreground text-sm">
+          {t("fields.description.description")}
+        </p>
+      </div>
+
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            {t("submitting")}
+          </>
+        ) : (
+          t("submit")
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
@@ -214,7 +214,7 @@ export function OrchestratorEditForm({
           onRemove={handleRemoveImage}
           onUpload={handleImageSelect}
           pendingLogoFiles={pendingImageFiles}
-          showRemoveButton={Boolean(displayImageValue) || removeImage}
+          showRemoveButton={Boolean(displayImageValue)}
         />
         <p className="text-muted-foreground text-sm">
           {t("image.description")}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
@@ -3,7 +3,7 @@
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { type FormEvent, useState } from "react";
 import { toast } from "sonner";
 
 import { OrganizationLogoUploadField } from "@/components/organizations/organization-logo-upload-field";
@@ -76,28 +76,11 @@ export function OrchestratorEditForm({
   );
   const [imageValue, setImageValue] = useState(orchestrator.image ?? "");
   const [pendingImageFiles, setPendingImageFiles] = useState<File[]>([]);
-  const [pendingImageFile, setPendingImageFile] = useState<File | null>(null);
-  const [removeImage, setRemoveImage] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSavingText, setIsSavingText] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [isRemovingImage, setIsRemovingImage] = useState(false);
 
-  const pendingPreviewUrl = useMemo(() => {
-    if (!pendingImageFile) {
-      return null;
-    }
-    return URL.createObjectURL(pendingImageFile);
-  }, [pendingImageFile]);
-
-  useEffect(() => {
-    return () => {
-      if (pendingPreviewUrl) {
-        URL.revokeObjectURL(pendingPreviewUrl);
-      }
-    };
-  }, [pendingPreviewUrl]);
-
-  const displayImageValue = removeImage
-    ? ""
-    : (pendingPreviewUrl ?? imageValue);
+  const isBusy = isSavingText || isUploadingImage || isRemovingImage;
 
   const imageLabels = {
     fileTooLarge: t("image.fileTooLarge"),
@@ -110,30 +93,86 @@ export function OrchestratorEditForm({
     uploadError: t("image.uploadError"),
   };
 
-  function handleImageSelect(files: File[]) {
-    const file = files[0];
-    if (!file) {
-      return;
-    }
-
-    setPendingImageFile(file);
-    setPendingImageFiles(files);
-    setRemoveImage(false);
+  function applySavedOrchestrator(saved: AdminOrchestratorItem) {
+    setBaseline(saved);
+    setName(saved.name);
+    setCaption(saved.caption ?? "");
+    setDescription(saved.description ?? "");
+    setImageValue(saved.image ?? "");
   }
 
-  function handleRemoveImage() {
-    // Pending pick: clear selection only — do not mark stored image for delete.
-    if (pendingImageFile) {
-      setPendingImageFile(null);
-      setPendingImageFiles([]);
+  function handleNotFound() {
+    toast.error(t("errors.notFound"));
+    router.push("/admin/orchestrators");
+  }
+
+  async function handleImageSelect(files: File[]) {
+    const file = files[0];
+    if (!file || isBusy) {
       return;
     }
 
-    setRemoveImage(true);
+    setPendingImageFiles(files);
+    setIsUploadingImage(true);
+    try {
+      const result = await updateAdminOrchestratorDisplayAction({
+        id: baseline.id,
+        imageIntent: "upload",
+        imageFile: file,
+      });
+
+      if (!result.ok) {
+        if (result.error.code === CommonErrorCode.NOT_FOUND) {
+          handleNotFound();
+          return;
+        }
+        toast.error(result.error.message ?? t("errors.imageSaveFailed"));
+        return;
+      }
+
+      applySavedOrchestrator(result.data.orchestrator);
+      toast.success(t("success.imageSaved"));
+      router.refresh();
+    } finally {
+      setPendingImageFiles([]);
+      setIsUploadingImage(false);
+    }
+  }
+
+  async function handleRemoveImage() {
+    if (!imageValue || isBusy) {
+      return;
+    }
+
+    setIsRemovingImage(true);
+    try {
+      const result = await updateAdminOrchestratorDisplayAction({
+        id: baseline.id,
+        imageIntent: "remove",
+      });
+
+      if (!result.ok) {
+        if (result.error.code === CommonErrorCode.NOT_FOUND) {
+          handleNotFound();
+          return;
+        }
+        toast.error(result.error.message ?? t("errors.imageSaveFailed"));
+        return;
+      }
+
+      applySavedOrchestrator(result.data.orchestrator);
+      toast.success(t("success.imageRemoved"));
+      router.refresh();
+    } finally {
+      setIsRemovingImage(false);
+    }
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (isBusy) {
+      return;
+    }
 
     const trimmedName = name.trim();
     if (trimmedName.length < MIN_NAME_LENGTH) {
@@ -146,30 +185,23 @@ export function OrchestratorEditForm({
       caption,
       description,
     });
-    const imageIntent = removeImage
-      ? "remove"
-      : pendingImageFile
-        ? "upload"
-        : "none";
 
-    if (!patchBody && imageIntent === "none") {
+    if (!patchBody) {
       toast.error(t("validation.noChanges"));
       return;
     }
 
-    setIsSubmitting(true);
+    setIsSavingText(true);
     try {
       const result = await updateAdminOrchestratorDisplayAction({
         id: baseline.id,
         patchBody,
-        imageIntent,
-        imageFile: pendingImageFile ?? undefined,
+        imageIntent: "none",
       });
 
       if (!result.ok) {
         if (result.error.code === CommonErrorCode.NOT_FOUND) {
-          toast.error(t("errors.notFound"));
-          router.push("/admin/orchestrators");
+          handleNotFound();
           return;
         }
 
@@ -177,25 +209,11 @@ export function OrchestratorEditForm({
         return;
       }
 
-      const saved = result.data.orchestrator;
-      setBaseline(saved);
-      setName(saved.name);
-      setCaption(saved.caption ?? "");
-      setDescription(saved.description ?? "");
-      setImageValue(saved.image ?? "");
-      setPendingImageFile(null);
-      setPendingImageFiles([]);
-      setRemoveImage(false);
-
-      if (result.data.imageError) {
-        toast.error(t("success.textSavedImageFailed"));
-      } else {
-        toast.success(t("success.saved"));
-      }
-
+      applySavedOrchestrator(result.data.orchestrator);
+      toast.success(t("success.saved"));
       router.refresh();
     } finally {
-      setIsSubmitting(false);
+      setIsSavingText(false);
     }
   }
 
@@ -205,16 +223,17 @@ export function OrchestratorEditForm({
         <Label>{t("image.label")}</Label>
         <OrganizationLogoUploadField
           accept={ORCHESTRATOR_IMAGE_ACCEPT}
-          disabled={isSubmitting}
-          isUploading={false}
+          disabled={isBusy}
+          isRemoving={isRemovingImage}
+          isUploading={isUploadingImage}
           labels={imageLabels}
-          logoValue={displayImageValue}
+          logoValue={imageValue}
           maxSize={ORCHESTRATOR_IMAGE_MAX_SIZE_BYTES}
           onPendingLogoFilesChange={setPendingImageFiles}
           onRemove={handleRemoveImage}
           onUpload={handleImageSelect}
           pendingLogoFiles={pendingImageFiles}
-          showRemoveButton={Boolean(displayImageValue)}
+          showRemoveButton={Boolean(imageValue)}
         />
         <p className="text-muted-foreground text-sm">
           {t("image.description")}
@@ -228,7 +247,7 @@ export function OrchestratorEditForm({
             id="orchestrator-name"
             value={name}
             onChange={(event) => setName(event.target.value)}
-            disabled={isSubmitting}
+            disabled={isBusy}
             autoComplete="off"
           />
           <p className="text-muted-foreground text-sm">
@@ -258,7 +277,7 @@ export function OrchestratorEditForm({
           id="orchestrator-caption"
           value={caption}
           onChange={(event) => setCaption(event.target.value)}
-          disabled={isSubmitting}
+          disabled={isBusy}
           autoComplete="off"
           maxLength={MAX_CAPTION_LENGTH}
         />
@@ -275,7 +294,7 @@ export function OrchestratorEditForm({
           id="orchestrator-description"
           value={description}
           onChange={(event) => setDescription(event.target.value)}
-          disabled={isSubmitting}
+          disabled={isBusy}
           rows={5}
         />
         <p className="text-muted-foreground text-sm">
@@ -283,8 +302,8 @@ export function OrchestratorEditForm({
         </p>
       </div>
 
-      <Button type="submit" disabled={isSubmitting}>
-        {isSubmitting ? (
+      <Button type="submit" disabled={isBusy}>
+        {isSavingText ? (
           <>
             <Loader2 className="mr-2 size-4 animate-spin" />
             {t("submitting")}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
@@ -13,12 +13,17 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { updateAdminOrchestratorDisplayAction } from "@/lib/actions/admin-orchestrators/action";
 import { CommonErrorCode } from "@/lib/actions/errors";
+import {
+  ORCHESTRATOR_IMAGE_ACCEPT,
+  ORCHESTRATOR_IMAGE_MAX_SIZE_BYTES,
+} from "@/lib/constants/orchestrator-image";
 import type {
   AdminOrchestratorItem,
   AdminOrchestratorPatchBody,
 } from "@/lib/services/admin-orchestrator.service";
 
 const MIN_NAME_LENGTH = 3;
+const MAX_CAPTION_LENGTH = 255;
 
 interface OrchestratorEditFormProps {
   orchestrator: AdminOrchestratorItem;
@@ -192,10 +197,12 @@ export function OrchestratorEditForm({
       <div className="space-y-2">
         <Label>{t("image.label")}</Label>
         <OrganizationLogoUploadField
+          accept={ORCHESTRATOR_IMAGE_ACCEPT}
           disabled={isSubmitting}
           isUploading={false}
           labels={imageLabels}
           logoValue={displayImageValue}
+          maxSize={ORCHESTRATOR_IMAGE_MAX_SIZE_BYTES}
           onPendingLogoFilesChange={setPendingImageFiles}
           onRemove={handleRemoveImage}
           onUpload={handleImageSelect}
@@ -246,6 +253,7 @@ export function OrchestratorEditForm({
           onChange={(event) => setCaption(event.target.value)}
           disabled={isSubmitting}
           autoComplete="off"
+          maxLength={MAX_CAPTION_LENGTH}
         />
         <p className="text-muted-foreground text-sm">
           {t("fields.caption.description")}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-edit-form.tsx
@@ -68,6 +68,7 @@ export function OrchestratorEditForm({
   const t = useTranslations("App.Admin.Orchestrators.EditForm");
   const router = useRouter();
 
+  const [baseline, setBaseline] = useState(orchestrator);
   const [name, setName] = useState(orchestrator.name);
   const [caption, setCaption] = useState(orchestrator.caption ?? "");
   const [description, setDescription] = useState(
@@ -121,8 +122,13 @@ export function OrchestratorEditForm({
   }
 
   function handleRemoveImage() {
-    setPendingImageFile(null);
-    setPendingImageFiles([]);
+    // Pending pick: clear selection only — do not mark stored image for delete.
+    if (pendingImageFile) {
+      setPendingImageFile(null);
+      setPendingImageFiles([]);
+      return;
+    }
+
     setRemoveImage(true);
   }
 
@@ -135,7 +141,7 @@ export function OrchestratorEditForm({
       return;
     }
 
-    const patchBody = buildPatchBody(orchestrator, {
+    const patchBody = buildPatchBody(baseline, {
       name,
       caption,
       description,
@@ -154,7 +160,7 @@ export function OrchestratorEditForm({
     setIsSubmitting(true);
     try {
       const result = await updateAdminOrchestratorDisplayAction({
-        id: orchestrator.id,
+        id: baseline.id,
         patchBody,
         imageIntent,
         imageFile: pendingImageFile ?? undefined,
@@ -171,17 +177,18 @@ export function OrchestratorEditForm({
         return;
       }
 
-      setName(result.data.orchestrator.name);
-      setCaption(result.data.orchestrator.caption ?? "");
-      setDescription(result.data.orchestrator.description ?? "");
-      setImageValue(result.data.orchestrator.image ?? "");
+      const saved = result.data.orchestrator;
+      setBaseline(saved);
+      setName(saved.name);
+      setCaption(saved.caption ?? "");
+      setDescription(saved.description ?? "");
+      setImageValue(saved.image ?? "");
       setPendingImageFile(null);
       setPendingImageFiles([]);
       setRemoveImage(false);
 
       if (result.data.imageError) {
-        toast.error(result.data.imageError);
-        toast.message(t("success.textSavedImageFailed"));
+        toast.error(t("success.textSavedImageFailed"));
       } else {
         toast.success(t("success.saved"));
       }
@@ -233,7 +240,7 @@ export function OrchestratorEditForm({
           <Label htmlFor="orchestrator-slug">{t("fields.slug.label")}</Label>
           <Input
             id="orchestrator-slug"
-            value={orchestrator.slug}
+            value={baseline.slug}
             disabled
             readOnly
           />

--- a/apps/web/src/components/admin/orchestrators/orchestrator-list.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-list.tsx
@@ -65,7 +65,7 @@ export function OrchestratorList({ orchestrators }: OrchestratorListProps) {
                     {orchestrator.slug}
                   </TableCell>
                   <TableCell className="text-muted-foreground">
-                    {orchestrator.caption ?? "—"}
+                    {orchestrator.caption ?? t("emptyCaption")}
                   </TableCell>
                 </TableRow>
               ))}

--- a/apps/web/src/components/admin/orchestrators/orchestrator-list.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-list.tsx
@@ -1,8 +1,6 @@
-"use client";
-
 import { Bot } from "lucide-react";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -19,8 +17,10 @@ interface OrchestratorListProps {
   orchestrators: AdminOrchestratorItem[];
 }
 
-export function OrchestratorList({ orchestrators }: OrchestratorListProps) {
-  const t = useTranslations("App.Admin.Orchestrators.OrchestratorList");
+export async function OrchestratorList({
+  orchestrators,
+}: OrchestratorListProps) {
+  const t = await getTranslations("App.Admin.Orchestrators.OrchestratorList");
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/components/admin/orchestrators/orchestrator-list.tsx
+++ b/apps/web/src/components/admin/orchestrators/orchestrator-list.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Bot } from "lucide-react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { AdminOrchestratorItem } from "@/lib/services/admin-orchestrator.service";
+
+interface OrchestratorListProps {
+  orchestrators: AdminOrchestratorItem[];
+}
+
+export function OrchestratorList({ orchestrators }: OrchestratorListProps) {
+  const t = useTranslations("App.Admin.Orchestrators.OrchestratorList");
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm tabular-nums">
+        {t("totalCount", { count: orchestrators.length })}
+      </p>
+
+      {orchestrators.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{t("empty")}</p>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <Table>
+            <TableHeader className="bg-muted/50">
+              <TableRow>
+                <TableHead className="pl-4">{t("orchestrator")}</TableHead>
+                <TableHead>{t("slug")}</TableHead>
+                <TableHead>{t("caption")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {orchestrators.map((orchestrator) => (
+                <TableRow key={orchestrator.id}>
+                  <TableCell className="pl-4">
+                    <Link
+                      href={`/admin/orchestrators/${orchestrator.id}`}
+                      className="flex items-center gap-3 hover:underline"
+                    >
+                      <Avatar className="size-10 rounded-md">
+                        <AvatarImage
+                          src={orchestrator.image ?? undefined}
+                          alt={orchestrator.name}
+                          className="object-cover"
+                        />
+                        <AvatarFallback className="rounded-md">
+                          <Bot className="size-4" />
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="font-medium">{orchestrator.name}</span>
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {orchestrator.slug}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {orchestrator.caption ?? "—"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organizations/organization-logo-upload-field.tsx
+++ b/apps/web/src/components/organizations/organization-logo-upload-field.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Building2, CloudUpload, Loader2, X } from "lucide-react";
+import type { ReactNode } from "react";
 import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -26,6 +27,8 @@ interface OrganizationLogoUploadFieldProps {
   /** MIME accept list; defaults to organization logo types. */
   accept?: string;
   disabled: boolean;
+  /** Empty-state icon; defaults to Building2 for organization logos. */
+  fallbackIcon?: ReactNode;
   isRemoving?: boolean;
   isUploading: boolean;
   labels: OrganizationLogoUploadLabels;
@@ -61,6 +64,7 @@ function translateFileRejectMessage(
 export function OrganizationLogoUploadField({
   accept = ORGANIZATION_LOGO_ACCEPT,
   disabled,
+  fallbackIcon,
   isRemoving = false,
   isUploading,
   labels,
@@ -102,7 +106,7 @@ export function OrganizationLogoUploadField({
                   className="object-cover"
                 />
                 <AvatarFallback className="bg-muted text-muted-foreground rounded-none">
-                  <Building2 className="size-8" />
+                  {fallbackIcon ?? <Building2 className="size-8" />}
                 </AvatarFallback>
               </Avatar>
               <div

--- a/apps/web/src/components/organizations/organization-logo-upload-field.tsx
+++ b/apps/web/src/components/organizations/organization-logo-upload-field.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { Building2, CloudUpload, Loader2, Trash2 } from "lucide-react";
+import { Building2, CloudUpload, Loader2, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
 import { FileUpload, FileUploadTrigger } from "@/components/ui/file-upload";
 import {
   ORGANIZATION_LOGO_ACCEPT,
   ORGANIZATION_LOGO_MAX_SIZE_BYTES,
 } from "@/lib/constants/organization-logo";
+import { cn } from "@/lib/utils";
 
 export interface OrganizationLogoUploadLabels {
   fileTooLarge: string;
@@ -73,7 +73,7 @@ export function OrganizationLogoUploadField({
   showRemoveButton = Boolean(logoValue),
 }: OrganizationLogoUploadFieldProps) {
   return (
-    <div className="max-w-24 space-y-3">
+    <div className="max-w-24">
       <FileUpload
         value={pendingLogoFiles}
         onValueChange={onPendingLogoFilesChange}
@@ -87,13 +87,13 @@ export function OrganizationLogoUploadField({
           toast.error(translateFileRejectMessage(message, labels));
         }}
       >
-        <div className="flex flex-col items-center gap-2">
+        <div className="relative size-24">
           <FileUploadTrigger asChild>
             <button
               type="button"
               disabled={disabled}
               aria-label={logoValue ? labels.replace : labels.upload}
-              className="group bg-muted focus-visible:ring-ring/60 relative size-24 cursor-pointer overflow-hidden rounded-lg border transition-opacity outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
+              className="group bg-muted focus-visible:ring-ring/60 relative size-full cursor-pointer overflow-hidden rounded-lg border transition-opacity outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Avatar className="size-full rounded-none">
                 <AvatarImage
@@ -106,9 +106,10 @@ export function OrganizationLogoUploadField({
                 </AvatarFallback>
               </Avatar>
               <div
-                className={`absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/60 px-2 text-white transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 ${
-                  isUploading ? "opacity-100" : "opacity-0"
-                }`}
+                className={cn(
+                  "absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/60 px-2 text-white transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100",
+                  isUploading ? "opacity-100" : "opacity-0",
+                )}
               >
                 {isUploading ? (
                   <Loader2 className="size-4 animate-spin" />
@@ -121,22 +122,29 @@ export function OrganizationLogoUploadField({
               </div>
             </button>
           </FileUploadTrigger>
+
           {showRemoveButton && onRemove ? (
-            <Button
+            <button
               type="button"
-              variant="destructive"
-              size="icon"
-              onClick={onRemove}
-              className="size-8"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onRemove();
+              }}
               aria-label={labels.remove}
-              disabled={disabled}
+              disabled={disabled || isRemoving}
+              className={cn(
+                "bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+                "focus-visible:ring-ring absolute -top-2 -right-2 z-10 flex size-6 items-center justify-center rounded-full border shadow-sm",
+                "outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+              )}
             >
               {isRemoving ? (
-                <Loader2 className="size-4 animate-spin" />
+                <Loader2 className="size-3 animate-spin" />
               ) : (
-                <Trash2 className="size-4" />
+                <X className="size-3.5" strokeWidth={2.5} />
               )}
-            </Button>
+            </button>
           ) : null}
         </div>
       </FileUpload>

--- a/apps/web/src/components/organizations/organization-logo-upload-field.tsx
+++ b/apps/web/src/components/organizations/organization-logo-upload-field.tsx
@@ -23,11 +23,15 @@ export interface OrganizationLogoUploadLabels {
 }
 
 interface OrganizationLogoUploadFieldProps {
+  /** MIME accept list; defaults to organization logo types. */
+  accept?: string;
   disabled: boolean;
   isRemoving?: boolean;
   isUploading: boolean;
   labels: OrganizationLogoUploadLabels;
   logoValue: string;
+  /** Max bytes; defaults to organization logo limit. */
+  maxSize?: number;
   onPendingLogoFilesChange: (files: File[]) => void;
   onRemove?: () => void;
   onUpload: (files: File[]) => void | Promise<void>;
@@ -55,11 +59,13 @@ function translateFileRejectMessage(
 }
 
 export function OrganizationLogoUploadField({
+  accept = ORGANIZATION_LOGO_ACCEPT,
   disabled,
   isRemoving = false,
   isUploading,
   labels,
   logoValue,
+  maxSize = ORGANIZATION_LOGO_MAX_SIZE_BYTES,
   onPendingLogoFilesChange,
   onRemove,
   onUpload,
@@ -71,9 +77,9 @@ export function OrganizationLogoUploadField({
       <FileUpload
         value={pendingLogoFiles}
         onValueChange={onPendingLogoFilesChange}
-        accept={ORGANIZATION_LOGO_ACCEPT}
+        accept={accept}
         maxFiles={1}
-        maxSize={ORGANIZATION_LOGO_MAX_SIZE_BYTES}
+        maxSize={maxSize}
         multiple={false}
         disabled={disabled}
         onAccept={onUpload}

--- a/apps/web/src/lib/actions/admin-orchestrators/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-orchestrators/__tests__/action.test.ts
@@ -95,4 +95,36 @@ describe("updateAdminOrchestratorDisplayAction", () => {
       expect(result.error.code).toBe(CommonErrorCode.BAD_INPUT);
     }
   });
+
+  it("strips slug from patch body before calling the service", async () => {
+    const payload = {
+      orchestrator: {
+        id: "orch_1",
+        name: "Hermes",
+        slug: "hermes",
+        caption: "Line",
+        description: null,
+        image: null,
+      },
+    };
+    updateDisplayMock.mockResolvedValue(payload);
+
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+      patchBody: {
+        name: "Hermes",
+        caption: "Line",
+        slug: "renamed-slug",
+      },
+      imageIntent: "none",
+    });
+
+    expect(updateDisplayMock).toHaveBeenCalledWith({
+      id: "orch_1",
+      patchBody: { name: "Hermes", caption: "Line" },
+      imageIntent: "none",
+      imageFile: undefined,
+    });
+    expect(result).toEqual({ ok: true, data: payload });
+  });
 });

--- a/apps/web/src/lib/actions/admin-orchestrators/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-orchestrators/__tests__/action.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/services/admin-orchestrator.service", () => ({
 
 import { CommonErrorCode } from "@/lib/actions/errors";
 import { AdminAccessRequiredError } from "@/lib/auth/errors";
+import { ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH } from "@/lib/constants/orchestrator-display";
 
 import { updateAdminOrchestratorDisplayAction } from "../action";
 
@@ -126,5 +127,52 @@ describe("updateAdminOrchestratorDisplayAction", () => {
       imageFile: undefined,
     });
     expect(result).toEqual({ ok: true, data: payload });
+  });
+
+  it("rejects a slug-only patch body as empty after sanitize", async () => {
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+      patchBody: {
+        slug: "renamed-slug",
+      },
+      imageIntent: "none",
+    });
+
+    expect(updateDisplayMock).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(CommonErrorCode.BAD_INPUT);
+    }
+  });
+
+  it("rejects upload intent without an image file", async () => {
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+      imageIntent: "upload",
+    });
+
+    expect(updateDisplayMock).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(CommonErrorCode.BAD_INPUT);
+      expect(result.error.message).toMatch(/image file/i);
+    }
+  });
+
+  it("rejects a name shorter than the minimum length", async () => {
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+      patchBody: { name: "ab" },
+      imageIntent: "none",
+    });
+
+    expect(updateDisplayMock).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(CommonErrorCode.BAD_INPUT);
+      expect(result.error.message).toContain(
+        String(ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH),
+      );
+    }
   });
 });

--- a/apps/web/src/lib/actions/admin-orchestrators/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-orchestrators/__tests__/action.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const updateDisplayMock = vi.fn();
+const assertAdminSessionMock = vi.fn();
+const revalidatePathMock = vi.fn();
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => revalidatePathMock(...args),
+}));
+
+vi.mock("@/middleware/auth-middleware", () => ({
+  withSession:
+    (handler: (params: unknown) => Promise<unknown>) =>
+    async (params: unknown) =>
+      await handler(params),
+}));
+
+vi.mock("@/lib/auth/admin-access", () => ({
+  assertAdminSession: (...args: unknown[]) => assertAdminSessionMock(...args),
+}));
+
+vi.mock("@/lib/services/admin-orchestrator.service", () => ({
+  adminOrchestratorService: {
+    updateDisplay: (...args: unknown[]) => updateDisplayMock(...args),
+  },
+}));
+
+import { CommonErrorCode } from "@/lib/actions/errors";
+import { AdminAccessRequiredError } from "@/lib/auth/errors";
+
+import { updateAdminOrchestratorDisplayAction } from "../action";
+
+describe("updateAdminOrchestratorDisplayAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    assertAdminSessionMock.mockImplementation(() => undefined);
+  });
+
+  it("updates display metadata for an admin session", async () => {
+    const payload = {
+      orchestrator: {
+        id: "orch_1",
+        name: "Hermes",
+        slug: "hermes",
+        caption: null,
+        description: null,
+        image: null,
+      },
+    };
+    updateDisplayMock.mockResolvedValue(payload);
+
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+      patchBody: { name: "Hermes" },
+      imageIntent: "none",
+    });
+
+    expect(assertAdminSessionMock).toHaveBeenCalled();
+    expect(updateDisplayMock).toHaveBeenCalledWith({
+      id: "orch_1",
+      patchBody: { name: "Hermes" },
+      imageIntent: "none",
+      imageFile: undefined,
+    });
+    expect(result).toEqual({ ok: true, data: payload });
+  });
+
+  it("rejects a non-admin session with UNAUTHORIZED", async () => {
+    assertAdminSessionMock.mockImplementation(() => {
+      throw new AdminAccessRequiredError();
+    });
+
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+      patchBody: { name: "Hermes" },
+    });
+
+    expect(updateDisplayMock).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(CommonErrorCode.UNAUTHORIZED);
+    }
+  });
+
+  it("rejects empty submissions", async () => {
+    const result = await updateAdminOrchestratorDisplayAction({
+      id: "orch_1",
+    });
+
+    expect(updateDisplayMock).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(CommonErrorCode.BAD_INPUT);
+    }
+  });
+});

--- a/apps/web/src/lib/actions/admin-orchestrators/action.ts
+++ b/apps/web/src/lib/actions/admin-orchestrators/action.ts
@@ -7,8 +7,12 @@ import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import {
+  ADMIN_ORCHESTRATOR_CAPTION_MAX_LENGTH,
+  ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH,
+} from "@/lib/constants/orchestrator-display";
+import {
+  type AdminOrchestratorDisplayPatchBody,
   type AdminOrchestratorImageIntent,
-  type AdminOrchestratorPatchBody,
   adminOrchestratorService,
   type UpdateAdminOrchestratorDisplayResult,
 } from "@/lib/services/admin-orchestrator.service";
@@ -36,34 +40,64 @@ function mapError(error: unknown): ActionError {
   return toCoreApiActionError(error);
 }
 
+/** Client payload may include non-display keys (e.g. slug); they are dropped. */
+interface UntrustedOrchestratorDisplayPatch {
+  name?: string;
+  caption?: string | null;
+  description?: string | null;
+  slug?: string;
+}
+
 interface UpdateAdminOrchestratorDisplayParameters
   extends AuthenticatedRequest {
   id: string;
-  patchBody?: AdminOrchestratorPatchBody;
+  patchBody?: UntrustedOrchestratorDisplayPatch;
   imageIntent?: AdminOrchestratorImageIntent;
   imageFile?: File;
 }
 
-/** UI may only edit display fields — never slug. */
+/**
+ * Pick display fields only — never slug — and validate name/caption.
+ * Returns Err when name or caption fail local rules.
+ */
 function sanitizeDisplayPatchBody(
-  patchBody: AdminOrchestratorPatchBody | undefined,
-): AdminOrchestratorPatchBody | undefined {
+  patchBody: UntrustedOrchestratorDisplayPatch | undefined,
+): Result<AdminOrchestratorDisplayPatchBody | undefined, ActionError> {
   if (!patchBody) {
-    return undefined;
+    return Ok(undefined);
   }
 
-  const sanitized: AdminOrchestratorPatchBody = {};
+  const sanitized: AdminOrchestratorDisplayPatchBody = {};
+
   if (patchBody.name !== undefined) {
-    sanitized.name = patchBody.name;
+    const name = patchBody.name.trim();
+    if (name.length < ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH) {
+      return Err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: `Name must be at least ${ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH} characters`,
+      });
+    }
+    sanitized.name = name;
   }
+
   if (patchBody.caption !== undefined) {
+    if (
+      patchBody.caption !== null &&
+      patchBody.caption.length > ADMIN_ORCHESTRATOR_CAPTION_MAX_LENGTH
+    ) {
+      return Err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: `Caption must be at most ${ADMIN_ORCHESTRATOR_CAPTION_MAX_LENGTH} characters`,
+      });
+    }
     sanitized.caption = patchBody.caption;
   }
+
   if (patchBody.description !== undefined) {
     sanitized.description = patchBody.description;
   }
 
-  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+  return Ok(Object.keys(sanitized).length > 0 ? sanitized : undefined);
 }
 
 export const updateAdminOrchestratorDisplayAction = withSession<
@@ -73,7 +107,12 @@ export const updateAdminOrchestratorDisplayAction = withSession<
   try {
     assertAdminSession(session);
 
-    const safePatchBody = sanitizeDisplayPatchBody(patchBody);
+    const sanitizeResult = sanitizeDisplayPatchBody(patchBody);
+    if (!sanitizeResult.ok) {
+      return sanitizeResult;
+    }
+
+    const safePatchBody = sanitizeResult.data;
     const hasPatchBody = Boolean(safePatchBody);
     if (!hasPatchBody && imageIntent === "none") {
       return Err({

--- a/apps/web/src/lib/actions/admin-orchestrators/action.ts
+++ b/apps/web/src/lib/actions/admin-orchestrators/action.ts
@@ -44,6 +44,28 @@ interface UpdateAdminOrchestratorDisplayParameters
   imageFile?: File;
 }
 
+/** UI may only edit display fields — never slug. */
+function sanitizeDisplayPatchBody(
+  patchBody: AdminOrchestratorPatchBody | undefined,
+): AdminOrchestratorPatchBody | undefined {
+  if (!patchBody) {
+    return undefined;
+  }
+
+  const sanitized: AdminOrchestratorPatchBody = {};
+  if (patchBody.name !== undefined) {
+    sanitized.name = patchBody.name;
+  }
+  if (patchBody.caption !== undefined) {
+    sanitized.caption = patchBody.caption;
+  }
+  if (patchBody.description !== undefined) {
+    sanitized.description = patchBody.description;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
 export const updateAdminOrchestratorDisplayAction = withSession<
   UpdateAdminOrchestratorDisplayParameters,
   Result<UpdateAdminOrchestratorDisplayResult, ActionError>
@@ -51,7 +73,8 @@ export const updateAdminOrchestratorDisplayAction = withSession<
   try {
     assertAdminSession(session);
 
-    const hasPatchBody = patchBody && Object.keys(patchBody).length > 0;
+    const safePatchBody = sanitizeDisplayPatchBody(patchBody);
+    const hasPatchBody = Boolean(safePatchBody);
     if (!hasPatchBody && imageIntent === "none") {
       return Err({
         code: CommonErrorCode.BAD_INPUT,
@@ -68,7 +91,7 @@ export const updateAdminOrchestratorDisplayAction = withSession<
 
     const result = await adminOrchestratorService.updateDisplay({
       id,
-      patchBody: hasPatchBody ? patchBody : undefined,
+      patchBody: safePatchBody,
       imageIntent,
       imageFile,
     });

--- a/apps/web/src/lib/actions/admin-orchestrators/action.ts
+++ b/apps/web/src/lib/actions/admin-orchestrators/action.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
+import { assertAdminSession } from "@/lib/auth/admin-access";
+import { isAdminAccessRequiredError } from "@/lib/auth/errors";
+import { toCoreApiActionError } from "@/lib/clients/core.client";
+import {
+  type AdminOrchestratorImageIntent,
+  type AdminOrchestratorPatchBody,
+  adminOrchestratorService,
+  type UpdateAdminOrchestratorDisplayResult,
+} from "@/lib/services/admin-orchestrator.service";
+import { Err, Ok, type Result } from "@/lib/ts-res";
+import {
+  type AuthenticatedRequest,
+  withSession,
+} from "@/middleware/auth-middleware";
+
+function revalidateOrchestratorRoutes(id?: string) {
+  revalidatePath("/admin/orchestrators");
+  if (id) {
+    revalidatePath(`/admin/orchestrators/${id}`);
+  }
+}
+
+function mapError(error: unknown): ActionError {
+  if (isAdminAccessRequiredError(error)) {
+    return {
+      code: CommonErrorCode.UNAUTHORIZED,
+      message: error.message,
+    };
+  }
+
+  return toCoreApiActionError(error);
+}
+
+interface UpdateAdminOrchestratorDisplayParameters
+  extends AuthenticatedRequest {
+  id: string;
+  patchBody?: AdminOrchestratorPatchBody;
+  imageIntent?: AdminOrchestratorImageIntent;
+  imageFile?: File;
+}
+
+export const updateAdminOrchestratorDisplayAction = withSession<
+  UpdateAdminOrchestratorDisplayParameters,
+  Result<UpdateAdminOrchestratorDisplayResult, ActionError>
+>(async ({ session, id, patchBody, imageIntent = "none", imageFile }) => {
+  try {
+    assertAdminSession(session);
+
+    const hasPatchBody = patchBody && Object.keys(patchBody).length > 0;
+    if (!hasPatchBody && imageIntent === "none") {
+      return Err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: "No orchestrator changes to save",
+      });
+    }
+
+    if (imageIntent === "upload" && !imageFile) {
+      return Err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: "Image file is required for upload",
+      });
+    }
+
+    const result = await adminOrchestratorService.updateDisplay({
+      id,
+      patchBody: hasPatchBody ? patchBody : undefined,
+      imageIntent,
+      imageFile,
+    });
+
+    revalidateOrchestratorRoutes(id);
+    return Ok(result);
+  } catch (error) {
+    return Err(mapError(error));
+  }
+});

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -36,6 +36,7 @@ import type {
   PatchEnterpriseContractRequest,
   PatchJobsByIdData,
   PatchNotificationsByIdReadData,
+  PatchOrchestratorsByIdData,
   PatchProjectsByIdData,
   PatchTasksByIdData,
   PostAgentsByIdJobsData,
@@ -67,6 +68,7 @@ import {
   deleteHermesMeInstanceIntegrationsByProvider as coreDeleteHermesMeInstanceIntegrationsByProvider,
   deleteHermesMeInstanceSkillsBySlug as coreDeleteHermesMeInstanceSkillsBySlug,
   deleteJobsByIdShare as coreDeleteJobsByIdShare,
+  deleteOrchestratorsByIdImage as coreDeleteOrchestratorsByIdImage,
   deleteOrganizationsByIdMembersByMemberIdSeat as coreDeleteOrganizationsByIdMembersByMemberIdSeat,
   deleteProjectsById as coreDeleteProjectsById,
   deleteProjectsByIdJobsByJobId as coreDeleteProjectsByIdJobsByJobId,
@@ -116,6 +118,8 @@ import {
   getJobsById as coreGetJobsById,
   getNotifications as coreGetNotifications,
   getNotificationsUnreadCount as coreGetNotificationsUnreadCount,
+  getOrchestrators as coreGetOrchestrators,
+  getOrchestratorsById as coreGetOrchestratorsById,
   getOrganizationBySlug as coreGetOrganizationBySlug,
   getOrganizationEnterpriseContractSummary as coreGetOrganizationEnterpriseContractSummary,
   getOrganizationsById as coreGetOrganizationsById,
@@ -164,6 +168,7 @@ import {
   patchJobsById as corePatchJobsById,
   patchNotificationsByIdRead as corePatchNotificationsByIdRead,
   patchNotificationsReadAll as corePatchNotificationsReadAll,
+  patchOrchestratorsById as corePatchOrchestratorsById,
   patchProjectsById as corePatchProjectsById,
   patchTasksById as corePatchTasksById,
   postAgentsByIdJobs as corePostAgentsByIdJobs,
@@ -184,6 +189,7 @@ import {
   postHermesMeSecrets as corePostHermesMeSecrets,
   postJobsByIdInputs as corePostJobsByIdInputs,
   postJobsByIdRefund as corePostJobsByIdRefund,
+  postOrchestratorsByIdImage as corePostOrchestratorsByIdImage,
   postOrganizationsByIdStripeCustomer as corePostOrganizationsByIdStripeCustomer,
   postOrganizationsByIdVendorGrants as corePostOrganizationsByIdVendorGrants,
   postOrganizationsByIdVendorGrantsByGrantIdApprove as corePostOrganizationsByIdVendorGrantsByGrantIdApprove,
@@ -921,6 +927,75 @@ export function createCoreClient(getClient: GetClient) {
           cache: "no-store",
         }),
       "Failed to list users",
+    );
+  }
+
+  async function listOrchestrators() {
+    return executeOperation(
+      getClient,
+      (client) =>
+        coreGetOrchestrators({
+          client,
+          cache: "no-store",
+        }),
+      "Failed to list orchestrators",
+    );
+  }
+
+  async function getOrchestratorById(id: string) {
+    return executeOperation(
+      getClient,
+      (client) =>
+        coreGetOrchestratorsById({
+          client,
+          path: { id },
+          cache: "no-store",
+        }),
+      "Failed to fetch orchestrator",
+    );
+  }
+
+  async function patchOrchestratorById(
+    id: string,
+    body: NonNullable<PatchOrchestratorsByIdData["body"]>,
+  ) {
+    return executeOperation(
+      getClient,
+      (client) =>
+        corePatchOrchestratorsById({
+          client,
+          path: { id },
+          body,
+          cache: "no-store",
+        }),
+      "Failed to update orchestrator",
+    );
+  }
+
+  async function uploadOrchestratorImage(id: string, file: Blob | File) {
+    return executeOperation(
+      getClient,
+      (client) =>
+        corePostOrchestratorsByIdImage({
+          client,
+          path: { id },
+          body: { file },
+          cache: "no-store",
+        }),
+      "Failed to upload orchestrator image",
+    );
+  }
+
+  async function deleteOrchestratorImage(id: string) {
+    return executeOperation(
+      getClient,
+      (client) =>
+        coreDeleteOrchestratorsByIdImage({
+          client,
+          path: { id },
+          cache: "no-store",
+        }),
+      "Failed to remove orchestrator image",
     );
   }
 
@@ -2986,6 +3061,11 @@ export function createCoreClient(getClient: GetClient) {
     getCoworkers,
     searchAdminUsers,
     listAdminUsers,
+    listOrchestrators,
+    getOrchestratorById,
+    patchOrchestratorById,
+    uploadOrchestratorImage,
+    deleteOrchestratorImage,
     listAdminTasks,
     getAdminTask,
     searchAdminOrganizations,

--- a/apps/web/src/lib/constants/orchestrator-display.ts
+++ b/apps/web/src/lib/constants/orchestrator-display.ts
@@ -1,0 +1,5 @@
+/** Matches Core orchestrator create/patch name rule. */
+export const ADMIN_ORCHESTRATOR_NAME_MIN_LENGTH = 3;
+
+/** Matches Core orchestrator caption max length. */
+export const ADMIN_ORCHESTRATOR_CAPTION_MAX_LENGTH = 255;

--- a/apps/web/src/lib/constants/orchestrator-image.ts
+++ b/apps/web/src/lib/constants/orchestrator-image.ts
@@ -1,0 +1,13 @@
+import {
+  ORCHESTRATOR_IMAGE_ALLOWED_MIME_TYPES,
+  ORCHESTRATOR_IMAGE_MAX_SIZE_BYTES,
+} from "@sokosumi/utils";
+
+export {
+  ORCHESTRATOR_IMAGE_ALLOWED_MIME_TYPES,
+  ORCHESTRATOR_IMAGE_MAX_SIZE_BYTES,
+};
+
+/** Comma-separated accept string for HTML file input / FileUpload. */
+export const ORCHESTRATOR_IMAGE_ACCEPT =
+  ORCHESTRATOR_IMAGE_ALLOWED_MIME_TYPES.join(",");

--- a/apps/web/src/lib/services/__tests__/admin-orchestrator.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/admin-orchestrator.service.test.ts
@@ -124,4 +124,44 @@ describe("adminOrchestratorService", () => {
     expect(result.orchestrator.name).toBe("Hermes Ops");
     expect(result.imageError).toBe("blob down");
   });
+
+  it("uploads image without a text patch", async () => {
+    uploadOrchestratorImageMock.mockResolvedValue({
+      data: {
+        ...orchestrator,
+        image: "https://example.com/new.png",
+      },
+    });
+
+    const file = new File(["x"], "new.png", { type: "image/png" });
+    const result = await adminOrchestratorService.updateDisplay({
+      id: "orch_1",
+      imageIntent: "upload",
+      imageFile: file,
+    });
+
+    expect(patchOrchestratorByIdMock).not.toHaveBeenCalled();
+    expect(uploadOrchestratorImageMock).toHaveBeenCalledWith("orch_1", file);
+    expect(result.orchestrator.image).toBe("https://example.com/new.png");
+    expect(result.imageError).toBeUndefined();
+  });
+
+  it("removes image without a text patch", async () => {
+    deleteOrchestratorImageMock.mockResolvedValue({
+      data: {
+        ...orchestrator,
+        image: null,
+      },
+    });
+
+    const result = await adminOrchestratorService.updateDisplay({
+      id: "orch_1",
+      imageIntent: "remove",
+    });
+
+    expect(patchOrchestratorByIdMock).not.toHaveBeenCalled();
+    expect(deleteOrchestratorImageMock).toHaveBeenCalledWith("orch_1");
+    expect(result.orchestrator.image).toBeNull();
+    expect(result.imageError).toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/services/__tests__/admin-orchestrator.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/admin-orchestrator.service.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const listOrchestratorsMock = vi.fn();
+const getOrchestratorByIdMock = vi.fn();
+const patchOrchestratorByIdMock = vi.fn();
+const uploadOrchestratorImageMock = vi.fn();
+const deleteOrchestratorImageMock = vi.fn();
+
+vi.mock("@/lib/clients/core.client", () => ({
+  CoreApiRequestError: class CoreApiRequestError extends Error {
+    status?: number;
+
+    constructor(message: string, options?: { status?: number }) {
+      super(message);
+      this.name = "CoreApiRequestError";
+      this.status = options?.status;
+    }
+  },
+  coreClient: {
+    listOrchestrators: (...args: unknown[]) => listOrchestratorsMock(...args),
+    getOrchestratorById: (...args: unknown[]) =>
+      getOrchestratorByIdMock(...args),
+    patchOrchestratorById: (...args: unknown[]) =>
+      patchOrchestratorByIdMock(...args),
+    uploadOrchestratorImage: (...args: unknown[]) =>
+      uploadOrchestratorImageMock(...args),
+    deleteOrchestratorImage: (...args: unknown[]) =>
+      deleteOrchestratorImageMock(...args),
+  },
+}));
+
+import { CoreApiRequestError } from "@/lib/clients/core.client";
+
+import { adminOrchestratorService } from "../admin-orchestrator.service";
+
+const orchestrator = {
+  id: "orch_1",
+  createdAt: new Date("2025-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2025-01-02T00:00:00.000Z"),
+  archivedAt: null,
+  slug: "hermes",
+  name: "Hermes",
+  caption: "Ops caption",
+  description: "Ops description",
+  image: "https://example.com/image.png",
+};
+
+describe("adminOrchestratorService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps list orchestrators", async () => {
+    listOrchestratorsMock.mockResolvedValue({ data: [orchestrator] });
+
+    const result = await adminOrchestratorService.listOrchestrators();
+
+    expect(result).toEqual([
+      {
+        id: "orch_1",
+        name: "Hermes",
+        slug: "hermes",
+        caption: "Ops caption",
+        description: "Ops description",
+        image: "https://example.com/image.png",
+      },
+    ]);
+  });
+
+  it("returns null when orchestrator is missing", async () => {
+    getOrchestratorByIdMock.mockRejectedValue(
+      new CoreApiRequestError("Not found", { status: 404 }),
+    );
+
+    const result = await adminOrchestratorService.getOrchestrator("orch_1");
+
+    expect(result).toBeNull();
+  });
+
+  it("patches text before uploading image", async () => {
+    patchOrchestratorByIdMock.mockResolvedValue({
+      data: { ...orchestrator, name: "Hermes Ops" },
+    });
+    uploadOrchestratorImageMock.mockResolvedValue({
+      data: {
+        ...orchestrator,
+        name: "Hermes Ops",
+        image: "https://example.com/new.png",
+      },
+    });
+
+    const file = new File(["x"], "new.png", { type: "image/png" });
+    const result = await adminOrchestratorService.updateDisplay({
+      id: "orch_1",
+      patchBody: { name: "Hermes Ops" },
+      imageIntent: "upload",
+      imageFile: file,
+    });
+
+    expect(patchOrchestratorByIdMock).toHaveBeenCalledBefore(
+      uploadOrchestratorImageMock,
+    );
+    expect(result.orchestrator.name).toBe("Hermes Ops");
+    expect(result.orchestrator.image).toBe("https://example.com/new.png");
+    expect(result.imageError).toBeUndefined();
+  });
+
+  it("keeps saved text when image upload fails", async () => {
+    patchOrchestratorByIdMock.mockResolvedValue({
+      data: { ...orchestrator, name: "Hermes Ops" },
+    });
+    uploadOrchestratorImageMock.mockRejectedValue(new Error("blob down"));
+
+    const file = new File(["x"], "new.png", { type: "image/png" });
+    const result = await adminOrchestratorService.updateDisplay({
+      id: "orch_1",
+      patchBody: { name: "Hermes Ops" },
+      imageIntent: "upload",
+      imageFile: file,
+    });
+
+    expect(result.orchestrator.name).toBe("Hermes Ops");
+    expect(result.imageError).toBe("blob down");
+  });
+});

--- a/apps/web/src/lib/services/admin-orchestrator.service.ts
+++ b/apps/web/src/lib/services/admin-orchestrator.service.ts
@@ -1,0 +1,123 @@
+import "server-only";
+
+import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
+import type { Orchestrator } from "@/lib/clients/generated/core";
+import type { PatchOrchestratorsByIdData } from "@/lib/clients/generated/core/types.gen";
+
+export interface AdminOrchestratorItem {
+  id: string;
+  name: string;
+  slug: string;
+  caption: string | null;
+  description: string | null;
+  image: string | null;
+}
+
+export type AdminOrchestratorPatchBody = NonNullable<
+  PatchOrchestratorsByIdData["body"]
+>;
+
+export type AdminOrchestratorImageIntent = "none" | "upload" | "remove";
+
+export interface UpdateAdminOrchestratorDisplayInput {
+  id: string;
+  patchBody?: AdminOrchestratorPatchBody;
+  imageIntent?: AdminOrchestratorImageIntent;
+  imageFile?: File | Blob;
+}
+
+export interface UpdateAdminOrchestratorDisplayResult {
+  orchestrator: AdminOrchestratorItem;
+  imageError?: string;
+}
+
+function mapOrchestrator(orchestrator: Orchestrator): AdminOrchestratorItem {
+  return {
+    id: orchestrator.id,
+    name: orchestrator.name,
+    slug: orchestrator.slug,
+    caption: orchestrator.caption,
+    description: orchestrator.description,
+    image: orchestrator.image,
+  };
+}
+
+export const adminOrchestratorService = {
+  async listOrchestrators(): Promise<AdminOrchestratorItem[]> {
+    const result = await coreClient.listOrchestrators();
+    return result.data.map(mapOrchestrator);
+  },
+
+  async getOrchestrator(id: string): Promise<AdminOrchestratorItem | null> {
+    try {
+      const result = await coreClient.getOrchestratorById(id);
+      return mapOrchestrator(result.data);
+    } catch (error) {
+      if (error instanceof CoreApiRequestError && error.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  },
+
+  async updateDisplay(
+    input: UpdateAdminOrchestratorDisplayInput,
+  ): Promise<UpdateAdminOrchestratorDisplayResult> {
+    const imageIntent = input.imageIntent ?? "none";
+    let orchestrator: AdminOrchestratorItem | null = null;
+
+    if (input.patchBody && Object.keys(input.patchBody).length > 0) {
+      const result = await coreClient.patchOrchestratorById(
+        input.id,
+        input.patchBody,
+      );
+      orchestrator = mapOrchestrator(result.data);
+    }
+
+    if (imageIntent === "none") {
+      if (!orchestrator) {
+        const existing = await this.getOrchestrator(input.id);
+        if (!existing) {
+          throw new CoreApiRequestError("Orchestrator not found", {
+            status: 404,
+          });
+        }
+        orchestrator = existing;
+      }
+
+      return { orchestrator };
+    }
+
+    try {
+      if (imageIntent === "remove") {
+        const result = await coreClient.deleteOrchestratorImage(input.id);
+        orchestrator = mapOrchestrator(result.data);
+      } else if (imageIntent === "upload") {
+        if (!input.imageFile) {
+          throw new Error("Image file is required for upload");
+        }
+        const result = await coreClient.uploadOrchestratorImage(
+          input.id,
+          input.imageFile,
+        );
+        orchestrator = mapOrchestrator(result.data);
+      }
+    } catch (error) {
+      if (!orchestrator) {
+        throw error;
+      }
+
+      return {
+        orchestrator,
+        imageError:
+          error instanceof Error ? error.message : "Failed to update image",
+      };
+    }
+
+    if (!orchestrator) {
+      throw new Error("Orchestrator update did not return data");
+    }
+
+    return { orchestrator };
+  },
+};

--- a/apps/web/src/lib/services/admin-orchestrator.service.ts
+++ b/apps/web/src/lib/services/admin-orchestrator.service.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import type { Orchestrator } from "@/lib/clients/generated/core";
-import type { PatchOrchestratorsByIdData } from "@/lib/clients/generated/core/types.gen";
 
 export interface AdminOrchestratorItem {
   id: string;
@@ -13,15 +12,18 @@ export interface AdminOrchestratorItem {
   image: string | null;
 }
 
-export type AdminOrchestratorPatchBody = NonNullable<
-  PatchOrchestratorsByIdData["body"]
->;
+/** Display fields only — never slug. */
+export interface AdminOrchestratorDisplayPatchBody {
+  name?: string;
+  caption?: string | null;
+  description?: string | null;
+}
 
 export type AdminOrchestratorImageIntent = "none" | "upload" | "remove";
 
 export interface UpdateAdminOrchestratorDisplayInput {
   id: string;
-  patchBody?: AdminOrchestratorPatchBody;
+  patchBody?: AdminOrchestratorDisplayPatchBody;
   imageIntent?: AdminOrchestratorImageIntent;
   imageFile?: File | Blob;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Platform admins can list first-party orchestrators and edit display metadata (name, caption, description, image) under `/admin/orchestrators`.

## Spec summary

- **Web-only** on existing Core admin APIs (`GET`/`PATCH` `/v1/orchestrators`, image `POST`/`DELETE`)
- Hub card → list → detail/edit form
- Direct `Orchestrator` columns (no overwrite table, no registry sync)
- Slug read-only; create/archive/API keys out of scope
- **Image upload/remove saves immediately**; text fields use **Save changes**

## Review fixes

- Orchestrator MIME/size accept (not org-logo SVG)
- Strip `slug` from admin display patches
- Remount edit form by id; keep post-save change baseline
- Caption max length; localized empty caption
- Image remove is a corner **X** overlay on the preview
- Image mutations no longer wait for form submit

## Verification

- `pnpm web:check` (exit 0)
- Husky precommit check + typecheck (exit 0)
- Targeted admin orchestrator action/service tests (exit 0)

## Test plan

- [x] As platform admin, open `/admin` and see Orchestrators section
- [x] List shows active orchestrators; open detail
- [x] Edit name/caption/description and save
- [x] Upload / replace / remove image (PNG/JPEG/WebP/GIF; SVG rejected)
- [x] Non-admin cannot reach `/admin/orchestrators`
- [ ] Confirm image remove uses corner X overlay (not red trash below preview)
- [ ] Confirm image upload/remove persists without clicking Save changes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-642](https://linear.app/masumi/issue/SOK-642/admin-manage-display-overwrites-for-orchestrators)

<div><a href="https://cursor.com/agents/bc-fbe44b21-be59-4906-9299-e1a90646931e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbe44b21-be59-4906-9299-e1a90646931e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

