### PR TITLE
fix(core): drop interactive tx on chat rooms list GET

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/auth.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/auth.test.ts
@@ -452,6 +452,8 @@ const membershipScopedCases: AuthRequestCase[] = [
   },
 ];
 
+// Room-scoped membership GETs that must not open interactive txs.
+// List GET / is not room-scoped (no single-room 404 path) — covered in get.test.ts.
 const membershipCasesWithoutInteractiveTx = new Set([
   "GET /{id}",
   "GET /{id}/messages",

--- a/apps/core/src/routes/v1/chats/rooms/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.test.ts
@@ -13,30 +13,41 @@ const {
   roomCountMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
+  messageGroupByMock,
+  queryRawUnsafeMock,
   prismaTransactionMock,
 } = vi.hoisted(() => ({
   roomFindManyMock: vi.fn(),
   roomCountMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
+  messageGroupByMock: vi.fn(),
+  queryRawUnsafeMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
-  default: { $transaction: prismaTransactionMock },
+  default: {
+    chatRoom: {
+      findMany: roomFindManyMock,
+      count: roomCountMock,
+    },
+    organization: {
+      findUnique: organizationFindUniqueMock,
+    },
+    member: {
+      findUnique: memberFindUniqueMock,
+    },
+    chatRoomMessage: {
+      groupBy: messageGroupByMock,
+    },
+    $queryRawUnsafe: queryRawUnsafeMock,
+    $transaction: prismaTransactionMock,
+  },
 }));
 
 const USER_ID = "user_123";
 const ORG_ID = "org_1";
-
-const tx = {
-  chatRoom: {
-    findMany: roomFindManyMock,
-    count: roomCountMock,
-  },
-  organization: { findUnique: organizationFindUniqueMock },
-  member: { findUnique: memberFindUniqueMock },
-};
 
 function createApp(organizationId: string | null) {
   const app = new OpenAPIHono<{ Variables: AuthVariables }>({
@@ -58,18 +69,29 @@ function createApp(organizationId: string | null) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  prismaTransactionMock.mockImplementation(async (cb) => cb(tx));
   organizationFindUniqueMock.mockResolvedValue({ id: ORG_ID });
   memberFindUniqueMock.mockResolvedValue({ role: MemberRole.MEMBER });
   roomFindManyMock.mockResolvedValue([]);
   roomCountMock.mockResolvedValue(0);
+  messageGroupByMock.mockResolvedValue([]);
+  queryRawUnsafeMock.mockResolvedValue([]);
 });
 
 describe("GET /chats/rooms", () => {
+  it("lists rooms without opening an interactive transaction", async () => {
+    const response = await createApp(ORG_ID).request("/");
+
+    expect(response.status).toBe(200);
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
+    expect(roomFindManyMock).toHaveBeenCalledOnce();
+    expect(roomCountMock).toHaveBeenCalledOnce();
+  });
+
   it("lists archived rooms the plain member created", async () => {
     const response = await createApp(ORG_ID).request("/?status=archived");
 
     expect(response.status).toBe(200);
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
     expect(roomFindManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
@@ -100,6 +122,7 @@ describe("GET /chats/rooms", () => {
       const response = await createApp(ORG_ID).request("/?status=archived");
 
       expect(response.status).toBe(200);
+      expect(prismaTransactionMock).not.toHaveBeenCalled();
       const where = roomFindManyMock.mock.calls[0]?.[0]?.where as Record<
         string,
         unknown
@@ -119,6 +142,7 @@ describe("GET /chats/rooms", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.data).toEqual([]);
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
     expect(roomFindManyMock).not.toHaveBeenCalled();
     expect(organizationFindUniqueMock).not.toHaveBeenCalled();
   });

--- a/apps/core/src/routes/v1/chats/rooms/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.test.ts
@@ -147,10 +147,22 @@ describe("GET /chats/rooms", () => {
     expect(organizationFindUniqueMock).not.toHaveBeenCalled();
   });
 
+  it("returns an empty page for kind=channel with no active organization", async () => {
+    const response = await createApp(null).request("/?kind=channel");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual([]);
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
+    expect(roomFindManyMock).not.toHaveBeenCalled();
+    expect(organizationFindUniqueMock).not.toHaveBeenCalled();
+  });
+
   it("defaults to active rooms (archivedAt null) without creator filter", async () => {
     const response = await createApp(ORG_ID).request("/");
 
     expect(response.status).toBe(200);
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
     const where = roomFindManyMock.mock.calls[0]?.[0]?.where as Record<
       string,
       unknown

--- a/apps/core/src/routes/v1/chats/rooms/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.ts
@@ -97,95 +97,88 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const takePlusOne = take + 1;
     const organizationId = userContext.organizationId;
 
-    const { rooms, unreadCounts, lastMessageAts, count, hasMore } =
-      await prisma.$transaction(async (tx) => {
-        let organizationRole: string | null = null;
-        if (organizationId) {
-          const membership = await resolveMemberOrganizationById({
-            id: organizationId,
-            userId: userContext.userId,
-            tx,
-          });
-          organizationRole = membership.role;
-        }
-
-        // Strict org match: active org → only that org's channels/directs.
-        // No active org → personal coworker directs only. A kind=channel filter
-        // with no org cannot match anything — return an empty page instead of
-        // silently overriding the filter to directs. Archived rooms are always
-        // org channels, so personal workspace returns empty for status=archived.
-        if (
-          (!organizationId && kind === "channel") ||
-          (!organizationId && status === "archived")
-        ) {
-          return {
-            rooms: [],
-            unreadCounts: new Map<string, number>(),
-            lastMessageAts: new Map<string, Date>(),
-            count: 0,
-            hasMore: false,
-          };
-        }
-
-        // Archived list is for restore: same gate as archive/restore endpoints.
-        // Owners/admins see every archived room they still belong to; everyone
-        // else only rooms they created. Keep the filter in SQL so cursor pages
-        // and counts stay honest.
-        const canManageAnyArchived =
-          organizationRole === MemberRole.OWNER ||
-          organizationRole === MemberRole.ADMIN;
-        const archivedLifecycleWhere =
-          status === "archived" && !canManageAnyArchived
-            ? { createdByUserId: userContext.userId }
-            : {};
-
-        const where = {
-          archivedAt: status === "archived" ? { not: null } : null,
-          ...(kind ? { kind } : {}),
-          userMembers: {
-            some: { userId: userContext.userId },
-          },
-          ...archivedLifecycleWhere,
-          ...(organizationId
-            ? { organizationId }
-            : {
-                organizationId: null,
-                kind: "direct" as const,
-              }),
-        };
-
-        const [rows, count] = await Promise.all([
-          tx.chatRoom.findMany({
-            where,
-            take: takePlusOne,
-            skip,
-            cursor: cursor ? { id: cursor } : undefined,
-            include: chatRoomInclude,
-            // `id` breaks ties so the cursor walk is a total order; `updatedAt`
-            // alone is not unique and would drop or repeat rows across pages.
-            orderBy: [
-              { updatedAt: "desc" },
-              { createdAt: "desc" },
-              { id: "desc" },
-            ],
-          }),
-          tx.chatRoom.count({ where }),
-        ]);
-
-        const hasMore = rows.length === takePlusOne;
-        const rooms = rows.slice(0, take);
-        const roomIds = rooms.map((room) => room.id);
-        const [unreadCounts, lastMessageAts] = await Promise.all([
-          getChatRoomUnreadCounts(roomIds, userContext.userId, tx),
-          getChatRoomLastMessageAts(roomIds, tx),
-        ]);
-
-        // Keep DB cursor order (`updatedAt` desc). Stream/message writes bump
-        // room.updatedAt; do not re-sort by lastMessageAts after `take` — that
-        // breaks cursor paging when membership exceeds one page.
-        return { rooms, unreadCounts, lastMessageAts, count, hasMore };
+    // Avoid interactive transaction on this read-only path — chat index loads
+    // listRooms in parallel with members + coworkers; interactive txs hold a
+    // pool connection and also forbid Promise.all inside (#2559 / P2028).
+    // Membership gate + list/count/unread do not need a shared snapshot.
+    let organizationRole: string | null = null;
+    if (organizationId) {
+      const membership = await resolveMemberOrganizationById({
+        id: organizationId,
+        userId: userContext.userId,
+        tx: prisma,
       });
+      organizationRole = membership.role;
+    }
 
+    // Strict org match: active org → only that org's channels/directs.
+    // No active org → personal coworker directs only. A kind=channel filter
+    // with no org cannot match anything — return an empty page instead of
+    // silently overriding the filter to directs. Archived rooms are always
+    // org channels, so personal workspace returns empty for status=archived.
+    if (
+      (!organizationId && kind === "channel") ||
+      (!organizationId && status === "archived")
+    ) {
+      return ok(
+        c,
+        z.array(chatRoomSchema).parse([]),
+        createPaginationMeta([], 0, take, false, cursor),
+      );
+    }
+
+    // Archived list is for restore: same gate as archive/restore endpoints.
+    // Owners/admins see every archived room they still belong to; everyone
+    // else only rooms they created. Keep the filter in SQL so cursor pages
+    // and counts stay honest.
+    const canManageAnyArchived =
+      organizationRole === MemberRole.OWNER ||
+      organizationRole === MemberRole.ADMIN;
+    const archivedLifecycleWhere =
+      status === "archived" && !canManageAnyArchived
+        ? { createdByUserId: userContext.userId }
+        : {};
+
+    const where = {
+      archivedAt: status === "archived" ? { not: null } : null,
+      ...(kind ? { kind } : {}),
+      userMembers: {
+        some: { userId: userContext.userId },
+      },
+      ...archivedLifecycleWhere,
+      ...(organizationId
+        ? { organizationId }
+        : {
+            organizationId: null,
+            kind: "direct" as const,
+          }),
+    };
+
+    const [rows, count] = await Promise.all([
+      prisma.chatRoom.findMany({
+        where,
+        take: takePlusOne,
+        skip,
+        cursor: cursor ? { id: cursor } : undefined,
+        include: chatRoomInclude,
+        // `id` breaks ties so the cursor walk is a total order; `updatedAt`
+        // alone is not unique and would drop or repeat rows across pages.
+        orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }, { id: "desc" }],
+      }),
+      prisma.chatRoom.count({ where }),
+    ]);
+
+    const hasMore = rows.length === takePlusOne;
+    const rooms = rows.slice(0, take);
+    const roomIds = rooms.map((room) => room.id);
+    const [unreadCounts, lastMessageAts] = await Promise.all([
+      getChatRoomUnreadCounts(roomIds, userContext.userId, prisma),
+      getChatRoomLastMessageAts(roomIds, prisma),
+    ]);
+
+    // Keep DB cursor order (`updatedAt` desc). Stream/message writes bump
+    // room.updatedAt; do not re-sort by lastMessageAts after `take` — that
+    // breaks cursor paging when membership exceeds one page.
     const paginationMeta = createPaginationMeta(
       rooms,
       count,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3456. `GET /v1/chats/rooms` (sidebar / chat-index `listRooms`) still opened a read-only interactive `$transaction` and ran `Promise.all` inside it (#2559). Chat index loads list + members + coworkers in parallel → same P2028 pool-contention class.

## Changes

- `GET /v1/chats/rooms`: membership gate + findMany/count + unread/last-message on default Prisma client (no interactive tx)
- Unit tests assert `$transaction` is never called; keep archived/active filter coverage

## Validation

- `pnpm --filter core test` on `rooms/get.test.ts` + `rooms/auth.test.ts` (38 passed)
- Pre-commit `pnpm check` + `pnpm typecheck` passed

## Notes

- Room detail page already avoids `listRooms()`; this cleans the chat-index / sidebar path
- Pattern matches Core AGENTS.md interactive-tx guidance from #3456

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3885c9e3-9e17-41b5-9c72-40ac68d63c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3885c9e3-9e17-41b5-9c72-40ac68d63c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

