### PR TITLE
fix(chat): dispatch coworker thread replies

### DIFF
--- a/apps/core/src/routes/v1/chat-channels/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chat-channels/[id]/messages/post.ts
@@ -21,6 +21,7 @@ import {
   mapChatChannelMessage,
   requireChatChannelUserAccess,
   resolveMentionedCoworkerIds,
+  resolveThreadReplyCoworkerMention,
 } from "../../helpers";
 
 const paramsSchema = z.object({
@@ -80,18 +81,16 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         channel.kind === "direct"
           ? channel.coworkerMembers.map(({ coworker }) => coworker.id)
           : [];
-      const mentionedCoworkerIds = resolveMentionedCoworkerIds({
-        content: body.content,
-        explicitCoworkerIds: [
-          ...(body.mentionedCoworkerIds ?? []),
-          ...directCoworkerIds,
-        ],
-        channelCoworkers: channel.coworkerMembers.map(({ coworker }) => ({
-          id: coworker.id,
-          name: coworker.name,
-          slug: coworker.slug,
-        })),
-      });
+      const channelCoworkers = channel.coworkerMembers.map(({ coworker }) => ({
+        id: coworker.id,
+        name: coworker.name,
+        slug: coworker.slug,
+      }));
+      const channelCoworkerIds = channelCoworkers.map(({ id }) => id);
+      let implicitThreadMention: {
+        coworkerId: string;
+        providerConversationId: string | null;
+      } | null = null;
       let parentMessageId: string | null = null;
       if (body.parentMessageId) {
         const parentMessage = await tx.chatChannelMessage.findFirst({
@@ -102,12 +101,39 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           select: {
             id: true,
             parentMessageId: true,
+            senderCoworkerId: true,
+            mentionResponseFor: {
+              select: {
+                coworkerId: true,
+                providerConversationId: true,
+              },
+            },
           },
         });
         if (!parentMessage) {
           throw badRequest("Thread message not found");
         }
         parentMessageId = parentMessage.parentMessageId ?? parentMessage.id;
+        implicitThreadMention = resolveThreadReplyCoworkerMention({
+          parentMessage,
+          channelCoworkerIds,
+        });
+      }
+      const mentionedCoworkerIds = resolveMentionedCoworkerIds({
+        content: body.content,
+        explicitCoworkerIds: [
+          ...(body.mentionedCoworkerIds ?? []),
+          ...directCoworkerIds,
+          ...(implicitThreadMention ? [implicitThreadMention.coworkerId] : []),
+        ],
+        channelCoworkers,
+      });
+      const providerConversationIdByCoworkerId = new Map<string, string>();
+      if (implicitThreadMention?.providerConversationId) {
+        providerConversationIdByCoworkerId.set(
+          implicitThreadMention.coworkerId,
+          implicitThreadMention.providerConversationId,
+        );
       }
 
       const message = await tx.chatChannelMessage.create({
@@ -117,9 +143,14 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           senderUserId: userContext.userId,
           content: body.content,
           mentionsAsSource: {
-            create: mentionedCoworkerIds.map((coworkerId) => ({
-              coworkerId,
-            })),
+            create: mentionedCoworkerIds.map((coworkerId) => {
+              const providerConversationId =
+                providerConversationIdByCoworkerId.get(coworkerId);
+              return {
+                coworkerId,
+                ...(providerConversationId && { providerConversationId }),
+              };
+            }),
           },
         },
         include: chatChannelMessageInclude,

--- a/apps/core/src/routes/v1/chat-channels/helpers.test.ts
+++ b/apps/core/src/routes/v1/chat-channels/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   buildDirectCoworkerChannelKey,
   buildDirectParticipantChannelKey,
   resolveMentionedCoworkerIds,
+  resolveThreadReplyCoworkerMention,
 } from "./helpers";
 
 const channelCoworkers = [
@@ -31,6 +32,62 @@ describe("resolveMentionedCoworkerIds", () => {
         channelCoworkers,
       }),
     ).toEqual(["coworker_hannah", "coworker_elena"]);
+  });
+});
+
+describe("resolveThreadReplyCoworkerMention", () => {
+  it("mentions the coworker who authored the thread root", () => {
+    expect(
+      resolveThreadReplyCoworkerMention({
+        parentMessage: {
+          senderCoworkerId: "coworker_elena",
+          mentionResponseFor: null,
+        },
+        channelCoworkerIds: ["coworker_elena", "coworker_hannah"],
+      }),
+    ).toEqual({
+      coworkerId: "coworker_elena",
+      providerConversationId: null,
+    });
+  });
+
+  it("reuses the provider conversation from the coworker response mention", () => {
+    expect(
+      resolveThreadReplyCoworkerMention({
+        parentMessage: {
+          senderCoworkerId: "coworker_elena",
+          mentionResponseFor: {
+            coworkerId: "coworker_elena",
+            providerConversationId: "provider-conversation-1",
+          },
+        },
+        channelCoworkerIds: ["coworker_elena"],
+      }),
+    ).toEqual({
+      coworkerId: "coworker_elena",
+      providerConversationId: "provider-conversation-1",
+    });
+  });
+
+  it("does not mention humans or coworkers outside the channel", () => {
+    expect(
+      resolveThreadReplyCoworkerMention({
+        parentMessage: {
+          senderCoworkerId: null,
+          mentionResponseFor: null,
+        },
+        channelCoworkerIds: ["coworker_elena"],
+      }),
+    ).toBeNull();
+    expect(
+      resolveThreadReplyCoworkerMention({
+        parentMessage: {
+          senderCoworkerId: "coworker_outside",
+          mentionResponseFor: null,
+        },
+        channelCoworkerIds: ["coworker_elena"],
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/core/src/routes/v1/chat-channels/helpers.ts
+++ b/apps/core/src/routes/v1/chat-channels/helpers.ts
@@ -460,3 +460,37 @@ export function resolveMentionedCoworkerIds(params: {
   const allowedIds = new Set(params.channelCoworkers.map(({ id }) => id));
   return [...mentionedIds].filter((coworkerId) => allowedIds.has(coworkerId));
 }
+
+export interface ThreadReplyCoworkerMention {
+  coworkerId: string;
+  providerConversationId: string | null;
+}
+
+export function resolveThreadReplyCoworkerMention(params: {
+  parentMessage: {
+    senderCoworkerId: string | null;
+    mentionResponseFor: {
+      coworkerId: string;
+      providerConversationId: string | null;
+    } | null;
+  } | null;
+  channelCoworkerIds: readonly string[];
+}): ThreadReplyCoworkerMention | null {
+  const senderCoworkerId = params.parentMessage?.senderCoworkerId;
+  if (
+    !senderCoworkerId ||
+    !params.channelCoworkerIds.includes(senderCoworkerId)
+  ) {
+    return null;
+  }
+
+  const providerConversationId =
+    params.parentMessage?.mentionResponseFor?.coworkerId === senderCoworkerId
+      ? params.parentMessage.mentionResponseFor.providerConversationId
+      : null;
+
+  return {
+    coworkerId: senderCoworkerId,
+    providerConversationId,
+  };
+}

--- a/apps/core/src/services/chat-channel-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-channel-coworker-dispatch.service.ts
@@ -62,6 +62,21 @@ export async function dispatchChatChannelMention(
               name: true,
             },
           },
+          parentMessage: {
+            select: {
+              content: true,
+              senderUser: {
+                select: {
+                  name: true,
+                },
+              },
+              senderCoworker: {
+                select: {
+                  name: true,
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -120,7 +135,25 @@ export async function dispatchChatChannelMention(
       },
     };
 
-    const prompt = `${senderName} mentioned you in #${mention.message.channel.name}:\n\n${mention.message.content}`;
+    const threadRoot = mention.message.parentMessage
+      ? [
+          `Thread root from ${
+            mention.message.parentMessage.senderUser?.name ??
+            mention.message.parentMessage.senderCoworker?.name ??
+            "a teammate"
+          }:`,
+          mention.message.parentMessage.content,
+          "",
+        ].join("\n")
+      : "";
+    const prompt = mention.message.parentMessageId
+      ? [
+          `${senderName} replied in a thread in #${mention.message.channel.name}:`,
+          "",
+          `${threadRoot}${senderName}:`,
+          mention.message.content,
+        ].join("\n")
+      : `${senderName} mentioned you in #${mention.message.channel.name}:\n\n${mention.message.content}`;
 
     const { text } = await generateText({
       model: getSokosumiProvider()(null),

--- a/apps/web/src/app/(app)/channels/components/channels-client.tsx
+++ b/apps/web/src/app/(app)/channels/components/channels-client.tsx
@@ -1978,6 +1978,7 @@ export function ChannelsClient({
 
       const shouldPoll =
         threadMentionedCoworkerIds.length > 0 ||
+        threadParentMessage.sender.type === "coworker" ||
         (isDirectChannel && selectedChannel.coworkerMembers.length > 0);
       if (shouldPoll) {
         refreshThreadForCoworkers(threadParentMessage.id);


### PR DESCRIPTION
## Summary
- Treat replies under AI coworker-authored channel thread roots as implicit coworker mentions.
- Reuse the coworker provider conversation from the original coworker response when available.
- Prompt coworkers with thread context and poll the open thread for their async reply.

## Verification
- pnpm --filter @sokosumi/core test src/routes/v1/chat-channels/helpers.test.ts
- pnpm --filter @sokosumi/core check
- pnpm --filter @sokosumi/core typecheck
- pnpm --filter web check
- pnpm --filter web typecheck
- commit hook: pnpm check && pnpm typecheck

## Notes
- Stacked on #3418 / codex/chat-channels so parallel work on that branch stays isolated.