### PR TITLE
fix(chat): harden channel deep-link, mention claim, DM race

### DIFF
--- a/apps/core/src/routes/v1/chat-channels/direct/post.ts
+++ b/apps/core/src/routes/v1/chat-channels/direct/post.ts
@@ -196,14 +196,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       );
       return result.created ? created(c, payload) : ok(c, payload);
     } catch (error) {
-      if (isSlugUniqueConstraintError(error)) {
-        throw conflict("Direct channel already exists");
-      }
-
-      if (isPrismaUniqueViolation(error) && directKeyRef.current) {
-        // A concurrent request inserted the same direct channel between our
-        // lookup and our insert. Return the winner instead of failing the
-        // loser. The transaction is aborted here, so re-read outside of it.
+      // Slug and directKey unique races both mean another request won the
+      // create. Prefer returning that channel over a 409 — including when the
+      // loser hits the slug constraint first (isSlugUniqueConstraintError is a
+      // P2002 subset that previously short-circuited before the re-read).
+      if (
+        (isSlugUniqueConstraintError(error) ||
+          isPrismaUniqueViolation(error)) &&
+        directKeyRef.current
+      ) {
         const existing = await prisma.chatChannel.findFirst({
           where: {
             organizationId: body.organizationId,
@@ -223,7 +224,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
       }
 
-      if (isPrismaUniqueViolation(error)) {
+      if (
+        isSlugUniqueConstraintError(error) ||
+        isPrismaUniqueViolation(error)
+      ) {
         throw conflict("Direct channel already exists");
       }
 

--- a/apps/core/src/services/chat-channel-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-channel-coworker-dispatch.service.ts
@@ -118,7 +118,6 @@ async function runChatChannelMentionDispatch(mentionId: string): Promise<void> {
               id: true,
               name: true,
               organizationId: true,
-              createdByUserId: true,
             },
           },
           senderUser: {
@@ -147,8 +146,27 @@ async function runChatChannelMentionDispatch(mentionId: string): Promise<void> {
     return;
   }
 
-  const userId =
-    mention.message.senderUserId ?? mention.message.channel.createdByUserId;
+  // Fail closed when the human sender row was deleted (SetNull): billing /
+  // provider auth as the channel creator would attribute cost to the wrong user.
+  const userId = mention.message.senderUserId;
+  if (!userId) {
+    await markMentionFailed(mentionId, "Mention sender is no longer available");
+    return;
+  }
+
+  // Claim before any provider work so concurrent dispatches cannot both run
+  // generateText. Only `pending` → `sent` wins; losers exit quietly.
+  const claimed = await prisma.chatChannelMention.updateMany({
+    where: { id: mentionId, status: "pending" },
+    data: {
+      status: "sent",
+      error: null,
+    },
+  });
+  if (claimed.count === 0) {
+    return;
+  }
+
   const senderName = mention.message.senderUser?.name ?? "A teammate";
   const baseURL = coworker.baseURL.trim();
   const threadRootId = mention.message.parentMessageId;
@@ -187,9 +205,7 @@ async function runChatChannelMentionDispatch(mentionId: string): Promise<void> {
   await prisma.chatChannelMention.update({
     where: { id: mentionId },
     data: {
-      status: "sent",
       providerConversationId: providerConversation.id,
-      error: null,
     },
   });
 
@@ -215,7 +231,8 @@ async function runChatChannelMentionDispatch(mentionId: string): Promise<void> {
       createdAt: { lte: mention.message.createdAt },
       ...(threadRootId
         ? { OR: [{ id: threadRootId }, { parentMessageId: threadRootId }] }
-        : {}),
+        : // Top-level mentions should not pull thread replies into CONTEXT.
+          { parentMessageId: null }),
     },
     orderBy: { createdAt: "desc" },
     take: CHANNEL_CONTEXT_MESSAGE_LIMIT,

--- a/apps/web/src/app/(app)/channels/page.tsx
+++ b/apps/web/src/app/(app)/channels/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CoreApiRequestError } from "@/lib/clients/core.client";
-import type { ChatChannelMessage } from "@/lib/clients/generated/core";
+import type {
+  ChatChannel,
+  ChatChannelMessage,
+} from "@/lib/clients/generated/core";
 import { chatChannelService, userService } from "@/lib/services";
 import { coworkerService } from "@/lib/services/coworker.service";
 
@@ -102,7 +106,7 @@ export default async function ChannelsPage({
       ? loadChannelMessages(requestedChannelId)
       : null;
 
-  const [channels, organizationMembers, coworkers, currentMember] =
+  const [listedChannels, organizationMembers, coworkers, currentMember] =
     await Promise.all([
       chatChannelService.listChannels(activeOrganization.id),
       userService.getOrganizationMembers(activeOrganization.id),
@@ -110,12 +114,26 @@ export default async function ChannelsPage({
       userService.getMyMemberInOrganization(activeOrganization.id),
     ]);
 
-  const selectedChannel =
-    isCreateChannelRequested || isNewDirectMessage
-      ? null
-      : (channels.find((channel) => channel.id === requestedChannelId) ??
-        channels[0] ??
-        null);
+  // List is capped (default 50). A deep-link outside that page must not fall
+  // back to channels[0] — that silently opens the wrong conversation.
+  let channels = listedChannels;
+  let selectedChannel: ChatChannel | null = null;
+  if (!isCreateChannelRequested && !isNewDirectMessage) {
+    if (requestedChannelId) {
+      selectedChannel =
+        channels.find((channel) => channel.id === requestedChannelId) ?? null;
+      if (!selectedChannel) {
+        const fetched = await chatChannelService.getChannel(requestedChannelId);
+        if (!fetched) {
+          notFound();
+        }
+        channels = [fetched, ...channels];
+        selectedChannel = fetched;
+      }
+    } else {
+      selectedChannel = channels[0] ?? null;
+    }
+  }
   const selectedChannelId = selectedChannel?.id ?? null;
   if (requestedMessagesPromise && requestedChannelId !== selectedChannelId) {
     void requestedMessagesPromise.catch((error) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Addresses Important findings from the PR #3422 review:

1. **Deep-link wrong channel** — if `?channel=` is outside the first list page, fetch via `getChannel` instead of falling back to `channels[0]`; `notFound()` when inaccessible
2. **Atomic mention claim** — `pending` → `sent` via `updateMany`; losers exit before `generateText`. Also fail-closed when `senderUserId` is null, and top-level CONTEXT excludes thread replies
3. **Direct DM slug race** — slug unique violations now re-read by `directKey` like other create races (no premature 409)

### Deferred (with reasoning)
- **Peer refresh / load-older** — Ably unconfigured; needs product call on polling cost vs realtime follow-up
- **Reaction toggle concurrency flip** — UI already guards double-tap; proper fix needs locking; residual rare

## Verification
- `pnpm --filter core test` (dispatch + helpers + messages/post)
- `biome check` on touched files
- Full web/core typecheck still fails on this branch for pre-existing invite-link / `thinking-orbs` env issues unrelated to this diff

Refs #3422

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70cf98ac-af02-460f-a9fd-e1eb6626a525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70cf98ac-af02-460f-a9fd-e1eb6626a525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

