### PR TITLE
fix(auth): block client writes to user stripeCustomerId

### DIFF
--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -984,7 +984,15 @@ describe("core auth config", () => {
       [
         {
           user: {
-            additionalFields: Record<string, { type: string }>;
+            additionalFields: Record<
+              string,
+              {
+                type: string;
+                required?: boolean;
+                defaultValue?: unknown;
+                input?: boolean;
+              }
+            >;
           };
         },
       ]
@@ -1001,6 +1009,12 @@ describe("core auth config", () => {
         "onboardingCompleted",
       ]),
     );
+    expect(config.user.additionalFields.stripeCustomerId).toEqual({
+      type: "string",
+      required: false,
+      defaultValue: null,
+      input: false,
+    });
 
     const [[organizationConfig]] = organizationPluginMock.mock.calls as Array<
       [

--- a/packages/utils/src/__tests__/better-auth-client-schema.test.ts
+++ b/packages/utils/src/__tests__/better-auth-client-schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  betterAuthOrganizationAdditionalFields,
+  betterAuthUserAdditionalFields,
+} from "../better-auth-client-schema.js";
+
+describe("betterAuthUserAdditionalFields", () => {
+  it("rejects client writes to user stripeCustomerId", () => {
+    expect(betterAuthUserAdditionalFields.stripeCustomerId).toEqual({
+      type: "string",
+      required: false,
+      defaultValue: null,
+      input: false,
+    });
+  });
+});
+
+describe("betterAuthOrganizationAdditionalFields", () => {
+  it("rejects client writes to organization stripeCustomerId", () => {
+    expect(betterAuthOrganizationAdditionalFields.stripeCustomerId).toEqual({
+      type: "string",
+      required: false,
+      defaultValue: null,
+      input: false,
+    });
+  });
+});

--- a/packages/utils/src/better-auth-client-schema.ts
+++ b/packages/utils/src/better-auth-client-schema.ts
@@ -32,6 +32,7 @@ export const betterAuthUserAdditionalFields = {
     type: "string",
     required: false,
     defaultValue: null,
+    input: false,
   },
   onboardingCompleted: {
     type: "boolean",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [SOK-653](https://linear.app/masumi/issue/SOK-653/user-stripecustomerid-is-client-writable-via-better-auth).

Authenticated users could set personal `user.stripeCustomerId` via Better Auth `updateUser` because the field lacked `input: false` (org field already had it). That let a member who can read an org Stripe customer ID rebind their user row to that customer — personal billing portal access and diverted `invoice.paid` credit grants.

## Changes

- Set `input: false` on user `stripeCustomerId` in `betterAuthUserAdditionalFields` (matches org)
- Assert the Core auth config wires that flag
- Add utils schema unit tests for user + org `input: false`

Server/Stripe provision paths (Prisma updates, Core stripe-customer routes) are unchanged.

## Verification

- `pnpm --filter @sokosumi/utils test src/__tests__/better-auth-client-schema.test.ts`
- `pnpm --filter @sokosumi/core test src/lib/auth.test.ts -t "defines user and organization additional fields"`
- Pre-commit: `pnpm check && pnpm typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-653](https://linear.app/masumi/issue/SOK-653/user-stripecustomerid-is-client-writable-via-better-auth)

<div><a href="https://cursor.com/agents/bc-44290fd5-3f78-4f85-ae82-0ade2b8b1551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44290fd5-3f78-4f85-ae82-0ade2b8b1551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

