### PR TITLE
fix(core): cancel scheduled tasks clears schedule and stops sync revive

### DIFF
--- a/apps/core/src/helpers/task.test.ts
+++ b/apps/core/src/helpers/task.test.ts
@@ -749,17 +749,29 @@ describe("task cancel helpers", () => {
       .mockResolvedValueOnce({ count: 1 });
     const taskLinkFindMany = vi.fn().mockResolvedValue([
       {
-        toTask: { id: "tsk_child_running", status: TaskStatus.RUNNING },
+        toTask: {
+          id: "tsk_child_running",
+          status: TaskStatus.RUNNING,
+          ownerId: "user_123",
+        },
       },
       {
-        toTask: { id: "tsk_child_done", status: TaskStatus.COMPLETED },
+        toTask: {
+          id: "tsk_child_done",
+          status: TaskStatus.COMPLETED,
+          ownerId: "user_123",
+        },
       },
       {
-        toTask: { id: "tsk_child_ready", status: TaskStatus.READY },
+        toTask: {
+          id: "tsk_child_ready",
+          status: TaskStatus.READY,
+          ownerId: "user_other",
+        },
       },
     ]);
 
-    await cascadeCancelNonTerminalParentChildren({
+    const canceledChildren = await cascadeCancelNonTerminalParentChildren({
       tx: {
         taskLink: { findMany: taskLinkFindMany },
         taskEvent: { create: taskEventCreate },
@@ -793,6 +805,10 @@ describe("task cancel helpers", () => {
         },
       }),
     );
+    expect(canceledChildren).toEqual([
+      { taskId: "tsk_child_running", userId: "user_123" },
+      { taskId: "tsk_child_ready", userId: "user_other" },
+    ]);
   });
 });
 

--- a/apps/core/src/helpers/task.test.ts
+++ b/apps/core/src/helpers/task.test.ts
@@ -1,11 +1,14 @@
 import { Channel, GrantResumeStatus, TaskStatus } from "@sokosumi/database";
 import { convertCreditsToCents } from "@sokosumi/utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AuthenticationContext } from "@/middleware/auth";
 import { TEST_VENDOR_ID } from "@/test-fixtures/vendor.js";
 import type { TaskWithIncludes } from "@/types/task";
 
 import {
+  cascadeCancelNonTerminalParentChildren,
+  getTaskStatusUpdateDataForEvent,
+  isTerminalTaskStatus,
   mapTask,
   mapTaskEvent,
   mapTaskEventActor,
@@ -451,6 +454,7 @@ describe("validateStatusTransition", () => {
       [TaskStatus.READY, TaskStatus.QUEUED],
       [TaskStatus.QUEUED, TaskStatus.DRAFT],
       [TaskStatus.QUEUED, TaskStatus.READY],
+      [TaskStatus.QUEUED, TaskStatus.CANCELED],
     ])("accepts %s → %s", (from, to) => {
       expect(() =>
         validateStatusTransition(userContext, from, to),
@@ -714,6 +718,81 @@ describe("validateStatusTransition", () => {
         ),
       ).toThrow("Invalid status transition from QUEUED to RUNNING");
     });
+  });
+});
+
+describe("task cancel helpers", () => {
+  it("identifies terminal task statuses", () => {
+    expect(isTerminalTaskStatus(TaskStatus.COMPLETED)).toBe(true);
+    expect(isTerminalTaskStatus(TaskStatus.FAILED)).toBe(true);
+    expect(isTerminalTaskStatus(TaskStatus.CANCELED)).toBe(true);
+    expect(isTerminalTaskStatus(TaskStatus.RUNNING)).toBe(false);
+    expect(isTerminalTaskStatus(TaskStatus.QUEUED)).toBe(false);
+  });
+
+  it("clears schedule fields when canceling", () => {
+    expect(getTaskStatusUpdateDataForEvent(TaskStatus.CANCELED)).toEqual({
+      status: TaskStatus.CANCELED,
+      metadata: null,
+      nextRunAt: null,
+    });
+    expect(getTaskStatusUpdateDataForEvent(TaskStatus.READY)).toEqual({
+      status: TaskStatus.READY,
+    });
+  });
+
+  it("cascades cancel to non-terminal PARENT children", async () => {
+    const taskEventCreate = vi.fn().mockResolvedValue({ id: "evt_child" });
+    const taskUpdateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 });
+    const taskLinkFindMany = vi.fn().mockResolvedValue([
+      {
+        toTask: { id: "tsk_child_running", status: TaskStatus.RUNNING },
+      },
+      {
+        toTask: { id: "tsk_child_done", status: TaskStatus.COMPLETED },
+      },
+      {
+        toTask: { id: "tsk_child_ready", status: TaskStatus.READY },
+      },
+    ]);
+
+    await cascadeCancelNonTerminalParentChildren({
+      tx: {
+        taskLink: { findMany: taskLinkFindMany },
+        taskEvent: { create: taskEventCreate },
+        task: { updateMany: taskUpdateMany },
+      } as never,
+      parentTaskId: "tsk_template",
+      actorData: {
+        userId: "user_123",
+        coworkerId: null,
+        orchestratorId: null,
+      },
+    });
+
+    expect(taskLinkFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          fromTaskId: "tsk_template",
+          type: "PARENT",
+        },
+      }),
+    );
+    expect(taskEventCreate).toHaveBeenCalledTimes(2);
+    expect(taskUpdateMany).toHaveBeenCalledTimes(2);
+    expect(taskUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "tsk_child_running", status: TaskStatus.RUNNING },
+        data: {
+          status: TaskStatus.CANCELED,
+          metadata: null,
+          nextRunAt: null,
+        },
+      }),
+    );
   });
 });
 

--- a/apps/core/src/helpers/task.ts
+++ b/apps/core/src/helpers/task.ts
@@ -300,11 +300,16 @@ interface CascadeCancelParentChildrenParams {
   actorData: TaskEventActorData;
 }
 
+export interface CascadedCancelChild {
+  taskId: string;
+  userId: string;
+}
+
 export async function cascadeCancelNonTerminalParentChildren({
   tx,
   parentTaskId,
   actorData,
-}: CascadeCancelParentChildrenParams): Promise<void> {
+}: CascadeCancelParentChildrenParams): Promise<CascadedCancelChild[]> {
   const parentLinks = await tx.taskLink.findMany({
     where: {
       fromTaskId: parentTaskId,
@@ -315,10 +320,13 @@ export async function cascadeCancelNonTerminalParentChildren({
         select: {
           id: true,
           status: true,
+          ownerId: true,
         },
       },
     },
   });
+
+  const canceledChildren: CascadedCancelChild[] = [];
 
   for (const link of parentLinks) {
     const child = link.toTask;
@@ -342,7 +350,14 @@ export async function cascadeCancelNonTerminalParentChildren({
     if (childUpdate.count !== 1) {
       throw conflict("Task status was changed by another request");
     }
+
+    canceledChildren.push({
+      taskId: child.id,
+      userId: child.ownerId,
+    });
   }
+
+  return canceledChildren;
 }
 
 export function validateStatusTransition(

--- a/apps/core/src/helpers/task.ts
+++ b/apps/core/src/helpers/task.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from "@sokosumi/database";
+import { Channel, Prisma, TaskLinkType, TaskStatus } from "@sokosumi/database";
 import { convertCentsToCredits } from "@sokosumi/utils";
 
 import type { AuthenticationContext } from "@/middleware/auth";
@@ -14,7 +14,7 @@ import {
   taskEventApiInclude,
 } from "@/types/task";
 
-import { unprocessableEntity } from "./error";
+import { conflict, unprocessableEntity } from "./error";
 import {
   coworkerSummaryFromLoadedRelation,
   orchestratorSummaryFromLoadedRelation,
@@ -233,7 +233,11 @@ function getAllowedTransitions(
       TaskStatus.CANCELED,
       TaskStatus.QUEUED,
     ],
-    [TaskStatus.QUEUED]: [TaskStatus.DRAFT, TaskStatus.READY],
+    [TaskStatus.QUEUED]: [
+      TaskStatus.DRAFT,
+      TaskStatus.READY,
+      TaskStatus.CANCELED,
+    ],
     [TaskStatus.READY]: [
       TaskStatus.DRAFT,
       TaskStatus.CANCELED,
@@ -256,6 +260,89 @@ function getAllowedTransitions(
     // Users may reopen CANCELED → READY with a required comment (SOK-631).
     [TaskStatus.CANCELED]: [TaskStatus.READY],
   };
+}
+
+export const TERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.CANCELED,
+]);
+
+export function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return TERMINAL_TASK_STATUSES.has(status);
+}
+
+export function getTaskStatusUpdateDataForEvent(status: TaskStatus): {
+  status: TaskStatus;
+  metadata?: null;
+  nextRunAt?: null;
+} {
+  if (status === TaskStatus.CANCELED) {
+    return {
+      status,
+      metadata: null,
+      nextRunAt: null,
+    };
+  }
+
+  return { status };
+}
+
+interface TaskEventActorData {
+  userId: string | null;
+  coworkerId: string | null;
+  orchestratorId: string | null;
+}
+
+interface CascadeCancelParentChildrenParams {
+  tx: Prisma.TransactionClient;
+  parentTaskId: string;
+  actorData: TaskEventActorData;
+}
+
+export async function cascadeCancelNonTerminalParentChildren({
+  tx,
+  parentTaskId,
+  actorData,
+}: CascadeCancelParentChildrenParams): Promise<void> {
+  const parentLinks = await tx.taskLink.findMany({
+    where: {
+      fromTaskId: parentTaskId,
+      type: TaskLinkType.PARENT,
+    },
+    select: {
+      toTask: {
+        select: {
+          id: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  for (const link of parentLinks) {
+    const child = link.toTask;
+    if (isTerminalTaskStatus(child.status)) {
+      continue;
+    }
+
+    await tx.taskEvent.create({
+      data: {
+        taskId: child.id,
+        status: TaskStatus.CANCELED,
+        channel: Channel.SOKOSUMI,
+        ...actorData,
+      },
+    });
+
+    const childUpdate = await tx.task.updateMany({
+      where: { id: child.id, status: child.status },
+      data: getTaskStatusUpdateDataForEvent(TaskStatus.CANCELED),
+    });
+    if (childUpdate.count !== 1) {
+      throw conflict("Task status was changed by another request");
+    }
+  }
 }
 
 export function validateStatusTransition(

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -2855,7 +2855,11 @@ describe("POST /{id}/events", () => {
       taskLink: {
         findMany: vi.fn().mockResolvedValue([
           {
-            toTask: { id: "tsk_child", status: TaskStatus.RUNNING },
+            toTask: {
+              id: "tsk_child",
+              status: TaskStatus.RUNNING,
+              ownerId: USER_ID,
+            },
           },
         ]),
       },
@@ -2891,5 +2895,16 @@ describe("POST /{id}/events", () => {
         },
       }),
     );
+    expect(publishTaskEventDataMock).toHaveBeenCalledTimes(2);
+    expect(publishTaskEventDataMock).toHaveBeenCalledWith({
+      userId: USER_ID,
+      taskId: TASK_ID,
+      eventType: "task_event",
+    });
+    expect(publishTaskEventDataMock).toHaveBeenCalledWith({
+      userId: USER_ID,
+      taskId: "tsk_child",
+      eventType: "task_event",
+    });
   });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.test.ts
@@ -156,6 +156,9 @@ interface TransactionMock {
   task: {
     updateMany: ReturnType<typeof vi.fn>;
   };
+  taskLink?: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
 }
 
 function createTask(
@@ -240,6 +243,12 @@ function enrichTaskEventRowForResponse(record: TaskEventRecord) {
 }
 
 function mockTransaction(tx: TransactionMock) {
+  if (!tx.taskLink) {
+    tx.taskLink = {
+      findMany: vi.fn().mockResolvedValue([]),
+    };
+  }
+
   const innerCreate = tx.taskEvent.create;
   const findUnique = (tx.taskEvent.findUnique ??= vi.fn());
   tx.taskEvent.findFirst ??= vi.fn().mockResolvedValue(null);
@@ -2755,5 +2764,132 @@ describe("POST /{id}/events", () => {
     expect(createPurchaseFromMasumiTaskPaymentMock).not.toHaveBeenCalled();
     expect(createTaskEventTransactionMock).not.toHaveBeenCalled();
     expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("clears schedule fields when canceling a queued task", async () => {
+    requireTaskCancelAccessMock.mockResolvedValue(
+      createTask({ status: TaskStatus.QUEUED }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi.fn().mockResolvedValue(
+          createTaskEvent({
+            status: TaskStatus.CANCELED,
+            userId: USER_ID,
+            coworkerId: null,
+          }),
+        ),
+      },
+      task: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      taskLink: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "user",
+      userId: USER_ID,
+      organizationId: null,
+      role: "user",
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(tx.task.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: TASK_ID, status: TaskStatus.QUEUED },
+        data: {
+          status: TaskStatus.CANCELED,
+          metadata: null,
+          nextRunAt: null,
+        },
+      }),
+    );
+    expect(tx.taskLink?.findMany).toHaveBeenCalled();
+  });
+
+  it("cascades cancel to non-terminal PARENT children", async () => {
+    requireTaskCancelAccessMock.mockResolvedValue(
+      createTask({ status: TaskStatus.QUEUED }),
+    );
+
+    const tx: TransactionMock = {
+      taskEvent: {
+        create: vi
+          .fn()
+          .mockResolvedValueOnce(
+            createTaskEvent({
+              id: "evt_parent",
+              status: TaskStatus.CANCELED,
+              userId: USER_ID,
+              coworkerId: null,
+            }),
+          )
+          .mockResolvedValueOnce(
+            createTaskEvent({
+              id: "evt_child",
+              status: TaskStatus.CANCELED,
+              userId: USER_ID,
+              coworkerId: null,
+            }),
+          ),
+      },
+      task: {
+        updateMany: vi
+          .fn()
+          .mockResolvedValueOnce({ count: 1 })
+          .mockResolvedValueOnce({ count: 1 }),
+      },
+      taskLink: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            toTask: { id: "tsk_child", status: TaskStatus.RUNNING },
+          },
+        ]),
+      },
+    };
+
+    mockTransaction(tx);
+
+    const app = createApp({
+      actor: "user",
+      userId: USER_ID,
+      organizationId: null,
+      role: "user",
+    });
+
+    const response = await app.request(`http://localhost/${TASK_ID}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: TaskStatus.CANCELED,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(2);
+    expect(tx.task.updateMany).toHaveBeenCalledTimes(2);
+    expect(tx.task.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: { id: "tsk_child", status: TaskStatus.RUNNING },
+        data: {
+          status: TaskStatus.CANCELED,
+          metadata: null,
+          nextRunAt: null,
+        },
+      }),
+    );
   });
 });

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -33,6 +33,8 @@ import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { requireOrchestratorIdForAttribution } from "@/helpers/orchestrator-instance";
 import { created, unprocessableWithData } from "@/helpers/response";
 import {
+  cascadeCancelNonTerminalParentChildren,
+  getTaskStatusUpdateDataForEvent,
   mapTaskEvent,
   taskEventApiInclude,
   validateStatusTransition,
@@ -573,10 +575,18 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         if (eventStatus != null) {
           const updateResult = await tx.task.updateMany({
             where: { id: taskId, status: task.status },
-            data: { status: eventStatus },
+            data: getTaskStatusUpdateDataForEvent(eventStatus),
           });
           if (updateResult.count !== 1) {
             throw conflict("Task status was changed by another request");
+          }
+
+          if (eventStatus === TaskStatus.CANCELED) {
+            await cascadeCancelNonTerminalParentChildren({
+              tx,
+              parentTaskId: taskId,
+              actorData,
+            });
           }
         }
 

--- a/apps/core/src/routes/v1/tasks/[id]/events/post.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/events/post.ts
@@ -33,6 +33,7 @@ import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { requireOrchestratorIdForAttribution } from "@/helpers/orchestrator-instance";
 import { created, unprocessableWithData } from "@/helpers/response";
 import {
+  type CascadedCancelChild,
   cascadeCancelNonTerminalParentChildren,
   getTaskStatusUpdateDataForEvent,
   mapTaskEvent,
@@ -453,155 +454,162 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const { id: taskId } = c.req.valid("param");
     const body = c.req.valid("json");
 
-    const { event, userId, masumiPayment, pausedForInsufficientBalance } =
-      await serializableTransaction(async (tx) => {
-        const { status, credits, authenticationUrl, channel, masumiPayment } =
-          body;
-        let comment = body.comment;
+    const {
+      event,
+      userId,
+      masumiPayment,
+      pausedForInsufficientBalance,
+      cascadedChildTaskIds,
+    } = await serializableTransaction(async (tx) => {
+      const { status, credits, authenticationUrl, channel, masumiPayment } =
+        body;
+      let comment = body.comment;
 
-        const hasNonCommentWrite =
-          status !== undefined ||
-          credits != null ||
-          authenticationUrl != null ||
-          masumiPayment != null;
+      const hasNonCommentWrite =
+        status !== undefined ||
+        credits != null ||
+        authenticationUrl != null ||
+        masumiPayment != null;
 
-        const isCancelOnlyWrite =
-          status === TaskStatus.CANCELED &&
-          credits == null &&
-          authenticationUrl == null &&
-          masumiPayment == null;
+      const isCancelOnlyWrite =
+        status === TaskStatus.CANCELED &&
+        credits == null &&
+        authenticationUrl == null &&
+        masumiPayment == null;
 
-        const task = isCancelOnlyWrite
-          ? await requireTaskCancelAccess(c.var, taskId, tx)
-          : hasNonCommentWrite
-            ? await requireTaskCollaboration(authContext, taskId, tx)
-            : await requireTaskCommentAccess(c.var, taskId, tx);
+      const task = isCancelOnlyWrite
+        ? await requireTaskCancelAccess(c.var, taskId, tx)
+        : hasNonCommentWrite
+          ? await requireTaskCollaboration(authContext, taskId, tx)
+          : await requireTaskCommentAccess(c.var, taskId, tx);
 
-        const isAgent = isCoworkerAgentContext(authContext);
+      const isAgent = isCoworkerAgentContext(authContext);
 
-        if (!isAgent && credits != null) {
-          throw unprocessableEntity(
-            "Only the assigned coworker can set credits on task events",
-          );
-        }
+      if (!isAgent && credits != null) {
+        throw unprocessableEntity(
+          "Only the assigned coworker can set credits on task events",
+        );
+      }
 
-        if (!isAgent && masumiPayment != null) {
-          throw unprocessableEntity(
-            "Only the assigned coworker can set masumiPayment on task events",
-          );
-        }
+      if (!isAgent && masumiPayment != null) {
+        throw unprocessableEntity(
+          "Only the assigned coworker can set masumiPayment on task events",
+        );
+      }
 
-        if (
-          status === undefined &&
-          comment === undefined &&
-          credits == null &&
-          masumiPayment == null
-        ) {
-          throw unprocessableEntity(
-            "At least one of status, comment, credits, or masumiPayment is required",
-          );
-        }
+      if (
+        status === undefined &&
+        comment === undefined &&
+        credits == null &&
+        masumiPayment == null
+      ) {
+        throw unprocessableEntity(
+          "At least one of status, comment, credits, or masumiPayment is required",
+        );
+      }
 
-        if (status !== undefined) {
-          validateStatusTransition(authContext, task.status, status);
-          validateTaskAssigneeAssignment({
-            status,
-            assigneeId: task.assigneeId,
-          });
-
-          if (
-            !isAgent &&
-            userTaskStatusTransitionRequiresComment(task.status, status)
-          ) {
-            const trimmedComment = comment?.trim();
-            if (!trimmedComment) {
-              throw unprocessableEntity(
-                "A comment is required when reopening a canceled or completed task to ready",
-              );
-            }
-            comment = trimmedComment;
-          }
-        }
-
-        let cents: bigint | undefined;
-        let transactionId: string | null = null;
-        let eventStatus: TaskStatus | null = status ?? null;
-        let chargedMasumiPayment = false;
-        let pausedForInsufficientBalance = false;
-
-        if (
-          isAgent &&
-          (masumiPayment != null || (credits != null && credits > 0))
-        ) {
-          const settled = await settleTaskEventCharge({
-            task,
-            credits,
-            masumiPayment,
-            tx,
-          });
-          cents = settled.cents;
-          transactionId = settled.transactionId;
-          chargedMasumiPayment = settled.chargedMasumiPayment;
-          if (settled.eventStatus != null) {
-            eventStatus = settled.eventStatus;
-            pausedForInsufficientBalance =
-              settled.eventStatus === TaskStatus.OUT_OF_CREDITS;
-          }
-        }
-
-        const actorData =
-          status !== undefined || eventStatus === TaskStatus.OUT_OF_CREDITS
-            ? await getStatusEventActorData(authContext)
-            : credits != null || masumiPayment != null
-              ? getCoworkerActorData(authContext)
-              : await getCommentEventActorData(authContext);
-
-        const createdEvent = await tx.taskEvent.create({
-          data: {
-            taskId,
-            status: eventStatus,
-            comment,
-            authenticationUrl,
-            channel,
-            cents,
-            transactionId,
-            ...actorData,
-          },
+      if (status !== undefined) {
+        validateStatusTransition(authContext, task.status, status);
+        validateTaskAssigneeAssignment({
+          status,
+          assigneeId: task.assigneeId,
         });
 
-        // Update task when the caller requested a status change, or when a
-        // failed charge replaced the outcome with OUT_OF_CREDITS (incl.
-        // credit-only bodies that had no status).
-        if (eventStatus != null) {
-          const updateResult = await tx.task.updateMany({
-            where: { id: taskId, status: task.status },
-            data: getTaskStatusUpdateDataForEvent(eventStatus),
-          });
-          if (updateResult.count !== 1) {
-            throw conflict("Task status was changed by another request");
+        if (
+          !isAgent &&
+          userTaskStatusTransitionRequiresComment(task.status, status)
+        ) {
+          const trimmedComment = comment?.trim();
+          if (!trimmedComment) {
+            throw unprocessableEntity(
+              "A comment is required when reopening a canceled or completed task to ready",
+            );
           }
+          comment = trimmedComment;
+        }
+      }
 
-          if (eventStatus === TaskStatus.CANCELED) {
-            await cascadeCancelNonTerminalParentChildren({
-              tx,
-              parentTaskId: taskId,
-              actorData,
-            });
-          }
+      let cents: bigint | undefined;
+      let transactionId: string | null = null;
+      let eventStatus: TaskStatus | null = status ?? null;
+      let chargedMasumiPayment = false;
+      let pausedForInsufficientBalance = false;
+      let cascadedChildren: CascadedCancelChild[] = [];
+
+      if (
+        isAgent &&
+        (masumiPayment != null || (credits != null && credits > 0))
+      ) {
+        const settled = await settleTaskEventCharge({
+          task,
+          credits,
+          masumiPayment,
+          tx,
+        });
+        cents = settled.cents;
+        transactionId = settled.transactionId;
+        chargedMasumiPayment = settled.chargedMasumiPayment;
+        if (settled.eventStatus != null) {
+          eventStatus = settled.eventStatus;
+          pausedForInsufficientBalance =
+            settled.eventStatus === TaskStatus.OUT_OF_CREDITS;
+        }
+      }
+
+      const actorData =
+        status !== undefined || eventStatus === TaskStatus.OUT_OF_CREDITS
+          ? await getStatusEventActorData(authContext)
+          : credits != null || masumiPayment != null
+            ? getCoworkerActorData(authContext)
+            : await getCommentEventActorData(authContext);
+
+      const createdEvent = await tx.taskEvent.create({
+        data: {
+          taskId,
+          status: eventStatus,
+          comment,
+          authenticationUrl,
+          channel,
+          cents,
+          transactionId,
+          ...actorData,
+        },
+      });
+
+      // Update task when the caller requested a status change, or when a
+      // failed charge replaced the outcome with OUT_OF_CREDITS (incl.
+      // credit-only bodies that had no status).
+      if (eventStatus != null) {
+        const updateResult = await tx.task.updateMany({
+          where: { id: taskId, status: task.status },
+          data: getTaskStatusUpdateDataForEvent(eventStatus),
+        });
+        if (updateResult.count !== 1) {
+          throw conflict("Task status was changed by another request");
         }
 
-        const payment =
-          chargedMasumiPayment && masumiPayment !== undefined
-            ? masumiPayment
-            : null;
+        if (eventStatus === TaskStatus.CANCELED) {
+          cascadedChildren = await cascadeCancelNonTerminalParentChildren({
+            tx,
+            parentTaskId: taskId,
+            actorData,
+          });
+        }
+      }
 
-        return {
-          event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
-          userId: task.ownerId,
-          masumiPayment: payment,
-          pausedForInsufficientBalance,
-        };
-      }, "Task changed by a concurrent request. Please retry.");
+      const payment =
+        chargedMasumiPayment && masumiPayment !== undefined
+          ? masumiPayment
+          : null;
+
+      return {
+        event: await mapCreatedTaskEventForResponse(tx, createdEvent.id),
+        userId: task.ownerId,
+        masumiPayment: payment,
+        pausedForInsufficientBalance,
+        cascadedChildTaskIds: cascadedChildren,
+      };
+    }, "Task changed by a concurrent request. Please retry.");
 
     if (event.status) {
       const taskEventId = event.id;
@@ -761,19 +769,37 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       waitUntil(masumiPurchasePromise);
     }
 
-    try {
-      await publishTaskEventData({
-        userId,
-        taskId,
-        eventType: "task_event",
-      });
-    } catch (error) {
-      Sentry.captureException(error, {
-        tags: {
-          error_type: "publish_task_event",
+    const taskIdsToPublish = [
+      { userId, taskId },
+      ...cascadedChildTaskIds.map((child) => ({
+        userId: child.userId,
+        taskId: child.taskId,
+      })),
+    ];
+
+    await Promise.all(
+      taskIdsToPublish.map(
+        async ({ userId: publishUserId, taskId: publishTaskId }) => {
+          try {
+            await publishTaskEventData({
+              userId: publishUserId,
+              taskId: publishTaskId,
+              eventType: "task_event",
+            });
+          } catch (error) {
+            Sentry.captureException(error, {
+              tags: {
+                error_type: "publish_task_event",
+              },
+              extra: {
+                taskId: publishTaskId,
+                userId: publishUserId,
+              },
+            });
+          }
         },
-      });
-    }
+      ),
+    );
 
     const parsedEvent = taskEventSchema.parse(event);
 

--- a/apps/core/src/services/__tests__/task-schedules-sync.test.ts
+++ b/apps/core/src/services/__tests__/task-schedules-sync.test.ts
@@ -5,6 +5,7 @@ const mockFindMany = vi.fn();
 const mockFindFirst = vi.fn();
 const mockTaskCreate = vi.fn();
 const mockTaskUpdate = vi.fn();
+const mockTaskUpdateMany = vi.fn();
 const mockTaskLinkCreate = vi.fn();
 const mockTaskEventCreate = vi.fn();
 const publishTaskEventDataMock = vi.fn();
@@ -21,6 +22,7 @@ vi.mock("@/lib/db/prisma", () => ({
       findFirst: mockFindFirst,
       create: mockTaskCreate,
       update: mockTaskUpdate,
+      updateMany: mockTaskUpdateMany,
     },
     taskLink: {
       create: mockTaskLinkCreate,
@@ -64,6 +66,7 @@ describe("taskSchedulesSyncService", () => {
           findFirst: mockFindFirst,
           create: mockTaskCreate,
           update: mockTaskUpdate,
+          updateMany: mockTaskUpdateMany,
         },
         taskLink: {
           create: mockTaskLinkCreate,
@@ -88,6 +91,7 @@ describe("taskSchedulesSyncService", () => {
     });
 
     mockTaskCreate.mockResolvedValue({ id: "clone-1" });
+    mockTaskUpdateMany.mockResolvedValue({ count: 1 });
     mockTaskUpdate.mockImplementation(async ({ data }) => {
       if (typeof data.metadata === "string") {
         metadata = data.metadata;
@@ -109,9 +113,9 @@ describe("taskSchedulesSyncService", () => {
       taskId: "clone-1",
       eventType: "task_event",
     });
-    expect(mockTaskUpdate).toHaveBeenCalledWith(
+    expect(mockTaskUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "template-1" },
+        where: { id: "template-1", status: "QUEUED" },
         data: expect.objectContaining({
           nextRunAt: new Date("2026-06-11T09:00:00.000Z"),
         }),
@@ -134,6 +138,7 @@ describe("taskSchedulesSyncService", () => {
           findFirst: mockFindFirst,
           create: mockTaskCreate,
           update: mockTaskUpdate,
+          updateMany: mockTaskUpdateMany,
         },
         taskLink: {
           create: mockTaskLinkCreate,
@@ -201,6 +206,7 @@ describe("taskSchedulesSyncService", () => {
           findFirst: mockFindFirst,
           create: mockTaskCreate,
           update: mockTaskUpdate,
+          updateMany: mockTaskUpdateMany,
         },
         taskLink: {
           create: mockTaskLinkCreate,
@@ -228,6 +234,7 @@ describe("taskSchedulesSyncService", () => {
       abortController.abort();
       return { id: "clone-1" };
     });
+    mockTaskUpdateMany.mockResolvedValue({ count: 1 });
     mockTaskUpdate.mockImplementation(async ({ data }) => {
       if (typeof data.metadata === "string") {
         metadata = data.metadata;
@@ -249,5 +256,62 @@ describe("taskSchedulesSyncService", () => {
       taskId: "clone-1",
       eventType: "task_event",
     });
+  });
+
+  it("skips promote when the template is no longer queued", async () => {
+    const { taskSchedulesSyncService } = await import(
+      "@/services/task-schedules-sync"
+    );
+
+    mockFindMany
+      .mockResolvedValueOnce([{ id: "template-1" }])
+      .mockResolvedValueOnce([]);
+
+    mockTransaction.mockImplementation(async (callback) =>
+      callback({
+        task: {
+          findFirst: mockFindFirst,
+          create: mockTaskCreate,
+          update: mockTaskUpdate,
+          updateMany: mockTaskUpdateMany,
+        },
+        taskLink: {
+          create: mockTaskLinkCreate,
+        },
+        taskEvent: {
+          create: mockTaskEventCreate,
+        },
+      }),
+    );
+
+    mockFindFirst.mockResolvedValue({
+      id: "template-1",
+      ownerId: "user-1",
+      organizationId: null,
+      workspaceId: "workspace-1",
+      projectId: null,
+      assigneeId: null,
+      name: "Template",
+      description: "Run once",
+      metadata: JSON.stringify({
+        version: 1,
+        mode: "once",
+        scheduledAt: "2026-06-01T09:00:00.000Z",
+        timezone: "UTC",
+      }),
+      nextRunAt: new Date("2026-06-08T09:00:00.000Z"),
+    });
+
+    mockTaskUpdateMany.mockResolvedValue({ count: 0 });
+
+    const result = await taskSchedulesSyncService.syncDueSchedules({
+      abortSignal: new AbortController().signal,
+      deadlineMs: Date.now() + 60_000,
+      shouldContinue: () => true,
+    });
+
+    expect(result.promoted).toBe(0);
+    expect(mockTaskEventCreate).not.toHaveBeenCalled();
+    expect(publishTaskEventDataMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/services/__tests__/task-schedules-sync.test.ts
+++ b/apps/core/src/services/__tests__/task-schedules-sync.test.ts
@@ -314,4 +314,68 @@ describe("taskSchedulesSyncService", () => {
     expect(mockTaskEventCreate).not.toHaveBeenCalled();
     expect(publishTaskEventDataMock).not.toHaveBeenCalled();
   });
+
+  it("rolls back recurring clones when re-arm fails after cancel", async () => {
+    const { taskSchedulesSyncService } = await import(
+      "@/services/task-schedules-sync"
+    );
+
+    mockFindMany
+      .mockResolvedValueOnce([{ id: "template-1" }])
+      .mockResolvedValueOnce([]);
+
+    mockTransaction.mockImplementation(async (callback) =>
+      callback({
+        task: {
+          findFirst: mockFindFirst,
+          create: mockTaskCreate,
+          update: mockTaskUpdate,
+          updateMany: mockTaskUpdateMany,
+        },
+        taskLink: {
+          create: mockTaskLinkCreate,
+        },
+        taskEvent: {
+          create: mockTaskEventCreate,
+        },
+      }),
+    );
+
+    mockFindFirst.mockResolvedValue({
+      id: "template-1",
+      ownerId: "user-1",
+      organizationId: null,
+      workspaceId: "workspace-1",
+      projectId: null,
+      assigneeId: null,
+      name: "Template",
+      description: "Run me",
+      metadata: JSON.stringify({
+        version: 1,
+        mode: "recurring",
+        scheduledAt: "2026-06-01T09:00:00.000Z",
+        expr: "0 9 * * *",
+        timezone: "UTC",
+        endsMode: "never",
+      }),
+      // Single due occurrence relative to fake now 2026-06-10T12:00Z
+      nextRunAt: new Date("2026-06-10T09:00:00.000Z"),
+    });
+
+    mockTaskCreate.mockResolvedValue({ id: "clone-orphan" });
+    // Claim lost: template already canceled/cleared before re-arm
+    mockTaskUpdateMany.mockResolvedValue({ count: 0 });
+
+    const result = await taskSchedulesSyncService.syncDueSchedules({
+      abortSignal: new AbortController().signal,
+      deadlineMs: Date.now() + 60_000,
+      shouldContinue: () => true,
+    });
+
+    expect(result.cloned).toBe(0);
+    expect(result.promoted).toBe(0);
+    // Clone create ran in-tx; TemplateClaimLostError rolls the tx back
+    expect(mockTaskCreate).toHaveBeenCalledTimes(1);
+    expect(publishTaskEventDataMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/core/src/services/task-schedules-sync.ts
+++ b/apps/core/src/services/task-schedules-sync.ts
@@ -228,124 +228,61 @@ async function cloneRecurringOccurrence(
   return clone.id;
 }
 
+/**
+ * Thrown inside the processDueTask transaction when clones were created but
+ * the template is no longer QUEUED (e.g. canceled mid-sync). Prisma rolls
+ * back the transaction so READY clones are not committed.
+ */
+class TemplateClaimLostError extends Error {
+  constructor() {
+    super("Task schedule template is no longer QUEUED");
+    this.name = "TemplateClaimLostError";
+  }
+}
+
+function assertTemplateClaimHeld(
+  claimed: boolean,
+  clonesCreated: number,
+): void {
+  if (!claimed && clonesCreated > 0) {
+    throw new TemplateClaimLostError();
+  }
+}
+
 async function processDueTask(
   templateId: string,
   options: TaskScheduleSyncExecutionOptions,
 ): Promise<ProcessDueTaskResult> {
-  return prisma.$transaction(async (tx) => {
-    const template = await tx.task.findFirst({
-      where: {
-        id: templateId,
-        status: TaskStatus.QUEUED,
-        archivedAt: null,
-        pendingVendorGrantId: null,
-        nextRunAt: { lte: new Date() },
-      },
-      select: {
-        id: true,
-        ownerId: true,
-        organizationId: true,
-        workspaceId: true,
-        projectId: true,
-        assigneeId: true,
-        name: true,
-        description: true,
-        metadata: true,
-        nextRunAt: true,
-      },
-    });
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const template = await tx.task.findFirst({
+        where: {
+          id: templateId,
+          status: TaskStatus.QUEUED,
+          archivedAt: null,
+          pendingVendorGrantId: null,
+          nextRunAt: { lte: new Date() },
+        },
+        select: {
+          id: true,
+          ownerId: true,
+          organizationId: true,
+          workspaceId: true,
+          projectId: true,
+          assigneeId: true,
+          name: true,
+          description: true,
+          metadata: true,
+          nextRunAt: true,
+        },
+      });
 
-    if (!template || !template.nextRunAt) {
-      return { outcome: "skipped", publishEvents: [] };
-    }
-
-    const scheduleMetadata = parseTaskScheduleMetadata(template.metadata);
-    if (!scheduleMetadata) {
-      const cleared = await clearTemplateSchedule(tx, template.id);
-      return {
-        outcome: "skipped",
-        publishEvents: cleared
-          ? [{ userId: template.ownerId, taskId: template.id }]
-          : [],
-      };
-    }
-
-    if (scheduleMetadata.mode === "once") {
-      const promoted = await promoteOneTimeTask(
-        tx,
-        template.id,
-        template.ownerId,
-      );
-      if (!promoted) {
+      if (!template || !template.nextRunAt) {
         return { outcome: "skipped", publishEvents: [] };
       }
-      return {
-        outcome: "promoted",
-        publishEvents: [{ userId: template.ownerId, taskId: template.id }],
-      };
-    }
 
-    const now = new Date();
-    let metadata = scheduleMetadata;
-    let nextRunAt = template.nextRunAt;
-    let clonesCreated = 0;
-    const clonedTaskIds: string[] = [];
-
-    while (nextRunAt && nextRunAt <= now) {
-      if (
-        !options.shouldContinue() ||
-        options.abortSignal.aborted ||
-        Date.now() >= options.deadlineMs
-      ) {
-        break;
-      }
-
-      if (isDueRunPastScheduleEnd(metadata, nextRunAt)) {
-        break;
-      }
-
-      if (!(await isTemplateStillQueued(tx, template.id))) {
-        break;
-      }
-
-      const cloneId = await cloneRecurringOccurrence(tx, template);
-      clonedTaskIds.push(cloneId);
-      clonesCreated += 1;
-
-      metadata = getUpdatedRecurringMetadata(metadata, nextRunAt);
-      const computedNextRun = computeScheduleNextRun(metadata, nextRunAt);
-
-      if (shouldEndRecurringAfterRun(metadata, computedNextRun)) {
-        const cleared = await clearTemplateSchedule(tx, template.id);
-        return {
-          outcome: clonesCreated > 0 ? "cloned" : "skipped",
-          publishEvents: buildRecurringPublishEvents(
-            template.ownerId,
-            template.id,
-            clonedTaskIds,
-            cleared,
-          ),
-        };
-      }
-
-      if (!computedNextRun) {
-        const cleared = await clearTemplateSchedule(tx, template.id);
-        return {
-          outcome: clonesCreated > 0 ? "cloned" : "skipped",
-          publishEvents: buildRecurringPublishEvents(
-            template.ownerId,
-            template.id,
-            clonedTaskIds,
-            cleared,
-          ),
-        };
-      }
-
-      nextRunAt = computedNextRun;
-    }
-
-    if (clonesCreated === 0) {
-      if (isDueRunPastScheduleEnd(metadata, template.nextRunAt)) {
+      const scheduleMetadata = parseTaskScheduleMetadata(template.metadata);
+      if (!scheduleMetadata) {
         const cleared = await clearTemplateSchedule(tx, template.id);
         return {
           outcome: "skipped",
@@ -354,19 +291,107 @@ async function processDueTask(
             : [],
         };
       }
-      return { outcome: "skipped", publishEvents: [] };
-    }
 
-    const updateResult = await tx.task.updateMany({
-      where: { id: template.id, status: TaskStatus.QUEUED },
-      data: {
-        metadata: JSON.stringify(metadata),
-        nextRunAt,
-      },
-    });
-    if (updateResult.count !== 1) {
+      if (scheduleMetadata.mode === "once") {
+        const promoted = await promoteOneTimeTask(
+          tx,
+          template.id,
+          template.ownerId,
+        );
+        if (!promoted) {
+          return { outcome: "skipped", publishEvents: [] };
+        }
+        return {
+          outcome: "promoted",
+          publishEvents: [{ userId: template.ownerId, taskId: template.id }],
+        };
+      }
+
+      const now = new Date();
+      let metadata = scheduleMetadata;
+      let nextRunAt = template.nextRunAt;
+      let clonesCreated = 0;
+      const clonedTaskIds: string[] = [];
+
+      while (nextRunAt && nextRunAt <= now) {
+        if (
+          !options.shouldContinue() ||
+          options.abortSignal.aborted ||
+          Date.now() >= options.deadlineMs
+        ) {
+          break;
+        }
+
+        if (isDueRunPastScheduleEnd(metadata, nextRunAt)) {
+          break;
+        }
+
+        if (!(await isTemplateStillQueued(tx, template.id))) {
+          break;
+        }
+
+        const cloneId = await cloneRecurringOccurrence(tx, template);
+        clonedTaskIds.push(cloneId);
+        clonesCreated += 1;
+
+        metadata = getUpdatedRecurringMetadata(metadata, nextRunAt);
+        const computedNextRun = computeScheduleNextRun(metadata, nextRunAt);
+
+        if (shouldEndRecurringAfterRun(metadata, computedNextRun)) {
+          const cleared = await clearTemplateSchedule(tx, template.id);
+          assertTemplateClaimHeld(cleared, clonesCreated);
+          return {
+            outcome: "cloned",
+            publishEvents: buildRecurringPublishEvents(
+              template.ownerId,
+              template.id,
+              clonedTaskIds,
+              true,
+            ),
+          };
+        }
+
+        if (!computedNextRun) {
+          const cleared = await clearTemplateSchedule(tx, template.id);
+          assertTemplateClaimHeld(cleared, clonesCreated);
+          return {
+            outcome: "cloned",
+            publishEvents: buildRecurringPublishEvents(
+              template.ownerId,
+              template.id,
+              clonedTaskIds,
+              true,
+            ),
+          };
+        }
+
+        nextRunAt = computedNextRun;
+      }
+
+      if (clonesCreated === 0) {
+        if (isDueRunPastScheduleEnd(metadata, template.nextRunAt)) {
+          const cleared = await clearTemplateSchedule(tx, template.id);
+          return {
+            outcome: "skipped",
+            publishEvents: cleared
+              ? [{ userId: template.ownerId, taskId: template.id }]
+              : [],
+          };
+        }
+        return { outcome: "skipped", publishEvents: [] };
+      }
+
+      const updateResult = await tx.task.updateMany({
+        where: { id: template.id, status: TaskStatus.QUEUED },
+        data: {
+          metadata: JSON.stringify(metadata),
+          nextRunAt,
+        },
+      });
+      assertTemplateClaimHeld(updateResult.count === 1, clonesCreated);
+
       return {
-        outcome: clonesCreated > 0 ? "cloned" : "skipped",
+        outcome: "cloned",
         publishEvents: buildRecurringPublishEvents(
           template.ownerId,
           template.id,
@@ -374,18 +399,13 @@ async function processDueTask(
           false,
         ),
       };
+    });
+  } catch (error) {
+    if (error instanceof TemplateClaimLostError) {
+      return { outcome: "skipped", publishEvents: [] };
     }
-
-    return {
-      outcome: "cloned",
-      publishEvents: buildRecurringPublishEvents(
-        template.ownerId,
-        template.id,
-        clonedTaskIds,
-        false,
-      ),
-    };
-  });
+    throw error;
+  }
 }
 
 function buildRecurringPublishEvents(

--- a/apps/core/src/services/task-schedules-sync.ts
+++ b/apps/core/src/services/task-schedules-sync.ts
@@ -103,33 +103,38 @@ function getCloneTaskData(
   };
 }
 
-function clearTemplateSchedule(
+async function clearTemplateSchedule(
   tx: Prisma.TransactionClient,
   templateId: string,
-): Promise<unknown> {
-  return tx.task.update({
-    where: { id: templateId },
+): Promise<boolean> {
+  const updateResult = await tx.task.updateMany({
+    where: { id: templateId, status: TaskStatus.QUEUED },
     data: {
       status: TaskStatus.DRAFT,
       metadata: null,
       nextRunAt: null,
     },
   });
+
+  return updateResult.count === 1;
 }
 
 async function promoteOneTimeTask(
   tx: Prisma.TransactionClient,
   templateId: string,
   userId: string,
-): Promise<void> {
-  await tx.task.update({
-    where: { id: templateId },
+): Promise<boolean> {
+  const updateResult = await tx.task.updateMany({
+    where: { id: templateId, status: TaskStatus.QUEUED },
     data: {
       status: TaskStatus.READY,
       metadata: null,
       nextRunAt: null,
     },
   });
+  if (updateResult.count !== 1) {
+    return false;
+  }
 
   await tx.taskEvent.create({
     data: {
@@ -139,6 +144,20 @@ async function promoteOneTimeTask(
       userId,
     },
   });
+
+  return true;
+}
+
+async function isTemplateStillQueued(
+  tx: Prisma.TransactionClient,
+  templateId: string,
+): Promise<boolean> {
+  const template = await tx.task.findFirst({
+    where: { id: templateId, status: TaskStatus.QUEUED },
+    select: { id: true },
+  });
+
+  return template != null;
 }
 
 function getUpdatedRecurringMetadata(
@@ -242,15 +261,24 @@ async function processDueTask(
 
     const scheduleMetadata = parseTaskScheduleMetadata(template.metadata);
     if (!scheduleMetadata) {
-      await clearTemplateSchedule(tx, template.id);
+      const cleared = await clearTemplateSchedule(tx, template.id);
       return {
         outcome: "skipped",
-        publishEvents: [{ userId: template.ownerId, taskId: template.id }],
+        publishEvents: cleared
+          ? [{ userId: template.ownerId, taskId: template.id }]
+          : [],
       };
     }
 
     if (scheduleMetadata.mode === "once") {
-      await promoteOneTimeTask(tx, template.id, template.ownerId);
+      const promoted = await promoteOneTimeTask(
+        tx,
+        template.id,
+        template.ownerId,
+      );
+      if (!promoted) {
+        return { outcome: "skipped", publishEvents: [] };
+      }
       return {
         outcome: "promoted",
         publishEvents: [{ userId: template.ownerId, taskId: template.id }],
@@ -276,6 +304,10 @@ async function processDueTask(
         break;
       }
 
+      if (!(await isTemplateStillQueued(tx, template.id))) {
+        break;
+      }
+
       const cloneId = await cloneRecurringOccurrence(tx, template);
       clonedTaskIds.push(cloneId);
       clonesCreated += 1;
@@ -284,27 +316,27 @@ async function processDueTask(
       const computedNextRun = computeScheduleNextRun(metadata, nextRunAt);
 
       if (shouldEndRecurringAfterRun(metadata, computedNextRun)) {
-        await clearTemplateSchedule(tx, template.id);
+        const cleared = await clearTemplateSchedule(tx, template.id);
         return {
           outcome: clonesCreated > 0 ? "cloned" : "skipped",
           publishEvents: buildRecurringPublishEvents(
             template.ownerId,
             template.id,
             clonedTaskIds,
-            true,
+            cleared,
           ),
         };
       }
 
       if (!computedNextRun) {
-        await clearTemplateSchedule(tx, template.id);
+        const cleared = await clearTemplateSchedule(tx, template.id);
         return {
           outcome: clonesCreated > 0 ? "cloned" : "skipped",
           publishEvents: buildRecurringPublishEvents(
             template.ownerId,
             template.id,
             clonedTaskIds,
-            true,
+            cleared,
           ),
         };
       }
@@ -314,22 +346,35 @@ async function processDueTask(
 
     if (clonesCreated === 0) {
       if (isDueRunPastScheduleEnd(metadata, template.nextRunAt)) {
-        await clearTemplateSchedule(tx, template.id);
+        const cleared = await clearTemplateSchedule(tx, template.id);
         return {
           outcome: "skipped",
-          publishEvents: [{ userId: template.ownerId, taskId: template.id }],
+          publishEvents: cleared
+            ? [{ userId: template.ownerId, taskId: template.id }]
+            : [],
         };
       }
       return { outcome: "skipped", publishEvents: [] };
     }
 
-    await tx.task.update({
-      where: { id: template.id },
+    const updateResult = await tx.task.updateMany({
+      where: { id: template.id, status: TaskStatus.QUEUED },
       data: {
         metadata: JSON.stringify(metadata),
         nextRunAt,
       },
     });
+    if (updateResult.count !== 1) {
+      return {
+        outcome: clonesCreated > 0 ? "cloned" : "skipped",
+        publishEvents: buildRecurringPublishEvents(
+          template.ownerId,
+          template.id,
+          clonedTaskIds,
+          false,
+        ),
+      };
+    }
 
     return {
       outcome: "cloned",

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -612,10 +612,15 @@ describe("TaskDetailActions", () => {
 
     await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
 
-    expect(screen.getByRole("link", { name: labels.edit })).toBeInTheDocument();
+    const edit = screen.getByRole("link", { name: labels.edit });
+    const cancel = screen.getByRole("menuitem", { name: labels.cancel });
+    expect(edit).toBeInTheDocument();
+    expect(cancel).toBeInTheDocument();
+
+    // Edit above Cancel in the overflow menu
     expect(
-      screen.getByRole("menuitem", { name: labels.cancel }),
-    ).toBeInTheDocument();
+      edit.compareDocumentPosition(cancel) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("sets task status to canceled when cancel is chosen for a queued task", async () => {

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -604,7 +604,7 @@ describe("TaskDetailActions", () => {
     },
   );
 
-  it("shows edit for queued tasks", async () => {
+  it("shows edit and cancel for queued tasks", async () => {
     const user = userEvent.setup();
     renderActions({
       status: TaskStatus.QUEUED,
@@ -613,6 +613,30 @@ describe("TaskDetailActions", () => {
     await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
 
     expect(screen.getByRole("link", { name: labels.edit })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: labels.cancel }),
+    ).toBeInTheDocument();
+  });
+
+  it("sets task status to canceled when cancel is chosen for a queued task", async () => {
+    const user = userEvent.setup();
+    const setTaskStatusFromDragMock = vi.mocked(setTaskStatusFromDrag);
+    setTaskStatusFromDragMock.mockResolvedValueOnce({ taskId: "task-1" });
+
+    renderActions({
+      status: TaskStatus.QUEUED,
+      organizations: undefined,
+    });
+
+    await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
+    await user.click(screen.getByRole("menuitem", { name: labels.cancel }));
+
+    await waitFor(() => {
+      expect(setTaskStatusFromDragMock).toHaveBeenCalledWith({
+        taskId: "task-1",
+        desiredStatus: TaskStatus.CANCELED,
+      });
+    });
   });
 
   it("hides archive while the coworker is running", async () => {

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -486,6 +486,20 @@ export function TaskDetailActions({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-56">
+            {canEdit ? (
+              <DropdownMenuItem asChild disabled={actionsDisabled}>
+                <Link
+                  href={`/tasks/${taskId}/edit`}
+                  className={
+                    actionsDisabled ? "pointer-events-none opacity-70" : ""
+                  }
+                >
+                  <Pencil className="size-4" aria-hidden />
+                  {labels.edit}
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+
             {statusActions.map((action) => {
               const StatusIcon = action.requiresComment
                 ? RotateCcw
@@ -508,23 +522,9 @@ export function TaskDetailActions({
               );
             })}
 
-            {statusActions.length > 0 &&
-            (canEdit || canManageRelations || canMove) ? (
+            {(canEdit || statusActions.length > 0) &&
+            (canManageRelations || canMove) ? (
               <DropdownMenuSeparator />
-            ) : null}
-
-            {canEdit ? (
-              <DropdownMenuItem asChild disabled={actionsDisabled}>
-                <Link
-                  href={`/tasks/${taskId}/edit`}
-                  className={
-                    actionsDisabled ? "pointer-events-none opacity-70" : ""
-                  }
-                >
-                  <Pencil className="size-4" aria-hidden />
-                  {labels.edit}
-                </Link>
-              </DropdownMenuItem>
             ) : null}
 
             {canManageRelations ? (

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -991,6 +991,7 @@ function getTaskStatusActions(
   }
 
   if (
+    status === TaskStatus.QUEUED ||
     status === TaskStatus.INPUT_REQUIRED ||
     status === TaskStatus.APPROVAL_REQUIRED ||
     status === TaskStatus.AUTHENTICATION_REQUIRED ||

--- a/packages/utils/src/__tests__/task-status-transitions.test.ts
+++ b/packages/utils/src/__tests__/task-status-transitions.test.ts
@@ -13,6 +13,7 @@ describe("canUserTransitionTaskStatus", () => {
   it.each([
     ["DRAFT", "QUEUED"],
     ["QUEUED", "READY"],
+    ["QUEUED", "CANCELED"],
     ["READY", "QUEUED"],
     ["RUNNING", "CANCELED"],
     ["AWAITING_EXTERNAL", "CANCELED"],

--- a/packages/utils/src/task-status-transitions.ts
+++ b/packages/utils/src/task-status-transitions.ts
@@ -28,7 +28,7 @@ const USER_TASK_STATUS_TRANSITIONS: Record<
   readonly UserTransitionTaskStatus[]
 > = {
   DRAFT: ["READY", "CANCELED", "QUEUED"],
-  QUEUED: ["DRAFT", "READY"],
+  QUEUED: ["DRAFT", "READY", "CANCELED"],
   READY: ["DRAFT", "CANCELED", "QUEUED"],
   GRANT_PENDING: [],
   INPUT_REQUIRED: ["CANCELED"],


### PR DESCRIPTION
## Summary

Fixes [SOK-662](https://linear.app/masumi/issue/SOK-662/cancelled-scheduled-task-keeps-running): canceling a scheduled (`QUEUED`) task now actually stops the series.

- Allow user `QUEUED` → `CANCELED`; Core cancel atomically clears `metadata` / `nextRunAt`
- Cascade-cancel non-terminal `PARENT`-linked children on parent cancel
- Cascade cancel publishes Ably `task_event` for each canceled child (owner channel)
- Schedule sync uses conditional `QUEUED` writes so canceled templates are not revived
- Recurring sync: if clones were created and template re-arm/clear loses the `QUEUED` claim (e.g. cancel won), throw to roll back the transaction so no orphan READY clones commit
- Web task detail: **Cancel** for `QUEUED` (below **Edit** in the overflow menu) so the Core cancel path is reachable from the UI, not only clear-schedule → `DRAFT`
- Tests cover cancel clear/cascade, Ably cascade publish, once-mode skip, recurring claim-fail rollback, and queued Cancel in web

### Review notes

| Area | Location | Finding |
|------|----------|---------|
| Soft TOCTOU | `task-schedules-sync.ts` recurring loop | `isTemplateStillQueued` does not lock the row. Cancel between check and clone create can still race; if re-arm/clear then fails, clones are rolled back (no orphan READY). Full `SELECT FOR UPDATE` only if product wants zero wasted in-tx work under race. |
| Clear-schedule | `DELETE …/schedule` | Intentionally does **not** cascade-cancel in-flight children — clear = stop future runs / editable `DRAFT`. Stop-all = **Cancel** on the `QUEUED` template. |
| Child cancel | occurrence vs template | Canceling a clone does not stop the parent schedule; cancel/clear the template for series stop. |
| Archive | `DELETE /tasks/{id}` | Still single-task only. Cascade-archive for schedule parents tracked in [SOK-664](https://linear.app/masumi/issue/SOK-664/archive-schedule-template-also-archives-occurrence-children). |

## Test plan

- [ ] Create a recurring scheduled task → open detail → overflow: **Edit**, then **Cancel**
- [ ] After cancel: template is `CANCELED`, schedule fields cleared, non-terminal children canceled
- [ ] Confirm Ably/task UI updates for parent and canceled children
- [ ] Clear schedule (edit flow) → `DRAFT`, no cascade cancel of in-flight children
- [ ] Cancel while schedule sync is due: no orphan READY clones after cancel wins race
- [ ] `pnpm --filter core test` (task events, schedule sync, helpers)
- [ ] `pnpm --filter web test` (`task-detail-actions`)

Linear Issue: [SOK-662](https://linear.app/masumi/issue/SOK-662/cancelled-scheduled-task-keeps-running)