### PR TITLE
fix(web): rename Add Organization to Create Organization

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -151,7 +151,7 @@
       "personalAccount": "Persönlicher Account",
       "organizationsHeading": "Organisationen",
       "createOrJoinOrganization": "Organisation erstellen oder beitreten",
-      "addOrganization": "Organisation hinzufügen"
+      "createOrganization": "Organisation erstellen"
     },
     "DataTable": {
       "Data": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "Switch workspace",
       "personalAccount": "Personal Account",
-      "addOrganization": "Add Organization",
+      "createOrganization": "Create Organization",
       "organizationsHeading": "Organizations",
       "createOrJoinOrganization": "Create or Join Organization"
     },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -151,7 +151,7 @@
       "personalAccount": "Cuenta personal",
       "organizationsHeading": "Organizaciones",
       "createOrJoinOrganization": "Crear o unirse a una organización",
-      "addOrganization": "Añadir organización"
+      "createOrganization": "Crear organización"
     },
     "DataTable": {
       "Data": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "Changer d’espace de travail",
       "personalAccount": "Compte personnel",
-      "addOrganization": "Ajouter une organisation",
+      "createOrganization": "Créer une organisation",
       "organizationsHeading": "Organisations",
       "createOrJoinOrganization": "Créer ou rejoindre une organisation"
     },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "Cambia spazio di lavoro",
       "personalAccount": "Account personale",
-      "addOrganization": "Aggiungi organizzazione",
+      "createOrganization": "Crea organizzazione",
       "organizationsHeading": "Organizzazioni",
       "createOrJoinOrganization": "Crea o unisciti a un’organizzazione"
     },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "ワークスペースを切り替える",
       "personalAccount": "個人アカウント",
-      "addOrganization": "組織を追加",
+      "createOrganization": "組織を作成",
       "organizationsHeading": "組織",
       "createOrJoinOrganization": "組織を作成または参加"
     },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "Trocar espaço de trabalho",
       "personalAccount": "Conta pessoal",
-      "addOrganization": "Adicionar organização",
+      "createOrganization": "Criar organização",
       "organizationsHeading": "Organizações",
       "createOrJoinOrganization": "Criar ou entrar em uma organização"
     },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "Mudar espaço de trabalho",
       "personalAccount": "Conta pessoal",
-      "addOrganization": "Adicionar organização",
+      "createOrganization": "Criar organização",
       "organizationsHeading": "Organizações",
       "createOrJoinOrganization": "Criar ou aderir a uma organização"
     },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -149,7 +149,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "切换工作区",
       "personalAccount": "个人账户",
-      "addOrganization": "添加组织",
+      "createOrganization": "创建组织",
       "organizationsHeading": "组织",
       "createOrJoinOrganization": "创建或加入组织"
     },

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -154,7 +154,7 @@ export default function HeaderWorkspaceSwitch({
     onSelectWorkspace(workspaceId);
   };
 
-  const handleAddOrganization = () => {
+  const handleCreateOrganization = () => {
     setIsDropdownOpen(false);
     showCreateOrganizationModal();
   };
@@ -211,12 +211,12 @@ export default function HeaderWorkspaceSwitch({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="flex cursor-pointer items-center gap-2 py-2"
-            onClick={handleAddOrganization}
+            onClick={handleCreateOrganization}
           >
             <Avatar className="bg-primary/10 flex size-6 items-center justify-center gap-2">
               <Plus className="text-primary size-4" />
             </Avatar>
-            <span>{tOrganizationSwitcher("addOrganization")}</span>
+            <span>{tOrganizationSwitcher("createOrganization")}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Renames the workspace switcher CTA from **Add Organization** to **Create Organization**
- Renames i18n key `addOrganization` → `createOrganization` and updates all locale catalogs
- Renames the click handler to match

## Test plan

- [ ] Open workspace switcher in header
- [ ] Confirm bottom action reads **Create Organization**
- [ ] Confirm it still opens the create-organization wizard

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d0a8d88-b8ce-4c6c-b91b-afd4df50ed84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d0a8d88-b8ce-4c6c-b91b-afd4df50ed84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

