### PR TITLE
fix(web): give the assistant's task-comment avatar its eyes back

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -554,6 +554,9 @@ export function TaskActivitySection({
                   ) : showAssistantOrb ? (
                     <AssistantOrb
                       seed={actorInfo?.avatarSeed ?? null}
+                      // Resting eyes so the assistant's comment avatar reads
+                      // as a face, not a blank disc.
+                      expression="idle"
                       animate={false}
                       size={24}
                       className="size-6 shrink-0 self-start"

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -275,6 +275,9 @@ function MetadataAvatarValue({
         {avatarSeed !== undefined ? (
           <AssistantOrb
             seed={avatarSeed}
+            // Resting eyes so the creator chip reads as the assistant's
+            // face, not a blank disc.
+            expression="idle"
             animate={false}
             size={20}
             className="size-5 shrink-0"


### PR DESCRIPTION
## What

In **Task Comments** (and the task properties **Creator** chip), the personal assistant's avatar rendered as a blank eyeless disc — see the green "Susi" orb in the report. `AssistantOrb` was rendered with no `expression`, so it drew the body without a face.

## Fix

Pass `expression="idle"` (the neutral resting eyes) at both orchestrator-actor render sites:
- `task-activity.tsx` — comment/event rows (24px)
- `task-metadata.tsx` — the Creator chip (20px)

Verified visually at both sizes across coloured and porcelain seeds: eyeless disc → clear open eyes.

## Testing
`pnpm check`, `pnpm --filter web typecheck`, and all 42 `tasks/` test files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)