### PR TITLE
fix(channels): anchor coworker mention picker

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4556,7 +4556,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4437,7 +4437,6 @@
         "attach": "Attach file",
         "emoji": "Emoji",
         "format": "Formatting",
-        "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",

--- a/apps/web/src/app/(app)/channels/components/channels-client.tsx
+++ b/apps/web/src/app/(app)/channels/components/channels-client.tsx
@@ -8,7 +8,6 @@ import {
 import {
   ArrowUp,
   AtSign,
-  Bot,
   CheckCircle2,
   Hash,
   Loader2,
@@ -18,7 +17,6 @@ import {
   Search,
   Settings2,
   SmilePlus,
-  Type,
   Users,
   X,
 } from "lucide-react";
@@ -662,7 +660,9 @@ function ChannelComposer({
                   className="size-8 rounded-full"
                   title={t("Toolbar.mention")}
                   aria-label={t("Toolbar.mention")}
-                  onClick={() => textareaRef.current?.openMentions()}
+                  onClick={(event) =>
+                    textareaRef.current?.openMentions(event.currentTarget)
+                  }
                 >
                   <AtSign className="size-4" aria-hidden />
                 </Button>
@@ -720,17 +720,6 @@ function ChannelComposer({
                     </div>
                   </PopoverContent>
                 </Popover>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-8 rounded-full"
-                  title={t("Toolbar.bold")}
-                  aria-label={t("Toolbar.bold")}
-                  onClick={() => textareaRef.current?.insertText("**bold**")}
-                >
-                  <Type className="size-4" aria-hidden />
-                </Button>
               </div>
               <Button
                 type="submit"
@@ -827,11 +816,6 @@ function ChatMessageRow({
       <div className="min-w-0 flex-1 space-y-1.5">
         <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
           <span className="truncate text-sm font-semibold">{sender.name}</span>
-          {sender.kind === "coworker" ? (
-            <Badge variant="secondary" className="h-5">
-              {t("coworkerBadge")}
-            </Badge>
-          ) : null}
           <time className="text-muted-foreground text-xs">
             {formatMessageTime(message.createdAt)}
           </time>
@@ -1092,7 +1076,6 @@ function ParticipantCheckboxes({
 
       <div className="min-w-0 space-y-2">
         <div className="text-muted-foreground flex items-center gap-2 text-xs font-medium uppercase tracking-wide">
-          <Bot className="size-3.5" aria-hidden />
           {t("Dialog.coworkers")}
         </div>
         <ScrollArea className="h-52 rounded-md border">

--- a/apps/web/src/components/ui/__tests__/mention-textarea.test.tsx
+++ b/apps/web/src/components/ui/__tests__/mention-textarea.test.tsx
@@ -51,7 +51,9 @@ function ImperativeMentionTextarea({
     <>
       <button
         type="button"
-        onClick={() => textareaRef.current?.openMentions()}
+        onClick={(event) =>
+          textareaRef.current?.openMentions(event.currentTarget)
+        }
       >
         mention
       </button>
@@ -114,7 +116,11 @@ describe("MentionTextarea", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "mention" }));
 
-    expect(onChange).toHaveBeenLastCalledWith("@");
+    expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByText("Elena")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Elena"));
+
+    expect(onChange).toHaveBeenLastCalledWith("@coworker_elena:elena ");
   });
 });

--- a/apps/web/src/components/ui/mention-textarea.tsx
+++ b/apps/web/src/components/ui/mention-textarea.tsx
@@ -47,7 +47,7 @@ export type { MentionRecordEntry, NormalizedMention };
 export interface MentionTextareaHandle {
   focus: () => void;
   insertText: (text: string) => void;
-  openMentions: () => void;
+  openMentions: (anchorElement?: HTMLElement | null) => void;
 }
 
 interface MentionTextareaProps<TData = unknown> {
@@ -256,6 +256,61 @@ function insertPlainTextAtSelection(root: HTMLElement, text: string): void {
   const textNode = document.createTextNode(text);
   range.insertNode(textNode);
   setCaretAfterNode(root, textNode);
+}
+
+function insertMentionAtSelection<TData>(
+  root: HTMLElement,
+  mention: NormalizedMention<TData>,
+  prependSpace: boolean,
+  appendSpace: boolean,
+  resolveDisplay: MentionDisplayResolver,
+): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  let range: Range;
+  if (selection.rangeCount > 0) {
+    range = selection.getRangeAt(0);
+    if (!root.contains(range.startContainer)) {
+      range = document.createRange();
+      range.selectNodeContents(root);
+      range.collapse(false);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  } else {
+    range = document.createRange();
+    range.selectNodeContents(root);
+    range.collapse(false);
+    selection.addRange(range);
+  }
+
+  const { displayName, isKnown } = resolveDisplay(mention.key, mention.slug);
+  const mentionSpan = createMentionSpan(
+    mention.key,
+    mention.slug,
+    displayName,
+    isKnown,
+    {
+      mentionClassName: MENTION_CLASSNAME,
+      unknownMentionClassName: UNKNOWN_MENTION_CLASSNAME,
+    },
+  );
+
+  range.deleteContents();
+  const fragment = document.createDocumentFragment();
+  if (prependSpace) {
+    fragment.appendChild(document.createTextNode(" "));
+  }
+  fragment.appendChild(mentionSpan);
+  let caretNode: Node = mentionSpan;
+  if (appendSpace) {
+    const spaceNode = document.createTextNode(" ");
+    fragment.appendChild(spaceNode);
+    caretNode = spaceNode;
+  }
+  range.insertNode(fragment);
+  setCaretAfterNode(root, caretNode);
 }
 
 function MentionTextareaInner<TData = unknown>(
@@ -502,7 +557,18 @@ function MentionTextareaInner<TData = unknown>(
       const { text, caret } = serializeEditor(editor);
       const trigger = getActiveTrigger(text, caret);
       if (!trigger) {
+        const previousChar = text[caret - 1];
+        const nextChar = text[caret];
+        insertMentionAtSelection(
+          editor,
+          mention,
+          caret > 0 && !isWhitespaceChar(previousChar ?? ""),
+          shouldAppendTrailingSpace(nextChar),
+          resolveDisplay,
+        );
+        syncEditorValue();
         closeSuggestions();
+        editor.focus();
         return;
       }
 
@@ -538,17 +604,27 @@ function MentionTextareaInner<TData = unknown>(
     [syncEditorValueAndMentions],
   );
 
-  const openMentionSuggestions = useCallback(() => {
-    const editor = editorRef.current;
-    if (!editor) return;
+  const openMentionSuggestions = useCallback(
+    (anchorElement?: HTMLElement | null) => {
+      const editor = editorRef.current;
+      if (!editor) return;
 
-    editor.focus();
-    const { text, caret } = serializeEditor(editor);
-    const prefix =
-      caret > 0 && !isWhitespaceChar(text[caret - 1] ?? "") ? " @" : "@";
-    insertPlainTextAtSelection(editor, prefix);
-    syncEditorValueAndMentions();
-  }, [syncEditorValueAndMentions]);
+      isSelectingRef.current = true;
+      const anchorRect =
+        anchorElement?.getBoundingClientRect() ??
+        getCaretRect(editor) ??
+        editor.getBoundingClientRect();
+      openSuggestions({
+        nextQuery: "",
+        nextTriggerPosition: getPopupPositionFromRect(anchorRect),
+      });
+
+      setTimeout(() => {
+        editor.focus();
+      }, 0);
+    },
+    [openSuggestions],
+  );
 
   useImperativeHandle(
     ref,


### PR DESCRIPTION
## Summary
- Open coworker mention suggestions from the @ toolbar button without inserting a literal @ into the message.
- Anchor the toolbar-opened picker to the @ button instead of the editor caret.
- Remove the unnecessary T/bold toolbar action and locale key.

## Verification
- pnpm --filter web test src/components/ui/__tests__/mention-textarea.test.tsx
- pnpm web:check
- pnpm --filter web typecheck
- commit hook: pnpm check && pnpm typecheck

## Notes
- Stacked on #3418 / codex/chat-channels so the parallel dirty worktree stays untouched.