### PR TITLE
fix(web): refresh open channels and load older messages

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Ältere Nachrichten laden",
+      "loadingOlder": "Ältere Nachrichten werden geladen…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4730,7 +4730,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Load older messages",
+      "loadingOlder": "Loading older messages…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Cargar mensajes anteriores",
+      "loadingOlder": "Cargando mensajes anteriores…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Charger les messages plus anciens",
+      "loadingOlder": "Chargement des messages plus anciens…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Carica messaggi precedenti",
+      "loadingOlder": "Caricamento messaggi precedenti…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "以前のメッセージを読み込む",
+      "loadingOlder": "以前のメッセージを読み込み中…"
     },
     "ChatRail": {
       "chat": "チャット"

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Carregar mensagens anteriores",
+      "loadingOlder": "Carregando mensagens anteriores…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "Carregar mensagens anteriores",
+      "loadingOlder": "A carregar mensagens anteriores…"
     },
     "ChatRail": {
       "chat": "Chat"

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4611,7 +4611,9 @@
         "empty": "No replies yet",
         "replyPlaceholder": "Reply in thread",
         "replyCount": "{count, plural, one {# reply} other {# replies}}"
-      }
+      },
+      "loadOlder": "加载更早的消息",
+      "loadingOlder": "正在加载更早的消息…"
     },
     "ChatRail": {
       "chat": "聊天"

--- a/apps/web/src/app/(app)/channels/actions.ts
+++ b/apps/web/src/app/(app)/channels/actions.ts
@@ -279,10 +279,18 @@ export async function sendChannelMessageAction(
 
 export async function listChannelMessagesAction(
   channelId: string,
-): Promise<ChannelActionResult<ChatChannelMessage[]>> {
+  options?: { cursor?: string },
+): Promise<
+  ChannelActionResult<{
+    messages: ChatChannelMessage[];
+    nextCursor: string | null;
+  }>
+> {
   try {
-    const messages = await chatChannelService.listMessages(channelId);
-    return { ok: true, data: messages };
+    const page = await chatChannelService.listMessages(channelId, {
+      cursor: options?.cursor,
+    });
+    return { ok: true, data: page };
   } catch (error) {
     return {
       ok: false,

--- a/apps/web/src/app/(app)/channels/components/channels-client.tsx
+++ b/apps/web/src/app/(app)/channels/components/channels-client.tsx
@@ -44,6 +44,7 @@ import {
   toggleMessageReactionAction,
   updateChannelAction,
 } from "@/app/channels/actions";
+import { mergeChannelMessages } from "@/app/channels/utils/merge-channel-messages";
 import DaySeparator from "@/app/chat/components/day-separator";
 import { slugify } from "@/app/chat/utils/bucket-slug";
 import { formatDaySeparator } from "@/app/chat/utils/date-utils";
@@ -115,6 +116,8 @@ interface ChannelsClientProps {
   isNewDirectMessage: boolean;
   messageLoadFailed: boolean;
   messages: ChatChannelMessage[];
+  /** Cursor for the next older page; null when the initial page is complete. */
+  messagesNextCursor: string | null;
 }
 
 const CHANNEL_COMPOSER_EMOJIS = [
@@ -134,6 +137,8 @@ const CHANNEL_COMPOSER_EMOJIS = [
 const COWORKER_RESPONSE_POLL_MS = 2500;
 /** ~2.5 minutes of polling before we stop waiting for a coworker reply. */
 const COWORKER_RESPONSE_POLL_MAX_ATTEMPTS = 60;
+/** Match sidebar channel-list cadence for peer traffic while a channel is open. */
+const CHANNEL_LIVE_POLL_MS = 15_000;
 
 interface ChannelComposerAttachment {
   url: string;
@@ -2080,6 +2085,7 @@ export function ChannelsClient({
   isNewDirectMessage,
   messageLoadFailed,
   messages,
+  messagesNextCursor,
 }: ChannelsClientProps) {
   const t = useTranslations("App.Channels");
   const tBreadcrumb = useTranslations("Components.Breadcrumb");
@@ -2093,6 +2099,9 @@ export function ChannelsClient({
   );
   const [messagesState, setMessagesState] =
     useState<ChatChannelMessage[]>(messages);
+  const [olderNextCursor, setOlderNextCursor] = useState<string | null>(
+    messagesNextCursor,
+  );
   const [threadParentMessage, setThreadParentMessage] =
     useState<ChatChannelMessage | null>(null);
   const [threadMessages, setThreadMessages] = useState<ChatChannelMessage[]>(
@@ -2112,6 +2121,7 @@ export function ChannelsClient({
   const [isSendingThreadReply, startSendingThreadReplyTransition] =
     useTransition();
   const [_isReacting, startReactionTransition] = useTransition();
+  const [isLoadingOlder, startLoadingOlderTransition] = useTransition();
   const pendingReactionsRef = useRef<Set<string>>(new Set());
   const selectedChannel = isNewDirectMessage
     ? null
@@ -2195,12 +2205,13 @@ export function ChannelsClient({
 
   useEffect(() => {
     setMessagesState(messages);
+    setOlderNextCursor(messagesNextCursor);
     setThreadParentMessage((current) =>
       current
         ? (messages.find((message) => message.id === current.id) ?? current)
         : current,
     );
-  }, [messages]);
+  }, [messages, messagesNextCursor]);
 
   useEffect(() => {
     setComposerValue("");
@@ -2213,9 +2224,12 @@ export function ChannelsClient({
     setThreadMentionedCoworkerIds([]);
   }, [selectedChannelId, isNewDirectMessage, isCreateChannelRequested]);
 
+  // Scroll on channel switch or when the newest message changes — not when
+  // an older page is prepended (length grows, last id stays the same).
+  const latestMessageId = messagesState.at(-1)?.id ?? null;
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ block: "end" });
-  }, [messagesState.length, selectedChannelId]);
+  }, [latestMessageId, selectedChannelId]);
 
   const latestVisibleMessageId = messagesState.at(-1)?.id ?? "empty";
   const selectedChannelReadId = selectedChannel?.id ?? null;
@@ -2287,11 +2301,14 @@ export function ChannelsClient({
         return;
       }
       if (result.ok) {
-        setMessagesState(result.data);
+        setMessagesState((current) =>
+          mergeChannelMessages(current, result.data.messages),
+        );
         setThreadParentMessage((current) =>
           current
-            ? (result.data.find((message) => message.id === current.id) ??
-              current)
+            ? (result.data.messages.find(
+                (message) => message.id === current.id,
+              ) ?? current)
             : current,
         );
       }
@@ -2315,6 +2332,53 @@ export function ChannelsClient({
       }
     };
   }, [selectedChannel?.id, hasPendingChannelCoworkerMention]);
+
+  // Peer traffic while the channel stays open: light poll + focus/visibility
+  // refetch. Merges into local state so previously loaded older pages survive.
+  useEffect(() => {
+    if (!selectedChannel) {
+      return;
+    }
+
+    const channelId = selectedChannel.id;
+    let cancelled = false;
+
+    const refreshLatest = async () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      const result = await listChannelMessagesAction(channelId);
+      if (cancelled || !result.ok) {
+        return;
+      }
+      setMessagesState((current) =>
+        mergeChannelMessages(current, result.data.messages),
+      );
+      setThreadParentMessage((current) =>
+        current
+          ? (result.data.messages.find(
+              (message) => message.id === current.id,
+            ) ?? current)
+          : current,
+      );
+    };
+
+    const intervalId = window.setInterval(refreshLatest, CHANNEL_LIVE_POLL_MS);
+    window.addEventListener("focus", refreshLatest);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void refreshLatest();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshLatest);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [selectedChannel?.id]);
 
   useEffect(() => {
     if (
@@ -2356,10 +2420,12 @@ export function ChannelsClient({
         setThreadMessages(threadResult.data);
       }
       if (channelResult.ok) {
-        setMessagesState(channelResult.data);
+        setMessagesState((current) =>
+          mergeChannelMessages(current, channelResult.data.messages),
+        );
         setThreadParentMessage((current) =>
           current
-            ? (channelResult.data.find(
+            ? (channelResult.data.messages.find(
                 (message) => message.id === current.id,
               ) ?? current)
             : current,
@@ -2448,6 +2514,26 @@ export function ChannelsClient({
         return;
       }
       setThreadMessages(result.data);
+    });
+  }
+
+  function handleLoadOlderMessages() {
+    if (!selectedChannel || !olderNextCursor || isLoadingOlder) {
+      return;
+    }
+
+    const channelId = selectedChannel.id;
+    const cursor = olderNextCursor;
+    startLoadingOlderTransition(async () => {
+      const result = await listChannelMessagesAction(channelId, { cursor });
+      if (!result.ok) {
+        toast.error(result.message);
+        return;
+      }
+      setMessagesState((current) =>
+        mergeChannelMessages(current, result.data.messages),
+      );
+      setOlderNextCursor(result.data.nextCursor);
     });
   }
 
@@ -2597,6 +2683,26 @@ export function ChannelsClient({
                       <p className="text-muted-foreground mt-1 text-sm">
                         {t("Empty.noMessagesDescription")}
                       </p>
+                    </div>
+                  ) : null}
+                  {olderNextCursor ? (
+                    <div className="mb-4 flex justify-center">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={isLoadingOlder}
+                        onClick={handleLoadOlderMessages}
+                      >
+                        {isLoadingOlder ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            {t("loadingOlder")}
+                          </>
+                        ) : (
+                          t("loadOlder")
+                        )}
+                      </Button>
                     </div>
                   ) : null}
                   {messagesState.map((message, index) => {

--- a/apps/web/src/app/(app)/channels/page.tsx
+++ b/apps/web/src/app/(app)/channels/page.tsx
@@ -27,16 +27,20 @@ function firstSearchValue(value: string | string[] | undefined): string | null {
   return value ?? null;
 }
 
-async function loadChannelMessages(
-  channelId: string | null,
-): Promise<{ messages: ChatChannelMessage[]; failed: boolean }> {
+async function loadChannelMessages(channelId: string | null): Promise<{
+  messages: ChatChannelMessage[];
+  nextCursor: string | null;
+  failed: boolean;
+}> {
   if (!channelId) {
-    return { messages: [], failed: false };
+    return { messages: [], nextCursor: null, failed: false };
   }
 
   try {
+    const page = await chatChannelService.listMessages(channelId);
     return {
-      messages: await chatChannelService.listMessages(channelId),
+      messages: page.messages,
+      nextCursor: page.nextCursor,
       failed: false,
     };
   } catch (error) {
@@ -46,7 +50,7 @@ async function loadChannelMessages(
         status: error.status,
         kind: error.kind,
       });
-      return { messages: [], failed: true };
+      return { messages: [], nextCursor: null, failed: true };
     }
 
     throw error;
@@ -143,12 +147,15 @@ export default async function ChannelsPage({
       });
     });
   }
-  const { messages, failed: messageLoadFailed } =
-    selectedChannelId &&
-    requestedChannelId === selectedChannelId &&
-    requestedMessagesPromise
-      ? await requestedMessagesPromise
-      : await loadChannelMessages(selectedChannelId);
+  const {
+    messages,
+    nextCursor: messagesNextCursor,
+    failed: messageLoadFailed,
+  } = selectedChannelId &&
+  requestedChannelId === selectedChannelId &&
+  requestedMessagesPromise
+    ? await requestedMessagesPromise
+    : await loadChannelMessages(selectedChannelId);
 
   return (
     <ChannelsClient
@@ -162,6 +169,7 @@ export default async function ChannelsPage({
       isNewDirectMessage={isNewDirectMessage}
       messageLoadFailed={messageLoadFailed}
       messages={messages}
+      messagesNextCursor={messagesNextCursor}
     />
   );
 }

--- a/apps/web/src/app/(app)/channels/utils/__tests__/merge-channel-messages.test.ts
+++ b/apps/web/src/app/(app)/channels/utils/__tests__/merge-channel-messages.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatChannelMessage } from "@/lib/clients/generated/core";
+
+import { mergeChannelMessages } from "../merge-channel-messages";
+
+function message(
+  id: string,
+  createdAt: string,
+  content = id,
+): ChatChannelMessage {
+  return {
+    id,
+    channelId: "channel-1",
+    parentMessageId: null,
+    content,
+    createdAt: new Date(createdAt),
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+  };
+}
+
+describe("mergeChannelMessages", () => {
+  it("keeps older loaded history when refreshing the latest page", () => {
+    const older = message("m1", "2026-07-01T10:00:00.000Z");
+    const mid = message("m2", "2026-07-01T11:00:00.000Z");
+    const latest = message("m3", "2026-07-01T12:00:00.000Z");
+    const refreshedLatest = message(
+      "m3",
+      "2026-07-01T12:00:00.000Z",
+      "updated",
+    );
+    const newer = message("m4", "2026-07-01T13:00:00.000Z");
+
+    const merged = mergeChannelMessages(
+      [older, mid, latest],
+      [refreshedLatest, newer],
+    );
+
+    expect(merged.map((row) => row.id)).toEqual(["m1", "m2", "m3", "m4"]);
+    expect(merged[2]?.content).toBe("updated");
+  });
+
+  it("prepends an older page without duplicating ids", () => {
+    const older = message("m1", "2026-07-01T10:00:00.000Z");
+    const mid = message("m2", "2026-07-01T11:00:00.000Z");
+    const latest = message("m3", "2026-07-01T12:00:00.000Z");
+
+    const merged = mergeChannelMessages([mid, latest], [older, mid]);
+
+    expect(merged.map((row) => row.id)).toEqual(["m1", "m2", "m3"]);
+  });
+});

--- a/apps/web/src/app/(app)/channels/utils/merge-channel-messages.ts
+++ b/apps/web/src/app/(app)/channels/utils/merge-channel-messages.ts
@@ -1,0 +1,27 @@
+import type { ChatChannelMessage } from "@/lib/clients/generated/core";
+
+/**
+ * Merge channel message pages by id. Incoming rows win (fresh reactions /
+ * mention status). Result is sorted oldest → newest for reading order.
+ */
+export function mergeChannelMessages(
+  existing: readonly ChatChannelMessage[],
+  incoming: readonly ChatChannelMessage[],
+): ChatChannelMessage[] {
+  const byId = new Map<string, ChatChannelMessage>();
+  for (const message of existing) {
+    byId.set(message.id, message);
+  }
+  for (const message of incoming) {
+    byId.set(message.id, message);
+  }
+
+  return Array.from(byId.values()).toSorted((left, right) => {
+    const timeDelta =
+      new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+    if (timeDelta !== 0) {
+      return timeDelta;
+    }
+    return left.id.localeCompare(right.id);
+  });
+}

--- a/apps/web/src/lib/services/chat-channel.service.ts
+++ b/apps/web/src/lib/services/chat-channel.service.ts
@@ -13,6 +13,11 @@ import type {
 
 const CHANNEL_MESSAGE_LIMIT = 100;
 
+export interface ChatChannelMessagesPage {
+  messages: ChatChannelMessage[];
+  nextCursor: string | null;
+}
+
 export const chatChannelService = (() => {
   const listChannels = cache(async function listChannels(
     organizationId: string,
@@ -64,11 +69,16 @@ export const chatChannelService = (() => {
 
   const listMessages = cache(async function listMessages(
     channelId: string,
-  ): Promise<ChatChannelMessage[]> {
+    options?: { cursor?: string; limit?: number },
+  ): Promise<ChatChannelMessagesPage> {
     const response = await coreClient.getChatChannelMessages(channelId, {
-      limit: CHANNEL_MESSAGE_LIMIT,
+      limit: options?.limit ?? CHANNEL_MESSAGE_LIMIT,
+      cursor: options?.cursor,
     });
-    return response.data;
+    return {
+      messages: response.data,
+      nextCursor: response.meta?.pagination?.nextCursor ?? null,
+    };
   });
 
   const listThreadMessages = cache(async function listThreadMessages(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes review finding **#3** for PR #3422 before merge:

1. **Live peer traffic** — while a channel is open and the tab is visible, refetch the latest message page on focus / visibility and every 15s (same cadence as the sidebar list). Merges into local state so previously loaded older pages are kept.
2. **Load older** — wire Core `nextCursor` through `chatChannelService` + `listChannelMessagesAction`, pass the initial cursor from the page, and add a “Load older messages” control at the top of the transcript.

Also updates coworker-mention polls to **merge** instead of replace, so they no longer drop older history.

## Verification
- `pnpm --filter web test 'src/app/(app)/channels/utils/__tests__/merge-channel-messages.test.ts'`
- `biome check` on touched TS files
- Web typecheck: no errors in changed channel files (pre-existing `thinking-orbs` failures remain on the branch)

Refs #3422

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70cf98ac-af02-460f-a9fd-e1eb6626a525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70cf98ac-af02-460f-a9fd-e1eb6626a525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

