### PR TITLE
fix(security): block designMdUrl SSRF

### DIFF
--- a/apps/core/src/helpers/design-md-metadata-auth.test.ts
+++ b/apps/core/src/helpers/design-md-metadata-auth.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getUserByIdMock,
+  organizationFindUniqueMock,
+  resolveDatabaseHookUserIdMock,
+} = vi.hoisted(() => ({
+  getUserByIdMock: vi.fn(),
+  organizationFindUniqueMock: vi.fn(),
+  resolveDatabaseHookUserIdMock: vi.fn(),
+}));
+
+vi.mock("@sokosumi/database/repositories", () => ({
+  userRepository: {
+    getUserById: (...args: unknown[]) => getUserByIdMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    organization: {
+      findUnique: (...args: unknown[]) => organizationFindUniqueMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/services/stripe-user-email.service", () => ({
+  resolveDatabaseHookUserId: (...args: unknown[]) =>
+    resolveDatabaseHookUserIdMock(...args),
+}));
+
+import {
+  applyDesignMdMetadataGuardToOrganizationCreate,
+  applyDesignMdMetadataGuardToOrganizationUpdate,
+  applyDesignMdMetadataGuardToUserCreate,
+  applyDesignMdMetadataGuardToUserUpdate,
+  sanitizeOrganizationMetadataForCreate,
+  sanitizeOrganizationMetadataForUpdate,
+  sanitizeUserMetadataForCreate,
+  sanitizeUserMetadataForUpdate,
+} from "./design-md-metadata-auth";
+
+describe("sanitizeOrganizationMetadataForCreate", () => {
+  it("strips designMd fields from create payloads", () => {
+    expect(
+      sanitizeOrganizationMetadataForCreate({
+        url: "https://acme.example",
+        designMdUrl: "https://evil.example/ssrf",
+      }),
+    ).toEqual({ url: "https://acme.example" });
+  });
+});
+
+describe("sanitizeOrganizationMetadataForUpdate", () => {
+  it("preserves existing designMd fields over client values", () => {
+    expect(
+      sanitizeOrganizationMetadataForUpdate(
+        {
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+        },
+        JSON.stringify({
+          designMdUrl:
+            "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+        }),
+      ),
+    ).toEqual({
+      url: "https://acme.example",
+      designMdUrl: "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+    });
+  });
+});
+
+describe("sanitizeUserMetadataForCreate", () => {
+  it("returns serialized metadata without designMd fields", () => {
+    expect(
+      sanitizeUserMetadataForCreate(
+        JSON.stringify({
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+        }),
+      ),
+    ).toBe(JSON.stringify({ url: "https://acme.example" }));
+  });
+});
+
+describe("sanitizeUserMetadataForUpdate", () => {
+  it("returns serialized metadata with preserved designMd fields", () => {
+    expect(
+      sanitizeUserMetadataForUpdate(
+        JSON.stringify({
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+        }),
+        JSON.stringify({
+          designMdUrl:
+            "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+          designMdExtractionId: "7",
+        }),
+      ),
+    ).toBe(
+      JSON.stringify({
+        url: "https://acme.example",
+        designMdUrl:
+          "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+        designMdExtractionId: "7",
+      }),
+    );
+  });
+});
+
+describe("applyDesignMdMetadataGuardToUserCreate", () => {
+  it("leaves payloads without metadata unchanged", () => {
+    const user = { email: "a@example.com", name: "A" };
+    expect(applyDesignMdMetadataGuardToUserCreate(user)).toBe(user);
+  });
+
+  it("strips designMd fields from metadata", () => {
+    expect(
+      applyDesignMdMetadataGuardToUserCreate({
+        email: "a@example.com",
+        metadata: JSON.stringify({
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+        }),
+      }),
+    ).toEqual({
+      email: "a@example.com",
+      metadata: JSON.stringify({ url: "https://acme.example" }),
+    });
+  });
+});
+
+describe("applyDesignMdMetadataGuardToUserUpdate", () => {
+  beforeEach(() => {
+    getUserByIdMock.mockReset();
+    resolveDatabaseHookUserIdMock.mockReset();
+  });
+
+  it("leaves payloads without metadata unchanged", async () => {
+    const updateData = { email: "new@example.com" };
+    await expect(
+      applyDesignMdMetadataGuardToUserUpdate(updateData, {}),
+    ).resolves.toBe(updateData);
+    expect(resolveDatabaseHookUserIdMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves server designMd fields from the existing user row", async () => {
+    resolveDatabaseHookUserIdMock.mockReturnValue("user_1");
+    getUserByIdMock.mockResolvedValue({
+      metadata: JSON.stringify({
+        designMdUrl:
+          "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      }),
+    });
+
+    await expect(
+      applyDesignMdMetadataGuardToUserUpdate(
+        {
+          metadata: JSON.stringify({
+            url: "https://acme.example",
+            designMdUrl: "https://evil.example/ssrf",
+          }),
+        },
+        { session: { user: { id: "user_1" } } },
+      ),
+    ).resolves.toEqual({
+      metadata: JSON.stringify({
+        url: "https://acme.example",
+        designMdUrl:
+          "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      }),
+    });
+  });
+});
+
+describe("applyDesignMdMetadataGuardToOrganizationCreate", () => {
+  it("strips designMd fields from organization metadata", () => {
+    expect(
+      applyDesignMdMetadataGuardToOrganizationCreate({
+        name: "Acme",
+        metadata: {
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+        },
+      }),
+    ).toEqual({
+      name: "Acme",
+      metadata: { url: "https://acme.example" },
+    });
+  });
+});
+
+describe("applyDesignMdMetadataGuardToOrganizationUpdate", () => {
+  beforeEach(() => {
+    organizationFindUniqueMock.mockReset();
+  });
+
+  it("preserves server designMd fields from the existing organization row", async () => {
+    organizationFindUniqueMock.mockResolvedValue({
+      metadata: JSON.stringify({
+        designMdUrl:
+          "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      }),
+    });
+
+    await expect(
+      applyDesignMdMetadataGuardToOrganizationUpdate(
+        {
+          name: "Acme",
+          metadata: {
+            url: "https://acme.example",
+            designMdUrl: "https://evil.example/ssrf",
+          },
+        },
+        "org_1",
+      ),
+    ).resolves.toEqual({
+      name: "Acme",
+      metadata: {
+        url: "https://acme.example",
+        designMdUrl:
+          "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      },
+    });
+    expect(organizationFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      select: { metadata: true },
+    });
+  });
+});

--- a/apps/core/src/helpers/design-md-metadata-auth.ts
+++ b/apps/core/src/helpers/design-md-metadata-auth.ts
@@ -1,0 +1,131 @@
+import { userRepository } from "@sokosumi/database/repositories";
+import {
+  serializeMetadataRecord,
+  withoutDesignMdMetadata,
+  withPreservedDesignMdMetadata,
+} from "@sokosumi/utils";
+
+import prisma from "@/lib/db/prisma";
+import { resolveDatabaseHookUserId } from "@/services/stripe-user-email.service";
+
+/**
+ * Better Auth org adapter stringifies object metadata; pass a record (or null).
+ * Strips client-supplied DESIGN.md fields on create.
+ */
+export function sanitizeOrganizationMetadataForCreate(
+  incomingMetadata: unknown,
+): Record<string, unknown> | null {
+  return withoutDesignMdMetadata(incomingMetadata);
+}
+
+/**
+ * Better Auth org adapter stringifies object metadata; pass a record (or null).
+ * Forces DESIGN.md fields to match the existing org row.
+ */
+export function sanitizeOrganizationMetadataForUpdate(
+  incomingMetadata: unknown,
+  existingMetadata: unknown,
+): Record<string, unknown> | null {
+  return withPreservedDesignMdMetadata(incomingMetadata, existingMetadata);
+}
+
+/**
+ * User.metadata is stored as a JSON string. Strips client DESIGN.md fields.
+ */
+export function sanitizeUserMetadataForCreate(
+  incomingMetadata: unknown,
+): string | null {
+  return serializeMetadataRecord(withoutDesignMdMetadata(incomingMetadata));
+}
+
+/**
+ * User.metadata is stored as a JSON string. Preserves server DESIGN.md fields.
+ */
+export function sanitizeUserMetadataForUpdate(
+  incomingMetadata: unknown,
+  existingMetadata: unknown,
+): string | null {
+  return serializeMetadataRecord(
+    withPreservedDesignMdMetadata(incomingMetadata, existingMetadata),
+  );
+}
+
+/** Strips client DESIGN.md keys from Better Auth user create payloads. */
+export function applyDesignMdMetadataGuardToUserCreate(
+  user: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!Object.hasOwn(user, "metadata")) {
+    return user;
+  }
+
+  return {
+    ...user,
+    metadata: sanitizeUserMetadataForCreate(user.metadata),
+  };
+}
+
+/**
+ * Forces DESIGN.md metadata fields on Better Auth user updates to match the
+ * existing DB row so clients cannot plant SSRF targets via `updateUser`.
+ */
+export async function applyDesignMdMetadataGuardToUserUpdate(
+  updateData: Record<string, unknown>,
+  ctx: unknown,
+): Promise<Record<string, unknown>> {
+  if (!Object.hasOwn(updateData, "metadata")) {
+    return updateData;
+  }
+
+  const userId = resolveDatabaseHookUserId(ctx, updateData);
+  const existing = userId
+    ? await userRepository.getUserById(userId, prisma)
+    : null;
+
+  return {
+    ...updateData,
+    metadata: sanitizeUserMetadataForUpdate(
+      updateData.metadata,
+      existing?.metadata ?? null,
+    ),
+  };
+}
+
+/** Strips client DESIGN.md keys from Better Auth organization create payloads. */
+export function applyDesignMdMetadataGuardToOrganizationCreate(
+  organization: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!Object.hasOwn(organization, "metadata")) {
+    return organization;
+  }
+
+  return {
+    ...organization,
+    metadata: sanitizeOrganizationMetadataForCreate(organization.metadata),
+  };
+}
+
+/**
+ * Forces DESIGN.md metadata fields on Better Auth organization updates to match
+ * the existing DB row so org admins cannot plant SSRF targets via metadata.
+ */
+export async function applyDesignMdMetadataGuardToOrganizationUpdate(
+  organization: Record<string, unknown>,
+  organizationId: string,
+): Promise<Record<string, unknown>> {
+  if (!Object.hasOwn(organization, "metadata")) {
+    return organization;
+  }
+
+  const existing = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: { metadata: true },
+  });
+
+  return {
+    ...organization,
+    metadata: sanitizeOrganizationMetadataForUpdate(
+      organization.metadata,
+      existing?.metadata ?? null,
+    ),
+  };
+}

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -317,6 +317,20 @@ vi.mock("@/services/stripe-user-email.service", () => ({
     syncUserEmailWithStripeMock(...args),
 }));
 
+vi.mock("@/helpers/design-md-metadata-auth", () => ({
+  applyDesignMdMetadataGuardToUserCreate: (user: Record<string, unknown>) =>
+    user,
+  applyDesignMdMetadataGuardToUserUpdate: async (
+    updateData: Record<string, unknown>,
+  ) => updateData,
+  applyDesignMdMetadataGuardToOrganizationCreate: (
+    organization: Record<string, unknown>,
+  ) => organization,
+  applyDesignMdMetadataGuardToOrganizationUpdate: async (
+    organization: Record<string, unknown>,
+  ) => organization,
+}));
+
 vi.mock("@sokosumi/email", () => ({
   renderMagicLinkEmail: (...args: unknown[]) =>
     renderMagicLinkEmailMock(...args),

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -57,6 +57,12 @@ import {
   getEnv,
   getWebAppBaseUrl,
 } from "@/config/env";
+import {
+  applyDesignMdMetadataGuardToOrganizationCreate,
+  applyDesignMdMetadataGuardToOrganizationUpdate,
+  applyDesignMdMetadataGuardToUserCreate,
+  applyDesignMdMetadataGuardToUserUpdate,
+} from "@/helpers/design-md-metadata-auth";
 import { prepareTasksForUserDeletion } from "@/helpers/user-deletion-tasks";
 import { uploadProfileImage } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
@@ -346,11 +352,12 @@ export const auth = betterAuth({
     user: {
       create: {
         before: async (user, _ctx) => {
+          const withName = {
+            ...user,
+            name: getStoredUserName(user.name, user.email),
+          };
           return {
-            data: {
-              ...user,
-              name: getStoredUserName(user.name, user.email),
-            },
+            data: applyDesignMdMetadataGuardToUserCreate(withName),
           };
         },
         after: async (user, _ctx) => {
@@ -393,7 +400,11 @@ export const auth = betterAuth({
       update: {
         before: async (data, ctx) => {
           await prepareStripeEmailSyncForUserUpdate(data, ctx, prisma);
-          return { data };
+          const guarded = await applyDesignMdMetadataGuardToUserUpdate(
+            data,
+            ctx,
+          );
+          return { data: guarded };
         },
         after: async (user, _ctx) => {
           void webhookService.callUserUpdated(user).catch((error) => {
@@ -607,6 +618,13 @@ export const auth = betterAuth({
     jwt({ disableSettingJwtHeader: true }),
     organization({
       organizationHooks: {
+        beforeCreateOrganization: async ({ organization }) => {
+          return {
+            data: applyDesignMdMetadataGuardToOrganizationCreate(
+              organization as Record<string, unknown>,
+            ),
+          };
+        },
         afterCreateOrganization: async ({ organization }) => {
           await ensureWorkspaceForCreatedOrganization(organization);
           void ensureStripeCustomerForCreatedOrganization(organization).catch(
@@ -623,6 +641,14 @@ export const auth = betterAuth({
               });
             },
           );
+        },
+        beforeUpdateOrganization: async ({ organization, member }) => {
+          return {
+            data: await applyDesignMdMetadataGuardToOrganizationUpdate(
+              organization as Record<string, unknown>,
+              member.organizationId,
+            ),
+          };
         },
         beforeAcceptInvitation: async ({ organization }) => {
           await ensureCanAcceptOrganizationInvitation(organization.id);

--- a/apps/core/src/services/stripe-user-email.service.ts
+++ b/apps/core/src/services/stripe-user-email.service.ts
@@ -12,7 +12,7 @@ export function resetStripeEmailSyncStateForTests(): void {
   pendingStripeEmailSyncByNormalizedEmail.clear();
 }
 
-function resolveDatabaseHookUserId(
+export function resolveDatabaseHookUserId(
   ctx: unknown,
   updateData: Record<string, unknown>,
 ): string | null {

--- a/apps/web/src/components/design-md/__tests__/design-md-edit-page-shared.test.ts
+++ b/apps/web/src/components/design-md/__tests__/design-md-edit-page-shared.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { ssrfSafeFetchMock } = vi.hoisted(() => ({
+  ssrfSafeFetchMock: vi.fn(),
+}));
+
+vi.mock("@sokosumi/net", () => ({
+  ssrfSafeFetch: ssrfSafeFetchMock,
+}));
+
+import { fetchDesignMdMarkdown } from "../design-md-edit-page-shared";
+
+describe("fetchDesignMdMarkdown", () => {
+  beforeEach(() => {
+    ssrfSafeFetchMock.mockReset();
+  });
+
+  it("refuses non-blob / non-design-md URLs without fetching", async () => {
+    await expect(
+      fetchDesignMdMarkdown("https://169.254.169.254/latest/meta-data/"),
+    ).resolves.toEqual({ error: true });
+    await expect(
+      fetchDesignMdMarkdown("https://evil.example/design.md"),
+    ).resolves.toEqual({ error: true });
+    expect(ssrfSafeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches allowlisted design-md blob URLs via ssrfSafeFetch", async () => {
+    const url =
+      "https://abc.public.blob.vercel-storage.com/design-md/content.md";
+    ssrfSafeFetchMock.mockResolvedValue(
+      new Response("# Hello", { status: 200 }),
+    );
+
+    await expect(fetchDesignMdMarkdown(url)).resolves.toEqual({
+      markdown: "# Hello",
+    });
+    expect(ssrfSafeFetchMock).toHaveBeenCalledWith(url, {
+      maxResponseBytes: 1024 * 1024,
+    });
+  });
+
+  it("returns error when ssrfSafeFetch rejects or response is not ok", async () => {
+    const url =
+      "https://abc.public.blob.vercel-storage.com/design-md/content.md";
+    ssrfSafeFetchMock.mockRejectedValue(new Error("connection refused"));
+    await expect(fetchDesignMdMarkdown(url)).resolves.toEqual({ error: true });
+
+    ssrfSafeFetchMock.mockResolvedValue(new Response("nope", { status: 404 }));
+    await expect(fetchDesignMdMarkdown(url)).resolves.toEqual({ error: true });
+  });
+});

--- a/apps/web/src/components/design-md/design-md-edit-page-shared.tsx
+++ b/apps/web/src/components/design-md/design-md-edit-page-shared.tsx
@@ -1,6 +1,11 @@
+import { ssrfSafeFetch } from "@sokosumi/net";
+import { isDesignMdBlobUrl } from "@sokosumi/utils";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+
+/** Match Core `LIMITS.DESIGN_MD_MAX_SIZE_BYTES` — editor content cap. */
+const MAX_DESIGN_MD_FETCH_BYTES = 1024 * 1024;
 
 interface DesignMdLoadErrorProps {
   backHref: string;
@@ -28,11 +33,24 @@ export function DesignMdLoadError({
   );
 }
 
+/**
+ * Loads DESIGN.md markdown for the editor.
+ *
+ * Only fetches Core-uploaded Vercel Blob URLs under `/design-md/` via
+ * {@link ssrfSafeFetch}. Client-writable metadata must not be able to point
+ * this at internal or metadata endpoints (SSRF).
+ */
 async function fetchDesignMdMarkdown(
   designMdUrl: string,
 ): Promise<{ markdown: string } | { error: true }> {
+  if (!isDesignMdBlobUrl(designMdUrl)) {
+    return { error: true };
+  }
+
   try {
-    const response = await fetch(designMdUrl, { cache: "no-store" });
+    const response = await ssrfSafeFetch(designMdUrl, {
+      maxResponseBytes: MAX_DESIGN_MD_FETCH_BYTES,
+    });
 
     if (!response.ok) {
       return { error: true };

--- a/apps/web/src/lib/schemas/organization.ts
+++ b/apps/web/src/lib/schemas/organization.ts
@@ -14,8 +14,6 @@ export const organizationInformationFormSchema = (
     metadata: z
       .object({
         url: z.string().nullable().optional(),
-        designMdUrl: z.string().nullable().optional(),
-        designMdExtractionId: z.string().nullable().optional(),
       })
       .catchall(z.unknown())
       .nullable()

--- a/packages/utils/src/__tests__/design-md-metadata-guard.test.ts
+++ b/packages/utils/src/__tests__/design-md-metadata-guard.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  withoutDesignMdMetadata,
+  withPreservedDesignMdMetadata,
+} from "../design-md-metadata-guard.js";
+
+describe("withoutDesignMdMetadata", () => {
+  it("strips designMd fields and keeps other keys", () => {
+    expect(
+      withoutDesignMdMetadata({
+        url: "https://acme.example",
+        designMdUrl: "https://evil.example/ssrf",
+        designMdExtractionId: "42",
+      }),
+    ).toEqual({
+      url: "https://acme.example",
+    });
+  });
+
+  it("returns null when only designMd fields were present", () => {
+    expect(
+      withoutDesignMdMetadata({
+        designMdUrl: "https://evil.example/ssrf",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("withPreservedDesignMdMetadata", () => {
+  it("overwrites client designMd fields with existing server values", () => {
+    expect(
+      withPreservedDesignMdMetadata(
+        {
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+          designMdExtractionId: "attacker",
+        },
+        {
+          designMdUrl:
+            "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+          designMdExtractionId: "99",
+          url: "https://old.example",
+        },
+      ),
+    ).toEqual({
+      url: "https://acme.example",
+      designMdUrl: "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      designMdExtractionId: "99",
+    });
+  });
+
+  it("restores designMd fields when client omits or clears them", () => {
+    expect(
+      withPreservedDesignMdMetadata(
+        { url: "https://acme.example" },
+        {
+          designMdUrl:
+            "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+          designMdExtractionId: "99",
+        },
+      ),
+    ).toEqual({
+      url: "https://acme.example",
+      designMdUrl: "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      designMdExtractionId: "99",
+    });
+
+    expect(
+      withPreservedDesignMdMetadata(null, {
+        designMdUrl:
+          "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+      }),
+    ).toEqual({
+      designMdUrl: "https://abc.public.blob.vercel-storage.com/design-md/ok.md",
+    });
+  });
+
+  it("does not invent designMd fields when none exist server-side", () => {
+    expect(
+      withPreservedDesignMdMetadata(
+        {
+          url: "https://acme.example",
+          designMdUrl: "https://evil.example/ssrf",
+        },
+        { url: "https://old.example" },
+      ),
+    ).toEqual({
+      url: "https://acme.example",
+    });
+  });
+});

--- a/packages/utils/src/__tests__/design-md-url.test.ts
+++ b/packages/utils/src/__tests__/design-md-url.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DESIGN_MD_BLOB_PATH_PREFIX,
+  isDesignMdBlobUrl,
+} from "../design-md-url.js";
+
+describe("DESIGN_MD_BLOB_PATH_PREFIX", () => {
+  it("matches Core upload directory pathname prefix", () => {
+    expect(DESIGN_MD_BLOB_PATH_PREFIX).toBe("/design-md/");
+  });
+});
+
+describe("isDesignMdBlobUrl", () => {
+  it("accepts https Vercel public blob URLs under /design-md/", () => {
+    expect(
+      isDesignMdBlobUrl(
+        "https://abc123.public.blob.vercel-storage.com/design-md/hash.md",
+      ),
+    ).toBe(true);
+    expect(
+      isDesignMdBlobUrl(
+        "https://public.blob.vercel-storage.com/design-md/nested/file.md",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects non-https, foreign hosts, and non-design-md paths", () => {
+    expect(
+      isDesignMdBlobUrl(
+        "http://abc123.public.blob.vercel-storage.com/design-md/hash.md",
+      ),
+    ).toBe(false);
+    expect(isDesignMdBlobUrl("https://evil.example/design-md/hash.md")).toBe(
+      false,
+    );
+    expect(
+      isDesignMdBlobUrl(
+        "https://abc123.public.blob.vercel-storage.com/users/u1/file.md",
+      ),
+    ).toBe(false);
+    expect(isDesignMdBlobUrl("https://169.254.169.254/latest/meta-data/")).toBe(
+      false,
+    );
+    expect(isDesignMdBlobUrl("not-a-url")).toBe(false);
+  });
+});

--- a/packages/utils/src/design-md-metadata-guard.ts
+++ b/packages/utils/src/design-md-metadata-guard.ts
@@ -1,0 +1,36 @@
+import {
+  buildMetadataWithDesignMd,
+  getNormalizedStringField,
+  type MetadataRecord,
+  parseMetadataRecord,
+} from "./metadata-record.js";
+
+/**
+ * Drops client-supplied `designMdUrl` / `designMdExtractionId` from metadata.
+ * Use on Better Auth create paths so only Core DESIGN.md PUT can set them.
+ */
+export function withoutDesignMdMetadata(
+  incomingMetadata: unknown,
+): MetadataRecord | null {
+  return buildMetadataWithDesignMd(parseMetadataRecord(incomingMetadata), {
+    url: null,
+    extractionId: null,
+  });
+}
+
+/**
+ * Keeps server-owned DESIGN.md fields from `existingMetadata`, ignoring any
+ * client-supplied `designMdUrl` / `designMdExtractionId` on the incoming write.
+ * Client Better Auth metadata updates cannot invent, replace, or clear them.
+ */
+export function withPreservedDesignMdMetadata(
+  incomingMetadata: unknown,
+  existingMetadata: unknown,
+): MetadataRecord | null {
+  const existing = parseMetadataRecord(existingMetadata);
+
+  return buildMetadataWithDesignMd(parseMetadataRecord(incomingMetadata), {
+    url: getNormalizedStringField(existing, "designMdUrl"),
+    extractionId: getNormalizedStringField(existing, "designMdExtractionId"),
+  });
+}

--- a/packages/utils/src/design-md-url.ts
+++ b/packages/utils/src/design-md-url.ts
@@ -1,0 +1,28 @@
+import { isVercelBlobPublicHost } from "./entity-image-upload.js";
+
+/**
+ * Blob path prefix used by Core when uploading DESIGN.md content
+ * (`STORAGE.DESIGN_MD_UPLOAD_DIR` in apps/core).
+ */
+export const DESIGN_MD_BLOB_PATH_PREFIX = "/design-md/";
+
+/**
+ * True when `url` is an HTTPS public Vercel Blob URL under `/design-md/…`.
+ * Used to stop SSRF via attacker-controlled `metadata.designMdUrl` values —
+ * only Core-uploaded DESIGN.md blobs match this shape.
+ */
+export function isDesignMdBlobUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") {
+      return false;
+    }
+    if (!isVercelBlobPublicHost(parsed.hostname)) {
+      return false;
+    }
+    const pathname = decodeURIComponent(parsed.pathname);
+    return pathname.startsWith(DESIGN_MD_BLOB_PATH_PREFIX);
+  } catch {
+    return false;
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -63,6 +63,14 @@ export {
   removeDesignMdAttachmentLinks,
 } from "./design-md-attachment.js";
 export {
+  withoutDesignMdMetadata,
+  withPreservedDesignMdMetadata,
+} from "./design-md-metadata-guard.js";
+export {
+  DESIGN_MD_BLOB_PATH_PREFIX,
+  isDesignMdBlobUrl,
+} from "./design-md-url.js";
+export {
   FILE_EXTENSION_ALLOWLIST,
   getExtensionFromUrl,
   getUrlBasename,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes authenticated SSRF via client-set `metadata.designMdUrl` (SOK-654).

Any authenticated user could plant an arbitrary URL in user/org metadata; `/account/design-md/edit` and org DESIGN.md edit then fetched it server-side and returned the body as editor markdown.

### Changes

- **Fetch path**: `fetchDesignMdMarkdown` only loads HTTPS Vercel Blob URLs under `/design-md/` and routes them through `ssrfSafeFetch` with a 1 MiB cap.
- **Write path**: Better Auth user/org create+update hooks strip or preserve server-owned `designMdUrl` / `designMdExtractionId` so clients cannot invent, replace, or clear them. Only Core DESIGN.md PUT remains the writer.
- Shared helpers in `@sokosumi/utils` (`isDesignMdBlobUrl`, `withPreservedDesignMdMetadata`, `withoutDesignMdMetadata`).

## Test plan

- [x] `pnpm --filter @sokosumi/utils test` (design-md url + metadata guard)
- [x] `pnpm --filter @sokosumi/core test src/helpers/design-md-metadata-auth.test.ts`
- [x] `pnpm --filter web test src/components/design-md/__tests__/design-md-edit-page-shared.test.ts`
- [x] `pnpm --filter @sokosumi/core test src/lib/auth.test.ts`
- [x] typecheck (pre-commit hook)

Closes SOK-654

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-654](https://linear.app/masumi/issue/SOK-654/authenticated-ssrf-via-designmd-metadata-url)

<div><a href="https://cursor.com/agents/bc-988f7b02-21ec-4cfa-ab32-9c509c227dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-988f7b02-21ec-4cfa-ab32-9c509c227dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

