### PR TITLE
fix(core): harden chat room stream turn dedup with DB uniques

### DIFF
--- a/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
+++ b/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
@@ -109,6 +109,48 @@ describe("persistAssistantToChatRoom", () => {
     expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledTimes(2);
   });
 
+  it("rethrows P2002 when race re-read finds nothing", async () => {
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.$transaction).mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+    );
+
+    await expect(
+      persistAssistantToChatRoom({
+        roomId: "room_1",
+        senderCoworkerId: "coworker_1",
+        contentText: "Hello",
+        responsesApiResponseId: "resp_missing",
+      }),
+    ).rejects.toMatchObject({ code: "P2002" });
+  });
+
+  it("trims responsesApiResponseId before persist", async () => {
+    await persistAssistantToChatRoom({
+      roomId: "room_1",
+      senderCoworkerId: "coworker_1",
+      contentText: "Hello",
+      responsesApiResponseId: "  resp_trim  ",
+    });
+
+    expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledWith({
+      where: {
+        roomId_responsesApiResponseId: {
+          roomId: "room_1",
+          responsesApiResponseId: "resp_trim",
+        },
+      },
+      select: { id: true },
+    });
+    expect(prisma.chatRoomMessage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          responsesApiResponseId: "resp_trim",
+        }),
+      }),
+    );
+  });
+
   it("rethrows non-unique errors after create fails", async () => {
     vi.mocked(prisma.$transaction).mockRejectedValue(new Error("db down"));
 
@@ -292,6 +334,22 @@ describe("persistUserMessageToChatRoom", () => {
 
     expect(result.id).toBe("msg_winner_user");
     expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows P2002 when race re-read finds nothing", async () => {
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.$transaction).mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+    );
+
+    await expect(
+      persistUserMessageToChatRoom({
+        roomId: "room_1",
+        senderUserId: "user_1",
+        contentText: "Hello",
+        clientMessageId: "ui_msg_missing",
+      }),
+    ).rejects.toMatchObject({ code: "P2002" });
   });
 
   it("stores client_message_id in metadata and clientMessageId column on create", async () => {

--- a/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
+++ b/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    chatRoomMessage: { create: vi.fn(), findFirst: vi.fn() },
+    chatRoomMessage: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+    },
     chatRoom: { update: vi.fn() },
     $transaction: vi.fn(),
   },
@@ -23,7 +26,7 @@ async function runTransactionCallback<T>(
 describe("persistAssistantToChatRoom", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(prisma.chatRoomMessage.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.chatRoomMessage.create).mockResolvedValue({
       id: "msg_assistant",
     } as never);
@@ -52,6 +55,7 @@ describe("persistAssistantToChatRoom", () => {
           senderCoworkerId: "coworker_1",
           content: "Hello from coworker",
           senderUserId: null,
+          responsesApiResponseId: null,
         }),
       }),
     );
@@ -62,7 +66,7 @@ describe("persistAssistantToChatRoom", () => {
   });
 
   it("returns existing message id when responsesApiResponseId already persisted", async () => {
-    vi.mocked(prisma.chatRoomMessage.findFirst).mockResolvedValue({
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue({
       id: "msg_existing",
     } as never);
 
@@ -74,17 +78,48 @@ describe("persistAssistantToChatRoom", () => {
     });
 
     expect(result.id).toBe("msg_existing");
-    expect(prisma.chatRoomMessage.findFirst).toHaveBeenCalledWith({
+    expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledWith({
       where: {
-        roomId: "room_1",
-        metadata: {
-          path: ["responses_api_response_id"],
-          equals: "resp_1",
+        roomId_responsesApiResponseId: {
+          roomId: "room_1",
+          responsesApiResponseId: "resp_1",
         },
       },
       select: { id: true },
     });
     expect(prisma.chatRoomMessage.create).not.toHaveBeenCalled();
+  });
+
+  it("returns existing id when concurrent create hits unique (P2002)", async () => {
+    vi.mocked(prisma.chatRoomMessage.findUnique)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "msg_winner" } as never);
+    vi.mocked(prisma.$transaction).mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+    );
+
+    const result = await persistAssistantToChatRoom({
+      roomId: "room_1",
+      senderCoworkerId: "coworker_1",
+      contentText: "Race finish",
+      responsesApiResponseId: "resp_race",
+    });
+
+    expect(result.id).toBe("msg_winner");
+    expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows non-unique errors after create fails", async () => {
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error("db down"));
+
+    await expect(
+      persistAssistantToChatRoom({
+        roomId: "room_1",
+        senderCoworkerId: "coworker_1",
+        contentText: "Hello",
+        responsesApiResponseId: "resp_1",
+      }),
+    ).rejects.toThrow("db down");
   });
 
   it("throws when assistant payload is empty", async () => {
@@ -96,15 +131,16 @@ describe("persistAssistantToChatRoom", () => {
       }),
     ).rejects.toThrow("Cannot persist empty assistant chat room message");
 
-    expect(prisma.chatRoomMessage.findFirst).not.toHaveBeenCalled();
+    expect(prisma.chatRoomMessage.findUnique).not.toHaveBeenCalled();
     expect(prisma.chatRoomMessage.create).not.toHaveBeenCalled();
   });
 
-  it("persists reasoning, thought timing, and ui parts in metadata", async () => {
+  it("persists reasoning, thought timing, ui parts, and response id", async () => {
     await persistAssistantToChatRoom({
       roomId: "room_1",
       senderCoworkerId: "coworker_1",
       contentText: "Here's the image.",
+      responsesApiResponseId: "resp_img",
       reasoning: [{ type: "reasoning", text: "Thinking..." }],
       thoughtTiming: { startedAtMs: 100, endedAtMs: 500 },
       uiParts: [
@@ -125,6 +161,7 @@ describe("persistAssistantToChatRoom", () => {
           senderCoworkerId: "coworker_1",
           senderUserId: null,
           content: "Here's the image.",
+          responsesApiResponseId: "resp_img",
           metadata: {
             reasoning: [{ type: "reasoning", text: "Thinking..." }],
             thought_timing_ms: { start: 100, end: 500 },
@@ -139,6 +176,7 @@ describe("persistAssistantToChatRoom", () => {
                 },
               ],
             },
+            responses_api_response_id: "resp_img",
           },
         },
       }),
@@ -149,7 +187,7 @@ describe("persistAssistantToChatRoom", () => {
 describe("persistUserMessageToChatRoom", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(prisma.chatRoomMessage.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.chatRoomMessage.create).mockResolvedValue({
       id: "msg_user",
     } as never);
@@ -179,6 +217,7 @@ describe("persistUserMessageToChatRoom", () => {
           senderCoworkerId: null,
           content: "Hello from user",
           metadata: undefined,
+          clientMessageId: null,
         },
       }),
     );
@@ -204,13 +243,14 @@ describe("persistUserMessageToChatRoom", () => {
           senderCoworkerId: null,
           content: "Make an image",
           metadata: { image_generation: true },
+          clientMessageId: null,
         },
       }),
     );
   });
 
   it("skips create when clientMessageId already persisted", async () => {
-    vi.mocked(prisma.chatRoomMessage.findFirst).mockResolvedValue({
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue({
       id: "msg_existing_user",
     } as never);
 
@@ -222,13 +262,11 @@ describe("persistUserMessageToChatRoom", () => {
     });
 
     expect(result.id).toBe("msg_existing_user");
-    expect(prisma.chatRoomMessage.findFirst).toHaveBeenCalledWith({
+    expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledWith({
       where: {
-        roomId: "room_1",
-        senderUserId: "user_1",
-        metadata: {
-          path: ["client_message_id"],
-          equals: "ui_msg_1",
+        roomId_clientMessageId: {
+          roomId: "room_1",
+          clientMessageId: "ui_msg_1",
         },
       },
       select: { id: true },
@@ -237,8 +275,27 @@ describe("persistUserMessageToChatRoom", () => {
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it("stores client_message_id in metadata on create", async () => {
-    vi.mocked(prisma.chatRoomMessage.findFirst).mockResolvedValue(null);
+  it("returns existing id when concurrent create hits unique (P2002)", async () => {
+    vi.mocked(prisma.chatRoomMessage.findUnique)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "msg_winner_user" } as never);
+    vi.mocked(prisma.$transaction).mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+    );
+
+    const result = await persistUserMessageToChatRoom({
+      roomId: "room_1",
+      senderUserId: "user_1",
+      contentText: "Hello race",
+      clientMessageId: "ui_msg_race",
+    });
+
+    expect(result.id).toBe("msg_winner_user");
+    expect(prisma.chatRoomMessage.findUnique).toHaveBeenCalledTimes(2);
+  });
+
+  it("stores client_message_id in metadata and clientMessageId column on create", async () => {
+    vi.mocked(prisma.chatRoomMessage.findUnique).mockResolvedValue(null);
 
     await persistUserMessageToChatRoom({
       roomId: "room_1",
@@ -250,6 +307,7 @@ describe("persistUserMessageToChatRoom", () => {
     expect(prisma.chatRoomMessage.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
+          clientMessageId: "ui_msg_2",
           metadata: { client_message_id: "ui_msg_2" },
         }),
       }),

--- a/apps/core/src/helpers/persist-assistant-to-chat-room.ts
+++ b/apps/core/src/helpers/persist-assistant-to-chat-room.ts
@@ -91,6 +91,7 @@ async function findUserByClientMessageId(
  * When `responsesApiResponseId` is set, DB unique `(roomId, responsesApiResponseId)`
  * guarantees at most one assistant row under concurrent writers (Redis lock is
  * happy-path only). Soft lookup + P2002 recovery return the existing id.
+ * Uniqueness is room-scoped (not per coworker), matching SOK-658.
  */
 export async function persistAssistantToChatRoom(params: {
   roomId: string;
@@ -116,11 +117,11 @@ export async function persistAssistantToChatRoom(params: {
     throw new Error("Cannot persist empty assistant chat room message");
   }
 
-  const responseId =
-    typeof responsesApiResponseId === "string" &&
-    responsesApiResponseId.length > 0
-      ? responsesApiResponseId
-      : null;
+  const trimmedResponseId =
+    typeof responsesApiResponseId === "string"
+      ? responsesApiResponseId.trim()
+      : "";
+  const responseId = trimmedResponseId.length > 0 ? trimmedResponseId : null;
 
   if (responseId) {
     const existing = await findAssistantByResponsesApiResponseId(
@@ -182,6 +183,10 @@ export async function persistAssistantToChatRoom(params: {
  * When `clientMessageId` is set, DB unique `(roomId, clientMessageId)` guarantees
  * at most one user row under concurrent writers (Redis lock is happy-path only).
  * Soft lookup + P2002 recovery return the existing id.
+ *
+ * Uniqueness is intentionally room-scoped (not per sender): SOK-658 requires one
+ * row per client turn id in the room transcript. Client message ids are opaque
+ * AI SDK ids; cross-member collisions are not expected.
  */
 export async function persistUserMessageToChatRoom(params: {
   roomId: string;

--- a/apps/core/src/helpers/persist-assistant-to-chat-room.ts
+++ b/apps/core/src/helpers/persist-assistant-to-chat-room.ts
@@ -1,3 +1,4 @@
+import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
 import type { PersistedChatUiPart } from "./message-content";
 
@@ -53,9 +54,43 @@ function buildAssistantMessageMetadata(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+async function findAssistantByResponsesApiResponseId(
+  roomId: string,
+  responsesApiResponseId: string,
+): Promise<{ id: string } | null> {
+  return prisma.chatRoomMessage.findUnique({
+    where: {
+      roomId_responsesApiResponseId: {
+        roomId,
+        responsesApiResponseId,
+      },
+    },
+    select: { id: true },
+  });
+}
+
+async function findUserByClientMessageId(
+  roomId: string,
+  clientMessageId: string,
+): Promise<{ id: string } | null> {
+  return prisma.chatRoomMessage.findUnique({
+    where: {
+      roomId_clientMessageId: {
+        roomId,
+        clientMessageId,
+      },
+    },
+    select: { id: true },
+  });
+}
+
 /**
  * Persists an assistant turn to `chat_room_message`.
  * Callers must not pass empty content (no text, reasoning, or ui parts) — throws if empty.
+ *
+ * When `responsesApiResponseId` is set, DB unique `(roomId, responsesApiResponseId)`
+ * guarantees at most one assistant row under concurrent writers (Redis lock is
+ * happy-path only). Soft lookup + P2002 recovery return the existing id.
  */
 export async function persistAssistantToChatRoom(params: {
   roomId: string;
@@ -88,16 +123,10 @@ export async function persistAssistantToChatRoom(params: {
       : null;
 
   if (responseId) {
-    const existing = await prisma.chatRoomMessage.findFirst({
-      where: {
-        roomId,
-        metadata: {
-          path: ["responses_api_response_id"],
-          equals: responseId,
-        },
-      },
-      select: { id: true },
-    });
+    const existing = await findAssistantByResponsesApiResponseId(
+      roomId,
+      responseId,
+    );
     if (existing) {
       return { id: existing.id };
     }
@@ -110,27 +139,50 @@ export async function persistAssistantToChatRoom(params: {
     responseId,
   );
 
-  const created = await prisma.$transaction(async (tx) => {
-    const message = await tx.chatRoomMessage.create({
-      data: {
-        roomId,
-        senderCoworkerId,
-        senderUserId: null,
-        content: contentText,
-        metadata,
-      },
-      select: { id: true },
+  try {
+    const created = await prisma.$transaction(async (tx) => {
+      const message = await tx.chatRoomMessage.create({
+        data: {
+          roomId,
+          senderCoworkerId,
+          senderUserId: null,
+          content: contentText,
+          metadata,
+          responsesApiResponseId: responseId,
+        },
+        select: { id: true },
+      });
+      // Sidebar / room list order by activity — keep in sync with stream writes.
+      await tx.chatRoom.update({
+        where: { id: roomId },
+        data: { updatedAt: new Date() },
+      });
+      return message;
     });
-    // Sidebar / room list order by activity — keep in sync with stream writes.
-    await tx.chatRoom.update({
-      where: { id: roomId },
-      data: { updatedAt: new Date() },
-    });
-    return message;
-  });
-  return { id: created.id };
+    return { id: created.id };
+  } catch (error) {
+    if (!responseId || !isPrismaUniqueViolation(error)) {
+      throw error;
+    }
+    // Interactive tx aborted after failed create — re-read on root client.
+    const raced = await findAssistantByResponsesApiResponseId(
+      roomId,
+      responseId,
+    );
+    if (raced) {
+      return { id: raced.id };
+    }
+    throw error;
+  }
 }
 
+/**
+ * Persists a user turn to `chat_room_message`.
+ *
+ * When `clientMessageId` is set, DB unique `(roomId, clientMessageId)` guarantees
+ * at most one user row under concurrent writers (Redis lock is happy-path only).
+ * Soft lookup + P2002 recovery return the existing id.
+ */
 export async function persistUserMessageToChatRoom(params: {
   roomId: string;
   senderUserId: string;
@@ -147,18 +199,10 @@ export async function persistUserMessageToChatRoom(params: {
 
   const trimmedClientId =
     typeof clientMessageId === "string" ? clientMessageId.trim() : "";
-  if (trimmedClientId.length > 0) {
-    const existing = await prisma.chatRoomMessage.findFirst({
-      where: {
-        roomId,
-        senderUserId,
-        metadata: {
-          path: ["client_message_id"],
-          equals: trimmedClientId,
-        },
-      },
-      select: { id: true },
-    });
+  const clientId = trimmedClientId.length > 0 ? trimmedClientId : null;
+
+  if (clientId) {
+    const existing = await findUserByClientMessageId(roomId, clientId);
     if (existing) {
       return { id: existing.id };
     }
@@ -166,30 +210,41 @@ export async function persistUserMessageToChatRoom(params: {
 
   const mergedMetadata: Record<string, unknown> = {
     ...(metadata ?? {}),
-    ...(trimmedClientId.length > 0
-      ? { client_message_id: trimmedClientId }
-      : {}),
+    ...(clientId ? { client_message_id: clientId } : {}),
   };
   const metadataToStore =
     Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined;
 
-  const created = await prisma.$transaction(async (tx) => {
-    const message = await tx.chatRoomMessage.create({
-      data: {
-        roomId,
-        senderUserId,
-        senderCoworkerId: null,
-        content: contentText,
-        metadata: metadataToStore,
-      },
-      select: { id: true },
+  try {
+    const created = await prisma.$transaction(async (tx) => {
+      const message = await tx.chatRoomMessage.create({
+        data: {
+          roomId,
+          senderUserId,
+          senderCoworkerId: null,
+          content: contentText,
+          metadata: metadataToStore,
+          clientMessageId: clientId,
+        },
+        select: { id: true },
+      });
+      await tx.chatRoom.update({
+        where: { id: roomId },
+        data: { updatedAt: new Date() },
+      });
+      return message;
     });
-    await tx.chatRoom.update({
-      where: { id: roomId },
-      data: { updatedAt: new Date() },
-    });
-    return message;
-  });
 
-  return { id: created.id };
+    return { id: created.id };
+  } catch (error) {
+    if (!clientId || !isPrismaUniqueViolation(error)) {
+      throw error;
+    }
+    // Interactive tx aborted after failed create — re-read on root client.
+    const raced = await findUserByClientMessageId(roomId, clientId);
+    if (raced) {
+      return { id: raced.id };
+    }
+    throw error;
+  }
 }

--- a/packages/database/prisma/migrations/20260731120000_chat_room_message_stream_turn_unique/migration.sql
+++ b/packages/database/prisma/migrations/20260731120000_chat_room_message_stream_turn_unique/migration.sql
@@ -1,0 +1,52 @@
+-- Durable stream-turn uniqueness for chat room messages (SOK-658).
+-- Soft metadata find-then-insert alone races under concurrency; Redis lock is
+-- happy-path only. These columns + unique indexes are the DB safety net.
+
+-- AlterTable
+ALTER TABLE "chat_room_message" ADD COLUMN "clientMessageId" TEXT;
+ALTER TABLE "chat_room_message" ADD COLUMN "responsesApiResponseId" TEXT;
+
+-- Backfill from existing metadata keys (trim empty strings to NULL).
+UPDATE "chat_room_message"
+SET "clientMessageId" = NULLIF(BTRIM(metadata->>'client_message_id'), '')
+WHERE metadata ? 'client_message_id';
+
+UPDATE "chat_room_message"
+SET "responsesApiResponseId" = NULLIF(BTRIM(metadata->>'responses_api_response_id'), '')
+WHERE metadata ? 'responses_api_response_id';
+
+-- Deduplicate before unique indexes: keep oldest row per (roomId, turn id).
+-- Cascades remove dependent reactions/mentions/replies on deleted duplicates.
+WITH ranked_client AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY "roomId", "clientMessageId"
+      ORDER BY "createdAt" ASC, id ASC
+    ) AS rn
+  FROM "chat_room_message"
+  WHERE "clientMessageId" IS NOT NULL
+)
+DELETE FROM "chat_room_message"
+WHERE id IN (SELECT id FROM ranked_client WHERE rn > 1);
+
+WITH ranked_response AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY "roomId", "responsesApiResponseId"
+      ORDER BY "createdAt" ASC, id ASC
+    ) AS rn
+  FROM "chat_room_message"
+  WHERE "responsesApiResponseId" IS NOT NULL
+)
+DELETE FROM "chat_room_message"
+WHERE id IN (SELECT id FROM ranked_response WHERE rn > 1);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "chat_room_message_roomId_clientMessageId_key"
+  ON "chat_room_message"("roomId", "clientMessageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "chat_room_message_roomId_responsesApiResponseId_key"
+  ON "chat_room_message"("roomId", "responsesApiResponseId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1728,10 +1728,21 @@ model ChatRoomMessage {
   metadata  Json?
   createdAt DateTime @default(now())
 
+  /// AI SDK / client message id for user stream-turn idempotency.
+  /// Also mirrored in metadata.client_message_id for transcript consumers.
+  clientMessageId String?
+  /// OpenAI Responses API response id for assistant stream-turn idempotency.
+  /// Also mirrored in metadata.responses_api_response_id for transcript consumers.
+  responsesApiResponseId String?
+
   mentionsAsSource   ChatRoomMention[]  @relation("ChatRoomMentionSource")
   mentionResponseFor ChatRoomMention?   @relation("ChatRoomMentionResponse")
   reactions          ChatRoomReaction[]
 
+  // DB uniqueness is the safety net for concurrent stream POSTs (Redis lock is
+  // happy-path only). Nullable columns: Postgres unique allows multiple NULLs.
+  @@unique([roomId, clientMessageId])
+  @@unique([roomId, responsesApiResponseId])
   @@index([roomId, createdAt])
   @@index([roomId, parentMessageId, createdAt])
   @@index([parentMessageId, createdAt])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-658](https://linear.app/masumi/issue/SOK-658/harden-room-stream-turn-dedup-without-relying-only-on-redis): concurrent room stream POSTs can no longer insert duplicate user/assistant turns when Redis locking is missing, degraded, or expired.

- Add `clientMessageId` / `responsesApiResponseId` columns on `chat_room_message` with unique `(roomId, turn id)` indexes (Postgres allows multiple NULLs).
- Migration backfills from existing metadata keys and dedupes before creating uniques.
- Persist helpers soft-lookup by unique key, then recover on `P2002` (same pattern as conversation assistant persist / orchestrator create).
- Redis stream lock left in place as happy-path single-flight.
- Uniqueness is **room-scoped** (not per sender), matching SOK-658 AC.

## Migration note

Dedup `DELETE` keeps the oldest row per turn id. Cascades may remove reactions / mentions / replies attached to newer duplicate rows. Chat rooms are recent; expected duplicate set is empty or race-only leaf messages. Preview/prod deploy still runs this once via `prisma migrate deploy`.

## Verification

- `pnpm --filter core exec vitest run src/helpers/__tests__/persist-assistant-to-chat-room.test.ts`
- Pre-commit: `pnpm check && pnpm typecheck`

## Review notes

- No Core DB integration harness for true concurrent inserts; race covered via P2002 recovery unit tests (same pattern as orchestrator / conversation persist).
- Room-scoped `clientMessageId` uniqueness is intentional per AC.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-658](https://linear.app/masumi/issue/SOK-658/harden-room-stream-turn-dedup-without-relying-only-on-redis)

<div><a href="https://cursor.com/agents/bc-e94a234a-6b5b-4d3b-b4bd-b2418e5090e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e94a234a-6b5b-4d3b-b4bd-b2418e5090e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

