### PR TITLE
chore(cursor): add pstack model overrides for cloud agents

### DIFF
--- a/.cursor/rules/pstack-models.mdc
+++ b/.cursor/rules/pstack-models.mdc
@@ -1,0 +1,25 @@
+---
+description: pstack per-role model choices (overrides skill defaults)
+alwaysApply: true
+---
+# pstack model configuration. One line per role. Delete a line to fall back to the skill default.
+# `inherit-parent` or `auto` as a value: the role runs on the parent chat model (omit Task `model`). Alias entries in a panel list still count toward its fan-out.
+# Checked into the repo so local and cloud agents share the same overrides (user home `~/.cursor/rules/pstack-models.mdc` may still exist from `/setup-pstack`).
+feature, refactoring: inherit-parent
+bug-fix: inherit-parent
+perf-issue: inherit-parent
+hillclimb: inherit-parent
+judgment and prose: inherit-parent
+hardest tasks: inherit-parent
+how explorer: inherit-parent
+how explainer: inherit-parent
+how critics: inherit-parent
+why investigators: inherit-parent
+why synthesizer: inherit-parent
+reflect tooling: inherit-parent
+reflect judgment, divergent, synthesizer: inherit-parent
+arena runners: inherit-parent
+arena cross-judge pool: inherit-parent
+swarm workers: inherit-parent
+architect runners: inherit-parent
+interrogate reviewers: inherit-parent

--- a/.cursor/skills/verify-sokosumi/SKILL.md
+++ b/.cursor/skills/verify-sokosumi/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: verify-sokosumi
+description: Drive the Sokosumi web app (and Core API) the way a user does — launch local web+core, doctor health, browser login via agent-browser, capture proof. Use when proving a UI/API change works, after feature work, or when a task needs end-to-end evidence beyond unit tests.
+---
+
+# Verify Sokosumi
+
+Project-local verification for agents that have never seen this app. Primary surface is the **web UI** at `:3000`. Secondary surface is the **Core API** at `:8787` (OpenAPI / curl). Web never talks to Postgres directly — Core owns the DB.
+
+Read `features/README.md` before driving. Use a matching feature file as the recipe. Prefer `agent-browser` over inventing selectors.
+
+## Launch
+
+Prefer **`http://localhost:3000`** / **`http://localhost:8787`** (not `127.0.0.1`) so Better Auth origin checks and cookies match `WEB_APP_BASE_URL` / `BETTER_AUTH_URL`.
+
+Ready when:
+
+- Core answers `GET http://localhost:8787/v1/openapi.json` with 2xx
+- Web answers `GET http://localhost:3000/signin` with 2xx
+
+Preconditions before launch:
+
+- `pnpm install` already done
+- `apps/web/.env` and `apps/core/.env` present (copy from `.env.example` if missing)
+- `APP_SIGNING_SECRET` (web) equals `BETTER_AUTH_SECRET` (core)
+- Database reachable (Neon agent branch, or local Postgres). Prefer `with-db.mjs` when an agent branch is provisioned.
+
+### Cursor agent session (required pattern)
+
+Short-lived agent shells often SIGHUP children when the launch command exits. Start Core and Web as **background jobs that stay alive**, then write the wrapper PIDs into the state file:
+
+```bash
+# background: pnpm core:dev
+# background: pnpm web:dev
+mkdir -p .cursor/verify-sokosumi-artifacts/state
+printf 'core=%s\nweb=%s\nstarted_at=%s\nweb_url=http://localhost:3000\ncore_url=http://localhost:8787\n' \
+  "<core-shell-pid>" "<web-shell-pid>" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  > .cursor/verify-sokosumi-artifacts/state/dev.pids
+```
+
+If `.cursor/cloud-agent-db.env` exists, wrap with `node scripts/cloud-agent-db/with-db.mjs -- pnpm core:dev` (same for web).
+
+### Durable human terminal
+
+```bash
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi launch
+```
+
+Helper starts `pnpm core:dev` and `pnpm web:dev` via `nohup`. If `.cursor/cloud-agent-db.env` exists, both are wrapped with `with-db.mjs`.
+
+Teardown:
+
+```bash
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi cleanup
+```
+
+For Cursor background shells, kill those shell PIDs (or stop the terminal jobs) after cleanup if the helper did not own them.
+
+## Doctor
+
+```bash
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi doctor
+```
+
+Require `doctor ok`. If `owned_by_verify=no`, do **read-only** checks only — never mutate a foreign instance. If ports already answer before `launch`, the helper refuses (no double-drive).
+
+Optional Core-only smoke:
+
+```bash
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi core-smoke
+```
+
+## Drive
+
+Harness: **agent-browser** (see `.agents/skills/agent-browser/SKILL.md` and `apps/web/AGENTS.md` Browser Automation). No Playwright/Cypress in this repo.
+
+Session reuse:
+
+```bash
+export AGENT_BROWSER_SESSION_NAME=sokosumi
+```
+
+Stable auth selectors: `[data-testid="auth-field-email"]`, `[data-testid="auth-field-currentPassword"]`, `[data-testid="auth-submit"]`.
+
+**Login rule:** fill fields, then **press Enter** — do not rely on clicking submit. react-hook-form can race a programmatic click.
+
+Credentials (pick one):
+
+| Source | Email | Password | When |
+| --- | --- | --- | --- |
+| Cloud-agent fixtures | `alice@sokosumi.test` | `Password123!` | Neon `cloud-agent-*` branches after migrate/seed |
+| Cloud-agent admin | `admin@sokosumi.test` | `Password123!` | Admin UI `/admin` |
+| Local signup | unique `*@sokosumi.test` via `/signup` | choose once | Empty/local DB without fixtures |
+| Coworker vault | `agent-browser auth save sokosumi …` | machine-local | Personal accounts — never commit |
+
+OAuth and magic-link do **not** work with placeholder credentials. Skip those paths.
+
+API drive (secondary): `curl` against Core with session cookies from the browser when needed; public smoke is OpenAPI JSON only.
+
+## Evidence
+
+Root: `.cursor/verify-sokosumi-artifacts/` (gitignored). Keep proofs; cleanup must not delete them.
+
+Per feature, under `.cursor/verify-sokosumi-artifacts/<feature-id>/`:
+
+- Screenshot(s) with app chrome visible. `agent-browser screenshot` writes under `~/.agent-browser/tmp/screenshots/` — copy the newest file into the feature artifact dir.
+- Interactive snapshot: `agent-browser snapshot -i > <path>.snapshot.txt`
+- For API: response body + HTTP status file
+- Record feature ID and entry point used. Never commit passwords; `account.txt` may store email only.
+
+Proof standards:
+
+- Exercise the **real user path** (browser UI or documented Core route), not test-only setters
+- Capture **action + resulting state**, not only the final screen
+- Confirm side effects when the feature mutates (new row visible on reload, URL change, second view)
+- Chat may show an Ably error modal when keys are placeholders — that does **not** prove chat works; prove landing/redirect or non-realtime surfaces instead unless Ably is configured
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi cleanup
+```
+
+Stops only pids recorded by `launch`. Never `killall node` / kill by process name. Leaves `.cursor/verify-sokosumi-artifacts/**` intact. Close the browser when done: `agent-browser close`.
+
+## Helpers
+
+Executable: `.cursor/skills/verify-sokosumi/bin/verify-sokosumi`
+
+```bash
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi launch
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi doctor
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi core-smoke
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi cleanup
+```
+
+Env overrides: `VERIFY_SOKOSUMI_WEB_URL`, `VERIFY_SOKOSUMI_CORE_URL`, `VERIFY_SOKOSUMI_STATE_DIR`, `VERIFY_SOKOSUMI_ARTIFACT_ROOT`.
+
+## Isolate
+
+Default ports **3000** (web) and **8787** (core) are shared. Second concurrent verify run on the same machine is **not** supported without changing ports and env URLs — helper refuses if ports already answer. Cloud agents get an isolated Neon branch per conversation; still one web+core pair per verify run.
+
+## Gotchas (always)
+
+- Ambient `DATABASE_URL` can override `.env` — use `with-db.mjs` when `.cursor/cloud-agent-db.env` exists
+- Empty local catalog: `/agents` or `GET /v1/agents` may fail until `credit_cost` rows exist
+- Ably placeholders break realtime chat UI
+- Fixtures exist only on agent Neon branches, not production/`main`
+- Node **24.x** required

--- a/.cursor/skills/verify-sokosumi/bin/verify-sokosumi
+++ b/.cursor/skills/verify-sokosumi/bin/verify-sokosumi
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# verify-sokosumi — launch / doctor / cleanup helpers for the verify-sokosumi skill.
+# Invoke from repo root: .cursor/skills/verify-sokosumi/bin/verify-sokosumi <command>
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+STATE_DIR="${VERIFY_SOKOSUMI_STATE_DIR:-$REPO_ROOT/.cursor/verify-sokosumi-artifacts/state}"
+ARTIFACT_ROOT="${VERIFY_SOKOSUMI_ARTIFACT_ROOT:-$REPO_ROOT/.cursor/verify-sokosumi-artifacts}"
+PID_FILE="$STATE_DIR/dev.pids"
+LOG_DIR="$STATE_DIR/logs"
+# Prefer localhost (not 127.0.0.1) so Better Auth origin/cookies match WEB_APP_BASE_URL.
+WEB_URL="${VERIFY_SOKOSUMI_WEB_URL:-http://localhost:3000}"
+CORE_URL="${VERIFY_SOKOSUMI_CORE_URL:-http://localhost:8787}"
+
+mkdir -p "$STATE_DIR" "$LOG_DIR" "$ARTIFACT_ROOT"
+
+function usage() {
+  cat <<'EOF'
+Usage: verify-sokosumi <command>
+
+Commands:
+  launch     Start Core (:8787) and Web (:3000) for this verification run.
+             Uses with-db.mjs when .cursor/cloud-agent-db.env exists.
+  doctor     Read-only health check (ports, OpenAPI, sign-in page).
+  cleanup    Stop processes started by launch (keeps proof artifacts).
+  core-smoke GET Core OpenAPI JSON; exit 0 if HTTP 200.
+
+Env overrides:
+  VERIFY_SOKOSUMI_WEB_URL   default http://localhost:3000
+  VERIFY_SOKOSUMI_CORE_URL  default http://localhost:8787
+  VERIFY_SOKOSUMI_STATE_DIR state/pids/logs directory
+  VERIFY_SOKOSUMI_ARTIFACT_ROOT proof artifact root
+EOF
+}
+
+function run_dev() {
+  # $1 = core|web filter name for pnpm --filter
+  local filter="$1"
+  if [[ -f "$REPO_ROOT/.cursor/cloud-agent-db.env" ]]; then
+    exec node "$REPO_ROOT/scripts/cloud-agent-db/with-db.mjs" -- pnpm --filter "$filter" dev
+  else
+    exec pnpm --filter "$filter" dev
+  fi
+}
+
+function http_code() {
+  local url="$1"
+  local code
+  code="$(curl -sS -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null)" || true
+  if [[ -z "$code" ]]; then
+    echo "000"
+  else
+    echo "$code"
+  fi
+}
+
+function wait_http() {
+  local url="$1"
+  local name="$2"
+  local attempts="${3:-90}"
+  local i code="000"
+  for ((i = 1; i <= attempts; i++)); do
+    code="$(http_code "$url")"
+    if [[ "$code" =~ ^[23] ]]; then
+      echo "$name ready ($code) at $url"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "error: $name not ready at $url (last HTTP $code)" >&2
+  return 1
+}
+
+function kill_tree() {
+  local pid="$1"
+  local label="$2"
+  if [[ -z "$pid" || "$pid" == "unknown" ]]; then
+    return 0
+  fi
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "$label pid=$pid already stopped"
+    return 0
+  fi
+  echo "stopping $label pid=$pid (tree)"
+  # Kill descendants first, then the root.
+  local children
+  children="$(pgrep -P "$pid" 2>/dev/null || true)"
+  local child
+  for child in $children; do
+    kill_tree "$child" "$label-child"
+  done
+  kill "$pid" 2>/dev/null || true
+  sleep 1
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+function launch() {
+  if [[ -f "$PID_FILE" ]]; then
+    echo "error: pid file exists ($PID_FILE). Run cleanup first, or refuse to double-drive." >&2
+    exit 1
+  fi
+
+  local web_code core_code
+  web_code="$(http_code "$WEB_URL/signin")"
+  core_code="$(http_code "$CORE_URL/v1/openapi.json")"
+  if [[ "$web_code" =~ ^[23] ]] || [[ "$core_code" =~ ^[23] ]]; then
+    echo "error: ports already answering (web=$web_code core=$core_code)." >&2
+    echo "Refuse to double-drive a shared instance. Stop foreign servers or change ports." >&2
+    exit 1
+  fi
+
+  # nohup + disown so servers survive this script exiting (macOS has no reliable setsid -f).
+  echo "Starting Core → $LOG_DIR/core.log"
+  nohup bash -c 'source "$0" run_dev_core' "$0" >"$LOG_DIR/core.log" 2>&1 &
+  local core_wrap=$!
+  disown "$core_wrap" 2>/dev/null || true
+
+  echo "Starting Web → $LOG_DIR/web.log"
+  nohup bash -c 'source "$0" run_dev_web' "$0" >"$LOG_DIR/web.log" 2>&1 &
+  local web_wrap=$!
+  disown "$web_wrap" 2>/dev/null || true
+
+  printf 'core=%s\nweb=%s\nstarted_at=%s\nweb_url=%s\ncore_url=%s\n' \
+    "$core_wrap" "$web_wrap" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$WEB_URL" "$CORE_URL" \
+    >"$PID_FILE"
+
+  wait_http "$CORE_URL/v1/openapi.json" "Core" 90
+  wait_http "$WEB_URL/signin" "Web" 90
+  echo "launch ok (pids in $PID_FILE)"
+}
+
+# Internal entrypoints used by nohup bash -c 'source "$0" …'
+function run_dev_core() {
+  run_dev core
+}
+
+function run_dev_web() {
+  run_dev web
+}
+
+function doctor() {
+  local ok=1
+  local core_code web_code
+
+  core_code="$(http_code "$CORE_URL/v1/openapi.json")"
+  web_code="$(http_code "$WEB_URL/signin")"
+
+  echo "core_openapi=$core_code ($CORE_URL/v1/openapi.json)"
+  echo "web_signin=$web_code ($WEB_URL/signin)"
+
+  if [[ ! "$core_code" =~ ^[23] ]]; then
+    echo "doctor fail: Core OpenAPI not healthy"
+    ok=0
+  fi
+  if [[ ! "$web_code" =~ ^[23] ]]; then
+    echo "doctor fail: Web /signin not healthy"
+    ok=0
+  fi
+
+  if [[ -f "$PID_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$PID_FILE"
+    echo "owned_by_verify=yes core_pid=${core:-?} web_pid=${web:-?}"
+    if [[ -n "${core:-}" && "${core}" != "unknown" ]] && ! kill -0 "$core" 2>/dev/null; then
+      echo "doctor fail: recorded core pid $core not running"
+      ok=0
+    fi
+    if [[ -n "${web:-}" && "${web}" != "unknown" ]] && ! kill -0 "$web" 2>/dev/null; then
+      echo "doctor fail: recorded web pid $web not running"
+      ok=0
+    fi
+  else
+    echo "owned_by_verify=no"
+    echo "warn: no pid file — do not mutate a foreign instance; read-only checks only"
+  fi
+
+  if [[ "$ok" -eq 1 ]]; then
+    echo "doctor ok"
+    return 0
+  fi
+  echo "doctor fail"
+  return 1
+}
+
+function cleanup() {
+  if [[ ! -f "$PID_FILE" ]]; then
+    echo "cleanup: no pid file; nothing owned to stop"
+    return 0
+  fi
+  # shellcheck disable=SC1090
+  source "$PID_FILE"
+  kill_tree "${core:-}" "core"
+  kill_tree "${web:-}" "web"
+  rm -f "$PID_FILE"
+  echo "cleanup ok (artifacts kept under $ARTIFACT_ROOT)"
+}
+
+function core_smoke() {
+  local code
+  code="$(http_code "$CORE_URL/v1/openapi.json")"
+  echo "core_openapi=$code"
+  [[ "$code" =~ ^[23] ]]
+}
+
+case "${1:-}" in
+  launch) launch ;;
+  doctor) doctor ;;
+  cleanup) cleanup ;;
+  core-smoke) core_smoke ;;
+  run_dev_core) run_dev_core ;;
+  run_dev_web) run_dev_web ;;
+  -h | --help | help | "") usage ;;
+  *)
+    echo "unknown command: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/.cursor/skills/verify-sokosumi/features/README.md
+++ b/.cursor/skills/verify-sokosumi/features/README.md
@@ -1,0 +1,47 @@
+# Sokosumi verification map
+
+Maintained source for verifying user-facing Sokosumi behavior. Read this index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Launch Core (`http://localhost:8787`) and Web (`http://localhost:3000`) for this run (Cursor background shells or `verify-sokosumi launch` in a durable terminal). Record pids in `.cursor/verify-sokosumi-artifacts/state/dev.pids`.
+- Run `.cursor/skills/verify-sokosumi/bin/verify-sokosumi doctor` and require `doctor ok` with `owned_by_verify=yes`.
+- Export `AGENT_BROWSER_SESSION_NAME=sokosumi`.
+- Prefer fixture `alice@sokosumi.test` / `Password123!` on cloud-agent Neon branches; otherwise create a disposable user (see [Sign up](./sign-up.md)).
+- Use **`localhost`**, not `127.0.0.1`, for browser URLs (Better Auth origin/cookies).
+- Never drive an instance that was not started by this verification run.
+- Put proof under `.cursor/verify-sokosumi-artifacts/<feature-id>/` (gitignored). Cleanup must keep those files.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Prefer `data-testid` and accessible names over CSS position or coordinates.
+- Sign-in: fill email/password, then `agent-browser press Enter` (do not click submit).
+- Re-snapshot after navigation (`agent-browser snapshot -i`).
+- Treat Ably/chat realtime failures as environment gaps unless the feature under test is chat messaging.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes a screenshot and an interactive snapshot with Sokosumi chrome visible.
+- Mutation proof includes a second read (reload or navigate away and back).
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features`
+2. `How to get to it (user POV)`
+3. `Driving it with agent-browser` (or `Driving it with curl` when API-only)
+4. `Gotchas`
+
+## Features
+
+- [Sign in](./sign-in.md) — email/password session, landing redirect, logout-adjacent checks.
+- [Browse agents](./browse-agents.md) — agents catalog list and agent detail.
+- [Chat landing](./chat-landing.md) — authenticated default landing at `/chat` (not Ably messaging).
+- [Jobs history](./jobs-history.md) — `/history` jobs list for the signed-in user.
+- [Sign up](./sign-up.md) — disposable account creation when fixtures are absent.

--- a/.cursor/skills/verify-sokosumi/features/browse-agents.md
+++ b/.cursor/skills/verify-sokosumi/features/browse-agents.md
@@ -1,0 +1,35 @@
+# Browse agents
+
+Browse agents lets a signed-in user open the agents catalog, inspect the list, and open an agent detail page when catalog data exists.
+
+## Sub-features
+
+- `agents-list` loads `/agents` for a signed-in user.
+- `agents-open-detail` opens `/agents/[agentId]` from a list entry when at least one agent is listed.
+- `agents-empty-or-error` distinguishes an empty/broken catalog (missing `credit_cost` on empty local DB) from a healthy list.
+
+## How to get to it (user POV)
+
+- Choose Agents in app navigation.
+- Open `/agents` directly.
+- From an agent card or row, open that agent’s detail URL.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Signed in (see [Sign in](./sign-in.md)); session healthy.
+- `verify-sokosumi doctor` ok.
+- Prefer a Neon fork or seeded catalog; empty local Postgres may 500 until credit costs exist.
+
+- **Open catalog.** Run `agent-browser open http://localhost:3000/agents` then `agent-browser wait --load networkidle` and `agent-browser snapshot -i`. Page is `/agents` and not `/signin`.
+- **Healthy list.** Snapshot shows one or more agent links/cards. Note one agent name and its href.
+- **Open detail.** Click that agent control (ref from snapshot). URL matches `/agents/<id>` (optional `/jobs` child). Detail shows the same agent identity.
+- **Empty/error path.** If the page errors or shows no agents, capture screenshot + snapshot and stop. Report unmet catalog precondition — do not invent hire/job success.
+- **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/browse-agents` then screenshot + `snapshot -i` for list and (if reached) detail under that directory.
+
+## Gotchas
+
+- Catalog depends on Core `GET /v1/agents` and credit-cost rows; local empty DB often fails here even when auth works.
+- Do not treat a marketing/landing redirect as catalog proof.
+- Hire/run-job flows are out of scope for this feature file — list + detail only.

--- a/.cursor/skills/verify-sokosumi/features/chat-landing.md
+++ b/.cursor/skills/verify-sokosumi/features/chat-landing.md
@@ -1,0 +1,34 @@
+# Chat landing
+
+Chat landing is the authenticated default home: after sign-in the user reaches `/chat` (or is redirected there). This feature verifies routing and shell, not realtime messaging.
+
+## Sub-features
+
+- `chat-default-landing` reaches `/chat` after authentication.
+- `chat-shell` shows the chat app chrome for the signed-in user.
+- `chat-ably-gap` records when Ably placeholders break messaging UI without failing the landing proof.
+
+## How to get to it (user POV)
+
+- Sign in and follow the default post-login redirect.
+- Open `/` while authenticated (redirects to `/chat`).
+- Open `/chat` directly.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Signed in (see [Sign in](./sign-in.md)).
+- `verify-sokosumi doctor` ok.
+
+- **Open landing.** Run `agent-browser open http://localhost:3000/chat` then `agent-browser wait --load networkidle`.
+- **Confirm URL.** Run `agent-browser get url`. URL contains `/chat` and is not `/signin`.
+- **Confirm shell.** Run `agent-browser snapshot -i`. Authenticated chrome is present (welcome / composer / nav).
+- **Ably note.** If a “Something went wrong” modal appears from Ably auth failure, screenshot it and continue — landing still counts if URL and chrome prove `/chat`. Do not claim message send/receive unless Ably keys are real.
+- **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/chat-landing`, save snapshot, `agent-browser screenshot`, copy newest shot into that directory.
+
+## Gotchas
+
+- Ably placeholder keys make `POST /api/ably/auth` fail; that is an environment gap, not a routing regression.
+- Proving a chat **message** requires configured Ably — out of scope unless keys are set.
+- `/` while logged out is not this feature; use [Sign in](./sign-in.md).

--- a/.cursor/skills/verify-sokosumi/features/jobs-history.md
+++ b/.cursor/skills/verify-sokosumi/features/jobs-history.md
@@ -1,0 +1,31 @@
+# Jobs history
+
+Jobs history lets a signed-in user open `/history` and see their jobs list (including an empty state).
+
+## Sub-features
+
+- `history-open` loads `/history` while authenticated.
+- `history-list-or-empty` shows either job rows or a clear empty state.
+- `history-gated` redirects anonymous users away from `/history` toward sign-in.
+
+## How to get to it (user POV)
+
+- Choose History (or equivalent) in app navigation.
+- Open `/history` directly.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Signed in for the happy path (see [Sign in](./sign-in.md)).
+- `verify-sokosumi doctor` ok.
+
+- **Open history.** Run `agent-browser open http://localhost:3000/history` then `agent-browser wait --load networkidle` and `agent-browser snapshot -i`. URL is `/history` (not `/signin`).
+- **List or empty.** Snapshot shows a jobs table/list **or** an empty-state message. Either is success; note which.
+- **Optional gate check.** In a fresh browser session without cookies, open `/history` and confirm redirect to sign-in. Do not reuse `AGENT_BROWSER_SESSION_NAME` for this check (use another `--session` or clear state).
+- **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/jobs-history` then screenshot + snapshot of the authenticated history view.
+
+## Gotchas
+
+- Empty history is valid proof for a new fixture user — do not require existing jobs.
+- Do not open agent job detail (`/agents/.../jobs/...`) and call it history; that is a different route.

--- a/.cursor/skills/verify-sokosumi/features/sign-in.md
+++ b/.cursor/skills/verify-sokosumi/features/sign-in.md
@@ -1,0 +1,37 @@
+# Sign in
+
+Sign in lets a user authenticate with email and password, reach the authenticated app, and confirm the session survives a reload of a protected route.
+
+## Sub-features
+
+- `signin-form` shows email and password fields on `/signin`.
+- `signin-submit` creates a session via Enter submit.
+- `signin-landing` lands on the authenticated default (`/chat` or redirect chain into the app).
+- `signin-persist` keeps the session after reload of a protected URL.
+
+## How to get to it (user POV)
+
+- Open `/signin` (or `/login`, which redirects to `/signin`).
+- From a gated page, follow the sign-in prompt to `/signin`.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- `verify-sokosumi doctor` reports `doctor ok` and `owned_by_verify=yes`.
+- Credentials available: fixture `alice@sokosumi.test` / `Password123!`, or a coworker vault `agent-browser auth login sokosumi`, or a user created via [Sign up](./sign-up.md).
+- `AGENT_BROWSER_SESSION_NAME=sokosumi` is set.
+
+- **Open form.** Run `agent-browser open http://localhost:3000/signin` then `agent-browser snapshot -i`. The page exposes `[data-testid="auth-field-email"]` and `[data-testid="auth-field-currentPassword"]` (locale may label fields `E-Mail` / `Passwort`).
+- **Fill credentials.** Either `agent-browser auth login sokosumi` (vault) or `agent-browser fill '[data-testid="auth-field-email"]' "<email>"` and `agent-browser fill '[data-testid="auth-field-currentPassword"]' "<password>"`.
+- **Submit.** Wait briefly after fill, then `agent-browser press Enter` and `agent-browser wait --load networkidle`. URL leaves `/signin` (typically `/chat`). Snapshot shows authenticated chrome (e.g. welcome heading, nav links).
+- **Persist.** Run `agent-browser open http://localhost:3000/agents` then `agent-browser wait --load networkidle`. URL stays on `/agents` (not bounced to `/signin`).
+- **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/sign-in`, save `snapshot -i` to `after-login.snapshot.txt`, run `agent-browser screenshot`, copy newest `~/.agent-browser/tmp/screenshots/*.png` to `after-login.png`. Artifacts show authenticated UI, not the sign-in form.
+
+## Gotchas
+
+- Clicking `[data-testid="auth-submit"]` after vault fill can no-op; always submit with Enter after a short wait.
+- OAuth buttons are not valid verification paths with placeholder credentials.
+- Wrong password leaves the user on `/signin`; do not treat a soft error toast alone as success.
+- Fixtures exist only on cloud-agent Neon branches — otherwise use [Sign up](./sign-up.md) first.
+- `127.0.0.1` can break auth cookies/origin; stick to `localhost`.

--- a/.cursor/skills/verify-sokosumi/features/sign-up.md
+++ b/.cursor/skills/verify-sokosumi/features/sign-up.md
@@ -1,0 +1,51 @@
+# Sign up
+
+Sign up creates a disposable email/password account when cloud-agent fixtures are unavailable (typical empty local DB). Use this only to unlock other features — not as a substitute for fixture login on agent branches.
+
+## Sub-features
+
+- `signup-form` shows registration fields on `/signup`.
+- `signup-submit` creates the user and signs them in (no email verification).
+- `signup-landing` lands inside the authenticated app after submit.
+
+## How to get to it (user POV)
+
+- Open `/signup` (or `/register`, which redirects to `/signup`).
+- From sign-in, follow the create-account link.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- `verify-sokosumi doctor` ok and `owned_by_verify=yes`.
+- Fixtures unavailable or intentionally unused.
+- Choose a unique email, e.g. `verify-$(date +%s)@sokosumi.test`, and a password meeting app rules (fixture-style `Password123!` is fine).
+
+- **Open form.** Run `agent-browser open http://localhost:3000/signup` then `agent-browser snapshot -i`.
+- **Fill required fields.** Name, email, password textboxes (locale labels vary). Prefer refs from the fresh snapshot.
+- **Accept terms.** Check the terms checkbox (`#termsAccepted` / accessible name about Nutzungsbedingungen / Terms). Submit stays **disabled** until terms are accepted.
+- **Submit.** When `Registrieren` / submit is enabled, prefer Enter or click submit. Wait for navigation away from `/signup`.
+- **Confirm session.** Open `/agents` or `/chat`; must not bounce to `/signin`.
+- **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/sign-up` then screenshot + snapshot of the post-signup authenticated view. Record the email in `account.txt` (no password).
+
+### Bootstrap when UI checkbox will not toggle
+
+If agent-browser cannot toggle the Radix terms checkbox (known gap: `click` / `check` / mouse down-up leave `aria-checked=false`), bootstrap the user via Better Auth then prove [Sign in](./sign-in.md) in the browser:
+
+```bash
+curl -sS -X POST "http://localhost:8787/auth/sign-up/email" \
+  -H 'content-type: application/json' \
+  -H 'origin: http://localhost:3000' \
+  -d '{"email":"<unique>@sokosumi.test","password":"Password123!","name":"Verify Agent","termsAccepted":true}'
+```
+
+Require HTTP 200 and a `user.email` in the body. Do **not** count API signup alone as UI signup proof — only as account creation so sign-in can be driven. Report the checkbox gap if the UI path was the intended entry.
+
+## Gotchas
+
+- Email verification is off in local/core config — do not wait for a verification email. A “confirm email” banner after login is OK.
+- OAuth signup paths are invalid with placeholder credentials.
+- Do not reuse an email that already exists; pick a fresh address per run.
+- On cloud-agent branches, prefer fixtures over signup unless testing signup itself.
+- Origin must be `http://localhost:3000` for Core auth API calls (`INVALID_ORIGIN` otherwise).
+- Submit button stays disabled until terms are accepted.

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ lint-report.json
 
 # Local Claude Code dev-server config (personal, per-machine)
 .claude/launch.json
+
+# verify-sokosumi proof artifacts (keep skill; discard run evidence)
+.cursor/verify-sokosumi-artifacts/


### PR DESCRIPTION
## Summary
- Add project-local `.cursor/rules/pstack-models.mdc` so pstack role models default to `inherit-parent` for local and cloud agents.
- Add `.cursor/skills/verify-sokosumi/` so agents can launch web+core, doctor health, drive real user paths with `agent-browser`, and keep proof artifacts (gitignored under `.cursor/verify-sokosumi-artifacts/`).

## Test plan
- [ ] New agent session shows pstack-models in always-applied rules
- [ ] Cloud/local agent can load `verify-sokosumi` and follow Launch → Doctor → Drive (sign-in feature) → Cleanup
- [ ] Confirm `.cursor/verify-sokosumi-artifacts/` stays untracked after a proof run