### PR TITLE
feat(chat): show coworker name on mention status badges

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "Rufe {name}",
+        "sent": "{name} denkt nach",
+        "responded": "{name} hat geantwortet",
+        "failed": "{name} fehlgeschlagen",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4676,10 +4676,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "Calling {name}",
+        "sent": "{name} thinking",
+        "responded": "{name} replied",
+        "failed": "{name} failed",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "Llamando a {name}",
+        "sent": "{name} pensando",
+        "responded": "{name} respondió",
+        "failed": "{name} falló",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "Appel de {name}",
+        "sent": "{name} réfléchit",
+        "responded": "{name} a répondu",
+        "failed": "{name} a échoué",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "Chiamata a {name}",
+        "sent": "{name} sta pensando",
+        "responded": "{name} ha risposto",
+        "failed": "{name} non è riuscito",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "{name} を呼び出しています",
+        "sent": "{name} が考えています",
+        "responded": "{name} が返信しました",
+        "failed": "{name} が失敗しました",
+        "nameFallback": "コワーカー"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "Chamando {name}",
+        "sent": "{name} pensando",
+        "responded": "{name} respondeu",
+        "failed": "{name} falhou",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "A chamar {name}",
+        "sent": "{name} a pensar",
+        "responded": "{name} respondeu",
+        "failed": "{name} falhou",
+        "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4557,10 +4557,11 @@
         "save": "Save changes"
       },
       "MentionStatus": {
-        "pending": "Calling coworker",
-        "sent": "Coworker thinking",
-        "responded": "Coworker replied",
-        "failed": "Coworker failed"
+        "pending": "正在呼叫 {name}",
+        "sent": "{name} 正在思考",
+        "responded": "{name} 已回复",
+        "failed": "{name} 失败",
+        "nameFallback": "同事"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",
       "directComposerPlaceholder": "Message {member}",

--- a/apps/web/src/app/(app)/chat/components/channel-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/channel-message-row.tsx
@@ -202,11 +202,13 @@ function MessageActions({
 
 function MessageMetaFooter({
   message,
+  coworkersById,
   onToggleReaction,
   onOpenThread,
   showThreadButton,
 }: {
   message: ChatRoomMessage;
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
   onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
   onOpenThread?: (message: ChatRoomMessage) => void;
   showThreadButton: boolean;
@@ -246,19 +248,26 @@ function MessageMetaFooter({
       ) : null}
       {message.mentions.length > 0 ? (
         <div className="flex flex-wrap gap-1.5 pt-1.5">
-          {message.mentions.map((mention) => (
-            <Badge
-              key={mention.id}
-              variant={mention.status === "failed" ? "destructive" : "outline"}
-            >
-              {mention.status === "responded" ? (
-                <CheckCircle2 className="size-3" />
-              ) : mention.status === "failed" ? null : (
-                <Loader2 className="size-3 animate-spin" />
-              )}
-              {t(`MentionStatus.${mention.status}`)}
-            </Badge>
-          ))}
+          {message.mentions.map((mention) => {
+            const name =
+              coworkersById.get(mention.coworkerId)?.name ??
+              t("MentionStatus.nameFallback");
+            return (
+              <Badge
+                key={mention.id}
+                variant={
+                  mention.status === "failed" ? "destructive" : "outline"
+                }
+              >
+                {mention.status === "responded" ? (
+                  <CheckCircle2 className="size-3" />
+                ) : mention.status === "failed" ? null : (
+                  <Loader2 className="size-3 animate-spin" />
+                )}
+                {t(`MentionStatus.${mention.status}`, { name })}
+              </Badge>
+            );
+          })}
         </div>
       ) : null}
     </>
@@ -326,6 +335,7 @@ export function ChatMessageRow({
         </div>
         <MessageMetaFooter
           message={message}
+          coworkersById={coworkersById}
           onToggleReaction={onToggleReaction}
           onOpenThread={onOpenThread}
           showThreadButton={showThreadButton}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Channel mention status badges now use the coworker name instead of generic "Coworker" copy (e.g. `Alex thinking`).

Multi-mention stays one badge per coworker; each badge resolves its name from the room `coworkersById` map and updates independently. Missing name falls back to localized `Coworker`.

## Changes

- Wire `coworkersById` into `MessageMetaFooter` in `channel-message-row.tsx`
- Update `App.Channels.MentionStatus` keys to `{name}` templates + `nameFallback` in all locale catalogs

## Verification

- `pnpm check` + `pnpm typecheck` (pre-commit)
- Locale key parity for `MentionStatus` across en/de/es/fr/it/pt/pt-BR/ja/zh-Hans

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d089a372-bb1c-4bff-b01d-7952b5f6d2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d089a372-bb1c-4bff-b01d-7952b5f6d2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

