### PR TITLE
perf(web): cut LCP latency on share and invite entry paths

### DIFF
--- a/apps/web/src/app/(flows)/accept-invitation/[id]/page.test.tsx
+++ b/apps/web/src/app/(flows)/accept-invitation/[id]/page.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const getPendingInvitationMock = vi.fn();
+
+vi.mock("@/lib/auth/auth.server", () => ({
+  getSession: (...args: unknown[]) => getSessionMock(...args),
+}));
+
+vi.mock("@/lib/services", () => ({
+  organizationService: {
+    getPendingInvitation: (...args: unknown[]) =>
+      getPendingInvitationMock(...args),
+  },
+  PendingInvitationErrorCode: {
+    EXPIRED: "EXPIRED",
+    NOT_FOUND: "NOT_FOUND",
+    INVITER_NOT_FOUND: "INVITER_NOT_FOUND",
+  },
+}));
+
+vi.mock("./components/invitation-card", () => ({
+  default: ({
+    invitation,
+    user,
+  }: {
+    invitation: { id: string };
+    user?: { id: string };
+  }) => (
+    <div>
+      invitation:{invitation.id}
+      {user ? ` user:${user.id}` : " anonymous"}
+    </div>
+  ),
+  InvitationErrorCard: ({ errorCode }: { errorCode: string }) => (
+    <div>error:{errorCode}</div>
+  ),
+}));
+
+describe("AcceptInvitationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not wait for session before loading the invitation", async () => {
+    let releaseSession: (() => void) | undefined;
+    const sessionGate = new Promise<void>((resolve) => {
+      releaseSession = resolve;
+    });
+
+    getSessionMock.mockImplementation(async () => {
+      await sessionGate;
+      return { user: { id: "user_1" } };
+    });
+
+    getPendingInvitationMock.mockResolvedValue({
+      invitation: {
+        id: "inv_1",
+        organizationId: "org_1",
+        email: "a@example.com",
+        role: "member",
+        status: "pending",
+        expiresAt: new Date("2026-08-01T00:00:00.000Z"),
+        inviterId: "user_2",
+        createdAt: new Date("2026-07-01T00:00:00.000Z"),
+        organization: { id: "org_1", name: "Acme", slug: "acme" },
+        inviter: { id: "user_2", email: "b@example.com" },
+      },
+    });
+
+    const pagePromise = import("./page").then(({ default: Page }) =>
+      Page({ params: Promise.resolve({ id: "inv_1" }) }),
+    );
+
+    await vi.waitFor(() => {
+      expect(getPendingInvitationMock).toHaveBeenCalledWith("inv_1");
+    });
+
+    // Invitation already in flight while session is still blocked.
+    expect(getSessionMock).toHaveBeenCalled();
+    releaseSession?.();
+
+    render(await pagePromise);
+
+    expect(screen.getByText("invitation:inv_1 user:user_1")).toBeVisible();
+  });
+
+  it("renders the error card when the invitation is not usable", async () => {
+    getSessionMock.mockResolvedValue(null);
+    getPendingInvitationMock.mockResolvedValue({
+      error: "EXPIRED",
+    });
+
+    const { default: Page } = await import("./page");
+    render(await Page({ params: Promise.resolve({ id: "inv_expired" }) }));
+
+    expect(screen.getByText("error:EXPIRED")).toBeVisible();
+  });
+});

--- a/apps/web/src/app/(flows)/accept-invitation/[id]/page.tsx
+++ b/apps/web/src/app/(flows)/accept-invitation/[id]/page.tsx
@@ -10,11 +10,14 @@ export default async function AcceptInvitationPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  // Start session before awaiting params so anonymous cookie short-circuit and
+  // logged-in Core session read run in parallel with invitation resolution.
+  const sessionPromise = getSession();
   const { id } = await params;
-
-  const session = await getSession();
-
-  const result = await organizationService.getPendingInvitation(id);
+  const [session, result] = await Promise.all([
+    sessionPromise,
+    organizationService.getPendingInvitation(id),
+  ]);
 
   if (result.error) {
     return <InvitationErrorCard errorCode={result.error} />;

--- a/apps/web/src/app/(flows)/layout.tsx
+++ b/apps/web/src/app/(flows)/layout.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 
 import { SokosumiLogo, ThemedLogo } from "@/components/masumi-logos";
 
-export default async function FlowsLayout({
+export default function FlowsLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;

--- a/apps/web/src/app/share/[token]/page.test.tsx
+++ b/apps/web/src/app/share/[token]/page.test.tsx
@@ -92,8 +92,8 @@ vi.mock("@/lib/services", () => ({
   },
 }));
 
-vi.mock("@/components/jobs", () => ({
-  JobDetailsView: ({ job }: { job: { id: string } }) => {
+vi.mock("@/components/jobs/job-details/job-details-view", () => ({
+  default: ({ job }: { job: { id: string } }) => {
     jobDetailsViewMock(job);
     return <div>job:{job.id}</div>;
   },

--- a/apps/web/src/app/share/[token]/page.tsx
+++ b/apps/web/src/app/share/[token]/page.tsx
@@ -1,28 +1,31 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import { JobDetailsView } from "@/components/jobs";
+import JobDetailsView from "@/components/jobs/job-details/job-details-view";
 import { siteConfig } from "@/config/site";
 import { getAgentResolvedImage } from "@/lib/helpers/agent";
 import { shareService } from "@/lib/services";
 import { SharedTaskView } from "../components/shared-task-view";
-
-async function getPublicShare(token: string) {
-  return await shareService.getPubliclySharedResource(token);
-}
 
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ token: string }>;
 }): Promise<Metadata> {
-  const [tJobs, tTasks] = await Promise.all([
+  // Start translations and token resolution immediately so metadata does not
+  // waterfall: translations ∥ (params → shared resource).
+  const translationsPromise = Promise.all([
     getTranslations("Share.Jobs.Metadata"),
     getTranslations("Share.Tasks.Metadata"),
   ]);
-
   const { token } = await params;
-  const resource = await getPublicShare(token);
+  const resourcePromise = shareService.getPubliclySharedResource(token);
+
+  const [[tJobs, tTasks], resource] = await Promise.all([
+    translationsPromise,
+    resourcePromise,
+  ]);
+
   if (!resource) {
     return notFound();
   }
@@ -99,7 +102,8 @@ export default async function SharePage({
   params: Promise<{ token: string }>;
 }) {
   const { token } = await params;
-  const resource = await getPublicShare(token);
+  // Deduped with generateMetadata via React cache() in shareService.
+  const resource = await shareService.getPubliclySharedResource(token);
   if (!resource) {
     return notFound();
   }

--- a/apps/web/src/app/share/components/share-page-cta.tsx
+++ b/apps/web/src/app/share/components/share-page-cta.tsx
@@ -21,6 +21,9 @@ export default function SharePageCTA({ className }: SharePageCTAProps) {
           alt=""
           fill
           className="object-cover"
+          sizes="100vw"
+          loading="lazy"
+          decoding="async"
           priority={false}
         />
         <div className="absolute inset-0 bg-black/20" />

--- a/apps/web/src/app/share/layout.tsx
+++ b/apps/web/src/app/share/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
-import QueryProvider from "@/contexts/query-provider";
-
 import Header from "./components/header";
 import SharePageCTA from "./components/share-page-cta";
 
@@ -22,18 +20,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function ShareLayout({ children }: ShareLayoutProps) {
+export default function ShareLayout({ children }: ShareLayoutProps) {
   return (
-    <QueryProvider>
-      <div className="flex w-full flex-col overflow-clip">
-        <Header className="h-16 p-4" />
-        <main className="relative min-h-[calc(100svh-64px)]">{children}</main>
-        <div className="container mx-auto flex justify-center p-4 md:p-8">
-          <div className="w-full">
-            <SharePageCTA />
-          </div>
+    <div className="flex w-full flex-col overflow-clip">
+      <Header className="h-16 p-4" />
+      <main className="relative min-h-[calc(100svh-64px)]">{children}</main>
+      <div className="container mx-auto flex justify-center p-4 md:p-8">
+        <div className="w-full">
+          <SharePageCTA />
         </div>
       </div>
-    </QueryProvider>
+    </div>
   );
 }

--- a/apps/web/src/lib/services/__tests__/share.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/share.service.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { getSharedResourceByTokenMock } = vi.hoisted(() => ({
+  getSharedResourceByTokenMock: vi.fn(),
+}));
+
+vi.mock("@/lib/clients/core.client", () => ({
+  CoreApiRequestError: class CoreApiRequestError extends Error {
+    status?: number;
+
+    constructor(
+      message: string,
+      options?: { details?: unknown; kind?: string; status?: number },
+    ) {
+      super(message);
+      this.name = "CoreApiRequestError";
+      this.status = options?.status;
+    }
+  },
+  coreClient: {
+    getSharedResourceByToken: (...args: unknown[]) =>
+      getSharedResourceByTokenMock(...args),
+  },
+}));
+
+import { CoreApiRequestError } from "@/lib/clients/core.client";
+
+import { shareService } from "../share.service";
+
+describe("shareService.getPubliclySharedResource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the shared resource from Core", async () => {
+    const sharedResource = {
+      kind: "job",
+      share: { allowSearchIndexing: true },
+      job: { id: "job_1" },
+    };
+    getSharedResourceByTokenMock.mockResolvedValue(sharedResource);
+
+    await expect(
+      shareService.getPubliclySharedResource("public-token"),
+    ).resolves.toBe(sharedResource);
+    expect(getSharedResourceByTokenMock).toHaveBeenCalledWith("public-token");
+  });
+
+  it("returns null for a 404 from Core", async () => {
+    getSharedResourceByTokenMock.mockRejectedValue(
+      new CoreApiRequestError("not found", { status: 404 }),
+    );
+
+    await expect(
+      shareService.getPubliclySharedResource("missing-token"),
+    ).resolves.toBeNull();
+  });
+
+  it("rethrows non-404 Core errors", async () => {
+    const error = new CoreApiRequestError("boom", { status: 500 });
+    getSharedResourceByTokenMock.mockRejectedValue(error);
+
+    await expect(
+      shareService.getPubliclySharedResource("bad-token"),
+    ).rejects.toBe(error);
+  });
+});

--- a/apps/web/src/lib/services/share.service.ts
+++ b/apps/web/src/lib/services/share.service.ts
@@ -1,9 +1,16 @@
 import "server-only";
 
+import { cache } from "react";
+
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 
+/**
+ * Public share reads are request-deduped with React `cache()` so
+ * `generateMetadata` and the page share one Core round-trip (LCP/TTFB on
+ * `/share/[token]`).
+ */
 export const shareService = (() => {
-  async function getPubliclySharedResource(token: string) {
+  const getPubliclySharedResource = cache(async (token: string) => {
     try {
       return await coreClient.getSharedResourceByToken(token);
     } catch (error) {
@@ -13,7 +20,7 @@ export const shareService = (() => {
 
       throw error;
     }
-  }
+  });
 
   return {
     getPubliclySharedResource,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves LCP/TTFB on public entry routes (`/share/[token]`, `/accept-invitation/[id]`).

- **Share**: request-dedupe public share Core reads with React `cache()` so `generateMetadata` and the page share one round-trip; run metadata translations in parallel with the share fetch; drop unused `QueryProvider` from the share shell; keep below-fold CTA image lazy.
- **Accept invitation**: start session early and load invitation in parallel (no session→invitation waterfall). Anonymous users already skip Core session via cookie short-circuit.
- **Flows layout**: drop unnecessary `async` on a sync layout.

## Verification

- `pnpm --filter web test` on share page, share service, and accept-invitation page tests (8 passed)
- `pnpm check` (biome) clean for changed files
- Web `tsc --noEmit` clean

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-649](https://linear.app/masumi/issue/SOK-649/improve-lcp-on-share-and-invitation-flows)

<div><a href="https://cursor.com/agents/bc-9a2f1b16-4278-4d2e-a264-282767e952fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a2f1b16-4278-4d2e-a264-282767e952fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

