### PR TITLE
feat(tasks): let org members cancel peer tasks

### DIFF
--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -26,6 +26,7 @@ import {
   requireMutableTaskOwnership,
   requireTaskArchiveAccess,
   requireTaskAssignableCoworker,
+  requireTaskCancelAccess,
   requireTaskCollaboration,
   requireTaskCommentAccess,
   requireTaskOwnership,
@@ -819,6 +820,121 @@ describe("requireTaskCommentAccess", () => {
 
     expect(requestWorkspaceGrantMock).not.toHaveBeenCalled();
     expect(getWorkspaceGrantMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireTaskCancelAccess", () => {
+  it("allows the task owner to cancel", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      id: "tsk_123",
+      ownerId: "user_123",
+      pendingVendorGrantId: null,
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: userAuthContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await requireTaskCancelAccess(vars, "tsk_123", tx);
+
+    expect(tx.task.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "tsk_123",
+        archivedAt: null,
+        workspaceId,
+      },
+    });
+  });
+
+  it("allows an org workspace member who does not own the task to cancel", async () => {
+    const tx = createTransactionClient();
+    const memberAuthContext: UserAuthenticationContext = {
+      actor: "user",
+      userId: "user_member",
+      organizationId: "org_123",
+      role: "user",
+    };
+
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      id: "tsk_123",
+      ownerId: "user_owner",
+      pendingVendorGrantId: null,
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: memberAuthContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await requireTaskCancelAccess(vars, "tsk_123", tx);
+  });
+
+  it("rejects a personal-workspace non-owner", async () => {
+    const tx = createTransactionClient();
+    const personalWorkspace: WorkspaceContext = {
+      workspaceId,
+      userId: "user_member",
+      organizationId: null,
+    };
+    const memberAuthContext: UserAuthenticationContext = {
+      actor: "user",
+      userId: "user_member",
+      organizationId: null,
+      role: "user",
+    };
+
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      id: "tsk_123",
+      ownerId: "user_owner",
+      pendingVendorGrantId: null,
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: memberAuthContext,
+      workspaceContext: personalWorkspace,
+    };
+
+    await expect(requireTaskCancelAccess(vars, "tsk_123", tx)).rejects.toThrow(
+      "Task not found",
+    );
+  });
+
+  it("uses coworker collaboration for coworker actors", async () => {
+    const tx = createTransactionClient();
+    const coworkerContext = createCoworkerContext("cow_123");
+
+    vi.mocked(tx.coworker.findFirst).mockResolvedValueOnce({
+      id: "cow_123",
+      slug: "ops-agent",
+      baseURL: null,
+    } as never);
+    vi.mocked(tx.task.findUnique).mockResolvedValueOnce({
+      id: "tsk_123",
+      assigneeId: "cow_123",
+      status: TaskStatus.READY,
+      pendingVendorGrantId: null,
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: coworkerContext,
+      workspaceContext: null,
+    };
+
+    await requireTaskCancelAccess(vars, "tsk_123", tx);
+
+    expect(tx.task.findUnique).toHaveBeenCalledWith({
+      where: {
+        id: "tsk_123",
+        status: { not: TaskStatus.DRAFT },
+        archivedAt: null,
+      },
+    });
   });
 });
 

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -936,6 +936,32 @@ describe("requireTaskCancelAccess", () => {
       },
     });
   });
+
+  it("rejects cancel while the task is parked", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
+      id: "tsk_123",
+      ownerId: "user_123",
+      status: TaskStatus.GRANT_PENDING,
+      pendingVendorGrantId: "grant_1",
+    } as never);
+
+    const vars: EnvVariables["Variables"] = {
+      isAuthenticated: true,
+      authContext: userAuthContext,
+      workspaceContext: jobReadWorkspaceContext,
+    };
+
+    await expect(
+      requireTaskCancelAccess(vars, "tsk_123", tx),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(HTTPException);
+      expect((error as HTTPException).cause).toMatchObject({
+        kind: "task_parked",
+      });
+      return true;
+    });
+  });
 });
 
 describe("requireTaskReadForRouteVars vendor grants", () => {

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -483,6 +483,41 @@ export async function requireTaskCommentAccess(
   return task;
 }
 
+/**
+ * Cancel access: task owner always, or any org-workspace member for a task in
+ * that workspace. Personal-workspace non-owners are denied. Coworker actors
+ * use the same rules as {@link requireTaskCollaboration}.
+ */
+export async function requireTaskCancelAccess(
+  vars: EnvVariables["Variables"],
+  taskId: string,
+  tx: Prisma.TransactionClient = prisma,
+): Promise<Task> {
+  const { authContext, workspaceContext } = vars;
+
+  if (
+    isUserAuthContext(authContext) ||
+    isOrchestratorAuthContext(authContext)
+  ) {
+    const userContext = requireUserContext(authContext);
+    const workspace = requireWorkspaceContext(workspaceContext);
+    const task = await requireTaskReadForWorkspace(workspace, taskId, tx);
+    requireTaskNotParked(task);
+
+    if (task.ownerId === userContext.userId) {
+      return task;
+    }
+
+    if (workspace.organizationId !== null) {
+      return task;
+    }
+
+    throw notFound("Task not found");
+  }
+
+  return await requireTaskCollaboration(authContext, taskId, tx);
+}
+
 // -----------------------------------------------------------------------------
 // Workspace-scoped reads (task/job in the active workspace)
 // -----------------------------------------------------------------------------

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -23,6 +23,7 @@ const {
   publishTaskEventDataMock,
   requireTaskCommentAccessMock,
   requireTaskCollaborationMock,
+  requireTaskCancelAccessMock,
   waitUntilCapturedPromises,
 } = vi.hoisted(() => ({
   calculateCentsFromMasumiAmountStringsMock: vi.fn(),
@@ -45,12 +46,14 @@ const {
   publishTaskEventDataMock: vi.fn(),
   requireTaskCommentAccessMock: vi.fn(),
   requireTaskCollaborationMock: vi.fn(),
+  requireTaskCancelAccessMock: vi.fn(),
   waitUntilCapturedPromises: [] as Promise<unknown>[],
 }));
 
 vi.mock("@/helpers/access-control", () => ({
   requireTaskCollaboration: requireTaskCollaborationMock,
   requireTaskCommentAccess: requireTaskCommentAccessMock,
+  requireTaskCancelAccess: requireTaskCancelAccessMock,
 }));
 
 vi.mock("@/helpers/notifications", () => ({
@@ -298,6 +301,7 @@ describe("POST /{id}/events", () => {
     });
     requireTaskCollaborationMock.mockResolvedValue(createTask());
     requireTaskCommentAccessMock.mockResolvedValue(createTask());
+    requireTaskCancelAccessMock.mockResolvedValue(createTask());
   });
 
   it("rejects coworkers creating OUT_OF_CREDITS events manually", async () => {
@@ -2483,7 +2487,7 @@ describe("POST /{id}/events", () => {
   });
 
   it("lets a delegated coworker cancel a task without charging", async () => {
-    requireTaskCollaborationMock.mockResolvedValue(
+    requireTaskCancelAccessMock.mockResolvedValue(
       createTask({ status: TaskStatus.READY, assigneeId: COWORKER_ID }),
     );
 
@@ -2523,6 +2527,8 @@ describe("POST /{id}/events", () => {
     });
 
     expect(response.status).toBe(201);
+    expect(requireTaskCancelAccessMock).toHaveBeenCalled();
+    expect(requireTaskCollaborationMock).not.toHaveBeenCalled();
     expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
     expect(tx.taskEvent.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2533,6 +2539,89 @@ describe("POST /{id}/events", () => {
         }),
       }),
     );
+  });
+
+  it("lets an org workspace member cancel another member's task", async () => {
+    requireTaskCancelAccessMock.mockResolvedValue(
+      createTask({
+        status: TaskStatus.RUNNING,
+        ownerId: "user_owner",
+        assigneeId: COWORKER_ID,
+      }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn().mockResolvedValue(
+          createTaskEvent({
+            status: TaskStatus.CANCELED,
+            userId: "user_member",
+            coworkerId: null,
+          }),
+        ),
+      },
+      task: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "user",
+      userId: "user_member",
+      organizationId: "org_123",
+      role: "user",
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(requireTaskCancelAccessMock).toHaveBeenCalled();
+    expect(requireTaskCollaborationMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-cancel status writes on collaboration for org peers", async () => {
+    requireTaskCollaborationMock.mockRejectedValue(
+      new HTTPException(404, { message: "Task not found" }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn(),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "user",
+      userId: "user_member",
+      organizationId: "org_123",
+      role: "user",
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.READY,
+        comment: "please reopen",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(requireTaskCollaborationMock).toHaveBeenCalled();
+    expect(requireTaskCancelAccessMock).not.toHaveBeenCalled();
   });
 
   it("rejects credits from a user session canceling a task", async () => {
@@ -2568,6 +2657,8 @@ describe("POST /{id}/events", () => {
     });
 
     expect(response.status).toBe(422);
+    expect(requireTaskCollaborationMock).toHaveBeenCalled();
+    expect(requireTaskCancelAccessMock).not.toHaveBeenCalled();
     expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
     expect(tx.taskEvent.create).not.toHaveBeenCalled();
     expect(tx.task.updateMany).not.toHaveBeenCalled();

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -2585,6 +2585,58 @@ describe("POST /{id}/events", () => {
     expect(response.status).toBe(201);
     expect(requireTaskCancelAccessMock).toHaveBeenCalled();
     expect(requireTaskCollaborationMock).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: TaskStatus.CANCELED,
+          userId: "user_member",
+          coworkerId: null,
+        }),
+      }),
+    );
+    expect(tx.task.updateMany).toHaveBeenCalled();
+  });
+
+  it("keeps cancel with credits on collaboration for org peers", async () => {
+    requireTaskCollaborationMock.mockResolvedValue(
+      createTask({
+        status: TaskStatus.RUNNING,
+        ownerId: "user_owner",
+        assigneeId: null,
+      }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn(),
+      },
+      task: {
+        updateMany: vi.fn(),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "user",
+      userId: "user_member",
+      organizationId: "org_123",
+      role: "user",
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+        credits: 5,
+      }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(requireTaskCollaborationMock).toHaveBeenCalled();
+    expect(requireTaskCancelAccessMock).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
   });
 
   it("keeps non-cancel status writes on collaboration for org peers", async () => {

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -14,6 +14,7 @@ import { paymentClient } from "@/clients/masumi-payment.client";
 import { LIMITS } from "@/config/constants";
 import { getEnv } from "@/config/env";
 import {
+  requireTaskCancelAccess,
   requireTaskCollaboration,
   requireTaskCommentAccess,
 } from "@/helpers/access-control";
@@ -462,9 +463,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           authenticationUrl != null ||
           masumiPayment != null;
 
-        const task = hasNonCommentWrite
-          ? await requireTaskCollaboration(authContext, taskId, tx)
-          : await requireTaskCommentAccess(c.var, taskId, tx);
+        const isCancelOnlyWrite =
+          status === TaskStatus.CANCELED &&
+          credits == null &&
+          authenticationUrl == null &&
+          masumiPayment == null;
+
+        const task = isCancelOnlyWrite
+          ? await requireTaskCancelAccess(c.var, taskId, tx)
+          : hasNonCommentWrite
+            ? await requireTaskCollaboration(authContext, taskId, tx)
+            : await requireTaskCommentAccess(c.var, taskId, tx);
 
         const isAgent = isCoworkerAgentContext(authContext);
 

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -714,6 +714,43 @@ describe("TaskDetailActions", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows cancel only for org collaborators in read-only mode", async () => {
+    const user = userEvent.setup();
+    renderActions({
+      status: TaskStatus.RUNNING,
+      isReadOnly: true,
+      canCancel: true,
+      organizations: undefined,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: labels.share }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
+
+    expect(
+      screen.getByRole("menuitem", { name: labels.cancel }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: labels.reopenToReady }),
+    ).toBeNull();
+  });
+
+  it("does not show reopen for org collaborators in read-only mode", () => {
+    renderActions({
+      status: TaskStatus.CANCELED,
+      isReadOnly: true,
+      canCancel: true,
+      organizations: undefined,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: actionsMenuLabel }),
+    ).not.toBeInTheDocument();
+  });
+
   it("disables the actions trigger while a status update is pending", async () => {
     const user = userEvent.setup();
     const deferred = createDeferred<{ taskId: string }>();

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -125,6 +125,7 @@ interface TaskDetailActionsProps {
   organizations?: MemberWithOrganization[];
   personalWorkspaceLabel: string;
   isReadOnly?: boolean;
+  canCancel?: boolean;
   forceReadOnly?: boolean;
   isTaskOwner?: boolean;
   isOrgOwnerOrAdmin?: boolean;
@@ -145,6 +146,7 @@ export function TaskDetailActions({
   organizations,
   personalWorkspaceLabel,
   isReadOnly = false,
+  canCancel = false,
   forceReadOnly = false,
   isTaskOwner = false,
   isOrgOwnerOrAdmin = false,
@@ -190,11 +192,16 @@ export function TaskDetailActions({
   );
 
   const canMutateTask = !isReadOnly;
+  const availableStatusActions = getTaskStatusActions(status, labels, {
+    hasCoworker: Boolean(defaultAssigneeId),
+  });
   const statusActions = canMutateTask
-    ? getTaskStatusActions(status, labels, {
-        hasCoworker: Boolean(defaultAssigneeId),
-      })
-    : [];
+    ? availableStatusActions
+    : canCancel
+      ? availableStatusActions.filter(
+          (action) => action.target === TaskStatus.CANCELED,
+        )
+      : [];
 
   const canEdit = canMutateTask && isTaskEditableStatus(status);
   const canArchiveParked = canArchiveParkedTaskForViewer({

--- a/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
@@ -20,6 +20,7 @@ import { getCoworkerOptions } from "@/app/tasks/utils/coworker-options";
 import { buildTaskActivityActors } from "@/app/tasks/utils/task-activity-actors";
 import { resolveTaskDetailViewerPlan } from "@/app/tasks/utils/task-activity-plan";
 import {
+  canCancelTaskForViewer,
   canCommentOnTaskForViewer,
   isReadOnlyForViewer,
 } from "@/app/tasks/utils/task-read-only";
@@ -442,6 +443,13 @@ async function TaskDetailActionsSlot({
     forceReadOnly,
     taskStatus: task.status,
   });
+  const canCancelTask = canCancelTaskForViewer({
+    taskWorkspaceOrganizationId: task.workspace.organizationId ?? null,
+    taskOwnerId: task.ownerId,
+    sessionUserId: session?.user.id,
+    forceReadOnly,
+    taskStatus: task.status,
+  });
   const orgId = task.workspace.organizationId ?? null;
   const viewerMembership =
     orgId === null
@@ -468,6 +476,7 @@ async function TaskDetailActionsSlot({
       organizations={members}
       personalWorkspaceLabel={personalWorkspaceMoveLabel}
       isReadOnly={isReadOnlyWorkspaceView}
+      canCancel={canCancelTask}
       forceReadOnly={forceReadOnly}
       isTaskOwner={session?.user.id === task.ownerId}
       isOrgOwnerOrAdmin={isOrgOwnerOrAdmin}

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
@@ -3,6 +3,7 @@ import { TaskStatus } from "@/lib/clients/generated/core";
 
 import {
   canArchiveParkedTaskForViewer,
+  canCancelTaskForViewer,
   canCommentOnTaskForViewer,
   isReadOnlyForViewer,
 } from "../task-read-only";
@@ -179,6 +180,68 @@ describe("canCommentOnTaskForViewer", () => {
   it("blocks comments while vendor grant approval is pending", () => {
     expect(
       canCommentOnTaskForViewer({
+        taskWorkspaceOrganizationId: "org_1",
+        taskOwnerId: "owner_1",
+        sessionUserId: "owner_1",
+        forceReadOnly: false,
+        taskStatus: TaskStatus.GRANT_PENDING,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("canCancelTaskForViewer", () => {
+  it("allows organization workspace collaborators to cancel without ownership", () => {
+    expect(
+      canCancelTaskForViewer({
+        taskWorkspaceOrganizationId: "org_1",
+        taskOwnerId: "owner_1",
+        sessionUserId: "member_2",
+        forceReadOnly: false,
+        taskStatus: TaskStatus.RUNNING,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows the task owner to cancel", () => {
+    expect(
+      canCancelTaskForViewer({
+        taskWorkspaceOrganizationId: "org_1",
+        taskOwnerId: "owner_1",
+        sessionUserId: "owner_1",
+        forceReadOnly: false,
+        taskStatus: TaskStatus.RUNNING,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks cancel when forced read-only", () => {
+    expect(
+      canCancelTaskForViewer({
+        taskWorkspaceOrganizationId: "org_1",
+        taskOwnerId: "owner_1",
+        sessionUserId: "member_2",
+        forceReadOnly: true,
+        taskStatus: TaskStatus.RUNNING,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not allow cancel for non-owners on personal workspace tasks", () => {
+    expect(
+      canCancelTaskForViewer({
+        taskWorkspaceOrganizationId: null,
+        taskOwnerId: "owner_1",
+        sessionUserId: "someone_else",
+        forceReadOnly: false,
+        taskStatus: TaskStatus.RUNNING,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks cancel while vendor grant approval is pending", () => {
+    expect(
+      canCancelTaskForViewer({
         taskWorkspaceOrganizationId: "org_1",
         taskOwnerId: "owner_1",
         sessionUserId: "owner_1",

--- a/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
@@ -59,19 +59,19 @@ export function canArchiveParkedTaskForViewer({
   return isTaskOwner || isOrgOwnerOrAdmin;
 }
 
-type CanCommentOnTaskForViewerParams = ReadOnlyForViewerParams;
+type OrgCollaboratorViewerParams = ReadOnlyForViewerParams;
 
 /**
- * Organization workspace collaborators may comment without owning the task.
- * Mutations stay gated by {@link isReadOnlyForViewer}.
+ * Owner or authenticated org-workspace collaborator, excluding force-read-only
+ * and parked (`GRANT_PENDING`) tasks. Shared by comment and cancel gates.
  */
-export function canCommentOnTaskForViewer({
+function canOrgCollaboratorActOnTaskForViewer({
   taskWorkspaceOrganizationId,
   taskOwnerId,
   sessionUserId,
   forceReadOnly,
   taskStatus,
-}: CanCommentOnTaskForViewerParams): boolean {
+}: OrgCollaboratorViewerParams): boolean {
   if (forceReadOnly || isGrantPendingStatus(taskStatus)) {
     return false;
   }
@@ -87,30 +87,22 @@ export function canCommentOnTaskForViewer({
   );
 }
 
-type CanCancelTaskForViewerParams = ReadOnlyForViewerParams;
+/**
+ * Organization workspace collaborators may comment without owning the task.
+ * Mutations stay gated by {@link isReadOnlyForViewer}.
+ */
+export function canCommentOnTaskForViewer(
+  params: OrgCollaboratorViewerParams,
+): boolean {
+  return canOrgCollaboratorActOnTaskForViewer(params);
+}
 
 /**
  * Organization workspace collaborators may cancel without owning the task.
  * Other mutations stay gated by {@link isReadOnlyForViewer}.
  */
-export function canCancelTaskForViewer({
-  taskWorkspaceOrganizationId,
-  taskOwnerId,
-  sessionUserId,
-  forceReadOnly,
-  taskStatus,
-}: CanCancelTaskForViewerParams): boolean {
-  if (forceReadOnly || isGrantPendingStatus(taskStatus)) {
-    return false;
-  }
-
-  if (sessionUserId === taskOwnerId) {
-    return true;
-  }
-
-  return (
-    taskWorkspaceOrganizationId !== null &&
-    sessionUserId !== null &&
-    sessionUserId !== undefined
-  );
+export function canCancelTaskForViewer(
+  params: OrgCollaboratorViewerParams,
+): boolean {
+  return canOrgCollaboratorActOnTaskForViewer(params);
 }

--- a/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
@@ -86,3 +86,31 @@ export function canCommentOnTaskForViewer({
     sessionUserId !== undefined
   );
 }
+
+type CanCancelTaskForViewerParams = ReadOnlyForViewerParams;
+
+/**
+ * Organization workspace collaborators may cancel without owning the task.
+ * Other mutations stay gated by {@link isReadOnlyForViewer}.
+ */
+export function canCancelTaskForViewer({
+  taskWorkspaceOrganizationId,
+  taskOwnerId,
+  sessionUserId,
+  forceReadOnly,
+  taskStatus,
+}: CanCancelTaskForViewerParams): boolean {
+  if (forceReadOnly || isGrantPendingStatus(taskStatus)) {
+    return false;
+  }
+
+  if (sessionUserId === taskOwnerId) {
+    return true;
+  }
+
+  return (
+    taskWorkspaceOrganizationId !== null &&
+    sessionUserId !== null &&
+    sessionUserId !== undefined
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Org workspace members can cancel another member's non-parked task. Edit, reopen, share, and other mutations stay owner-only.

## Changes

- **Core:** `requireTaskCancelAccess` — owner or any org-workspace member; cancel-only writes on `POST /v1/tasks/{id}/events` use it
- **Web:** `canCancelTaskForViewer` (shared org-collaborator helper with comment) + Cancel-only menu item for read-only org collaborators

## Review follow-ups

- Parked cancel reject test
- Peer cancel write asserts + peer cancel+credits stays on collaboration
- DRY comment/cancel UI gates
- Left DRAFT/READY UI vs API as owner parity (no change)

## Verification

- `pnpm --filter @sokosumi/core test` (access-control + events post)
- `pnpm --filter web test` (task-read-only + task-detail-actions)
- `pnpm check` + `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57c408e7-01b2-4c92-bde0-1c6eeabbdab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57c408e7-01b2-4c92-bde0-1c6eeabbdab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

