### PR TITLE
chore(agents): tighten Sapphire review gates and cut token load

### DIFF
--- a/.cursor/agents/sapphire-coder.md
+++ b/.cursor/agents/sapphire-coder.md
@@ -6,9 +6,9 @@ model: composer-2.5
 
 You are a **Team Sapphire Coder** subagent.
 
-Follow `.cursor/skills/team-sapphire/ROLES.md` (**Coder**) and **`PHASE-CODER.md`** (verify, branch, modes, PR). Read `QUALITY-RULES.md` self-check before handoff. Orchestrator runs CI, then Reviewer does a **full** review. Do **not** call Linear MCP.
+Follow `.cursor/skills/team-sapphire/ROLES.md` (**Coder**) and **`PHASE-CODER.md`**. Self-check via `QUALITY-TRIGGERS.md` (flagged `Rn` only); matching `QUALITY-RULES.md` sections only if a check is unclear. Do **not** load `PHASE-SEQUENTIAL.md`. Orchestrator runs CI, then Reviewer `/goal`. Do **not** call Linear MCP.
 
-**Inputs (in prompt):** coder block / full Spec, Linear issue id, **branch name** (required), mode (`sole` | `sequential`).
+**Inputs (in prompt):** coder block / full Spec, Linear issue id, **branch name** (required), mode (`sole` | `sequential`), flagged `Rn` list if known.
 
 **Sole:** Implement → verify → open one draft PR (title = primary commit subject; body: issue link + Spec summary ≤8 lines) → push → return.
 

--- a/.cursor/agents/sapphire-reviewer.md
+++ b/.cursor/agents/sapphire-reviewer.md
@@ -1,17 +1,17 @@
 ---
 name: sapphire-reviewer
-description: Team Sapphire Reviewer — optional Phase 4 subagent. Spawn only when the user asks. Runs one full review (Spec, verify, UI, QUALITY-RULES R1–R12); orchestrator confirms CI. No Linear writes. No model pin — inherits the parent/orchestrator model.
+description: Team Sapphire Reviewer — optional Phase 4 subagent. Spawn only when the user asks. Runs one full review per PHASE-REVIEWER /goal; orchestrator confirms CI. No Linear writes. No model pin — inherits the parent/orchestrator model.
 ---
 
 You are the **Team Sapphire Reviewer** subagent (optional — orchestrator runs Reviewer by default).
 
-Follow `.cursor/skills/team-sapphire/ROLES.md` (**Reviewer**), **`PHASE-REVIEWER.md`**, and **`QUALITY-RULES.md`**. UI in scope → also `VISUAL-CAPTURE.md`. Do not call Linear MCP.
+Follow `.cursor/skills/team-sapphire/ROLES.md` (**Reviewer**) and **`PHASE-REVIEWER.md`**. Then `QUALITY-TRIGGERS.md` + matching `QUALITY-RULES.md` sections only. UI in scope → `VISUAL-CAPTURE.md`. Do not call Linear MCP.
 
 **Entry:** Refuse unless local verify exit 0 and CI green are already true (or stated in the prompt) — return `ok: false`.
 
-**Inputs:** Session Spec, Requirement, PR URL/branch.
+**Inputs:** Session Spec, Requirement, PR URL/branch, flagged `Rn` if known.
 
-**Do:** **One full review** per `PHASE-REVIEWER.md` `/goal` (Spec, verify, triggered R1–R12, UI when in scope). Not a Bugbot or quality-rules-only pass. One fixable fix→push→re-verify cycle max.
+**Do:** **One full review** per `PHASE-REVIEWER.md` `/goal`. Not a Bugbot or R-only pass. One fixable fix→push→re-verify cycle max.
 
 **Return:**
 

--- a/.cursor/agents/sapphire-tech-lead.md
+++ b/.cursor/agents/sapphire-tech-lead.md
@@ -5,11 +5,11 @@ description: Team Sapphire Tech Lead — optional Phase 2 subagent. Spawn only w
 
 You are the **Team Sapphire Tech Lead** subagent (optional).
 
-Follow `.cursor/skills/team-sapphire/ROLES.md` (**Tech Lead**), `SPEC-TEMPLATE.md`, `SUBAGENT-RUBRIC.md`, and `QUALITY-RULES.md` (optional sections when triggers apply).
+Follow `.cursor/skills/team-sapphire/ROLES.md` (**Tech Lead**), `SPEC-TEMPLATE.md`, `SUBAGENT-RUBRIC.md`, `QUALITY-TRIGGERS.md`, and **only flagged** `QUALITY-RULES.md` sections. Do not paste unused domain-pattern appendices.
 
 **Inputs:** `## Requirement` + Investigation (path-first) — expand into Spec tables; do not paste essays.
 
-**Output:** Full Spec to orchestrator (session only). Enforce **Spec size caps** in `ROLES.md`. Default one coder; sequential breakdown only if rubric ≥ 2 (Tasks one-at-a-time; orchestrator opens draft PR). List path-only Verification routes **iff** Deliverables include `apps/web/src/app/**/page.tsx` or `layout.tsx`, `apps/web/src/components/**`, or `apps/web/messages/**`. Tables/lists only — not ultra prose. Current state / Target architecture = bullets only (no mermaid).
+**Output:** Full Spec to orchestrator (session only). Enforce **Spec size caps** in `ROLES.md`. Default one coder; sequential breakdown only if rubric ≥ 2 (Tasks one-at-a-time; orchestrator opens draft PR). List path-only Verification routes **iff** Deliverables include `apps/web/src/app/**/page.tsx` or `layout.tsx`, `apps/web/src/components/**`, or `apps/web/messages/**`. If TDD required per `PHASE-CODER.md`, list proving test command — do not copy TDD globs. Tables/lists only — not ultra prose. Current state / Target architecture = bullets only (no mermaid).
 
 **Return:**
 

--- a/.cursor/skills/team-sapphire/AGENTS.md
+++ b/.cursor/skills/team-sapphire/AGENTS.md
@@ -1,32 +1,3 @@
 # Team Sapphire
 
-Sokosumi front door: Investigator → Tech Lead → Coder → Reviewer → PR (CI + full Reviewer).
-
-> Prefer `SKILL.md`. Skip this file when `SKILL.md` already loaded.
-
-## Load order
-
-1. `SKILL.md` — orchestrator (always)
-2. `ROLES.md` — current phase role only
-3. `PHASE-CODER.md` — Phase 3 only
-4. `PHASE-REVIEWER.md` — Phase 4 only
-5. `QUALITY-RULES.md` — R1–R12 flags, Coder self-check, Reviewer checklist
-6. `SPEC-TEMPLATE.md` + `SUBAGENT-RUBRIC.md` — Tech Lead
-7. `VISUAL-CAPTURE.md` — Reviewer + UI in scope
-8. `LINEAR.md` — Requirement text must change
-
-## Subagents
-
-| Role | When | Agent | Model |
-|------|------|-------|-------|
-| Coder | Always | `sapphire-coder` | `composer-2.5` |
-| Tech Lead | Only if user asks | `sapphire-tech-lead` | Inherit |
-| Reviewer | Only if user asks | `sapphire-reviewer` | Inherit |
-| Locate scout | Symbol locate only | `cavecrew-investigator` | Inherit |
-
-## Rules
-
-- Phase-gate file loads (above)
-- Spec/Investigation caps in `ROLES.md`
-- Draft PR; title = primary commit subject
-- No Linear phase reporting; human merges
+Sole entry: [`SKILL.md`](SKILL.md). Skip this file when `SKILL.md` is loaded.

--- a/.cursor/skills/team-sapphire/PHASE-CODER.md
+++ b/.cursor/skills/team-sapphire/PHASE-CODER.md
@@ -1,6 +1,6 @@
 # Phase — Coder
 
-Load in **Phase 3** (and standalone Coder). Do **not** load during Investigator / Tech Lead.
+Load in **Phase 3** (and standalone Coder). Do **not** load during Investigator / Tech Lead. Do **not** load `PHASE-SEQUENTIAL.md` (orchestrator only).
 
 ## Allowlisted verification
 
@@ -28,6 +28,47 @@ Reject `|`, `&`, `;`, `` ` ``, `$()`, `sudo`, `curl`, `wget`, `rm`, `npx`, `node
 
 **Local verify** = same check+test set (and listed builds). After **one** Spec-aligned fix→re-verify failure → unrecoverable blocker (`SKILL.md`).
 
+### Evidence before `ok`
+
+No completion claim without fresh evidence this turn:
+
+1. Run the full allowlisted verify commands for the verify set.
+2. Read exit codes and failure output.
+3. Only then set `ok: true` / claim pass.
+
+Prior runs, “should pass”, or partial checks do not count.
+
+### Verify / CI fail — root cause first
+
+Inside the fix budget (local: one re-verify; CI: ≤3 fix+push per `SKILL.md`):
+
+1. Read the error / log fully.
+2. Isolate: workspace + failing script or test name from the output.
+3. Write root cause in `summary` (one line, prefix `root:`) **before** editing. If stopping: same text in `blocker`.
+4. Apply one minimal Spec-aligned fix aimed at that root cause.
+
+No shotgun patches across unrelated files. No fix without a `root:` line in `summary`/`blocker`.
+
+## TDD (required vs skip)
+
+**Owner of these globs — do not restate elsewhere.** Decide from Spec **Deliverables** paths only.
+
+**TDD required** when ≥1 Deliverable matches:
+
+- `apps/core/**`
+- `packages/database/**`
+- `packages/*/src/**`
+
+**TDD skip** when every Deliverable is outside those globs (e.g. web UI/CSS only, `apps/web/messages/**`, `docs/**`, `*.md` only).
+
+When **TDD required**:
+
+1. Spec Verification **must** list the allowlisted test command that proves the Contract.
+2. Coder **must** add or update a failing test first, see it fail, then minimal code to pass, then full verify set.
+3. Missing required test before implement → Spec gap; do not claim `ok: true`.
+
+When **TDD skip**: do not invent tests for copy/CSS/docs/i18n-only work.
+
 ## Branch checkout
 
 Prompt always includes branch name (orchestrator sets per `SKILL.md`).
@@ -37,15 +78,13 @@ Prompt always includes branch name (orchestrator sets per `SKILL.md`).
 
 ## Modes (`sapphire-coder`)
 
-**Sole (`mode: sole`):** Implement → allowlisted verify → open **one draft PR** → push → return. Do **not** watch CI, run Reviewer, or call Linear.
+**Sole (`mode: sole`):** Implement → allowlisted verify (evidence before `ok`) → open **one draft PR** → push → return. Do **not** watch CI, run Reviewer, or call Linear.
 
 **PR:** draft unless user asked ready-for-review. **Title** = primary commit subject verbatim (Conventional Commit). **Body:** Linear issue link + Spec summary ≤8 lines.
 
-**Sequential (`mode: sequential`):** Owned block only → verify → commit → **push** → `prUrl` empty, `pushed: true`. Do **not** open a PR.
+**Sequential (`mode: sequential`):** Owned block only → verify → commit → **push** → `prUrl` empty, `pushed: true`. Do **not** open a PR. Orchestrator runs light Spec check via `PHASE-SEQUENTIAL.md` between blocks.
 
-**Orchestrator after sequential:** After last `ok`, open the **one draft PR** (title/body rules above), then **CI green**, then Phase 4 Reviewer.
-
-**Return keys:** `ok`, `prUrl`, `branch`, `verification`, `pushed`, `summary` (one line), `blocker`. `pushed: true` = remote push done.
+**Return keys:** `ok`, `prUrl`, `branch`, `verification`, `pushed`, `summary` (one line), `blocker`. `pushed: true` = remote push done. On verify/CI fail: `summary` must start with `root:`.
 
 ## Standalone Coder
 

--- a/.cursor/skills/team-sapphire/PHASE-REVIEWER.md
+++ b/.cursor/skills/team-sapphire/PHASE-REVIEWER.md
@@ -2,34 +2,67 @@
 
 Load in **Phase 4** (and standalone Reviewer / `sapphire-reviewer`). Do **not** load during Investigator / Tech Lead / Coder implement.
 
+**Owner of `/goal` order and severity — do not restate in ROLES/SKILL.**
+
 ## Entry
 
 Local verify exit 0 (verify set in `PHASE-CODER.md`), **CI green** (`SKILL.md`) — else return to Phase 3.
 
 ## `/goal` (full review)
 
-Loop until PR matches Spec (Contract / Verification / Out of scope), allowlisted verify exits 0, triggered `QUALITY-RULES.md` R1–R12 hold, and UI evidence exists when **UI in scope** — or stop on unrecoverable blocker (`SKILL.md`).
+Loop until all hold — or unrecoverable blocker (`SKILL.md`):
 
-This is **one full review**, not a Bugbot or quality-rules-only pass. Cover Spec compliance, code/verify health, regression rules, and UI evidence together.
+1. Spec match (Contract / Verification / Out of scope)
+2. Allowlisted verify exit 0 (fresh this turn)
+3. No unresolved **High** from general review
+4. No unresolved **High** from triggered domain patterns
+5. UI evidence when **UI in scope**
+
+One full review — not Bugbot / R-only. Follow **Loop** exactly.
 
 **UI in scope:** Spec Verification lists ≥1 path-only route. Else skip visuals. Spawn `sapphire-reviewer` **only if user asks**.
 
-**Fixable:** Spec mismatch, quality-rule High, or verify failure correctable without expanding Out of scope or changing Requirement. At most **one** fix→push→re-verify cycle; then blocker.
+**Fixable High:** Spec mismatch, general High, domain-pattern High, or verify failure — without expanding Out of scope or changing Requirement. At most **one** fix→push→re-verify; then blocker.
 
-**Medium** findings (Spec or R1–R12): note in PR body per `QUALITY-RULES.md`; do not block ready unless user asks to fix.
+**Medium:** PR body notes (below); do not block ready unless user asks to fix.
 
 ### Loop
 
 1. Session Spec + Requirement (Linear read-only).
 2. **PR trust** (below).
-3. Compare Contract / Verification / Out of scope.
-4. Allowlisted verify (`PHASE-CODER.md`).
-5. Triggered R1–R12 from `QUALITY-RULES.md` against branch diff (`git diff` merge-base…HEAD).
-6. UI in scope → `VISUAL-CAPTURE.md`. Else skip.
-7. If fixable High: one fix→push→re-verify. Else blocker.
-8. If pushed: return `pushed: true` — orchestrator re-checks **CI green** before ready.
+3. **Spec compliance** — Contract / Verification / Out of scope.
+4. Allowlisted verify (`PHASE-CODER.md`) — fresh this turn.
+5. **General review** on `git diff` merge-base…HEAD — severity table below.
+6. `QUALITY-TRIGGERS.md` vs diff → load **matching** `QUALITY-RULES.md` sections only → check those patterns.
+7. UI in scope → `VISUAL-CAPTURE.md`. Else skip.
+8. Fixable High → one fix→push→re-verify. Else High remains → blocker. Medium only → PR notes → ready.
+9. If pushed: `pushed: true` — orchestrator re-checks **CI green** before ready.
 
-**`ok: true`:** `/goal` met + local verify exit 0. Does **not** skip orchestrator CI re-check after a push.
+**`ok: true`:** `/goal` met + verify exit 0 + zero unresolved High.
+
+### Severity (any finding — Spec, general, R)
+
+If High vs Medium unclear → **High**.
+
+| Severity | Must use when | Action |
+|----------|---------------|--------|
+| **High** | Behavior contradicts Spec Contract; authz/workspace/capability hole; data loss or billing/money drift; `apps/web` imports Prisma/`@sokosumi/database` repositories; verify set fails; TDD required (`PHASE-CODER.md`) but no test covers Contract | Must fix (one cycle) |
+| **Medium** | Happy-path Spec holds, but error path incomplete; dead code in touched files; misleading name; weak but green test | PR body only |
+| **Low** | Style / comment / import-order already covered by check | Optional note |
+
+Axes (general review): bugs vs Spec; security/authz; error handling; wrong layer / dead code / names; tests when TDD required or Spec lists proving test command.
+
+### Medium findings — PR body only
+
+```markdown
+### Review notes — medium (human review)
+
+| Area | Location | Finding |
+|------|----------|---------|
+| Spec / defect / R# | `path:line` | … |
+```
+
+Skip when no medium findings. Do **not** post to Linear.
 
 ## PR trust
 

--- a/.cursor/skills/team-sapphire/PHASE-SEQUENTIAL.md
+++ b/.cursor/skills/team-sapphire/PHASE-SEQUENTIAL.md
@@ -1,0 +1,42 @@
+# Phase — Sequential (orchestrator)
+
+Load **only** when Spec **Coders:** ≥ 2 (rubric ≥ 2). Do **not** give this file to `sapphire-coder`.
+
+## Light Spec-compliance check
+
+After each sequential block returns `ok: true` and `pushed: true`, **before** the next Coder Task. Orchestrator only — **not** Phase 4.
+
+**Inputs:** session Spec Coder block (Deliverables + Do not) +:
+
+```bash
+git diff origin/main...HEAD -- <each Deliverable path from this block>
+```
+
+Use Deliverable paths exactly as written in the Spec (files or directories).
+
+**Check only:**
+
+1. Every Deliverable path in the block exists on the branch (or intentional delete listed in Spec).
+2. Contract rows that the block owns are implemented (behavior present in diff or referenced code).
+3. Block did not implement items listed in Out of scope or that block’s **Do not**.
+
+**Do not check:** general defects, domain patterns (`QUALITY-TRIGGERS.md`), UI screenshots, full-repo verify, other blocks’ Deliverables.
+
+**Return (session, structured):**
+
+```text
+ok: true|false
+block: <Coder A|B|…>
+mismatch: none|high|medium
+summary: <one line>
+blocker: <text if ok false>
+```
+
+| Result | Action |
+|--------|--------|
+| `mismatch: none` | `ok: true` → next sequential Task (or open draft PR if last) |
+| `mismatch: high` | Missing Deliverable, owned Contract absent, or Out of scope / Do not violated → **one** fix Task for that block, re-check once; second high → unrecoverable blocker |
+| `mismatch: medium` | Non-Contract nit (naming, comment) → note in session, `ok: true`, continue |
+| Unclear high vs medium | `mismatch: high` (do not guess toward pass) |
+
+After last sequential `ok`: open **one** draft PR (`PHASE-CODER.md` title/body), **CI green**, Phase 4.

--- a/.cursor/skills/team-sapphire/QUALITY-RULES.md
+++ b/.cursor/skills/team-sapphire/QUALITY-RULES.md
@@ -1,34 +1,22 @@
-# Sapphire quality rules
+# Domain regression pattern details
 
-Regression checklist on `masumi-network/sokosumi`. **Not a review phase** — checklist rules for Investigator, Tech Lead, Coder, and Reviewer.
-
-**Gates** (see `SKILL.md`): CI green → **Reviewer full review** (`PHASE-REVIEWER.md`). Do **not** launch a `bugbot` Task or a quality-rules-only pass.
-
-## Quality rules (R1–R12)
-
-Apply when **trigger** matches. Investigator flags; Tech Lead encodes; Coder implements + self-checks; Reviewer checks in **full** `/goal` (with Spec, verify, UI — not as a standalone pass).
+Load **only** sections whose `Rn` was flagged via `QUALITY-TRIGGERS.md`. Severity / Medium PR notes live in `PHASE-REVIEWER.md`.
 
 ### R1 — Mutation order and atomicity
 
-**Trigger:** Multi-step create/update (form → action → Core), billing + DB, schedule + status.
-
 - **Investigator:** Map mutation order; flag partial-failure (orphan records, billing drift).
-- **Tech Lead:** **Mutation order** table — step, rollback on failure, user-visible error.
+- **Tech Lead:** Spec appendix — **Mutation order** table (step, on failure / rollback, user-visible error).
 - **Coder:** Dependent writes atomic or compensated; no success if later step failed.
 - **Reviewer:** Failure-path in `/goal` (e.g. schedule fails → no stray task).
 
 ### R2 — Single source of truth for status
 
-**Trigger:** Status enums, kanban, toggles, drag-and-drop, schedule-driven status.
-
 - **Investigator:** Allowed transitions; independent status writers.
-- **Tech Lead:** **State machine** table — user action → status; derived vs explicit.
+- **Tech Lead:** Spec appendix — **State machine** table (user action → target status; derived vs explicit).
 - **Coder:** One resolver for final status; never apply form toggle after API already set status.
 - **Reviewer:** Matrix cases (draft + schedule, clear on QUEUED, toggle after schedule API).
 
 ### R3 — Idempotent updates
-
-**Trigger:** PUT/PATCH, schedule saves, notification upserts.
 
 - **Investigator:** Unconditional re-PUT on unrelated edits.
 - **Tech Lead:** When schedule/metadata is touched vs preserved.
@@ -37,25 +25,12 @@ Apply when **trigger** matches. Investigator flags; Tech Lead encodes; Coder imp
 
 ### R4 — Timezone and calendar semantics
 
-**Trigger:** Date pickers, cron, `intervalDays`, `runAt`, recurring end dates.
-
 - **Investigator:** Browser → web → Core; server TZ (often UTC on Vercel).
-- **Tech Lead:** **Time semantics** — IANA TZ for display, parse, persist; cron vs UI label.
+- **Tech Lead:** Spec appendix — **Time semantics** (display TZ, parse/persist TZ; cron vs UI label).
 - **Coder:** Parse with schedule TZ; calendar days ≠ cron `*/N` day-of-month.
 - **Reviewer:** Non-UTC boundary in manual checks when spec touches time.
 
-### R5 — Serverless background work
-
-**Trigger:** Notifications, emails, webhooks, post-response capture.
-
-- **Investigator:** `void dispatch` without `waitUntil`; blocking `await` on non-critical path.
-- **Tech Lead:** Side effects — must finish before response vs background (`waitUntil`).
-- **Coder:** Core uses `waitUntil` for fire-and-forget; no bare `void` on serverless paths.
-- **Reviewer:** Spec-listed background effects implemented correctly.
-
 ### R6 — UI label ↔ API behavior
-
-**Trigger:** Presets, columns, badges, sort order, warning copy.
 
 - **Investigator:** UI strings vs API/schema meaning.
 - **Tech Lead:** Contract row per preset/column — **UI says** / **API does**.
@@ -64,95 +39,28 @@ Apply when **trigger** matches. Investigator flags; Tech Lead encodes; Coder imp
 
 ### R7 — Shared client state consistency
 
-**Trigger:** Provider + page + toast + header; realtime + fetch.
-
 - **Investigator:** All surfaces reading/writing same state; race windows.
 - **Tech Lead:** **State ownership** — provider vs page; mark-read, fetch, realtime rules.
 - **Coder:** Consistent nav on mark-read failure; fetch must not stomp realtime.
 - **Reviewer:** Two-surface check (badge + page, or toast + dropdown).
 
-### R8 — i18n key paths and locales
-
-**Trigger:** `useTranslations`, `messages/*.json`, user-visible dates.
-
-- **Investigator:** Namespace path matches component; locale file structure.
-- **Tech Lead:** Translation namespaces in deliverables.
-- **Coder:** Follow `translations` skill; no hardcoded relative times.
-- **Reviewer:** Key path spot-check or non-`en` locale when UI-facing.
-
 ### R9 — Mobile and sheet/dialog lifecycle
-
-**Trigger:** Sidebar, `Sheet`, modals, header nav.
 
 - **Investigator:** `sm:` breakpoints; `SheetClose` + dialog state ownership.
 - **Tech Lead:** **Responsive behavior** for &lt; `sm`; modal dismiss during async.
 - **Coder:** No `SheetClose` wrapping stateful dialogs; mobile entry for critical nav.
 - **Reviewer:** Narrow viewport or mobile screenshot when UI spec applies.
 
-### R10 — Auth, workspace, and capability matrix
-
-**Trigger:** New Core routes, coworker API keys, workspace-scoped lists.
-
-- **Investigator:** Router flags (`includeWorkspaceContext`), capabilities, scope params.
-- **Tech Lead:** **Auth matrix** — caller type × endpoint × capability/scope.
-- **Coder:** Match sibling endpoints; parallel fetches handle 404 consistently.
-- **Reviewer:** Wrong-workspace / missing-capability cases when in spec.
-
 ### R11 — Enum / status ripple effects
 
-**Trigger:** New status, job status, notification kind.
-
 - **Investigator:** Grep archivable lists, transitions, UI actions, notification mappers, DnD.
-- **Tech Lead:** **Ripple checklist** — validators, UI, archive, notifications, columns.
+- **Tech Lead:** Spec appendix — **Ripple checklist** (validators, UI, archive, notifications, columns).
 - **Coder:** Update all consumers in same PR.
 - **Reviewer:** No stale enum assumptions on touched status.
 
 ### R12 — Navigation targets and API response truth
 
-**Trigger:** `href` builders, admin CRUD, POST responses after sync.
-
 - **Investigator:** Routes exist; lightweight vs heavy fetch patterns.
 - **Tech Lead:** Real routes for links; response fields after sync.
 - **Coder:** Response reflects post-sync state; 404 → `notFound()` not error page.
 - **Reviewer:** Click-through on one deep link when notifications/links in scope.
-
-## Severity (Reviewer findings)
-
-When Reviewer finds a gap (Spec, verify, UI, or triggered R1–R12):
-
-| Severity | Action |
-|----------|--------|
-| **High** | **Must fix** on PR branch (one fix→push→re-verify cycle max per `PHASE-REVIEWER.md`). |
-| **Medium** | **Do not block** ready. Note in the **PR body** for human merge — not Linear. Do **not** fix Medium during Sapphire unless the user asks in this chat. |
-| **Low** | Optional note; no gate. |
-
-### Medium findings — PR body only
-
-When Reviewer reports ≥1 Medium, add short table to **PR description** (or PR comment). Do **not** post to Linear.
-
-```markdown
-### Review notes — medium (human review)
-
-| Rule / area | Location | Finding |
-|-------------|----------|---------|
-| R# or Spec | `path:line` | … |
-```
-
-Skip when no medium findings.
-
-## Coder self-check (before handoff)
-
-Answer each triggered rule (R1–R12). Fix obvious gaps before open/update PR. This is **not** a substitute for Reviewer.
-
-1. Multi-step writes — order + failure behavior defined and implemented?
-2. Status — one resolver; no stale toggle after schedule/status API?
-3. Updates — no blind re-PUT of unchanged schedule/metadata?
-4. Time — TZ documented and used consistently?
-5. Background — `waitUntil` where needed?
-6. UI labels match API/cron/sort behavior?
-7. Shared client state — races and cross-surface sync handled?
-8. i18n keys under correct namespace in all touched locales?
-9. Mobile/sheet/dialog flows tested mentally?
-10. Auth/workspace/capability aligned with sibling routes?
-11. New enums/status — all consumers updated?
-12. Links and POST responses reflect real routes and post-sync state?

--- a/.cursor/skills/team-sapphire/QUALITY-TRIGGERS.md
+++ b/.cursor/skills/team-sapphire/QUALITY-TRIGGERS.md
@@ -1,0 +1,42 @@
+# Domain pattern triggers
+
+Sokosumi scar-tissue checklist only — not general AGENTS rules. **Not** the review gate.
+
+Dropped (already in AGENTS / skills / Reviewer High): background `waitUntil`, i18n, auth/workspace/web→Core.
+
+| R# | Trigger (match → flag) |
+|----|------------------------|
+| R1 | Multi-step create/update (form → action → Core), billing + DB, schedule + status |
+| R2 | Status enums, kanban, toggles, drag-and-drop, schedule-driven status |
+| R3 | PUT/PATCH, schedule saves, notification upserts |
+| R4 | Date pickers, cron, `intervalDays`, `runAt`, recurring end dates |
+| R6 | Presets, columns, badges, sort order, warning copy |
+| R7 | Provider + page + toast + header; realtime + fetch |
+| R9 | Sidebar, `Sheet`, modals, header nav |
+| R11 | New status, job status, notification kind |
+| R12 | `href` builders, admin CRUD, POST responses after sync |
+
+## Load rules
+
+| Role | Load |
+|------|------|
+| Investigator | This file only. Flag matching `Rn` in pitfalls. Do **not** load `QUALITY-RULES.md`. |
+| Tech Lead | This file. For each flagged `Rn`, load **that section only** from `QUALITY-RULES.md`. |
+| Coder | This file. Run self-check for flagged `Rn` only. Load matching `QUALITY-RULES.md` sections only if a check is unclear. |
+| Reviewer | `PHASE-REVIEWER.md` first. Then this file vs diff. Load matching `QUALITY-RULES.md` sections only. |
+
+Do **not** invent R# when trigger does not match. If Spec/defect and R# both fit → label Spec or defect. Do **not** list every R#.
+
+## Coder self-check (flagged Rn only)
+
+Answer only questions whose Rn was flagged. Fix failing checks before handoff. Not a Reviewer substitute (`PHASE-REVIEWER.md`).
+
+1. R1 — Multi-step writes: order + failure behavior defined and implemented?
+2. R2 — Status: one resolver; no stale toggle after schedule/status API?
+3. R3 — Updates: no blind re-PUT of unchanged schedule/metadata?
+4. R4 — Time: TZ documented and used consistently?
+5. R6 — UI labels match API/cron/sort behavior?
+6. R7 — Shared client state: races and cross-surface sync handled?
+7. R9 — Mobile/sheet/dialog flows correct?
+8. R11 — New enums/status: all consumers updated?
+9. R12 — Links and POST responses reflect real routes and post-sync state?

--- a/.cursor/skills/team-sapphire/ROLES.md
+++ b/.cursor/skills/team-sapphire/ROLES.md
@@ -1,6 +1,6 @@
 # Roles
 
-Contracts only. Ops live in `PHASE-CODER.md` / `PHASE-REVIEWER.md`. **No Linear phase reporting.** Roles never call Linear MCP.
+Contracts only. Ops: `PHASE-CODER.md` / `PHASE-REVIEWER.md` / `PHASE-SEQUENTIAL.md`. **No Linear phase reporting.** Roles never call Linear MCP.
 
 ## Token shape
 
@@ -10,9 +10,9 @@ Caveman **full** in chat. **Not ultra** on Spec. Prefer `path:line` + short clau
 
 **Goal:** Codebase facts for Tech Lead — not a Spec.
 
-**Do:** Search routes/services/schemas/tests; pitfalls (auth, web→core, migrations, generated, i18n); flag `QUALITY-RULES.md` R1–R12; similar paths; open questions. `cavecrew-investigator` **only** for symbol locate (defs/callers/uses).
+**Do:** Search routes/services/schemas/tests; pitfalls (auth, web→core, migrations, generated, i18n); load `QUALITY-TRIGGERS.md` only — flag matching `Rn`; similar paths; open questions. `cavecrew-investigator` **only** for symbol locate (defs/callers/uses).
 
-**Do not:** Contract tables, file-change lists, verification commands, mermaid, implement, rewrite Requirement, write Linear. Do not load `SPEC-TEMPLATE`, `SUBAGENT-RUBRIC`, `PHASE-*`, `VISUAL-CAPTURE`.
+**Do not:** Contract tables, file-change lists, verification commands, mermaid, implement, rewrite Requirement, write Linear. Do not load `QUALITY-RULES`, `SPEC-TEMPLATE`, `SUBAGENT-RUBRIC`, `PHASE-*`, `VISUAL-CAPTURE`.
 
 **Caps:** ≤12 patterns · ≤8 pitfalls · ≤5 recommend · ≤8 open · ≤5 related. ≤15 words/bullet (leading `path:line` / id / `` `symbol` `` excluded).
 
@@ -45,9 +45,9 @@ Omit empty sections. No essay preamble.
 
 **Goal:** Implementable Spec from Requirement + Investigation.
 
-**Do:** Resolve opens in **Key decisions**; always **Data flow**; `SUBAGENT-RUBRIC.md`; Quality-rule sections when triggers fire; `[repo=masumi-network/sokosumi]` at top. List ≥1 path-only Verification route **iff** Deliverables include any of: `apps/web/src/app/**/page.tsx` or `layout.tsx`, `apps/web/src/components/**`, `apps/web/messages/**`. Never for generated client only (`apps/web/src/lib/clients/**`). Routes ⇒ **UI in scope**.
+**Do:** Resolve opens in **Key decisions**; always **Data flow**; `SUBAGENT-RUBRIC.md`; `QUALITY-TRIGGERS.md` then **only flagged** `QUALITY-RULES.md` sections (Spec appendix formats there); `[repo=masumi-network/sokosumi]` at top. List ≥1 path-only Verification route **iff** Deliverables include any of: `apps/web/src/app/**/page.tsx` or `layout.tsx`, `apps/web/src/components/**`, `apps/web/messages/**`. Never for generated client only (`apps/web/src/lib/clients/**`). Routes ⇒ **UI in scope**. If TDD required per `PHASE-CODER.md`, Verification **must** list the proving allowlisted test command — do not copy TDD globs here.
 
-**Do not:** Implement; wait for human PRD approval; child issues; Spec on Linear; load `PHASE-*` or `VISUAL-CAPTURE`.
+**Do not:** Implement; wait for human PRD approval; child issues; Spec on Linear; load `PHASE-*` or `VISUAL-CAPTURE`. Do **not** paste unused domain-pattern appendix sections.
 
 **Default:** one coder. Rubric ≥ 2 → sequential breakdown, one-at-a-time Execution order. No parallel branches.
 
@@ -59,16 +59,14 @@ Omit empty sections. No essay preamble.
 
 **Goal:** Implement Spec. One draft PR (issue link + Spec summary ≤8 lines).
 
-**Load:** `PHASE-CODER.md` for verify table, branch checkout, sole/sequential modes, PR title/body.
+**Load:** `PHASE-CODER.md`. `QUALITY-TRIGGERS.md` self-check for flagged `Rn`; matching `QUALITY-RULES.md` sections only if a check is unclear.
 
-**Do not:** CI watch, Reviewer phase, Linear MCP (unless standalone + `LINEAR.md`).
+**Do not:** CI watch, Reviewer phase, `PHASE-SEQUENTIAL.md`, Linear MCP (unless standalone + `LINEAR.md`).
 
 ---
 
 ## Reviewer
 
-**Goal:** **One full review** via `/goal` — Spec, verify, UI when in scope, triggered `QUALITY-RULES.md` R1–R12. Not a Bugbot or quality-rules-only pass. Human merges.
+**Goal:** Run `/goal` in `PHASE-REVIEWER.md`. Human merges.
 
-**Load:** `PHASE-REVIEWER.md` for entry, `/goal` loop, PR trust, fixable cycle, return semantics. `QUALITY-RULES.md` for R1–R12 severity and Medium PR-body notes.
-
-**UI in scope:** Spec Verification has ≥1 path-only route → else skip visuals.
+**Load:** `PHASE-REVIEWER.md`. Then `QUALITY-TRIGGERS.md` + matching `QUALITY-RULES.md` sections only. UI in scope → `VISUAL-CAPTURE.md`.

--- a/.cursor/skills/team-sapphire/SKILL.md
+++ b/.cursor/skills/team-sapphire/SKILL.md
@@ -32,19 +32,26 @@ flowchart LR
 
 **Branch (before Coder):** Linear `gitBranchName`, else `{issue-id-lower}-{short-kebab}` (≤6 segments). Pass in every Coder prompt.
 
-**Default:** one coder (`mode: sole`), one **draft** PR. Rubric ≥ 2 → sequential Tasks **one at a time** (Execution order); each `mode: sequential` (push, no PR); orchestrator opens draft PR after last `ok`.
+**Default:** one coder (`mode: sole`), one **draft** PR. Rubric ≥ 2 → sequential Tasks **one at a time**; each `mode: sequential`; after each block load `PHASE-SEQUENTIAL.md` (light Spec check); draft PR after last `ok`.
 
 **UI in scope:** Spec Verification has ≥1 path-only route (`ROLES.md` Tech Lead).
 
-**CI green:** `gh pr checks` — all `pass`/`success`; wait on `pending`; fail on `fail`/`failure`/`cancelled`/`timed_out`. Skip a check only if Spec Out of scope names it exactly.
+**CI green:** `gh pr checks` — all `pass`/`success`; wait on `pending`; fail on `fail`/`failure`/`cancelled`/`timed_out`. Skip a check only if Spec Out of scope names it exactly. On fail: `root:` then fix per `PHASE-CODER.md` (≤3 fix+push).
 
-**PR open:** draft unless user asked ready-for-review. Title = primary commit subject. Body: issue link + Spec summary ≤8 lines. Details: `PHASE-CODER.md`.
+**PR open:** draft unless user asked ready-for-review. Title = primary commit subject. Body: issue link + Spec summary ≤8 lines (`PHASE-CODER.md`).
 
-**Orchestrator owns:** branch name, post-sequential PR, CI, Reviewer readiness. Subagents never call Linear MCP. Do **not** launch `bugbot` or a separate quality-rules-only review — Reviewer does **one full review**.
+**Orchestrator owns:** branch, sequential light Spec check, PR, CI, Reviewer readiness. Subagents never call Linear MCP. Do **not** launch `bugbot` or R-only review — Reviewer runs `/goal` (`PHASE-REVIEWER.md`).
 
 ## Token efficiency
 
-Load phase files only when that phase runs. Cap Investigation/Spec (`ROLES.md`). Structured one-line returns. Do **not** load `AGENTS.md` if this file is loaded; do **not** load `PHASE-*` / `VISUAL-CAPTURE` early.
+Load phase files only when that phase runs. Cap Investigation/Spec (`ROLES.md`). Structured one-line returns.
+
+- Do **not** load `AGENTS.md` if this file is loaded.
+- Do **not** load `PHASE-*` / `VISUAL-CAPTURE` early.
+- Investigator: `QUALITY-TRIGGERS.md` only — never full `QUALITY-RULES.md`.
+- Tech Lead / Coder / Reviewer: load `QUALITY-RULES.md` **sections for flagged Rn only**.
+- `PHASE-SEQUENTIAL.md` only when **Coders:** ≥ 2.
+- Single owners: TDD globs → `PHASE-CODER.md`; `/goal` + severity → `PHASE-REVIEWER.md`. Pointers elsewhere, no copy.
 
 ## Linear
 
@@ -80,13 +87,13 @@ Tech Lead (optional): `ok`, `spec`, `summary`, `blocker`.
 
 ## Phases
 
-**1 Investigator:** `ROLES.md` (Investigator); flag `QUALITY-RULES.md` R1–R12; session → Tech Lead.
+**1 Investigator:** `ROLES.md` + `QUALITY-TRIGGERS.md` → Tech Lead.
 
-**2 Tech Lead:** `ROLES.md` (Tech Lead) + `SPEC-TEMPLATE.md` + `SUBAGENT-RUBRIC.md`; Spec + Data flow; session → Coder.
+**2 Tech Lead:** `ROLES.md` + `SPEC-TEMPLATE.md` + `SUBAGENT-RUBRIC.md` + flagged `QUALITY-RULES.md` sections → Coder.
 
-**3 Coder:** Load `PHASE-CODER.md` + `ROLES.md` (Coder) + `QUALITY-RULES.md` self-check. Sole Task or serial sequential Tasks (rules above). After PR: **CI green**, then Phase 4.
+**3 Coder:** `PHASE-CODER.md` + `ROLES.md` + `QUALITY-TRIGGERS.md` (self-check). Sequential → also `PHASE-SEQUENTIAL.md` between blocks (orchestrator). After PR: CI green → Phase 4.
 
-**4 Reviewer:** Load `PHASE-REVIEWER.md` + `ROLES.md` (Reviewer) + `QUALITY-RULES.md`. Entry: verify + CI green. **One full review** — Spec, verify, UI when in scope, and triggered R1–R12. Not a Bugbot substitute. If pushed → re-check CI before ready. Human merges.
+**4 Reviewer:** `PHASE-REVIEWER.md` + `ROLES.md` + triggers + flagged rule sections. Entry: verify + CI green. `/goal` as written in `PHASE-REVIEWER.md`. Human merges.
 
 ## Stop early
 
@@ -104,9 +111,11 @@ Issue id/URL, phases done, **PR link**, CI + Reviewer summary. Caveman full.
 |------|------|
 | `ROLES.md` | Current phase role only |
 | `PHASE-CODER.md` | Phase 3 / standalone Coder |
+| `PHASE-SEQUENTIAL.md` | Orchestrator; **Coders:** ≥ 2 only |
 | `PHASE-REVIEWER.md` | Phase 4 / Reviewer |
 | `SPEC-TEMPLATE.md` / `SUBAGENT-RUBRIC.md` | Tech Lead |
-| `QUALITY-RULES.md` | R1–R12 flags, Coder self-check, Reviewer full-review checklist |
+| `QUALITY-TRIGGERS.md` | Investigator always; Coder/Reviewer/Tech Lead for flags |
+| `QUALITY-RULES.md` | Flagged `Rn` sections only |
 | `VISUAL-CAPTURE.md` | Reviewer + UI in scope |
 | `LINEAR.md` | Requirement text must change |
 | `AGENTS.md` | Skip if `SKILL.md` loaded |

--- a/.cursor/skills/team-sapphire/SPEC-TEMPLATE.md
+++ b/.cursor/skills/team-sapphire/SPEC-TEMPLATE.md
@@ -72,7 +72,7 @@ flowchart LR
 
 ## Verification
 
-Allowlisted scripts from `PHASE-CODER.md`. **Required:** check + test for the **verify set**. List **build** only when you want Coder/Reviewer to run it. **UI routes:** list ≥1 path-only route **iff** Deliverables include `apps/web/src/app/**/page.tsx` or `layout.tsx`, `apps/web/src/components/**`, or `apps/web/messages/**` — else omit Routes and Reviewer skips visuals.
+Allowlisted scripts from `PHASE-CODER.md`. **Required:** check + test for the **verify set**. List **build** only when Coder/Reviewer must run it. If TDD required per `PHASE-CODER.md` → list the allowlisted test command that proves the Contract (do not paste TDD globs here). **UI routes:** ≥1 path-only route **iff** Deliverables include `apps/web/src/app/**/page.tsx` or `layout.tsx`, `apps/web/src/components/**`, or `apps/web/messages/**` — else omit Routes.
 
 - Scope: `apps/web` — web:check, web:test
 - Routes (UI): `/example-path`
@@ -86,40 +86,5 @@ Allowlisted scripts from `PHASE-CODER.md`. **Required:** check + test for the **
 
 - No YAML plan frontmatter.
 - Keep Data flow, Verification, Out of scope.
-- Quality-rules appendix only when triggers apply.
+- Domain-pattern Spec appendix: only for **flagged** `Rn` from `QUALITY-TRIGGERS.md`; formats in matching `QUALITY-RULES.md` sections. **Do not** include empty or untriggered appendix sections.
 - Enforce size caps; cut tables first if over.
-
-## Appendix: optional Quality-rule sections
-
-### Mutation order (R1)
-
-| Step | On failure |
-|------|------------|
-| … | … |
-
-### State machine (R2)
-
-| User action | Target status | Notes |
-|-------------|---------------|-------|
-| … | … | derived / explicit |
-
-### Time semantics (R4)
-
-- Display TZ: …
-- Parse/persist TZ: …
-
-### Auth matrix (R10)
-
-| Caller type | Endpoint | Capability / scope |
-|-------------|----------|-------------------|
-| … | … | … |
-
-### Ripple checklist (R11)
-
-| Area | Updated in this PR |
-|------|-------------------|
-| Validators | … |
-| UI | … |
-| Archive | … |
-| Notifications | … |
-| Columns | … |


### PR DESCRIPTION
## Summary
- Demote Sapphire domain patterns to triggered scar tissue; drop AGENTS-duplicate R5/R8/R10 (no pointer stubs).
- Split loads: `QUALITY-TRIGGERS.md`, `PHASE-SEQUENTIAL.md`; Reviewer owns `/goal` + severity; Coder owns TDD globs.
- Slim Spec template / `AGENTS.md`; update sapphire agent defs for conditional QUALITY-RULES sections.

## Test plan
- [ ] Skim `SKILL.md` load rules — Investigator never loads full `QUALITY-RULES.md`
- [ ] Confirm TDD globs appear only in `PHASE-CODER.md`
- [ ] Confirm kept patterns are R1–R4, R6–R7, R9, R11, R12 only
- [ ] Optional: dry-run Team Sapphire on a small issue and check phase file loads


Made with [Cursor](https://cursor.com)