### PR TITLE
chore(cursor): allow GitHub API in agent sandbox

### DIFF
--- a/.cursor/sandbox.json
+++ b/.cursor/sandbox.json
@@ -1,0 +1,6 @@
+{
+  "networkPolicy": {
+    "default": "deny",
+    "allow": ["*.github.com", "raw.githubusercontent.com"]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.cursor/sandbox.json` network allowlist for `*.github.com` and `raw.githubusercontent.com`
- Unblocks Cursor agent `gh` / GitHub API (was CONNECT 403 via sandbox proxy)

## Test plan
- [ ] In agent shell: `curl -sS -o /dev/null -w \"%{http_code}\n\" https://api.github.com/` → 200
- [ ] In agent shell: `gh auth status` and `gh api user -q .login` succeed