### PR TITLE
chore(claude): add web SessionStart hook that bootstraps dev env

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 # SessionStart hook for Claude Code on the web.
 #
-# Prepares the Sokosumi monorepo so linters, type checks, and tests work:
-#   1. Ensures Node 24.x (the repo's required runtime) via nvm.
-#   2. Activates pnpm (pinned by the root package.json "packageManager" field).
-#   3. Installs dependencies. `pnpm install` triggers each workspace's
-#      `prepare` script, which generates the Prisma clients and builds the
-#      shared packages (@sokosumi/database, /masumi, /utils, ...).
+# Bootstraps the Sokosumi monorepo so linters, type checks, tests, AND the dev
+# servers work out of the box on a fresh cloud session:
+#   1. Node 24.x (the repo's required runtime) via nvm + pnpm (pinned).
+#   2. `pnpm install` — also generates Prisma clients and builds shared packages.
+#   3. Local dev `.env` files for apps/core and apps/web (derived from the
+#      committed .env.example; nothing secret, and .env stays gitignored).
+#   4. Local PostgreSQL: start the cluster, ensure the sokosumi role + core DB.
+#   5. `prisma migrate deploy` + seed the credit_cost table (needed so the
+#      agents/categories endpoints return 200 instead of 500).
 #
-# Idempotent and non-interactive: safe to re-run. Node 24 install is skipped
-# when already present. Runs only in the remote (web) environment.
+# Everything here uses only NON-SECRET dev values (the same public placeholders
+# already committed in .env.example). Real secrets belong in the cloud
+# environment's env-var config or a gitignored .claude/settings.local.json,
+# never in this file.
+#
+# Idempotent and non-interactive: safe to re-run. Runs only in the remote (web)
+# environment. Steps degrade gracefully when their tooling is unavailable.
 set -euo pipefail
 
 # Only run in Claude Code on the web; local machines manage their own toolchain.
@@ -17,13 +25,19 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Load nvm. The nvm shell function is only defined in login/interactive
-# shells, so a non-interactive hook shell must source nvm.sh directly. Try the
-# known locations in order (the web container ships it under /opt/nvm).
-#
-# nvm.sh is not strict-mode-safe: it references unset vars and returns non-zero
-# while auto-selecting the default version on source. Relax -e/-u around nvm so
-# those benign returns do not abort the hook, then restore strict mode.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+cd "$PROJECT_DIR"
+
+# Single source of truth for local dev DB connection (also used by the apps).
+LOCAL_DATABASE_URL="postgresql://sokosumi:sokosumi@localhost:5432/core?schema=public"
+
+# ---------------------------------------------------------------------------
+# 1. Node 24 + pnpm
+# ---------------------------------------------------------------------------
+# The nvm shell function is only defined in login/interactive shells, so a
+# non-interactive hook shell must source nvm.sh directly. nvm.sh is not
+# strict-mode-safe (references unset vars, returns non-zero while auto-selecting
+# the default version), so relax -e/-u around it, then restore strict mode.
 set +eu
 for _nvm_sh in \
   "${NVM_DIR:-}/nvm.sh" \
@@ -42,26 +56,99 @@ if ! command -v nvm >/dev/null 2>&1; then
   exit 1
 fi
 
-# Ensure Node 24.x. `nvm install` is a no-op if it is already present.
-nvm install 24 >/dev/null
+nvm install 24 >/dev/null   # no-op if already installed
 nvm use 24 >/dev/null
 set -eu
 
-# Persist the Node 24 bin dir on PATH for the rest of the session so the
-# agent's shells resolve node/pnpm 24 instead of the container default (Node 22).
+# Persist Node 24 + the local DATABASE_URL for the rest of the session so the
+# agent's shells resolve node/pnpm 24 and connect to the local DB (overriding
+# any stale DATABASE_URL the platform may inject).
 NODE_BIN_DIR="$(dirname "$(nvm which 24)")"
+export PATH="$NODE_BIN_DIR:$PATH"
+export DATABASE_URL="$LOCAL_DATABASE_URL"
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   echo "export PATH=\"$NODE_BIN_DIR:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "export DATABASE_URL=\"$LOCAL_DATABASE_URL\"" >> "$CLAUDE_ENV_FILE"
 fi
-export PATH="$NODE_BIN_DIR:$PATH"
 
-# Activate the pnpm version pinned by package.json "packageManager".
 corepack enable >/dev/null 2>&1 || true
-
 echo "Node: $(node -v) | pnpm: $(pnpm -v)"
 
-# Install workspace dependencies. `prepare` scripts generate Prisma clients
-# and build the shared packages as part of this step.
+# ---------------------------------------------------------------------------
+# 2. Dependencies (also generates Prisma clients + builds shared packages)
+# ---------------------------------------------------------------------------
 pnpm install
+
+# ---------------------------------------------------------------------------
+# 3. Local dev .env files (only written when missing, to preserve manual edits)
+# ---------------------------------------------------------------------------
+write_core_env() {
+  local target="apps/core/.env"
+  [ -f "$target" ] && { echo "env: $target exists, leaving as-is"; return; }
+  cp apps/core/.env.example "$target"
+  # Local fixes so the Zod env schema passes and Postgres is reachable:
+  sed -i 's#@sokosumi:5432/core#@localhost:5432/core#' "$target"          # DB host -> localhost
+  sed -i 's#^POSTMARK_FROM_EMAIL=.*#POSTMARK_FROM_EMAIL="noreply@example.com"#' "$target"  # valid email
+  sed -i 's#^HERMES_ORCH_BASE_URL=.*#HERMES_ORCH_BASE_URL="http://localhost:9999"#' "$target"  # valid URL
+  sed -i 's#^BETTER_AUTH_COOKIE_DOMAIN=#\#BETTER_AUTH_COOKIE_DOMAIN=#' "$target"  # cookies on localhost
+  sed -i 's#^COMPOSIO_API_KEY=#\#COMPOSIO_API_KEY=#' "$target"            # placeholder fails ak_ format
+  echo "env: wrote $target"
+}
+
+write_web_env() {
+  local target="apps/web/.env"
+  [ -f "$target" ] && { echo "env: $target exists, leaving as-is"; return; }
+  cp apps/web/.env.example "$target"
+  # APP_SIGNING_SECRET must match Core BETTER_AUTH_SECRET (both public example values).
+  local core_secret
+  core_secret="$(grep -E '^BETTER_AUTH_SECRET=' apps/core/.env.example | cut -d= -f2- | tr -d '"')"
+  sed -i "s#^APP_SIGNING_SECRET=.*#APP_SIGNING_SECRET=\"${core_secret}\"#" "$target"
+  sed -i 's#^AGENT_HIRED_WEBHOOK=#\#AGENT_HIRED_WEBHOOK=#' "$target"       # placeholder not a valid URL
+  echo "env: wrote $target"
+}
+
+write_core_env
+write_web_env
+
+# ---------------------------------------------------------------------------
+# 4. Local PostgreSQL (start cluster + ensure role/db). Skipped if absent.
+# ---------------------------------------------------------------------------
+if command -v pg_ctlcluster >/dev/null 2>&1 && command -v psql >/dev/null 2>&1; then
+  # Start the default cluster if it is not already online.
+  if command -v pg_lsclusters >/dev/null 2>&1 && ! pg_lsclusters -h 2>/dev/null | awk '{print $4}' | grep -q online; then
+    pg_ctlcluster 16 main start 2>/dev/null || sudo pg_ctlcluster 16 main start 2>/dev/null || true
+  fi
+
+  # Ensure role + database exist (idempotent).
+  sudo -u postgres psql -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<'SQL' || true
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'sokosumi') THEN
+    CREATE ROLE sokosumi LOGIN PASSWORD 'sokosumi' CREATEDB;
+  END IF;
+END$$;
+SQL
+  sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='core'" 2>/dev/null | grep -q 1 \
+    || sudo -u postgres createdb -O sokosumi core 2>/dev/null || true
+
+  # ---------------------------------------------------------------------------
+  # 5. Migrate + seed credit_cost (needed so agents/categories return 200).
+  # ---------------------------------------------------------------------------
+  if PGPASSWORD=sokosumi psql -h localhost -U sokosumi -d core -c 'SELECT 1' >/dev/null 2>&1; then
+    pnpm prisma:migrate:deploy >/dev/null 2>&1 || echo "db: migrate deploy failed (check logs)"
+
+    # Seed 'lovelace' credit cost: creditsPerUnit 0.0001 * CREDITS_BASE(1e10) = 1_000_000.
+    PGPASSWORD=sokosumi psql -h localhost -U sokosumi -d core -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<'SQL' || echo "db: credit_cost seed skipped"
+INSERT INTO "CreditCost" (id, "createdAt", "updatedAt", unit, "centsPerUnit")
+VALUES (gen_random_uuid()::text, now(), now(), 'lovelace', 1000000)
+ON CONFLICT (unit) DO NOTHING;
+SQL
+    echo "db: ready (migrated + credit_cost seeded)"
+  else
+    echo "db: cannot connect as sokosumi; skipped migrate/seed"
+  fi
+else
+  echo "db: PostgreSQL tooling not found; skipped DB bootstrap"
+fi
 
 echo "Sokosumi session-start hook complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Prepares the Sokosumi monorepo so linters, type checks, and tests work:
+#   1. Ensures Node 24.x (the repo's required runtime) via nvm.
+#   2. Activates pnpm (pinned by the root package.json "packageManager" field).
+#   3. Installs dependencies. `pnpm install` triggers each workspace's
+#      `prepare` script, which generates the Prisma clients and builds the
+#      shared packages (@sokosumi/database, /masumi, /utils, ...).
+#
+# Idempotent and non-interactive: safe to re-run. Node 24 install is skipped
+# when already present. Runs only in the remote (web) environment.
+set -euo pipefail
+
+# Only run in Claude Code on the web; local machines manage their own toolchain.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Load nvm. The nvm shell function is only defined in login/interactive
+# shells, so a non-interactive hook shell must source nvm.sh directly. Try the
+# known locations in order (the web container ships it under /opt/nvm).
+#
+# nvm.sh is not strict-mode-safe: it references unset vars and returns non-zero
+# while auto-selecting the default version on source. Relax -e/-u around nvm so
+# those benign returns do not abort the hook, then restore strict mode.
+set +eu
+for _nvm_sh in \
+  "${NVM_DIR:-}/nvm.sh" \
+  "/opt/nvm/nvm.sh" \
+  "/etc/profile.d/nvm.sh" \
+  "$HOME/.nvm/nvm.sh"; do
+  if [ -n "$_nvm_sh" ] && [ -s "$_nvm_sh" ]; then
+    # shellcheck disable=SC1090
+    . "$_nvm_sh"
+    break
+  fi
+done
+
+if ! command -v nvm >/dev/null 2>&1; then
+  echo "session-start hook: nvm not found; cannot select Node 24." >&2
+  exit 1
+fi
+
+# Ensure Node 24.x. `nvm install` is a no-op if it is already present.
+nvm install 24 >/dev/null
+nvm use 24 >/dev/null
+set -eu
+
+# Persist the Node 24 bin dir on PATH for the rest of the session so the
+# agent's shells resolve node/pnpm 24 instead of the container default (Node 22).
+NODE_BIN_DIR="$(dirname "$(nvm which 24)")"
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$NODE_BIN_DIR:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+fi
+export PATH="$NODE_BIN_DIR:$PATH"
+
+# Activate the pnpm version pinned by package.json "packageManager".
+corepack enable >/dev/null 2>&1 || true
+
+echo "Node: $(node -v) | pnpm: $(pnpm -v)"
+
+# Install workspace dependencies. `prepare` scripts generate Prisma clients
+# and build the shared packages as part of this step.
+pnpm install
+
+echo "Sokosumi session-start hook complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ lint-report.json
 
 # Local Claude Code dev-server config (personal, per-machine)
 .claude/launch.json
+
+# Local Claude Code settings — holds machine-local overrides and any real
+# secrets (env block). Never commit; use for values that must stay out of git.
+.claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "prisma:migrate:deploy": "pnpm --filter @sokosumi/database prisma:migrate:deploy",
     "prisma:migrate:reset": "pnpm --filter @sokosumi/database prisma:migrate:reset",
     "prisma:studio": "pnpm --filter @sokosumi/database prisma:studio",
+    "data:seed:dev": "pnpm --filter @sokosumi/database seed:dev-marketplace",
     "perf:report": "lighthouse https://sokosumi-app-preprod.vercel.app/ --only-categories=performance --output=html --output=json --output-path=./.cursor/sokosumi-perf --chrome-flags='--headless --no-sandbox --disable-gpu'",
     "perf:report:auth": "node scripts/perf-report-authenticated.mjs",
     "prepare": "husky"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -58,6 +58,7 @@
     "prisma:migrate:deploy": "pnpm exec prisma migrate deploy",
     "prisma:migrate:reset": "pnpm exec prisma migrate reset",
     "prisma:studio": "pnpm exec prisma studio",
+    "seed:dev-marketplace": "pnpm exec tsx scripts/seed-dev-marketplace.ts",
     "lint": "biome lint .",
     "lint:write": "biome lint --write .",
     "check": "biome check .",

--- a/packages/database/scripts/seed-dev-marketplace.ts
+++ b/packages/database/scripts/seed-dev-marketplace.ts
@@ -1,0 +1,206 @@
+/**
+ * Dev-only seed: populate a handful of marketplace agents + categories so the
+ * Agents / Tasks / Chat pages are explorable in a local/cloud dev environment
+ * without a real Masumi registry sync.
+ *
+ * These are MOCK agents — they point at a non-routable apiBaseUrl and cannot
+ * actually run jobs. They exist purely to render the marketplace UI. For real
+ * hire/job flows, run the registry sync against Preprod instead.
+ *
+ * Requires the `lovelace` credit_cost row to exist (FIXED pricing is only
+ * "available" when every pricing unit is present in CreditCost). Safe to
+ * re-run: agents are upserted by their unique blockchainIdentifier and
+ * categories by their unique slug.
+ *
+ * Run against a dev DB only:
+ *   DATABASE_URL="postgres://..." npx tsx packages/database/scripts/seed-dev-marketplace.ts
+ */
+import { createPrismaClient } from "../src/client";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const prisma = createPrismaClient(DATABASE_URL);
+
+interface CategorySeed {
+  slug: string;
+  name: string;
+  description: string;
+  priority: number;
+}
+
+const CATEGORIES: CategorySeed[] = [
+  {
+    slug: "writing",
+    name: "Writing",
+    description: "Drafting, editing, and summarization agents.",
+    priority: 10,
+  },
+  {
+    slug: "development",
+    name: "Development",
+    description: "Coding, review, and debugging agents.",
+    priority: 20,
+  },
+  {
+    slug: "research",
+    name: "Research",
+    description: "Search, analysis, and synthesis agents.",
+    priority: 30,
+  },
+];
+
+interface AgentSeed {
+  blockchainIdentifier: string;
+  name: string;
+  description: string;
+  authorOrganization: string;
+  categorySlugs: string[];
+  // Fixed price in lovelace; omit for a FREE agent.
+  priceLovelace?: bigint;
+}
+
+const AGENTS: AgentSeed[] = [
+  {
+    blockchainIdentifier: "dev-mock-agent-copywriter",
+    name: "Copywriter",
+    description:
+      "Turns a short brief into polished marketing copy, product descriptions, and social posts.",
+    authorOrganization: "Sokosumi Dev",
+    categorySlugs: ["writing"],
+    priceLovelace: 2_000_000n, // 2 ADA -> 200 credits
+  },
+  {
+    blockchainIdentifier: "dev-mock-agent-code-reviewer",
+    name: "Code Reviewer",
+    description:
+      "Reviews a diff for bugs, style, and security issues and explains each finding in plain language.",
+    authorOrganization: "Sokosumi Dev",
+    categorySlugs: ["development"],
+    priceLovelace: 5_000_000n, // 5 ADA -> 500 credits
+  },
+  {
+    blockchainIdentifier: "dev-mock-agent-researcher",
+    name: "Researcher",
+    description:
+      "Runs a multi-source web sweep and returns a cited synthesis of the findings.",
+    authorOrganization: "Sokosumi Dev",
+    categorySlugs: ["research", "writing"],
+    // FREE agent (no priceLovelace) — always available regardless of credit costs.
+  },
+];
+
+async function seedCategories(): Promise<Map<string, string>> {
+  const bySlug = new Map<string, string>();
+  for (const category of CATEGORIES) {
+    const record = await prisma.category.upsert({
+      where: { slug: category.slug },
+      update: {
+        name: category.name,
+        description: category.description,
+        priority: category.priority,
+      },
+      create: {
+        slug: category.slug,
+        name: category.name,
+        description: category.description,
+        priority: category.priority,
+      },
+    });
+    bySlug.set(category.slug, record.id);
+    console.log(`category: ${category.slug}`);
+  }
+  return bySlug;
+}
+
+async function seedAgent(
+  seed: AgentSeed,
+  categoryIdBySlug: Map<string, string>,
+): Promise<void> {
+  const categoryConnect = seed.categorySlugs
+    .map((slug) => categoryIdBySlug.get(slug))
+    .filter((id): id is string => Boolean(id))
+    .map((id) => ({ id }));
+
+  // Build the pricing graph. FIXED needs an AgentFixedPricing with lovelace
+  // amounts; FREE needs only the pricingType.
+  const pricingCreate =
+    seed.priceLovelace === undefined
+      ? { pricingType: "FREE" as const }
+      : {
+          pricingType: "FIXED" as const,
+          fixedPricing: {
+            create: {
+              amounts: {
+                create: [{ unit: "lovelace", amount: seed.priceLovelace }],
+              },
+            },
+          },
+        };
+
+  const existing = await prisma.agent.findUnique({
+    where: { blockchainIdentifier: seed.blockchainIdentifier },
+    select: { id: true },
+  });
+
+  if (existing) {
+    // Keep re-runs simple: refresh the mutable descriptive fields + categories.
+    await prisma.agent.update({
+      where: { id: existing.id },
+      data: {
+        name: seed.name,
+        description: seed.description,
+        authorOrganization: seed.authorOrganization,
+        status: "ONLINE",
+        isShown: true,
+        categories: { set: categoryConnect },
+      },
+    });
+    console.log(`agent: ${seed.blockchainIdentifier} (updated)`);
+    return;
+  }
+
+  await prisma.agent.create({
+    data: {
+      blockchainIdentifier: seed.blockchainIdentifier,
+      name: seed.name,
+      description: seed.description,
+      apiBaseUrl: "https://mock.invalid/agent",
+      authorOrganization: seed.authorOrganization,
+      lastUptimeCheck: new Date(),
+      uptimeCount: 100,
+      uptimeCheckCount: 100,
+      status: "ONLINE",
+      isShown: true,
+      pricing: { create: pricingCreate },
+      categories: { connect: categoryConnect },
+    },
+  });
+  console.log(`agent: ${seed.blockchainIdentifier} (created)`);
+}
+
+async function main(): Promise<void> {
+  const creditCostCount = await prisma.creditCost.count();
+  if (creditCostCount === 0) {
+    console.warn(
+      "warning: CreditCost table is empty — FIXED-priced agents will be hidden until a 'lovelace' credit cost exists.",
+    );
+  }
+
+  const categoryIdBySlug = await seedCategories();
+  for (const agent of AGENTS) {
+    await seedAgent(agent, categoryIdBySlug);
+  }
+
+  console.log("dev marketplace seed complete");
+  await prisma.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await prisma.$disconnect();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a SessionStart hook so a fresh **Claude Code on the web** session boots fully ready — not just for linters/type-checks/tests, but runnable end-to-end (both apps, DB, seed data) with zero manual steps. All values used are non-secret dev scaffolding (the same public placeholders already committed in `.env.example`); real secrets are never committed.

## Changes

- **New: `.claude/hooks/session-start.sh`** — runs only in the web env (`CLAUDE_CODE_REMOTE == "true"`), idempotent and non-interactive:
  1. Ensures **Node 24.x** (the repo's required runtime) via nvm + activates the pinned **pnpm** via corepack.
  2. `pnpm install` — also generates the Prisma clients and builds the shared packages via each workspace's `prepare` script.
  3. Writes local dev **`.env` files** for `apps/core` and `apps/web`, derived from the committed `.env.example` with the minimal fixes needed to pass Zod validation (DB host → `localhost`, valid dummy email/URL, disable `BETTER_AUTH_COOKIE_DOMAIN` for localhost cookies, match web `APP_SIGNING_SECRET` to Core `BETTER_AUTH_SECRET`). Only written when missing, so manual edits are preserved. `.env` stays gitignored.
  4. Starts the local **PostgreSQL** cluster and ensures the `sokosumi` role + `core` database.
  5. Runs `prisma migrate deploy` and **seeds the `credit_cost` table** (`lovelace`) so the agents/categories endpoints return 200 instead of 500.
  - Persists Node 24 on `PATH` and the local `DATABASE_URL` via `CLAUDE_ENV_FILE` (overrides any stale injected value).

- **Modified: `.claude/settings.json`** — registers the SessionStart hook.

- **Modified: `.gitignore`** — ignores `.claude/settings.local.json`, the recommended place for real secrets (an `env` block) that must stay out of git.

## Env strategy (no committed secrets)

- **Non-secret dev scaffolding** → generated by the hook; `.env` files remain gitignored.
- **Real secrets** (Stripe/registry/API keys) → a gitignored `.claude/settings.local.json` `env` block, or the cloud environment's env-var configuration — never committed.

## Verification

- Hook run from a clean `.env` state → exit 0; regenerated both `.env` files, DB migrated + `credit_cost` seeded.
- Re-run → idempotent (env files left as-is, `credit_cost` stays a single row).
- `biome check .claude/settings.json` → clean; `Validate PR Title` passing.
- Both dev servers healthy: Core `/` → 200, `/v1/openapi.json` → 200; Web `/signin` → 200.
- Authenticated `GET /v1/agents` and `/v1/categories` → **200** (`data: []`; empty only because no agents are synced in a fresh DB), confirming the credit-cost 500 is resolved.

## Notes

- Hook runs **synchronously** (guarantees readiness before the session starts, at the cost of a slower first boot). Can switch to async if faster startup is preferred.
- Effective once merged to the default branch — all future web sessions pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdR8yGadw5yqjUahxd962a