### PR TITLE
fix(chat): harden archive/leave races and cover web lifecycle

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.test.ts
@@ -10,14 +10,14 @@ import mountArchiveChatRoom from "./post";
 
 const {
   roomFindFirstMock,
-  roomUpdateMock,
+  roomUpdateManyMock,
   queryRawMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
   prismaTransactionMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
-  roomUpdateMock: vi.fn(),
+  roomUpdateManyMock: vi.fn(),
   queryRawMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
@@ -33,7 +33,7 @@ const CREATOR_ID = "user_creator";
 const OTHER_ID = "user_other";
 
 const tx = {
-  chatRoom: { findFirst: roomFindFirstMock, update: roomUpdateMock },
+  chatRoom: { findFirst: roomFindFirstMock, updateMany: roomUpdateManyMock },
   organization: { findUnique: organizationFindUniqueMock },
   member: { findUnique: memberFindUniqueMock },
   $queryRaw: queryRawMock,
@@ -109,28 +109,25 @@ beforeEach(() => {
   organizationFindUniqueMock.mockResolvedValue({ id: "org_1" });
   memberFindUniqueMock.mockResolvedValue({ role: "member" });
   queryRawMock.mockResolvedValue([{ id: ROOM_ID }]);
+  roomUpdateManyMock.mockResolvedValue({ count: 1 });
 });
 
 describe("POST /chats/rooms/{id}/archive", () => {
   it("archives a room for its creator and returns the timestamp", async () => {
     roomFindFirstMock.mockResolvedValue(room());
-    roomUpdateMock.mockResolvedValue({
-      id: ROOM_ID,
-      archivedAt: new Date("2026-02-02T10:00:00.000Z"),
-    });
 
     const response = await archive();
 
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.data.id).toBe(ROOM_ID);
-    expect(body.data.archivedAt).toBe("2026-02-02T10:00:00.000Z");
+    expect(typeof body.data.archivedAt).toBe("string");
 
     const sqlParts = queryRawMock.mock.calls[0]?.[0] as TemplateStringsArray;
     expect(sqlParts.join(" ")).toContain("FOR UPDATE");
-    expect(roomUpdateMock).toHaveBeenCalledWith(
+    expect(roomUpdateManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: ROOM_ID },
+        where: { id: ROOM_ID, archivedAt: null },
         data: { archivedAt: expect.any(Date) },
       }),
     );
@@ -144,10 +141,6 @@ describe("POST /chats/rooms/{id}/archive", () => {
     async (_label, role) => {
       roomFindFirstMock.mockResolvedValue(room({ createdByUserId: OTHER_ID }));
       memberFindUniqueMock.mockResolvedValue({ role });
-      roomUpdateMock.mockResolvedValue({
-        id: ROOM_ID,
-        archivedAt: new Date("2026-02-02T10:00:00.000Z"),
-      });
 
       expect((await archive()).status).toBe(200);
     },
@@ -163,7 +156,7 @@ describe("POST /chats/rooms/{id}/archive", () => {
     memberFindUniqueMock.mockResolvedValue({ role: "member" });
 
     expect((await archive()).status).toBe(403);
-    expect(roomUpdateMock).not.toHaveBeenCalled();
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it("rejects the last human member when they are not creator or elevated", async () => {
@@ -173,7 +166,7 @@ describe("POST /chats/rooms/{id}/archive", () => {
     memberFindUniqueMock.mockResolvedValue({ role: "member" });
 
     expect((await archive()).status).toBe(403);
-    expect(roomUpdateMock).not.toHaveBeenCalled();
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it("refuses to archive a direct room", async () => {
@@ -181,7 +174,7 @@ describe("POST /chats/rooms/{id}/archive", () => {
 
     expect((await archive()).status).toBe(400);
     expect(queryRawMock).not.toHaveBeenCalled();
-    expect(roomUpdateMock).not.toHaveBeenCalled();
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it("refuses to archive a room that has no organization", async () => {
@@ -189,13 +182,20 @@ describe("POST /chats/rooms/{id}/archive", () => {
 
     expect((await archive()).status).toBe(400);
     expect(queryRawMock).not.toHaveBeenCalled();
-    expect(roomUpdateMock).not.toHaveBeenCalled();
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it("404s when the room is not visible to the caller", async () => {
     roomFindFirstMock.mockResolvedValue(null);
 
     expect((await archive()).status).toBe(404);
-    expect(roomUpdateMock).not.toHaveBeenCalled();
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
+  });
+
+  it("404s when a concurrent archive already set archivedAt under the lock", async () => {
+    roomFindFirstMock.mockResolvedValue(room());
+    roomUpdateManyMock.mockResolvedValue({ count: 0 });
+
+    expect((await archive()).status).toBe(404);
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { badRequest, forbidden } from "@/helpers/error";
+import { badRequest, forbidden, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { ok } from "@/helpers/response";
@@ -54,8 +54,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id } = c.req.valid("param");
 
     const archived = await prisma.$transaction(async (tx) => {
-      // Filters on archivedAt: null, so archiving twice 404s rather than
-      // moving the timestamp — the room is already gone either way.
+      // Access helper filters archivedAt: null. Concurrent archive still needs
+      // a conditional write under the lock (parity with restore).
       const existing = await requireChatRoomUserAccess(
         id,
         userContext.userId,
@@ -101,18 +101,18 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         );
       }
 
-      return tx.chatRoom.update({
-        where: { id: existing.id },
-        data: { archivedAt: new Date() },
-        select: { id: true, archivedAt: true },
+      const archivedAt = new Date();
+      const updated = await tx.chatRoom.updateMany({
+        where: { id: existing.id, archivedAt: null },
+        data: { archivedAt },
       });
-    });
+      // Another txn may have archived under the lock after our access check.
+      if (updated.count === 0) {
+        throw notFound("Room not found");
+      }
 
-    // `update` cannot clear the value we just set, but the column is nullable
-    // so narrow it rather than asserting.
-    if (!archived.archivedAt) {
-      throw badRequest("Room could not be archived.");
-    }
+      return { id: existing.id, archivedAt };
+    });
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.test.ts
@@ -104,7 +104,7 @@ beforeEach(() => {
   prismaTransactionMock.mockImplementation(async (cb) => cb(tx));
   organizationFindUniqueMock.mockResolvedValue({ id: "org_1" });
   memberFindUniqueMock.mockResolvedValue({ role: "member" });
-  queryRawMock.mockResolvedValue([{ id: ROOM_ID }]);
+  queryRawMock.mockResolvedValue([{ id: ROOM_ID, archivedAt: null }]);
   userMemberCountMock.mockResolvedValue(1);
   userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
   readStateDeleteManyMock.mockResolvedValue({ count: 1 });
@@ -128,6 +128,7 @@ describe("DELETE /chats/rooms/{id}/members/me", () => {
     const sql = sqlParts.join(" ");
     expect(sql).toContain("FOR UPDATE");
     expect(sql).toContain("chat_room");
+    expect(sql).toContain("archivedAt");
     expect(userMemberCountMock).toHaveBeenCalledWith({
       where: { roomId: ROOM_ID, userId: { not: SELF_ID } },
     });
@@ -174,5 +175,16 @@ describe("DELETE /chats/rooms/{id}/members/me", () => {
 
     expect((await leave()).status).toBe(404);
     expect(userMemberDeleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("404s when the room was archived under the lock", async () => {
+    roomFindFirstMock.mockResolvedValue(room());
+    queryRawMock.mockResolvedValue([
+      { id: ROOM_ID, archivedAt: new Date("2026-02-02T10:00:00.000Z") },
+    ]);
+
+    expect((await leave()).status).toBe(404);
+    expect(userMemberDeleteManyMock).not.toHaveBeenCalled();
+    expect(readStateDeleteManyMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { badRequest } from "@/helpers/error";
+import { badRequest, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -68,13 +68,20 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       // Serialize concurrent leaves so two "last but one" members cannot both
       // exit under READ COMMITTED and leave an empty roster. Matches the
       // FOR UPDATE pattern used on reaction toggles and coworker warmup.
-      const lockedRooms = await tx.$queryRaw<Array<{ id: string }>>`
-        SELECT "id" FROM "chat_room"
+      // Re-read archivedAt under the lock: a concurrent archive can commit
+      // after the earlier access check and before we hold the row.
+      const lockedRooms = await tx.$queryRaw<
+        Array<{ id: string; archivedAt: Date | null }>
+      >`
+        SELECT "id", "archivedAt" FROM "chat_room"
         WHERE "id" = ${existing.id}::uuid
         FOR UPDATE
       `;
       if (lockedRooms.length === 0) {
         throw badRequest("Room could not be left.");
+      }
+      if (lockedRooms[0]?.archivedAt !== null) {
+        throw notFound("Room not found");
       }
 
       // Re-count under the lock — the earlier include snapshot can be stale

--- a/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const getChatRoomsMock = vi.fn();
+const archiveChatRoomMock = vi.fn();
+const leaveChatRoomMock = vi.fn();
+const restoreChatRoomMock = vi.fn();
 
 vi.mock("@/lib/clients/core.client", () => ({
   CoreApiRequestError: class CoreApiRequestError extends Error {
@@ -14,6 +17,9 @@ vi.mock("@/lib/clients/core.client", () => ({
   },
   coreClient: {
     getChatRooms: (...args: unknown[]) => getChatRoomsMock(...args),
+    archiveChatRoom: (...args: unknown[]) => archiveChatRoomMock(...args),
+    leaveChatRoom: (...args: unknown[]) => leaveChatRoomMock(...args),
+    restoreChatRoom: (...args: unknown[]) => restoreChatRoomMock(...args),
   },
 }));
 
@@ -23,6 +29,20 @@ function room(id: string) {
     name: id,
     slug: id,
     kind: "channel" as const,
+  };
+}
+
+function emptyPage(data: ReturnType<typeof room>[]) {
+  return {
+    data,
+    meta: {
+      pagination: {
+        cursor: null,
+        limit: 100,
+        total: data.length,
+        nextCursor: null,
+      },
+    },
   };
 }
 
@@ -78,17 +98,7 @@ describe("chatRoomService.listRooms", () => {
   });
 
   it("passes kind filter on every page", async () => {
-    getChatRoomsMock.mockResolvedValue({
-      data: [room("dm-1")],
-      meta: {
-        pagination: {
-          cursor: null,
-          limit: 100,
-          total: 1,
-          nextCursor: null,
-        },
-      },
-    });
+    getChatRoomsMock.mockResolvedValue(emptyPage([room("dm-1")]));
 
     const { chatRoomService } = await import("../chat-room.service");
     await chatRoomService.listRooms("direct");
@@ -98,5 +108,89 @@ describe("chatRoomService.listRooms", () => {
       status: "active",
       kind: "direct",
     });
+  });
+
+  it("passes archived status when listing archived rooms", async () => {
+    getChatRoomsMock.mockResolvedValue(emptyPage([room("archived-1")]));
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const rooms = await chatRoomService.listRooms("channel", "archived");
+
+    expect(rooms.map((item) => item.id)).toEqual(["archived-1"]);
+    expect(getChatRoomsMock).toHaveBeenCalledWith({
+      limit: 100,
+      status: "archived",
+      kind: "channel",
+    });
+  });
+});
+
+describe("chatRoomService.listArchivedRooms", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("requests archived organization channels", async () => {
+    getChatRoomsMock.mockResolvedValue(emptyPage([room("archived-1")]));
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const rooms = await chatRoomService.listArchivedRooms();
+
+    expect(rooms.map((item) => item.id)).toEqual(["archived-1"]);
+    expect(getChatRoomsMock).toHaveBeenCalledWith({
+      limit: 100,
+      status: "archived",
+      kind: "channel",
+    });
+  });
+});
+
+describe("chatRoomService lifecycle wrappers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("archiveRoom returns Core archive payload", async () => {
+    archiveChatRoomMock.mockResolvedValue({
+      data: {
+        id: "room-1",
+        archivedAt: "2026-02-02T10:00:00.000Z",
+      },
+    });
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const result = await chatRoomService.archiveRoom("room-1");
+
+    expect(archiveChatRoomMock).toHaveBeenCalledWith("room-1");
+    expect(result).toEqual({
+      id: "room-1",
+      archivedAt: "2026-02-02T10:00:00.000Z",
+    });
+  });
+
+  it("leaveRoom returns Core leave payload", async () => {
+    leaveChatRoomMock.mockResolvedValue({
+      data: { id: "room-1", remainingUserMemberCount: 2 },
+    });
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const result = await chatRoomService.leaveRoom("room-1");
+
+    expect(leaveChatRoomMock).toHaveBeenCalledWith("room-1");
+    expect(result).toEqual({ id: "room-1", remainingUserMemberCount: 2 });
+  });
+
+  it("restoreRoom returns restored room", async () => {
+    restoreChatRoomMock.mockResolvedValue({
+      data: room("room-1"),
+    });
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const result = await chatRoomService.restoreRoom("room-1");
+
+    expect(restoreChatRoomMock).toHaveBeenCalledWith("room-1");
+    expect(result).toEqual(room("room-1"));
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Review follow-ups for #3423 (Important findings 2–4). Finding 1 (last plain member silent UX) deferred on purpose.

## Changes

- **Leave:** re-read `archivedAt` under `FOR UPDATE`; 404 if room archived mid-flight
- **Archive:** conditional `updateMany` where `archivedAt: null` (parity with restore); concurrent archive → 404
- **Web tests:** archived list + archive/leave/restore service wrappers

## Verification

- `pnpm --filter core test` archive + leave route tests
- `pnpm --filter web test` `chat-room.service.test.ts`
- `pnpm check` + `pnpm typecheck` (pre-commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c9bed98-3630-4b4d-a930-e625855061eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c9bed98-3630-4b4d-a930-e625855061eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

