### PR TITLE
feat(web): show PA orb on orchestrator task comments

### DIFF
--- a/apps/core/src/helpers/loaded-relation-summaries.ts
+++ b/apps/core/src/helpers/loaded-relation-summaries.ts
@@ -95,6 +95,7 @@ export function coworkerSummaryFromLoadedRelation(
 interface OrchestratorSummaryFields {
   id: string;
   name: string | null;
+  avatarSeed: string | null;
 }
 
 /**
@@ -119,5 +120,6 @@ export function orchestratorSummaryFromLoadedRelation(
   return {
     id: orchestrator.id,
     name: orchestrator.name,
+    avatarSeed: orchestrator.avatarSeed,
   };
 }

--- a/apps/core/src/helpers/loaded-relation-summaries.ts
+++ b/apps/core/src/helpers/loaded-relation-summaries.ts
@@ -92,20 +92,29 @@ export function coworkerSummaryFromLoadedRelation(
   };
 }
 
-interface OrchestratorSummaryFields {
+interface OrchestratorLoadedRelation {
   id: string;
   name: string | null;
   avatarSeed: string | null;
+  userId: string;
+  user: UserSummaryFields | null;
+}
+
+export interface OrchestratorSummaryFields {
+  id: string;
+  name: string | null;
+  avatarSeed: string | null;
+  owner: UserSummaryFields;
 }
 
 /**
  * When `orchestratorId` is null, there is no creator orchestrator summary.
- * When it is set, the orchestrator relation must be loaded.
+ * When it is set, the orchestrator relation (including owner user) must be loaded.
  */
 export function orchestratorSummaryFromLoadedRelation(
   context: string,
   orchestratorId: string | null,
-  orchestrator: OrchestratorSummaryFields | null,
+  orchestrator: OrchestratorLoadedRelation | null,
 ): OrchestratorSummaryFields | null {
   if (orchestratorId == null) {
     return null;
@@ -121,5 +130,10 @@ export function orchestratorSummaryFromLoadedRelation(
     id: orchestrator.id,
     name: orchestrator.name,
     avatarSeed: orchestrator.avatarSeed,
+    owner: userSummaryFromLoadedRelation(
+      `${context} orchestrator owner`,
+      orchestrator.userId,
+      orchestrator.user,
+    ),
   };
 }

--- a/apps/core/src/helpers/task.test.ts
+++ b/apps/core/src/helpers/task.test.ts
@@ -836,6 +836,7 @@ describe("mapTaskEventActor", () => {
     const orchestrator = {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
+      avatarSeed: "orb:jewel-sky:user_123",
     };
     const event = buildTaskEventFixture({
       orchestratorId: orchestrator.id,
@@ -874,6 +875,7 @@ describe("mapTaskEventActor", () => {
     const orchestrator = {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
+      avatarSeed: null,
     };
 
     expect(
@@ -896,6 +898,7 @@ describe("mapTaskEventActor", () => {
     const orchestrator = {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
+      avatarSeed: null,
     };
 
     expect(
@@ -1088,6 +1091,7 @@ describe("mapTask", () => {
     const creatorOrchestrator = {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
+      avatarSeed: null,
     };
     const task = {
       id: "tsk_alias",

--- a/apps/core/src/helpers/task.test.ts
+++ b/apps/core/src/helpers/task.test.ts
@@ -837,6 +837,8 @@ describe("mapTaskEventActor", () => {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
       avatarSeed: "orb:jewel-sky:user_123",
+      userId: defaultTaskUser.id,
+      user: defaultTaskUser,
     };
     const event = buildTaskEventFixture({
       orchestratorId: orchestrator.id,
@@ -846,7 +848,12 @@ describe("mapTaskEventActor", () => {
     expect(mapTaskEventActor(event)).toEqual({
       type: "orchestrator",
       id: orchestrator.id,
-      orchestrator,
+      orchestrator: {
+        id: orchestrator.id,
+        name: orchestrator.name,
+        avatarSeed: orchestrator.avatarSeed,
+        owner: defaultTaskUser,
+      },
     });
   });
 
@@ -876,6 +883,8 @@ describe("mapTaskEventActor", () => {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
       avatarSeed: null,
+      userId: defaultTaskUser.id,
+      user: defaultTaskUser,
     };
 
     expect(
@@ -890,7 +899,12 @@ describe("mapTaskEventActor", () => {
     ).toEqual({
       type: "orchestrator",
       id: orchestrator.id,
-      orchestrator,
+      orchestrator: {
+        id: orchestrator.id,
+        name: orchestrator.name,
+        avatarSeed: orchestrator.avatarSeed,
+        owner: defaultTaskUser,
+      },
     });
   });
 
@@ -899,6 +913,8 @@ describe("mapTaskEventActor", () => {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
       avatarSeed: null,
+      userId: defaultTaskUser.id,
+      user: defaultTaskUser,
     };
 
     expect(
@@ -913,7 +929,12 @@ describe("mapTaskEventActor", () => {
     ).toEqual({
       type: "orchestrator",
       id: orchestrator.id,
-      orchestrator,
+      orchestrator: {
+        id: orchestrator.id,
+        name: orchestrator.name,
+        avatarSeed: orchestrator.avatarSeed,
+        owner: defaultTaskUser,
+      },
     });
   });
 
@@ -1092,6 +1113,8 @@ describe("mapTask", () => {
       id: "01960001-0001-7001-8001-000000000099",
       name: "Hermes",
       avatarSeed: null,
+      userId: defaultTaskUser.id,
+      user: defaultTaskUser,
     };
     const task = {
       id: "tsk_alias",
@@ -1124,6 +1147,13 @@ describe("mapTask", () => {
       },
     } as unknown as TaskWithIncludes;
 
+    const mappedOrchestrator = {
+      id: creatorOrchestrator.id,
+      name: creatorOrchestrator.name,
+      avatarSeed: creatorOrchestrator.avatarSeed,
+      owner: defaultTaskUser,
+    };
+
     expect(mapTask(task)).toMatchObject({
       ownerId: "user_123",
       userId: "user_123",
@@ -1134,10 +1164,10 @@ describe("mapTask", () => {
       creator: {
         type: "orchestrator",
         id: creatorOrchestrator.id,
-        orchestrator: creatorOrchestrator,
+        orchestrator: mappedOrchestrator,
       },
       orchestratorId: creatorOrchestrator.id,
-      orchestrator: creatorOrchestrator,
+      orchestrator: mappedOrchestrator,
     });
   });
 

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -228,6 +228,8 @@ function enrichTaskEventRowForResponse(record: TaskEventRecord) {
           id: record.orchestratorId,
           name: "Task orchestrator",
           avatarSeed: null,
+          userId: USER_ID,
+          user: { id: USER_ID, name: "Task user", image: null },
         }
       : null,
     transaction: null as { amount: bigint } | null,
@@ -1293,6 +1295,7 @@ describe("POST /{id}/events", () => {
         id: ORCHESTRATOR_ID,
         name: "Task orchestrator",
         avatarSeed: null,
+        owner: { id: USER_ID, name: "Task user", image: null },
       },
     });
   });

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -227,6 +227,7 @@ function enrichTaskEventRowForResponse(record: TaskEventRecord) {
       ? {
           id: record.orchestratorId,
           name: "Task orchestrator",
+          avatarSeed: null,
         }
       : null,
     transaction: null as { amount: bigint } | null,
@@ -1291,6 +1292,7 @@ describe("POST /{id}/events", () => {
       orchestrator: {
         id: ORCHESTRATOR_ID,
         name: "Task orchestrator",
+        avatarSeed: null,
       },
     });
   });

--- a/apps/core/src/routes/v1/tasks/whitelist-enforcement.test.ts
+++ b/apps/core/src/routes/v1/tasks/whitelist-enforcement.test.ts
@@ -70,7 +70,8 @@ const {
               | undefined) ?? {
               id: creatorOrchestratorId,
               name: "Orchestrator",
-              slug: "orchestrator",
+              avatarSeed: null,
+              owner: { id: "user_fallback", name: "Owner", image: null },
             },
           };
         }

--- a/apps/core/src/schemas/orchestrator.schema.ts
+++ b/apps/core/src/schemas/orchestrator.schema.ts
@@ -6,6 +6,9 @@ export const orchestratorSummarySchema = z
       example: "01960001-0001-7001-8001-000000000099",
     }),
     name: z.string().nullable().openapi({ example: "Atlas" }),
+    avatarSeed: z.string().nullable().openapi({
+      example: "orb:jewel-sky:user_123",
+    }),
   })
   .openapi("OrchestratorSummary");
 

--- a/apps/core/src/schemas/orchestrator.schema.ts
+++ b/apps/core/src/schemas/orchestrator.schema.ts
@@ -1,5 +1,7 @@
 import { z } from "@hono/zod-openapi";
 
+import { userSummarySchema } from "@/schemas/user.schema";
+
 export const orchestratorSummarySchema = z
   .object({
     id: z.string().uuid().openapi({
@@ -9,6 +11,7 @@ export const orchestratorSummarySchema = z
     avatarSeed: z.string().nullable().openapi({
       example: "orb:jewel-sky:user_123",
     }),
+    owner: userSummarySchema,
   })
   .openapi("OrchestratorSummary");
 

--- a/apps/core/src/types/task.ts
+++ b/apps/core/src/types/task.ts
@@ -18,8 +18,15 @@ export const taskEventApiInclude = {
     select: { id: true, name: true, image: true, slug: true, vendorId: true },
   },
   orchestrator: {
-    select: { id: true, name: true, avatarSeed: true },
+    select: {
+      id: true,
+      name: true,
+      avatarSeed: true,
+      userId: true,
+      user: { select: { id: true, name: true, image: true } },
+    },
   },
+
   transaction: { select: { amount: true } },
 } as const;
 

--- a/apps/core/src/types/task.ts
+++ b/apps/core/src/types/task.ts
@@ -18,7 +18,7 @@ export const taskEventApiInclude = {
     select: { id: true, name: true, image: true, slug: true, vendorId: true },
   },
   orchestrator: {
-    select: { id: true, name: true },
+    select: { id: true, name: true, avatarSeed: true },
   },
   transaction: { select: { amount: true } },
 } as const;

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "Coworker",
         "actorUser": "Nutzer",
         "actorOrchestrator": "Orchestrator",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "System",
         "originFromApp": "von {appName}",
         "channelApp": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1570,6 +1570,7 @@
         "actorCoworker": "Coworker",
         "actorUser": "User",
         "actorOrchestrator": "Orchestrator",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "System",
         "originFromApp": "from {appName}",
         "channelApp": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "Coworker",
         "actorUser": "Usuario",
         "actorOrchestrator": "Orquestador",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "Sistema",
         "originFromApp": "de {appName}",
         "channelApp": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "Collègue",
         "actorUser": "Utilisateur",
         "actorOrchestrator": "Orchestrateur",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "Système",
         "originFromApp": "depuis {appName}",
         "channelApp": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "Coworker",
         "actorUser": "Utente",
         "actorOrchestrator": "Orchestratore",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "Sistema",
         "originFromApp": "da {appName}",
         "channelApp": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "同僚",
         "actorUser": "ユーザー",
         "actorOrchestrator": "オーケストレーター",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "システム",
         "originFromApp": "{appName}から",
         "channelApp": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "Coworker",
         "actorUser": "Usuário",
         "actorOrchestrator": "Orquestrador",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "Sistema",
         "originFromApp": "de {appName}",
         "channelApp": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "Colega de trabalho",
         "actorUser": "Utilizador",
         "actorOrchestrator": "Orquestrador",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "Sistema",
         "originFromApp": "de {appName}",
         "channelApp": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1558,6 +1558,7 @@
         "actorCoworker": "协作伙伴",
         "actorUser": "用户",
         "actorOrchestrator": "编排器",
+        "actorOrchestratorWithOwner": "{assistant} · {owner}",
         "actorSystem": "系统",
         "originFromApp": "来自 {appName}",
         "channelApp": {

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
@@ -120,8 +120,21 @@ vi.mock("@/components/jobs/job-details/file-chip-with-metadata", () => ({
 }));
 
 vi.mock("@/components/aurora-orb", () => ({
-  AssistantOrb: ({ seed, alt }: { seed: string | null; alt?: string }) => (
-    <div data-testid="assistant-orb" data-seed={seed ?? ""} aria-label={alt} />
+  AssistantOrb: ({
+    seed,
+    alt,
+    animate,
+  }: {
+    seed: string | null;
+    alt?: string;
+    animate?: boolean;
+  }) => (
+    <div
+      data-testid="assistant-orb"
+      data-seed={seed ?? ""}
+      data-animate={animate === false ? "false" : "true"}
+      aria-label={alt}
+    />
   ),
 }));
 
@@ -572,6 +585,46 @@ describe("TaskActivitySection", () => {
       "data-seed",
       "orb:jewel-sky:user_123",
     );
+    expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
+      "data-animate",
+      "false",
+    );
+  });
+
+  it("shows static placeholder orb when orchestrator avatarSeed is null", () => {
+    const events: TaskEvent[] = [
+      createEvent("orch-null-seed", {
+        createdAt: "2026-01-01T12:00:00.000Z",
+        status: null,
+        comment: "Unnamed orb update",
+        userId: null,
+        coworkerId: null,
+        orchestratorId: "orch-1",
+        orchestrator: {
+          id: "orch-1",
+          name: "Hermes",
+          avatarSeed: null,
+          owner: {
+            id: "user-1",
+            name: "Ada Lovelace",
+            image: null,
+          },
+        },
+      }),
+    ];
+
+    render(<TaskActivitySection {...baseProps} events={events} />);
+
+    expect(screen.getByText("Hermes · Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
+      "data-seed",
+      "",
+    );
+    expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
+      "data-animate",
+      "false",
+    );
+    expect(screen.queryByText("HL")).not.toBeInTheDocument();
   });
 
   it("prefers nested actor over conflicting deprecated flat FKs", () => {

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
@@ -59,6 +59,10 @@ vi.mock("next-intl", () => ({
         return `from ${values?.appName ?? ""}`.trim();
       }
 
+      if (key === "actorOrchestratorWithOwner") {
+        return `${values?.assistant ?? ""} · ${values?.owner ?? ""}`.trim();
+      }
+
       return labels[key] ?? key;
     };
 
@@ -538,7 +542,7 @@ describe("TaskActivitySection", () => {
     expect(screen.getByLabelText("from Email")).toBeInTheDocument();
   });
 
-  it("shows orchestrator actor name and orb for orchestrator-authored events", () => {
+  it("shows orchestrator actor name with owner and orb for orchestrator-authored events", () => {
     const events: TaskEvent[] = [
       createEvent("orch-event", {
         createdAt: "2026-01-01T12:00:00.000Z",
@@ -551,13 +555,18 @@ describe("TaskActivitySection", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          owner: {
+            id: "user-1",
+            name: "Ada Lovelace",
+            image: null,
+          },
         },
       }),
     ];
 
     render(<TaskActivitySection {...baseProps} events={events} />);
 
-    expect(screen.getByText("Hermes")).toBeInTheDocument();
+    expect(screen.getByText("Hermes · Ada Lovelace")).toBeInTheDocument();
     expect(screen.queryByText("System")).not.toBeInTheDocument();
     expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
       "data-seed",
@@ -577,13 +586,18 @@ describe("TaskActivitySection", () => {
             id: "orch-1",
             name: "Hermes",
             avatarSeed: "orb:jewel-sky:user_123",
+            owner: {
+              id: "user-1",
+              name: "Ada Lovelace",
+              image: null,
+            },
           },
         },
         // Legacy dual FK: flat userId would have won the old coworker>user>orch order.
         userId: "user-2",
         user: {
           id: "user-2",
-          name: "Ada Lovelace",
+          name: "Grace Hopper",
           image: null,
         },
         coworkerId: null,
@@ -592,14 +606,19 @@ describe("TaskActivitySection", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          owner: {
+            id: "user-1",
+            name: "Ada Lovelace",
+            image: null,
+          },
         },
       }),
     ];
 
     render(<TaskActivitySection {...baseProps} events={events} />);
 
-    expect(screen.getByText("Hermes")).toBeInTheDocument();
-    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    expect(screen.getByText("Hermes · Ada Lovelace")).toBeInTheDocument();
+    expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument();
   });
 
   it("shows upgrade plan billing CTA for latest out-of-credits event on free plan", () => {

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
@@ -115,6 +115,12 @@ vi.mock("@/components/jobs/job-details/file-chip-with-metadata", () => ({
   ),
 }));
 
+vi.mock("@/components/aurora-orb", () => ({
+  AssistantOrb: ({ seed, alt }: { seed: string | null; alt?: string }) => (
+    <div data-testid="assistant-orb" data-seed={seed ?? ""} aria-label={alt} />
+  ),
+}));
+
 function createEvent(
   id: string,
   {
@@ -532,17 +538,19 @@ describe("TaskActivitySection", () => {
     expect(screen.getByLabelText("from Email")).toBeInTheDocument();
   });
 
-  it("shows orchestrator actor name for orchestrator-authored events", () => {
+  it("shows orchestrator actor name and orb for orchestrator-authored events", () => {
     const events: TaskEvent[] = [
       createEvent("orch-event", {
         createdAt: "2026-01-01T12:00:00.000Z",
-        status: TaskStatus.READY,
+        status: null,
+        comment: "Assistant update",
         userId: null,
         coworkerId: null,
         orchestratorId: "orch-1",
         orchestrator: {
           id: "orch-1",
           name: "Hermes",
+          avatarSeed: "orb:jewel-sky:user_123",
         },
       }),
     ];
@@ -551,6 +559,10 @@ describe("TaskActivitySection", () => {
 
     expect(screen.getByText("Hermes")).toBeInTheDocument();
     expect(screen.queryByText("System")).not.toBeInTheDocument();
+    expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
+      "data-seed",
+      "orb:jewel-sky:user_123",
+    );
   });
 
   it("prefers nested actor over conflicting deprecated flat FKs", () => {
@@ -564,6 +576,7 @@ describe("TaskActivitySection", () => {
           orchestrator: {
             id: "orch-1",
             name: "Hermes",
+            avatarSeed: "orb:jewel-sky:user_123",
           },
         },
         // Legacy dual FK: flat userId would have won the old coworker>user>orch order.
@@ -578,6 +591,7 @@ describe("TaskActivitySection", () => {
         orchestrator: {
           id: "orch-1",
           name: "Hermes",
+          avatarSeed: "orb:jewel-sky:user_123",
         },
       }),
     ];

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-metadata.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { TaskMetadata } from "@/app/tasks/components/task-metadata";
 import { TaskStatus } from "@/lib/clients/generated/core";
 import type { Task } from "@/lib/clients/generated/core/types.gen";
+
+vi.mock("@/components/aurora-orb", () => ({
+  AssistantOrb: ({ seed, alt }: { seed: string | null; alt?: string }) => (
+    <div data-testid="assistant-orb" data-seed={seed ?? ""} aria-label={alt} />
+  ),
+}));
 
 const baseLabels = {
   propertiesTitle: "Properties",
@@ -130,6 +136,7 @@ describe("TaskMetadata", () => {
             orchestrator: {
               id: "01960001-0001-7001-8001-000000000099",
               name: "Hermes",
+              avatarSeed: null,
             },
           },
         })}
@@ -142,5 +149,9 @@ describe("TaskMetadata", () => {
 
     expect(screen.getByText("Creator")).toBeInTheDocument();
     expect(screen.getByText("Hermes")).toBeInTheDocument();
+    expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
+      "data-seed",
+      "",
+    );
   });
 });

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-metadata.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-metadata.test.tsx
@@ -26,6 +26,13 @@ const baseLabels = {
   created: "Created",
   updated: "Updated",
   schedule: "Schedule",
+  formatOrchestratorActorName: ({
+    assistant,
+    owner,
+  }: {
+    assistant: string;
+    owner: string;
+  }) => `${assistant} · ${owner}`,
 };
 
 function createTask(
@@ -126,7 +133,7 @@ describe("TaskMetadata", () => {
     expect(screen.getByText("Creator Coworker")).toBeInTheDocument();
   });
 
-  it("shows orchestrator creator", () => {
+  it("shows orchestrator creator with owner name", () => {
     render(
       <TaskMetadata
         task={createTask({
@@ -137,6 +144,11 @@ describe("TaskMetadata", () => {
               id: "01960001-0001-7001-8001-000000000099",
               name: "Hermes",
               avatarSeed: null,
+              owner: {
+                id: "user_2",
+                name: "Ada Lovelace",
+                image: null,
+              },
             },
           },
         })}
@@ -148,7 +160,7 @@ describe("TaskMetadata", () => {
     );
 
     expect(screen.getByText("Creator")).toBeInTheDocument();
-    expect(screen.getByText("Hermes")).toBeInTheDocument();
+    expect(screen.getByText("Hermes · Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByTestId("assistant-orb")).toHaveAttribute(
       "data-seed",
       "",

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -440,7 +440,13 @@ export function TaskActivitySection({
               coworkerById,
               orchestratorById,
             );
-            const actorName = actorInfo?.name ?? actorLabel;
+            const actorName =
+              actorInfo?.ownerName != null
+                ? t("actorOrchestratorWithOwner", {
+                    assistant: actorInfo.name,
+                    owner: actorInfo.ownerName,
+                  })
+                : (actorInfo?.name ?? actorLabel);
             const actorImage = actorInfo?.image ?? null;
             const showAssistantOrb =
               actorInfo != null && "avatarSeed" in actorInfo;

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -448,8 +448,7 @@ export function TaskActivitySection({
                   })
                 : (actorInfo?.name ?? actorLabel);
             const actorImage = actorInfo?.image ?? null;
-            const showAssistantOrb =
-              actorInfo != null && "avatarSeed" in actorInfo;
+            const showAssistantOrb = actorKind === "orchestrator";
             const action = event.comment
               ? actionCommentedLabel
               : actionUpdatedStatusLabel;
@@ -554,7 +553,8 @@ export function TaskActivitySection({
                     </div>
                   ) : showAssistantOrb ? (
                     <AssistantOrb
-                      seed={actorInfo.avatarSeed ?? null}
+                      seed={actorInfo?.avatarSeed ?? null}
+                      animate={false}
                       size={24}
                       className="size-6 shrink-0 self-start"
                       alt={actorName}

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -25,6 +25,7 @@ import {
   resolveTaskEventActorKind,
   type TaskActivityActorInfo,
 } from "@/app/tasks/utils/task-activity-actors";
+import { AssistantOrb } from "@/components/aurora-orb";
 import { ExpandableMarkdown } from "@/components/expandable-markdown";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { SourcesGrid } from "@/components/sources/sources-grid";
@@ -441,6 +442,8 @@ export function TaskActivitySection({
             );
             const actorName = actorInfo?.name ?? actorLabel;
             const actorImage = actorInfo?.image ?? null;
+            const showAssistantOrb =
+              actorInfo != null && "avatarSeed" in actorInfo;
             const action = event.comment
               ? actionCommentedLabel
               : actionUpdatedStatusLabel;
@@ -543,6 +546,13 @@ export function TaskActivitySection({
                         aria-hidden
                       />
                     </div>
+                  ) : showAssistantOrb ? (
+                    <AssistantOrb
+                      seed={actorInfo.avatarSeed ?? null}
+                      size={24}
+                      className="size-6 shrink-0 self-start"
+                      alt={actorName}
+                    />
                   ) : (
                     <Avatar className="size-6 shrink-0 self-start">
                       {actorImage ? (

--- a/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
@@ -396,6 +396,8 @@ async function TaskOverviewSection({
           created: t("created"),
           updated: t("updated"),
           schedule: t("schedule"),
+          formatOrchestratorActorName: (values) =>
+            t("actorOrchestratorWithOwner", values),
         }}
       />
     </>

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -25,6 +25,10 @@ interface TaskMetadataLabels {
   created: string;
   updated: string;
   schedule: string;
+  formatOrchestratorActorName: (values: {
+    assistant: string;
+    owner: string;
+  }) => string;
 }
 
 interface TaskMetadataTask {
@@ -46,6 +50,7 @@ interface TaskCreatorDisplay {
 
 function resolveTaskCreatorDisplay(
   task: TaskMetadataTask,
+  formatOrchestratorActorName: TaskMetadataLabels["formatOrchestratorActorName"],
 ): TaskCreatorDisplay | null {
   switch (task.creator.type) {
     case "user": {
@@ -80,7 +85,10 @@ function resolveTaskCreatorDisplay(
       }
 
       return {
-        name: orchestrator.name ?? "Assistant",
+        name: formatOrchestratorActorName({
+          assistant: orchestrator.name ?? "Assistant",
+          owner: orchestrator.owner.name,
+        }),
         image: null,
         avatarSeed: orchestrator.avatarSeed ?? null,
       };
@@ -111,7 +119,10 @@ export function TaskMetadata({
     ? resolveIpfsOrHttpUrl(task.owner.image)
     : null;
   const assigneeImage = getCoworkerImage(task.assignee);
-  const creator = resolveTaskCreatorDisplay(task);
+  const creator = resolveTaskCreatorDisplay(
+    task,
+    labels.formatOrchestratorActorName,
+  );
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -275,6 +275,7 @@ function MetadataAvatarValue({
         {avatarSeed !== undefined ? (
           <AssistantOrb
             seed={avatarSeed}
+            animate={false}
             size={20}
             className="size-5 shrink-0"
             alt={name}

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -2,6 +2,7 @@ import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
 import Link from "next/link";
 
 import { getCoworkerImage } from "@/app/tasks/utils/coworker-image";
+import { AssistantOrb } from "@/components/aurora-orb";
 import { TaskScheduleDisplay } from "@/components/task-schedule-display";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { Task } from "@/lib/clients/generated/core/types.gen";
@@ -40,6 +41,7 @@ interface TaskMetadataTask {
 interface TaskCreatorDisplay {
   name: string;
   image: string | null;
+  avatarSeed?: string | null;
 }
 
 function resolveTaskCreatorDisplay(
@@ -80,6 +82,7 @@ function resolveTaskCreatorDisplay(
       return {
         name: orchestrator.name ?? "Assistant",
         image: null,
+        avatarSeed: orchestrator.avatarSeed ?? null,
       };
     }
     default: {
@@ -139,6 +142,7 @@ export function TaskMetadata({
             name={creator.name}
             image={creator.image}
             fallback={creator.name}
+            avatarSeed={creator.avatarSeed}
           />
         ) : null}
 
@@ -243,6 +247,7 @@ interface MetadataAvatarValueProps {
   name: string;
   image: string | null;
   fallback: string;
+  avatarSeed?: string | null;
 }
 
 function MetadataAvatarValue({
@@ -250,19 +255,29 @@ function MetadataAvatarValue({
   name,
   image,
   fallback,
+  avatarSeed,
 }: MetadataAvatarValueProps) {
   return (
     <div className="flex items-center justify-between gap-4">
       <span className="text-muted-foreground text-sm">{label}</span>
       <div className="flex min-w-0 items-center gap-2">
-        <Avatar className="size-5">
-          {image ? (
-            <AvatarImage src={image} alt={name} className="object-cover" />
-          ) : null}
-          <AvatarFallback className="bg-muted text-[10px]">
-            {fallback.slice(0, 1).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
+        {avatarSeed !== undefined ? (
+          <AssistantOrb
+            seed={avatarSeed}
+            size={20}
+            className="size-5 shrink-0"
+            alt={name}
+          />
+        ) : (
+          <Avatar className="size-5">
+            {image ? (
+              <AvatarImage src={image} alt={name} className="object-cover" />
+            ) : null}
+            <AvatarFallback className="bg-muted text-[10px]">
+              {fallback.slice(0, 1).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+        )}
         <span className="truncate text-right text-sm font-medium">{name}</span>
       </div>
     </div>

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-activity-actors.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-activity-actors.test.ts
@@ -18,6 +18,7 @@ describe("resolveTaskEventActorKind", () => {
         orchestrator: {
           id: "orch-1",
           name: "Hermes",
+          avatarSeed: "orb:jewel-sky:user_123",
         },
       },
       userId: "user-1",
@@ -85,6 +86,7 @@ describe("getEventActorInfo", () => {
         orchestrator: {
           id: "orch-1",
           name: "Hermes",
+          avatarSeed: "orb:jewel-sky:user_123",
         },
       },
     } as TaskEvent;
@@ -92,6 +94,7 @@ describe("getEventActorInfo", () => {
     expect(getEventActorInfo(event)).toEqual({
       name: "Hermes",
       image: null,
+      avatarSeed: "orb:jewel-sky:user_123",
     });
   });
 });
@@ -117,6 +120,7 @@ describe("buildTaskActivityActors", () => {
         orchestrator: {
           id: "orch-1",
           name: "Hermes",
+          avatarSeed: "orb:jewel-sky:user_123",
         },
       },
       events: [
@@ -197,6 +201,7 @@ describe("buildTaskActivityActors", () => {
             orchestrator: {
               id: "orch-2",
               name: "Athena",
+              avatarSeed: null,
             },
           },
           userId: null,
@@ -207,6 +212,7 @@ describe("buildTaskActivityActors", () => {
           orchestrator: {
             id: "orch-2",
             name: "Athena",
+            avatarSeed: null,
           },
           transactionId: null,
           credits: null,
@@ -245,10 +251,12 @@ describe("buildTaskActivityActors", () => {
       "orch-1": {
         name: "Hermes",
         image: null,
+        avatarSeed: "orb:jewel-sky:user_123",
       },
       "orch-2": {
         name: "Athena",
         image: null,
+        avatarSeed: null,
       },
     });
   });

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-activity-actors.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-activity-actors.test.ts
@@ -78,7 +78,7 @@ describe("getEventActorInfo", () => {
     });
   });
 
-  it("reads name and image from nested orchestrator actor", () => {
+  it("reads name, owner, and avatarSeed from nested orchestrator actor", () => {
     const event = {
       actor: {
         type: "orchestrator",
@@ -87,6 +87,11 @@ describe("getEventActorInfo", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          owner: {
+            id: "user-1",
+            name: "Ada Lovelace",
+            image: null,
+          },
         },
       },
     } as TaskEvent;
@@ -95,6 +100,7 @@ describe("getEventActorInfo", () => {
       name: "Hermes",
       image: null,
       avatarSeed: "orb:jewel-sky:user_123",
+      ownerName: "Ada Lovelace",
     });
   });
 });
@@ -121,6 +127,11 @@ describe("buildTaskActivityActors", () => {
           id: "orch-1",
           name: "Hermes",
           avatarSeed: "orb:jewel-sky:user_123",
+          owner: {
+            id: "user-1",
+            name: "Ada Lovelace",
+            image: null,
+          },
         },
       },
       events: [
@@ -202,6 +213,11 @@ describe("buildTaskActivityActors", () => {
               id: "orch-2",
               name: "Athena",
               avatarSeed: null,
+              owner: {
+                id: "user-3",
+                name: "Grace Hopper",
+                image: null,
+              },
             },
           },
           userId: null,
@@ -213,6 +229,11 @@ describe("buildTaskActivityActors", () => {
             id: "orch-2",
             name: "Athena",
             avatarSeed: null,
+            owner: {
+              id: "user-3",
+              name: "Grace Hopper",
+              image: null,
+            },
           },
           transactionId: null,
           credits: null,
@@ -252,11 +273,13 @@ describe("buildTaskActivityActors", () => {
         name: "Hermes",
         image: null,
         avatarSeed: "orb:jewel-sky:user_123",
+        ownerName: "Ada Lovelace",
       },
       "orch-2": {
         name: "Athena",
         image: null,
         avatarSeed: null,
+        ownerName: "Grace Hopper",
       },
     });
   });

--- a/apps/web/src/app/(app)/tasks/utils/task-activity-actors.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-activity-actors.ts
@@ -8,6 +8,8 @@ export interface TaskActivityActorInfo {
   name: string;
   image: string | null;
   avatarSeed?: string | null;
+  /** Present for orchestrator actors — format with i18n at render. */
+  ownerName?: string;
 }
 
 export interface TaskActivityActors {
@@ -22,6 +24,17 @@ type TaskActivityActorSource = Pick<
   Task,
   "owner" | "assignee" | "creator" | "events"
 >;
+
+type OrchestratorActorSummary = {
+  id: string;
+  name: string | null;
+  avatarSeed?: string | null;
+  owner: {
+    id: string;
+    name: string;
+    image?: string | null;
+  };
+};
 
 /**
  * Prefer nested `actor`. Fall back to deprecated flat FKs for older payloads.
@@ -75,11 +88,7 @@ export function getEventActorInfo(
         };
       }
       case "orchestrator":
-        return {
-          name: event.actor.orchestrator.name ?? "Assistant",
-          image: null,
-          avatarSeed: event.actor.orchestrator.avatarSeed ?? null,
-        };
+        return orchestratorActorInfo(event.actor.orchestrator);
       default: {
         const _exhaustive: never = event.actor;
         return _exhaustive;
@@ -91,11 +100,7 @@ export function getEventActorInfo(
   // Prefer order matches Core: orchestrator → coworker → user.
   if (event.orchestratorId) {
     if (event.orchestrator) {
-      return {
-        name: event.orchestrator.name ?? "Assistant",
-        image: null,
-        avatarSeed: event.orchestrator.avatarSeed ?? null,
-      };
+      return orchestratorActorInfo(event.orchestrator);
     }
 
     return orchestratorById?.[event.orchestratorId];
@@ -206,6 +211,17 @@ export function buildTaskActivityActors(
   };
 }
 
+function orchestratorActorInfo(
+  orchestrator: OrchestratorActorSummary,
+): TaskActivityActorInfo {
+  return {
+    name: orchestrator.name ?? "Assistant",
+    image: null,
+    avatarSeed: orchestrator.avatarSeed ?? null,
+    ownerName: orchestrator.owner.name,
+  };
+}
+
 function addUserActor(
   userById: Record<string, TaskActivityActorInfo>,
   user: {
@@ -237,15 +253,7 @@ function addCoworkerActor(
 
 function addOrchestratorActor(
   orchestratorById: Record<string, TaskActivityActorInfo>,
-  orchestrator: {
-    id: string;
-    name: string | null;
-    avatarSeed?: string | null;
-  },
+  orchestrator: OrchestratorActorSummary,
 ) {
-  orchestratorById[orchestrator.id] = {
-    name: orchestrator.name ?? "Assistant",
-    image: null,
-    avatarSeed: orchestrator.avatarSeed ?? null,
-  };
+  orchestratorById[orchestrator.id] = orchestratorActorInfo(orchestrator);
 }

--- a/apps/web/src/app/(app)/tasks/utils/task-activity-actors.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-activity-actors.ts
@@ -7,6 +7,7 @@ import { getCoworkerImage } from "./coworker-image";
 export interface TaskActivityActorInfo {
   name: string;
   image: string | null;
+  avatarSeed?: string | null;
 }
 
 export interface TaskActivityActors {
@@ -77,6 +78,7 @@ export function getEventActorInfo(
         return {
           name: event.actor.orchestrator.name ?? "Assistant",
           image: null,
+          avatarSeed: event.actor.orchestrator.avatarSeed ?? null,
         };
       default: {
         const _exhaustive: never = event.actor;
@@ -92,6 +94,7 @@ export function getEventActorInfo(
       return {
         name: event.orchestrator.name ?? "Assistant",
         image: null,
+        avatarSeed: event.orchestrator.avatarSeed ?? null,
       };
     }
 
@@ -237,10 +240,12 @@ function addOrchestratorActor(
   orchestrator: {
     id: string;
     name: string | null;
+    avatarSeed?: string | null;
   },
 ) {
   orchestratorById[orchestrator.id] = {
     name: orchestrator.name ?? "Assistant",
     image: null,
+    avatarSeed: orchestrator.avatarSeed ?? null,
   };
 }

--- a/apps/web/src/components/aurora-orb.tsx
+++ b/apps/web/src/components/aurora-orb.tsx
@@ -164,16 +164,21 @@ interface PlaceholderOrbProps {
    * Fire a one-shot transient expression — bump `nonce` to trigger.
    */
   event?: OrbEvent | null;
+  /**
+   * Live rAF loop. Default true (hero / pre-setup). Pass false for lists —
+   * draws a single static frame.
+   */
+  animate?: boolean;
 }
 
 /**
- * The pre-setup "placeholder" orb — a heavily-animated, seedless mother-of-pearl
- * sphere whose full-spectrum iridescence sweeps continuously (it never settles
- * on a colour). Shown wherever the assistant's avatar appears before the user
- * picks their committed orb (sidebar nav, landing hero); once they pick, the
- * surface swaps to their chosen `AuroraOrb`.
+ * The pre-setup "placeholder" orb — a seedless mother-of-pearl sphere.
+ * Shown wherever the assistant's avatar appears before the user picks their
+ * committed orb (sidebar nav, landing hero); once they pick, the surface
+ * swaps to their chosen `AuroraOrb`.
  *
- * Always a live `<canvas>` + one rAF loop. Display size comes from `className`.
+ * Default is a live `<canvas>` + rAF loop. Pass `animate={false}` for lists.
+ * Display size comes from `className`.
  */
 export function PlaceholderOrb({
   size = 64,
@@ -182,6 +187,7 @@ export function PlaceholderOrb({
   alt = "",
   expression = null,
   event = null,
+  animate = true,
 }: PlaceholderOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const handleRef = useRef<MountHandle | null>(null);
@@ -194,7 +200,7 @@ export function PlaceholderOrb({
     if (!canvas) return;
     const handle = mount(canvas, {
       placeholder: true,
-      animate: true,
+      animate,
       speed: speedRef.current,
       size,
       expression: expressionRef.current,
@@ -204,7 +210,7 @@ export function PlaceholderOrb({
       handle.stop();
       handleRef.current = null;
     };
-  }, [size]);
+  }, [size, animate]);
   useEffect(() => {
     handleRef.current?.setExpression(expression ?? null);
   }, [expression]);
@@ -242,13 +248,19 @@ interface AssistantOrbProps {
   speed?: number;
   className?: string;
   alt?: string;
+  /**
+   * Live rAF loop. Default true (PA hero / nav). Pass false for list rows —
+   * static PNG when seeded, single-frame placeholder when not.
+   */
+  animate?: boolean;
 }
 
 /**
  * The assistant's avatar at any point in its lifecycle: the white
  * `PlaceholderOrb` when no colour has been committed (`seed === null`),
- * otherwise the chosen `AuroraOrb`. Always animated. One component so every
- * surface (setup, provisioning, progress) renders the same identity + eyes.
+ * otherwise the chosen `AuroraOrb`. One component so every surface renders
+ * the same identity + eyes. Defaults to animated; pass `animate={false}` for
+ * lists and other repeated small avatars.
  */
 export function AssistantOrb({
   seed,
@@ -258,6 +270,7 @@ export function AssistantOrb({
   speed = 1.2,
   className,
   alt = "",
+  animate = true,
 }: AssistantOrbProps) {
   if (seed === null) {
     return (
@@ -268,13 +281,14 @@ export function AssistantOrb({
         event={event}
         className={className}
         alt={alt}
+        animate={animate}
       />
     );
   }
   return (
     <AuroraOrb
       seed={seed}
-      animate
+      animate={animate}
       size={size}
       speed={speed}
       expression={expression}

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -2201,12 +2201,16 @@ export const OrchestratorSummarySchema = {
                 'null'
             ],
             example: 'orb:jewel-sky:user_123'
+        },
+        owner: {
+            $ref: '#/components/schemas/UserSummary'
         }
     },
     required: [
         'id',
         'name',
-        'avatarSeed'
+        'avatarSeed',
+        'owner'
     ]
 } as const;
 
@@ -2349,12 +2353,16 @@ export const TaskEventSchema = {
                         'null'
                     ],
                     example: 'orb:jewel-sky:user_123'
+                },
+                owner: {
+                    $ref: '#/components/schemas/UserSummary'
                 }
             },
             required: [
                 'id',
                 'name',
-                'avatarSeed'
+                'avatarSeed',
+                'owner'
             ],
             deprecated: true,
             description: 'Deprecated. Prefer actor. Emitted only when the preferred actor is orchestrator (prefer order: orchestrator → coworker → user). Legacy multi-FK rows may still set other actor FKs without this summary.'

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -2194,11 +2194,19 @@ export const OrchestratorSummarySchema = {
                 'null'
             ],
             example: 'Atlas'
+        },
+        avatarSeed: {
+            type: [
+                'string',
+                'null'
+            ],
+            example: 'orb:jewel-sky:user_123'
         }
     },
     required: [
         'id',
-        'name'
+        'name',
+        'avatarSeed'
     ]
 } as const;
 
@@ -2334,11 +2342,19 @@ export const TaskEventSchema = {
                         'null'
                     ],
                     example: 'Atlas'
+                },
+                avatarSeed: {
+                    type: [
+                        'string',
+                        'null'
+                    ],
+                    example: 'orb:jewel-sky:user_123'
                 }
             },
             required: [
                 'id',
-                'name'
+                'name',
+                'avatarSeed'
             ],
             deprecated: true,
             description: 'Deprecated. Prefer actor. Emitted only when the preferred actor is orchestrator (prefer order: orchestrator → coworker → user). Legacy multi-FK rows may still set other actor FKs without this summary.'

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -570,6 +570,7 @@ export type OrchestratorSummary = {
     id: string;
     name: string | null;
     avatarSeed: string | null;
+    owner: UserSummary;
 };
 
 export type TaskEvent = {
@@ -626,6 +627,7 @@ export type TaskEvent = {
         id: string;
         name: string | null;
         avatarSeed: string | null;
+        owner: UserSummary;
     } | null;
     transactionId?: string | null;
     credits?: number | null;

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -569,6 +569,7 @@ export type TaskCreatorOrchestrator = {
 export type OrchestratorSummary = {
     id: string;
     name: string | null;
+    avatarSeed: string | null;
 };
 
 export type TaskEvent = {
@@ -624,6 +625,7 @@ export type TaskEvent = {
     orchestrator?: {
         id: string;
         name: string | null;
+        avatarSeed: string | null;
     } | null;
     transactionId?: string | null;
     credits?: number | null;
@@ -3297,12 +3299,12 @@ export type WorkspaceOrganization = {
 export type OrganizationSlug = string;
 
 /**
- * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+ * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
  */
 export type ContextUserId = string;
 
 /**
- * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+ * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
  */
 export type ContextOrganizationId = string;
 
@@ -5502,11 +5504,11 @@ export type GetAgentsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -5585,11 +5587,11 @@ export type GetAgentsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -5657,11 +5659,11 @@ export type GetAgentsByIdReviewsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -5738,11 +5740,11 @@ export type GetAgentsByIdReviewsMeData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -5810,11 +5812,11 @@ export type GetAgentsByIdRatingsEligibilityData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -5882,11 +5884,11 @@ export type PostAgentsByIdRatingsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -5982,11 +5984,11 @@ export type GetAgentsByIdInputSchemaData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -7003,11 +7005,11 @@ export type GetAgentsByIdJobsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8062,11 +8064,11 @@ export type PostAgentsByIdJobsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8204,11 +8206,11 @@ export type GetCategoriesData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8260,11 +8262,11 @@ export type GetChatData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8481,11 +8483,11 @@ export type PostChatData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8628,11 +8630,11 @@ export type GetChatStreamByConversationIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8901,11 +8903,11 @@ export type GetConversationsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -8985,11 +8987,11 @@ export type PostConversationsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -9083,11 +9085,11 @@ export type GetConversationsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -9186,11 +9188,11 @@ export type PatchConversationsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -9289,11 +9291,11 @@ export type GetConversationsByIdWarmupData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -9392,11 +9394,11 @@ export type PatchConversationsByIdArchiveData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -9495,11 +9497,11 @@ export type GetConversationsByIdMessagesData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -9607,11 +9609,11 @@ export type PostConversationsByIdMessagesData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -10854,11 +10856,11 @@ export type PostHermesChatData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -10977,11 +10979,11 @@ export type DeleteHermesMeInstanceData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11061,11 +11063,11 @@ export type GetHermesMeInstanceData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11145,11 +11147,11 @@ export type PatchHermesMeInstanceData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11257,11 +11259,11 @@ export type PostHermesMeInstanceData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11355,11 +11357,11 @@ export type GetHermesMeMessagesData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11434,11 +11436,11 @@ export type GetHermesMeUnreadCountData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11504,11 +11506,11 @@ export type PostHermesMeInboxSeenData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11588,11 +11590,11 @@ export type PostHermesMeSecretsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11700,11 +11702,11 @@ export type PostHermesMeInstanceOnboardData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11798,11 +11800,11 @@ export type GetHermesMeInstanceOnboardingProgressData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11882,11 +11884,11 @@ export type GetHermesMeInstanceIntegrationsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -11966,11 +11968,11 @@ export type GetHermesMeInstanceSchedulesData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12050,11 +12052,11 @@ export type PatchHermesMeInstanceSchedulesByScheduleIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12164,11 +12166,11 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdApproveData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12264,11 +12266,11 @@ export type PostHermesMeInstanceConfirmationsByConfirmationIdRejectData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12364,11 +12366,11 @@ export type DeleteHermesMeInstanceIntegrationsByProviderData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12450,11 +12452,11 @@ export type PostHermesMeInstanceIntegrationsInitiateData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12548,11 +12550,11 @@ export type PostHermesMeInstanceIntegrationsFinalizeData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12646,11 +12648,11 @@ export type GetHermesMeInstanceSkillsCatalogData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12720,11 +12722,11 @@ export type GetHermesMeInstanceSkillsCatalogSearchData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12793,11 +12795,11 @@ export type GetHermesMeInstanceSkillsCatalogCuratedData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12863,11 +12865,11 @@ export type GetHermesMeInstanceSkillsCatalogDetailData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -12950,11 +12952,11 @@ export type GetHermesMeInstanceSkillsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -13020,11 +13022,11 @@ export type PostHermesMeInstanceSkillsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -13146,11 +13148,11 @@ export type GetHermesMeInstanceSkillsPreinstalledData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -13216,11 +13218,11 @@ export type DeleteHermesMeInstanceSkillsBySlugData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -13316,11 +13318,11 @@ export type GetHistoryData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -13527,11 +13529,11 @@ export type GetUsersByIdCreditsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -15920,11 +15922,11 @@ export type GetUsersByIdStripeCustomerData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -16023,11 +16025,11 @@ export type PostUsersByIdStripeCustomerData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -16126,11 +16128,11 @@ export type GetUsersByIdBillingDetailsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -16229,11 +16231,11 @@ export type GetUsersByIdSubscriptionData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18351,11 +18353,11 @@ export type GetProjectsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18444,11 +18446,11 @@ export type PostProjectsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18514,11 +18516,11 @@ export type GetProjectsStatsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18603,11 +18605,11 @@ export type PostProjectsByIdJobsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18703,11 +18705,11 @@ export type DeleteProjectsByIdJobsByJobIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18790,11 +18792,11 @@ export type PostProjectsByIdTasksData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18890,11 +18892,11 @@ export type DeleteProjectsByIdTasksByTaskIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -18977,11 +18979,11 @@ export type DeleteProjectsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19063,11 +19065,11 @@ export type GetProjectsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19149,11 +19151,11 @@ export type PatchProjectsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19249,11 +19251,11 @@ export type GetJobsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19358,11 +19360,11 @@ export type GetJobsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19460,11 +19462,11 @@ export type PatchJobsByIdData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19574,11 +19576,11 @@ export type PostJobsByIdRefundData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19688,11 +19690,11 @@ export type GetJobsByIdFilesData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19788,11 +19790,11 @@ export type GetJobsByIdLinksData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -19888,11 +19890,11 @@ export type GetJobsByIdInputRequestData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20003,11 +20005,11 @@ export type PostJobsByIdInputsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20145,11 +20147,11 @@ export type GetJobsByIdEventsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20245,11 +20247,11 @@ export type DeleteJobsByIdShareData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20335,11 +20337,11 @@ export type PutJobsByIdShareData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20423,11 +20425,11 @@ export type PutJobsByIdWorkspaceData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20537,11 +20539,11 @@ export type GetNotificationsData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20638,11 +20640,11 @@ export type GetNotificationsUnreadCountData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20708,11 +20710,11 @@ export type PatchNotificationsByIdReadData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -20811,11 +20813,11 @@ export type PatchNotificationsReadAllData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -22416,6 +22418,34 @@ export type PostOrchestratorsMePurgeErrors = {
             method: string;
         };
     };
+    /**
+     * Internal Server Error
+     */
+    500: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
+     * Service Unavailable
+     */
+    503: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
 };
 
 export type PostOrchestratorsMePurgeError = PostOrchestratorsMePurgeErrors[keyof PostOrchestratorsMePurgeErrors];
@@ -22444,11 +22474,11 @@ export type GetTasksData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };
@@ -22581,11 +22611,11 @@ export type PostTasksData = {
          */
         'X-Organization-Slug'?: string;
         /**
-         * Optional workspace user id when authenticating as a coworker or orchestrator API key. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
+         * Optional workspace user id when authenticating as a coworker or orchestrator service token. Selects which user workspace the request runs in for user-scoped operations. Must be set if X-Context-Organization-Id is present.
          */
         'X-Context-User-Id'?: string;
         /**
-         * Optional workspace organization id when authenticating as a coworker or orchestrator API key. Requires X-Context-User-Id; the user must be a member of this organization.
+         * Optional workspace organization id when authenticating as a coworker or orchestrator service token. Requires X-Context-User-Id; the user must be a member of this organization.
          */
         'X-Context-Organization-Id'?: string;
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Orchestrator-authored task comments and matching creator display show the personal assistant **name + owner name** with the aurora orb from `avatarSeed`, matching Personal Assistant identity.

- Extend `OrchestratorSummary` with nullable `avatarSeed` and nested `owner` (`UserSummary`) via Orchestrator → User join (no `TaskEvent.userId` dual FK)
- Regenerate web Core client
- Task activity + creator metadata render `AssistantOrb` and i18n label `{assistant} · {owner}`
- No new orchestrator-by-id API; public share redesign out of scope

## Verification

- `pnpm --filter core check` / `pnpm core:test` — pass
- `pnpm web:check` / targeted web task tests — pass
- Pre-commit `pnpm check` + `pnpm typecheck` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-644](https://linear.app/masumi/issue/SOK-644/show-personal-assistant-name-and-orb-on-task-comments)

<div><a href="https://cursor.com/agents/bc-d8d37217-81e4-479b-a38c-9b37bf73a104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8d37217-81e4-479b-a38c-9b37bf73a104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

