### PR TITLE
perf(web): improve LCP on chat, agents, and task detail

### DIFF
--- a/apps/web/src/app/(app)/agents/loading.tsx
+++ b/apps/web/src/app/(app)/agents/loading.tsx
@@ -1,0 +1,29 @@
+import { AgentsSkeleton } from "@/components/agents";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function AgentsLoading() {
+  return (
+    <div className="w-full">
+      <div className="space-y-16 px-2 pb-8 md:space-y-24">
+        <section className="space-y-8">
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-56 md:h-8" />
+            <Skeleton className="h-4 w-80 md:h-5" />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 3 }, (_, index) => (
+              <Skeleton key={index} className="h-40 w-full rounded-xl" />
+            ))}
+          </div>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-48 md:h-8" />
+            <Skeleton className="h-4 w-72 md:h-5" />
+          </div>
+          <AgentsSkeleton />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -1,20 +1,19 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
 import {
   CreateTaskModal,
   CreateTaskModalProvider,
 } from "@/app/tasks/components/create-task-modal";
-import { buildAgentNameById } from "@/app/tasks/utils/agent-names";
 import { getCoworkerOptions } from "@/app/tasks/utils/coworker-options";
-import { AgentsNotAvailable } from "@/components/agents";
+import { AgentsNotAvailable, AgentsSkeleton } from "@/components/agents";
 import { CoworkerGallerySection } from "@/components/agents/coworker-gallery-section";
+import { Skeleton } from "@/components/ui/skeleton";
 import { mapCoreCategoriesToCategories } from "@/lib/agents/core-dto-mappers";
 import { getAllCoreAgents } from "@/lib/agents/core-loaders";
-import { getSession } from "@/lib/auth/auth.server";
 import { coreClient } from "@/lib/clients/core.client";
 import { coworkerService } from "@/lib/services/coworker.service";
-import { designMdService } from "@/lib/services/design-md.service";
 import { getAgentRatingStatsMap } from "@/lib/types/core-dto";
 
 import FilteredAgents from "./components/filtered-agents";
@@ -34,20 +33,34 @@ function logAgentsCatalogFetchFailure(scope: string, error: unknown): void {
   });
 }
 
-export default async function GalleryPage() {
-  const [coreAgents, categoriesResponse, coworkers, session] =
-    await Promise.all([
-      getAllCoreAgents().catch((error) => {
-        logAgentsCatalogFetchFailure("agent catalog", error);
-        return [];
-      }),
-      coreClient.getCategories().catch((error) => {
-        logAgentsCatalogFetchFailure("categories", error);
-        return { data: [] };
-      }),
-      coworkerService.listCoworkers("tasks").catch(() => []),
-      getSession(),
-    ]);
+function AgentsCatalogFallback() {
+  return (
+    <section className="space-y-8">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48 md:h-8" />
+        <Skeleton className="h-4 w-72 md:h-5" />
+      </div>
+      <AgentsSkeleton />
+    </section>
+  );
+}
+
+/**
+ * Tier 2 — full catalog streams after Tier 1 paints so LCP is the coworker
+ * gallery, not a blocked wait on every catalog page.
+ */
+async function AllAgentsTier() {
+  const [coreAgents, categoriesResponse, t] = await Promise.all([
+    getAllCoreAgents().catch((error) => {
+      logAgentsCatalogFetchFailure("agent catalog", error);
+      return [];
+    }),
+    coreClient.getCategories().catch((error) => {
+      logAgentsCatalogFetchFailure("categories", error);
+      return { data: [] };
+    }),
+    getTranslations("App.Agents"),
+  ]);
 
   if (!coreAgents.length) {
     return <AgentsNotAvailable />;
@@ -55,50 +68,45 @@ export default async function GalleryPage() {
 
   const categories = mapCoreCategoriesToCategories(categoriesResponse.data);
   const ratingStatsMap = getAgentRatingStatsMap(coreAgents);
-  const t = await getTranslations("App.Agents");
 
-  // Wiring for the create-task modal so a task can be started in place from the
-  // coworker gallery (no navigation to /tasks, picker step pre-skipped). All
-  // data still flows from the Core API — coworkers via coworkerService,
-  // agent names from Core agents, design.md via its service.
-  const initialDesignMdAttachment = session?.user.id
-    ? await designMdService.resolveEffectiveDesignMd()
-    : null;
+  return (
+    <section className="space-y-8">
+      <div className="space-y-2">
+        <h2 className="text-foreground text-xl font-light md:text-2xl">
+          {t("allAgentsTitle")}
+        </h2>
+        <p className="text-muted-foreground text-sm md:text-base">
+          {t("allAgentsSubtitle")}
+        </p>
+      </div>
+      <FilteredAgents
+        agents={coreAgents}
+        ratingStatsMap={ratingStatsMap}
+        categories={categories}
+      />
+    </section>
+  );
+}
+
+export default async function GalleryPage() {
+  // Tier 1 is the LCP surface: coworkers only. CreateTaskModal lazy-loads agent
+  // names + design.md when opened (same pattern as the tasks board).
+  const coworkers = await coworkerService
+    .listCoworkers("tasks")
+    .catch(() => []);
   const coworkerOptions = getCoworkerOptions(coworkers);
-  const agentNameById = buildAgentNameById(coreAgents);
 
   return (
     <div className="w-full">
       <div className="space-y-16 px-2 pb-8 md:space-y-24">
-        {/* Tier 1 — curated: your coworkers + their ready-to-run offers */}
         <CreateTaskModalProvider>
-          <CoworkerGallerySection
-            coworkers={coworkers}
-            agentCount={coreAgents.length}
-          />
-          <CreateTaskModal
-            coworkerOptions={coworkerOptions}
-            agentNameById={agentNameById}
-            initialDesignMdAttachment={initialDesignMdAttachment}
-          />
+          <CoworkerGallerySection coworkers={coworkers} />
+          <CreateTaskModal coworkerOptions={coworkerOptions} />
         </CreateTaskModalProvider>
 
-        {/* Tier 2 — browse the full catalog, grouped by what agents do */}
-        <section className="space-y-8">
-          <div className="space-y-2">
-            <h2 className="text-foreground text-xl font-light md:text-2xl">
-              {t("allAgentsTitle")}
-            </h2>
-            <p className="text-muted-foreground text-sm md:text-base">
-              {t("allAgentsSubtitle")}
-            </p>
-          </div>
-          <FilteredAgents
-            agents={coreAgents}
-            ratingStatsMap={ratingStatsMap}
-            categories={categories}
-          />
-        </section>
+        <Suspense fallback={<AgentsCatalogFallback />}>
+          <AllAgentsTier />
+        </Suspense>
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-interface.tsx
@@ -84,7 +84,6 @@ import {
 import { useConversationsContext } from "@/contexts/conversations-context";
 import { useCoworkersContext } from "@/contexts/coworkers-context";
 import type { Conversation } from "@/lib/actions/conversation";
-import type { TaskDesignMdAttachmentSeed } from "@/lib/utils/task-attachments";
 import { isCoworkerWarmupReadyForWelcomeSend } from "../utils/welcome-send-warmup";
 import MessageList from "./message-list";
 
@@ -261,7 +260,6 @@ interface ChatInterfaceProps {
   navigationMode?: "route" | "controlled";
   controlledConversationId?: string | null;
   onConversationCreated?: (conversationId: string) => void;
-  initialDesignMdAttachment?: TaskDesignMdAttachmentSeed | null;
 }
 
 export default function ChatInterface({
@@ -273,7 +271,6 @@ export default function ChatInterface({
   navigationMode = "route",
   controlledConversationId = null,
   onConversationCreated,
-  initialDesignMdAttachment = null,
 }: ChatInterfaceProps) {
   const t = useTranslations("App.Chat.Chat");
   const params = useParams<{ conversationId?: string }>();

--- a/apps/web/src/app/(app)/chat-ui/components/chat-layout-client.tsx
+++ b/apps/web/src/app/(app)/chat-ui/components/chat-layout-client.tsx
@@ -15,14 +15,12 @@ import {
 } from "@/app/chat-ui/utils/chat-route-base";
 import { useConversationsContext } from "@/contexts/conversations-context";
 import { useCoworkersContext } from "@/contexts/coworkers-context";
-import type { TaskDesignMdAttachmentSeed } from "@/lib/utils/task-attachments";
 
 interface ChatLayoutClientProps {
   mobileKeyboardOptimized?: boolean;
   organizationSlug: string | null;
   userImageUrl: string;
   userName: string | undefined;
-  initialDesignMdAttachment?: TaskDesignMdAttachmentSeed | null;
 }
 
 export function ChatLayoutClient({
@@ -30,7 +28,6 @@ export function ChatLayoutClient({
   organizationSlug,
   userImageUrl,
   userName,
-  initialDesignMdAttachment = null,
 }: ChatLayoutClientProps) {
   const pathname = usePathname();
   const { conversations } = useConversationsContext();
@@ -150,7 +147,6 @@ export function ChatLayoutClient({
             organizationSlug={organizationSlug}
             userImageUrl={userImageUrl}
             userName={userName}
-            initialDesignMdAttachment={initialDesignMdAttachment}
           />
         </div>
       </div>

--- a/apps/web/src/app/(app)/chat/layout.tsx
+++ b/apps/web/src/app/(app)/chat/layout.tsx
@@ -3,7 +3,6 @@ import { ChatLayoutClient } from "@/app/chat-ui/components/chat-layout-client";
 import DefaultErrorBoundary from "@/components/default-error-boundary";
 import { getSession } from "@/lib/auth/auth.server";
 import { userService } from "@/lib/services";
-import { designMdService } from "@/lib/services/design-md.service";
 
 import { ChatErrorFallback } from "./components/chat-error-fallback";
 
@@ -33,10 +32,10 @@ export default async function ChatLayout({
       default: "404",
     });
 
+  // Session is request-cached with the app layout; org is request-cached too.
+  // Do not await design.md here — chat UI does not use it, and it blocked LCP.
   const activeOrganization = await userService.getActiveOrganization();
   const organizationSlug = activeOrganization?.slug ?? null;
-  const initialDesignMdAttachment =
-    await designMdService.resolveEffectiveDesignMd();
 
   return (
     <DefaultErrorBoundary fallback={<ChatErrorFallback />}>
@@ -45,7 +44,6 @@ export default async function ChatLayout({
         organizationSlug={organizationSlug}
         userImageUrl={userImageUrl}
         userName={session.user.name ?? undefined}
-        initialDesignMdAttachment={initialDesignMdAttachment}
       />
     </DefaultErrorBoundary>
   );

--- a/apps/web/src/app/(app)/components/chat-rail.tsx
+++ b/apps/web/src/app/(app)/components/chat-rail.tsx
@@ -21,20 +21,17 @@ import {
   CHAT_RAIL_READY_POLL_MS,
   CHAT_RAIL_READY_TIMEOUT_MS,
 } from "@/lib/constants/chat-rail-ready";
-import type { TaskDesignMdAttachmentSeed } from "@/lib/utils/task-attachments";
 
 interface ChatRailProps {
   organizationSlug: string | null;
   userImageUrl: string;
   userName?: string;
-  initialDesignMdAttachment?: TaskDesignMdAttachmentSeed | null;
 }
 
 export default function ChatRail({
   organizationSlug,
   userImageUrl,
   userName,
-  initialDesignMdAttachment = null,
 }: ChatRailProps) {
   const pathname = usePathname();
   const tChat = useTranslations("App.Chat.Chat");
@@ -213,7 +210,6 @@ export default function ChatRail({
           userImageUrl={userImageUrl}
           userName={userName}
           showGreetingAndSuggestions={false}
-          initialDesignMdAttachment={initialDesignMdAttachment}
         />
       </div>
     </div>

--- a/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog-loader.tsx
@@ -64,9 +64,10 @@ export async function OnboardingDialogLoader({
   subscriptionOnly = false,
 }: OnboardingDialogLoaderProps) {
   if (subscriptionOnly) {
-    // Defense-in-depth: layout already skips mounting this loader when coverage
-    // is true (and React cache() dedupes). Keep the check so direct callers and
-    // tests still suppress the hint without relying on layout wiring.
+    // Defense-in-depth: layout mounts this loader for free-plan users and lets
+    // us suppress the gate when coverage exists (React cache() dedupes). Keep
+    // the check so direct callers and tests still suppress the hint without
+    // relying on layout wiring.
     const hasPaidOrEnterpriseCoverage = await userHasPaidOrEnterpriseCoverage();
     if (hasPaidOrEnterpriseCoverage) {
       return <SuppressedSubscriptionOnboardingGate loginId={loginId} />;

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
 import { HistorySearchDialogProvider } from "@/app/components/history-search-dialog-provider";
 import { EmergencyDialog } from "@/components/emergency-dialog";
@@ -24,21 +25,18 @@ import type {
   Notice,
 } from "@/lib/clients/generated/core";
 import { NoticeKind } from "@/lib/clients/generated/core";
-import { userHasPaidOrEnterpriseCoverage, userService } from "@/lib/services";
+import { userService } from "@/lib/services";
 import { coworkerService } from "@/lib/services/coworker.service";
-import { designMdService } from "@/lib/services/design-md.service";
 import {
   hasSubscriptionOnboardingGateBeenServedForSession,
   SUBSCRIPTION_ONBOARDING_GATE_SESSION_COOKIE_NAME,
 } from "@/lib/subscription-onboarding-gate-cookie";
-import { resolveSubscriptionOnboardingGateDecision } from "@/lib/subscription-onboarding-gate-decision";
 import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 import { resolveAccountNotice } from "./components/account-notice-state";
 import { AuthSessionGuard } from "./components/auth-session-guard";
 import ChatRail from "./components/chat-rail";
 import Header from "./components/header";
 import { LoginAccountNoticeToast } from "./components/login-account-notice-toast.client";
-import { MarkSubscriptionOnboardingGateSeen } from "./components/mark-subscription-onboarding-gate-seen";
 import { NoticeDialogProvider } from "./components/notice-dialog-context";
 import { NotificationToastListener } from "./components/notification-toast-listener";
 import { NotificationToaster } from "./components/notification-toaster.client";
@@ -79,20 +77,21 @@ export default async function AppLayout({ children }: AppLayoutProps) {
   const defaultChatRailOpen =
     cookieStore.get("chat_sidebar_state")?.value === "true";
 
+  // Critical shared data only. design.md is unused by chat UI and was blocking
+  // LCP on every (app) route. Coverage checks run inside OnboardingDialogLoader
+  // (Suspense) so paid-user Stripe work does not delay page paint.
   const [
     shouldShowOnboarding,
     pendingNoticesResult,
     activeOrganization,
     creditsResultRaw,
     coworkersResult,
-    initialDesignMdAttachment,
   ] = await Promise.all([
     userService.showOnboarding(session),
     getPendingNoticesAction(),
     userService.getActiveOrganization(),
     coreClient.getMyCredits().catch(() => null),
     coworkerService.listCoworkers().catch(() => []),
-    designMdService.resolveEffectiveDesignMd(),
   ]);
   const creditsResult = creditsResultRaw as GetUsersByIdCreditsResponse | null;
   const coworkers = coworkersResult.map(mapDbCoworkerToChatCoworker);
@@ -131,23 +130,8 @@ export default async function AppLayout({ children }: AppLayoutProps) {
       subscriptionOnboardingGateCookie,
       session.session.id,
     );
-  // Credits can report "free" while the user still has personal/org paid
-  // coverage or an enterprise contract — check before mounting the gate.
-  const shouldResolveCoverage =
-    shouldShowFreeSubscriptionGate && !subscriptionOnboardingGateAlreadyServed;
-  const hasPaidOrEnterpriseCoverage = shouldResolveCoverage
-    ? await userHasPaidOrEnterpriseCoverage()
-    : false;
-  const subscriptionOnboardingGateDecision =
-    resolveSubscriptionOnboardingGateDecision({
-      alreadyServed: subscriptionOnboardingGateAlreadyServed,
-      hasPaidOrEnterpriseCoverage,
-      shouldShowFreeSubscriptionGate,
-    });
   const shouldLoadSubscriptionOnboarding =
-    subscriptionOnboardingGateDecision === "load";
-  const shouldMarkSubscriptionOnboardingGateSeen =
-    subscriptionOnboardingGateDecision === "mark-seen";
+    shouldShowFreeSubscriptionGate && !subscriptionOnboardingGateAlreadyServed;
   const currentTimestampMs = creditsResult?.meta?.timestamp
     ? new Date(creditsResult.meta.timestamp).getTime()
     : 0;
@@ -206,7 +190,6 @@ export default async function AppLayout({ children }: AppLayoutProps) {
                 organizationSlug={activeOrganization?.slug ?? null}
                 userImageUrl={userImageUrl}
                 userName={session.user.name ?? undefined}
-                initialDesignMdAttachment={initialDesignMdAttachment}
               />
             </div>
           </AppChatRailProvider>
@@ -231,21 +214,21 @@ export default async function AppLayout({ children }: AppLayoutProps) {
               <CoworkersProvider initialCoworkers={coworkers}>
                 {content}
                 {shouldShowOnboarding ? (
-                  <OnboardingDialogLoader
-                    activeOrganization={activeOrganization}
-                    loginId={session.session.id}
-                    subscriptionOnly={false}
-                  />
+                  <Suspense fallback={null}>
+                    <OnboardingDialogLoader
+                      activeOrganization={activeOrganization}
+                      loginId={session.session.id}
+                      subscriptionOnly={false}
+                    />
+                  </Suspense>
                 ) : shouldLoadSubscriptionOnboarding ? (
-                  <OnboardingDialogLoader
-                    activeOrganization={activeOrganization}
-                    loginId={session.session.id}
-                    subscriptionOnly
-                  />
-                ) : shouldMarkSubscriptionOnboardingGateSeen ? (
-                  <MarkSubscriptionOnboardingGateSeen
-                    loginId={session.session.id}
-                  />
+                  <Suspense fallback={null}>
+                    <OnboardingDialogLoader
+                      activeOrganization={activeOrganization}
+                      loginId={session.session.id}
+                      subscriptionOnly
+                    />
+                  </Suspense>
                 ) : null}
               </CoworkersProvider>
             </AccountNoticeProvider>

--- a/apps/web/src/app/(app)/tasks/[taskId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/__tests__/page.test.tsx
@@ -133,7 +133,8 @@ describe("TaskDetailPage", () => {
       targetAccountName: "Workspace Org",
       successMessage: 'switchedWorkspace:{"account":"Workspace Org"}',
     });
-    expect(getTaskByIdMock).not.toHaveBeenCalled();
+    // Task read starts in parallel with the workspace check for the happy path;
+    // the result is unused when a workspace switch is required.
     expect(taskDetailViewMock).not.toHaveBeenCalled();
     expect(
       screen.getByTestId("task-workspace-switch-dialog"),
@@ -187,7 +188,5 @@ describe("TaskDetailPage", () => {
         }),
       }),
     ).rejects.toThrow("notFound");
-
-    expect(getTaskByIdMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/tasks/[taskId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/__tests__/page.test.tsx
@@ -95,6 +95,8 @@ describe("TaskDetailPage", () => {
   });
 
   it("renders a workspace switch dialog when a task belongs to another workspace", async () => {
+    // Active-workspace read misses; workspace probe reveals the target org.
+    getTaskByIdMock.mockResolvedValue(null);
     getTaskWorkspaceMock.mockResolvedValue({
       name: "Quarterly report",
       workspaceId: "11111111-1111-7111-8111-111111111111",
@@ -123,6 +125,8 @@ describe("TaskDetailPage", () => {
       }),
     );
 
+    expect(getTaskByIdMock).toHaveBeenCalledWith("task_1");
+    expect(getTaskWorkspaceMock).toHaveBeenCalledWith("task_1");
     expect(taskWorkspaceSwitchDialogMock).toHaveBeenCalledWith({
       currentAccountName: "Personal Account",
       currentOrganization: null,
@@ -133,8 +137,6 @@ describe("TaskDetailPage", () => {
       targetAccountName: "Workspace Org",
       successMessage: 'switchedWorkspace:{"account":"Workspace Org"}',
     });
-    // Task read starts in parallel with the workspace check for the happy path;
-    // the result is unused when a workspace switch is required.
     expect(taskDetailViewMock).not.toHaveBeenCalled();
     expect(
       screen.getByTestId("task-workspace-switch-dialog"),
@@ -146,11 +148,6 @@ describe("TaskDetailPage", () => {
       id: "task_1",
       name: "Quarterly report",
     };
-    getTaskWorkspaceMock.mockResolvedValue({
-      name: "Quarterly report",
-      workspaceId: "11111111-1111-7111-8111-111111111111",
-      organizationId: "org_workspace",
-    });
     getSessionMock.mockResolvedValue({
       session: {
         activeOrganizationId: "org_workspace",
@@ -169,6 +166,8 @@ describe("TaskDetailPage", () => {
       }),
     );
 
+    expect(getTaskByIdMock).toHaveBeenCalledWith("task_1");
+    expect(getTaskWorkspaceMock).not.toHaveBeenCalled();
     expect(taskWorkspaceSwitchDialogMock).not.toHaveBeenCalled();
     expect(taskDetailViewMock).toHaveBeenCalledWith({
       task,
@@ -176,8 +175,15 @@ describe("TaskDetailPage", () => {
     expect(screen.getByTestId("task-detail-view")).toBeInTheDocument();
   });
 
-  it("returns not found when the task workspace cannot be resolved", async () => {
+  it("returns not found when the task cannot be resolved in any accessible workspace", async () => {
+    getTaskByIdMock.mockResolvedValue(null);
     getTaskWorkspaceMock.mockResolvedValue(null);
+    getSessionMock.mockResolvedValue({
+      session: {
+        activeOrganizationId: "org_workspace",
+      },
+      user: sessionUser,
+    });
 
     const { default: TaskDetailPage } = await import("../page");
 
@@ -188,5 +194,35 @@ describe("TaskDetailPage", () => {
         }),
       }),
     ).rejects.toThrow("notFound");
+
+    expect(getTaskByIdMock).toHaveBeenCalledWith("task_1");
+    expect(getTaskWorkspaceMock).toHaveBeenCalledWith("task_1");
+  });
+
+  it("returns not found when the active-workspace task read fails but the workspace already matches", async () => {
+    getTaskByIdMock.mockResolvedValue(null);
+    getTaskWorkspaceMock.mockResolvedValue({
+      name: "Quarterly report",
+      workspaceId: "11111111-1111-7111-8111-111111111111",
+      organizationId: "org_workspace",
+    });
+    getSessionMock.mockResolvedValue({
+      session: {
+        activeOrganizationId: "org_workspace",
+      },
+      user: sessionUser,
+    });
+
+    const { default: TaskDetailPage } = await import("../page");
+
+    await expect(
+      TaskDetailPage({
+        params: Promise.resolve({
+          taskId: "task_1",
+        }),
+      }),
+    ).rejects.toThrow("notFound");
+
+    expect(taskWorkspaceSwitchDialogMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
@@ -17,6 +17,9 @@ export default async function TaskDetailPage({
 }) {
   const { taskId } = await params;
 
+  // Start the full task read immediately so the happy path (same workspace)
+  // does not wait for a second Core round-trip after the workspace check.
+  const taskPromise = taskService.getTaskById(taskId);
   const [taskWorkspace, session] = await Promise.all([
     taskService.getTaskWorkspace(taskId),
     getSession(),
@@ -66,7 +69,7 @@ export default async function TaskDetailPage({
     );
   }
 
-  const task = await taskService.getTaskById(taskId);
+  const task = await taskPromise;
 
   if (!task) {
     return notFound();

--- a/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
+++ b/apps/web/src/app/(app)/tasks/[taskId]/page.tsx
@@ -17,63 +17,63 @@ export default async function TaskDetailPage({
 }) {
   const { taskId } = await params;
 
-  // Start the full task read immediately so the happy path (same workspace)
-  // does not wait for a second Core round-trip after the workspace check.
-  const taskPromise = taskService.getTaskById(taskId);
-  const [taskWorkspace, session] = await Promise.all([
-    taskService.getTaskWorkspace(taskId),
+  // Happy path is active-workspace scoped: one Core read. Only probe workspace
+  // mapping when that miss might mean "switch workspace" rather than 404.
+  const [task, session] = await Promise.all([
+    taskService.getTaskById(taskId),
     getSession(),
   ]);
 
-  if (!taskWorkspace) {
+  if (!session) {
     return notFound();
   }
 
-  if (!session) {
+  if (task) {
+    return <TaskDetailView task={task} />;
+  }
+
+  const taskWorkspace = await taskService.getTaskWorkspace(taskId);
+
+  if (!taskWorkspace) {
     return notFound();
   }
 
   const activeOrganizationId = session.session.activeOrganizationId ?? null;
   const targetOrganizationId = taskWorkspace.organizationId ?? null;
 
-  if (activeOrganizationId !== targetOrganizationId) {
-    const [members, tDetail, tOrganizationSwitcher] = await Promise.all([
-      userService.getMyMembersWithOrganizations(),
-      getTranslations("App.Tasks.Detail"),
-      getTranslations("Components.OrganizationSwitcher"),
-    ]);
-    const targetAccountName = resolveAccountName(
-      targetOrganizationId,
-      members,
-      tOrganizationSwitcher("personalAccount"),
-    );
-    const currentAccountName = resolveAccountName(
-      activeOrganizationId,
-      members,
-      tOrganizationSwitcher("personalAccount"),
-    );
-
-    return (
-      <TaskWorkspaceSwitchDialog
-        currentAccountName={currentAccountName}
-        currentOrganization={resolveOrganization(activeOrganizationId, members)}
-        sessionUser={session.user}
-        taskName={taskWorkspace.name}
-        targetOrganization={resolveOrganization(targetOrganizationId, members)}
-        targetOrganizationId={targetOrganizationId}
-        targetAccountName={targetAccountName}
-        successMessage={tDetail("switchedWorkspace", {
-          account: targetAccountName,
-        })}
-      />
-    );
-  }
-
-  const task = await taskPromise;
-
-  if (!task) {
+  // Same workspace but task read failed — real miss, not a switch case.
+  if (activeOrganizationId === targetOrganizationId) {
     return notFound();
   }
 
-  return <TaskDetailView task={task} />;
+  const [members, tDetail, tOrganizationSwitcher] = await Promise.all([
+    userService.getMyMembersWithOrganizations(),
+    getTranslations("App.Tasks.Detail"),
+    getTranslations("Components.OrganizationSwitcher"),
+  ]);
+  const targetAccountName = resolveAccountName(
+    targetOrganizationId,
+    members,
+    tOrganizationSwitcher("personalAccount"),
+  );
+  const currentAccountName = resolveAccountName(
+    activeOrganizationId,
+    members,
+    tOrganizationSwitcher("personalAccount"),
+  );
+
+  return (
+    <TaskWorkspaceSwitchDialog
+      currentAccountName={currentAccountName}
+      currentOrganization={resolveOrganization(activeOrganizationId, members)}
+      sessionUser={session.user}
+      taskName={taskWorkspace.name}
+      targetOrganization={resolveOrganization(targetOrganizationId, members)}
+      targetOrganizationId={targetOrganizationId}
+      targetAccountName={targetAccountName}
+      successMessage={tDetail("switchedWorkspace", {
+        account: targetAccountName,
+      })}
+    />
+  );
 }

--- a/apps/web/src/lib/services/design-md.service.ts
+++ b/apps/web/src/lib/services/design-md.service.ts
@@ -9,6 +9,7 @@ import {
   type DesignMdJobPayload,
 } from "@sokosumi/masumi/tools";
 import type { Session } from "@sokosumi/utils";
+import { cache } from "react";
 import { getEnvPublicConfig } from "@/config/env.public";
 import { getEnvSecrets } from "@/config/env.secrets";
 import { coreClient } from "@/lib/clients/core.client";
@@ -311,11 +312,13 @@ export const designMdService = (() => {
     });
   }
 
-  async function resolveEffectiveDesignMd(): Promise<EffectiveDesignMdAttachment | null> {
-    const { data } = await coreClient.getWorkspaceDesignMd();
+  const resolveEffectiveDesignMd = cache(
+    async (): Promise<EffectiveDesignMdAttachment | null> => {
+      const { data } = await coreClient.getWorkspaceDesignMd();
 
-    return data.designMd;
-  }
+      return data.designMd;
+    },
+  );
 
   async function appendDesignMdToDescription(
     description: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves LCP on high-traffic day-to-day surfaces (`/chat`, `/agents`, `/tasks/[taskId]`).

- **Shared app shell:** stop blocking every `(app)` route on unused `design.md`; suspend onboarding/coverage work so page content can paint first
- **`/chat`:** remove dead `initialDesignMdAttachment` plumbing and the Core round-trip it triggered
- **`/agents`:** paint coworker gallery (LCP) without waiting for full agent catalog; stream catalog in `Suspense`; lazy-load create-task modal data on open
- **`/tasks/[taskId]`:** happy path uses active-workspace `getTaskById` only; probe `getTaskWorkspace` only when that miss might mean a workspace switch
- **`designMdService.resolveEffectiveDesignMd`:** request-dedupe with `React.cache`

Task board–specific load work stays out of scope.

## Verification

- `pnpm web:check`
- `pnpm web:test` (task detail page: 4 passed)
- CI on push

Routes: `/chat`, `/agents`, `/tasks/[taskId]`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-648](https://linear.app/masumi/issue/SOK-648/improve-lcp-on-high-traffic-chat-tasks-and-agents-surfaces)

<div><a href="https://cursor.com/agents/bc-b10d21b7-2ebb-4f51-aaeb-4301321523f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b10d21b7-2ebb-4f51-aaeb-4301321523f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

