### PR TITLE
fix(web): allow app sidebar to scroll when content overflows

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-submenu.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-submenu.tsx
@@ -113,7 +113,7 @@ function SubmenuPanelView({
     <div
       ref={panelRef}
       tabIndex={isActive ? -1 : undefined}
-      className={cn(TRACK_PANEL_CLASS, "outline-hidden overflow-hidden")}
+      className={cn(TRACK_PANEL_CLASS, "outline-hidden overflow-x-clip")}
       aria-hidden={!isActive}
       {...(!isActive ? { inert: true } : {})}
     >
@@ -208,7 +208,9 @@ export function SidebarSubmenu({
 
   return (
     <SidebarSubmenuContext value={contextValue}>
-      <div className="relative w-full overflow-hidden">
+      {/* Clip horizontal slide panels only (overflow-x-clip keeps overflow-y
+          visible so tall nav reaches SidebarContent's overflow-y-auto). */}
+      <div className="relative w-full overflow-x-clip">
         <div
           className={cn("flex w-full", SLIDE_TRANSITION_CLASS)}
           style={{

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -128,7 +128,8 @@ export default async function Sidebar({
         </div>
       </SidebarHeader>
       <SidebarContent className="min-h-0 w-full flex-1">
-        <div className="flex min-h-0 flex-col gap-0">
+        {/* Grow with nav content (no min-h-0 shrink) so SidebarContent can scroll. */}
+        <div className="flex w-full flex-col gap-0">
           <SidebarNav
             members={members}
             activeOrganizationId={activeOrganizationId}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long channel / DM lists left the app sidebar stuck — users could not scroll past mid-list items (e.g. Marketing).

`SidebarContent` already had `overflow-y-auto`, but nested `overflow-hidden` on the settings submenu slide track clipped vertical overflow, and a `min-h-0` wrapper shrank the nav column so the scroll host never gained a scroll range.

## Changes

- Clip submenu slide panels with `overflow-x-clip` only (keeps `overflow-y` visible; avoids the `overflow-x: hidden` → `overflow-y: auto` CSS quirk)
- Drop `min-h-0` on the sidebar nav column so content height can exceed the viewport and `SidebarContent` scrolls
- Header / footer stay fixed; middle nav (including Channels / DMs) scrolls

## Test plan

- [ ] Open app with enough channels/DMs that they exceed viewport height
- [ ] Scroll sidebar — items above and below the fold are reachable; account chip stays at bottom
- [ ] Open Settings submenu slide — horizontal slide still works; tall settings content still scrolls
- [ ] Collapse sidebar to icon mode — no layout break

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a609f242-65b1-4bf6-bd46-962b6694202c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a609f242-65b1-4bf6-bd46-962b6694202c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

