### PR TITLE
perf(web): reduce TTFB on landing and auth entry paths

### DIFF
--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -60,4 +60,42 @@ describe("proxy", () => {
     );
     expect(getSessionCookieMock).not.toHaveBeenCalled();
   });
+
+  it("edge-redirects anonymous / to /signin without running the app shell", async () => {
+    const { NextRequest } = await import("next/server");
+    const { proxy } = await import("../proxy");
+    getSessionCookieMock.mockReturnValue(null);
+    const request = new NextRequest(
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/",
+    );
+
+    const response = await proxy(request);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/signin",
+    );
+    expect(response?.headers.get("Cross-Origin-Opener-Policy")).toBe(
+      CROSS_ORIGIN_OPENER_POLICY,
+    );
+    expect(getSessionCookieMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("edge-redirects authenticated / to /chat without running the app shell", async () => {
+    const { NextRequest } = await import("next/server");
+    const { proxy } = await import("../proxy");
+    const request = new NextRequest(
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/",
+    );
+
+    const response = await proxy(request);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/chat",
+    );
+    expect(response?.headers.get("Cross-Origin-Opener-Policy")).toBe(
+      CROSS_ORIGIN_OPENER_POLICY,
+    );
+  });
 });

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -29,18 +29,20 @@ export default async function AuthLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await getSession({ refresh: true });
+  // Pathname from proxy (`x-pathname`). Callback/OAuth pages never redirect
+  // away on an existing session, so skip the Core session read entirely.
+  const headersList = await headers();
+  const pathname = headersList.get("x-pathname") || "";
+  const shouldSkipSessionCheck =
+    pathname.startsWith("/auth/callback/") || pathname.startsWith("/oauth");
 
-  if (session) {
-    // Get pathname from middleware header
-    const headersList = await headers();
-    const pathname = headersList.get("x-pathname") || "";
-
-    // Skip redirect for OAuth and auth callback routes
-    const shouldSkipRedirect =
-      pathname.startsWith("/auth/callback/") || pathname.startsWith("/oauth");
-
-    if (!shouldSkipRedirect) {
+  if (!shouldSkipSessionCheck) {
+    // Cookie-cache session is enough for "already signed in → leave auth UI".
+    // `refresh: true` forced a Core DB hit on every signin/signup visit and
+    // dominated TTFB for anonymous users (now also short-circuited in
+    // getSession when no session cookie is present).
+    const session = await getSession();
+    if (session) {
       redirect(DEFAULT_AUTHENTICATED_LANDING_PATH);
     }
   }

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -6,6 +6,9 @@ const captureMessageMock = vi.fn();
 const setTagMock = vi.fn();
 const setContextMock = vi.fn();
 
+const SESSION_COOKIE =
+  "sokosumi-localhost-preprod.session_token=session-token-value";
+
 vi.mock("server-only", () => ({}));
 
 vi.mock("@sentry/nextjs", () => ({
@@ -28,6 +31,14 @@ vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
 }));
 
+vi.mock("@/config/env.secrets", () => ({
+  getEnvSecrets: () => ({
+    NETWORK: "Preprod",
+    VERCEL_ENV: "development",
+    VERCEL_GIT_COMMIT_REF: "main",
+  }),
+}));
+
 vi.mock("@/lib/clients/utils/core-api-base-url", () => ({
   getServerCoreAppBaseUrl: () => "http://localhost:8787",
 }));
@@ -36,8 +47,26 @@ describe("auth.server", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    headersMock.mockResolvedValue(new Headers({ cookie: "session=abc" }));
+    headersMock.mockResolvedValue(new Headers({ cookie: SESSION_COOKIE }));
     vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("skips Core when no session cookie is present", async () => {
+    headersMock.mockResolvedValue(new Headers({}));
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession()).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips Core for refresh when no session cookie is present", async () => {
+    headersMock.mockResolvedValue(new Headers({}));
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("gets a refreshed session by disabling Better Auth cookie cache", async () => {
@@ -67,7 +96,7 @@ describe("auth.server", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       new URL("http://localhost:8787/auth/get-session?disableCookieCache=true"),
       {
-        headers: { cookie: "session=abc" },
+        headers: { cookie: SESSION_COOKIE },
         cache: "no-store",
         signal: expect.any(AbortSignal),
       },
@@ -145,7 +174,7 @@ describe("auth.server", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       new URL("http://localhost:8787/auth/list-accounts"),
       {
-        headers: { cookie: "session=abc" },
+        headers: { cookie: SESSION_COOKIE },
         cache: "no-store",
         signal: expect.any(AbortSignal),
       },
@@ -270,7 +299,7 @@ describe("auth.server", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       new URL("http://localhost:8787/auth/subscription/list?customerType=user"),
       {
-        headers: { cookie: "session=abc" },
+        headers: { cookie: SESSION_COOKIE },
         cache: "no-store",
         signal: expect.any(AbortSignal),
       },
@@ -394,7 +423,7 @@ describe("auth.server", () => {
         "http://localhost:8787/auth/oauth2/public-client?client_id=client_123",
       ),
       {
-        headers: { cookie: "session=abc" },
+        headers: { cookie: SESSION_COOKIE },
         cache: "no-store",
         signal: expect.any(AbortSignal),
       },

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -1,11 +1,14 @@
 import "server-only";
 
 import type { Account, Session } from "@sokosumi/utils";
+import { resolveBetterAuthCookiePrefix } from "@sokosumi/utils";
+import { getSessionCookie } from "better-auth/cookies";
 import { err, ok, type Result } from "neverthrow";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
 import type { ActiveSubscription } from "@/components/billing/subscription-plan-utils";
+import { getEnvSecrets } from "@/config/env.secrets";
 import { buildAuthHeaders } from "@/lib/clients/core.client";
 import { getServerCoreAppBaseUrl } from "@/lib/clients/utils/core-api-base-url";
 import { joinCoreApiPath } from "@/lib/clients/utils/core-api-base-url.shared";
@@ -147,10 +150,38 @@ function parseCoreAuthArrayResponse<T>(
   });
 }
 
+function getBetterAuthCookiePrefixFromEnv(): string {
+  const env = getEnvSecrets();
+  return resolveBetterAuthCookiePrefix({
+    network: env.NETWORK,
+    vercelEnv: env.VERCEL_ENV,
+    vercelGitCommitRef: env.VERCEL_GIT_COMMIT_REF,
+  });
+}
+
+/**
+ * Cheap presence check — no Core round-trip. Anonymous auth entry paths
+ * (signin/signup) must not pay Core RTT when no session cookie exists.
+ */
+function hasSessionCookie(requestHeaders: Headers): boolean {
+  return (
+    getSessionCookie(requestHeaders, {
+      cookiePrefix: getBetterAuthCookiePrefixFromEnv(),
+    }) != null
+  );
+}
+
 async function fetchSession(
   requestHeaders: Headers,
   options?: GetSessionOptions,
 ): Promise<Session | null> {
+  // Skip Core entirely when the browser did not send a session cookie. Auth
+  // entry pages call getSession on every visit; anonymous users were paying a
+  // full Core RTT for a guaranteed null.
+  if (!hasSessionCookie(requestHeaders)) {
+    return null;
+  }
+
   // Concatenate rather than `new URL(path, base)` so a base URL with a
   // sub-path (e.g. `https://host/core`) is preserved instead of dropped by
   // absolute-path resolution.

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -4,6 +4,7 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { applyDocumentSecurityHeaders } from "@/config/document-security-headers";
 import { getEnvSecrets } from "@/config/env.secrets";
+import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
 const EXCLUDED_PATHS = [
   "/auth/",
@@ -52,6 +53,22 @@ export async function proxy(request: NextRequest) {
     if (pathname !== "/maintenance") {
       return NextResponse.redirect(new URL("/maintenance", request.url));
     }
+  }
+
+  // `/` is only an entry hop: resolve destination at the edge so we never run
+  // root + (app) RSC (metadata, messages, layout) before the first redirect.
+  if (pathname === "/") {
+    const sessionCookie = getSessionCookie(request, {
+      cookiePrefix: betterAuthCookiePrefix,
+    });
+    const destination = sessionCookie
+      ? DEFAULT_AUTHENTICATED_LANDING_PATH
+      : "/signin";
+    const redirectResponse = NextResponse.redirect(
+      new URL(destination, request.url),
+    );
+    applyDocumentSecurityHeaders(redirectResponse);
+    return redirectResponse;
   }
 
   // Create response early so we can always set pathname + document headers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Skip Core `/auth/get-session` when no session cookie is present (anonymous signin/signup no longer pay Core RTT).
- Auth layout: skip session entirely on `/auth/callback/*` and `/oauth/*`; use cached `getSession()` (no `refresh: true`) for already-signed-in bounce.
- Proxy resolves `/` at the edge: cookie → `/chat`, no cookie → `/signin` (avoids full RSC before first redirect).

## Verification

- `pnpm web:check`
- `pnpm web:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-647](https://linear.app/masumi/issue/SOK-647/reduce-ttfb-on-landing-and-auth-entry-paths)

<div><a href="https://cursor.com/agents/bc-850a4c42-856d-4b4b-91f5-1cdded7233fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-850a4c42-856d-4b4b-91f5-1cdded7233fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

