### PR TITLE
feat(admin): group overview tools by operator domain

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2863,7 +2863,7 @@
       },
       "Overview": {
         "title": "Administration",
-        "description": "Interne Tools für Konten, Abrechnung, Katalog und Support.",
+        "description": "Interne Tools für Konten, Abrechnung, Katalog und Betrieb.",
         "Groups": {
           "accounts": "Konten",
           "billing": "Abrechnung & Vertrieb",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2863,7 +2863,13 @@
       },
       "Overview": {
         "title": "Administration",
-        "description": "Interne Tools zur Verwaltung von Organisationen und Abrechnung.",
+        "description": "Interne Tools für Konten, Abrechnung, Katalog und Support.",
+        "Groups": {
+          "accounts": "Konten",
+          "billing": "Abrechnung & Vertrieb",
+          "catalog": "Marketplace-Katalog",
+          "operations": "Betrieb"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Enterprise-Verträge",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3065,7 +3065,13 @@
       },
       "Overview": {
         "title": "Admin",
-        "description": "Internal tools for managing organizations and billing.",
+        "description": "Internal tools for accounts, billing, catalog, and support.",
+        "Groups": {
+          "accounts": "Accounts",
+          "billing": "Billing & commercial",
+          "catalog": "Marketplace catalog",
+          "operations": "Operations"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Enterprise contracts",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3065,7 +3065,7 @@
       },
       "Overview": {
         "title": "Admin",
-        "description": "Internal tools for accounts, billing, catalog, and support.",
+        "description": "Internal tools for accounts, billing, catalog, and operations.",
         "Groups": {
           "accounts": "Accounts",
           "billing": "Billing & commercial",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2863,7 +2863,13 @@
       },
       "Overview": {
         "title": "Administración",
-        "description": "Herramientas internas para gestionar organizaciones y facturación.",
+        "description": "Herramientas internas para cuentas, facturación, catálogo y soporte.",
+        "Groups": {
+          "accounts": "Cuentas",
+          "billing": "Facturación y comercial",
+          "catalog": "Catálogo del marketplace",
+          "operations": "Operaciones"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Contratos empresariales",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2863,7 +2863,7 @@
       },
       "Overview": {
         "title": "Administración",
-        "description": "Herramientas internas para cuentas, facturación, catálogo y soporte.",
+        "description": "Herramientas internas para cuentas, facturación, catálogo y operaciones.",
         "Groups": {
           "accounts": "Cuentas",
           "billing": "Facturación y comercial",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2894,7 +2894,7 @@
       },
       "Overview": {
         "title": "Administration",
-        "description": "Outils internes pour les comptes, la facturation, le catalogue et le support.",
+        "description": "Outils internes pour les comptes, la facturation, le catalogue et les opérations.",
         "Groups": {
           "accounts": "Comptes",
           "billing": "Facturation et commercial",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2894,7 +2894,13 @@
       },
       "Overview": {
         "title": "Administration",
-        "description": "Outils internes pour gérer les organisations et la facturation.",
+        "description": "Outils internes pour les comptes, la facturation, le catalogue et le support.",
+        "Groups": {
+          "accounts": "Comptes",
+          "billing": "Facturation et commercial",
+          "catalog": "Catalogue marketplace",
+          "operations": "Opérations"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Contrats entreprise",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2894,7 +2894,13 @@
       },
       "Overview": {
         "title": "Amministrazione",
-        "description": "Strumenti interni per gestire organizzazioni e fatturazione.",
+        "description": "Strumenti interni per account, fatturazione, catalogo e supporto.",
+        "Groups": {
+          "accounts": "Account",
+          "billing": "Fatturazione e commerciale",
+          "catalog": "Catalogo marketplace",
+          "operations": "Operazioni"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Contratti enterprise",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2894,7 +2894,7 @@
       },
       "Overview": {
         "title": "Amministrazione",
-        "description": "Strumenti interni per account, fatturazione, catalogo e supporto.",
+        "description": "Strumenti interni per account, fatturazione, catalogo e operazioni.",
         "Groups": {
           "accounts": "Account",
           "billing": "Fatturazione e commerciale",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2894,7 +2894,7 @@
       },
       "Overview": {
         "title": "管理",
-        "description": "アカウント、請求、カタログ、サポート向けの内部ツール。",
+        "description": "アカウント、請求、カタログ、運用向けの内部ツール。",
         "Groups": {
           "accounts": "アカウント",
           "billing": "請求と商用",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2894,7 +2894,13 @@
       },
       "Overview": {
         "title": "管理",
-        "description": "組織と請求を管理するための内部ツール。",
+        "description": "アカウント、請求、カタログ、サポート向けの内部ツール。",
+        "Groups": {
+          "accounts": "アカウント",
+          "billing": "請求と商用",
+          "catalog": "マーケットプレイスカタログ",
+          "operations": "運用"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "エンタープライズ契約",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2894,7 +2894,7 @@
       },
       "Overview": {
         "title": "Administração",
-        "description": "Ferramentas internas para contas, cobrança, catálogo e suporte.",
+        "description": "Ferramentas internas para contas, cobrança, catálogo e operações.",
         "Groups": {
           "accounts": "Contas",
           "billing": "Cobrança e comercial",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -2894,7 +2894,13 @@
       },
       "Overview": {
         "title": "Administração",
-        "description": "Ferramentas internas para gerenciar organizações e cobrança.",
+        "description": "Ferramentas internas para contas, cobrança, catálogo e suporte.",
+        "Groups": {
+          "accounts": "Contas",
+          "billing": "Cobrança e comercial",
+          "catalog": "Catálogo do marketplace",
+          "operations": "Operações"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Contratos empresariais",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2894,7 +2894,13 @@
       },
       "Overview": {
         "title": "Administração",
-        "description": "Ferramentas internas para gerir organizações e faturação.",
+        "description": "Ferramentas internas para contas, faturação, catálogo e suporte.",
+        "Groups": {
+          "accounts": "Contas",
+          "billing": "Faturação e comercial",
+          "catalog": "Catálogo do marketplace",
+          "operations": "Operações"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "Contratos empresariais",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2894,7 +2894,7 @@
       },
       "Overview": {
         "title": "Administração",
-        "description": "Ferramentas internas para contas, faturação, catálogo e suporte.",
+        "description": "Ferramentas internas para contas, faturação, catálogo e operações.",
         "Groups": {
           "accounts": "Contas",
           "billing": "Faturação e comercial",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2894,7 +2894,13 @@
       },
       "Overview": {
         "title": "管理",
-        "description": "用于管理组织和计费的内部工具。",
+        "description": "用于账户、计费、目录与支持的内部工具。",
+        "Groups": {
+          "accounts": "账户",
+          "billing": "计费与商务",
+          "catalog": "市场目录",
+          "operations": "运营"
+        },
         "Sections": {
           "enterpriseContracts": {
             "title": "企业合同",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -2894,7 +2894,7 @@
       },
       "Overview": {
         "title": "管理",
-        "description": "用于账户、计费、目录与支持的内部工具。",
+        "description": "用于账户、计费、目录与运营的内部工具。",
         "Groups": {
           "accounts": "账户",
           "billing": "计费与商务",

--- a/apps/web/src/app/(app)/admin/admin-sections.ts
+++ b/apps/web/src/app/(app)/admin/admin-sections.ts
@@ -39,7 +39,9 @@ export const ADMIN_SECTION_GROUPS: AdminSectionGroup[] = [
 /**
  * Single source of truth for the admin tools surfaced on the `/admin` overview
  * hub. Add a new admin tool here (plus its `App.Admin.Overview.Sections.<key>`
- * translations) to have it appear on the hub.
+ * translations) to have it appear on the hub. If you introduce a new
+ * `AdminSectionGroup` value, also append it to `ADMIN_SECTION_GROUPS` or the
+ * section will not render.
  */
 export const ADMIN_SECTIONS: AdminSection[] = [
   {

--- a/apps/web/src/app/(app)/admin/admin-sections.ts
+++ b/apps/web/src/app/(app)/admin/admin-sections.ts
@@ -10,12 +10,31 @@ import {
   Users,
 } from "lucide-react";
 
+/** Operator-facing groups on the `/admin` overview hub. */
+export type AdminSectionGroup =
+  | "accounts"
+  | "billing"
+  | "catalog"
+  | "operations";
+
 export interface AdminSection {
   /** Stable key used for the React key and i18n lookups. */
   key: string;
   href: string;
   Icon: LucideIcon;
+  group: AdminSectionGroup;
 }
+
+/**
+ * Display order of admin groups on the overview hub. Sections are rendered
+ * under these headings in this order.
+ */
+export const ADMIN_SECTION_GROUPS: AdminSectionGroup[] = [
+  "accounts",
+  "billing",
+  "catalog",
+  "operations",
+];
 
 /**
  * Single source of truth for the admin tools surfaced on the `/admin` overview
@@ -24,48 +43,57 @@ export interface AdminSection {
  */
 export const ADMIN_SECTIONS: AdminSection[] = [
   {
-    key: "agents",
-    href: "/admin/agents",
-    Icon: Bot,
-  },
-  {
-    key: "enterpriseContracts",
-    href: "/admin/enterprise-contracts",
-    Icon: Building2,
-  },
-  {
-    key: "invoices",
-    href: "/admin/invoices",
-    Icon: Coins,
-  },
-  {
-    key: "freeCredits",
-    href: "/admin/free-credits",
-    Icon: LifeBuoy,
+    key: "users",
+    href: "/admin/users",
+    Icon: Users,
+    group: "accounts",
   },
   {
     key: "organizations",
     href: "/admin/organizations",
     Icon: Building,
+    group: "accounts",
   },
   {
-    key: "users",
-    href: "/admin/users",
-    Icon: Users,
+    key: "invoices",
+    href: "/admin/invoices",
+    Icon: Coins,
+    group: "billing",
   },
   {
-    key: "tasks",
-    href: "/admin/tasks",
-    Icon: ListTodo,
+    key: "freeCredits",
+    href: "/admin/free-credits",
+    Icon: LifeBuoy,
+    group: "billing",
+  },
+  {
+    key: "enterpriseContracts",
+    href: "/admin/enterprise-contracts",
+    Icon: Building2,
+    group: "billing",
+  },
+  {
+    key: "agents",
+    href: "/admin/agents",
+    Icon: Bot,
+    group: "catalog",
   },
   {
     key: "coworkers",
     href: "/admin/coworkers",
     Icon: BotMessageSquare,
+    group: "catalog",
   },
   {
     key: "orchestrators",
     href: "/admin/orchestrators",
     Icon: Bot,
+    group: "catalog",
+  },
+  {
+    key: "tasks",
+    href: "/admin/tasks",
+    Icon: ListTodo,
+    group: "operations",
   },
 ];

--- a/apps/web/src/app/(app)/admin/page.tsx
+++ b/apps/web/src/app/(app)/admin/page.tsx
@@ -18,7 +18,7 @@ import {
 
 export const metadata: Metadata = {
   title: "Admin",
-  description: "Internal admin console",
+  description: "Internal tools for accounts, billing, catalog, and operations.",
 };
 
 function sectionsByGroup(group: AdminSectionGroup): AdminSection[] {

--- a/apps/web/src/app/(app)/admin/page.tsx
+++ b/apps/web/src/app/(app)/admin/page.tsx
@@ -9,19 +9,28 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-import { ADMIN_SECTIONS } from "./admin-sections";
+import {
+  ADMIN_SECTION_GROUPS,
+  ADMIN_SECTIONS,
+  type AdminSection,
+  type AdminSectionGroup,
+} from "./admin-sections";
 
 export const metadata: Metadata = {
   title: "Admin",
   description: "Internal admin console",
 };
 
+function sectionsByGroup(group: AdminSectionGroup): AdminSection[] {
+  return ADMIN_SECTIONS.filter((section) => section.group === group);
+}
+
 export default async function AdminOverviewPage() {
   const t = await getTranslations("App.Admin.Overview");
 
   return (
     <div className="min-h-full w-full">
-      <div className="mx-auto max-w-6xl space-y-8 px-4 py-2">
+      <div className="mx-auto max-w-6xl space-y-10 px-4 py-2">
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">
             {t("title")}
@@ -29,25 +38,49 @@ export default async function AdminOverviewPage() {
           <p className="text-muted-foreground text-sm">{t("description")}</p>
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2">
-          {ADMIN_SECTIONS.map(({ key, href, Icon }) => (
-            <Link
-              key={key}
-              href={href}
-              className="focus-visible:ring-ring rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        {ADMIN_SECTION_GROUPS.map((group) => {
+          const sections = sectionsByGroup(group);
+          if (sections.length === 0) {
+            return null;
+          }
+
+          return (
+            <section
+              key={group}
+              className="space-y-4"
+              aria-labelledby={`admin-group-${group}`}
             >
-              <Card className="hover:border-primary/40 h-full gap-3 transition-colors hover:shadow-sm">
-                <CardHeader>
-                  <Icon className="text-muted-foreground size-5" aria-hidden />
-                  <CardTitle>{t(`Sections.${key}.title`)}</CardTitle>
-                  <CardDescription>
-                    {t(`Sections.${key}.description`)}
-                  </CardDescription>
-                </CardHeader>
-              </Card>
-            </Link>
-          ))}
-        </div>
+              <h2
+                id={`admin-group-${group}`}
+                className="text-muted-foreground text-sm font-medium tracking-wide uppercase"
+              >
+                {t(`Groups.${group}`)}
+              </h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {sections.map(({ key, href, Icon }) => (
+                  <Link
+                    key={key}
+                    href={href}
+                    className="focus-visible:ring-ring rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                  >
+                    <Card className="hover:border-primary/40 h-full gap-3 transition-colors hover:shadow-sm">
+                      <CardHeader>
+                        <Icon
+                          className="text-muted-foreground size-5"
+                          aria-hidden
+                        />
+                        <CardTitle>{t(`Sections.${key}.title`)}</CardTitle>
+                        <CardDescription>
+                          {t(`Sections.${key}.description`)}
+                        </CardDescription>
+                      </CardHeader>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Group the `/admin` overview hub into **Accounts**, **Billing & commercial**, **Marketplace catalog**, and **Operations** so tools match how operators work (people → money → product → debug).
- Add `group` to `ADMIN_SECTIONS` and render section headings with the existing card grid under each group.
- Update the hub description and add localized group labels across all locale catalogs.

## Test plan
- [ ] Open `/admin` as an admin user and confirm four group headings appear in order.
- [ ] Confirm cards under each group: Users/Organizations; Invoices/Free credits/Enterprise contracts; Agents/Coworkers/Orchestrators; Tasks.
- [ ] Click through each card to verify links still work.
- [ ] Spot-check a non-English locale for group title translations.