### PR TITLE
fix(core): block coworker impersonation on org DESIGN.md put

### DIFF
--- a/apps/core/src/routes/v1/organizations/[id]/design-md/put.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/put.test.ts
@@ -17,17 +17,6 @@ const {
   uploadDesignMdContentMock: vi.fn(),
 }));
 
-vi.mock("@/middleware/auth", () => ({
-  requireUserContext: (authContext: AuthenticationContext | null) => {
-    if (!authContext || authContext.actor !== "user") {
-      throw new HTTPException(403, {
-        message: "User authentication required",
-      });
-    }
-    return { source: "session" as const, ...authContext };
-  },
-}));
-
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     organization: { findUnique: organizationFindUniqueMock },
@@ -85,8 +74,9 @@ function setMembership(role: string | null, metadata: unknown) {
 function putDesignMd(
   id: string,
   body: { content: string | null; extractionId: string | null },
+  authContext: AuthenticationContext | null = USER_AUTH_CONTEXT,
 ) {
-  return createApp().request(`http://localhost/${id}/design-md`, {
+  return createApp(authContext).request(`http://localhost/${id}/design-md`, {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -186,5 +176,50 @@ describe("PUT /organizations/{id}/design-md", () => {
 
     expect(response.status).toBe(503);
     expect(updateOrganizationByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects coworker context even with X-Context-User-Id", async () => {
+    setMembership("owner", JSON.stringify({}));
+
+    const response = await putDesignMd(
+      "org_123",
+      { content: "# Brand", extractionId: null },
+      {
+        actor: "coworker",
+        coworkerId: "coworker_1",
+        vendorId: "vendor_1",
+        context: { userId: "user_123", organizationId: "org_123" },
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(organizationFindUniqueMock).not.toHaveBeenCalled();
+    expect(uploadDesignMdContentMock).not.toHaveBeenCalled();
+    expect(updateOrganizationByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("allows orchestrator with context headers as the context user", async () => {
+    setMembership("owner", JSON.stringify({ invoiceEmail: "b@acme.example" }));
+    uploadDesignMdContentMock.mockResolvedValueOnce(
+      "https://blob.example/org.md",
+    );
+
+    const response = await putDesignMd(
+      "org_123",
+      { content: "# Brand", extractionId: "55" },
+      {
+        actor: "orchestrator",
+        orchestratorId: "orch_1",
+        context: { userId: "user_123", organizationId: "org_123" },
+      },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(uploadDesignMdContentMock).toHaveBeenCalledWith("# Brand", "55");
+    expect(body.data.designMd).toEqual({
+      url: "https://blob.example/org.md",
+      extractionId: "55",
+    });
   });
 });

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/put.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/put.ts
@@ -10,7 +10,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import { uploadDesignMdContent } from "@/lib/design-md-blob";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
-import { requireUserContext } from "@/middleware/auth";
+import { requireOwnerUserContext } from "@/middleware/auth";
 import {
   designMdWriteSchema,
   persistedDesignMdSchema,
@@ -70,7 +70,7 @@ const route = createRoute({
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserContext(c.var.authContext);
+    const userContext = requireOwnerUserContext(c.var.authContext);
     const { id } = c.req.valid("param");
     const body = c.req.valid("json");
 


### PR DESCRIPTION
## Summary

Follow-up residual surface from #3425 review:

- **Bug:** After #3408, `PUT /v1/organizations/{id}/design-md` used `requireUserContext`, so a coworker API key with `X-Context-User-Id` set to an org owner/admin could overwrite org DESIGN.md.
- **Fix:** Switch to `requireOwnerUserContext` (session or orch+context; rejects coworker).
- **Tests:** Drop auth mock; assert coworker+context → 403 and orch+context → 200 with real middleware.

`GET .../design-md` stays on `requireUserContext` (any org member may read).

Depends on #3425 (merged).

## Validation

- `pnpm --filter @sokosumi/core test` on `design-md/put.test.ts` — 8 passed
- Pre-commit `pnpm check && pnpm typecheck` passed