### PR TITLE
feat(tasks): allow org members to archive or cancel others' scheduled tasks

### DIFF
--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -184,6 +184,24 @@ describe("requireMutableTaskOwnership", () => {
   });
 });
 
+function archiveAccessVars(
+  workspaceContext: WorkspaceContext | null = jobReadWorkspaceContext,
+  authContext: UserAuthenticationContext = userAuthContext,
+): EnvVariables["Variables"] {
+  return {
+    isAuthenticated: true,
+    authContext,
+    workspaceContext,
+  };
+}
+
+const scheduledTaskMetadata = JSON.stringify({
+  version: 1,
+  mode: "once",
+  scheduledAt: "2026-08-01T10:00:00.000Z",
+  runAt: "2026-08-01T10:00:00.000Z",
+});
+
 describe("requireTaskArchiveAccess", () => {
   beforeEach(() => {
     resolveMemberOrganizationByIdMock.mockReset();
@@ -198,7 +216,7 @@ describe("requireTaskArchiveAccess", () => {
     } as never);
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_123", tx),
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_123", tx),
     ).resolves.toMatchObject({ id: "tsk_123" });
   });
 
@@ -216,7 +234,7 @@ describe("requireTaskArchiveAccess", () => {
     resolveMemberOrganizationByIdMock.mockResolvedValue({ id: "org_123" });
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_parked", tx),
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_parked", tx),
     ).resolves.toMatchObject({ id: "tsk_parked" });
 
     expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
@@ -236,12 +254,7 @@ describe("requireTaskArchiveAccess", () => {
         id: "tsk_parked_scheduled",
         status: TaskStatus.GRANT_PENDING,
         ownerId: "user_other",
-        metadata: JSON.stringify({
-          version: 1,
-          mode: "once",
-          scheduledAt: "2026-08-01T10:00:00.000Z",
-          runAt: "2026-08-01T10:00:00.000Z",
-        }),
+        metadata: scheduledTaskMetadata,
         nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
         workspace: { organizationId: "org_123" },
       } as never);
@@ -251,10 +264,10 @@ describe("requireTaskArchiveAccess", () => {
     );
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_parked_scheduled", tx),
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_parked_scheduled", tx),
     ).rejects.toThrow();
 
-    // Parked branch must win over scheduled any-member path.
+    // Parked branch must win over scheduled workspace-member path.
     expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "org_123",
@@ -271,48 +284,84 @@ describe("requireTaskArchiveAccess", () => {
       .mockResolvedValueOnce(null);
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_123", tx),
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_123", tx),
     ).rejects.toThrow("Task not found");
   });
 
-  it("allows any org member to archive scheduled tasks they do not own", async () => {
+  it("allows an org workspace member who does not own the scheduled task to archive", async () => {
     const tx = createTransactionClient();
+    const memberAuthContext: UserAuthenticationContext = {
+      actor: "user",
+      userId: "user_member",
+      organizationId: "org_123",
+      role: "user",
+    };
+    const scheduledTask = {
+      id: "tsk_scheduled",
+      status: TaskStatus.READY,
+      ownerId: "user_owner",
+      workspaceId,
+      metadata: scheduledTaskMetadata,
+      nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+      workspace: { organizationId: "org_123" },
+    };
+
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        id: "tsk_scheduled",
-        status: TaskStatus.READY,
-        ownerId: "user_other",
-        metadata: JSON.stringify({
-          version: 1,
-          mode: "once",
-          scheduledAt: "2026-08-01T10:00:00.000Z",
-          runAt: "2026-08-01T10:00:00.000Z",
-        }),
-        nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
-        workspace: { organizationId: "org_123" },
-      } as never);
-
-    resolveMemberOrganizationByIdMock.mockResolvedValue({ id: "org_123" });
+      .mockResolvedValueOnce(scheduledTask as never)
+      .mockResolvedValueOnce(scheduledTask as never);
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_scheduled", tx),
+      requireTaskArchiveAccess(
+        archiveAccessVars(jobReadWorkspaceContext, memberAuthContext),
+        "tsk_scheduled",
+        tx,
+      ),
     ).resolves.toMatchObject({ id: "tsk_scheduled" });
 
-    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "org_123",
-        userId: "user_123",
-      }),
-    );
-    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        allowedRoles: expect.anything(),
-      }),
-    );
+    expect(tx.task.findFirst).toHaveBeenNthCalledWith(3, {
+      where: {
+        id: "tsk_scheduled",
+        archivedAt: null,
+        workspaceId,
+      },
+    });
+    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
   });
 
-  it("rejects non-members for scheduled tasks they do not own", async () => {
+  it("rejects when scheduled task is in a different workspace than the active one", async () => {
+    const tx = createTransactionClient();
+    const otherWorkspaceId = "22222222-2222-7222-8222-222222222222";
+    const scheduledTask = {
+      id: "tsk_scheduled",
+      status: TaskStatus.READY,
+      ownerId: "user_owner",
+      workspaceId: otherWorkspaceId,
+      metadata: scheduledTaskMetadata,
+      nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+      workspace: { organizationId: "org_123" },
+    };
+
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(scheduledTask as never)
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_scheduled", tx),
+    ).rejects.toThrow("Task not found");
+
+    expect(tx.task.findFirst).toHaveBeenNthCalledWith(3, {
+      where: {
+        id: "tsk_scheduled",
+        archivedAt: null,
+        workspaceId,
+      },
+    });
+    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects scheduled archive when active workspace context is missing", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)
@@ -320,18 +369,55 @@ describe("requireTaskArchiveAccess", () => {
         id: "tsk_scheduled",
         status: TaskStatus.READY,
         ownerId: "user_other",
-        metadata: null,
+        metadata: scheduledTaskMetadata,
         nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
         workspace: { organizationId: "org_123" },
       } as never);
 
-    resolveMemberOrganizationByIdMock.mockRejectedValue(
-      new HTTPException(404, { message: "Organization not found" }),
-    );
+    await expect(
+      requireTaskArchiveAccess(archiveAccessVars(null), "tsk_scheduled", tx),
+    ).rejects.toThrow("Workspace is missing");
+
+    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a personal-workspace non-owner for scheduled archive", async () => {
+    const tx = createTransactionClient();
+    const personalWorkspace: WorkspaceContext = {
+      workspaceId,
+      userId: "user_member",
+      organizationId: null,
+    };
+    const memberAuthContext: UserAuthenticationContext = {
+      actor: "user",
+      userId: "user_member",
+      organizationId: null,
+      role: "user",
+    };
+    const scheduledTask = {
+      id: "tsk_scheduled",
+      status: TaskStatus.READY,
+      ownerId: "user_owner",
+      workspaceId,
+      metadata: null,
+      nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+      workspace: { organizationId: "org_123" },
+    };
+
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(scheduledTask as never)
+      .mockResolvedValueOnce(scheduledTask as never);
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_scheduled", tx),
-    ).rejects.toThrow();
+      requireTaskArchiveAccess(
+        archiveAccessVars(personalWorkspace, memberAuthContext),
+        "tsk_scheduled",
+        tx,
+      ),
+    ).rejects.toThrow("Task not found");
+
+    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
   });
 
   it("rejects org members for non-scheduled tasks they do not own", async () => {
@@ -348,7 +434,7 @@ describe("requireTaskArchiveAccess", () => {
       } as never);
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_plain", tx),
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_plain", tx),
     ).rejects.toThrow("Task not found");
 
     expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
@@ -368,7 +454,7 @@ describe("requireTaskArchiveAccess", () => {
       } as never);
 
     await expect(
-      requireTaskArchiveAccess(sessionUserContext, "tsk_personal", tx),
+      requireTaskArchiveAccess(archiveAccessVars(), "tsk_personal", tx),
     ).rejects.toThrow("Task not found");
 
     expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -239,7 +239,7 @@ describe("requireTaskArchiveAccess", () => {
     ).rejects.toThrow("Task not found");
   });
 
-  it("allows org owner/admin to archive scheduled tasks they do not own", async () => {
+  it("allows any org member to archive scheduled tasks they do not own", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)
@@ -267,12 +267,16 @@ describe("requireTaskArchiveAccess", () => {
       expect.objectContaining({
         id: "org_123",
         userId: "user_123",
-        allowedRoles: [MemberRole.OWNER, MemberRole.ADMIN],
+      }),
+    );
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        allowedRoles: expect.anything(),
       }),
     );
   });
 
-  it("rejects plain org members for scheduled tasks they do not own", async () => {
+  it("rejects non-members for scheduled tasks they do not own", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)
@@ -294,7 +298,7 @@ describe("requireTaskArchiveAccess", () => {
     ).rejects.toThrow();
   });
 
-  it("rejects org owner/admin for non-scheduled tasks they do not own", async () => {
+  it("rejects org members for non-scheduled tasks they do not own", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)
@@ -314,7 +318,7 @@ describe("requireTaskArchiveAccess", () => {
     expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
   });
 
-  it("rejects org owner/admin for scheduled tasks in a personal workspace", async () => {
+  it("rejects org members for scheduled tasks in a personal workspace", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -185,6 +185,10 @@ describe("requireMutableTaskOwnership", () => {
 });
 
 describe("requireTaskArchiveAccess", () => {
+  beforeEach(() => {
+    resolveMemberOrganizationByIdMock.mockReset();
+  });
+
   it("allows the task owner including parked tasks", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst).mockResolvedValueOnce({
@@ -233,6 +237,101 @@ describe("requireTaskArchiveAccess", () => {
     await expect(
       requireTaskArchiveAccess(sessionUserContext, "tsk_123", tx),
     ).rejects.toThrow("Task not found");
+  });
+
+  it("allows org owner/admin to archive scheduled tasks they do not own", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "tsk_scheduled",
+        status: TaskStatus.READY,
+        ownerId: "user_other",
+        metadata: JSON.stringify({
+          version: 1,
+          mode: "once",
+          scheduledAt: "2026-08-01T10:00:00.000Z",
+          runAt: "2026-08-01T10:00:00.000Z",
+        }),
+        nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+        workspace: { organizationId: "org_123" },
+      } as never);
+
+    resolveMemberOrganizationByIdMock.mockResolvedValue({ id: "org_123" });
+
+    await expect(
+      requireTaskArchiveAccess(sessionUserContext, "tsk_scheduled", tx),
+    ).resolves.toMatchObject({ id: "tsk_scheduled" });
+
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "org_123",
+        userId: "user_123",
+        allowedRoles: [MemberRole.OWNER, MemberRole.ADMIN],
+      }),
+    );
+  });
+
+  it("rejects plain org members for scheduled tasks they do not own", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "tsk_scheduled",
+        status: TaskStatus.READY,
+        ownerId: "user_other",
+        metadata: null,
+        nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+        workspace: { organizationId: "org_123" },
+      } as never);
+
+    resolveMemberOrganizationByIdMock.mockRejectedValue(
+      new HTTPException(404, { message: "Organization not found" }),
+    );
+
+    await expect(
+      requireTaskArchiveAccess(sessionUserContext, "tsk_scheduled", tx),
+    ).rejects.toThrow();
+  });
+
+  it("rejects org owner/admin for non-scheduled tasks they do not own", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "tsk_plain",
+        status: TaskStatus.READY,
+        ownerId: "user_other",
+        metadata: null,
+        nextRunAt: null,
+        workspace: { organizationId: "org_123" },
+      } as never);
+
+    await expect(
+      requireTaskArchiveAccess(sessionUserContext, "tsk_plain", tx),
+    ).rejects.toThrow("Task not found");
+
+    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects org owner/admin for scheduled tasks in a personal workspace", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "tsk_personal",
+        status: TaskStatus.READY,
+        ownerId: "user_other",
+        metadata: null,
+        nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+        workspace: { organizationId: null },
+      } as never);
+
+    await expect(
+      requireTaskArchiveAccess(sessionUserContext, "tsk_personal", tx),
+    ).rejects.toThrow("Task not found");
+
+    expect(resolveMemberOrganizationByIdMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/core/src/helpers/access-control.test.ts
+++ b/apps/core/src/helpers/access-control.test.ts
@@ -228,7 +228,43 @@ describe("requireTaskArchiveAccess", () => {
     );
   });
 
-  it("rejects non-owners for non-parked tasks", async () => {
+  it("keeps parked+scheduled archive OWNER/ADMIN-only for non-owners", async () => {
+    const tx = createTransactionClient();
+    vi.mocked(tx.task.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "tsk_parked_scheduled",
+        status: TaskStatus.GRANT_PENDING,
+        ownerId: "user_other",
+        metadata: JSON.stringify({
+          version: 1,
+          mode: "once",
+          scheduledAt: "2026-08-01T10:00:00.000Z",
+          runAt: "2026-08-01T10:00:00.000Z",
+        }),
+        nextRunAt: new Date("2026-08-01T10:00:00.000Z"),
+        workspace: { organizationId: "org_123" },
+      } as never);
+
+    resolveMemberOrganizationByIdMock.mockRejectedValue(
+      new HTTPException(404, { message: "Organization not found" }),
+    );
+
+    await expect(
+      requireTaskArchiveAccess(sessionUserContext, "tsk_parked_scheduled", tx),
+    ).rejects.toThrow();
+
+    // Parked branch must win over scheduled any-member path.
+    expect(resolveMemberOrganizationByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "org_123",
+        userId: "user_123",
+        allowedRoles: [MemberRole.OWNER, MemberRole.ADMIN],
+      }),
+    );
+  });
+
+  it("rejects when task is missing", async () => {
     const tx = createTransactionClient();
     vi.mocked(tx.task.findFirst)
       .mockResolvedValueOnce(null)

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -103,8 +103,8 @@ export async function requireMutableTaskOwnership(
 }
 
 /**
- * Soft-archive access: task owner always, or org OWNER/ADMIN when the task is
- * parked (`GRANT_PENDING`) or has an active schedule in that organization workspace.
+ * Soft-archive access: task owner always; org OWNER/ADMIN for parked
+ * (`GRANT_PENDING`); any org member for tasks with an active schedule.
  */
 export async function requireTaskArchiveAccess(
   userContext: UserContext,
@@ -141,15 +141,25 @@ export async function requireTaskArchiveAccess(
   const isParked = task.status === TaskStatus.GRANT_PENDING;
   const isScheduled = hasActiveTaskSchedule(task.metadata, task.nextRunAt);
 
-  if (!isParked && !isScheduled) {
+  if (isParked) {
+    await resolveMemberOrganizationById({
+      id: organizationId,
+      userId: userContext.userId,
+      tx,
+      allowedRoles: [MemberRole.OWNER, MemberRole.ADMIN],
+    });
+    return task;
+  }
+
+  if (!isScheduled) {
     throw notFound("Task not found");
   }
 
+  // Any org member may archive scheduled tasks (same membership gate as cancel).
   await resolveMemberOrganizationById({
     id: organizationId,
     userId: userContext.userId,
     tx,
-    allowedRoles: [MemberRole.OWNER, MemberRole.ADMIN],
   });
 
   return task;

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -6,6 +6,7 @@ import {
   TaskStatus,
   VendorGrantStatus,
 } from "@sokosumi/database";
+import { hasActiveTaskSchedule } from "@sokosumi/utils";
 
 import prisma from "@/lib/db/prisma";
 import type { EnvVariables } from "@/lib/hono";
@@ -26,7 +27,7 @@ import {
 import type { CoworkerCapability } from "./coworker-capability";
 import { forbidden, notFound } from "./error";
 import { resolveMemberOrganizationById } from "./organization";
-import { hasActiveTaskSchedule } from "./task-schedule";
+
 import {
   getWorkspaceGrant,
   requestWorkspaceGrantCommitted,

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -155,7 +155,8 @@ export async function requireTaskArchiveAccess(
     throw notFound("Task not found");
   }
 
-  // Any org member may archive scheduled tasks (same membership gate as cancel).
+  // Any org member of the task workspace's organization (not workspace-scoped
+  // like cancel, which requires the active workspace context).
   await resolveMemberOrganizationById({
     id: organizationId,
     userId: userContext.userId,

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -105,13 +105,18 @@ export async function requireMutableTaskOwnership(
 
 /**
  * Soft-archive access: task owner always; org OWNER/ADMIN for parked
- * (`GRANT_PENDING`); any org member for tasks with an active schedule.
+ * (`GRANT_PENDING`); for active schedules, any org-workspace member for a
+ * task in that workspace (same active-workspace gate as
+ * {@link requireTaskCancelAccess}). Coworker actors are out (route uses
+ * owner user context).
  */
 export async function requireTaskArchiveAccess(
-  userContext: UserContext,
+  vars: EnvVariables["Variables"],
   taskId: string,
   tx: Prisma.TransactionClient = prisma,
 ): Promise<Task> {
+  const userContext = requireUserContext(vars.authContext);
+
   const owned = await tx.task.findFirst({
     where: {
       id: taskId,
@@ -156,15 +161,20 @@ export async function requireTaskArchiveAccess(
     throw notFound("Task not found");
   }
 
-  // Any org member of the task workspace's organization (not workspace-scoped
-  // like cancel, which requires the active workspace context).
-  await resolveMemberOrganizationById({
-    id: organizationId,
-    userId: userContext.userId,
+  // Match cancel: task must be in the active workspace; personal-workspace
+  // non-owners are denied.
+  const workspace = requireWorkspaceContext(vars.workspaceContext);
+  const workspaceTask = await requireTaskReadForWorkspace(
+    workspace,
+    taskId,
     tx,
-  });
+  );
 
-  return task;
+  if (workspace.organizationId !== null) {
+    return workspaceTask;
+  }
+
+  throw notFound("Task not found");
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/core/src/helpers/access-control.ts
+++ b/apps/core/src/helpers/access-control.ts
@@ -23,10 +23,10 @@ import {
   requireWorkspaceContext,
   type WorkspaceContext,
 } from "@/middleware/workspace";
-
 import type { CoworkerCapability } from "./coworker-capability";
 import { forbidden, notFound } from "./error";
 import { resolveMemberOrganizationById } from "./organization";
+import { hasActiveTaskSchedule } from "./task-schedule";
 import {
   getWorkspaceGrant,
   requestWorkspaceGrantCommitted,
@@ -104,7 +104,7 @@ export async function requireMutableTaskOwnership(
 
 /**
  * Soft-archive access: task owner always, or org OWNER/ADMIN when the task is
- * parked (`GRANT_PENDING`) in that organization workspace.
+ * parked (`GRANT_PENDING`) or has an active schedule in that organization workspace.
  */
 export async function requireTaskArchiveAccess(
   userContext: UserContext,
@@ -123,29 +123,36 @@ export async function requireTaskArchiveAccess(
     return owned;
   }
 
-  const parked = await tx.task.findFirst({
+  const task = await tx.task.findFirst({
     where: {
       id: taskId,
       archivedAt: null,
-      status: TaskStatus.GRANT_PENDING,
     },
     include: {
       workspace: { select: { organizationId: true } },
     },
   });
 
-  if (!parked?.workspace.organizationId) {
+  const organizationId = task?.workspace.organizationId;
+  if (!task || !organizationId) {
+    throw notFound("Task not found");
+  }
+
+  const isParked = task.status === TaskStatus.GRANT_PENDING;
+  const isScheduled = hasActiveTaskSchedule(task.metadata, task.nextRunAt);
+
+  if (!isParked && !isScheduled) {
     throw notFound("Task not found");
   }
 
   await resolveMemberOrganizationById({
-    id: parked.workspace.organizationId,
+    id: organizationId,
     userId: userContext.userId,
     tx,
     allowedRoles: [MemberRole.OWNER, MemberRole.ADMIN],
   });
 
-  return parked;
+  return task;
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/core/src/helpers/task-schedule.ts
+++ b/apps/core/src/helpers/task-schedule.ts
@@ -233,6 +233,13 @@ export function parseTaskScheduleMetadata(
   }
 }
 
+export function hasActiveTaskSchedule(
+  metadata: string | null | undefined,
+  nextRunAt: Date | null | undefined,
+): boolean {
+  return Boolean(parseTaskScheduleMetadata(metadata) || nextRunAt);
+}
+
 export function buildTaskScheduleMetadata(
   input: PutTaskScheduleRequest,
   scheduledAt: Date,

--- a/apps/core/src/helpers/task-schedule.ts
+++ b/apps/core/src/helpers/task-schedule.ts
@@ -233,13 +233,6 @@ export function parseTaskScheduleMetadata(
   }
 }
 
-export function hasActiveTaskSchedule(
-  metadata: string | null | undefined,
-  nextRunAt: Date | null | undefined,
-): boolean {
-  return Boolean(parseTaskScheduleMetadata(metadata) || nextRunAt);
-}
-
 export function buildTaskScheduleMetadata(
   input: PutTaskScheduleRequest,
   scheduledAt: Date,

--- a/apps/core/src/routes/v1/tasks/[id]/delete.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/delete.ts
@@ -27,7 +27,7 @@ const route = createRoute({
   method: "delete",
   path: "/{id}",
   description:
-    "Archive task. Owners may archive any of their tasks (including parked). Organization owners/admins may archive parked tasks awaiting vendor workspace grant approval or scheduled tasks owned by other members.",
+    "Archive task. Owners may archive any of their tasks (including parked). Organization owners/admins may archive parked tasks awaiting vendor workspace grant approval. Any organization member may archive scheduled tasks owned by other members.",
   tags: ["Tasks"],
   request: {
     params: paramsSchema,

--- a/apps/core/src/routes/v1/tasks/[id]/delete.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/delete.ts
@@ -27,7 +27,7 @@ const route = createRoute({
   method: "delete",
   path: "/{id}",
   description:
-    "Archive task. Owners may archive any of their tasks (including parked). Organization owners/admins may archive parked tasks awaiting vendor workspace grant approval.",
+    "Archive task. Owners may archive any of their tasks (including parked). Organization owners/admins may archive parked tasks awaiting vendor workspace grant approval or scheduled tasks owned by other members.",
   tags: ["Tasks"],
   request: {
     params: paramsSchema,

--- a/apps/core/src/routes/v1/tasks/[id]/delete.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/delete.ts
@@ -27,7 +27,7 @@ const route = createRoute({
   method: "delete",
   path: "/{id}",
   description:
-    "Archive task. Owners may archive any of their tasks (including parked). Organization owners/admins may archive parked tasks awaiting vendor workspace grant approval. Any organization member may archive scheduled tasks owned by other members.",
+    "Archive task. Owners may archive any of their tasks (including parked). Organization owners/admins may archive parked tasks awaiting vendor workspace grant approval. Organization workspace members may archive scheduled tasks in the active workspace (same scoping as cancel).",
   tags: ["Tasks"],
   request: {
     params: paramsSchema,
@@ -45,11 +45,11 @@ const route = createRoute({
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const { authContext } = c.var;
-    const userContext = requireOwnerUserContext(authContext);
+    requireOwnerUserContext(authContext);
     const { id } = c.req.valid("param");
 
     const task = await prisma.$transaction(async (tx) => {
-      const currentTask = await requireTaskArchiveAccess(userContext, id, tx);
+      const currentTask = await requireTaskArchiveAccess(c.var, id, tx);
 
       if (!canArchiveTaskStatus(currentTask.status)) {
         throw unprocessableEntity(

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -750,6 +750,30 @@ describe("TaskDetailActions", () => {
     expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
   });
 
+  it("shows cancel and archive for org member on a queued scheduled task they do not own", async () => {
+    const user = userEvent.setup();
+    renderActions({
+      status: TaskStatus.QUEUED,
+      isReadOnly: true,
+      canCancel: true,
+      isTaskOwner: false,
+      isOrgOwnerOrAdmin: false,
+      hasActiveSchedule: true,
+      currentOrganizationId: "org-current",
+      organizations: undefined,
+    });
+
+    await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
+
+    expect(
+      screen.getByRole("menuitem", { name: labels.cancel }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: labels.archive }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
+  });
+
   it("hides share and overflow actions in read-only workspace mode", () => {
     renderActions({
       isReadOnly: true,

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -701,6 +701,26 @@ describe("TaskDetailActions", () => {
     expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
   });
 
+  it("shows archive for org admin on a scheduled task they do not own", async () => {
+    const user = userEvent.setup();
+    renderActions({
+      status: TaskStatus.READY,
+      isReadOnly: true,
+      isTaskOwner: false,
+      isOrgOwnerOrAdmin: true,
+      hasActiveSchedule: true,
+      currentOrganizationId: "org-current",
+      organizations: undefined,
+    });
+
+    await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
+
+    expect(
+      screen.getByRole("menuitem", { name: labels.archive }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
+  });
+
   it("hides share and overflow actions in read-only workspace mode", () => {
     renderActions({
       isReadOnly: true,

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -701,13 +701,13 @@ describe("TaskDetailActions", () => {
     expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
   });
 
-  it("shows archive for org admin on a scheduled task they do not own", async () => {
+  it("shows archive for org member on a scheduled task they do not own", async () => {
     const user = userEvent.setup();
     renderActions({
       status: TaskStatus.READY,
       isReadOnly: true,
       isTaskOwner: false,
-      isOrgOwnerOrAdmin: true,
+      isOrgOwnerOrAdmin: false,
       hasActiveSchedule: true,
       currentOrganizationId: "org-current",
       organizations: undefined,

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -750,6 +750,23 @@ describe("TaskDetailActions", () => {
     expect(screen.queryByRole("menuitem", { name: labels.edit })).toBeNull();
   });
 
+  it("hides archive for plain org member on grant-pending scheduled task", async () => {
+    renderActions({
+      status: "GRANT_PENDING" as TaskStatus,
+      isReadOnly: true,
+      isTaskOwner: false,
+      isOrgOwnerOrAdmin: false,
+      hasActiveSchedule: true,
+      currentOrganizationId: "org-current",
+      organizations: undefined,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: actionsMenuLabel }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: labels.archive })).toBeNull();
+  });
+
   it("shows cancel and archive for org member on a queued scheduled task they do not own", async () => {
     const user = userEvent.setup();
     renderActions({

--- a/apps/web/src/app/(app)/tasks/components/task-card.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-card.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { hasActiveTaskSchedule } from "@sokosumi/utils";
 import type { TaskWithCoworker } from "@/app/tasks/types/task-board";
 import { TaskScheduleDisplay } from "@/components/task-schedule-display";
 import { TaskStatus } from "@/lib/clients/generated/core";
 import type { TaskStatus as TaskStatusType } from "@/lib/types/core-dto";
 import { cn } from "@/lib/utils";
-import { hasActiveSchedule } from "@/lib/utils/task-schedule";
 import { TaskDetailLink } from "./task-detail-link";
 import type { DragHandleProps } from "./task-dnd";
 import { TaskMetaDetails } from "./task-meta";
@@ -75,7 +75,7 @@ export function TaskCard({
             ) : null}
 
             {task.status === TaskStatus.QUEUED &&
-            hasActiveSchedule(
+            hasActiveTaskSchedule(
               task.metadata,
               task.nextRunAt ? new Date(task.nextRunAt) : null,
             ) ? (

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -31,7 +31,10 @@ import { useTranslations } from "next-intl";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
-import { canArchiveParkedTaskForViewer } from "@/app/tasks/utils/task-read-only";
+import {
+  canArchiveParkedTaskForViewer,
+  canArchiveScheduledTaskForViewer,
+} from "@/app/tasks/utils/task-read-only";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -129,6 +132,7 @@ interface TaskDetailActionsProps {
   forceReadOnly?: boolean;
   isTaskOwner?: boolean;
   isOrgOwnerOrAdmin?: boolean;
+  hasActiveSchedule?: boolean;
 }
 
 export function TaskDetailActions({
@@ -150,6 +154,7 @@ export function TaskDetailActions({
   forceReadOnly = false,
   isTaskOwner = false,
   isOrgOwnerOrAdmin = false,
+  hasActiveSchedule = false,
 }: TaskDetailActionsProps) {
   const tApp = useTranslations("App");
   const tDetailActions = useTranslations("App.Tasks.Detail.actions");
@@ -210,8 +215,17 @@ export function TaskDetailActions({
     isTaskOwner,
     isOrgOwnerOrAdmin,
   });
+  const canArchiveScheduled = canArchiveScheduledTaskForViewer({
+    forceReadOnly,
+    taskStatus: status,
+    isTaskOwner,
+    isOrgOwnerOrAdmin,
+    taskWorkspaceOrganizationId: currentOrganizationId ?? null,
+    hasActiveSchedule,
+  });
   const canArchiveTask =
     canArchiveParked ||
+    canArchiveScheduled ||
     (isTaskArchivableStatus(status) && !isReadOnly && !forceReadOnly);
   const isFinalized =
     status === TaskStatus.COMPLETED ||

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -219,7 +219,6 @@ export function TaskDetailActions({
     forceReadOnly,
     taskStatus: status,
     isTaskOwner,
-    isOrgOwnerOrAdmin,
     taskWorkspaceOrganizationId: currentOrganizationId ?? null,
     hasActiveSchedule,
   });

--- a/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
@@ -35,6 +35,7 @@ import { projectService } from "@/lib/services/project.service";
 import { userService } from "@/lib/services/user.service";
 import { resolveAccountName } from "@/lib/utils/account-name";
 import { formatShortDateTime } from "@/lib/utils/datetime";
+import { hasActiveSchedule } from "@/lib/utils/task-schedule";
 import {
   buildVendorGrantReviewHref,
   canApproveVendorGrants,
@@ -483,6 +484,7 @@ async function TaskDetailActionsSlot({
       forceReadOnly={forceReadOnly}
       isTaskOwner={session?.user.id === task.ownerId}
       isOrgOwnerOrAdmin={isOrgOwnerOrAdmin}
+      hasActiveSchedule={hasActiveSchedule(task.metadata, task.nextRunAt)}
       actionsMenuLabel={tMembersTableHeader("actions")}
       labels={{
         edit: t("actions.edit"),

--- a/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
@@ -1,5 +1,8 @@
-import type { SubscriptionPlanName } from "@sokosumi/utils";
-import { resolveIpfsOrHttpUrl } from "@sokosumi/utils";
+import {
+  hasActiveTaskSchedule,
+  resolveIpfsOrHttpUrl,
+  type SubscriptionPlanName,
+} from "@sokosumi/utils";
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
@@ -35,7 +38,6 @@ import { projectService } from "@/lib/services/project.service";
 import { userService } from "@/lib/services/user.service";
 import { resolveAccountName } from "@/lib/utils/account-name";
 import { formatShortDateTime } from "@/lib/utils/datetime";
-import { hasActiveSchedule } from "@/lib/utils/task-schedule";
 import {
   buildVendorGrantReviewHref,
   canApproveVendorGrants,
@@ -484,7 +486,7 @@ async function TaskDetailActionsSlot({
       forceReadOnly={forceReadOnly}
       isTaskOwner={session?.user.id === task.ownerId}
       isOrgOwnerOrAdmin={isOrgOwnerOrAdmin}
-      hasActiveSchedule={hasActiveSchedule(task.metadata, task.nextRunAt)}
+      hasActiveSchedule={hasActiveTaskSchedule(task.metadata, task.nextRunAt)}
       actionsMenuLabel={tMembersTableHeader("actions")}
       labels={{
         edit: t("actions.edit"),

--- a/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-dnd.tsx
@@ -7,6 +7,7 @@ import {
   useDraggable,
   useDroppable,
 } from "@dnd-kit/core";
+import { hasActiveTaskSchedule } from "@sokosumi/utils";
 import { type CSSProperties, type ReactNode, useRef } from "react";
 import type {
   KanbanColumnId,
@@ -14,7 +15,6 @@ import type {
 } from "@/app/tasks/types/task-board";
 import { TaskStatus } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
-import { hasActiveSchedule } from "@/lib/utils/task-schedule";
 
 /** Columns whose tasks can be dragged. */
 const DND_DRAG_COLUMNS = new Set<KanbanColumnId>(["backlog", "todo", "done"]);
@@ -84,7 +84,7 @@ export function isTaskDnDDraggable(
     return true;
   }
 
-  return !hasActiveSchedule(
+  return !hasActiveTaskSchedule(
     task.metadata,
     task.nextRunAt ? new Date(task.nextRunAt) : null,
   );

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
@@ -201,6 +201,37 @@ describe("canArchiveScheduledTaskForViewer", () => {
       }),
     ).toBe(false);
   });
+
+  it("blocks grant-pending scheduled tasks for plain org members", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.GRANT_PENDING,
+        isTaskOwner: false,
+        taskWorkspaceOrganizationId: "org_1",
+        hasActiveSchedule: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps parked archive on owner/admin for grant-pending scheduled tasks", () => {
+    expect(
+      canArchiveParkedTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.GRANT_PENDING,
+        isTaskOwner: true,
+        isOrgOwnerOrAdmin: false,
+      }),
+    ).toBe(true);
+    expect(
+      canArchiveParkedTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.GRANT_PENDING,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: true,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("canCommentOnTaskForViewer", () => {

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
@@ -142,52 +142,36 @@ describe("canArchiveParkedTaskForViewer", () => {
 });
 
 describe("canArchiveScheduledTaskForViewer", () => {
-  it("allows org owner/admin to archive a scheduled task they do not own", () => {
+  it("allows any org collaborator to archive a scheduled task they do not own", () => {
     expect(
       canArchiveScheduledTaskForViewer({
         forceReadOnly: false,
         taskStatus: TaskStatus.READY,
         isTaskOwner: false,
-        isOrgOwnerOrAdmin: true,
         taskWorkspaceOrganizationId: "org_1",
         hasActiveSchedule: true,
       }),
     ).toBe(true);
   });
 
-  it("blocks plain members from archiving scheduled tasks they do not own", () => {
+  it("blocks when the task has no active schedule", () => {
     expect(
       canArchiveScheduledTaskForViewer({
         forceReadOnly: false,
         taskStatus: TaskStatus.READY,
         isTaskOwner: false,
-        isOrgOwnerOrAdmin: false,
-        taskWorkspaceOrganizationId: "org_1",
-        hasActiveSchedule: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("blocks org owner/admin when the task has no active schedule", () => {
-    expect(
-      canArchiveScheduledTaskForViewer({
-        forceReadOnly: false,
-        taskStatus: TaskStatus.READY,
-        isTaskOwner: false,
-        isOrgOwnerOrAdmin: true,
         taskWorkspaceOrganizationId: "org_1",
         hasActiveSchedule: false,
       }),
     ).toBe(false);
   });
 
-  it("blocks org owner/admin for personal-workspace scheduled tasks", () => {
+  it("blocks personal-workspace scheduled tasks for non-owners", () => {
     expect(
       canArchiveScheduledTaskForViewer({
         forceReadOnly: false,
         taskStatus: TaskStatus.READY,
         isTaskOwner: false,
-        isOrgOwnerOrAdmin: true,
         taskWorkspaceOrganizationId: null,
         hasActiveSchedule: true,
       }),
@@ -200,7 +184,6 @@ describe("canArchiveScheduledTaskForViewer", () => {
         forceReadOnly: true,
         taskStatus: TaskStatus.READY,
         isTaskOwner: false,
-        isOrgOwnerOrAdmin: true,
         taskWorkspaceOrganizationId: "org_1",
         hasActiveSchedule: true,
       }),
@@ -213,7 +196,6 @@ describe("canArchiveScheduledTaskForViewer", () => {
         forceReadOnly: false,
         taskStatus: TaskStatus.RUNNING,
         isTaskOwner: false,
-        isOrgOwnerOrAdmin: true,
         taskWorkspaceOrganizationId: "org_1",
         hasActiveSchedule: true,
       }),

--- a/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
+++ b/apps/web/src/app/(app)/tasks/utils/__tests__/task-read-only.test.ts
@@ -3,6 +3,7 @@ import { TaskStatus } from "@/lib/clients/generated/core";
 
 import {
   canArchiveParkedTaskForViewer,
+  canArchiveScheduledTaskForViewer,
   canCancelTaskForViewer,
   canCommentOnTaskForViewer,
   isReadOnlyForViewer,
@@ -135,6 +136,86 @@ describe("canArchiveParkedTaskForViewer", () => {
         taskStatus: TaskStatus.GRANT_PENDING,
         isTaskOwner: true,
         isOrgOwnerOrAdmin: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("canArchiveScheduledTaskForViewer", () => {
+  it("allows org owner/admin to archive a scheduled task they do not own", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.READY,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: true,
+        taskWorkspaceOrganizationId: "org_1",
+        hasActiveSchedule: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks plain members from archiving scheduled tasks they do not own", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.READY,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: false,
+        taskWorkspaceOrganizationId: "org_1",
+        hasActiveSchedule: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks org owner/admin when the task has no active schedule", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.READY,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: true,
+        taskWorkspaceOrganizationId: "org_1",
+        hasActiveSchedule: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks org owner/admin for personal-workspace scheduled tasks", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.READY,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: true,
+        taskWorkspaceOrganizationId: null,
+        hasActiveSchedule: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("never unlocks archive under forceReadOnly", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: true,
+        taskStatus: TaskStatus.READY,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: true,
+        taskWorkspaceOrganizationId: "org_1",
+        hasActiveSchedule: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks non-archivable statuses even when scheduled", () => {
+    expect(
+      canArchiveScheduledTaskForViewer({
+        forceReadOnly: false,
+        taskStatus: TaskStatus.RUNNING,
+        isTaskOwner: false,
+        isOrgOwnerOrAdmin: true,
+        taskWorkspaceOrganizationId: "org_1",
+        hasActiveSchedule: true,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
@@ -61,18 +61,21 @@ export function canArchiveParkedTaskForViewer({
   return isTaskOwner || isOrgOwnerOrAdmin;
 }
 
+/**
+ * Any org-workspace collaborator may archive a scheduled task they do not own
+ * (mirrors Core scheduled-archive membership gate). Parked archive stays on
+ * {@link canArchiveParkedTaskForViewer}.
+ */
 export function canArchiveScheduledTaskForViewer({
   forceReadOnly,
   taskStatus,
   isTaskOwner,
-  isOrgOwnerOrAdmin,
   taskWorkspaceOrganizationId,
   hasActiveSchedule,
 }: {
   forceReadOnly: boolean;
   taskStatus: string;
   isTaskOwner: boolean;
-  isOrgOwnerOrAdmin: boolean;
   taskWorkspaceOrganizationId: string | null;
   hasActiveSchedule: boolean;
 }): boolean {
@@ -80,7 +83,7 @@ export function canArchiveScheduledTaskForViewer({
     return false;
   }
 
-  if (!isOrgOwnerOrAdmin || taskWorkspaceOrganizationId === null) {
+  if (taskWorkspaceOrganizationId === null) {
     return false;
   }
 

--- a/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
@@ -63,8 +63,8 @@ export function canArchiveParkedTaskForViewer({
 
 /**
  * Any org-workspace collaborator may archive a scheduled task they do not own
- * (mirrors Core scheduled-archive membership gate). Parked archive stays on
- * {@link canArchiveParkedTaskForViewer}.
+ * (mirrors Core scheduled-archive membership gate). Parked (`GRANT_PENDING`)
+ * stays on {@link canArchiveParkedTaskForViewer} (owner/admin only).
  */
 export function canArchiveScheduledTaskForViewer({
   forceReadOnly,
@@ -79,7 +79,7 @@ export function canArchiveScheduledTaskForViewer({
   taskWorkspaceOrganizationId: string | null;
   hasActiveSchedule: boolean;
 }): boolean {
-  if (forceReadOnly || isTaskOwner) {
+  if (forceReadOnly || isTaskOwner || isGrantPendingStatus(taskStatus)) {
     return false;
   }
 

--- a/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
@@ -1,3 +1,5 @@
+import { isTaskArchivableStatus } from "@sokosumi/utils";
+
 import { TaskStatus } from "@/lib/clients/generated/core";
 
 interface ReadOnlyForViewerParams {
@@ -57,6 +59,36 @@ export function canArchiveParkedTaskForViewer({
   }
 
   return isTaskOwner || isOrgOwnerOrAdmin;
+}
+
+export function canArchiveScheduledTaskForViewer({
+  forceReadOnly,
+  taskStatus,
+  isTaskOwner,
+  isOrgOwnerOrAdmin,
+  taskWorkspaceOrganizationId,
+  hasActiveSchedule,
+}: {
+  forceReadOnly: boolean;
+  taskStatus: string;
+  isTaskOwner: boolean;
+  isOrgOwnerOrAdmin: boolean;
+  taskWorkspaceOrganizationId: string | null;
+  hasActiveSchedule: boolean;
+}): boolean {
+  if (forceReadOnly || isTaskOwner) {
+    return false;
+  }
+
+  if (!isOrgOwnerOrAdmin || taskWorkspaceOrganizationId === null) {
+    return false;
+  }
+
+  if (!hasActiveSchedule || !isTaskArchivableStatus(taskStatus)) {
+    return false;
+  }
+
+  return true;
 }
 
 type OrgCollaboratorViewerParams = ReadOnlyForViewerParams;

--- a/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
+++ b/apps/web/src/app/(app)/tasks/utils/task-read-only.ts
@@ -63,8 +63,9 @@ export function canArchiveParkedTaskForViewer({
 
 /**
  * Any org-workspace collaborator may archive a scheduled task they do not own
- * (mirrors Core scheduled-archive membership gate). Parked (`GRANT_PENDING`)
- * stays on {@link canArchiveParkedTaskForViewer} (owner/admin only).
+ * (mirrors Core scheduled-archive active-workspace gate, same as cancel).
+ * Parked (`GRANT_PENDING`) stays on {@link canArchiveParkedTaskForViewer}
+ * (owner/admin only). Viewer only sees tasks in the active workspace.
  */
 export function canArchiveScheduledTaskForViewer({
   forceReadOnly,

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { userTaskStatusTransitionRequiresComment } from "@sokosumi/utils";
+import {
+  hasActiveTaskSchedule,
+  userTaskStatusTransitionRequiresComment,
+} from "@sokosumi/utils";
 import { revalidatePath } from "next/cache";
 
 import {
@@ -19,7 +22,6 @@ import { taskScheduleService } from "@/lib/services/task-schedule.service";
 import type { TaskScheduleSelection } from "@/lib/types/task-schedule";
 import { normalizeOptionalProjectId } from "@/lib/utils/project";
 import {
-  hasActiveSchedule,
   hasTaskScheduleChanged,
   selectionToApiBody,
 } from "@/lib/utils/task-schedule";
@@ -514,7 +516,7 @@ export const setTaskStatusFromDrag = withSession<
     const shouldClearSchedule =
       currentStatus === TaskStatus.QUEUED &&
       desiredStatus !== TaskStatus.QUEUED &&
-      hasActiveSchedule(task.metadata, task.nextRunAt);
+      hasActiveTaskSchedule(task.metadata, task.nextRunAt);
 
     if (shouldClearSchedule) {
       const clearedTask = await taskScheduleService.clearSchedule(taskId);

--- a/apps/web/src/lib/utils/task-schedule.ts
+++ b/apps/web/src/lib/utils/task-schedule.ts
@@ -275,13 +275,6 @@ export function isValidCronExpression(expr: string, timezone: string): boolean {
   }
 }
 
-export function hasActiveSchedule(
-  metadata: string | null | undefined,
-  nextRunAt: Date | null | undefined,
-): boolean {
-  return Boolean(parseTaskScheduleMetadata(metadata) || nextRunAt);
-}
-
 function normalizeScheduleApiBodyValue(value: unknown): unknown {
   if (value instanceof Date) {
     return value.toISOString();

--- a/packages/utils/src/__tests__/task-schedule.test.ts
+++ b/packages/utils/src/__tests__/task-schedule.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { hasActiveTaskSchedule } from "../task-schedule.js";
+
+const onceMetadata = JSON.stringify({
+  version: 1,
+  mode: "once",
+  scheduledAt: "2026-08-01T10:00:00.000Z",
+  runAt: "2026-08-01T10:00:00.000Z",
+});
+
+const recurringMetadata = JSON.stringify({
+  version: 1,
+  mode: "recurring",
+  scheduledAt: "2026-08-01T10:00:00.000Z",
+  expr: "0 9 * * *",
+  timezone: "UTC",
+  endsMode: "never",
+});
+
+describe("hasActiveTaskSchedule", () => {
+  it("returns true for valid once metadata without nextRunAt", () => {
+    expect(hasActiveTaskSchedule(onceMetadata, null)).toBe(true);
+  });
+
+  it("returns true for valid recurring metadata without nextRunAt", () => {
+    expect(hasActiveTaskSchedule(recurringMetadata, null)).toBe(true);
+  });
+
+  it("returns true when only nextRunAt is set (Date)", () => {
+    expect(
+      hasActiveTaskSchedule(null, new Date("2026-08-01T10:00:00.000Z")),
+    ).toBe(true);
+  });
+
+  it("returns true when only nextRunAt is set (ISO string)", () => {
+    expect(hasActiveTaskSchedule(null, "2026-08-01T10:00:00.000Z")).toBe(true);
+  });
+
+  it("returns false when both are empty", () => {
+    expect(hasActiveTaskSchedule(null, null)).toBe(false);
+    expect(hasActiveTaskSchedule(undefined, undefined)).toBe(false);
+    expect(hasActiveTaskSchedule("", null)).toBe(false);
+  });
+
+  it("returns false for invalid JSON metadata without nextRunAt", () => {
+    expect(hasActiveTaskSchedule("{not-json", null)).toBe(false);
+  });
+
+  it("returns false for unsupported version/mode without nextRunAt", () => {
+    expect(
+      hasActiveTaskSchedule(JSON.stringify({ version: 2, mode: "once" }), null),
+    ).toBe(false);
+    expect(
+      hasActiveTaskSchedule(
+        JSON.stringify({ version: 1, mode: "other" }),
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when nextRunAt is present even if metadata is invalid", () => {
+    expect(
+      hasActiveTaskSchedule("{not-json", new Date("2026-08-01T10:00:00.000Z")),
+    ).toBe(true);
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -203,6 +203,7 @@ export {
   TASK_FILE_MAX_NAME_LENGTH,
   TASK_FILE_MAX_SIZE_BYTES,
 } from "./task-file-upload.js";
+export { hasActiveTaskSchedule } from "./task-schedule.js";
 export {
   canUserTransitionTaskStatus,
   type UserTransitionTaskStatus,

--- a/packages/utils/src/task-schedule.ts
+++ b/packages/utils/src/task-schedule.ts
@@ -1,0 +1,42 @@
+/**
+ * Lightweight schedule detection shared by Core access control and web UI.
+ *
+ * Structural metadata check only (version + mode). Full field validation stays
+ * in Core's Zod `parseTaskScheduleMetadata` for write/sync paths.
+ */
+
+function hasTaskScheduleMetadataShape(
+  metadata: string | null | undefined,
+): boolean {
+  if (!metadata) {
+    return false;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    if (!parsed || typeof parsed !== "object") {
+      return false;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (record.version !== 1) {
+      return false;
+    }
+
+    return record.mode === "once" || record.mode === "recurring";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether a task currently has an active schedule (metadata or nextRunAt).
+ *
+ * Accepts `Date` (Prisma) or ISO string (API DTOs).
+ */
+export function hasActiveTaskSchedule(
+  metadata: string | null | undefined,
+  nextRunAt: Date | string | null | undefined,
+): boolean {
+  return hasTaskScheduleMetadataShape(metadata) || Boolean(nextRunAt);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Any organization member can **archive** or **cancel** scheduled tasks in the same org workspace, even when they did not create them.

**Behavior**
- **Cancel** (`QUEUED` → Canceled): clears schedule metadata/`nextRunAt` and stops schedule-sync revive (via [#3464](https://github.com/masumi-network/sokosumi/pull/3464)); any org member via existing cancel access
- **Archive**: soft-delete; any org member when the task has an active schedule (`requireTaskArchiveAccess`); OWNER/ADMIN still required for parked `GRANT_PENDING`
- Scheduled non-owner archive uses the **same active-workspace gate as cancel** (not org-wide membership alone)
- UI shows Cancel and Archive for eligible non-owners on scheduled/queued tasks
- Non-scheduled others’ tasks stay owner-only; coworker actors stay out

**Review follow-up**
- Hide scheduled-archive UI for parked `GRANT_PENDING` so Web matches Core parked-first ACL
- Regression tests for parked+scheduled + plain org member
- Scope scheduled archive to active workspace for product parity with cancel

**Verification**
- `pnpm --filter core test src/helpers/access-control.test.ts`
- `pnpm --filter web test` task-detail-actions / task-read-only tests

Linear Issue: [SOK-663](https://linear.app/masumi/issue/SOK-663/delete-scheduled-tasks-created-by-other-coworkers)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-663](https://linear.app/masumi/issue/SOK-663/delete-scheduled-tasks-created-by-other-coworkers)

<div><a href="https://cursor.com/agents/bc-ed8f72ae-ec3f-444e-88a8-b77832f6e380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed8f72ae-ec3f-444e-88a8-b77832f6e380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

