### PR TITLE
perf(core): parallelize Hermes assistant plan-coverage org lookups

### DIFF
--- a/apps/core/src/routes/v1/hermes/index.test.ts
+++ b/apps/core/src/routes/v1/hermes/index.test.ts
@@ -2324,6 +2324,43 @@ describe("Hermes route contracts", () => {
     );
   });
 
+  it("resolves member organization billing plans concurrently", async () => {
+    // Multi-org coverage must not await each org serially — chat/provision
+    // hit this path on every gated call. Concurrent max in-flight count
+    // proves the parallel fan-out (sequential loop stays at 1).
+    resolveActiveSubscriptionMock.mockResolvedValue(null);
+    memberFindManyMock.mockResolvedValue([
+      { organizationId: "org_a" },
+      { organizationId: "org_b" },
+    ]);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    resolveOrganizationBillingPlanMock.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inFlight -= 1;
+      return {
+        mode: "self_serve" as const,
+        plan: "starter",
+        purchasedSeats: 1,
+        subscriptionId: "sub_starter",
+        cancelAtPeriodEnd: false,
+        periodEnd: null,
+      };
+    });
+
+    const response = await createApp().request("/me/instance", {
+      method: "POST",
+      headers: { Authorization: "Bearer test_api_key" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(resolveOrganizationBillingPlanMock).toHaveBeenCalledTimes(2);
+    expect(maxInFlight).toBeGreaterThanOrEqual(2);
+  });
+
   it("provisions when a member organization has an active enterprise contract", async () => {
     memberFindManyMock.mockResolvedValue([{ organizationId: "org_ent" }]);
     resolveActiveSubscriptionMock.mockResolvedValue(null);

--- a/apps/core/src/routes/v1/hermes/index.ts
+++ b/apps/core/src/routes/v1/hermes/index.ts
@@ -2085,27 +2085,32 @@ async function userHasAssistantPlanCoverage(userId: string): Promise<boolean> {
   // Org memberships via the canonical billing-plan resolver (enterprise
   // contract first, then self-serve Stripe). Enterprise orgs often have no
   // subscription row at all — the old Stripe-only loop missed them.
+  // Resolve orgs in parallel: this runs on every gated chat/provision call
+  // and sequential awaits scaled with membership count (SOK-661). Matches
+  // web's `hasAssistantPlanCoverage` fan-out.
   const memberships = await prisma.member.findMany({
     where: { userId },
     select: { organizationId: true },
   });
-  for (const { organizationId } of memberships) {
-    const billingPlan = await resolveOrganizationBillingPlan(
-      organizationId,
-      prisma,
-    );
+  if (memberships.length === 0) return false;
+
+  const billingPlans = await Promise.all(
+    memberships.map(({ organizationId }) =>
+      resolveOrganizationBillingPlan(organizationId, prisma),
+    ),
+  );
+
+  return billingPlans.some((billingPlan) => {
     // Match the canonical coverage checks (organization-subscription-auth,
     // seat service): an "active" contract past its commercial term is not
     // consumable and must not grant assistant access.
     if (billingPlan.mode === "enterprise_contract" && billingPlan.isConsumable)
       return true;
-    if (
+    return (
       billingPlan.mode === "self_serve" &&
       planUnlocksPersonalAssistant(billingPlan.plan)
-    )
-      return true;
-  }
-  return false;
+    );
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Parallelize `userHasAssistantPlanCoverage` org `resolveOrganizationBillingPlan` calls with `Promise.all` (matches web `hasAssistantPlanCoverage`).
- Add concurrency regression test: multi-org coverage fan-out keeps ≥2 in-flight resolves.
- Correctness unchanged: personal Standard+ first, then any member org (enterprise only when consumable).

Closes linear issue from review follow-up of the Standard plan gate.

**Base:** `feat/hermes-standard-plan-gate` (stacked on #3435)  
**Linear:** [SOK-661](https://linear.app/masumi/issue/SOK-661/speed-up-personal-assistant-plan-coverage-checks-on-core-hot-paths)

## Why a separate PR

Performance-only change on Core hot paths; keeps the Standard plan-gate PR reviewable for product/auth semantics.

## Test plan

- [x] `pnpm --filter core test src/routes/v1/hermes/index.test.ts` (70 tests, including concurrency case)
- [ ] CI green on stack after #3435 merges (or when rebased onto main)