### PR TITLE
feat(core): allow orch+context on user-facing API routes

### DIFF
--- a/.grok/workflows/orchestrator-impersonation-audit.rhai
+++ b/.grok/workflows/orchestrator-impersonation-audit.rhai
@@ -3,7 +3,7 @@ let meta = #{
     description: "Audit that orchestrator service token + X-Context-* headers can access every user-available Core API surface (flag unexpected session-only gates)",
     when_to_use: "Verify Hermes orchestrator impersonation parity: service token + context headers should reach user-scoped endpoints. Invoke as /orchestrator-impersonation-audit",
     phases: [
-        #{ title: "Map auth primitives", detail: "requireUserContext vs requireUserAuthContext vs forbidOrchestratorActor" },
+        #{ title: "Map auth primitives", detail: "requireUserContext vs requireUserAuthContext vs requireOwnerUserContext" },
         #{ title: "Inventory domains", detail: "parallel scan of Core v1 route trees by domain" },
         #{ title: "Cross-check policy", detail: "docs + intentional exclusions vs code" },
         #{ title: "Verify gaps", detail: "adversarial check that each gap is real and unexpected" },
@@ -161,7 +161,7 @@ prim_prompt += "Repo root is the workspace. Focus under: " + root + "\n\n";
 prim_prompt += "MUST use tools (grep, read_file, list_dir). Do not answer from memory.\n\n";
 prim_prompt += "Read and summarize these files thoroughly:\n";
 prim_prompt += "1. apps/core/src/middleware/auth.ts — requireUserContext, requireUserAuthContext,\n";
-prim_prompt += "   requireOwnerUserContext, forbidOrchestratorActor, requireOrchestratorAuthContext,\n";
+prim_prompt += "   requireOwnerUserContext, requireOrchestratorAuthContext,\n";
 prim_prompt += "   requireAdminAuthContext, isOrchestratorAuthContext, UserContext type.\n";
 prim_prompt += "2. apps/core/src/middleware/coworker-context.ts — X-Context-User-Id / X-Context-Organization-Id\n";
 prim_prompt += "   binding for coworker AND orchestrator; orchestratorId binding.\n";
@@ -221,7 +221,6 @@ for d in domains {
     p += "- With X-Context-User-Id (+ optional X-Context-Organization-Id), Core binds workspace user.\n";
     p += "- requireUserContext / requireOwnerUserContext: ALLOW orchestrator+context.\n";
     p += "- requireUserAuthContext / requireAdminAuthContext: DENY orchestrator (session/API-key only).\n";
-    p += "- forbidOrchestratorActor: explicit DENY even with context.\n";
     p += "- requireCoworkerAuthContext / requireOrchestratorAuthContext: actor-specific (n_a for user parity).\n\n";
     p += "Documented intentional orchestrator denials (from docs/orchestrator/hermes-orchestrator-actor.md):\n";
     p += "- /v1/hermes/* product chat: user session only (orchestrator 403)\n";
@@ -319,9 +318,9 @@ policy_prompt += "Cross-check orchestrator impersonation policy docs against Cor
 policy_prompt += "MUST read with tools:\n";
 policy_prompt += "- docs/orchestrator/hermes-orchestrator-actor.md\n";
 policy_prompt += "- docs/hermes-orchestrator-approve-overrides.md if present\n";
-policy_prompt += "- apps/core/src/middleware/auth.ts (forbidOrchestratorActor, requireUserContext)\n";
+policy_prompt += "- apps/core/src/middleware/auth.ts (requireUserContext, requireUserAuthContext)\n";
 policy_prompt += "- apps/core/src/routes/v1/auth-actor-guards.test.ts\n";
-policy_prompt += "- grep forbidOrchestratorActor and requireUserAuthContext under apps/core/src/routes\n\n";
+policy_prompt += "- grep requireUserAuthContext under apps/core/src/routes\n\n";
 policy_prompt += "Summarize the product policy: when orchestrator+context may act as user.\n";
 policy_prompt += "List documented exclusions with source path.\n";
 policy_prompt += "gaps_vs_docs: places where code deny/allow diverges from docs, or docs are silent\n";

--- a/.grok/workflows/orchestrator-impersonation-audit.rhai
+++ b/.grok/workflows/orchestrator-impersonation-audit.rhai
@@ -202,7 +202,7 @@ let domains = [
     #{ id: "users", path: "apps/core/src/routes/v1/users", focus: "/users/me and /users/{id} including credits, prefs, design-md, orgs, grants" },
     #{ id: "organizations", path: "apps/core/src/routes/v1/organizations", focus: "org detail, members, billing, seats, vendor-grants, design-md" },
     #{ id: "agents", path: "apps/core/src/routes/v1/agents", focus: "agent catalog, jobs, ratings, reviews/me" },
-    #{ id: "conversations-chat", path: "apps/core/src/routes/v1/conversations and apps/core/src/routes/v1/chat", focus: "marketplace conversations + chat stream; expect intentional orchestrator forbid" },
+    #{ id: "conversations-chat", path: "apps/core/src/routes/v1/conversations and apps/core/src/routes/v1/chat", focus: "marketplace conversations + chat stream; orch+context should be parity_ok (acts as context user)" },
     #{ id: "notifications", path: "apps/core/src/routes/v1/notifications", focus: "list, read, unread-count" },
     #{ id: "checkout-products-coupons", path: "apps/core/src/routes/v1/checkout, products, coupons", focus: "billing checkout, products catalog, coupon claim" },
     #{ id: "workspaces-history-misc", path: "apps/core/src/routes/v1/workspaces, history, invitations, categories, share, hermes, developer, vendors, credit-costs", focus: "remaining user-facing mounts; hermes is user-session product surface" },
@@ -225,7 +225,7 @@ for d in domains {
     p += "- requireCoworkerAuthContext / requireOrchestratorAuthContext: actor-specific (n_a for user parity).\n\n";
     p += "Documented intentional orchestrator denials (from docs/orchestrator/hermes-orchestrator-actor.md):\n";
     p += "- /v1/hermes/* product chat: user session only (orchestrator 403)\n";
-    p += "- marketplace chat / conversations: orchestrator 403\n";
+    p += "- marketplace chat / conversations: ALLOW orch+context (parity_ok); bare orch denied\n";
     p += "- POST /v1/tasks/{id}/jobs: coworker only (orchestrator 403)\n";
     p += "Session-bound ops (PII, Stripe checkout, coupon claim, notifications) may use requireUserAuthContext\n";
     p += "by design — still list them as unexpected_deny IF they look like general user workspace APIs that\n";
@@ -375,8 +375,8 @@ if to_verify.len() > 0 {
         vp += "2. An orchestrator with service token + X-Context-User-Id is rejected by this guard\n";
         vp += "   (or equivalent logic).\n";
         vp += "3. The denial is NOT justified by documented product rules in\n";
-        vp += "   docs/orchestrator/hermes-orchestrator-actor.md (hermes product, marketplace chat,\n";
-        vp += "   conversations, POST tasks/{id}/jobs coworker-only).\n";
+        vp += "   docs/orchestrator/hermes-orchestrator-actor.md (hermes product session-only,\n";
+        vp += "   POST tasks/{id}/jobs coworker-only). Marketplace chat/conversations ALLOW orch+ctx.\n";
         vp += "4. If guard is requireUserAuthContext for clear session-bound billing/consent/PII,\n";
         vp += "   set real=false severity=invalid — intentional session-only, not a bug.\n";
         vp += "5. If Hermes/workspace orchestration would reasonably need this user surface,\n";
@@ -454,9 +454,9 @@ report_prompt += "INVARIANT under test:\n";
 report_prompt += "An orchestrator authenticated with ORCHESTRATOR_SERVICE_TOKEN that sends\n";
 report_prompt += "X-Context-User-Id / X-Context-Organization-Id must be able to call every Core API\n";
 report_prompt += "endpoint available to that user, except documented intentional exclusions\n";
-report_prompt += "(Hermes product /v1/hermes/*, marketplace chat/conversations, coworker-only\n";
-report_prompt += "POST /v1/tasks/{id}/jobs) and clearly session-bound surfaces (Stripe checkout,\n";
-report_prompt += "OAuth consent, admin).\n\n";
+report_prompt += "(Hermes product /v1/hermes/*, coworker-only POST /v1/tasks/{id}/jobs) and\n";
+report_prompt += "clearly session-bound surfaces (Stripe checkout, OAuth consent, admin).\n";
+report_prompt += "Marketplace chat/conversations SHOULD allow orch+context.\n\n";
 report_prompt += "Use ONLY this JSON evidence (do not invent endpoints):\n";
 report_prompt += payload_json + "\n\n";
 report_prompt += "Report structure (markdown):\n";

--- a/.grok/workflows/orchestrator-impersonation-audit.rhai
+++ b/.grok/workflows/orchestrator-impersonation-audit.rhai
@@ -1,0 +1,511 @@
+let meta = #{
+    name: "orchestrator-impersonation-audit",
+    description: "Audit that orchestrator service token + X-Context-* headers can access every user-available Core API surface (flag unexpected session-only gates)",
+    when_to_use: "Verify Hermes orchestrator impersonation parity: service token + context headers should reach user-scoped endpoints. Invoke as /orchestrator-impersonation-audit",
+    phases: [
+        #{ title: "Map auth primitives", detail: "requireUserContext vs requireUserAuthContext vs forbidOrchestratorActor" },
+        #{ title: "Inventory domains", detail: "parallel scan of Core v1 route trees by domain" },
+        #{ title: "Cross-check policy", detail: "docs + intentional exclusions vs code" },
+        #{ title: "Verify gaps", detail: "adversarial check that each gap is real and unexpected" },
+        #{ title: "Report", detail: "markdown audit report with pass/fail and file:line evidence" },
+    ],
+};
+
+let primitives_schema = #{
+    "type": "object",
+    "required": ["summary", "primitives"],
+    "properties": #{
+        "summary": #{ "type": "string" },
+        "primitives": #{
+            "type": "array",
+            "maxItems": 12,
+            "items": #{
+                "type": "object",
+                "required": ["name", "allows_orchestrator_with_context", "file", "notes"],
+                "properties": #{
+                    "name": #{ "type": "string" },
+                    "allows_orchestrator_with_context": #{ "type": "boolean" },
+                    "file": #{ "type": "string" },
+                    "notes": #{ "type": "string" },
+                },
+            },
+        },
+    },
+};
+
+let domain_schema = #{
+    "type": "object",
+    "required": ["domain", "endpoints", "unexpected_denials", "intentional_exclusions", "notes"],
+    "properties": #{
+        "domain": #{ "type": "string" },
+        "endpoints": #{
+            "type": "array",
+            "maxItems": 40,
+            "items": #{
+                "type": "object",
+                "required": ["method_path", "file", "guard", "user_accessible", "orchestrator_with_context", "classification"],
+                "properties": #{
+                    "method_path": #{ "type": "string" },
+                    "file": #{ "type": "string" },
+                    "guard": #{ "type": "string" },
+                    "user_accessible": #{ "type": "boolean" },
+                    "orchestrator_with_context": #{ "type": "string", "enum": ["allowed", "denied", "unknown", "n_a"] },
+                    "classification": #{
+                        "type": "string",
+                        "enum": ["parity_ok", "intentional_deny", "unexpected_deny", "orchestrator_only", "non_user", "needs_review"],
+                    },
+                },
+            },
+        },
+        "unexpected_denials": #{
+            "type": "array",
+            "maxItems": 20,
+            "items": #{
+                "type": "object",
+                "required": ["method_path", "file", "guard", "why_unexpected"],
+                "properties": #{
+                    "method_path": #{ "type": "string" },
+                    "file": #{ "type": "string" },
+                    "guard": #{ "type": "string" },
+                    "why_unexpected": #{ "type": "string" },
+                },
+            },
+        },
+        "intentional_exclusions": #{
+            "type": "array",
+            "maxItems": 15,
+            "items": #{
+                "type": "object",
+                "required": ["method_path", "file", "reason"],
+                "properties": #{
+                    "method_path": #{ "type": "string" },
+                    "file": #{ "type": "string" },
+                    "reason": #{ "type": "string" },
+                },
+            },
+        },
+        "notes": #{ "type": "string" },
+    },
+};
+
+let policy_schema = #{
+    "type": "object",
+    "required": ["policy_summary", "documented_exclusions", "gaps_vs_docs"],
+    "properties": #{
+        "policy_summary": #{ "type": "string" },
+        "documented_exclusions": #{
+            "type": "array",
+            "maxItems": 20,
+            "items": #{
+                "type": "object",
+                "required": ["surface", "source", "expected"],
+                "properties": #{
+                    "surface": #{ "type": "string" },
+                    "source": #{ "type": "string" },
+                    "expected": #{ "type": "string" },
+                },
+            },
+        },
+        "gaps_vs_docs": #{
+            "type": "array",
+            "maxItems": 15,
+            "items": #{
+                "type": "object",
+                "required": ["issue", "evidence"],
+                "properties": #{
+                    "issue": #{ "type": "string" },
+                    "evidence": #{ "type": "string" },
+                },
+            },
+        },
+    },
+};
+
+let gap_verdict_schema = #{
+    "type": "object",
+    "required": ["real", "severity", "reason", "evidence", "fix_suggestion"],
+    "properties": #{
+        "real": #{ "type": "boolean" },
+        "severity": #{ "type": "string", "enum": ["blocker", "major", "minor", "nit", "invalid"] },
+        "reason": #{ "type": "string" },
+        "evidence": #{ "type": "string" },
+        "fix_suggestion": #{ "type": "string" },
+    },
+};
+
+let report_schema = #{
+    "type": "object",
+    "required": ["markdown", "verdict", "unexpected_count", "intentional_count"],
+    "properties": #{
+        "markdown": #{ "type": "string" },
+        "verdict": #{ "type": "string", "enum": ["pass", "pass_with_gaps", "fail"] },
+        "unexpected_count": #{ "type": "integer" },
+        "intentional_count": #{ "type": "integer" },
+    },
+};
+
+// Optional args.root defaults to monorepo Core routes.
+let root = "apps/core/src";
+if args != () && args.root != () {
+    root = args.root;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Map auth primitives (single agent — foundational)
+// ---------------------------------------------------------------------------
+phase("Map auth primitives");
+
+let prim_prompt = "";
+prim_prompt += "You audit Sokosumi Core orchestrator impersonation auth primitives.\n";
+prim_prompt += "Repo root is the workspace. Focus under: " + root + "\n\n";
+prim_prompt += "MUST use tools (grep, read_file, list_dir). Do not answer from memory.\n\n";
+prim_prompt += "Read and summarize these files thoroughly:\n";
+prim_prompt += "1. apps/core/src/middleware/auth.ts — requireUserContext, requireUserAuthContext,\n";
+prim_prompt += "   requireOwnerUserContext, forbidOrchestratorActor, requireOrchestratorAuthContext,\n";
+prim_prompt += "   requireAdminAuthContext, isOrchestratorAuthContext, UserContext type.\n";
+prim_prompt += "2. apps/core/src/middleware/coworker-context.ts — X-Context-User-Id / X-Context-Organization-Id\n";
+prim_prompt += "   binding for coworker AND orchestrator; orchestratorId binding.\n";
+prim_prompt += "3. apps/core/src/lib/orchestrator-service-token.ts\n";
+prim_prompt += "4. apps/core/src/middleware/workspace.ts if present\n";
+prim_prompt += "5. apps/core/src/routes/v1/users/user-path-access.ts and user-route-context.ts\n\n";
+prim_prompt += "For each primitive, set allows_orchestrator_with_context=true only if an actor with\n";
+prim_prompt += "actor=orchestrator AND context.userId set can pass that guard.\n";
+prim_prompt += "requireUserAuthContext must be false (session/API-key user only).\n";
+prim_prompt += "requireUserContext and requireOwnerUserContext must be true for contextual orchestrator.\n\n";
+prim_prompt += "Return structured primitives list with exact file paths.\n";
+prim_prompt += "Empty primitives only if you grepped and the files are missing.\n";
+
+let prim = agent(prim_prompt, #{
+    label: "auth-primitives",
+    capability_mode: "read-only",
+    output_schema: primitives_schema,
+});
+
+if prim == () || !prim.success || prim.output.primitives == () {
+    pause("infra", "Auth primitives mapper failed — resume to retry.");
+}
+
+log("Auth primitives mapped: " + prim.output.primitives.len().to_string());
+
+// ---------------------------------------------------------------------------
+// Phase 2: Inventory route domains in parallel
+// ---------------------------------------------------------------------------
+phase("Inventory domains");
+
+// Domains that should be user-accessible (and thus candidates for orchestrator parity).
+// admin/enterprise intentionally non-user for this audit (admin role).
+// coworkers/me and orchestrators/me are actor-specific.
+let domains = [
+    #{ id: "tasks", path: "apps/core/src/routes/v1/tasks", focus: "task CRUD, events, schedule, share, workspace, links, jobs" },
+    #{ id: "jobs", path: "apps/core/src/routes/v1/jobs", focus: "job list/detail, inputs, refund, share, workspace, files, events" },
+    #{ id: "projects", path: "apps/core/src/routes/v1/projects", focus: "project CRUD, nested tasks/jobs" },
+    #{ id: "users", path: "apps/core/src/routes/v1/users", focus: "/users/me and /users/{id} including credits, prefs, design-md, orgs, grants" },
+    #{ id: "organizations", path: "apps/core/src/routes/v1/organizations", focus: "org detail, members, billing, seats, vendor-grants, design-md" },
+    #{ id: "agents", path: "apps/core/src/routes/v1/agents", focus: "agent catalog, jobs, ratings, reviews/me" },
+    #{ id: "conversations-chat", path: "apps/core/src/routes/v1/conversations and apps/core/src/routes/v1/chat", focus: "marketplace conversations + chat stream; expect intentional orchestrator forbid" },
+    #{ id: "notifications", path: "apps/core/src/routes/v1/notifications", focus: "list, read, unread-count" },
+    #{ id: "checkout-products-coupons", path: "apps/core/src/routes/v1/checkout, products, coupons", focus: "billing checkout, products catalog, coupon claim" },
+    #{ id: "workspaces-history-misc", path: "apps/core/src/routes/v1/workspaces, history, invitations, categories, share, hermes, developer, vendors, credit-costs", focus: "remaining user-facing mounts; hermes is user-session product surface" },
+];
+
+let domain_jobs = [];
+for d in domains {
+    let p = "";
+    p += "You audit Core API route domain for orchestrator impersonation parity.\n";
+    p += "Domain id: " + d.id + "\n";
+    p += "Paths: " + d.path + "\n";
+    p += "Focus: " + d.focus + "\n\n";
+    p += "MUST use grep/read_file/list_dir on the actual route files. Never invent endpoints.\n\n";
+    p += "Policy under test:\n";
+    p += "- Orchestrator authenticates with ORCHESTRATOR_SERVICE_TOKEN (actor=orchestrator).\n";
+    p += "- With X-Context-User-Id (+ optional X-Context-Organization-Id), Core binds workspace user.\n";
+    p += "- requireUserContext / requireOwnerUserContext: ALLOW orchestrator+context.\n";
+    p += "- requireUserAuthContext / requireAdminAuthContext: DENY orchestrator (session/API-key only).\n";
+    p += "- forbidOrchestratorActor: explicit DENY even with context.\n";
+    p += "- requireCoworkerAuthContext / requireOrchestratorAuthContext: actor-specific (n_a for user parity).\n\n";
+    p += "Documented intentional orchestrator denials (from docs/orchestrator/hermes-orchestrator-actor.md):\n";
+    p += "- /v1/hermes/* product chat: user session only (orchestrator 403)\n";
+    p += "- marketplace chat / conversations: orchestrator 403\n";
+    p += "- POST /v1/tasks/{id}/jobs: coworker only (orchestrator 403)\n";
+    p += "Session-bound ops (PII, Stripe checkout, coupon claim, notifications) may use requireUserAuthContext\n";
+    p += "by design — still list them as unexpected_deny IF they look like general user workspace APIs that\n";
+    p += "Hermes would need, OR as intentional_exclusions if clearly session-bound billing/consent/PII.\n";
+    p += "When unsure, use classification needs_review and put in unexpected_denials with why.\n\n";
+    p += "Procedure:\n";
+    p += "1. list_dir the domain path(s); find route handlers (get.ts, post.ts, patch.ts, put.ts, delete.ts).\n";
+    p += "2. For each handler, grep which auth guard it imports/calls.\n";
+    p += "3. Infer method_path from OpenAPI route registration (path + method) or folder structure.\n";
+    p += "4. Classify each user-accessible endpoint:\n";
+    p += "   - parity_ok: user can call AND orchestrator+context allowed\n";
+    p += "   - intentional_deny: user can call, orchestrator denied, matches documented product rule\n";
+    p += "   - unexpected_deny: user can call, orchestrator denied, NOT clearly session-only/product rule\n";
+    p += "   - orchestrator_only / non_user: skip parity\n";
+    p += "   - needs_review: ambiguous\n";
+    p += "5. Populate unexpected_denials and intentional_exclusions arrays (may be empty after real search).\n";
+    p += "6. Cap endpoints at 40; prefer mutations + high-traffic reads if over cap; note truncation in notes.\n\n";
+    p += "Also check nearby *.test.ts for createOrchestratorContextApp / actor=orchestrator coverage.\n";
+    p += "Put coverage gaps in notes only (not unexpected_denials unless the guard itself is wrong).\n";
+
+    domain_jobs.push(#{
+        prompt: p,
+        label: "domain:" + d.id,
+        capability_mode: "read-only",
+        output_schema: domain_schema,
+    });
+}
+
+let domain_results = parallel(domain_jobs);
+
+let all_unexpected = [];
+let all_intentional = [];
+let domain_summaries = [];
+let i = 0;
+for r in domain_results {
+    let domain_id = domains[i].id;
+    if r == () || !r.success || r.output == () {
+        log("Domain inventory failed: " + domain_id);
+        domain_summaries.push(#{
+            domain: domain_id,
+            status: "failed",
+            unexpected: 0,
+            intentional: 0,
+        });
+    } else {
+        let out = r.output;
+        let u_count = 0;
+        let int_count = 0;
+        if out.unexpected_denials != () {
+            for g in out.unexpected_denials {
+                all_unexpected.push(#{
+                    domain: domain_id,
+                    method_path: g.method_path,
+                    file: g.file,
+                    guard: g.guard,
+                    why_unexpected: g.why_unexpected,
+                });
+                u_count += 1;
+            }
+        }
+        if out.intentional_exclusions != () {
+            for e in out.intentional_exclusions {
+                all_intentional.push(#{
+                    domain: domain_id,
+                    method_path: e.method_path,
+                    file: e.file,
+                    reason: e.reason,
+                });
+                int_count += 1;
+            }
+        }
+        domain_summaries.push(#{
+            domain: domain_id,
+            status: "ok",
+            unexpected: u_count,
+            intentional: int_count,
+            notes: out.notes,
+        });
+        log(domain_id + ": unexpected=" + u_count.to_string() + " intentional=" + int_count.to_string());
+    }
+    i += 1;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Cross-check documented policy
+// ---------------------------------------------------------------------------
+phase("Cross-check policy");
+
+let policy_prompt = "";
+policy_prompt += "Cross-check orchestrator impersonation policy docs against Core code.\n\n";
+policy_prompt += "MUST read with tools:\n";
+policy_prompt += "- docs/orchestrator/hermes-orchestrator-actor.md\n";
+policy_prompt += "- docs/hermes-orchestrator-approve-overrides.md if present\n";
+policy_prompt += "- apps/core/src/middleware/auth.ts (forbidOrchestratorActor, requireUserContext)\n";
+policy_prompt += "- apps/core/src/routes/v1/auth-actor-guards.test.ts\n";
+policy_prompt += "- grep forbidOrchestratorActor and requireUserAuthContext under apps/core/src/routes\n\n";
+policy_prompt += "Summarize the product policy: when orchestrator+context may act as user.\n";
+policy_prompt += "List documented exclusions with source path.\n";
+policy_prompt += "gaps_vs_docs: places where code deny/allow diverges from docs, or docs are silent\n";
+policy_prompt += "about a broad requireUserAuthContext class that blocks impersonation.\n";
+policy_prompt += "Empty gaps_vs_docs is valid only after grepping and finding none.\n";
+
+let policy = agent(policy_prompt, #{
+    label: "policy-docs",
+    capability_mode: "read-only",
+    output_schema: policy_schema,
+});
+
+if policy == () || !policy.success {
+    log("Policy cross-check agent failed; continuing with domain findings only");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Adversarial verify unexpected denials (cap)
+// ---------------------------------------------------------------------------
+phase("Verify gaps");
+
+const MAX_VERIFY = 12;
+let to_verify = [];
+let vi = 0;
+for g in all_unexpected {
+    if vi < MAX_VERIFY {
+        to_verify.push(g);
+        vi += 1;
+    }
+}
+if all_unexpected.len() > MAX_VERIFY {
+    log("Truncated verification to " + MAX_VERIFY.to_string() + " of " + all_unexpected.len().to_string() + " gaps");
+}
+
+let confirmed_gaps = [];
+let dismissed_gaps = [];
+
+if to_verify.len() > 0 {
+    let vjobs = [];
+    for g in to_verify {
+        let vp = "";
+        vp += "Adversarially verify this claimed orchestrator impersonation gap.\n\n";
+        vp += "Claimed gap:\n";
+        vp += "- domain: " + g.domain + "\n";
+        vp += "- endpoint: " + g.method_path + "\n";
+        vp += "- file: " + g.file + "\n";
+        vp += "- guard: " + g.guard + "\n";
+        vp += "- why: " + g.why_unexpected + "\n\n";
+        vp += "You MUST open the file and read the handler. Confirm:\n";
+        vp += "1. A normal user session can access this endpoint.\n";
+        vp += "2. An orchestrator with service token + X-Context-User-Id is rejected by this guard\n";
+        vp += "   (or equivalent logic).\n";
+        vp += "3. The denial is NOT justified by documented product rules in\n";
+        vp += "   docs/orchestrator/hermes-orchestrator-actor.md (hermes product, marketplace chat,\n";
+        vp += "   conversations, POST tasks/{id}/jobs coworker-only).\n";
+        vp += "4. If guard is requireUserAuthContext for clear session-bound billing/consent/PII,\n";
+        vp += "   set real=false severity=invalid — intentional session-only, not a bug.\n";
+        vp += "5. If Hermes/workspace orchestration would reasonably need this user surface,\n";
+        vp += "   set real=true.\n\n";
+        vp += "Set real=true only with concrete file evidence you read. Default real=false when unsure.\n";
+        vp += "fix_suggestion: e.g. switch requireUserAuthContext → requireUserContext, or document exclusion.\n";
+
+        vjobs.push(#{
+            prompt: vp,
+            label: "verify:" + g.domain,
+            capability_mode: "read-only",
+            output_schema: gap_verdict_schema,
+        });
+    }
+
+    let verdicts = parallel(vjobs);
+    let j = 0;
+    for v in verdicts {
+        let gap = to_verify[j];
+        if v != () && v.success && v.output != () && v.output.real == true
+            && v.output.evidence != () && v.output.evidence != "" {
+            confirmed_gaps.push(#{
+                domain: gap.domain,
+                method_path: gap.method_path,
+                file: gap.file,
+                guard: gap.guard,
+                severity: v.output.severity,
+                reason: v.output.reason,
+                evidence: v.output.evidence,
+                fix_suggestion: v.output.fix_suggestion,
+            });
+        } else {
+            let why = "unverified or not real";
+            if v != () && v.success && v.output != () && v.output.reason != () {
+                why = v.output.reason;
+            }
+            dismissed_gaps.push(#{
+                domain: gap.domain,
+                method_path: gap.method_path,
+                file: gap.file,
+                reason: why,
+            });
+        }
+        j += 1;
+    }
+} else {
+    log("No unexpected denials claimed by domain scanners");
+}
+
+log("Confirmed gaps: " + confirmed_gaps.len().to_string()
+    + " / claimed: " + all_unexpected.len().to_string()
+    + " (verified up to " + to_verify.len().to_string() + ")");
+
+// ---------------------------------------------------------------------------
+// Phase 5: Synthesize report
+// ---------------------------------------------------------------------------
+phase("Report");
+
+let payload = #{
+    primitives_summary: if prim.success { prim.output.summary } else { "unavailable" },
+    primitives: if prim.success { prim.output.primitives } else { [] },
+    domain_summaries: domain_summaries,
+    intentional_exclusions: all_intentional,
+    claimed_unexpected: all_unexpected,
+    confirmed_gaps: confirmed_gaps,
+    dismissed_gaps: dismissed_gaps,
+    policy: if policy != () && policy.success { policy.output } else { () },
+};
+
+let payload_json = json_encode(payload);
+
+let report_prompt = "";
+report_prompt += "Write a markdown audit report for orchestrator impersonation parity.\n\n";
+report_prompt += "INVARIANT under test:\n";
+report_prompt += "An orchestrator authenticated with ORCHESTRATOR_SERVICE_TOKEN that sends\n";
+report_prompt += "X-Context-User-Id / X-Context-Organization-Id must be able to call every Core API\n";
+report_prompt += "endpoint available to that user, except documented intentional exclusions\n";
+report_prompt += "(Hermes product /v1/hermes/*, marketplace chat/conversations, coworker-only\n";
+report_prompt += "POST /v1/tasks/{id}/jobs) and clearly session-bound surfaces (Stripe checkout,\n";
+report_prompt += "OAuth consent, admin).\n\n";
+report_prompt += "Use ONLY this JSON evidence (do not invent endpoints):\n";
+report_prompt += payload_json + "\n\n";
+report_prompt += "Report structure (markdown):\n";
+report_prompt += "# Orchestrator impersonation audit\n";
+report_prompt += "## Verdict (pass | pass_with_gaps | fail)\n";
+report_prompt += "## Auth primitives (table)\n";
+report_prompt += "## Domain coverage summary\n";
+report_prompt += "## Confirmed unexpected denials (fix these — file, guard, evidence, suggestion)\n";
+report_prompt += "## Intentional exclusions (OK)\n";
+report_prompt += "## Dismissed claims\n";
+report_prompt += "## Policy / docs alignment\n";
+report_prompt += "## Recommended next steps (tests: auth-actor-guards style createOrchestratorContextApp)\n\n";
+report_prompt += "verdict=fail if any confirmed gap has severity blocker or major.\n";
+report_prompt += "verdict=pass_with_gaps if only minor/nit confirmed gaps or needs_review leftovers.\n";
+report_prompt += "verdict=pass if confirmed_gaps empty and domains mostly ok.\n";
+report_prompt += "unexpected_count = confirmed_gaps length. intentional_count = intentional_exclusions length.\n";
+report_prompt += "Keep markdown complete but concise; every confirmed gap must cite file path.\n";
+
+let report = agent(report_prompt, #{
+    label: "synthesize-report",
+    capability_mode: "read-only",
+    output_schema: report_schema,
+});
+
+if report == () || !report.success || report.output.markdown == () {
+    // Fallback minimal report if synthesizer fails
+    let fallback = "# Orchestrator impersonation audit\n\n";
+    fallback += "Synthesizer failed. Raw counts:\n";
+    fallback += "- claimed unexpected: " + all_unexpected.len().to_string() + "\n";
+    fallback += "- confirmed gaps: " + confirmed_gaps.len().to_string() + "\n";
+    fallback += "- intentional: " + all_intentional.len().to_string() + "\n";
+    let path = write_scratch_file("orchestrator-impersonation-audit.md", fallback);
+    complete(#{
+        path: path,
+        verdict: "fail",
+        unexpected_count: confirmed_gaps.len(),
+        intentional_count: all_intentional.len(),
+        summary: "Report synthesizer failed; raw counts only",
+    });
+}
+
+let md = report.output.markdown;
+let path = write_scratch_file("orchestrator-impersonation-audit.md", md);
+
+complete(#{
+    path: path,
+    verdict: report.output.verdict,
+    unexpected_count: report.output.unexpected_count,
+    intentional_count: report.output.intentional_count,
+    summary: "Orchestrator impersonation audit: " + report.output.verdict
+        + " (" + report.output.unexpected_count.to_string() + " confirmed unexpected denials)",
+});

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -1313,6 +1313,20 @@ describe("requireConversationCoworkerAccess", () => {
     expect(tx.coworker.findFirst).not.toHaveBeenCalled();
   });
 
+  it("rejects bare orchestrator without context headers", async () => {
+    const tx = createTransactionClient();
+    const bareOrchestrator: OrchestratorAuthenticationContext = {
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    };
+
+    await expect(
+      requireConversationCoworkerAccess(bareOrchestrator, null, tx),
+    ).rejects.toThrow(
+      "Context headers (X-Context-User-Id) are required for this resource",
+    );
+  });
+
   it("allows a delegated coworker on its own conversation (coworker_id)", async () => {
     const tx = createTransactionClient();
 

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -1300,7 +1300,7 @@ describe("requireConversationCoworkerAccess", () => {
     expect(tx.coworker.findFirst).not.toHaveBeenCalled();
   });
 
-  it("rejects orchestrator actors (marketplace chat is out of scope)", async () => {
+  it("is a no-op for orchestrator with context (acts as context user)", async () => {
     const tx = createTransactionClient();
     const orchestratorContext: OrchestratorAuthenticationContext = {
       actor: "orchestrator",
@@ -1308,9 +1308,9 @@ describe("requireConversationCoworkerAccess", () => {
       context: { userId: "user_123", organizationId: null },
     };
 
-    await expect(
-      requireConversationCoworkerAccess(orchestratorContext, null, tx),
-    ).rejects.toThrow("Orchestrator cannot access marketplace conversations");
+    await requireConversationCoworkerAccess(orchestratorContext, null, tx);
+
+    expect(tx.coworker.findFirst).not.toHaveBeenCalled();
   });
 
   it("allows a delegated coworker on its own conversation (coworker_id)", async () => {

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -666,10 +666,18 @@ export async function requireConversationCoworkerAccess(
   metadata: Prisma.JsonValue | null,
   tx: Prisma.TransactionClient = prisma,
 ): Promise<void> {
-  if (
-    isUserAuthContext(authContext) ||
-    isOrchestratorAuthContext(authContext)
-  ) {
+  if (isUserAuthContext(authContext)) {
+    return;
+  }
+
+  // Orchestrator acts as the context user; ownership is enforced by the
+  // caller’s userId-scoped query. Bare service token has no user scope.
+  if (isOrchestratorAuthContext(authContext)) {
+    if (!authContext.context) {
+      throw forbidden(
+        "Context headers (X-Context-User-Id) are required for this resource",
+      );
+    }
     return;
   }
 
@@ -700,7 +708,7 @@ export async function requireConversationCoworkerAccess(
  * authenticated coworker and drops any client-supplied `coworker_slug`, so the
  * binding cannot diverge (the chat handler resolves the coworker from
  * `coworker_id`; the real slug is derived from it). No-op for user sessions and
- * orchestrator context actors.
+ * orchestrator context actors. Bare orchestrator is rejected.
  *
  * Mutates and returns the passed metadata object.
  */
@@ -708,10 +716,16 @@ export function pinCoworkerConversationBinding(
   authContext: AuthenticationContext,
   metadata: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (
-    isUserAuthContext(authContext) ||
-    isOrchestratorAuthContext(authContext)
-  ) {
+  if (isUserAuthContext(authContext)) {
+    return metadata;
+  }
+
+  if (isOrchestratorAuthContext(authContext)) {
+    if (!authContext.context) {
+      throw forbidden(
+        "Context headers (X-Context-User-Id) are required for this resource",
+      );
+    }
     return metadata;
   }
 

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -649,7 +649,8 @@ export async function resolveConversationCoworkerId(
  *
  * - User actors: no-op — ownership is already enforced by the `userId`-scoped
  *   query that loaded the conversation.
- * - Orchestrator actors: always forbidden (marketplace chat is out of scope).
+ * - Orchestrator with context headers: no-op — acts as the context user; ownership
+ *   is enforced by the same `userId`-scoped query via {@link requireUserContext}.
  * - Delegated coworker actors: the conversation's bound coworker
  *   (`metadata.coworker_id` / `coworker_slug`) must equal the authenticated
  *   `coworkerId`. Delegation alone (user-exists + org-membership) is not enough;
@@ -658,19 +659,17 @@ export async function resolveConversationCoworkerId(
  * Non-delegated coworkers never reach this on user-scoped routes
  * (`requireUserContext` throws first); the delegation branch guards defensively.
  *
- * @throws {forbidden} When the actor is an orchestrator, or a delegated coworker
- *   is not the conversation's coworker.
+ * @throws {forbidden} When a delegated coworker is not the conversation's coworker.
  */
 export async function requireConversationCoworkerAccess(
   authContext: AuthenticationContext,
   metadata: Prisma.JsonValue | null,
   tx: Prisma.TransactionClient = prisma,
 ): Promise<void> {
-  if (isOrchestratorAuthContext(authContext)) {
-    throw forbidden("Orchestrator cannot access marketplace conversations");
-  }
-
-  if (isUserAuthContext(authContext)) {
+  if (
+    isUserAuthContext(authContext) ||
+    isOrchestratorAuthContext(authContext)
+  ) {
     return;
   }
 
@@ -700,7 +699,8 @@ export async function requireConversationCoworkerAccess(
  * is delegated. For coworker actors this stamps `coworker_id` to the
  * authenticated coworker and drops any client-supplied `coworker_slug`, so the
  * binding cannot diverge (the chat handler resolves the coworker from
- * `coworker_id`; the real slug is derived from it). No-op for user sessions.
+ * `coworker_id`; the real slug is derived from it). No-op for user sessions and
+ * orchestrator context actors.
  *
  * Mutates and returns the passed metadata object.
  */
@@ -708,11 +708,10 @@ export function pinCoworkerConversationBinding(
   authContext: AuthenticationContext,
   metadata: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (isOrchestratorAuthContext(authContext)) {
-    throw forbidden("Orchestrator cannot access marketplace conversations");
-  }
-
-  if (isUserAuthContext(authContext)) {
+  if (
+    isUserAuthContext(authContext) ||
+    isOrchestratorAuthContext(authContext)
+  ) {
     return metadata;
   }
 

--- a/apps/core/src/middleware/auth.ts
+++ b/apps/core/src/middleware/auth.ts
@@ -217,20 +217,6 @@ export function requireUserAuthContext(
 }
 
 /**
- * Rejects orchestrator actors (bare or contextual). Use on surfaces that are
- * user/coworker-only (marketplace chat, task scheduling) even when
- * {@link requireUserContext} would accept an orchestrator with workspace context.
- */
-export function forbidOrchestratorActor(
-  authContext: AuthenticationContext,
-  message: string,
-): void {
-  if (isOrchestratorAuthContext(authContext)) {
-    throw forbidden(message);
-  }
-}
-
-/**
  * Rejects coworker actors (bare or contextual). Use on owner-only mutations
  * where {@link requireUserContext} would otherwise treat `X-Context-User-Id` as
  * the task owner. Orchestrator with workspace context remains allowed.

--- a/apps/core/src/routes/v1/agents/[id]/ratings/eligibility/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/ratings/eligibility/get.test.ts
@@ -37,7 +37,14 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-function createApp() {
+function createApp(
+  authContext: AuthVariables["authContext"] = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
+) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables;
   }>({
@@ -51,12 +58,7 @@ function createApp() {
   app.use("*", async (c, next) => {
     c.set("requestId", "test-req-id");
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId: null,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     return await next();
   });
 
@@ -111,6 +113,41 @@ describe("GET /agents/{id}/ratings/eligibility", () => {
     );
 
     expect(response.status).toBe(404);
+    expect(doesUserHaveFinishedJobWithAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    doesUserHaveFinishedJobWithAgentMock.mockResolvedValue(true);
+
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+    const response = await app.request(
+      "http://localhost/agent_123/ratings/eligibility",
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual({ eligible: true });
+    expect(doesUserHaveFinishedJobWithAgentMock).toHaveBeenCalledWith(
+      "user_123",
+      "agent_123",
+      expect.anything(),
+    );
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    });
+    const response = await app.request(
+      "http://localhost/agent_123/ratings/eligibility",
+    );
+
+    expect(response.status).toBe(403);
     expect(doesUserHaveFinishedJobWithAgentMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/agents/[id]/ratings/eligibility/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/ratings/eligibility/get.ts
@@ -9,7 +9,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { agentRatingEligibilitySchema } from "@/schemas/agent.schema";
 
 const params = z.object({
@@ -24,7 +24,7 @@ const route = withGlobalHeaderParameters(
     method: "get",
     path: "/{id}/ratings/eligibility",
     description:
-      "Check whether the authenticated caller is eligible to rate an agent (has finished at least one job with it)",
+      "Check whether the authenticated caller is eligible to rate an agent (has finished at least one job with it). Session user or orchestrator/coworker with context headers.",
     tags: ["Agents"],
     request: {
       params,
@@ -35,6 +35,7 @@ const route = withGlobalHeaderParameters(
         "Whether the caller may rate the agent",
       ),
       401: jsonErrorResponse("Unauthorized"),
+      403: jsonErrorResponse("Forbidden"),
       404: jsonErrorResponse("Not Found"),
     },
   }),
@@ -42,7 +43,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const eligible = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/agents/[id]/ratings/post.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/ratings/post.test.ts
@@ -40,7 +40,14 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-function createApp() {
+function createApp(
+  authContext: AuthVariables["authContext"] = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
+) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables;
   }>({
@@ -54,12 +61,7 @@ function createApp() {
   app.use("*", async (c, next) => {
     c.set("requestId", "test-req-id");
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId: null,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     return await next();
   });
 
@@ -146,5 +148,47 @@ describe("POST /agents/{id}/ratings", () => {
 
     expect(response.status).toBe(422);
     expect(requireAvailableAgentOrThrowMock).not.toHaveBeenCalled();
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+    const response = await app.request(
+      postRating({ rating: 5, comment: "Great results." }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(doesUserHaveFinishedJobWithAgentMock).toHaveBeenCalledWith(
+      "user_123",
+      "agent_123",
+      expect.anything(),
+    );
+    expect(upsertUserAgentReviewMock).toHaveBeenCalledWith(
+      "agent_123",
+      "user_123",
+      5,
+      "Great results.",
+      expect.anything(),
+    );
+    expect(body.data).toEqual({
+      id: "rating_123",
+      rating: 5,
+      comment: "Great results.",
+    });
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    });
+    const response = await app.request(postRating({ rating: 5 }));
+
+    expect(response.status).toBe(403);
+    expect(upsertUserAgentReviewMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/agents/[id]/ratings/post.ts
+++ b/apps/core/src/routes/v1/agents/[id]/ratings/post.ts
@@ -13,7 +13,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   agentMyReviewSchema,
   agentRatingRequestSchema,
@@ -31,7 +31,7 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/{id}/ratings",
     description:
-      "Create or update the authenticated caller's rating for an agent. Requires the caller to have finished at least one job with the agent.",
+      "Create or update the authenticated caller's rating for an agent. Requires the caller to have finished at least one job with the agent. Session user or orchestrator/coworker with context headers.",
     tags: ["Agents"],
     request: {
       params,
@@ -58,7 +58,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const { rating, comment } = c.req.valid("json");
 

--- a/apps/core/src/routes/v1/agents/[id]/reviews/me/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/me/get.test.ts
@@ -33,7 +33,14 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-function createApp() {
+function createApp(
+  authContext: AuthVariables["authContext"] = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
+) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables;
   }>({
@@ -47,12 +54,7 @@ function createApp() {
   app.use("*", async (c, next) => {
     c.set("requestId", "test-req-id");
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId: null,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     return await next();
   });
 
@@ -120,6 +122,45 @@ describe("GET /agents/{id}/reviews/me", () => {
     const response = await app.request("http://localhost/agent_123/reviews/me");
 
     expect(response.status).toBe(404);
+    expect(getUserAgentReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    getUserAgentReviewMock.mockResolvedValue({
+      id: "rating_123",
+      rating: 4,
+      comment: "Solid output.",
+    });
+
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+    const response = await app.request("http://localhost/agent_123/reviews/me");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getUserAgentReviewMock).toHaveBeenCalledWith(
+      "agent_123",
+      "user_123",
+      expect.anything(),
+    );
+    expect(body.data).toEqual({
+      id: "rating_123",
+      rating: 4,
+      comment: "Solid output.",
+    });
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    });
+    const response = await app.request("http://localhost/agent_123/reviews/me");
+
+    expect(response.status).toBe(403);
     expect(getUserAgentReviewMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/agents/[id]/reviews/me/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/reviews/me/get.ts
@@ -13,7 +13,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { agentMyReviewResponseSchema } from "@/schemas/agent.schema";
 
 const params = z.object({
@@ -27,7 +27,8 @@ const route = withGlobalHeaderParameters(
   createRoute({
     method: "get",
     path: "/{id}/reviews/me",
-    description: "Get the authenticated caller's own review for an agent",
+    description:
+      "Get the authenticated caller's own review for an agent. Session user or orchestrator/coworker with context headers.",
     tags: ["Agents"],
     request: {
       params,
@@ -38,6 +39,7 @@ const route = withGlobalHeaderParameters(
         "The caller's own review for the agent, or null if they have not rated it",
       ),
       401: jsonErrorResponse("Unauthorized"),
+      403: jsonErrorResponse("Forbidden"),
       404: jsonErrorResponse("Not Found"),
     },
   }),
@@ -45,7 +47,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const review = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/auth-actor-guards.test.ts
+++ b/apps/core/src/routes/v1/auth-actor-guards.test.ts
@@ -34,27 +34,6 @@ function createCoworkerContextApp(
   return app;
 }
 
-function createOrchestratorContextApp(
-  mount: (app: OpenAPIHonoWithAuth) => void,
-): OpenAPIHono<{ Variables: AuthVariables }> {
-  const app = new OpenAPIHono<{
-    Variables: AuthVariables;
-  }>();
-
-  app.use("*", async (c, next) => {
-    c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "orchestrator",
-      orchestratorId: "orch_123",
-      context: { userId: "user_123", organizationId: null },
-    });
-    return await next();
-  });
-
-  mount(app as unknown as OpenAPIHonoWithAuth);
-  return app;
-}
-
 function createCoworkerUserRouteContextApp(
   mount: (app: OpenAPIHonoWithAuth<UserRouteVariables>) => void,
 ): OpenAPIHono<{ Variables: AuthVariables }> {
@@ -106,13 +85,6 @@ describe("route actor guards", () => {
   it("returns 403 for coworker auth on agent jobs routes", async () => {
     const app = createCoworkerContextApp(mountGetAgentJobs);
     const response = await app.request("http://localhost/agent_123/jobs");
-
-    expect(response.status).toBe(403);
-  });
-
-  it("returns 403 for contextual orchestrator on conversation routes", async () => {
-    const app = createOrchestratorContextApp(mountGetConversations);
-    const response = await app.request("http://localhost/");
 
     expect(response.status).toBe(403);
   });

--- a/apps/core/src/routes/v1/chat/get.ts
+++ b/apps/core/src/routes/v1/chat/get.ts
@@ -16,7 +16,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   getChatUiMessagesQuerySchema,
   getChatUiMessagesResponseDataSchema,
@@ -68,10 +68,6 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(withGlobalHeaderParameters(route), async (c) => {
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
       const query = c.req.valid("query");
       const { conversationId } = query;

--- a/apps/core/src/routes/v1/chat/get.ts
+++ b/apps/core/src/routes/v1/chat/get.ts
@@ -26,7 +26,7 @@ const route = createRoute({
   method: "get",
   path: "/",
   description:
-    "Load persisted messages as AI SDK UIMessage[] for the chat UI (same source as POST /chat persistence).",
+    "Load persisted messages as AI SDK UIMessage[] for the chat UI (same source as POST /chat persistence). Session user or orchestrator/coworker with context headers.",
   tags: ["Chat"],
   request: {
     query: getChatUiMessagesQuerySchema,

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -80,11 +80,7 @@ import {
   getOpenRouterChatApiKeyForProvider,
   getSokosumiProvider,
 } from "@/lib/sokosumi-ai-provider";
-import {
-  forbidOrchestratorActor,
-  isUserAuthContext,
-  requireUserContext,
-} from "@/middleware/auth";
+import { isCoworkerAuthContext, requireUserContext } from "@/middleware/auth";
 import {
   AI_SDK_CHAT_MESSAGES_REQUIREMENT,
   aiSdkChatRequestSchema,
@@ -542,10 +538,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       waitUntil(release());
     };
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
 
       const {
@@ -561,7 +553,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       // A delegated coworker may only act on a conversation assigned to it.
       // Without a conversationId there is no resource to authorize against, so a
       // coworker would be driving a transient chat as the delegated user — deny.
-      if (!isUserAuthContext(c.var.authContext) && !conversationId) {
+      // Orchestrator+context may start a new chat like a user session.
+      if (isCoworkerAuthContext(c.var.authContext) && !conversationId) {
         throw forbidden(
           "You can only access conversations assigned to your coworker",
         );

--- a/apps/core/src/routes/v1/chat/post.ts
+++ b/apps/core/src/routes/v1/chat/post.ts
@@ -491,7 +491,7 @@ const route = createRoute({
   method: "post",
   path: "/",
   description:
-    "Stream chat via Vercel AI SDK (`@sokosumi/ai-provider`) to OpenRouter or a coworker Responses endpoint.",
+    "Stream chat via Vercel AI SDK (`@sokosumi/ai-provider`) to OpenRouter or a coworker Responses endpoint. Session user or orchestrator/coworker with context headers (coworkers require an assigned conversationId).",
   tags: ["Chat"],
   request: {
     body: {

--- a/apps/core/src/routes/v1/chat/stream-get.ts
+++ b/apps/core/src/routes/v1/chat/stream-get.ts
@@ -17,7 +17,7 @@ import {
   getResumableUiStreamContext,
   isUiStreamResumptionConfigured,
 } from "@/lib/resumable-ui-stream-context";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 
 /** `resumable-stream` rejects with this after a fixed ~1s Redis pub/sub handshake timeout. */
 function isResumableStreamAckTimeoutError(error: unknown): boolean {
@@ -61,10 +61,6 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(withGlobalHeaderParameters(route), async (c) => {
-    forbidOrchestratorActor(
-      c.var.authContext,
-      "Orchestrator cannot access marketplace conversations",
-    );
     const userContext = requireUserContext(c.var.authContext);
     const { conversationId } = c.req.valid("param");
 

--- a/apps/core/src/routes/v1/conversations/[id]/archive.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/archive.ts
@@ -9,7 +9,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { conversationSchema } from "@/schemas/conversation.schema";
 
 const archiveConversationRequestSchema = z
@@ -80,10 +80,6 @@ const route = withGlobalHeaderParameters(
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");

--- a/apps/core/src/routes/v1/conversations/[id]/get.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/get.ts
@@ -9,7 +9,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { conversationSchema } from "@/schemas/conversation.schema";
 
 const route = withGlobalHeaderParameters(
@@ -63,10 +63,6 @@ const route = withGlobalHeaderParameters(
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
       const { id } = c.req.valid("param");
 

--- a/apps/core/src/routes/v1/conversations/[id]/messages/get.test.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/get.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { defaultValidationHook } from "@/lib/hono";
-import type { AuthVariables } from "@/middleware/auth";
+import type { AuthenticationContext, AuthVariables } from "@/middleware/auth";
+import { TEST_VENDOR_ID } from "@/test-fixtures/vendor.js";
 
 import mountGetConversationMessages from "./get";
 
@@ -30,7 +31,14 @@ interface ConversationMessagesTestTransaction {
   };
 }
 
-function createApp() {
+function createApp(
+  authContext: AuthenticationContext = {
+    actor: "user",
+    userId: "user_123",
+    organizationId: null,
+    role: "user",
+  },
+) {
   const app = new OpenAPIHono<{
     Variables: AuthVariables & { requestId: string };
   }>({
@@ -39,18 +47,43 @@ function createApp() {
 
   app.use("*", async (c, next) => {
     c.set("isAuthenticated", true);
-    c.set("authContext", {
-      actor: "user",
-      userId: "user_123",
-      organizationId: null,
-      role: "user",
-    });
+    c.set("authContext", authContext);
     c.set("requestId", "req_test");
     return await next();
   });
 
   mountGetConversationMessages(app as unknown as OpenAPIHonoWithAuth);
   return app;
+}
+
+function mockConversationWithMessages(
+  metadata: Record<string, unknown> | null = null,
+) {
+  prismaTransactionMock.mockImplementation(
+    (callback: (tx: ConversationMessagesTestTransaction) => Promise<unknown>) =>
+      callback({
+        conversation: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: CONVERSATION_ID,
+            userId: "user_123",
+            metadata,
+          }),
+        },
+        conversationMessage: {
+          findMany: vi.fn().mockResolvedValue([
+            {
+              id: ASSISTANT_MESSAGE_ID,
+              role: "assistant",
+              contentType: "output_text",
+              contentText: "Hello",
+              createdAt: new Date("2026-05-01T17:00:00.000Z"),
+              metadata: null,
+            },
+          ]),
+          count: vi.fn().mockResolvedValue(1),
+        },
+      }),
+  );
 }
 
 describe("GET /conversations/{id}/messages", () => {
@@ -130,5 +163,41 @@ describe("GET /conversations/{id}/messages", () => {
         createdAt: 1777654800,
       },
     ]);
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    mockConversationWithMessages({ coworker_id: "cow_123" });
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    }).request(`http://localhost/${CONVERSATION_ID}/messages`);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    mockConversationWithMessages();
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    }).request(`http://localhost/${CONVERSATION_ID}/messages`);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 for delegated coworker on another coworker's conversation", async () => {
+    mockConversationWithMessages({ coworker_id: "cow_other" });
+
+    const response = await createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+      vendorId: TEST_VENDOR_ID,
+      context: { userId: "user_123", organizationId: null },
+    }).request(`http://localhost/${CONVERSATION_ID}/messages`);
+
+    expect(response.status).toBe(403);
   });
 });

--- a/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
@@ -29,7 +29,8 @@ const route = withGlobalHeaderParameters(
   createRoute({
     method: "get",
     path: "/{id}/messages",
-    description: "Get messages for a conversation (paginated)",
+    description:
+      "Get messages for a conversation (paginated). Session user or orchestrator/coworker with context headers; coworkers must be bound to the conversation.",
     tags: ["Conversations"],
     request: {
       params: z.object({

--- a/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
@@ -20,7 +20,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { conversationMessageSchema } from "@/schemas/conversation-message.schema";
 import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
 
@@ -82,7 +82,7 @@ const route = withGlobalHeaderParameters(
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     try {
-      const authContext = requireUserAuthContext(c.var.authContext);
+      const userContext = requireUserContext(c.var.authContext);
       const { id } = c.req.valid("param");
       const queryParams = c.req.valid("query");
 
@@ -93,7 +93,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         const conversation = await tx.conversation.findFirst({
           where: {
             id,
-            userId: authContext.userId,
+            userId: userContext.userId,
             archivedAt: null,
           },
         });

--- a/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/get.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
+import { requireConversationCoworkerAccess } from "@/helpers/access-control";
 import {
   conversationMessageToApiContent,
   imageGenerationFromMessageMetadata,
@@ -101,6 +102,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         if (!conversation) {
           throw notFound("Conversation not found");
         }
+
+        // Per-resource delegation check: a delegated coworker may only read a
+        // conversation bound to it (no-op for user sessions / orch+context).
+        await requireConversationCoworkerAccess(
+          c.var.authContext,
+          conversation.metadata,
+          tx,
+        );
 
         const where = {
           conversationId: conversation.id,

--- a/apps/core/src/routes/v1/conversations/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/messages/post.ts
@@ -16,7 +16,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   conversationMessageSchema,
   createConversationMessageRequestSchema,
@@ -77,10 +77,6 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    forbidOrchestratorActor(
-      c.var.authContext,
-      "Orchestrator cannot access marketplace conversations",
-    );
     const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");

--- a/apps/core/src/routes/v1/conversations/[id]/patch.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/patch.ts
@@ -12,7 +12,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   conversationSchema,
   updateConversationRequestSchema,
@@ -75,10 +75,6 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    forbidOrchestratorActor(
-      c.var.authContext,
-      "Orchestrator cannot access marketplace conversations",
-    );
     const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");

--- a/apps/core/src/routes/v1/conversations/[id]/warmup/get.ts
+++ b/apps/core/src/routes/v1/conversations/[id]/warmup/get.ts
@@ -12,7 +12,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { readCoworkerReadyState } from "@/routes/v1/chat/warmup-coworker";
 import { conversationWarmupStateSchema } from "@/schemas/conversation.schema";
 
@@ -65,10 +65,6 @@ const route = withGlobalHeaderParameters(
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
       const { id } = c.req.valid("param");
 

--- a/apps/core/src/routes/v1/conversations/get.test.ts
+++ b/apps/core/src/routes/v1/conversations/get.test.ts
@@ -97,4 +97,36 @@ describe("GET /conversations", () => {
     expect(response.status).toBe(200);
     expect(body.data.map((c) => c.id)).toEqual([idA]);
   });
+
+  it("returns every conversation for orchestrator with context headers", async () => {
+    conversationFindManyMock.mockResolvedValueOnce([
+      conversation(idA, { coworker_id: "cow_123" }),
+      conversation(idB, { coworker_id: "cow_other" }),
+    ]);
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    }).request("http://localhost/");
+    const body = (await response.json()) as { data: Array<{ id: string }> };
+
+    expect(response.status).toBe(200);
+    expect(conversationFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user_123", archivedAt: null },
+      }),
+    );
+    expect(body.data.map((c) => c.id)).toEqual([idA, idB]);
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    }).request("http://localhost/");
+
+    expect(response.status).toBe(403);
+    expect(conversationFindManyMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/routes/v1/conversations/get.ts
+++ b/apps/core/src/routes/v1/conversations/get.ts
@@ -19,7 +19,8 @@ const route = withGlobalHeaderParameters(
   createRoute({
     method: "get",
     path: "/",
-    description: "List all conversations for the authenticated user",
+    description:
+      "List all conversations for the effective user (session user, or orchestrator/coworker with context headers). Delegated coworkers only see conversations bound to their coworker id.",
     tags: ["Conversations"],
     responses: {
       200: jsonSuccessResponse(

--- a/apps/core/src/routes/v1/conversations/get.ts
+++ b/apps/core/src/routes/v1/conversations/get.ts
@@ -9,8 +9,7 @@ import {
   withGlobalHeaderParameters,
 } from "@/lib/hono";
 import {
-  forbidOrchestratorActor,
-  isUserAuthContext,
+  isCoworkerAuthContext,
   requireCoworkerAuthContext,
   requireUserContext,
 } from "@/middleware/auth";
@@ -53,10 +52,6 @@ const route = withGlobalHeaderParameters(
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
 
       // Database is the source of truth - fetch conversations
@@ -71,9 +66,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       // A delegated coworker may only see conversations assigned to it. Scope
       // by the stable `metadata.coworker_id` binding (no slug resolution here);
       // conversations without that binding are excluded for coworker actors.
+      // Orchestrator+context acts as the context user and sees the full user list.
       const authContext = c.var.authContext;
       let visibleConversations = conversations;
-      if (!isUserAuthContext(authContext)) {
+      if (isCoworkerAuthContext(authContext)) {
         const { coworkerId } = requireCoworkerAuthContext(authContext);
         visibleConversations = conversations.filter((conv) => {
           const meta = (conv.metadata as Record<string, unknown> | null) ?? {};

--- a/apps/core/src/routes/v1/conversations/post.ts
+++ b/apps/core/src/routes/v1/conversations/post.ts
@@ -13,7 +13,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { forbidOrchestratorActor, requireUserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { ensureCoworkerProviderConversation } from "@/routes/v1/chat/coworker-conversation";
 import { warmupCoworkerConversation } from "@/routes/v1/chat/warmup-coworker";
 import {
@@ -66,10 +66,6 @@ const route = withGlobalHeaderParameters(
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     try {
-      forbidOrchestratorActor(
-        c.var.authContext,
-        "Orchestrator cannot access marketplace conversations",
-      );
       const userContext = requireUserContext(c.var.authContext);
       const body = c.req.valid("json");
 

--- a/apps/core/src/routes/v1/history/get.test.ts
+++ b/apps/core/src/routes/v1/history/get.test.ts
@@ -175,6 +175,51 @@ describe("GET /history", () => {
     expect(body.meta.pagination.nextCursor).toBeNull();
   });
 
+  it("allows orchestrator with context headers as the context user", async () => {
+    const app = createApp(
+      {
+        actor: "orchestrator",
+        orchestratorId: "orch_123",
+        context: { userId: "user_123", organizationId: "org_123" },
+      },
+      {
+        workspaceId: WORKSPACE_CONTEXT.workspaceId,
+        userId: "user_123",
+        organizationId: "org_123",
+      },
+    );
+    const response = await app.request("http://localhost/");
+
+    expect(response.status).toBe(200);
+    expect(historyFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: expect.arrayContaining([
+            expect.objectContaining({
+              OR: expect.arrayContaining([
+                expect.objectContaining({ userId: "user_123" }),
+              ]),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const app = createApp(
+      {
+        actor: "orchestrator",
+        orchestratorId: "orch_123",
+      },
+      null,
+    );
+    const response = await app.request("http://localhost/");
+
+    expect(response.status).toBe(403);
+    expect(historyFindManyMock).not.toHaveBeenCalled();
+  });
+
   it("keeps conversations user-scoped when scope=workspace", async () => {
     const app = createApp();
     const response = await app.request("http://localhost/?scope=workspace");

--- a/apps/core/src/routes/v1/history/get.ts
+++ b/apps/core/src/routes/v1/history/get.ts
@@ -25,7 +25,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext, type UserContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { requireWorkspaceContext } from "@/middleware/workspace";
 import {
   historyListResponseExample,
@@ -144,8 +144,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const session = requireUserAuthContext(c.var.authContext);
-    const userContext: UserContext = { source: "session", ...session };
+    const userContext = requireUserContext(c.var.authContext);
     const workspaceContext = requireWorkspaceContext(c.var.workspaceContext);
     const queryParams = c.req.valid("query");
     const { cursor, take, skip } = parseCursorPagination(queryParams);

--- a/apps/core/src/routes/v1/history/get.ts
+++ b/apps/core/src/routes/v1/history/get.ts
@@ -39,7 +39,7 @@ const historyScopeQuerySchema = z
   .openapi({
     param: { name: "scope", in: "query" },
     description:
-      "Workspace visibility scope for task and job rows. Conversations are always scoped to the authenticated user.",
+      "Workspace visibility scope for task and job rows. Conversations are always scoped to the effective user (session or context headers).",
     example: "workspace",
   });
 

--- a/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
+++ b/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
@@ -23,7 +23,8 @@ const route = withGlobalHeaderParameters(
   createRoute({
     method: "patch",
     path: "/{id}/read",
-    description: "Mark a single notification as read (owner only)",
+    description:
+      "Mark a single notification as read for the effective user (session user, or orchestrator/coworker with context headers; owner only)",
     tags: ["Notifications"],
     request: {
       params: paramsSchema,

--- a/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
+++ b/apps/core/src/routes/v1/notifications/[id]/read/patch.ts
@@ -8,7 +8,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { notificationItemSchema } from "@/schemas/notification.schema";
 
 const paramsSchema = z.object({
@@ -65,7 +65,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     // Check ownership

--- a/apps/core/src/routes/v1/notifications/get.test.ts
+++ b/apps/core/src/routes/v1/notifications/get.test.ts
@@ -138,6 +138,33 @@ describe("GET /notifications", () => {
     );
   });
 
+  it("allows orchestrator with context headers as the context user", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: "org_123" },
+    });
+    const response = await app.request("http://localhost/");
+
+    expect(response.status).toBe(200);
+    expect(notificationFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user_123" },
+      }),
+    );
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    });
+    const response = await app.request("http://localhost/");
+
+    expect(response.status).toBe(403);
+    expect(notificationFindManyMock).not.toHaveBeenCalled();
+  });
+
   it("validates cursors against the same user and filter scope", async () => {
     notificationFindFirstMock.mockResolvedValue({ id: "notif_cursor" });
 

--- a/apps/core/src/routes/v1/notifications/get.ts
+++ b/apps/core/src/routes/v1/notifications/get.ts
@@ -65,7 +65,7 @@ const route = withGlobalHeaderParameters(
     method: "get",
     path: "/",
     description:
-      "List notifications for the authenticated user with cursor pagination",
+      "List notifications for the effective user (session user, or orchestrator/coworker with context headers) with cursor pagination",
     tags: ["Notifications"],
     request: {
       query,

--- a/apps/core/src/routes/v1/notifications/get.ts
+++ b/apps/core/src/routes/v1/notifications/get.ts
@@ -20,7 +20,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   notificationKindSchema,
   notificationListSchema,
@@ -147,7 +147,7 @@ function mapNotificationToItem(notification: {
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const queryParams = c.req.valid("query");
     const { cursor, take, skip } = parseCursorPagination(queryParams);
 

--- a/apps/core/src/routes/v1/notifications/mutations.test.ts
+++ b/apps/core/src/routes/v1/notifications/mutations.test.ts
@@ -155,6 +155,28 @@ describe("PATCH /notifications/{id}/read", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("allows orchestrator with context headers to mark owned notifications read", async () => {
+    const existing = createNotificationRow();
+    notificationFindUniqueMock.mockResolvedValue(existing);
+    notificationUpdateMock.mockResolvedValue({
+      ...existing,
+      isRead: true,
+      readAt: new Date("2026-06-16T15:00:00.000Z"),
+    });
+
+    const app = createApp(mountMarkNotificationRead, {
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+    const response = await app.request("http://localhost/notif_123/read", {
+      method: "PATCH",
+    });
+
+    expect(response.status).toBe(200);
+    expect(notificationUpdateMock).toHaveBeenCalled();
+  });
 });
 
 describe("PATCH /notifications/read-all", () => {
@@ -184,6 +206,27 @@ describe("PATCH /notifications/read-all", () => {
     const body = (await response.json()) as { data: { count: number } };
     expect(body.data.count).toBe(3);
   });
+
+  it("allows orchestrator with context headers for read-all", async () => {
+    const app = createApp(mountMarkAllRead, {
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+    const response = await app.request("http://localhost/read-all", {
+      method: "PATCH",
+    });
+
+    expect(response.status).toBe(200);
+    expect(notificationUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user_123",
+          isRead: false,
+        },
+      }),
+    );
+  });
 });
 
 describe("GET /notifications/unread-count", () => {
@@ -206,5 +249,22 @@ describe("GET /notifications/unread-count", () => {
 
     const body = (await response.json()) as { data: { count: number } };
     expect(body.data.count).toBe(5);
+  });
+
+  it("allows orchestrator with context headers for unread count", async () => {
+    const app = createApp(mountGetUnreadCount, {
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+    const response = await app.request("http://localhost/unread-count");
+
+    expect(response.status).toBe(200);
+    expect(notificationCountMock).toHaveBeenCalledWith({
+      where: {
+        userId: "user_123",
+        isRead: false,
+      },
+    });
   });
 });

--- a/apps/core/src/routes/v1/notifications/read-all/patch.ts
+++ b/apps/core/src/routes/v1/notifications/read-all/patch.ts
@@ -22,7 +22,8 @@ const route = withGlobalHeaderParameters(
   createRoute({
     method: "patch",
     path: "/read-all",
-    description: "Mark all notifications as read for the authenticated user",
+    description:
+      "Mark all notifications as read for the effective user (session user, or orchestrator/coworker with context headers)",
     tags: ["Notifications"],
     responses: {
       200: jsonSuccessResponse(

--- a/apps/core/src/routes/v1/notifications/read-all/patch.ts
+++ b/apps/core/src/routes/v1/notifications/read-all/patch.ts
@@ -7,7 +7,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 
 const responseSchema = z
   .object({
@@ -44,7 +44,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
 
     const result = await prisma.notification.updateMany({
       where: {

--- a/apps/core/src/routes/v1/notifications/unread-count/get.ts
+++ b/apps/core/src/routes/v1/notifications/unread-count/get.ts
@@ -15,7 +15,7 @@ const route = withGlobalHeaderParameters(
     method: "get",
     path: "/unread-count",
     description:
-      "Get the count of unread notifications for the authenticated user",
+      "Get the count of unread notifications for the effective user (session user, or orchestrator/coworker with context headers)",
     tags: ["Notifications"],
     responses: {
       200: jsonSuccessResponse(unreadCountSchema, "Unread count retrieved", {

--- a/apps/core/src/routes/v1/notifications/unread-count/get.ts
+++ b/apps/core/src/routes/v1/notifications/unread-count/get.ts
@@ -7,7 +7,7 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { unreadCountSchema } from "@/schemas/notification.schema";
 
 const route = withGlobalHeaderParameters(
@@ -33,7 +33,7 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
 
     const count = await prisma.notification.count({
       where: {

--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.test.ts
@@ -17,13 +17,31 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
-    if (!authContext || authContext.actor !== "user") {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
+    if (!authContext) {
       throw new HTTPException(403, {
         message: "User authentication required",
       });
     }
-    return { source: "session" as const, ...authContext };
+    if (authContext.actor === "user") {
+      return { source: "session" as const, ...authContext };
+    }
+    if (
+      (authContext.actor === "coworker" ||
+        authContext.actor === "orchestrator") &&
+      "context" in authContext &&
+      authContext.context
+    ) {
+      return {
+        source: "context" as const,
+        userId: authContext.context.userId,
+        organizationId: authContext.context.organizationId,
+      };
+    }
+    throw new HTTPException(403, {
+      message:
+        "Context headers (X-Context-User-Id) are required for this resource",
+    });
   },
   hasAdminRole: (role: string | null | undefined) => role === "admin",
 }));
@@ -111,7 +129,7 @@ describe("GET /organizations/{id}/billing-details", () => {
     expect(getOrganizationBillingDetailsMock).not.toHaveBeenCalled();
   });
 
-  it("returns 403 for coworker with X-Context-User-Id matching a user", async () => {
+  it("allows coworker with context headers as the context user", async () => {
     const response = await createApp({
       actor: "coworker",
       coworkerId: "cow_123",
@@ -119,8 +137,26 @@ describe("GET /organizations/{id}/billing-details", () => {
       context: { userId: "user_123", organizationId: "org_123" },
     }).request("http://localhost/org_123/billing-details");
 
-    expect(response.status).toBe(403);
-    expect(getOrganizationBillingDetailsMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(getOrganizationBillingDetailsMock).toHaveBeenCalledWith(
+      "org_123",
+      "user_123",
+    );
+    expect(getOrganizationBillingDetailsByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: "org_123" },
+    }).request("http://localhost/org_123/billing-details");
+
+    expect(response.status).toBe(200);
+    expect(getOrganizationBillingDetailsMock).toHaveBeenCalledWith(
+      "org_123",
+      "user_123",
+    );
   });
 
   it("returns 403 when the user is not an owner or admin", async () => {

--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
@@ -19,7 +19,7 @@ const route = createRoute({
   method: "get",
   path: "/{id}/billing-details",
   description:
-    "Get billing address and tax IDs stored on the organization's Stripe customer. Organization owners and admins, or platform admins with a session, may access this route.",
+    "Get billing address and tax IDs stored on the organization's Stripe customer. Organization owners and admins (session user or orchestrator/coworker with context headers), or platform admins with a user session, may access this route.",
   tags: ["Organizations"],
   request: {
     params,

--- a/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-details/get.ts
@@ -3,7 +3,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { hasAdminRole, requireUserAuthContext } from "@/middleware/auth";
+import { hasAdminRole, requireUserContext } from "@/middleware/auth";
 import { stripeCustomerBillingDetailsSchema } from "@/schemas/stripe.schema";
 import { stripeCustomerBillingService } from "@/services/stripe-customer-billing.service";
 
@@ -52,12 +52,14 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     // Platform admins with user auth (session or API key) can read org billing
-    // without membership. Org members still use membership checks below.
-    const isPlatformAdmin = hasAdminRole(userContext.role);
+    // without membership. Org members / orch+ctx still use membership checks below.
+    // Contextual actors have no platform role on the context payload.
+    const isPlatformAdmin =
+      userContext.source === "session" && hasAdminRole(userContext.role);
 
     const billingDetails = isPlatformAdmin
       ? await stripeCustomerBillingService.getOrganizationBillingDetailsById(id)

--- a/apps/core/src/routes/v1/organizations/[id]/billing-plan/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/billing-plan/get.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { organizationBillingPlanSchema } from "@/schemas/organization-billing-plan.schema";
 
 const params = z.object({
@@ -56,7 +56,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const billingPlan = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/get.test.ts
@@ -11,7 +11,7 @@ const { organizationFindUniqueMock, memberFindUniqueMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, { message: "User authentication required" });
     }

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/get.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { persistedDesignMdSchema } from "@/schemas/design-md.schema";
 
 const params = z.object({
@@ -54,7 +54,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const { organization } = await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/put.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/put.test.ts
@@ -18,7 +18,7 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/put.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/put.ts
@@ -10,7 +10,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import { uploadDesignMdContent } from "@/lib/design-md-blob";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   designMdWriteSchema,
   persistedDesignMdSchema,
@@ -70,7 +70,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");
 

--- a/apps/core/src/routes/v1/organizations/[id]/enterprise-contract-summary/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/enterprise-contract-summary/get.ts
@@ -8,7 +8,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { enterpriseContractBillingSummarySchema } from "@/schemas/enterprise-contract-summary.schema";
 
 const params = z.object({
@@ -63,7 +63,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const now = new Date();
 

--- a/apps/core/src/routes/v1/organizations/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/get.test.ts
@@ -10,7 +10,7 @@ const { prismaTransactionMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext) {
       throw new HTTPException(403, {
         message: "User authentication required",
@@ -25,7 +25,8 @@ vi.mock("@/middleware/auth", () => ({
     }
 
     if (
-      authContext.actor === "coworker" &&
+      (authContext.actor === "coworker" ||
+        authContext.actor === "orchestrator") &&
       "context" in authContext &&
       authContext.context
     ) {
@@ -37,7 +38,8 @@ vi.mock("@/middleware/auth", () => ({
     }
 
     throw new HTTPException(403, {
-      message: "User authentication required",
+      message:
+        "Context headers (X-Context-User-Id) are required for this resource",
     });
   },
 }));

--- a/apps/core/src/routes/v1/organizations/[id]/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/get.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { organizationWithRoleSchema } from "@/schemas/organization.schema";
 
 const params = z.object({
@@ -58,7 +58,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const organization = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/organizations/[id]/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/get.ts
@@ -20,7 +20,8 @@ const params = z.object({
 const route = createRoute({
   method: "get",
   path: "/{id}",
-  description: "Get organization details by ID for the current member",
+  description:
+    "Get organization details by ID for the effective user when they are a member (session user, or orchestrator/coworker with context headers)",
   tags: ["Organizations"],
   request: {
     params,

--- a/apps/core/src/routes/v1/organizations/[id]/invitations/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/invitations/get.test.ts
@@ -16,7 +16,7 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/invitations/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/invitations/get.ts
@@ -7,7 +7,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { pendingInvitationsSchema } from "@/schemas/invitation.schema";
 
 const params = z.object({
@@ -61,7 +61,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/delete.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/delete.test.ts
@@ -28,7 +28,7 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/delete.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/delete.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { organizationSeatUnassignmentSchema } from "@/schemas/organization-seat.schema";
 import {
   mapSeatRepositoryError,
@@ -60,7 +60,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id, memberId } = c.req.valid("param");
 
     try {

--- a/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/put.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/put.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/services/subscription-seat-credits.service", () => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/put.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/members/[memberId]/seat/put.ts
@@ -12,7 +12,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { organizationSeatAssignmentSchema } from "@/schemas/organization-seat.schema";
 import {
   grantUnusedSeatSubscriptionCreditsIfEligible,
@@ -70,7 +70,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id, memberId } = c.req.valid("param");
 
     // Pre-warm the per-seat credits cache before opening the transaction: on

--- a/apps/core/src/routes/v1/organizations/[id]/members/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/members/get.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { membersSchema } from "@/schemas/member.schema";
 
 const params = z.object({
@@ -64,7 +64,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const members = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.test.ts
@@ -22,7 +22,7 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/seat-summary/get.ts
@@ -10,7 +10,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { organizationSeatSummarySchema } from "@/schemas/organization-seat.schema";
 
 const params = z.object({
@@ -60,7 +60,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const summary = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/organizations/[id]/stripe-customer/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/stripe-customer/get.test.ts
@@ -11,7 +11,7 @@ const { organizationFindUniqueMock, memberFindUniqueMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/stripe-customer/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/stripe-customer/get.ts
@@ -5,7 +5,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { stripeCustomerSchema } from "@/schemas/stripe.schema";
 
 const params = z.object({
@@ -48,7 +48,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const { organization } = await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/stripe-customer/post.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/stripe-customer/post.test.ts
@@ -16,7 +16,7 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/stripe-customer/post.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/stripe-customer/post.ts
@@ -21,7 +21,7 @@ const route = createRoute({
   method: "post",
   path: "/{id}/stripe-customer",
   description:
-    "Ensure a Stripe customer exists for an organization. Any member of the organization may call it. Returns the existing customer id when already provisioned, otherwise creates the Stripe customer, persists the id immediately, and returns the new id.",
+    "Ensure a Stripe customer exists for an organization. Any member of the organization may call it (session user, or orchestrator/coworker with context headers). Returns the existing customer id when already provisioned, otherwise creates the Stripe customer, persists the id immediately, and returns the new id.",
   tags: ["Organizations"],
   request: {
     params,

--- a/apps/core/src/routes/v1/organizations/[id]/stripe-customer/post.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/stripe-customer/post.ts
@@ -5,7 +5,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { provisionedStripeCustomerSchema } from "@/schemas/stripe.schema";
 import { provisionOrganizationStripeCustomer } from "@/services/stripe-customer-provision.service";
 
@@ -49,7 +49,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const { organization } = await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/subscription/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/subscription/get.test.ts
@@ -93,7 +93,9 @@ describe("GET /organizations/{id}/subscription", () => {
     expect(resolveActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
   });
 
-  it("returns 403 for coworker with X-Context-User-Id matching a member", async () => {
+  it("allows coworker with context headers as the context user", async () => {
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+
     const response = await createApp({
       actor: "coworker",
       coworkerId: "cow_1",
@@ -101,8 +103,25 @@ describe("GET /organizations/{id}/subscription", () => {
       context: { userId: "user_1", organizationId: "org_1" },
     }).request("http://localhost/org_1/subscription");
 
-    expect(response.status).toBe(403);
-    expect(resolveActiveSubscriptionByReferenceIdMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_1", id: "org_1" }),
+    );
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_1",
+      context: { userId: "user_1", organizationId: "org_1" },
+    }).request("http://localhost/org_1/subscription");
+
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_1", id: "org_1" }),
+    );
   });
 
   it("returns 404 when the organization does not exist", async () => {

--- a/apps/core/src/routes/v1/organizations/[id]/subscription/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/subscription/get.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { activeSubscriptionResponseSchema } from "@/schemas/subscription.schema";
 
 const params = z.object({
@@ -58,7 +58,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
 
     const subscription = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/organizations/[id]/subscription/seats/put.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/subscription/seats/put.test.ts
@@ -28,7 +28,7 @@ const {
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
         message: "User authentication required",

--- a/apps/core/src/routes/v1/organizations/[id]/subscription/seats/put.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/subscription/seats/put.ts
@@ -19,7 +19,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   organizationSubscriptionSeatsSchema,
   updateOrganizationSubscriptionSeatsSchema,
@@ -109,7 +109,7 @@ async function increaseStripeSubscriptionSeats(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const { seats } = c.req.valid("json");
 

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/approve/post.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/approve/post.test.ts
@@ -166,22 +166,77 @@ describe("POST /organizations/{id}/vendor-grants/{grantId}/approve", () => {
     });
   });
 
-  it("rejects coworker context with 403 via real requireUserAuthContext", async () => {
-    const coworkerAuth: AuthenticationContext = {
+  it("allows coworker context as the context user via requireUserContext", async () => {
+    const existing = {
+      id: grantId,
+      vendorId,
+      workspaceId,
+      permission: VendorPermission.workspace,
+      status: VendorGrantStatus.PENDING,
+      requestedByUserId: "user_ctx",
+      resolvedAt: null,
+      resolvedById: null,
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+      vendor: { name: "Acme", slug: "acme" },
+    };
+    vendorGrantFindFirstMock.mockResolvedValue(existing);
+    vendorGrantUpdateMock.mockResolvedValue({
+      ...existing,
+      status: VendorGrantStatus.GRANTED,
+      resolvedAt: new Date("2026-07-02T00:00:00.000Z"),
+      resolvedById: "user_123",
+    });
+
+    const response = await createApp({
       actor: "coworker",
       coworkerId: "coworker_1",
       vendorId,
       context: { userId: "user_123", organizationId: orgId },
-    };
+    }).request(`http://localhost/${orgId}/vendor-grants/${grantId}/approve`, {
+      method: "POST",
+    });
 
-    const response = await createApp(coworkerAuth).request(
-      `http://localhost/${orgId}/vendor-grants/${grantId}/approve`,
-      { method: "POST" },
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123" }),
     );
+  });
 
-    expect(response.status).toBe(403);
-    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
-    expect(vendorGrantFindFirstMock).not.toHaveBeenCalled();
+  it("allows orchestrator with context headers as the context user", async () => {
+    const existing = {
+      id: grantId,
+      vendorId,
+      workspaceId,
+      permission: VendorPermission.workspace,
+      status: VendorGrantStatus.PENDING,
+      requestedByUserId: "user_ctx",
+      resolvedAt: null,
+      resolvedById: null,
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+      vendor: { name: "Acme", slug: "acme" },
+    };
+    vendorGrantFindFirstMock.mockResolvedValue(existing);
+    vendorGrantUpdateMock.mockResolvedValue({
+      ...existing,
+      status: VendorGrantStatus.GRANTED,
+      resolvedAt: new Date("2026-07-02T00:00:00.000Z"),
+      resolvedById: "user_123",
+    });
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_1",
+      context: { userId: "user_123", organizationId: orgId },
+    }).request(`http://localhost/${orgId}/vendor-grants/${grantId}/approve`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123" }),
+    );
   });
 
   it("unparks linked tasks when grant is already GRANTED", async () => {

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/approve/post.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/approve/post.ts
@@ -11,7 +11,7 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { vendorGrantSchema } from "@/schemas/vendor-grant.schema";
 
 const params = z.object({
@@ -46,7 +46,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id, grantId } = c.req.valid("param");
 
     await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/deny/post.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/deny/post.test.ts
@@ -165,21 +165,40 @@ describe("POST /organizations/{id}/vendor-grants/{grantId}/deny", () => {
     );
   });
 
-  it("rejects coworker context with 403 via real requireUserAuthContext", async () => {
-    const coworkerAuth: AuthenticationContext = {
+  it("allows coworker context as the context user via requireUserContext", async () => {
+    const existing = {
+      id: grantId,
+      vendorId,
+      workspaceId,
+      permission: VendorPermission.workspace,
+      status: VendorGrantStatus.PENDING,
+      requestedByUserId: null,
+      resolvedAt: null,
+      resolvedById: null,
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+      vendor: { name: "Acme", slug: "acme" },
+    };
+    vendorGrantFindFirstMock.mockResolvedValue(existing);
+    vendorGrantUpdateMock.mockResolvedValue({
+      ...existing,
+      status: VendorGrantStatus.DENIED,
+      resolvedAt: new Date("2026-07-02T00:00:00.000Z"),
+      resolvedById: "user_123",
+    });
+
+    const response = await createApp({
       actor: "coworker",
       coworkerId: "coworker_1",
       vendorId,
       context: { userId: "user_123", organizationId: orgId },
-    };
+    }).request(`http://localhost/${orgId}/vendor-grants/${grantId}/deny`, {
+      method: "POST",
+    });
 
-    const response = await createApp(coworkerAuth).request(
-      `http://localhost/${orgId}/vendor-grants/${grantId}/deny`,
-      { method: "POST" },
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123" }),
     );
-
-    expect(response.status).toBe(403);
-    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
-    expect(vendorGrantFindFirstMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/deny/post.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/deny/post.ts
@@ -11,7 +11,7 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { vendorGrantSchema } from "@/schemas/vendor-grant.schema";
 
 const params = z.object({
@@ -44,7 +44,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id, grantId } = c.req.valid("param");
 
     await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/revoke/post.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/revoke/post.test.ts
@@ -182,21 +182,76 @@ describe("POST /organizations/{id}/vendor-grants/{grantId}/revoke", () => {
     expect(response.status).toBe(404);
   });
 
-  it("rejects coworker context with 403 via real requireUserAuthContext", async () => {
-    const coworkerAuth: AuthenticationContext = {
+  it("allows coworker context as the context user via requireUserContext", async () => {
+    const existing = {
+      id: grantId,
+      vendorId,
+      workspaceId,
+      permission: VendorPermission.workspace,
+      status: VendorGrantStatus.GRANTED,
+      requestedByUserId: null,
+      resolvedAt: new Date("2026-07-01T12:00:00.000Z"),
+      resolvedById: "user_123",
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+      vendor: { name: "Acme", slug: "acme" },
+    };
+    vendorGrantFindFirstMock.mockResolvedValue(existing);
+    vendorGrantUpdateMock.mockResolvedValue({
+      ...existing,
+      status: VendorGrantStatus.REVOKED,
+      resolvedAt: new Date("2026-07-02T00:00:00.000Z"),
+      resolvedById: "user_123",
+    });
+
+    const response = await createApp({
       actor: "coworker",
       coworkerId: "coworker_1",
       vendorId,
       context: { userId: "user_123", organizationId: orgId },
-    };
+    }).request(`http://localhost/${orgId}/vendor-grants/${grantId}/revoke`, {
+      method: "POST",
+    });
 
-    const response = await createApp(coworkerAuth).request(
-      `http://localhost/${orgId}/vendor-grants/${grantId}/revoke`,
-      { method: "POST" },
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123" }),
     );
+  });
 
-    expect(response.status).toBe(403);
-    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
-    expect(vendorGrantFindFirstMock).not.toHaveBeenCalled();
+  it("allows orchestrator with context headers as the context user", async () => {
+    const existing = {
+      id: grantId,
+      vendorId,
+      workspaceId,
+      permission: VendorPermission.workspace,
+      status: VendorGrantStatus.GRANTED,
+      requestedByUserId: null,
+      resolvedAt: new Date("2026-07-01T12:00:00.000Z"),
+      resolvedById: "user_123",
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+      vendor: { name: "Acme", slug: "acme" },
+    };
+    vendorGrantFindFirstMock.mockResolvedValue(existing);
+    vendorGrantUpdateMock.mockResolvedValue({
+      ...existing,
+      status: VendorGrantStatus.REVOKED,
+      resolvedAt: new Date("2026-07-02T00:00:00.000Z"),
+      resolvedById: "user_123",
+    });
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_1",
+      context: { userId: "user_123", organizationId: orgId },
+    }).request(`http://localhost/${orgId}/vendor-grants/${grantId}/revoke`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123" }),
+    );
   });
 });

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/revoke/post.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/[grantId]/revoke/post.ts
@@ -11,7 +11,7 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { vendorGrantSchema } from "@/schemas/vendor-grant.schema";
 
 const params = z.object({
@@ -46,7 +46,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id, grantId } = c.req.valid("param");
 
     await resolveMemberOrganizationById({

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/get.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/get.ts
@@ -7,7 +7,7 @@ import { ok } from "@/helpers/response";
 import { toVendorGrantApiShape } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   vendorGrantSchema,
   vendorGrantStatusSchema,
@@ -44,7 +44,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const filters = c.req.valid("query");
 

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/post.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/post.test.ts
@@ -201,7 +201,9 @@ describe("POST /organizations/{id}/vendor-grants", () => {
     expect(vendorGrantUpsertMock).not.toHaveBeenCalled();
   });
 
-  it("rejects coworker context with 403 via real requireUserAuthContext", async () => {
+  it("allows coworker context as the context user via requireUserContext", async () => {
+    vendorGrantUpsertMock.mockResolvedValue(baseGrant());
+
     const coworkerAuth: AuthenticationContext = {
       actor: "coworker",
       coworkerId: "coworker_1",
@@ -218,8 +220,28 @@ describe("POST /organizations/{id}/vendor-grants", () => {
       },
     );
 
-    expect(response.status).toBe(403);
-    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
-    expect(vendorGrantUpsertMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(201);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123", id: orgId }),
+    );
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    vendorGrantUpsertMock.mockResolvedValue(baseGrant());
+
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_1",
+      context: { userId: "user_123", organizationId: orgId },
+    }).request(`http://localhost/${orgId}/vendor-grants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vendorId }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user_123", id: orgId }),
+    );
   });
 });

--- a/apps/core/src/routes/v1/organizations/[id]/vendor-grants/post.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/vendor-grants/post.ts
@@ -11,7 +11,7 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import {
   createVendorGrantRequestSchema,
   vendorGrantSchema,
@@ -52,7 +52,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");
 

--- a/apps/core/src/routes/v1/organizations/orch-context-access.test.ts
+++ b/apps/core/src/routes/v1/organizations/orch-context-access.test.ts
@@ -1,0 +1,173 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { errorHandler } from "@/helpers/error-handler";
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import type { AuthenticationContext, AuthVariables } from "@/middleware/auth";
+
+import mountGetOrganization from "./[id]/get";
+import mountGetOrganizationStripeCustomer from "./[id]/stripe-customer/get";
+import mountGetOrganizationSubscription from "./[id]/subscription/get";
+import mountGetOrganizationBySlug from "./slug/[slug]/get";
+
+/**
+ * Shared matrix: bare orch must fail requireUserContext; orch+ctx may pass
+ * membership and reach the handler body. Uses real requireUserContext.
+ */
+
+const {
+  resolveMemberOrganizationByIdMock,
+  resolveMemberOrganizationBySlugMock,
+  resolveActiveSubscriptionByReferenceIdMock,
+  prismaTransactionMock,
+} = vi.hoisted(() => ({
+  resolveMemberOrganizationByIdMock: vi.fn(),
+  resolveMemberOrganizationBySlugMock: vi.fn(),
+  resolveActiveSubscriptionByReferenceIdMock: vi.fn(),
+  prismaTransactionMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/organization", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/helpers/organization")>()),
+  resolveMemberOrganizationById: resolveMemberOrganizationByIdMock,
+  resolveMemberOrganizationBySlug: resolveMemberOrganizationBySlugMock,
+}));
+
+vi.mock("@sokosumi/database/repositories", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@sokosumi/database/repositories")>();
+  return {
+    ...actual,
+    subscriptionRepository: {
+      ...actual.subscriptionRepository,
+      resolveActiveSubscriptionByReferenceId:
+        resolveActiveSubscriptionByReferenceIdMock,
+    },
+  };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: prismaTransactionMock,
+  },
+}));
+
+const ORG = {
+  id: "org_123",
+  name: "Acme",
+  slug: "acme",
+  logo: null,
+  metadata: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  stripeCustomerId: "cus_org_123",
+};
+
+const BARE_ORCH: AuthenticationContext = {
+  actor: "orchestrator",
+  orchestratorId: "orch_123",
+};
+
+const ORCH_CTX: AuthenticationContext = {
+  actor: "orchestrator",
+  orchestratorId: "orch_123",
+  context: { userId: "user_123", organizationId: "org_123" },
+};
+
+function createApp(
+  mount: (app: OpenAPIHonoWithAuth) => void,
+  authContext: AuthenticationContext,
+) {
+  const app = new OpenAPIHono<{
+    Variables: AuthVariables & { requestId: string };
+  }>();
+
+  app.use("*", async (c, next) => {
+    c.set("requestId", "req_orch_org_matrix");
+    c.set("isAuthenticated", true);
+    c.set("authContext", authContext);
+    return await next();
+  });
+  app.onError(errorHandler);
+  mount(app as unknown as OpenAPIHonoWithAuth);
+  return app;
+}
+
+describe("organization routes: orchestrator context matrix", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveMemberOrganizationByIdMock.mockResolvedValue({
+      organization: ORG,
+      role: "member",
+      member: { role: "member" },
+    });
+    resolveMemberOrganizationBySlugMock.mockResolvedValue({
+      organization: ORG,
+      role: "member",
+      member: { role: "member" },
+    });
+    resolveActiveSubscriptionByReferenceIdMock.mockResolvedValue(null);
+    prismaTransactionMock.mockImplementation(
+      async (callback: (tx: unknown) => unknown) => await callback({}),
+    );
+  });
+
+  const cases: Array<{
+    name: string;
+    mount: (app: OpenAPIHonoWithAuth) => void;
+    path: string;
+  }> = [
+    {
+      name: "GET /organizations/{id}",
+      mount: mountGetOrganization,
+      path: "/org_123",
+    },
+    {
+      name: "GET /organizations/slug/{slug}",
+      mount: mountGetOrganizationBySlug,
+      path: "/slug/acme",
+    },
+    {
+      name: "GET /organizations/{id}/subscription",
+      mount: mountGetOrganizationSubscription,
+      path: "/org_123/subscription",
+    },
+    {
+      name: "GET /organizations/{id}/stripe-customer",
+      mount: mountGetOrganizationStripeCustomer,
+      path: "/org_123/stripe-customer",
+    },
+  ];
+
+  for (const routeCase of cases) {
+    describe(routeCase.name, () => {
+      it("returns 403 for bare orchestrator without context headers", async () => {
+        const response = await createApp(routeCase.mount, BARE_ORCH).request(
+          `http://localhost${routeCase.path}`,
+        );
+
+        expect(response.status).toBe(403);
+        expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
+        expect(resolveMemberOrganizationBySlugMock).not.toHaveBeenCalled();
+      });
+
+      it("allows orchestrator with context headers as the context user", async () => {
+        const response = await createApp(routeCase.mount, ORCH_CTX).request(
+          `http://localhost${routeCase.path}`,
+        );
+
+        expect(response.status).toBe(200);
+        const membershipCalled =
+          resolveMemberOrganizationByIdMock.mock.calls.length > 0 ||
+          resolveMemberOrganizationBySlugMock.mock.calls.length > 0;
+        expect(membershipCalled).toBe(true);
+        const membershipCall =
+          resolveMemberOrganizationByIdMock.mock.calls[0] ??
+          resolveMemberOrganizationBySlugMock.mock.calls[0];
+        expect(membershipCall?.[0]).toEqual(
+          expect.objectContaining({ userId: "user_123" }),
+        );
+      });
+    });
+  }
+});

--- a/apps/core/src/routes/v1/organizations/slug/[slug]/get.test.ts
+++ b/apps/core/src/routes/v1/organizations/slug/[slug]/get.test.ts
@@ -10,7 +10,7 @@ const { prismaTransactionMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
-  requireUserAuthContext: (authContext: AuthenticationContext | null) => {
+  requireUserContext: (authContext: AuthenticationContext | null) => {
     if (!authContext) {
       throw new HTTPException(403, {
         message: "User authentication required",
@@ -25,7 +25,8 @@ vi.mock("@/middleware/auth", () => ({
     }
 
     if (
-      authContext.actor === "coworker" &&
+      (authContext.actor === "coworker" ||
+        authContext.actor === "orchestrator") &&
       "context" in authContext &&
       authContext.context
     ) {
@@ -37,7 +38,8 @@ vi.mock("@/middleware/auth", () => ({
     }
 
     throw new HTTPException(403, {
-      message: "User authentication required",
+      message:
+        "Context headers (X-Context-User-Id) are required for this resource",
     });
   },
 }));

--- a/apps/core/src/routes/v1/organizations/slug/[slug]/get.ts
+++ b/apps/core/src/routes/v1/organizations/slug/[slug]/get.ts
@@ -5,7 +5,7 @@ import { resolveMemberOrganizationBySlug } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { organizationRecordSchema } from "@/schemas/organization.schema";
 
 const params = z.object({
@@ -56,7 +56,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const userContext = requireUserContext(c.var.authContext);
     const { slug } = c.req.valid("param");
 
     const organization = await prisma.$transaction(async (tx) => {

--- a/apps/core/src/routes/v1/organizations/slug/[slug]/get.ts
+++ b/apps/core/src/routes/v1/organizations/slug/[slug]/get.ts
@@ -20,7 +20,8 @@ const route = createRoute({
   method: "get",
   path: "/slug/{slug}",
   operationId: "getOrganizationBySlug",
-  description: "Get the raw organization record by slug for the current member",
+  description:
+    "Get the raw organization record by slug for the effective user when they are a member (session user, or orchestrator/coworker with context headers)",
   tags: ["Organizations"],
   request: {
     params,

--- a/apps/core/src/routes/v1/tasks/[id]/workspace/get.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/workspace/get.test.ts
@@ -116,7 +116,31 @@ describe("GET /tasks/{id}/workspace", () => {
     expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
   });
 
-  it("rejects delegated coworker API keys", async () => {
+  it("allows orchestrator with context headers as the context user", async () => {
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: {
+        userId: "user_123",
+        organizationId: "org_123",
+      },
+    }).request("/tsk_123/workspace");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual({
+      name: "Research competitor pricing",
+      workspaceId: "11111111-1111-7111-8111-111111111111",
+      organizationId: "org_123",
+    });
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith({
+      id: "org_123",
+      userId: "user_123",
+      tx: expect.any(Object),
+    });
+  });
+
+  it("allows coworker with context headers as the context user", async () => {
     const response = await createApp({
       actor: "coworker",
       coworkerId: "cow_123",
@@ -128,8 +152,41 @@ describe("GET /tasks/{id}/workspace", () => {
     }).request("/tsk_123/workspace");
     const body = await response.json();
 
+    expect(response.status).toBe(200);
+    expect(body.data.workspaceId).toBe("11111111-1111-7111-8111-111111111111");
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith({
+      id: "org_123",
+      userId: "user_123",
+      tx: expect.any(Object),
+    });
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const response = await createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    }).request("/tsk_123/workspace");
+    const body = await response.json();
+
     expect(response.status).toBe(403);
-    expect(body.message).toBe("User authentication required");
+    expect(body.message).toBe(
+      "Context headers (X-Context-User-Id) are required for this resource",
+    );
+    expect(taskFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for bare coworker without context headers", async () => {
+    const response = await createApp({
+      actor: "coworker",
+      coworkerId: "cow_123",
+      vendorId: TEST_VENDOR_ID,
+    }).request("/tsk_123/workspace");
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.message).toBe(
+      "Context headers (X-Context-User-Id) are required for this resource",
+    );
     expect(taskFindUniqueMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/workspace/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/workspace/get.ts
@@ -6,7 +6,7 @@ import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import { requireUserContext } from "@/middleware/auth";
 import { taskWorkspaceSchema } from "@/schemas/task.schema";
 
 const paramsSchema = z.object({
@@ -19,7 +19,8 @@ const paramsSchema = z.object({
 const route = createRoute({
   method: "get",
   path: "/{id}/workspace",
-  description: "Resolve a task id to its workspace and organization id",
+  description:
+    "Resolve a task id to its workspace and organization id. Session user or orchestrator/coworker with context headers.",
   tags: ["Tasks"],
   request: {
     params: paramsSchema,
@@ -45,7 +46,7 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { authContext } = c.var;
-    const userAuthContext = requireUserAuthContext(authContext);
+    const userContext = requireUserContext(authContext);
     const { id } = c.req.valid("param");
 
     const task = await prisma.task.findUnique({
@@ -72,10 +73,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     if (task.workspace.organizationId) {
       await resolveMemberOrganizationById({
         id: task.workspace.organizationId,
-        userId: userAuthContext.userId,
+        userId: userContext.userId,
         tx: prisma,
       });
-    } else if (task.ownerId !== userAuthContext.userId) {
+    } else if (task.ownerId !== userContext.userId) {
       throw forbidden("You do not have access to this task");
     }
 

--- a/apps/core/src/routes/v1/users/[id]/vendor-grants/[grantId]/approve/post.ts
+++ b/apps/core/src/routes/v1/users/[id]/vendor-grants/[grantId]/approve/post.ts
@@ -9,7 +9,6 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
 import { usersRoutePathUserIdSchema } from "@/routes/v1/users/user-path-access";
 import {
   requireUserRouteContext,
@@ -47,8 +46,9 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
   app.openapi(route, async (c) => {
     const { grantId } = c.req.valid("param");
-    const session = requireUserAuthContext(c.var.authContext);
-    const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
+    const { resolvedUserId, userContext } = requireUserRouteContext(
+      c.var.userRouteContext,
+    );
 
     const workspace = await prisma.workspace.findUnique({
       where: { userId: resolvedUserId },
@@ -64,7 +64,7 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
         {
           grantId,
           workspaceId: workspace.id,
-          resolvedById: session.userId,
+          resolvedById: userContext.userId,
         },
         tx,
       ),

--- a/apps/core/src/routes/v1/users/[id]/vendor-grants/[grantId]/deny/post.ts
+++ b/apps/core/src/routes/v1/users/[id]/vendor-grants/[grantId]/deny/post.ts
@@ -9,7 +9,6 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
 import { usersRoutePathUserIdSchema } from "@/routes/v1/users/user-path-access";
 import {
   requireUserRouteContext,
@@ -46,8 +45,9 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
   app.openapi(route, async (c) => {
     const { grantId } = c.req.valid("param");
-    const session = requireUserAuthContext(c.var.authContext);
-    const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
+    const { resolvedUserId, userContext } = requireUserRouteContext(
+      c.var.userRouteContext,
+    );
 
     const workspace = await prisma.workspace.findUnique({
       where: { userId: resolvedUserId },
@@ -63,7 +63,7 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
         {
           grantId,
           workspaceId: workspace.id,
-          resolvedById: session.userId,
+          resolvedById: userContext.userId,
         },
         tx,
       ),

--- a/apps/core/src/routes/v1/users/[id]/vendor-grants/[grantId]/revoke/post.ts
+++ b/apps/core/src/routes/v1/users/[id]/vendor-grants/[grantId]/revoke/post.ts
@@ -9,7 +9,6 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
 import { usersRoutePathUserIdSchema } from "@/routes/v1/users/user-path-access";
 import {
   requireUserRouteContext,
@@ -46,8 +45,9 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
   app.openapi(route, async (c) => {
     const { grantId } = c.req.valid("param");
-    const session = requireUserAuthContext(c.var.authContext);
-    const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
+    const { resolvedUserId, userContext } = requireUserRouteContext(
+      c.var.userRouteContext,
+    );
 
     const workspace = await prisma.workspace.findUnique({
       where: { userId: resolvedUserId },
@@ -63,7 +63,7 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
         {
           grantId,
           workspaceId: workspace.id,
-          resolvedById: session.userId,
+          resolvedById: userContext.userId,
         },
         tx,
       ),

--- a/apps/core/src/routes/v1/users/[id]/vendor-grants/post.ts
+++ b/apps/core/src/routes/v1/users/[id]/vendor-grants/post.ts
@@ -9,7 +9,6 @@ import {
 } from "@/helpers/vendor-grants";
 import prisma from "@/lib/db/prisma";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
 import { usersRoutePathUserIdSchema } from "@/routes/v1/users/user-path-access";
 import {
   requireUserRouteContext,
@@ -53,8 +52,9 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
   app.openapi(route, async (c) => {
     c.req.valid("param");
     const body = c.req.valid("json");
-    const session = requireUserAuthContext(c.var.authContext);
-    const { resolvedUserId } = requireUserRouteContext(c.var.userRouteContext);
+    const { resolvedUserId, userContext } = requireUserRouteContext(
+      c.var.userRouteContext,
+    );
 
     const workspace = await prisma.workspace.findUnique({
       where: { userId: resolvedUserId },
@@ -79,7 +79,7 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
         {
           vendorId: body.vendorId,
           workspaceId: workspace.id,
-          resolvedById: session.userId,
+          resolvedById: userContext.userId,
         },
         tx,
       ),

--- a/apps/core/src/routes/v1/users/me/uploads/get.route.test.ts
+++ b/apps/core/src/routes/v1/users/me/uploads/get.route.test.ts
@@ -36,6 +36,17 @@ vi.mock("@/lib/db/prisma", () => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
+  hasAdminRole: (role: string | null | undefined) =>
+    role?.split(",").some((value) => value.trim().toLowerCase() === "admin") ??
+    false,
+  isUserAuthContext: (
+    authContext: AuthenticationContext | null,
+  ): authContext is Extract<AuthenticationContext, { actor: "user" }> =>
+    authContext?.actor === "user",
+  isOrchestratorAuthContext: (
+    authContext: AuthenticationContext | null,
+  ): authContext is Extract<AuthenticationContext, { actor: "orchestrator" }> =>
+    authContext?.actor === "orchestrator",
   requireUserAuthContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
@@ -44,6 +55,31 @@ vi.mock("@/middleware/auth", () => ({
     }
 
     return authContext;
+  },
+  requireUserContext: (authContext: AuthenticationContext | null) => {
+    if (!authContext) {
+      throw new HTTPException(403, {
+        message: "User authentication required",
+      });
+    }
+    if (authContext.actor === "user") {
+      return { source: "session" as const, ...authContext };
+    }
+    if (
+      (authContext.actor === "orchestrator" ||
+        authContext.actor === "coworker") &&
+      authContext.context
+    ) {
+      return {
+        source: "context" as const,
+        userId: authContext.context.userId,
+        organizationId: authContext.context.organizationId,
+      };
+    }
+    throw new HTTPException(403, {
+      message:
+        "Context headers (X-Context-User-Id) are required for this resource",
+    });
   },
 }));
 

--- a/apps/core/src/routes/v1/users/me/uploads/post.route.test.ts
+++ b/apps/core/src/routes/v1/users/me/uploads/post.route.test.ts
@@ -38,6 +38,17 @@ vi.mock("@/lib/db/prisma", () => ({
 }));
 
 vi.mock("@/middleware/auth", () => ({
+  hasAdminRole: (role: string | null | undefined) =>
+    role?.split(",").some((value) => value.trim().toLowerCase() === "admin") ??
+    false,
+  isUserAuthContext: (
+    authContext: AuthenticationContext | null,
+  ): authContext is Extract<AuthenticationContext, { actor: "user" }> =>
+    authContext?.actor === "user",
+  isOrchestratorAuthContext: (
+    authContext: AuthenticationContext | null,
+  ): authContext is Extract<AuthenticationContext, { actor: "orchestrator" }> =>
+    authContext?.actor === "orchestrator",
   requireUserAuthContext: (authContext: AuthenticationContext | null) => {
     if (!authContext || authContext.actor !== "user") {
       throw new HTTPException(403, {
@@ -46,6 +57,31 @@ vi.mock("@/middleware/auth", () => ({
     }
 
     return authContext;
+  },
+  requireUserContext: (authContext: AuthenticationContext | null) => {
+    if (!authContext) {
+      throw new HTTPException(403, {
+        message: "User authentication required",
+      });
+    }
+    if (authContext.actor === "user") {
+      return { source: "session" as const, ...authContext };
+    }
+    if (
+      (authContext.actor === "orchestrator" ||
+        authContext.actor === "coworker") &&
+      authContext.context
+    ) {
+      return {
+        source: "context" as const,
+        userId: authContext.context.userId,
+        organizationId: authContext.context.organizationId,
+      };
+    }
+    throw new HTTPException(403, {
+      message:
+        "Context headers (X-Context-User-Id) are required for this resource",
+    });
   },
 }));
 

--- a/apps/core/src/routes/v1/users/user-path-access.test.ts
+++ b/apps/core/src/routes/v1/users/user-path-access.test.ts
@@ -38,13 +38,41 @@ describe("requireAccessToTargetUserData", () => {
     ).toThrow();
   });
 
-  it("rejects orchestrator context even when user id matches", () => {
+  it("allows orchestrator context when user id matches", () => {
+    const ctx = requireAccessToTargetUserData(
+      {
+        actor: "orchestrator",
+        orchestratorId: "orch_1",
+        context: { userId: target, organizationId: "org_1" },
+      },
+      target,
+    );
+    expect(ctx).toEqual({
+      source: "context",
+      userId: target,
+      organizationId: "org_1",
+    });
+  });
+
+  it("rejects bare orchestrator without context headers", () => {
     expect(() =>
       requireAccessToTargetUserData(
         {
           actor: "orchestrator",
           orchestratorId: "orch_1",
-          context: { userId: target, organizationId: null },
+        },
+        target,
+      ),
+    ).toThrow();
+  });
+
+  it("rejects orchestrator context for a different user id", () => {
+    expect(() =>
+      requireAccessToTargetUserData(
+        {
+          actor: "orchestrator",
+          orchestratorId: "orch_1",
+          context: { userId: "usr_other", organizationId: null },
         },
         target,
       ),
@@ -110,6 +138,35 @@ describe("resolveUsersPathUserId", () => {
     expect(userContext.userId).toBe("usr_self");
   });
 
+  it("resolves me to the orchestrator context user id", () => {
+    const { resolvedUserId, userContext } = resolveUsersPathUserId(
+      {
+        actor: "orchestrator",
+        orchestratorId: "orch_1",
+        context: { userId: "usr_ctx", organizationId: null },
+      },
+      USERS_PATH_ME,
+    );
+    expect(resolvedUserId).toBe("usr_ctx");
+    expect(userContext).toEqual({
+      source: "context",
+      userId: "usr_ctx",
+      organizationId: null,
+    });
+  });
+
+  it("rejects bare orchestrator for me", () => {
+    expect(() =>
+      resolveUsersPathUserId(
+        {
+          actor: "orchestrator",
+          orchestratorId: "orch_1",
+        },
+        USERS_PATH_ME,
+      ),
+    ).toThrow();
+  });
+
   it("rejects coworker for me", () => {
     expect(() =>
       resolveUsersPathUserId(
@@ -135,6 +192,20 @@ describe("resolveUsersPathUserId", () => {
       "usr_self",
     );
     expect(resolvedUserId).toBe("usr_self");
+    expect(userContext.userId).toBe("usr_self");
+  });
+
+  it("allows orchestrator with matching concrete user id", () => {
+    const { resolvedUserId, userContext } = resolveUsersPathUserId(
+      {
+        actor: "orchestrator",
+        orchestratorId: "orch_1",
+        context: { userId: "usr_self", organizationId: null },
+      },
+      "usr_self",
+    );
+    expect(resolvedUserId).toBe("usr_self");
+    expect(userContext.source).toBe("context");
     expect(userContext.userId).toBe("usr_self");
   });
 });

--- a/apps/core/src/routes/v1/users/user-path-access.ts
+++ b/apps/core/src/routes/v1/users/user-path-access.ts
@@ -4,14 +4,20 @@ import { forbidden } from "@/helpers/error";
 import {
   type AuthenticationContext,
   hasAdminRole,
-  requireUserAuthContext,
+  isOrchestratorAuthContext,
+  isUserAuthContext,
+  requireUserContext,
   type UserAuthenticationContext,
+  type UserContext,
 } from "@/middleware/auth";
 
-/** Path segment meaning "the authenticated session user" (Better Auth only). */
+/** Path segment meaning "the authenticated effective user" (session or context). */
 export const USERS_PATH_ME = "me" as const;
 
-/** Session-only user context returned from user-path access checks. */
+/**
+ * Session-only user context (admin or self). Prefer {@link UserContext} for
+ * callers that also accept orchestrator context headers.
+ */
 export type SessionUserContext = {
   source: "session";
 } & UserAuthenticationContext;
@@ -20,23 +26,26 @@ export type SessionUserContext = {
 export const usersRoutePathUserIdSchema = z.string().openapi({
   param: { name: "id", in: "path" },
   description:
-    "Pass the literal `me` for the authenticated session user, or a user id when the session caller may access that user's data.",
+    "Pass the literal `me` for the authenticated effective user (session user, or orchestrator with X-Context-User-Id), or a user id when the caller may access that user's data.",
   example: "me",
 });
 
 /**
- * Resolves the first `/{id}` segment on user routes: `me` → session user id and
- * session-only auth; otherwise enforces {@link requireAccessToTargetUserData}.
+ * Resolves the first `/{id}` segment on user routes: `me` → effective user id;
+ * otherwise enforces {@link requireAccessToTargetUserData}.
+ *
+ * Orchestrator with `X-Context-User-Id` may access that user's tree (path `me`
+ * or matching concrete id). Coworker actors remain rejected.
  */
 export function resolveUsersPathUserId(
   authContext: AuthenticationContext,
   pathUserSegment: string,
-): { resolvedUserId: string; userContext: SessionUserContext } {
+): { resolvedUserId: string; userContext: UserContext } {
   if (pathUserSegment === USERS_PATH_ME) {
-    const session = requireUserAuthContext(authContext);
+    const userContext = requireEffectiveUserPathContext(authContext);
     return {
-      resolvedUserId: session.userId,
-      userContext: { source: "session", ...session },
+      resolvedUserId: userContext.userId,
+      userContext,
     };
   }
 
@@ -48,20 +57,51 @@ export function resolveUsersPathUserId(
 }
 
 /**
- * Ensures the caller may access or mutate data for `resolvedUserId`: the
- * session user matches `resolvedUserId`, or the session user has an admin role.
- * Coworker and orchestrator actors are rejected — user path data is session-only.
+ * Effective user for path `me` and self-id access: session user, or
+ * orchestrator with context headers. Rejects coworker actors.
+ */
+function requireEffectiveUserPathContext(
+  authContext: AuthenticationContext,
+): UserContext {
+  if (isUserAuthContext(authContext)) {
+    return { source: "session", ...authContext };
+  }
+
+  if (isOrchestratorAuthContext(authContext)) {
+    return requireUserContext(authContext);
+  }
+
+  throw forbidden("User authentication required");
+}
+
+/**
+ * Ensures the caller may access or mutate data for `resolvedUserId`:
+ * - session user matches `resolvedUserId`, or session user has admin role
+ * - orchestrator with context whose `userId` matches `resolvedUserId`
+ *
+ * Coworker actors are rejected — user path data is not available to coworker keys.
  */
 export function requireAccessToTargetUserData(
   authContext: AuthenticationContext,
   resolvedUserId: string,
-): SessionUserContext {
-  const session = requireUserAuthContext(authContext);
-  if (session.userId === resolvedUserId) {
-    return { source: "session", ...session };
+): UserContext {
+  if (isUserAuthContext(authContext)) {
+    if (authContext.userId === resolvedUserId) {
+      return { source: "session", ...authContext };
+    }
+    if (hasAdminRole(authContext.role)) {
+      return { source: "session", ...authContext };
+    }
+    throw forbidden("You are not allowed to access this user's data");
   }
-  if (hasAdminRole(session.role)) {
-    return { source: "session", ...session };
+
+  if (isOrchestratorAuthContext(authContext)) {
+    const userContext = requireUserContext(authContext);
+    if (userContext.userId !== resolvedUserId) {
+      throw forbidden("You are not allowed to access this user's data");
+    }
+    return userContext;
   }
-  throw forbidden("You are not allowed to access this user's data");
+
+  throw forbidden("User authentication required");
 }

--- a/apps/core/src/routes/v1/users/user-route-context.test.ts
+++ b/apps/core/src/routes/v1/users/user-route-context.test.ts
@@ -97,4 +97,50 @@ describe("usersPathUserContextMiddleware", () => {
     expect(response.status).toBe(403);
     expect(userFindUniqueMock).not.toHaveBeenCalled();
   });
+
+  it("allows orchestrator with context headers for matching user id", async () => {
+    userFindUniqueMock.mockResolvedValue({ id: "user_123" });
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+
+    const response = await app.request("http://localhost/user_123/uploads");
+
+    expect(response.status).toBe(200);
+    expect(userFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user_123" },
+      select: { id: true },
+    });
+  });
+
+  it("allows orchestrator with context headers for me", async () => {
+    userFindUniqueMock.mockResolvedValue({ id: "user_123" });
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+      context: { userId: "user_123", organizationId: null },
+    });
+
+    const response = await app.request("http://localhost/me/uploads");
+
+    expect(response.status).toBe(200);
+    expect(userFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user_123" },
+      select: { id: true },
+    });
+  });
+
+  it("returns 403 for bare orchestrator without context headers", async () => {
+    const app = createApp({
+      actor: "orchestrator",
+      orchestratorId: "orch_123",
+    });
+
+    const response = await app.request("http://localhost/me/uploads");
+
+    expect(response.status).toBe(403);
+    expect(userFindUniqueMock).not.toHaveBeenCalled();
+  });
 });

--- a/docs/orchestrator/hermes-orchestrator-actor.md
+++ b/docs/orchestrator/hermes-orchestrator-actor.md
@@ -26,6 +26,29 @@ Same as coworkers for workspace-scoped routes:
 After context is validated, Core binds `orchestratorId` to that user’s **active**
 (`archivedAt` null) orchestrator row when present.
 
+## User-power surfaces (full act-as-user)
+
+With service token **and** context headers, Core treats the request as the
+context user for membership and ownership checks. That is **not read-only**:
+Hermes can exercise the same user capabilities those routes expose, including
+mutations.
+
+Notable examples:
+
+| Surface | Scope |
+| --- | --- |
+| `/v1/users/{id\|me}/*` | Path must be `me` or the context user id (session admin may still target others). Includes preferences, uploads, Stripe customer provision, vendor grants, OAuth consent revoke, etc. |
+| `/v1/organizations/*` | Context user must be an org member (owner/admin where the route requires it). Includes seats, vendor grants, design-md, Stripe customer provision, billing reads. |
+| Marketplace chat / conversations | Ownership scoped to context user id (coworker assignee rules still apply to coworker keys only). |
+| Notifications, history, tasks/jobs/projects/workspaces | Effective user / workspace context as for a normal user session. |
+
+**Still session-only (orchestrator 403 even with context):** `/v1/hermes/*`
+product chat, Stripe checkout/products/coupons, developer console, vendor admin
+management, platform admin.
+
+Bare service token (no context headers) has **no** user workspace on these
+routes — `requireUserContext` returns 403.
+
 ## Product vs service routes
 
 | Concern | User session | Orchestrator service token |

--- a/docs/orchestrator/hermes-orchestrator-actor.md
+++ b/docs/orchestrator/hermes-orchestrator-actor.md
@@ -43,7 +43,7 @@ After context is validated, Core binds `orchestratorId` to that user’s **activ
 | DRAFT tasks | Hidden | Visible (user-like in workspace) |
 | Status transitions | Agent table (assignee) or user table (delegated) | **DRAFT ↔ READY only** (task events); schedule put/delete may still move `QUEUED` |
 | `POST /v1/tasks/{id}/jobs` | Assigned coworker | **403** (coworker only) |
-| Marketplace chat / conversations | User or assigned coworker | **403** (use `/v1/hermes/*`) |
+| Marketplace chat / conversations | User or assigned coworker | With context headers (acts as context user); use `/v1/hermes/*` for Hermes product chat |
 | Task assignee (`assigneeId`) | Marketplace coworker | Never the orchestrator |
 | Task creator | `creator.type = "coworker"` | `creator.type = "orchestrator"` → **user’s** orchestrator row |
 | Event attribution | `coworkerId` on events | `orchestratorId` on events (per-user row) |


### PR DESCRIPTION
## Summary

- Expand orchestrator service-token + `X-Context-*` impersonation so Hermes can act as the context user on more Core surfaces that previously required a session only.
- Scopes opened: agent ratings/reviews, GET task workspace, `/users/{id|me}/*`, marketplace chat/conversations, notifications, history, and organization routes.
- Still session-only (by design): Hermes product `/hermes/*`, Stripe checkout/products/coupons, developer console, vendor admin, admin/enterprise.
- Adds `.grok/workflows/orchestrator-impersonation-audit.rhai` to re-audit route parity.

## Commits

1. `feat(core): allow orch+context on agent ratings and reviews`
2. `fix(core): allow orch+context on GET task workspace`
3. `feat(core): allow orch+context on /users path tree`
4. `feat(core): allow orch+context on marketplace chat`
5. `feat(core): allow orch+context on notifications and history`
6. `feat(core): allow orch+context on organization routes`
7. `chore(grok): add orchestrator impersonation audit workflow`

## Access matrix (post-change)

Paths under `/v1`. Auth = Bearer service token + optional `X-Context-User-Id` / `X-Context-Organization-Id`.

### Legend

| Symbol | Meaning |
| --- | --- |
| ✅ | Allowed |
| ❌ | Denied at actor/guard |
| 🌐 | Public (no auth) |
| 🛠 | Orch service-only (not a user route) |
| admin | Admin session only |
| ✅* | User only if vendor admin / assignee |

| Guard | Orch bare | Orch+ctx |
| --- | --- | --- |
| `any-auth` | ✅ | ✅ |
| `userCtx` / `ownerCtx` / `user-path` | ❌ | ✅ |
| `session` | ❌ | ❌ |
| `admin` / `mgmt→session` | ❌ | ❌ |
| `coworker` | ❌ | ❌ |
| `orch service` | 🛠 | 🛠 |

### Catalog / public

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET | `/agents` | ✅ | ✅ | ✅ |
| GET | `/agents/{id}` | ✅ | ✅ | ✅ |
| GET | `/agents/{id}/input-schema` | ✅ | ✅ | ✅ |
| GET | `/agents/{id}/reviews` | ✅ | ✅ | ✅ |
| GET | `/categories` | ✅ | ✅ | ✅ |
| GET | `/coworkers/{id}` | ✅ | ✅ | ✅ |
| GET | `/share/{token}` | 🌐 | 🌐 | 🌐 |
| GET | `/invitations/{id}` | 🌐 | 🌐 | 🌐 |

### Agents (user-scoped)

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET | `/agents/{id}/jobs` | ✅ | ❌ | ✅ |
| POST | `/agents/{id}/jobs` | ✅ | ❌ | ✅ |
| GET | `/agents/{id}/ratings/eligibility` | ✅ | ❌ | ✅ |
| POST | `/agents/{id}/ratings` | ✅ | ❌ | ✅ |
| GET | `/agents/{id}/reviews/me` | ✅ | ❌ | ✅ |

### Tasks

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET/POST | `/tasks` | ✅ | ❌ | ✅ |
| GET | `/tasks/{id}` | ✅ | ❌ | ✅ |
| PATCH/DELETE | `/tasks/{id}` | ✅ | ❌ | ✅ |
| GET/POST | `/tasks/{id}/events` | ✅ | ❌ | ✅ |
| GET | `/tasks/{id}/jobs` | ✅ | ❌ | ✅ |
| POST | `/tasks/{id}/jobs` | ❌ | ❌ | ❌ (coworker only) |
| GET/POST/PATCH/DELETE | `/tasks/{id}/links…` | ✅ | ❌ | ✅ |
| PUT/DELETE | `/tasks/{id}/schedule` | ✅ | ❌ | ✅ |
| PUT/DELETE | `/tasks/{id}/share` | ✅ | ❌ | ✅ |
| GET/PUT | `/tasks/{id}/workspace` | ✅ | ❌ | ✅ |

### Jobs / projects / workspaces / vendors list

| Domain | Orch+ctx |
| --- | --- |
| All `/jobs/*` | ✅ |
| All `/projects/*` | ✅ |
| GET `/workspaces/{id}`, `/workspaces/design-md` | ✅ |
| GET `/vendors` | ✅ |

### Marketplace chat / conversations

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET/POST | `/chat` | ✅ | ❌ | ✅ |
| GET | `/chat/stream/{conversationId}` | ✅ | ❌ | ✅ |
| GET/POST | `/conversations` | ✅ | ❌ | ✅ |
| GET/PATCH | `/conversations/{id}` | ✅ | ❌ | ✅ |
| PATCH | `/conversations/{id}/archive` | ✅ | ❌ | ✅ |
| GET | `/conversations/{id}/warmup` | ✅ | ❌ | ✅ |
| GET/POST | `/conversations/{id}/messages` | ✅ | ❌ | ✅ |

### Notifications / history

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET | `/notifications` | ✅ | ❌ | ✅ |
| GET | `/notifications/unread-count` | ✅ | ❌ | ✅ |
| PATCH | `/notifications/{id}/read` | ✅ | ❌ | ✅ |
| PATCH | `/notifications/read-all` | ✅ | ❌ | ✅ |
| GET | `/history` | ✅ | ❌ | ✅ |

### Users `/users/{id\|me}/*`

Path must match context user (`me` → context user id). Session admin can still target other users.

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET | `/users/{id}` | ✅ | ❌ | ✅ |
| GET | `/users/{id}/credits` | ✅ | ❌ | ✅ |
| GET/PUT | `/users/{id}/design-md` | ✅ | ❌ | ✅ |
| GET | `/users/{id}/billing-details` | ✅ | ❌ | ✅ |
| GET | `/users/{id}/members` | ✅ | ❌ | ✅ |
| GET/POST | `/users/{id}/onboarding` | ✅ | ❌ | ✅ |
| GET | `/users/{id}/organizations…` | ✅ | ❌ | ✅ |
| GET/PATCH | `/users/{id}/preferences` | ✅ | ❌ | ✅ |
| PUT | `/users/{id}/preferred-organization` | ✅ | ❌ | ✅ |
| GET/POST | `/users/{id}/stripe-customer` | ✅ | ❌ | ✅ |
| GET | `/users/{id}/subscription` | ✅ | ❌ | ✅ |
| GET/POST | `/users/{id}/uploads` | ✅ | ❌ | ✅ |
| POST | `/users/{id}/utm-attribution` | ✅ | ❌ | ✅ |
| GET/POST | `/users/{id}/notices…` | ✅ | ❌ | ✅ |
| DELETE | `/users/{id}/oauth-consents/{consentId}` | ✅ | ❌ | ✅ |
| GET/POST | `/users/{id}/vendor-grants…` | ✅ | ❌ | ✅ |

### Organizations

Membership (and owner/admin where required) still applies to the **context user**.

| Method | Path | User | Orch bare | Orch+ctx |
| --- | --- | --- | --- | --- |
| GET | `/organizations/{id}` | ✅ | ❌ | ✅ |
| GET | `/organizations/slug/{slug}` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/members` | ✅ | ❌ | ✅ |
| PUT/DELETE | `/organizations/{id}/members/{memberId}/seat` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/seat-summary` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/invitations` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/billing-details` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/billing-plan` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/enterprise-contract-summary` | ✅ | ❌ | ✅ |
| GET/PUT | `/organizations/{id}/design-md` | ✅ | ❌ | ✅ |
| GET/POST | `/organizations/{id}/stripe-customer` | ✅ | ❌ | ✅ |
| GET | `/organizations/{id}/subscription` | ✅ | ❌ | ✅ |
| PUT | `/organizations/{id}/subscription/seats` | ✅ | ❌ | ✅ |
| GET/POST | `/organizations/{id}/vendor-grants…` | ✅ | ❌ | ✅ |

### Still session-only (User ✅ · Orch bare/ctx ❌)

| Group | Paths |
| --- | --- |
| Hermes product | all `/hermes/*` |
| Checkout | `POST /checkout/credits`, `GET /checkout/sessions/{id}` |
| Products | `/products/credits`, `/products/credits/catalog`, `/products/subscription` |
| Coupons | `GET/POST /coupons/{id}…` |
| Developer | `/developer/tasks…` |
| Coworker mgmt | `GET /coworkers` + api-keys/image/delete (mgmt) |
| Vendor admin | `/vendors/me`, members, assignments, `PATCH /vendors/{id}` |

### Admin / non-user

| Group | Orch |
| --- | --- |
| `/admin/*`, `/enterprise/*`, `/credit-costs/*` | ❌ |
| `POST /orchestrators/me/usage`, `/purge` | 🛠 (orch service; body `userId`) |
| `/coworkers/me/*` | ❌ (coworker key) |
| `POST /tasks/{id}/jobs` | ❌ (coworker only) |

### What this PR changed vs main (before)

| Area | Before Orch+ctx | After |
| --- | --- | --- |
| Agent ratings/reviews/me | ❌ | ✅ |
| GET task workspace | ❌ | ✅ |
| `/users/{id\|me}/*` | ❌ | ✅ |
| Chat / conversations | ❌ | ✅ |
| Notifications | ❌ | ✅ |
| History | ❌ | ✅ |
| Organizations | ❌ | ✅ |

## Test plan

- [ ] `pnpm --filter core test src/routes/v1/agents src/routes/v1/tasks/\[id\]/workspace src/routes/v1/users src/routes/v1/chat src/routes/v1/conversations src/routes/v1/notifications src/routes/v1/history src/routes/v1/organizations src/helpers/access-control.test.ts`
- [ ] Confirm bare orchestrator without context headers still 403s on userCtx routes
- [ ] Confirm orch+ctx with matching user membership can hit a sample org and user path (`/users/me/credits`, `/organizations/{id}`)
- [ ] Confirm marketplace chat still scopes ownership to context userId
- [ ] Confirm `/v1/hermes/*` remains session-only