### PR TITLE
feat(chat): stream coworker DM thread replies via room stream

### DIFF
--- a/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
+++ b/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
@@ -56,6 +56,7 @@ describe("persistAssistantToChatRoom", () => {
           content: "Hello from coworker",
           senderUserId: null,
           responsesApiResponseId: null,
+          parentMessageId: null,
         }),
       }),
     );
@@ -63,6 +64,23 @@ describe("persistAssistantToChatRoom", () => {
       where: { id: "room_1" },
       data: { updatedAt: expect.any(Date) },
     });
+  });
+
+  it("persists parentMessageId for thread assistant turns", async () => {
+    await persistAssistantToChatRoom({
+      roomId: "room_1",
+      senderCoworkerId: "coworker_1",
+      contentText: "Thread reply",
+      parentMessageId: "parent_1",
+    });
+
+    expect(prisma.chatRoomMessage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          parentMessageId: "parent_1",
+        }),
+      }),
+    );
   });
 
   it("returns existing message id when responsesApiResponseId already persisted", async () => {
@@ -198,12 +216,13 @@ describe("persistAssistantToChatRoom", () => {
 
     expect(prisma.chatRoomMessage.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: {
+        data: expect.objectContaining({
           roomId: "room_1",
           senderCoworkerId: "coworker_1",
           senderUserId: null,
           content: "Here's the image.",
           responsesApiResponseId: "resp_img",
+          parentMessageId: null,
           metadata: {
             reasoning: [{ type: "reasoning", text: "Thinking..." }],
             thought_timing_ms: { start: 100, end: 500 },
@@ -220,7 +239,7 @@ describe("persistAssistantToChatRoom", () => {
             },
             responses_api_response_id: "resp_img",
           },
-        },
+        }),
       }),
     );
   });
@@ -260,6 +279,7 @@ describe("persistUserMessageToChatRoom", () => {
           content: "Hello from user",
           metadata: undefined,
           clientMessageId: null,
+          parentMessageId: null,
         },
       }),
     );
@@ -267,6 +287,23 @@ describe("persistUserMessageToChatRoom", () => {
       where: { id: "room_1" },
       data: { updatedAt: expect.any(Date) },
     });
+  });
+
+  it("persists parentMessageId for thread user turns", async () => {
+    await persistUserMessageToChatRoom({
+      roomId: "room_1",
+      senderUserId: "user_1",
+      contentText: "Thread reply",
+      parentMessageId: "parent_1",
+    });
+
+    expect(prisma.chatRoomMessage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          parentMessageId: "parent_1",
+        }),
+      }),
+    );
   });
 
   it("persists optional metadata", async () => {
@@ -286,6 +323,7 @@ describe("persistUserMessageToChatRoom", () => {
           content: "Make an image",
           metadata: { image_generation: true },
           clientMessageId: null,
+          parentMessageId: null,
         },
       }),
     );

--- a/apps/core/src/helpers/__tests__/room-stream-thread.test.ts
+++ b/apps/core/src/helpers/__tests__/room-stream-thread.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    chatRoomMessage: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/routes/v1/chats/stream/coworker-conversation", () => ({
+  CoworkerConversationError: class CoworkerConversationError extends Error {
+    upstreamStatus: number;
+    constructor(message: string, upstreamStatus: number) {
+      super(message);
+      this.upstreamStatus = upstreamStatus;
+    }
+  },
+  createCoworkerConversation: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  convertToModelMessages: vi.fn(async () => [
+    { role: "user", content: "converted" },
+  ]),
+}));
+
+import { convertToModelMessages } from "ai";
+
+import prisma from "@/lib/db/prisma";
+import { createCoworkerConversation } from "@/routes/v1/chats/stream/coworker-conversation";
+
+import {
+  buildRoomStreamThreadModelMessages,
+  ensureThreadProviderConversation,
+  THREAD_PROVIDER_CONVERSATION_ID_KEY,
+} from "../room-stream-thread";
+
+describe("ensureThreadProviderConversation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns existing thread provider conversation from parent metadata", async () => {
+    vi.mocked(prisma.chatRoomMessage.findFirst).mockResolvedValue({
+      id: "parent_1",
+      metadata: { [THREAD_PROVIDER_CONVERSATION_ID_KEY]: "conv_existing" },
+    } as never);
+
+    const result = await ensureThreadProviderConversation({
+      roomId: "room_1",
+      parentMessageId: "parent_1",
+      userId: "user_1",
+      organizationId: null,
+      coworkerSlug: "hannah",
+      responsesApiBaseUrl: "https://responses.example.com/v1",
+    });
+
+    expect(result).toEqual({
+      providerConversationId: "conv_existing",
+      justCreated: false,
+    });
+    expect(createCoworkerConversation).not.toHaveBeenCalled();
+  });
+
+  it("creates and stores a new thread provider conversation", async () => {
+    vi.mocked(prisma.chatRoomMessage.findFirst)
+      .mockResolvedValueOnce({
+        id: "parent_1",
+        metadata: null,
+      } as never)
+      .mockResolvedValueOnce({
+        id: "parent_1",
+        metadata: { [THREAD_PROVIDER_CONVERSATION_ID_KEY]: "conv_new" },
+      } as never);
+    vi.mocked(createCoworkerConversation).mockResolvedValue({
+      id: "conv_new",
+    } as never);
+    vi.mocked(prisma.chatRoomMessage.update).mockResolvedValue({} as never);
+
+    const result = await ensureThreadProviderConversation({
+      roomId: "room_1",
+      parentMessageId: "parent_1",
+      userId: "user_1",
+      organizationId: "org_1",
+      coworkerSlug: "hannah",
+      responsesApiBaseUrl: "https://responses.example.com/v1",
+    });
+
+    expect(createCoworkerConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sokosumiConversationId: "parent_1",
+        coworkerSlug: "hannah",
+      }),
+    );
+    expect(prisma.chatRoomMessage.update).toHaveBeenCalledWith({
+      where: { id: "parent_1" },
+      data: {
+        metadata: { [THREAD_PROVIDER_CONVERSATION_ID_KEY]: "conv_new" },
+      },
+    });
+    expect(result).toEqual({
+      providerConversationId: "conv_new",
+      justCreated: true,
+    });
+  });
+});
+
+describe("buildRoomStreamThreadModelMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("embeds thread context on first AI turn", async () => {
+    vi.mocked(prisma.chatRoomMessage.findMany).mockResolvedValue([
+      {
+        id: "parent_1",
+        content: "Root question",
+        senderUserId: "user_1",
+        senderCoworkerId: null,
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:00:00.000Z"),
+        senderUser: { name: "Ada" },
+        senderCoworker: null,
+      },
+      {
+        id: "reply_1",
+        content: "Follow-up",
+        senderUserId: "user_1",
+        senderCoworkerId: null,
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:01:00.000Z"),
+        senderUser: { name: "Ada" },
+        senderCoworker: null,
+      },
+    ] as never);
+
+    const result = await buildRoomStreamThreadModelMessages({
+      roomId: "room_1",
+      parentMessageId: "parent_1",
+      roomName: "Hannah DM",
+      senderName: "Ada",
+      lastUserMessageText: "Follow-up",
+    });
+
+    expect(convertToModelMessages).not.toHaveBeenCalled();
+    expect(result.modelMessages).toHaveLength(1);
+    expect(result.modelMessages[0]).toMatchObject({ role: "user" });
+    expect(String(result.modelMessages[0]?.content)).toContain("Root question");
+    expect(String(result.modelMessages[0]?.content)).toContain("Follow-up");
+  });
+
+  it("converts full thread history after an assistant turn exists", async () => {
+    vi.mocked(prisma.chatRoomMessage.findMany).mockResolvedValue([
+      {
+        id: "parent_1",
+        content: "Root",
+        senderUserId: "user_1",
+        senderCoworkerId: null,
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:00:00.000Z"),
+        senderUser: { name: "Ada" },
+        senderCoworker: null,
+      },
+      {
+        id: "asst_1",
+        content: "Answer",
+        senderUserId: null,
+        senderCoworkerId: "cow_1",
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:01:00.000Z"),
+        senderUser: null,
+        senderCoworker: { name: "Hannah" },
+      },
+      {
+        id: "reply_2",
+        content: "More",
+        senderUserId: "user_1",
+        senderCoworkerId: null,
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:02:00.000Z"),
+        senderUser: { name: "Ada" },
+        senderCoworker: null,
+      },
+    ] as never);
+
+    const result = await buildRoomStreamThreadModelMessages({
+      roomId: "room_1",
+      parentMessageId: "parent_1",
+      roomName: "Hannah DM",
+      senderName: "Ada",
+      lastUserMessageText: "More",
+    });
+
+    expect(convertToModelMessages).toHaveBeenCalledOnce();
+    expect(result.modelMessages).toEqual([
+      { role: "user", content: "converted" },
+    ]);
+  });
+});

--- a/apps/core/src/helpers/__tests__/room-stream-thread.test.ts
+++ b/apps/core/src/helpers/__tests__/room-stream-thread.test.ts
@@ -36,7 +36,35 @@ import {
   buildRoomStreamThreadModelMessages,
   ensureThreadProviderConversation,
   THREAD_PROVIDER_CONVERSATION_ID_KEY,
+  threadHasPriorAssistantReply,
 } from "../room-stream-thread";
+
+describe("threadHasPriorAssistantReply", () => {
+  it("ignores coworker root — first thread AI turn still needs embedded context", () => {
+    expect(
+      threadHasPriorAssistantReply(
+        [
+          { id: "parent_1", senderCoworkerId: "cow_1" },
+          { id: "reply_1", senderCoworkerId: null },
+        ],
+        "parent_1",
+      ),
+    ).toBe(false);
+  });
+
+  it("detects an assistant reply under the root", () => {
+    expect(
+      threadHasPriorAssistantReply(
+        [
+          { id: "parent_1", senderCoworkerId: "cow_1" },
+          { id: "asst_1", senderCoworkerId: "cow_1" },
+          { id: "reply_2", senderCoworkerId: null },
+        ],
+        "parent_1",
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("ensureThreadProviderConversation", () => {
   beforeEach(() => {
@@ -113,18 +141,8 @@ describe("buildRoomStreamThreadModelMessages", () => {
     vi.clearAllMocks();
   });
 
-  it("embeds thread context on first AI turn", async () => {
+  it("embeds thread context on first AI turn under a user root", async () => {
     vi.mocked(prisma.chatRoomMessage.findMany).mockResolvedValue([
-      {
-        id: "parent_1",
-        content: "Root question",
-        senderUserId: "user_1",
-        senderCoworkerId: null,
-        metadata: null,
-        createdAt: new Date("2026-07-01T12:00:00.000Z"),
-        senderUser: { name: "Ada" },
-        senderCoworker: null,
-      },
       {
         id: "reply_1",
         content: "Follow-up",
@@ -132,6 +150,16 @@ describe("buildRoomStreamThreadModelMessages", () => {
         senderCoworkerId: null,
         metadata: null,
         createdAt: new Date("2026-07-01T12:01:00.000Z"),
+        senderUser: { name: "Ada" },
+        senderCoworker: null,
+      },
+      {
+        id: "parent_1",
+        content: "Root question",
+        senderUserId: "user_1",
+        senderCoworkerId: null,
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:00:00.000Z"),
         senderUser: { name: "Ada" },
         senderCoworker: null,
       },
@@ -145,6 +173,11 @@ describe("buildRoomStreamThreadModelMessages", () => {
       lastUserMessageText: "Follow-up",
     });
 
+    expect(prisma.chatRoomMessage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+    );
     expect(convertToModelMessages).not.toHaveBeenCalled();
     expect(result.modelMessages).toHaveLength(1);
     expect(result.modelMessages[0]).toMatchObject({ role: "user" });
@@ -152,15 +185,95 @@ describe("buildRoomStreamThreadModelMessages", () => {
     expect(String(result.modelMessages[0]?.content)).toContain("Follow-up");
   });
 
-  it("converts full thread history after an assistant turn exists", async () => {
+  it("embeds coworker root on first AI thread turn (does not treat root as prior reply)", async () => {
     vi.mocked(prisma.chatRoomMessage.findMany).mockResolvedValue([
       {
-        id: "parent_1",
-        content: "Root",
+        id: "reply_1",
+        content: "Was kannst du mir anbieten?",
         senderUserId: "user_1",
         senderCoworkerId: null,
         metadata: null,
+        createdAt: new Date("2026-07-01T12:01:00.000Z"),
+        senderUser: { name: "Ada" },
+        senderCoworker: null,
+      },
+      {
+        id: "parent_1",
+        content: "Hallo Andreas! Wie kann ich dir heute helfen?",
+        senderUserId: null,
+        senderCoworkerId: "cow_1",
+        metadata: null,
         createdAt: new Date("2026-07-01T12:00:00.000Z"),
+        senderUser: null,
+        senderCoworker: { name: "Hannah" },
+      },
+    ] as never);
+
+    const result = await buildRoomStreamThreadModelMessages({
+      roomId: "room_1",
+      parentMessageId: "parent_1",
+      roomName: "Hannah DM",
+      senderName: "Ada",
+      lastUserMessageText: "Was kannst du mir anbieten?",
+    });
+
+    expect(convertToModelMessages).not.toHaveBeenCalled();
+    expect(String(result.modelMessages[0]?.content)).toContain(
+      "Hallo Andreas! Wie kann ich dir heute helfen?",
+    );
+    expect(String(result.modelMessages[0]?.content)).toContain(
+      "Was kannst du mir anbieten?",
+    );
+  });
+
+  it("keeps the newest messages when the thread exceeds the context window", async () => {
+    const rows = Array.from({ length: 12 }, (_, index) => {
+      const n = 12 - index;
+      return {
+        id: `msg_${n}`,
+        content: `Message ${n}`,
+        senderUserId: n === 1 ? null : "user_1",
+        senderCoworkerId: n === 1 ? "cow_1" : null,
+        metadata: null,
+        createdAt: new Date(
+          `2026-07-01T12:${String(n).padStart(2, "0")}:00.000Z`,
+        ),
+        senderUser: n === 1 ? null : { name: "Ada" },
+        senderCoworker: n === 1 ? { name: "Hannah" } : null,
+      };
+    });
+    // Newest-first page from Prisma: drop oldest (msg_1 root) from window.
+    vi.mocked(prisma.chatRoomMessage.findMany).mockResolvedValue(
+      rows.slice(0, 11) as never,
+    );
+
+    const result = await buildRoomStreamThreadModelMessages({
+      roomId: "room_1",
+      parentMessageId: "msg_1",
+      roomName: "Hannah DM",
+      senderName: "Ada",
+      lastUserMessageText: "Message 12",
+    });
+
+    // Window is msgs 2..12 (newest 11). Prior assistant under root: none in this
+    // synthetic set after dropping root — still embeds prompt with newest context.
+    expect(convertToModelMessages).not.toHaveBeenCalled();
+    expect(String(result.modelMessages[0]?.content)).toContain("Message 12");
+    expect(String(result.modelMessages[0]?.content)).toContain("Message 2");
+    expect(String(result.modelMessages[0]?.content)).not.toMatch(
+      /Message 1(?!\d)/,
+    );
+  });
+
+  it("converts full thread history after an assistant reply exists under the root", async () => {
+    vi.mocked(prisma.chatRoomMessage.findMany).mockResolvedValue([
+      {
+        id: "reply_2",
+        content: "More",
+        senderUserId: "user_1",
+        senderCoworkerId: null,
+        metadata: null,
+        createdAt: new Date("2026-07-01T12:02:00.000Z"),
         senderUser: { name: "Ada" },
         senderCoworker: null,
       },
@@ -175,12 +288,12 @@ describe("buildRoomStreamThreadModelMessages", () => {
         senderCoworker: { name: "Hannah" },
       },
       {
-        id: "reply_2",
-        content: "More",
+        id: "parent_1",
+        content: "Root",
         senderUserId: "user_1",
         senderCoworkerId: null,
         metadata: null,
-        createdAt: new Date("2026-07-01T12:02:00.000Z"),
+        createdAt: new Date("2026-07-01T12:00:00.000Z"),
         senderUser: { name: "Ada" },
         senderCoworker: null,
       },

--- a/apps/core/src/helpers/persist-assistant-to-chat-room.ts
+++ b/apps/core/src/helpers/persist-assistant-to-chat-room.ts
@@ -101,6 +101,8 @@ export async function persistAssistantToChatRoom(params: {
   reasoning?: unknown;
   thoughtTiming?: { startedAtMs: number; endedAtMs: number };
   uiParts?: PersistedChatUiPart[];
+  /** Thread root id when this turn is a thread reply. */
+  parentMessageId?: string | null;
 }): Promise<{ id: string }> {
   const {
     roomId,
@@ -110,6 +112,7 @@ export async function persistAssistantToChatRoom(params: {
     reasoning,
     thoughtTiming,
     uiParts,
+    parentMessageId,
   } = params;
   const reasoningSteps = reasoningPartsToMetadata(reasoning);
   const hasUiParts = uiParts != null && uiParts.length > 0;
@@ -150,6 +153,7 @@ export async function persistAssistantToChatRoom(params: {
           content: contentText,
           metadata,
           responsesApiResponseId: responseId,
+          parentMessageId: parentMessageId ?? null,
         },
         select: { id: true },
       });
@@ -198,9 +202,17 @@ export async function persistUserMessageToChatRoom(params: {
    * we do not insert duplicate user rows after a failed/aborted stream.
    */
   clientMessageId?: string | null;
+  /** Thread root id when this turn is a thread reply. */
+  parentMessageId?: string | null;
 }): Promise<{ id: string }> {
-  const { roomId, senderUserId, contentText, metadata, clientMessageId } =
-    params;
+  const {
+    roomId,
+    senderUserId,
+    contentText,
+    metadata,
+    clientMessageId,
+    parentMessageId,
+  } = params;
 
   const trimmedClientId =
     typeof clientMessageId === "string" ? clientMessageId.trim() : "";
@@ -230,6 +242,7 @@ export async function persistUserMessageToChatRoom(params: {
           content: contentText,
           metadata: metadataToStore,
           clientMessageId: clientId,
+          parentMessageId: parentMessageId ?? null,
         },
         select: { id: true },
       });

--- a/apps/core/src/helpers/room-stream-thread.ts
+++ b/apps/core/src/helpers/room-stream-thread.ts
@@ -113,12 +113,26 @@ export async function ensureThreadProviderConversation(options: {
 }
 
 /**
+ * True when the thread already has an assistant reply under the root.
+ * The root itself may be a coworker message — that does NOT count as a prior
+ * thread AI turn (fresh remote conversation still needs embedded context).
+ */
+export function threadHasPriorAssistantReply(
+  rows: readonly { id: string; senderCoworkerId: string | null }[],
+  parentMessageId: string,
+): boolean {
+  return rows.some(
+    (row) => row.senderCoworkerId != null && row.id !== parentMessageId,
+  );
+}
+
+/**
  * Build model messages for a room-stream thread reply.
  *
- * Loads thread root + siblings (oldest first). Conversation mode only sends
- * the last turn to the remote API, so the first AI turn in a fresh thread
- * conversation embeds prior thread context via `buildRoomMentionPrompt`
- * (same discipline as channel mention dispatch).
+ * Loads the newest thread window (root + siblings), oldest first. Conversation
+ * mode only sends the last turn to the remote API, so the first AI turn in a
+ * fresh thread conversation embeds prior thread context via
+ * `buildRoomMentionPrompt` (same discipline as channel mention dispatch).
  */
 export async function buildRoomStreamThreadModelMessages(options: {
   roomId: string;
@@ -127,7 +141,7 @@ export async function buildRoomStreamThreadModelMessages(options: {
   senderName: string;
   lastUserMessageText: string;
 }): Promise<{ modelMessages: ModelMessage[]; uiMessages: UIMessage[] }> {
-  const rows = await prisma.chatRoomMessage.findMany({
+  const newestFirst = await prisma.chatRoomMessage.findMany({
     where: {
       roomId: options.roomId,
       OR: [
@@ -135,7 +149,8 @@ export async function buildRoomStreamThreadModelMessages(options: {
         { parentMessageId: options.parentMessageId },
       ],
     },
-    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    // Newest window (match channel dispatch); reverse for chronological model input.
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: THREAD_CONTEXT_MESSAGE_LIMIT + 1,
     select: {
       id: true,
@@ -148,13 +163,15 @@ export async function buildRoomStreamThreadModelMessages(options: {
       senderCoworker: { select: { name: true } },
     },
   });
+  const rows = [...newestFirst].reverse();
 
   const uiMessages = chatRoomMessagesToUiMessages(rows);
-  const hasPriorAssistant = rows.some(
-    (row, index) => row.senderCoworkerId != null && index < rows.length - 1,
+  const hasPriorAssistantReply = threadHasPriorAssistantReply(
+    rows,
+    options.parentMessageId,
   );
 
-  if (!hasPriorAssistant) {
+  if (!hasPriorAssistantReply) {
     const contextMessages: RoomContextMessage[] = rows
       .slice(0, -1)
       .map((row) => ({

--- a/apps/core/src/helpers/room-stream-thread.ts
+++ b/apps/core/src/helpers/room-stream-thread.ts
@@ -1,0 +1,181 @@
+import { convertToModelMessages, type ModelMessage, type UIMessage } from "ai";
+
+import { chatRoomMessagesToUiMessages } from "@/helpers/chat-room-messages-to-ui-messages";
+import prisma from "@/lib/db/prisma";
+import {
+  CoworkerConversationError,
+  createCoworkerConversation,
+} from "@/routes/v1/chats/stream/coworker-conversation";
+import {
+  buildRoomMentionPrompt,
+  type RoomContextMessage,
+} from "@/services/chat-room-coworker-dispatch.service";
+
+/** Metadata key for a thread-scoped remote conversation (not room.providerConversationId). */
+export const THREAD_PROVIDER_CONVERSATION_ID_KEY =
+  "thread_provider_conversation_id";
+
+/** Match channel mention dispatch context window. */
+const THREAD_CONTEXT_MESSAGE_LIMIT = 10;
+
+function readThreadProviderConversationId(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const value = (metadata as Record<string, unknown>)[
+    THREAD_PROVIDER_CONVERSATION_ID_KEY
+  ];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function mergeMetadataWithThreadConversationId(
+  metadata: unknown,
+  providerConversationId: string,
+): Record<string, unknown> {
+  const base =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? { ...(metadata as Record<string, unknown>) }
+      : {};
+  return {
+    ...base,
+    [THREAD_PROVIDER_CONVERSATION_ID_KEY]: providerConversationId,
+  };
+}
+
+/**
+ * Creates or reuses a remote coworker conversation scoped to a thread root.
+ * Stored on the parent message metadata so top-level room conversation context
+ * does not bleed into thread replies (and vice versa).
+ */
+export async function ensureThreadProviderConversation(options: {
+  roomId: string;
+  parentMessageId: string;
+  userId: string;
+  organizationId: string | null;
+  coworkerSlug: string;
+  responsesApiBaseUrl: string;
+}): Promise<{ providerConversationId: string; justCreated: boolean }> {
+  const parent = await prisma.chatRoomMessage.findFirst({
+    where: {
+      id: options.parentMessageId,
+      roomId: options.roomId,
+      parentMessageId: null,
+    },
+    select: { id: true, metadata: true },
+  });
+  if (!parent) {
+    throw new CoworkerConversationError(
+      "Thread parent message not found for provider conversation",
+      400,
+    );
+  }
+
+  const existingId = readThreadProviderConversationId(parent.metadata);
+  if (existingId) {
+    return { providerConversationId: existingId, justCreated: false };
+  }
+
+  const created = await createCoworkerConversation({
+    responsesApiBaseUrl: options.responsesApiBaseUrl,
+    sokosumiUserId: options.userId,
+    sokosumiOrganizationId: options.organizationId,
+    coworkerSlug: options.coworkerSlug,
+    // Correlate remote conversation to the thread root, not the room.
+    sokosumiConversationId: options.parentMessageId,
+  });
+
+  const nextMetadata = mergeMetadataWithThreadConversationId(
+    parent.metadata,
+    created.id,
+  );
+
+  await prisma.chatRoomMessage.update({
+    where: { id: options.parentMessageId },
+    data: { metadata: nextMetadata },
+  });
+
+  // Concurrent writers may overwrite — prefer whatever is stored now.
+  const after = await prisma.chatRoomMessage.findFirst({
+    where: { id: options.parentMessageId, roomId: options.roomId },
+    select: { metadata: true },
+  });
+  const storedId = readThreadProviderConversationId(after?.metadata);
+  if (!storedId) {
+    throw new CoworkerConversationError(
+      "Could not persist coworker provider conversation id on thread parent",
+      503,
+    );
+  }
+  return {
+    providerConversationId: storedId,
+    justCreated: storedId === created.id,
+  };
+}
+
+/**
+ * Build model messages for a room-stream thread reply.
+ *
+ * Loads thread root + siblings (oldest first). Conversation mode only sends
+ * the last turn to the remote API, so the first AI turn in a fresh thread
+ * conversation embeds prior thread context via `buildRoomMentionPrompt`
+ * (same discipline as channel mention dispatch).
+ */
+export async function buildRoomStreamThreadModelMessages(options: {
+  roomId: string;
+  parentMessageId: string;
+  roomName: string;
+  senderName: string;
+  lastUserMessageText: string;
+}): Promise<{ modelMessages: ModelMessage[]; uiMessages: UIMessage[] }> {
+  const rows = await prisma.chatRoomMessage.findMany({
+    where: {
+      roomId: options.roomId,
+      OR: [
+        { id: options.parentMessageId },
+        { parentMessageId: options.parentMessageId },
+      ],
+    },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    take: THREAD_CONTEXT_MESSAGE_LIMIT + 1,
+    select: {
+      id: true,
+      content: true,
+      senderUserId: true,
+      senderCoworkerId: true,
+      metadata: true,
+      createdAt: true,
+      senderUser: { select: { name: true } },
+      senderCoworker: { select: { name: true } },
+    },
+  });
+
+  const uiMessages = chatRoomMessagesToUiMessages(rows);
+  const hasPriorAssistant = rows.some(
+    (row, index) => row.senderCoworkerId != null && index < rows.length - 1,
+  );
+
+  if (!hasPriorAssistant) {
+    const contextMessages: RoomContextMessage[] = rows
+      .slice(0, -1)
+      .map((row) => ({
+        senderName:
+          row.senderCoworker?.name ?? row.senderUser?.name ?? "Unknown sender",
+        isCoworker: row.senderCoworkerId != null,
+        content: row.content,
+      }));
+    const prompt = buildRoomMentionPrompt({
+      roomName: options.roomName,
+      senderName: options.senderName,
+      content: options.lastUserMessageText,
+      isThreadReply: true,
+      contextMessages,
+    });
+    const modelMessages: ModelMessage[] = [{ role: "user", content: prompt }];
+    return { modelMessages, uiMessages };
+  }
+
+  const modelMessages = await convertToModelMessages(
+    uiMessages.map(({ id: _id, ...rest }) => rest),
+  );
+  return { modelMessages, uiMessages };
+}

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -1,8 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import type { Prisma } from "@sokosumi/database";
 import { waitUntil } from "@vercel/functions";
 
-import { badRequest, notFound } from "@/helpers/error";
+import { notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { created } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
@@ -25,6 +24,7 @@ import {
   mapChatRoomMessage,
   requireChatRoomUserWriteAccess,
   resolveMentionedCoworkerIds,
+  resolveThreadParentMessageId,
 } from "../../helpers";
 
 const paramsSchema = z.object({
@@ -64,30 +64,6 @@ const route = withGlobalHeaderParameters(
     },
   }),
 );
-
-async function resolveThreadParentMessageId(
-  tx: Prisma.TransactionClient,
-  roomId: string,
-  requestedParentMessageId: string | undefined,
-): Promise<string | null> {
-  if (!requestedParentMessageId) {
-    return null;
-  }
-  const parentMessage = await tx.chatRoomMessage.findFirst({
-    where: {
-      id: requestedParentMessageId,
-      roomId,
-    },
-    select: {
-      id: true,
-      parentMessageId: true,
-    },
-  });
-  if (!parentMessage) {
-    throw badRequest("Thread message not found");
-  }
-  return parentMessage.parentMessageId ?? parentMessage.id;
-}
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -12,6 +12,8 @@ const {
   chatRoomUpdateMock,
   chatRoomUpdateManyMock,
   chatRoomMessageCreateMock,
+  chatRoomMessageFindFirstMock,
+  userFindUniqueMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
   prismaTransactionMock,
@@ -35,11 +37,15 @@ const {
   releaseStreamLockMock,
   startStreamLockHeartbeatMock,
   waitUntilMock,
+  ensureThreadProviderConversationMock,
+  buildRoomStreamThreadModelMessagesMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
   chatRoomUpdateMock: vi.fn(),
   chatRoomUpdateManyMock: vi.fn(),
   chatRoomMessageCreateMock: vi.fn(),
+  chatRoomMessageFindFirstMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
@@ -63,6 +69,8 @@ const {
   releaseStreamLockMock: vi.fn(),
   startStreamLockHeartbeatMock: vi.fn(),
   waitUntilMock: vi.fn(),
+  ensureThreadProviderConversationMock: vi.fn(),
+  buildRoomStreamThreadModelMessagesMock: vi.fn(),
 }));
 
 vi.mock("@vercel/functions", () => ({
@@ -105,6 +113,14 @@ vi.mock("@/helpers/persist-assistant-to-chat-room", () => ({
   persistUserMessageToChatRoom: persistUserMessageToChatRoomMock,
 }));
 
+vi.mock("@/helpers/room-stream-thread", () => ({
+  THREAD_PROVIDER_CONVERSATION_ID_KEY: "thread_provider_conversation_id",
+  ensureThreadProviderConversation: (...args: unknown[]) =>
+    ensureThreadProviderConversationMock(...args),
+  buildRoomStreamThreadModelMessages: (...args: unknown[]) =>
+    buildRoomStreamThreadModelMessagesMock(...args),
+}));
+
 vi.mock(
   "@/routes/v1/chats/stream/coworker-conversation",
   async (importOriginal) => {
@@ -130,6 +146,10 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     chatRoomMessage: {
       create: chatRoomMessageCreateMock,
+      findFirst: chatRoomMessageFindFirstMock,
+    },
+    user: {
+      findUnique: userFindUniqueMock,
     },
     organization: {
       findUnique: organizationFindUniqueMock,
@@ -149,6 +169,7 @@ vi.mock("@/lib/db/prisma", () => ({
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const USER_ID = "user_123";
 const COWORKER_ID = "coworker_1";
+const PARENT_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440099";
 
 const userAuthContext: AuthVariables["authContext"] = {
   actor: "user",
@@ -188,6 +209,7 @@ function roomWithOneCoworker(
   return {
     id: ROOM_ID,
     kind: overrides.kind ?? "direct",
+    name: "Hannah DM",
     organizationId:
       "organizationId" in overrides ? overrides.organizationId : "org_1",
     providerConversationId:
@@ -229,6 +251,9 @@ beforeEach(() => {
     callback({
       chatRoom: {
         findFirst: roomFindFirstMock,
+      },
+      chatRoomMessage: {
+        findFirst: chatRoomMessageFindFirstMock,
       },
       organization: {
         findUnique: organizationFindUniqueMock,
@@ -288,6 +313,21 @@ beforeEach(() => {
   );
   streamTextMock.mockReturnValue({
     toUIMessageStreamResponse: toUIMessageStreamResponseMock,
+  });
+  userFindUniqueMock.mockResolvedValue({ name: "Ada" });
+  ensureThreadProviderConversationMock.mockResolvedValue({
+    providerConversationId: "conv_thread_1",
+    justCreated: true,
+  });
+  buildRoomStreamThreadModelMessagesMock.mockResolvedValue({
+    modelMessages: [{ role: "user", content: "thread prompt" }],
+    uiMessages: [
+      {
+        id: PARENT_MESSAGE_ID,
+        role: "user",
+        parts: [{ type: "text", text: "root" }],
+      },
+    ],
   });
 });
 
@@ -394,6 +434,7 @@ describe("POST /chats/rooms/{id}/stream", () => {
         roomId: ROOM_ID,
         senderUserId: USER_ID,
         contentText: "Hello",
+        parentMessageId: null,
       }),
     );
 
@@ -414,9 +455,93 @@ describe("POST /chats/rooms/{id}/stream", () => {
     expect(streamArgs.providerOptions.sokosumi.coworkerSlug).toBe("hannah");
 
     expect(createCoworkerConversationMock).not.toHaveBeenCalled();
+    expect(ensureThreadProviderConversationMock).not.toHaveBeenCalled();
+    expect(buildRoomStreamThreadModelMessagesMock).not.toHaveBeenCalled();
     expect(chatRoomUpdateManyMock).not.toHaveBeenCalled();
     expect(conversationCreateMock).not.toHaveBeenCalled();
     expect(conversationMessageCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("persists thread replies under parentMessageId with thread-scoped conversation", async () => {
+    roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+    chatRoomMessageFindFirstMock.mockResolvedValue({
+      id: PARENT_MESSAGE_ID,
+      parentMessageId: null,
+    });
+
+    const response = await postStream({
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "Thread reply" }] },
+      ],
+      parentMessageId: PARENT_MESSAGE_ID,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-sokosumi-parent-message-id")).toBe(
+      PARENT_MESSAGE_ID,
+    );
+
+    expect(persistUserMessageToChatRoomMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: ROOM_ID,
+        contentText: "Thread reply",
+        parentMessageId: PARENT_MESSAGE_ID,
+      }),
+    );
+    expect(ensureThreadProviderConversationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: ROOM_ID,
+        parentMessageId: PARENT_MESSAGE_ID,
+        coworkerSlug: "hannah",
+      }),
+    );
+    expect(buildRoomStreamThreadModelMessagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: ROOM_ID,
+        parentMessageId: PARENT_MESSAGE_ID,
+        lastUserMessageText: "Thread reply",
+      }),
+    );
+    expect(createCoworkerConversationMock).not.toHaveBeenCalled();
+
+    const streamArgs = streamTextMock.mock.calls[0]![0] as {
+      messages: unknown[];
+      providerOptions: {
+        sokosumi: { providerConversationId: string | null };
+      };
+      onFinish: (finishEvent: { text: string }) => Promise<void>;
+    };
+    expect(streamArgs.providerOptions.sokosumi.providerConversationId).toBe(
+      "conv_thread_1",
+    );
+    expect(streamArgs.messages).toEqual([
+      { role: "user", content: "thread prompt" },
+    ]);
+
+    await streamArgs.onFinish({ text: "Thread assistant reply" });
+    expect(persistAssistantToChatRoomMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: ROOM_ID,
+        contentText: "Thread assistant reply",
+        parentMessageId: PARENT_MESSAGE_ID,
+      }),
+    );
+  });
+
+  it("returns 400 when parentMessageId is not in the room", async () => {
+    roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+    chatRoomMessageFindFirstMock.mockResolvedValue(null);
+
+    const response = await postStream({
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "Thread reply" }] },
+      ],
+      parentMessageId: PARENT_MESSAGE_ID,
+    });
+
+    expect(response.status).toBe(400);
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(persistUserMessageToChatRoomMock).not.toHaveBeenCalled();
   });
 
   it("ensures providerConversationId on chatRoom when missing (no conversation* writes)", async () => {
@@ -489,6 +614,7 @@ describe("POST /chats/rooms/{id}/stream", () => {
         roomId: ROOM_ID,
         senderCoworkerId: COWORKER_ID,
         contentText: "Assistant reply",
+        parentMessageId: null,
         thoughtTiming: expect.objectContaining({
           startedAtMs: expect.any(Number),
           endedAtMs: expect.any(Number),

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -31,6 +31,11 @@ import {
   persistAssistantToChatRoom,
   persistUserMessageToChatRoom,
 } from "@/helpers/persist-assistant-to-chat-room";
+import {
+  buildRoomStreamThreadModelMessages,
+  ensureThreadProviderConversation,
+  THREAD_PROVIDER_CONVERSATION_ID_KEY,
+} from "@/helpers/room-stream-thread";
 import prisma from "@/lib/db/prisma";
 import {
   type OpenAPIHonoWithAuth,
@@ -46,10 +51,13 @@ import { throwCoworkerRemoteConversationHttpError } from "@/routes/v1/chats/stre
 import { mapChatRequestToUiMessages } from "@/routes/v1/chats/stream/map-chat-request-to-ui-messages.js";
 import {
   AI_SDK_CHAT_MESSAGES_REQUIREMENT,
-  aiSdkChatRequestSchema,
+  roomStreamRequestSchema,
 } from "@/schemas/chat-request.schema.js";
 
-import { requireChatRoomUserWriteAccess } from "../../helpers";
+import {
+  requireChatRoomUserWriteAccess,
+  resolveThreadParentMessageId,
+} from "../../helpers";
 import { ensureCoworkerProviderConversationForRoom } from "./coworker-provider-conversation";
 
 /**
@@ -90,14 +98,14 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/{id}/stream",
     description:
-      "Stream a coworker 1:1 reply into a chat room (AI SDK SSE). Persists to chat_room_message; does not write conversation* rows. Requires a direct room with exactly one user member (the caller) and one coworker member.",
+      "Stream a coworker 1:1 reply into a chat room (AI SDK SSE). Persists to chat_room_message; does not write conversation* rows. Optional parentMessageId scopes the turn as a thread reply under that top-level message. Requires a direct room with exactly one user member (the caller) and one coworker member.",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
       body: {
         content: {
           "application/json": {
-            schema: aiSdkChatRequestSchema,
+            schema: roomStreamRequestSchema,
           },
         },
       },
@@ -127,7 +135,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
     const userContext = requireUserAuthContext(c.var.authContext);
     const { id: roomId } = c.req.valid("param");
-    const { messages, model } = c.req.valid("json");
+    const {
+      messages,
+      model,
+      parentMessageId: requestedParentMessageId,
+    } = c.req.valid("json");
 
     if (!Array.isArray(messages) || messages.length === 0) {
       throw unprocessableEntity(AI_SDK_CHAT_MESSAGES_REQUIREMENT);
@@ -150,6 +162,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         "Room stream requires a 1:1 direct with exactly one AI coworker member. Use message POST for channels and human-only rooms.",
       );
     }
+
+    const parentMessageId = await prisma.$transaction(async (tx) =>
+      resolveThreadParentMessageId(tx, room.id, requestedParentMessageId),
+    );
 
     const roomCoworker = room.coworkerMembers[0]!.coworker;
     const coworker = await requireCoworkerChatCapability(roomCoworker.id);
@@ -234,17 +250,19 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           senderUserId: userContext.userId,
           contentText: lastUserMessageText,
           clientMessageId,
+          parentMessageId,
         });
       }
 
       // Room owns org scope (null = personal). Do not inherit active session org.
       const roomOrganizationId = room.organizationId;
 
-      let providerConversationId = room.providerConversationId?.trim() || null;
-      if (!providerConversationId) {
+      let providerConversationId: string | null = null;
+      if (parentMessageId) {
         try {
-          const ensured = await ensureCoworkerProviderConversationForRoom({
+          const ensured = await ensureThreadProviderConversation({
             roomId: room.id,
+            parentMessageId,
             userId: userContext.userId,
             organizationId: roomOrganizationId,
             coworkerSlug: coworker.slug,
@@ -253,6 +271,22 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           providerConversationId = ensured.providerConversationId;
         } catch (error) {
           throwCoworkerRemoteConversationHttpError(error);
+        }
+      } else {
+        providerConversationId = room.providerConversationId?.trim() || null;
+        if (!providerConversationId) {
+          try {
+            const ensured = await ensureCoworkerProviderConversationForRoom({
+              roomId: room.id,
+              userId: userContext.userId,
+              organizationId: roomOrganizationId,
+              coworkerSlug: coworker.slug,
+              responsesApiBaseUrl: coworker.baseURL.trim(),
+            });
+            providerConversationId = ensured.providerConversationId;
+          } catch (error) {
+            throwCoworkerRemoteConversationHttpError(error);
+          }
         }
       }
 
@@ -280,9 +314,27 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       let uiStreamResumptionRegistered = false;
       let uiStreamResumptionRegistration: Promise<void> | undefined;
 
-      const modelMessages = await convertToModelMessages(
-        uiMessages.map(({ id: _id, ...rest }) => rest),
-      );
+      let modelMessages;
+      let originalUiMessages = uiMessages;
+      if (parentMessageId) {
+        const sender = await prisma.user.findUnique({
+          where: { id: userContext.userId },
+          select: { name: true },
+        });
+        const threadBuilt = await buildRoomStreamThreadModelMessages({
+          roomId: room.id,
+          parentMessageId,
+          roomName: room.name,
+          senderName: sender?.name?.trim() || "A teammate",
+          lastUserMessageText,
+        });
+        modelMessages = threadBuilt.modelMessages;
+        originalUiMessages = threadBuilt.uiMessages;
+      } else {
+        modelMessages = await convertToModelMessages(
+          uiMessages.map(({ id: _id, ...rest }) => rest),
+        );
+      }
 
       const responsesApiResponseIdRef: { current: string | null } = {
         current: null,
@@ -295,6 +347,36 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       };
 
       const onInvalidProviderConversationId = async () => {
+        if (parentMessageId) {
+          // Thread conversations live on parent metadata — clear so next turn
+          // recreates. Do not touch room.providerConversationId.
+          try {
+            const parent = await prisma.chatRoomMessage.findFirst({
+              where: { id: parentMessageId, roomId: room.id },
+              select: { metadata: true },
+            });
+            if (
+              parent?.metadata &&
+              typeof parent.metadata === "object" &&
+              !Array.isArray(parent.metadata)
+            ) {
+              const next = {
+                ...(parent.metadata as Record<string, unknown>),
+              };
+              delete next[THREAD_PROVIDER_CONVERSATION_ID_KEY];
+              await prisma.chatRoomMessage.update({
+                where: { id: parentMessageId },
+                data: { metadata: next },
+              });
+            }
+          } catch (error) {
+            console.error(
+              "Failed to clear thread providerConversationId after invalid remote conversation (POST /rooms/{id}/stream):",
+              error,
+            );
+          }
+          return;
+        }
         try {
           await prisma.chatRoom.update({
             where: { id: room.id },
@@ -381,6 +463,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             responsesApiResponseId: responsesApiResponseIdRef.current,
             reasoning: finishEvent.reasoning,
             thoughtTiming,
+            parentMessageId,
           };
           // Retries: silent persist loss made streamed replies vanish after refetch.
           let lastError: unknown;
@@ -403,12 +486,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       });
 
       return result.toUIMessageStreamResponse({
-        originalMessages: uiMessages,
+        originalMessages: originalUiMessages,
         generateMessageId: generateId,
         headers: {
           "Cache-Control": "no-cache",
           Connection: "keep-alive",
           "x-sokosumi-room-id": room.id,
+          ...(parentMessageId
+            ? { "x-sokosumi-parent-message-id": parentMessageId }
+            : {}),
         },
         onError: (error: unknown) => {
           console.error(

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -4,6 +4,7 @@ import { waitUntil } from "@vercel/functions";
 import {
   convertToModelMessages,
   generateId,
+  type ModelMessage,
   streamText,
   type UIMessage,
   validateUIMessages,
@@ -314,7 +315,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       let uiStreamResumptionRegistered = false;
       let uiStreamResumptionRegistration: Promise<void> | undefined;
 
-      let modelMessages;
+      let modelMessages: ModelMessage[];
       let originalUiMessages = uiMessages;
       if (parentMessageId) {
         const sender = await prisma.user.findUnique({

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -505,6 +505,7 @@ export async function requireArchivedChatRoomUserAccess(
 // transaction — hundreds of unused rows per message on a large room.
 const chatRoomWriteSelect = {
   id: true,
+  name: true,
   organizationId: true,
   slug: true,
   kind: true,
@@ -556,6 +557,34 @@ export async function requireChatRoomUserWriteAccess(
   await assertRoomOrganizationAccess(room.organizationId, userId, tx);
 
   return room;
+}
+
+/**
+ * Resolve a thread parent for write paths. Nested reply ids collapse to the
+ * top-level root so all siblings share one parentMessageId.
+ */
+export async function resolveThreadParentMessageId(
+  tx: Prisma.TransactionClient,
+  roomId: string,
+  requestedParentMessageId: string | undefined,
+): Promise<string | null> {
+  if (!requestedParentMessageId) {
+    return null;
+  }
+  const parentMessage = await tx.chatRoomMessage.findFirst({
+    where: {
+      id: requestedParentMessageId,
+      roomId,
+    },
+    select: {
+      id: true,
+      parentMessageId: true,
+    },
+  });
+  if (!parentMessage) {
+    throw badRequest("Thread message not found");
+  }
+  return parentMessage.parentMessageId ?? parentMessage.id;
 }
 
 export async function requireChatRoomUserMembership(

--- a/apps/core/src/schemas/chat-request.schema.ts
+++ b/apps/core/src/schemas/chat-request.schema.ts
@@ -68,3 +68,14 @@ export const aiSdkChatRequestSchema = z
       }
     }
   });
+
+/**
+ * POST /v1/chats/rooms/{id}/stream — AI SDK chat body plus optional thread parent.
+ * `roomId` is accepted when the web proxy forwards it; Core uses the path id.
+ */
+export const roomStreamRequestSchema = aiSdkChatRequestSchema.and(
+  z.object({
+    parentMessageId: z.string().uuid().optional(),
+    roomId: z.string().uuid().optional(),
+  }),
+);

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-coworker-direct.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-coworker-direct.test.ts
@@ -81,19 +81,25 @@ describe("coworker DM cutover gating (rooms-client wiring)", () => {
     expect(shouldUseCoworkerRoomStream(humanDirect)).toBe(false);
   });
 
-  it("hides thread button on coworker-only directs (SOK-656 Option A)", () => {
+  it("shows thread button on coworker-only directs (SOK-656 Option B)", () => {
     expect(
       shouldShowChatRoomThreadButton({
         room: coworkerOnlyDirect,
         isStreamOverlay: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("hides thread button on stream overlays even for channels", () => {
     expect(
       shouldShowChatRoomThreadButton({
         room: humanChannel,
+        isStreamOverlay: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowChatRoomThreadButton({
+        room: coworkerOnlyDirect,
         isStreamOverlay: true,
       }),
     ).toBe(false);

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -82,6 +82,7 @@ export function RoomComposer({
   isSending,
   sendDisabled,
   showMentionShortcut = true,
+  allowAttachments = true,
 }: {
   value: string;
   onValueChange: Dispatch<SetStateAction<string>>;
@@ -95,6 +96,8 @@ export function RoomComposer({
   sendDisabled: boolean;
   /** Channels always; direct rooms only when roster has more than two people. */
   showMentionShortcut?: boolean;
+  /** False when the send path cannot persist uploads (e.g. coworker stream). */
+  allowAttachments?: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const formRef = useRef<HTMLFormElement | null>(null);
@@ -203,32 +206,36 @@ export function RoomComposer({
               <AtSign className="size-4" aria-hidden />
             </Button>
           ) : null}
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            tabIndex={-1}
-            onChange={(event) => {
-              void handleFilesSelected(event.currentTarget.files);
-            }}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-            title={t("Toolbar.attach")}
-            aria-label={t("Toolbar.attach")}
-            disabled={isUploadingFiles}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            {isUploadingFiles ? (
-              <Loader2 className="size-4 animate-spin" aria-hidden />
-            ) : (
-              <Paperclip className="size-4" aria-hidden />
-            )}
-          </Button>
+          {allowAttachments ? (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                tabIndex={-1}
+                onChange={(event) => {
+                  void handleFilesSelected(event.currentTarget.files);
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
+                title={t("Toolbar.attach")}
+                aria-label={t("Toolbar.attach")}
+                disabled={isUploadingFiles}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {isUploadingFiles ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                ) : (
+                  <Paperclip className="size-4" aria-hidden />
+                )}
+              </Button>
+            </>
+          ) : null}
           <RoomComposerEmojiPicker
             title={t("Toolbar.emoji")}
             ariaLabel={t("Toolbar.emoji")}

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -167,7 +167,7 @@ export function shouldUseCoworkerRoomStream(room: {
 
 /**
  * Thread chrome on room messages.
- * Stream overlays never show threads. Coworker 1:1 hides until SOK-656.
+ * Stream overlays never show threads (ephemeral stream ids).
  */
 export function shouldShowChatRoomThreadButton(options: {
   room: {
@@ -178,7 +178,6 @@ export function shouldShowChatRoomThreadButton(options: {
   isStreamOverlay: boolean;
 }): boolean {
   if (options.isStreamOverlay) return false;
-  if (isCoworkerOnlyDirectRoom(options.room)) return false;
   return true;
 }
 

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -20,7 +20,10 @@ import {
   toggleMessageReactionAction,
 } from "@/app/chat/actions";
 import DaySeparator from "@/app/chat/components/day-separator";
-import { useCoworkerDirectRoomStream } from "@/app/chat/hooks/use-coworker-direct-room-stream";
+import {
+  readStoredStreamParentMessageId,
+  useCoworkerDirectRoomStream,
+} from "@/app/chat/hooks/use-coworker-direct-room-stream";
 import { formatDaySeparator } from "@/app/chat/utils/date-utils";
 import {
   mergeMessagesWithStreamOverlay,
@@ -232,7 +235,11 @@ export function RoomsClient({
 
   const refreshRoomMessagesAfterStream = useCallback(
     async (roomId: string): Promise<boolean> => {
-      const threadParentId = threadParentMessageRef.current?.id ?? null;
+      // Prefer open panel; fall back to sessionStorage so settle still refreshes
+      // the thread when the panel was closed mid-stream / after remount.
+      const threadParentId =
+        threadParentMessageRef.current?.id ??
+        readStoredStreamParentMessageId(roomId);
       const [roomResult, threadResult] = await Promise.all([
         listRoomMessagesAction(roomId),
         threadParentId
@@ -249,17 +256,24 @@ export function RoomsClient({
       setMessagesState((current) =>
         mergeRoomMessages(current, roomResult.data.messages),
       );
-      if (threadResult?.ok) {
+      if (threadResult?.ok && threadParentId) {
         setThreadMessages((current) =>
           mergeRoomMessages(current, threadResult.data.messages),
         );
-        setThreadParentMessage((current) =>
-          current
-            ? (roomResult.data.messages.find(
+        setThreadParentMessage((current) => {
+          const fromRoom =
+            roomResult.data.messages.find(
+              (message) => message.id === threadParentId,
+            ) ?? null;
+          if (current) {
+            return (
+              roomResult.data.messages.find(
                 (message) => message.id === current.id,
-              ) ?? current)
-            : current,
-        );
+              ) ?? current
+            );
+          }
+          return fromRoom;
+        });
       }
       return true;
     },
@@ -269,6 +283,7 @@ export function RoomsClient({
   const {
     streamOverlayMessages,
     isStreaming: isCoworkerStreaming,
+    activeStreamParentMessageId,
     sendStreamMessage,
     consumePendingStreamMessage,
   } = useCoworkerDirectRoomStream({
@@ -323,6 +338,35 @@ export function RoomsClient({
     }
     consumePendingStreamMessage(pending);
   }, [isCoworkerStreamRoom, selectedRoomId, consumePendingStreamMessage]);
+
+  // Re-open thread panel when a thread stream is active/resumed so overlays
+  // stay visible after remount or if the panel was closed mid-stream.
+  useEffect(() => {
+    if (
+      !isCoworkerStreamRoom ||
+      !selectedRoom ||
+      !activeStreamParentMessageId
+    ) {
+      return;
+    }
+    if (threadParentMessage?.id === activeStreamParentMessageId) {
+      return;
+    }
+    const parent =
+      messagesState.find(
+        (message) => message.id === activeStreamParentMessageId,
+      ) ?? null;
+    if (!parent) {
+      return;
+    }
+    loadThreadMessages(parent);
+  }, [
+    isCoworkerStreamRoom,
+    selectedRoom,
+    activeStreamParentMessageId,
+    threadParentMessage?.id,
+    messagesState,
+  ]);
 
   // Pending draft stays in sessionStorage until stream settles successfully
   // (cleared in useCoworkerDirectRoomStream.onFinish). Clearing on stream
@@ -1001,7 +1045,7 @@ export function RoomsClient({
                               ? loadThreadMessages
                               : undefined
                           }
-                          // Coworker 1:1: stream owns replies; threads deferred (SOK-656).
+                          // Stream overlays never show thread chrome.
                           showThreadButton={shouldShowChatRoomThreadButton({
                             room: selectedRoom,
                             isStreamOverlay,
@@ -1036,6 +1080,7 @@ export function RoomsClient({
                 showMentionShortcut={shouldShowRoomMentionShortcut(
                   selectedRoom,
                 )}
+                allowAttachments={!isCoworkerStreamRoom}
               />
             </>
           ) : (
@@ -1089,6 +1134,7 @@ export function RoomsClient({
             }}
             onToggleReaction={handleToggleReaction}
             showMentionShortcut={shouldShowRoomMentionShortcut(selectedRoom)}
+            allowAttachments={!isCoworkerStreamRoom}
           />
         ) : null}
       </main>

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -169,6 +169,8 @@ export function RoomsClient({
   );
   const [threadParentMessage, setThreadParentMessage] =
     useState<ChatRoomMessage | null>(null);
+  const threadParentMessageRef = useRef<ChatRoomMessage | null>(null);
+  threadParentMessageRef.current = threadParentMessage;
   const [threadMessages, setThreadMessages] = useState<ChatRoomMessage[]>([]);
   const [threadOlderNextCursor, setThreadOlderNextCursor] = useState<
     string | null
@@ -230,17 +232,35 @@ export function RoomsClient({
 
   const refreshRoomMessagesAfterStream = useCallback(
     async (roomId: string): Promise<boolean> => {
-      const result = await listRoomMessagesAction(roomId);
-      if (!result.ok) {
-        toast.error(result.message);
+      const threadParentId = threadParentMessageRef.current?.id ?? null;
+      const [roomResult, threadResult] = await Promise.all([
+        listRoomMessagesAction(roomId),
+        threadParentId
+          ? listThreadMessagesAction(roomId, threadParentId)
+          : Promise.resolve(null),
+      ]);
+      if (!roomResult.ok) {
+        toast.error(roomResult.message);
         return false;
       }
       if (!isStillSelectedRoom(roomId)) {
         return false;
       }
       setMessagesState((current) =>
-        mergeRoomMessages(current, result.data.messages),
+        mergeRoomMessages(current, roomResult.data.messages),
       );
+      if (threadResult?.ok) {
+        setThreadMessages((current) =>
+          mergeRoomMessages(current, threadResult.data.messages),
+        );
+        setThreadParentMessage((current) =>
+          current
+            ? (roomResult.data.messages.find(
+                (message) => message.id === current.id,
+              ) ?? current)
+            : current,
+        );
+      }
       return true;
     },
     [],
@@ -259,9 +279,36 @@ export function RoomsClient({
     onStreamSettled: refreshRoomMessagesAfterStream,
   });
 
+  const topLevelStreamOverlayMessages = useMemo(
+    () =>
+      streamOverlayMessages.filter(
+        (message) => message.parentMessageId == null,
+      ),
+    [streamOverlayMessages],
+  );
+
   const displayMessages = useMemo(() => {
-    return mergeMessagesWithStreamOverlay(messagesState, streamOverlayMessages);
-  }, [messagesState, streamOverlayMessages]);
+    return mergeMessagesWithStreamOverlay(
+      messagesState,
+      topLevelStreamOverlayMessages,
+    );
+  }, [messagesState, topLevelStreamOverlayMessages]);
+
+  const threadStreamOverlayMessages = useMemo(() => {
+    if (!threadParentMessage) {
+      return [];
+    }
+    return streamOverlayMessages.filter(
+      (message) => message.parentMessageId === threadParentMessage.id,
+    );
+  }, [streamOverlayMessages, threadParentMessage]);
+
+  const displayThreadMessages = useMemo(() => {
+    return mergeMessagesWithStreamOverlay(
+      threadMessages,
+      threadStreamOverlayMessages,
+    );
+  }, [threadMessages, threadStreamOverlayMessages]);
 
   // Draft coworker DM stashes text then navigates — auto-stream once room opens.
   // Keep sessionStorage until stream actually starts so Strict Mode remount
@@ -387,7 +434,8 @@ export function RoomsClient({
   // Scroll on room switch or when the newest message changes — not when
   // an older page is prepended (length grows, last id stays the same).
   const latestMessageId = displayMessages.at(-1)?.id ?? null;
-  const latestStreamContent = streamOverlayMessages.at(-1)?.content ?? "";
+  const latestStreamContent =
+    topLevelStreamOverlayMessages.at(-1)?.content ?? "";
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ block: "end" });
   }, [latestMessageId, latestStreamContent, selectedRoomId]);
@@ -802,12 +850,18 @@ export function RoomsClient({
   function handleSendThreadReply(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!selectedRoom || !threadParentMessage) return;
-    // Coworker 1:1 thread AI replies: SOK-656. Hide UI for now; fail closed if opened.
-    if (shouldUseCoworkerRoomStream(selectedRoom)) return;
     const roomId = selectedRoom.id;
     const parentMessageId = threadParentMessage.id;
     const content = threadComposerValue.trim();
     if (!content) return;
+
+    if (shouldUseCoworkerRoomStream(selectedRoom)) {
+      setThreadComposerValue("");
+      setThreadComposerAttachments([]);
+      setThreadMentionedCoworkerIds([]);
+      sendStreamMessage(content, { parentMessageId });
+      return;
+    }
 
     const mentionIds = threadMentionedCoworkerIds;
     startSendingThreadReplyTransition(async () => {
@@ -1010,7 +1064,7 @@ export function RoomsClient({
         {selectedRoom && threadParentMessage ? (
           <ThreadPanel
             parentMessage={threadParentMessage}
-            replies={threadMessages}
+            replies={displayThreadMessages}
             isLoading={isThreadLoading}
             olderNextCursor={threadOlderNextCursor}
             isLoadingOlder={isLoadingOlderThread}
@@ -1024,7 +1078,10 @@ export function RoomsClient({
             replyAttachments={threadComposerAttachments}
             onReplyAttachmentsChange={setThreadComposerAttachments}
             onSubmitReply={handleSendThreadReply}
-            isSendingReply={isSendingThreadReply}
+            isSendingReply={
+              isSendingThreadReply ||
+              (isCoworkerStreaming && threadStreamOverlayMessages.length > 0)
+            }
             onClose={() => {
               setThreadParentMessage(null);
               setThreadMessages([]);

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -33,6 +33,7 @@ export function ThreadPanel({
   onClose,
   onToggleReaction,
   showMentionShortcut = true,
+  allowAttachments = true,
 }: {
   parentMessage: ChatRoomMessage;
   replies: ChatRoomMessage[];
@@ -56,6 +57,7 @@ export function ThreadPanel({
   onClose: () => void;
   onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
   showMentionShortcut?: boolean;
+  allowAttachments?: boolean;
 }) {
   const t = useTranslations("App.Channels");
 
@@ -159,6 +161,7 @@ export function ThreadPanel({
         isSending={isSendingReply}
         sendDisabled={replyValue.trim().length === 0}
         showMentionShortcut={showMentionShortcut}
+        allowAttachments={allowAttachments}
       />
     </aside>
   );

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-coworker-direct-room-stream.test.ts
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-coworker-direct-room-stream.test.ts
@@ -6,7 +6,9 @@ import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 import {
   createResumePendingCoworkerShell,
   RESUME_PENDING_STREAM_MESSAGE_ID,
+  readStoredStreamParentMessageId,
   shouldShowResumePendingCoworkerShell,
+  writeStoredStreamParentMessageId,
 } from "../use-coworker-direct-room-stream";
 
 const coworker = {
@@ -99,8 +101,18 @@ describe("createResumePendingCoworkerShell", () => {
 
     expect(shell.id).toBe(RESUME_PENDING_STREAM_MESSAGE_ID);
     expect(shell.content).toBe("");
+    expect(shell.parentMessageId).toBeNull();
     expect(shell.sender).toEqual({ type: "coworker", coworker });
     expect(shell.metadata).toEqual({ streaming: true });
+  });
+
+  it("can tag resume shell with thread parent for panel routing", () => {
+    const shell = createResumePendingCoworkerShell({
+      roomId: "room-1",
+      coworker,
+      parentMessageId: "parent-1",
+    });
+    expect(shell.parentMessageId).toBe("parent-1");
   });
 
   it("survives overlay merge so reopen mid-stream can show Thinking", () => {
@@ -118,5 +130,41 @@ describe("createResumePendingCoworkerShell", () => {
       RESUME_PENDING_STREAM_MESSAGE_ID,
     ]);
     expect(merged.at(-1)?.content.trim()).toBe("");
+  });
+});
+
+describe("stream parent sessionStorage helpers", () => {
+  it("round-trips parent id and clears on null", () => {
+    writeStoredStreamParentMessageId("room-1", "parent-1");
+    expect(readStoredStreamParentMessageId("room-1")).toBe("parent-1");
+    writeStoredStreamParentMessageId("room-1", null);
+    expect(readStoredStreamParentMessageId("room-1")).toBeNull();
+  });
+
+  it("ignores blank stored values", () => {
+    sessionStorage.setItem("sokosumi:room-stream-parent:room-2", "   ");
+    expect(readStoredStreamParentMessageId("room-2")).toBeNull();
+  });
+});
+
+describe("thread vs top-level overlay split", () => {
+  it("routes overlays by parentMessageId for panel vs main", () => {
+    const topLevel = createResumePendingCoworkerShell({
+      roomId: "room-1",
+      coworker,
+      parentMessageId: null,
+    });
+    const thread = createResumePendingCoworkerShell({
+      roomId: "room-1",
+      coworker,
+      parentMessageId: "parent-1",
+    });
+    const overlays = [topLevel, thread];
+    expect(
+      overlays.filter((message) => message.parentMessageId == null),
+    ).toEqual([topLevel]);
+    expect(
+      overlays.filter((message) => message.parentMessageId === "parent-1"),
+    ).toEqual([thread]);
   });
 });

--- a/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
@@ -22,6 +22,41 @@ const autoStreamStartedRoomIds = new Set<string>();
 /** Empty coworker shell shown while resume SSE is active but messages empty. */
 export const RESUME_PENDING_STREAM_MESSAGE_ID = "stream:resume-pending";
 
+function streamParentStorageKey(roomId: string): string {
+  return `sokosumi:room-stream-parent:${roomId}`;
+}
+
+export function readStoredStreamParentMessageId(roomId: string): string | null {
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+  try {
+    const value = sessionStorage.getItem(streamParentStorageKey(roomId));
+    return value?.trim() ? value.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredStreamParentMessageId(
+  roomId: string,
+  parentMessageId: string | null,
+): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+  try {
+    const key = streamParentStorageKey(roomId);
+    if (parentMessageId) {
+      sessionStorage.setItem(key, parentMessageId);
+    } else {
+      sessionStorage.removeItem(key);
+    }
+  } catch {
+    // Private mode / quota — overlay parent may be wrong on resume only.
+  }
+}
+
 /**
  * Show resume-pending shell only for `streaming` (active SSE), not `submitted`.
  * Idle room enter gets 204 while status is briefly `submitted` — shell would flash.
@@ -128,6 +163,11 @@ export interface UseCoworkerDirectRoomStreamResult {
   streamOverlayMessages: ChatRoomMessage[];
   isStreaming: boolean;
   /**
+   * Parent id for an in-flight / resumed thread stream (null = top-level).
+   * Rooms client opens the thread panel when this is set so overlays stay visible.
+   */
+  activeStreamParentMessageId: string | null;
+  /**
    * Stream a top-level turn, or a thread reply when `parentMessageId` is set.
    */
   sendStreamMessage: (
@@ -155,6 +195,15 @@ export function useCoworkerDirectRoomStream({
   const [streamParentMessageId, setStreamParentMessageId] = useState<
     string | null
   >(null);
+
+  // Restore thread parent for mid-stream resume (sessionStorage survives remount).
+  useEffect(() => {
+    if (!roomId) {
+      setStreamParentMessageId(null);
+      return;
+    }
+    setStreamParentMessageId(readStoredStreamParentMessageId(roomId));
+  }, [roomId]);
 
   const transport = useMemo(
     () =>
@@ -211,6 +260,7 @@ export function useCoworkerDirectRoomStream({
       const failedRoomId = roomIdRef.current;
       if (failedRoomId) {
         autoStreamStartedRoomIds.delete(failedRoomId);
+        writeStoredStreamParentMessageId(failedRoomId, null);
       }
       setStreamParentMessageId(null);
       toast.error(error.message || "Failed to stream coworker reply.");
@@ -226,6 +276,7 @@ export function useCoworkerDirectRoomStream({
       const settled = await onStreamSettledRef.current(settledRoomId);
       if (settled && roomIdRef.current === settledRoomId) {
         clearPendingRoomMessage(settledRoomId);
+        writeStoredStreamParentMessageId(settledRoomId, null);
         setMessages([]);
         setStreamParentMessageId(null);
       }
@@ -238,7 +289,6 @@ export function useCoworkerDirectRoomStream({
   useEffect(() => {
     if (!roomId) {
       setMessages([]);
-      setStreamParentMessageId(null);
       return;
     }
     void resumeStream();
@@ -318,13 +368,17 @@ export function useCoworkerDirectRoomStream({
         return;
       }
       const parentMessageId = options?.parentMessageId?.trim() || null;
+      // Shared useChat instance — clear leftover turns so a failed settle cannot
+      // retag prior top-level UI messages with a new thread parentMessageId.
+      setMessages([]);
       setStreamParentMessageId(parentMessageId);
+      writeStoredStreamParentMessageId(roomId, parentMessageId);
       void sendMessage(
         { text: trimmed },
         parentMessageId ? { body: { parentMessageId } } : undefined,
       );
     },
-    [enabled, roomId, sendMessage],
+    [enabled, roomId, sendMessage, setMessages],
   );
 
   const consumePendingStreamMessage = useCallback(
@@ -348,6 +402,7 @@ export function useCoworkerDirectRoomStream({
   return {
     streamOverlayMessages,
     isStreaming,
+    activeStreamParentMessageId: streamParentMessageId,
     sendStreamMessage,
     consumePendingStreamMessage,
   };

--- a/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CHAT_API_PATH } from "@/app/chat/utils/chat-route-base";
 import { extractMessageContent } from "@/app/chat/utils/message-utils";
@@ -42,15 +42,17 @@ export function createResumePendingCoworkerShell({
   roomId,
   coworker,
   createdAt = new Date(),
+  parentMessageId = null,
 }: {
   roomId: string;
   coworker: ChatRoomCoworkerParticipant;
   createdAt?: Date;
+  parentMessageId?: string | null;
 }): ChatRoomMessage {
   return {
     id: RESUME_PENDING_STREAM_MESSAGE_ID,
     roomId,
-    parentMessageId: null,
+    parentMessageId,
     content: "",
     createdAt,
     sender: { type: "coworker", coworker },
@@ -68,6 +70,7 @@ function uiMessageToTransientRoomMessage({
   currentUser,
   coworker,
   createdAt,
+  parentMessageId,
 }: {
   message: UIMessage;
   roomId: string;
@@ -75,6 +78,7 @@ function uiMessageToTransientRoomMessage({
   coworker: ChatRoomCoworkerParticipant | null;
   /** Monotonic clock — must preserve useChat array order across equal ms. */
   createdAt: Date;
+  parentMessageId: string | null;
 }): ChatRoomMessage {
   const content = extractMessageContent(message);
 
@@ -82,7 +86,7 @@ function uiMessageToTransientRoomMessage({
     return {
       id: `stream:${message.id}`,
       roomId,
-      parentMessageId: null,
+      parentMessageId,
       content,
       createdAt,
       sender: currentUser
@@ -99,7 +103,7 @@ function uiMessageToTransientRoomMessage({
   return {
     id: `stream:${message.id}`,
     roomId,
-    parentMessageId: null,
+    parentMessageId,
     content,
     createdAt,
     sender: coworker ? { type: "coworker", coworker } : { type: "unknown" },
@@ -123,7 +127,13 @@ export interface UseCoworkerDirectRoomStreamParams {
 export interface UseCoworkerDirectRoomStreamResult {
   streamOverlayMessages: ChatRoomMessage[];
   isStreaming: boolean;
-  sendStreamMessage: (text: string) => void;
+  /**
+   * Stream a top-level turn, or a thread reply when `parentMessageId` is set.
+   */
+  sendStreamMessage: (
+    text: string,
+    options?: { parentMessageId?: string },
+  ) => void;
   /** Consume a one-shot draft pending message for this room (Strict Mode safe). */
   consumePendingStreamMessage: (text: string) => void;
 }
@@ -142,6 +152,9 @@ export function useCoworkerDirectRoomStream({
   organizationSlugRef.current = organizationSlug;
   const onStreamSettledRef = useRef(onStreamSettled);
   onStreamSettledRef.current = onStreamSettled;
+  const [streamParentMessageId, setStreamParentMessageId] = useState<
+    string | null
+  >(null);
 
   const transport = useMemo(
     () =>
@@ -199,6 +212,7 @@ export function useCoworkerDirectRoomStream({
       if (failedRoomId) {
         autoStreamStartedRoomIds.delete(failedRoomId);
       }
+      setStreamParentMessageId(null);
       toast.error(error.message || "Failed to stream coworker reply.");
     },
     async onFinish() {
@@ -213,6 +227,7 @@ export function useCoworkerDirectRoomStream({
       if (settled && roomIdRef.current === settledRoomId) {
         clearPendingRoomMessage(settledRoomId);
         setMessages([]);
+        setStreamParentMessageId(null);
       }
     },
   });
@@ -223,6 +238,7 @@ export function useCoworkerDirectRoomStream({
   useEffect(() => {
     if (!roomId) {
       setMessages([]);
+      setStreamParentMessageId(null);
       return;
     }
     void resumeStream();
@@ -262,6 +278,7 @@ export function useCoworkerDirectRoomStream({
             roomId,
             coworker,
             createdAt: new Date(baseMs),
+            parentMessageId: streamParentMessageId,
           }),
         ];
       }
@@ -281,17 +298,31 @@ export function useCoworkerDirectRoomStream({
           currentUser,
           coworker,
           createdAt: new Date(baseMs + index),
+          parentMessageId: streamParentMessageId,
         }),
       );
-  }, [enabled, roomId, messages, currentUser, coworker, status]);
+  }, [
+    enabled,
+    roomId,
+    messages,
+    currentUser,
+    coworker,
+    status,
+    streamParentMessageId,
+  ]);
 
   const sendStreamMessage = useCallback(
-    (text: string) => {
+    (text: string, options?: { parentMessageId?: string }) => {
       const trimmed = text.trim();
       if (!enabled || !roomId || !trimmed) {
         return;
       }
-      void sendMessage({ text: trimmed });
+      const parentMessageId = options?.parentMessageId?.trim() || null;
+      setStreamParentMessageId(parentMessageId);
+      void sendMessage(
+        { text: trimmed },
+        parentMessageId ? { body: { parentMessageId } } : undefined,
+      );
     },
     [enabled, roomId, sendMessage],
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SOK-656 Option B: coworker 1:1 DM thread replies stream through the room stream and get an AI reply (no longer silent message POST).

- Core `POST /v1/chats/rooms/{id}/stream` accepts optional `parentMessageId`
- User + assistant turns persist under that thread root
- Thread uses a dedicated remote provider conversation (parent message metadata) so top-level room context does not bleed
- First thread AI turn embeds thread root/siblings via the same prompt helper as channel mention dispatch
- Web re-enables the thread button on coworker-only directs; thread composer calls the room stream
- Stream overlay sets `parentMessageId` and merges into the thread panel (not the main list)
- Message POST skip-mention on coworker-only directs unchanged

### Review follow-ups (second commit)

- Ignore coworker root when detecting prior thread assistants (context embed on first human reply under AI root)
- Load newest thread message window (`desc` + reverse)
- Restore `parentMessageId` from sessionStorage on mid-stream resume; auto-open thread panel while thread stream active
- Clear shared `useChat` messages before each send (avoid overlay contamination)
- Hide attachments on coworker stream composers (stream path does not upload them)
- Settle refresh falls back to stored parent when panel closed

**Note:** OpenAPI / generated Core client regen not required for this path — web BFF `POST /api/chat` forwards the JSON body including `parentMessageId`.

## Test plan

- [x] `pnpm --filter core test` stream post + room-stream-thread helpers
- [x] `pnpm --filter web test` room-helpers coworker gate + stream hook
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [x] Manual (preprod): coworker DM → thread under AI message → user + AI reply in panel; main shows reply count

Fixes SOK-656
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-656](https://linear.app/masumi/issue/SOK-656/support-coworker-dm-thread-replies-via-room-stream)

<div><a href="https://cursor.com/agents/bc-30f3ba9e-0a12-4d33-afe7-d95caa18f571?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30f3ba9e-0a12-4d33-afe7-d95caa18f571&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

