### PR TITLE
fix(chat): lock channel message before reaction toggle

### DIFF
--- a/apps/core/src/routes/v1/chat-channels/[id]/messages/[messageId]/reactions/post.test.ts
+++ b/apps/core/src/routes/v1/chat-channels/[id]/messages/[messageId]/reactions/post.test.ts
@@ -1,0 +1,205 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import { defaultValidationHook } from "@/lib/hono";
+import type { AuthVariables } from "@/middleware/auth";
+
+import mountToggleReaction from "./post";
+
+const {
+  channelFindFirstMock,
+  organizationFindUniqueMock,
+  memberFindUniqueMock,
+  queryRawMock,
+  deleteManyMock,
+  createManyMock,
+  messageFindUniqueOrThrowMock,
+  prismaTransactionMock,
+} = vi.hoisted(() => ({
+  channelFindFirstMock: vi.fn(),
+  organizationFindUniqueMock: vi.fn(),
+  memberFindUniqueMock: vi.fn(),
+  queryRawMock: vi.fn(),
+  deleteManyMock: vi.fn(),
+  createManyMock: vi.fn(),
+  messageFindUniqueOrThrowMock: vi.fn(),
+  prismaTransactionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    $transaction: prismaTransactionMock,
+  },
+}));
+
+const CHANNEL_ID = "550e8400-e29b-41d4-a716-446655440000";
+const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
+const USER_ID = "user_123";
+
+const tx = {
+  $queryRaw: queryRawMock,
+  chatChannel: {
+    findFirst: channelFindFirstMock,
+  },
+  organization: {
+    findUnique: organizationFindUniqueMock,
+  },
+  member: {
+    findUnique: memberFindUniqueMock,
+  },
+  chatChannelReaction: {
+    deleteMany: deleteManyMock,
+    createMany: createManyMock,
+  },
+  chatChannelMessage: {
+    findUniqueOrThrow: messageFindUniqueOrThrowMock,
+  },
+};
+
+function createApp(authContext: AuthVariables["authContext"]) {
+  const app = new OpenAPIHono<{ Variables: AuthVariables }>({
+    defaultHook: defaultValidationHook,
+  });
+
+  app.use("*", async (c, next) => {
+    c.set("isAuthenticated", true);
+    c.set("authContext", authContext);
+    return await next();
+  });
+
+  mountToggleReaction(app as unknown as OpenAPIHonoWithAuth);
+  return app;
+}
+
+const userAuthContext: AuthVariables["authContext"] = {
+  actor: "user",
+  userId: USER_ID,
+  organizationId: "org_1",
+  role: "user",
+};
+
+const mappedMessage = {
+  id: MESSAGE_ID,
+  channelId: CHANNEL_ID,
+  parentMessageId: null,
+  content: "hello",
+  createdAt: new Date("2026-07-01T12:00:00.000Z"),
+  senderUserId: USER_ID,
+  senderCoworkerId: null,
+  metadata: null,
+  senderUser: {
+    id: USER_ID,
+    name: "Ada",
+    email: "ada@example.com",
+    image: null,
+  },
+  senderCoworker: null,
+  mentionsAsSource: [],
+  reactions: [],
+  _count: { replies: 0 },
+  replies: [],
+};
+
+describe("POST /chat-channels/:id/messages/:messageId/reactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaTransactionMock.mockImplementation(
+      async (fn: (client: typeof tx) => Promise<unknown>) => fn(tx),
+    );
+    channelFindFirstMock.mockResolvedValue({
+      id: CHANNEL_ID,
+      organizationId: "org_1",
+      kind: "channel",
+      archivedAt: null,
+      userMembers: [{ userId: USER_ID }],
+      coworkerMembers: [],
+    });
+    organizationFindUniqueMock.mockResolvedValue({ id: "org_1" });
+    memberFindUniqueMock.mockResolvedValue({
+      id: "member_1",
+      userId: USER_ID,
+      organizationId: "org_1",
+      role: "member",
+    });
+    queryRawMock.mockResolvedValue([{ id: MESSAGE_ID }]);
+    deleteManyMock.mockResolvedValue({ count: 0 });
+    createManyMock.mockResolvedValue({ count: 1 });
+    messageFindUniqueOrThrowMock.mockResolvedValue(mappedMessage);
+  });
+
+  it("locks the message with FOR UPDATE before toggling", async () => {
+    const callOrder: string[] = [];
+    queryRawMock.mockImplementation(async () => {
+      callOrder.push("lock");
+      return [{ id: MESSAGE_ID }];
+    });
+    deleteManyMock.mockImplementation(async () => {
+      callOrder.push("delete");
+      return { count: 0 };
+    });
+    createManyMock.mockImplementation(async () => {
+      callOrder.push("create");
+      return { count: 1 };
+    });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(
+      `/${CHANNEL_ID}/messages/${MESSAGE_ID}/reactions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emoji: "👍" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(callOrder).toEqual(["lock", "delete", "create"]);
+
+    const sqlParts = queryRawMock.mock.calls[0]?.[0] as TemplateStringsArray;
+    const sql = sqlParts.join(" ");
+    expect(sql).toContain("FOR UPDATE");
+    expect(sql).toContain("chat_channel_message");
+  });
+
+  it("removes an existing reaction without inserting", async () => {
+    deleteManyMock.mockResolvedValue({ count: 1 });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(
+      `/${CHANNEL_ID}/messages/${MESSAGE_ID}/reactions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emoji: "🎉" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: {
+        messageId: MESSAGE_ID,
+        userId: USER_ID,
+        emoji: "🎉",
+      },
+    });
+    expect(createManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the locked message is missing", async () => {
+    queryRawMock.mockResolvedValue([]);
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(
+      `/${CHANNEL_ID}/messages/${MESSAGE_ID}/reactions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emoji: "👍" }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/routes/v1/chat-channels/[id]/messages/[messageId]/reactions/post.ts
+++ b/apps/core/src/routes/v1/chat-channels/[id]/messages/[messageId]/reactions/post.ts
@@ -77,23 +77,23 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     const message = await prisma.$transaction(async (tx) => {
       await requireChatChannelUserMembership(id, userContext.userId, tx);
-      const existingMessage = await tx.chatChannelMessage.findFirst({
-        where: {
-          id: messageId,
-          channelId: id,
-        },
-        select: { id: true },
-      });
-      if (!existingMessage) {
+
+      // Lock the message row so concurrent toggles of the same reaction cannot
+      // interleave delete-then-create and flip the row back on. Without this,
+      // two "remove" intents both delete (counts 1 and 0) and the loser
+      // re-inserts. Matches the FOR UPDATE pattern used on conversation writes.
+      const lockedMessages = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "chat_channel_message"
+        WHERE "id" = ${messageId}::uuid AND "channelId" = ${id}::uuid
+        FOR UPDATE
+      `;
+      if (lockedMessages.length === 0) {
         throw notFound("Message not found");
       }
 
-      // Toggle without a read-then-write: concurrent taps on the same emoji
-      // would otherwise race on the (messageId, userId, emoji) unique index.
-      // `deleteMany` reports a count instead of throwing P2025 when the
-      // reaction is already gone, and `skipDuplicates` turns the insert into
-      // ON CONFLICT DO NOTHING so a lost create race cannot abort the
-      // surrounding transaction with P2002.
+      // Under the message lock, delete-then-create is a true toggle: either we
+      // removed an existing row, or we insert one. `skipDuplicates` still
+      // guards the unique index if a concurrent path somehow races past the lock.
       const removed = await tx.chatChannelReaction.deleteMany({
         where: {
           messageId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes Important finding #5 from the PR #3422 review: concurrent reaction toggles could flip state (two removes both delete then one re-inserts).

## Change
- `POST …/reactions` now `SELECT … FOR UPDATE` on the channel message row inside the existing transaction before delete-then-create toggle (same pattern as conversation chat writes).
- Missing locked message → 404; no toggle work runs.
- Unit tests cover lock order, remove-without-insert, and missing message.

## Verification
- `pnpm --filter core exec vitest run 'src/routes/v1/chat-channels/[id]/messages/[messageId]/reactions/post.test.ts'`

Stacked on `codex/chat-channels` after #3436 / #3437. With this, all Important review findings for #3422 are addressed; only minor/deferred items remain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70cf98ac-af02-460f-a9fd-e1eb6626a525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70cf98ac-af02-460f-a9fd-e1eb6626a525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

