### PR TITLE
refactor(web): remove conversation helpers from coreClient

### DIFF
--- a/apps/web/src/lib/clients/__tests__/core.client.test.ts
+++ b/apps/web/src/lib/clients/__tests__/core.client.test.ts
@@ -10,7 +10,7 @@ const { redirectMock } = vi.hoisted(() => ({
   }),
 }));
 
-const getConversationsMock = vi.fn();
+const getChatRoomsMock = vi.fn();
 const getAgentsByIdInputSchemaMock = vi.fn();
 const getShareByTokenMock = vi.fn();
 const getHistoryMock = vi.fn();
@@ -52,7 +52,7 @@ vi.mock("@/lib/clients/generated/core", () => ({
   deleteJobsByIdShare: deleteJobsByIdShareMock,
   deleteTasksByIdShare: deleteTasksByIdShareMock,
   getAgentsByIdInputSchema: getAgentsByIdInputSchemaMock,
-  getChatsConversations: getConversationsMock,
+  getChatsRooms: getChatRoomsMock,
   getHistory: getHistoryMock,
   getTasks: getTasksMock,
   getShareByToken: getShareByTokenMock,
@@ -83,7 +83,7 @@ describe("core.client", () => {
   });
 
   it("executes generated operations through the generated client", async () => {
-    getConversationsMock.mockResolvedValue({
+    getChatRoomsMock.mockResolvedValue({
       data: {
         data: [],
         meta: {
@@ -95,13 +95,13 @@ describe("core.client", () => {
     });
 
     const { coreClient } = await import("../core.client");
-    const response = await coreClient.getConversations();
+    const response = await coreClient.getChatRooms();
 
     expect(createClientMock).toHaveBeenCalledWith({
       baseUrl: "http://localhost:8787/v1",
       headers: { cookie: "session=abc" },
     });
-    expect(getConversationsMock).toHaveBeenCalledWith({
+    expect(getChatRoomsMock).toHaveBeenCalledWith({
       cache: "no-store",
       client: mockClient,
     });

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -6,7 +6,6 @@ import type {
   CreateAdminVendorData,
   CreateChatRoomMessageRequest,
   CreateChatRoomRequest,
-  CreateConversationMessageRequest,
   CreateEnterpriseContractRequest,
   DeleteHermesMeInstanceIntegrationsByProviderData,
   DeleteJobsByIdShareError,
@@ -115,10 +114,6 @@ import {
   getChatsRoomsById as coreGetChatsRoomsById,
   getChatsRoomsByIdMessages as coreGetChatsRoomsByIdMessages,
   getCheckoutSessionAnalytics as coreGetCheckoutSessionAnalytics,
-  getChatsConversations as coreGetConversations,
-  getChatsConversationsById as coreGetConversationsById,
-  getChatsConversationsByIdMessages as coreGetConversationsByIdMessages,
-  getChatsConversationsByIdWarmup as coreGetConversationsByIdWarmup,
   getCouponDetails as coreGetCouponDetails,
   getCoworkers as coreGetCoworkers,
   getCoworkersById as coreGetCoworkersById,
@@ -197,8 +192,6 @@ import {
   patchAdminAgentMetadataOverride as corePatchAdminAgentMetadataOverride,
   patchAdminVendor as corePatchAdminVendor,
   patchChatsRoomsById as corePatchChatsRoomsById,
-  patchChatsConversationsById as corePatchConversationsById,
-  patchChatsConversationsByIdArchive as corePatchConversationsByIdArchive,
   patchCoworkersById as corePatchCoworkersById,
   patchCoworkersByIdWhitelist as corePatchCoworkersByIdWhitelist,
   patchEnterpriseContractsById as corePatchEnterpriseContractsById,
@@ -218,8 +211,6 @@ import {
   postChatsRoomsByIdMessagesByMessageIdReactions as corePostChatsRoomsByIdMessagesByMessageIdReactions,
   postChatsRoomsByIdRead as corePostChatsRoomsByIdRead,
   postChatsRoomsByIdRestore as corePostChatsRoomsByIdRestore,
-  postChatsConversations as corePostConversations,
-  postChatsConversationsByIdMessages as corePostConversationsByIdMessages,
   postCoworkersByIdImage as corePostCoworkersByIdImage,
   postCoworkersByIdUnarchive as corePostCoworkersByIdUnarchive,
   postEnterpriseContracts as corePostEnterpriseContracts,
@@ -522,125 +513,6 @@ export function toCoreApiActionError(error: unknown): ActionError {
 }
 
 export function createCoreClient(getClient: GetClient) {
-  async function getConversations() {
-    return executeOperation(
-      getClient,
-      (client) =>
-        coreGetConversations({
-          client,
-          cache: "no-store",
-        }),
-      "Failed to fetch conversations",
-    );
-  }
-
-  async function createConversation(body: {
-    openaiId?: string;
-    title?: string;
-    metadata?: Record<string, unknown>;
-  }) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        corePostConversations({
-          client,
-          body,
-        }),
-      "Failed to create conversation",
-    );
-  }
-
-  async function getConversation(id: string) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        coreGetConversationsById({
-          client,
-          path: { id },
-          cache: "no-store",
-        }),
-      "Failed to fetch conversation",
-    );
-  }
-
-  async function updateConversation(
-    id: string,
-    body: {
-      metadata?: Record<string, unknown>;
-      title?: string;
-    },
-  ) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        corePatchConversationsById({
-          client,
-          path: { id },
-          body,
-        }),
-      "Failed to update conversation",
-    );
-  }
-
-  async function archiveConversation(id: string, archived: boolean = true) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        corePatchConversationsByIdArchive({
-          client,
-          path: { id },
-          body: { archived },
-        }),
-      "Failed to archive conversation",
-    );
-  }
-
-  async function getConversationMessages(
-    id: string,
-    query?: { cursor?: string; limit?: number },
-  ) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        coreGetConversationsByIdMessages({
-          client,
-          path: { id },
-          query,
-          cache: "no-store",
-        }),
-      "Failed to fetch conversation messages",
-    );
-  }
-
-  async function getConversationWarmup(id: string) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        coreGetConversationsByIdWarmup({
-          client,
-          path: { id },
-          cache: "no-store",
-        }),
-      "Failed to fetch conversation warmup state",
-    );
-  }
-
-  async function addConversationMessage(
-    id: string,
-    body: CreateConversationMessageRequest,
-  ) {
-    return executeOperation(
-      getClient,
-      (client) =>
-        corePostConversationsByIdMessages({
-          client,
-          path: { id },
-          body,
-        }),
-      "Failed to add conversation message",
-    );
-  }
-
   async function getChatRooms(query?: GetChatsRoomsData["query"]) {
     return executeOperation(
       getClient,
@@ -3613,11 +3485,8 @@ export function createCoreClient(getClient: GetClient) {
     archiveChatRoom,
     restoreChatRoom,
     leaveChatRoom,
-    addConversationMessage,
-    archiveConversation,
     assignOrganizationSeat,
     createChatRoom,
-    createConversation,
     createAgentJob,
     createMyFileUploadSession,
     createTask,
@@ -3637,10 +3506,6 @@ export function createCoreClient(getClient: GetClient) {
     getChatRooms,
     markChatRoomRead,
     toggleChatRoomMessageReaction,
-    getConversation,
-    getConversationMessages,
-    getConversationWarmup,
-    getConversations,
     getHermesInstance,
     getHermesMessages,
     getHermesOnboardingProgress,
@@ -3801,7 +3666,6 @@ export function createCoreClient(getClient: GetClient) {
     putTaskSchedule,
     putTaskShare,
     unassignOrganizationSeat,
-    updateConversation,
     updateHermesInstance,
     updateOrganizationSubscriptionSeats,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-657](https://linear.app/masumi/issue/SOK-657/remove-web-conversation-client-after-rooms-cutover)

## Summary
- Remove conversation list/create/get/archive/message helpers from web `coreClient` wrappers
- Keep generated `@deprecated` conversation SDK as legacy-only (no OpenAPI/regen)
- Retarget Core client smoke test to `getChatRooms`
- No Core routes, DB tables, or history UI changes (soft cutover cleanup after rooms)

## Verification
- `pnpm web:check`
- `pnpm web:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-657](https://linear.app/masumi/issue/SOK-657/remove-web-conversation-client-after-rooms-cutover)

<div><a href="https://cursor.com/agents/bc-8a475211-e0fb-4010-8fcf-f091c2f2ca90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a475211-e0fb-4010-8fcf-f091c2f2ca90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

