### PR TITLE
feat(core): restore room stream pending mirror

### DIFF
--- a/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
+++ b/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
@@ -84,15 +84,4 @@ describe("coworker-pending-response-mirror", () => {
       coworkerPendingResponseRedisKey(ROOM_SCOPE),
     );
   });
-
-  it("sets the pending response mirror under the thread-scoped key", async () => {
-    await setPendingResponseMirror(THREAD_SCOPE, "resp_thread");
-
-    expect(redisSetMock).toHaveBeenCalledWith(
-      coworkerPendingResponseRedisKey(THREAD_SCOPE),
-      "resp_thread",
-      "EX",
-      COWORKER_STREAM_LOCK_TTL_SECONDS,
-    );
-  });
 });

--- a/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
+++ b/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
@@ -85,7 +85,7 @@ describe("coworker-pending-response-mirror", () => {
     );
   });
 
-  it("uses a distinct key for thread scope so top-level and threads do not collide", async () => {
+  it("sets the pending response mirror under the thread-scoped key", async () => {
     await setPendingResponseMirror(THREAD_SCOPE, "resp_thread");
 
     expect(redisSetMock).toHaveBeenCalledWith(
@@ -93,9 +93,6 @@ describe("coworker-pending-response-mirror", () => {
       "resp_thread",
       "EX",
       COWORKER_STREAM_LOCK_TTL_SECONDS,
-    );
-    expect(redisSetMock.mock.calls[0]![0]).not.toBe(
-      coworkerPendingResponseRedisKey(ROOM_SCOPE),
     );
   });
 });

--- a/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
+++ b/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
@@ -20,6 +20,12 @@ import {
 } from "./coworker-pending-response-mirror";
 import { COWORKER_STREAM_LOCK_TTL_SECONDS } from "./coworker-stream-lock";
 
+const ROOM_SCOPE = { roomId: "room-1" };
+const THREAD_SCOPE = {
+  roomId: "room-1",
+  parentMessageId: "parent-msg-1",
+};
+
 describe("coworker-pending-response-mirror", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -33,40 +39,63 @@ describe("coworker-pending-response-mirror", () => {
     redisDelMock.mockResolvedValue(1);
   });
 
-  it("builds the expected redis key", () => {
-    expect(coworkerPendingResponseRedisKey("conv-1")).toBe(
-      "coworker:pending_resp:conv-1",
+  it("builds room-scoped and thread-scoped redis keys", () => {
+    expect(coworkerPendingResponseRedisKey(ROOM_SCOPE)).toBe(
+      "coworker:pending_resp:room:room-1",
     );
+    expect(coworkerPendingResponseRedisKey(THREAD_SCOPE)).toBe(
+      "coworker:pending_resp:room:room-1:thread:parent-msg-1",
+    );
+    expect(
+      coworkerPendingResponseRedisKey({
+        roomId: "room-1",
+        parentMessageId: "  ",
+      }),
+    ).toBe("coworker:pending_resp:room:room-1");
   });
 
   it("no-ops when redis is unavailable", async () => {
     getRedisClientMock.mockReturnValue(null);
 
-    await setPendingResponseMirror("conv-1", "resp_1");
-    await clearPendingResponseMirror("conv-1");
-    await expect(getPendingResponseMirror("conv-1")).resolves.toBeNull();
+    await setPendingResponseMirror(ROOM_SCOPE, "resp_1");
+    await clearPendingResponseMirror(ROOM_SCOPE);
+    await expect(getPendingResponseMirror(ROOM_SCOPE)).resolves.toBeNull();
 
     expect(redisSetMock).not.toHaveBeenCalled();
     expect(redisDelMock).not.toHaveBeenCalled();
     expect(redisGetMock).not.toHaveBeenCalled();
   });
 
-  it("sets, reads, and clears the pending response mirror", async () => {
-    await setPendingResponseMirror("conv-1", "resp_1");
+  it("sets, reads, and clears the pending response mirror for a room", async () => {
+    await setPendingResponseMirror(ROOM_SCOPE, "resp_1");
 
     expect(redisSetMock).toHaveBeenCalledWith(
-      coworkerPendingResponseRedisKey("conv-1"),
+      coworkerPendingResponseRedisKey(ROOM_SCOPE),
       "resp_1",
       "EX",
       COWORKER_STREAM_LOCK_TTL_SECONDS,
     );
 
     redisGetMock.mockResolvedValueOnce("resp_1");
-    await expect(getPendingResponseMirror("conv-1")).resolves.toBe("resp_1");
+    await expect(getPendingResponseMirror(ROOM_SCOPE)).resolves.toBe("resp_1");
 
-    await clearPendingResponseMirror("conv-1");
+    await clearPendingResponseMirror(ROOM_SCOPE);
     expect(redisDelMock).toHaveBeenCalledWith(
-      coworkerPendingResponseRedisKey("conv-1"),
+      coworkerPendingResponseRedisKey(ROOM_SCOPE),
+    );
+  });
+
+  it("uses a distinct key for thread scope so top-level and threads do not collide", async () => {
+    await setPendingResponseMirror(THREAD_SCOPE, "resp_thread");
+
+    expect(redisSetMock).toHaveBeenCalledWith(
+      coworkerPendingResponseRedisKey(THREAD_SCOPE),
+      "resp_thread",
+      "EX",
+      COWORKER_STREAM_LOCK_TTL_SECONDS,
+    );
+    expect(redisSetMock.mock.calls[0]![0]).not.toBe(
+      coworkerPendingResponseRedisKey(ROOM_SCOPE),
     );
   });
 });

--- a/apps/core/src/helpers/coworker-pending-response-mirror.ts
+++ b/apps/core/src/helpers/coworker-pending-response-mirror.ts
@@ -2,14 +2,23 @@ import { getRedisClient } from "@/lib/redis";
 
 import { COWORKER_STREAM_LOCK_TTL_SECONDS } from "./coworker-stream-lock";
 
+export interface CoworkerPendingResponseScope {
+  roomId: string;
+  parentMessageId?: string | null;
+}
+
 export function coworkerPendingResponseRedisKey(
-  internalConversationId: string,
+  scope: CoworkerPendingResponseScope,
 ): string {
-  return `coworker:pending_resp:${internalConversationId}`;
+  const parentMessageId = scope.parentMessageId?.trim();
+  if (parentMessageId) {
+    return `coworker:pending_resp:room:${scope.roomId}:thread:${parentMessageId}`;
+  }
+  return `coworker:pending_resp:room:${scope.roomId}`;
 }
 
 export async function setPendingResponseMirror(
-  internalConversationId: string,
+  scope: CoworkerPendingResponseScope,
   responseId: string,
 ): Promise<void> {
   const redis = getRedisClient();
@@ -19,7 +28,7 @@ export async function setPendingResponseMirror(
 
   try {
     await redis.set(
-      coworkerPendingResponseRedisKey(internalConversationId),
+      coworkerPendingResponseRedisKey(scope),
       responseId,
       "EX",
       COWORKER_STREAM_LOCK_TTL_SECONDS,
@@ -33,7 +42,7 @@ export async function setPendingResponseMirror(
 }
 
 export async function getPendingResponseMirror(
-  internalConversationId: string,
+  scope: CoworkerPendingResponseScope,
 ): Promise<string | null> {
   const redis = getRedisClient();
   if (!redis) {
@@ -41,9 +50,7 @@ export async function getPendingResponseMirror(
   }
 
   try {
-    const value = await redis.get(
-      coworkerPendingResponseRedisKey(internalConversationId),
-    );
+    const value = await redis.get(coworkerPendingResponseRedisKey(scope));
     return typeof value === "string" && value.trim().length > 0
       ? value.trim()
       : null;
@@ -57,7 +64,7 @@ export async function getPendingResponseMirror(
 }
 
 export async function clearPendingResponseMirror(
-  internalConversationId: string,
+  scope: CoworkerPendingResponseScope,
 ): Promise<void> {
   const redis = getRedisClient();
   if (!redis) {
@@ -65,7 +72,7 @@ export async function clearPendingResponseMirror(
   }
 
   try {
-    await redis.del(coworkerPendingResponseRedisKey(internalConversationId));
+    await redis.del(coworkerPendingResponseRedisKey(scope));
   } catch (error) {
     console.error(
       "[coworker-pending-response-mirror] Failed to clear pending mirror:",

--- a/apps/core/src/helpers/history.ts
+++ b/apps/core/src/helpers/history.ts
@@ -511,6 +511,12 @@ export function mapHistoryRow(
         agentIcon: agentPreview?.icon ?? null,
       };
     }
+    default: {
+      // Exhaustiveness for HistoryKind (TASK | JOB after rooms cutover). Also
+      // keeps typecheck green if a local Prisma client still lists removed
+      // values (e.g. CONVERSATION) until `pnpm prisma:generate` is re-run.
+      throw new Error(`Unsupported history kind: ${String(row.kind)}`);
+    }
   }
 }
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -900,6 +900,30 @@ describe("POST /chats/rooms/{id}/stream", () => {
         parentMessageId: null,
       });
     });
+
+    it("clears the pending mirror on UI stream error", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+      const waitUntilPromises: Promise<unknown>[] = [];
+      waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
+        waitUntilPromises.push(promise);
+      });
+
+      const response = await postStream();
+      expect(response.status).toBe(200);
+
+      const init = toUIMessageStreamResponseMock.mock.calls[0]![0] as {
+        onError?: (error: unknown) => string;
+      };
+      expect(init.onError?.(new Error("stream boom"))).toBe(
+        "An error occurred.",
+      );
+      await Promise.all(waitUntilPromises);
+
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
+    });
   });
 
   describe("room stream lock", () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -313,10 +313,6 @@ beforeEach(() => {
   getPendingResponseMirrorMock.mockResolvedValue(null);
   setPendingResponseMirrorMock.mockResolvedValue(undefined);
   clearPendingResponseMirrorMock.mockResolvedValue(undefined);
-  pollCoworkerResponseStatusMock.mockResolvedValue({
-    status: "completed",
-    responseId: "resp_stale",
-  });
   waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
     void promise;
   });
@@ -745,17 +741,10 @@ describe("POST /chats/rooms/{id}/stream", () => {
 
       expect(response.status).toBe(409);
       expect(pollCoworkerResponseStatusMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          responseId: "resp_inflight",
-          responsesApiBaseUrl: "https://responses.example.com/v1",
-          userId: USER_ID,
-          organizationId: "org_1",
-          coworkerSlug: "hannah",
-        }),
+        expect.objectContaining({ responseId: "resp_inflight" }),
       );
       expect(clearPendingResponseMirrorMock).not.toHaveBeenCalled();
       expect(streamTextMock).not.toHaveBeenCalled();
-      expect(persistUserMessageToChatRoomMock).not.toHaveBeenCalled();
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
         ROOM_ID,
         "instance-test:token-1",
@@ -778,7 +767,6 @@ describe("POST /chats/rooms/{id}/stream", () => {
         parentMessageId: null,
       });
       expect(streamTextMock).toHaveBeenCalledOnce();
-      expect(persistUserMessageToChatRoomMock).toHaveBeenCalledOnce();
     });
 
     it("returns 503 and clears mirror when pending status cannot be verified", async () => {
@@ -798,7 +786,6 @@ describe("POST /chats/rooms/{id}/stream", () => {
         parentMessageId: null,
       });
       expect(streamTextMock).not.toHaveBeenCalled();
-      expect(persistUserMessageToChatRoomMock).not.toHaveBeenCalled();
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
         ROOM_ID,
         "instance-test:token-1",
@@ -815,7 +802,7 @@ describe("POST /chats/rooms/{id}/stream", () => {
         providerOptions: {
           sokosumi: {
             onResponseStarted: (id: string) => Promise<void>;
-            onResponseCompleted: (id: string) => Promise<void>;
+            onResponseCompleted: () => Promise<void>;
           };
         };
       };
@@ -826,14 +813,14 @@ describe("POST /chats/rooms/{id}/stream", () => {
         "resp_new",
       );
 
-      await streamArgs.providerOptions.sokosumi.onResponseCompleted("resp_new");
+      await streamArgs.providerOptions.sokosumi.onResponseCompleted();
       expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
         roomId: ROOM_ID,
         parentMessageId: null,
       });
     });
 
-    it("scopes mirror set/clear to the thread parentMessageId", async () => {
+    it("scopes mirror get/set to the thread parentMessageId", async () => {
       roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
       chatRoomMessageFindFirstMock.mockResolvedValue({
         id: PARENT_MESSAGE_ID,
@@ -857,7 +844,6 @@ describe("POST /chats/rooms/{id}/stream", () => {
         providerOptions: {
           sokosumi: {
             onResponseStarted: (id: string) => Promise<void>;
-            onResponseCompleted: (id: string) => Promise<void>;
           };
         };
       };
@@ -869,60 +855,6 @@ describe("POST /chats/rooms/{id}/stream", () => {
         { roomId: ROOM_ID, parentMessageId: PARENT_MESSAGE_ID },
         "resp_thread",
       );
-
-      await streamArgs.providerOptions.sokosumi.onResponseCompleted(
-        "resp_thread",
-      );
-      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
-        roomId: ROOM_ID,
-        parentMessageId: PARENT_MESSAGE_ID,
-      });
-    });
-
-    it("clears the pending mirror on UI stream finish", async () => {
-      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
-      const waitUntilPromises: Promise<unknown>[] = [];
-      waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
-        waitUntilPromises.push(promise);
-      });
-
-      const response = await postStream();
-      expect(response.status).toBe(200);
-
-      const init = toUIMessageStreamResponseMock.mock.calls[0]![0] as {
-        onFinish?: () => Promise<void>;
-      };
-      await init.onFinish!();
-      await Promise.all(waitUntilPromises);
-
-      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
-        roomId: ROOM_ID,
-        parentMessageId: null,
-      });
-    });
-
-    it("clears the pending mirror on UI stream error", async () => {
-      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
-      const waitUntilPromises: Promise<unknown>[] = [];
-      waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
-        waitUntilPromises.push(promise);
-      });
-
-      const response = await postStream();
-      expect(response.status).toBe(200);
-
-      const init = toUIMessageStreamResponseMock.mock.calls[0]![0] as {
-        onError?: (error: unknown) => string;
-      };
-      expect(init.onError?.(new Error("stream boom"))).toBe(
-        "An error occurred.",
-      );
-      await Promise.all(waitUntilPromises);
-
-      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
-        roomId: ROOM_ID,
-        parentMessageId: null,
-      });
     });
   });
 
@@ -1005,6 +937,10 @@ describe("POST /chats/rooms/{id}/stream", () => {
       expect(waitUntilPromises).toHaveLength(2);
       await Promise.all(waitUntilPromises);
 
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
         ROOM_ID,
         "instance-test:token-1",
@@ -1050,6 +986,10 @@ describe("POST /chats/rooms/{id}/stream", () => {
       expect(waitUntilPromises).toHaveLength(2);
       await Promise.all(waitUntilPromises);
 
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
         ROOM_ID,
         "instance-test:token-1",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -37,6 +37,10 @@ const {
   waitUntilMock,
   ensureThreadProviderConversationMock,
   buildRoomStreamThreadModelMessagesMock,
+  getPendingResponseMirrorMock,
+  setPendingResponseMirrorMock,
+  clearPendingResponseMirrorMock,
+  pollCoworkerResponseStatusMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
   chatRoomUpdateMock: vi.fn(),
@@ -67,6 +71,10 @@ const {
   waitUntilMock: vi.fn(),
   ensureThreadProviderConversationMock: vi.fn(),
   buildRoomStreamThreadModelMessagesMock: vi.fn(),
+  getPendingResponseMirrorMock: vi.fn(),
+  setPendingResponseMirrorMock: vi.fn(),
+  clearPendingResponseMirrorMock: vi.fn(),
+  pollCoworkerResponseStatusMock: vi.fn(),
 }));
 
 vi.mock("@vercel/functions", () => ({
@@ -97,6 +105,20 @@ vi.mock("@/helpers/coworker-stream-lock", () => ({
   acquireStreamLock: acquireStreamLockMock,
   releaseStreamLock: releaseStreamLockMock,
   startStreamLockHeartbeat: startStreamLockHeartbeatMock,
+}));
+
+vi.mock("@/helpers/coworker-pending-response-mirror", () => ({
+  getPendingResponseMirror: (...args: unknown[]) =>
+    getPendingResponseMirrorMock(...args),
+  setPendingResponseMirror: (...args: unknown[]) =>
+    setPendingResponseMirrorMock(...args),
+  clearPendingResponseMirror: (...args: unknown[]) =>
+    clearPendingResponseMirrorMock(...args),
+}));
+
+vi.mock("@/helpers/coworker-response-poll", () => ({
+  pollCoworkerResponseStatus: (...args: unknown[]) =>
+    pollCoworkerResponseStatusMock(...args),
 }));
 
 vi.mock("@/lib/resumable-ui-stream-context", () => ({
@@ -288,6 +310,13 @@ beforeEach(() => {
   });
   releaseStreamLockMock.mockResolvedValue(true);
   startStreamLockHeartbeatMock.mockReturnValue(() => {});
+  getPendingResponseMirrorMock.mockResolvedValue(null);
+  setPendingResponseMirrorMock.mockResolvedValue(undefined);
+  clearPendingResponseMirrorMock.mockResolvedValue(undefined);
+  pollCoworkerResponseStatusMock.mockResolvedValue({
+    status: "completed",
+    responseId: "resp_stale",
+  });
   waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
     void promise;
   });
@@ -703,6 +732,176 @@ describe("POST /chats/rooms/{id}/stream", () => {
     });
   });
 
+  describe("pending response mirror", () => {
+    it("returns 409 when a mirrored pending response is still in progress", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+      getPendingResponseMirrorMock.mockResolvedValueOnce("resp_inflight");
+      pollCoworkerResponseStatusMock.mockResolvedValueOnce({
+        status: "in_progress",
+        responseId: "resp_inflight",
+      });
+
+      const response = await postStream();
+
+      expect(response.status).toBe(409);
+      expect(pollCoworkerResponseStatusMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseId: "resp_inflight",
+          responsesApiBaseUrl: "https://responses.example.com/v1",
+          userId: USER_ID,
+          organizationId: "org_1",
+          coworkerSlug: "hannah",
+        }),
+      );
+      expect(clearPendingResponseMirrorMock).not.toHaveBeenCalled();
+      expect(streamTextMock).not.toHaveBeenCalled();
+      expect(persistUserMessageToChatRoomMock).not.toHaveBeenCalled();
+      expect(releaseStreamLockMock).toHaveBeenCalledWith(
+        ROOM_ID,
+        "instance-test:token-1",
+      );
+    });
+
+    it("clears a completed mirrored pending response and proceeds", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+      getPendingResponseMirrorMock.mockResolvedValueOnce("resp_done");
+      pollCoworkerResponseStatusMock.mockResolvedValueOnce({
+        status: "completed",
+        responseId: "resp_done",
+      });
+
+      const response = await postStream();
+
+      expect(response.status).toBe(200);
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
+      expect(streamTextMock).toHaveBeenCalledOnce();
+      expect(persistUserMessageToChatRoomMock).toHaveBeenCalledOnce();
+    });
+
+    it("returns 503 and clears mirror when pending status cannot be verified", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+      getPendingResponseMirrorMock.mockResolvedValueOnce("resp_unknown");
+      pollCoworkerResponseStatusMock.mockResolvedValueOnce({
+        status: "error",
+        responseId: "resp_unknown",
+        cause: new Error("retrieve failed"),
+      });
+
+      const response = await postStream();
+
+      expect(response.status).toBe(503);
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
+      expect(streamTextMock).not.toHaveBeenCalled();
+      expect(persistUserMessageToChatRoomMock).not.toHaveBeenCalled();
+      expect(releaseStreamLockMock).toHaveBeenCalledWith(
+        ROOM_ID,
+        "instance-test:token-1",
+      );
+    });
+
+    it("sets the room-scoped mirror on response start and clears on completed", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+
+      const response = await postStream();
+      expect(response.status).toBe(200);
+
+      const streamArgs = streamTextMock.mock.calls[0]![0] as {
+        providerOptions: {
+          sokosumi: {
+            onResponseStarted: (id: string) => Promise<void>;
+            onResponseCompleted: (id: string) => Promise<void>;
+          };
+        };
+      };
+
+      await streamArgs.providerOptions.sokosumi.onResponseStarted("resp_new");
+      expect(setPendingResponseMirrorMock).toHaveBeenCalledWith(
+        { roomId: ROOM_ID, parentMessageId: null },
+        "resp_new",
+      );
+
+      await streamArgs.providerOptions.sokosumi.onResponseCompleted("resp_new");
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
+    });
+
+    it("scopes mirror set/clear to the thread parentMessageId", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+      chatRoomMessageFindFirstMock.mockResolvedValue({
+        id: PARENT_MESSAGE_ID,
+        parentMessageId: null,
+      });
+
+      const response = await postStream({
+        messages: [
+          { role: "user", parts: [{ type: "text", text: "Thread reply" }] },
+        ],
+        parentMessageId: PARENT_MESSAGE_ID,
+      });
+      expect(response.status).toBe(200);
+
+      expect(getPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: PARENT_MESSAGE_ID,
+      });
+
+      const streamArgs = streamTextMock.mock.calls[0]![0] as {
+        providerOptions: {
+          sokosumi: {
+            onResponseStarted: (id: string) => Promise<void>;
+            onResponseCompleted: (id: string) => Promise<void>;
+          };
+        };
+      };
+
+      await streamArgs.providerOptions.sokosumi.onResponseStarted(
+        "resp_thread",
+      );
+      expect(setPendingResponseMirrorMock).toHaveBeenCalledWith(
+        { roomId: ROOM_ID, parentMessageId: PARENT_MESSAGE_ID },
+        "resp_thread",
+      );
+
+      await streamArgs.providerOptions.sokosumi.onResponseCompleted(
+        "resp_thread",
+      );
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: PARENT_MESSAGE_ID,
+      });
+    });
+
+    it("clears the pending mirror on UI stream finish", async () => {
+      roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
+      const waitUntilPromises: Promise<unknown>[] = [];
+      waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
+        waitUntilPromises.push(promise);
+      });
+
+      const response = await postStream();
+      expect(response.status).toBe(200);
+
+      const init = toUIMessageStreamResponseMock.mock.calls[0]![0] as {
+        onFinish?: () => Promise<void>;
+      };
+      await init.onFinish!();
+      await Promise.all(waitUntilPromises);
+
+      expect(clearPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
+    });
+  });
+
   describe("room stream lock", () => {
     it("returns 409 when the coworker stream lock is already held", async () => {
       roomFindFirstMock.mockResolvedValue(roomWithOneCoworker());
@@ -779,8 +978,8 @@ describe("POST /chats/rooms/{id}/stream", () => {
         onFinish?: () => Promise<void>;
       };
       await init.onFinish!();
-      expect(waitUntilPromises).toHaveLength(1);
-      await waitUntilPromises[0]!;
+      expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1);
+      await Promise.all(waitUntilPromises);
 
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
         ROOM_ID,
@@ -824,8 +1023,8 @@ describe("POST /chats/rooms/{id}/stream", () => {
       expect(init.onError?.(new Error("stream boom"))).toBe(
         "An error occurred.",
       );
-      expect(waitUntilPromises).toHaveLength(1);
-      await waitUntilPromises[0]!;
+      expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1);
+      await Promise.all(waitUntilPromises);
 
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
         ROOM_ID,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -1002,7 +1002,7 @@ describe("POST /chats/rooms/{id}/stream", () => {
         onFinish?: () => Promise<void>;
       };
       await init.onFinish!();
-      expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1);
+      expect(waitUntilPromises).toHaveLength(2);
       await Promise.all(waitUntilPromises);
 
       expect(releaseStreamLockMock).toHaveBeenCalledWith(
@@ -1047,7 +1047,7 @@ describe("POST /chats/rooms/{id}/stream", () => {
       expect(init.onError?.(new Error("stream boom"))).toBe(
         "An error occurred.",
       );
-      expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1);
+      expect(waitUntilPromises).toHaveLength(2);
       await Promise.all(waitUntilPromises);
 
       expect(releaseStreamLockMock).toHaveBeenCalledWith(

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -268,9 +268,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
         if (pollResult.status === "in_progress") {
           throw conflict(
-            parentMessageId
-              ? "A coworker response is already in progress for this thread."
-              : "A coworker response is already in progress for this room.",
+            "A coworker response is already in progress for this room.",
           );
         }
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -244,19 +244,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
       };
 
-    const clearPendingMirrorBestEffort = () => {
-      waitUntil(
-        clearPendingResponseMirror(pendingResponseScope).catch((error) => {
-          console.error(
-            "Failed to clear pending response mirror (POST /rooms/{id}/stream):",
-            error,
-          );
-        }),
-      );
-    };
-
     const finalizeCoworkerStreamLock = () => {
-      clearPendingMirrorBestEffort();
+      waitUntil(clearPendingResponseMirror(pendingResponseScope));
       const release = releaseOwnedCoworkerStreamLock;
       if (!release) {
         return;
@@ -455,24 +444,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         webSearchEnabled: false,
         onResponseStarted: async (responseId: string) => {
           responsesApiResponseIdRef.current = responseId;
-          try {
-            await setPendingResponseMirror(pendingResponseScope, responseId);
-          } catch (error) {
-            console.error(
-              "Failed to set pending response mirror (POST /rooms/{id}/stream):",
-              error,
-            );
-          }
+          await setPendingResponseMirror(pendingResponseScope, responseId);
         },
-        onResponseCompleted: async (_responseId: string) => {
-          try {
-            await clearPendingResponseMirror(pendingResponseScope);
-          } catch (error) {
-            console.error(
-              "Failed to clear pending response mirror on response completed (POST /rooms/{id}/stream):",
-              error,
-            );
-          }
+        onResponseCompleted: async () => {
+          await clearPendingResponseMirror(pendingResponseScope);
         },
         onInvalidProviderConversationId,
       };

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -16,6 +16,12 @@ import {
   setActiveUiStreamIdForRoom,
 } from "@/helpers/active-ui-stream-room-metadata";
 import {
+  clearPendingResponseMirror,
+  getPendingResponseMirror,
+  setPendingResponseMirror,
+} from "@/helpers/coworker-pending-response-mirror";
+import { pollCoworkerResponseStatus } from "@/helpers/coworker-response-poll";
+import {
   acquireStreamLock,
   releaseStreamLock,
   startStreamLockHeartbeat,
@@ -67,7 +73,7 @@ import { ensureCoworkerProviderConversationForRoom } from "./coworker-provider-c
  * Deferred to follow-up (parity with legacy conversation stream):
  * - Image generation / OpenRouter paths
  * - Web search
- * - Pending-response mirror / conversation metadata chain
+ * - Stream path attachments / multimodal uploads
  */
 
 const paramsSchema = z.object({
@@ -225,6 +231,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       ? startStreamLockHeartbeat(room.id, streamLockOwnerToken)
       : null;
 
+    const pendingResponseScope = {
+      roomId: room.id,
+      parentMessageId,
+    };
+
     let releaseOwnedCoworkerStreamLock: (() => Promise<void>) | null =
       async () => {
         stopHeartbeat?.();
@@ -233,7 +244,19 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
       };
 
+    const clearPendingMirrorBestEffort = () => {
+      waitUntil(
+        clearPendingResponseMirror(pendingResponseScope).catch((error) => {
+          console.error(
+            "Failed to clear pending response mirror (POST /rooms/{id}/stream):",
+            error,
+          );
+        }),
+      );
+    };
+
     const finalizeCoworkerStreamLock = () => {
+      clearPendingMirrorBestEffort();
       const release = releaseOwnedCoworkerStreamLock;
       if (!release) {
         return;
@@ -243,6 +266,35 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     };
 
     try {
+      const mirroredPending =
+        await getPendingResponseMirror(pendingResponseScope);
+      if (mirroredPending) {
+        const pollResult = await pollCoworkerResponseStatus({
+          responsesApiBaseUrl: coworker.baseURL.trim(),
+          responseId: mirroredPending,
+          userId: userContext.userId,
+          organizationId: room.organizationId,
+          coworkerSlug: coworker.slug,
+        });
+
+        if (pollResult.status === "in_progress") {
+          throw conflict(
+            parentMessageId
+              ? "A coworker response is already in progress for this thread."
+              : "A coworker response is already in progress for this room.",
+          );
+        }
+
+        await clearPendingResponseMirror(pendingResponseScope);
+
+        if (pollResult.status === "error") {
+          throw serviceUnavailable(
+            "Coworker chat could not verify an in-flight response. Try again shortly.",
+            { reportToSentry: false },
+          );
+        }
+      }
+
       if (lastMessage.role === "user" || lastMessage.role === "system") {
         const clientMessageId =
           typeof lastMessage.id === "string" ? lastMessage.id : null;
@@ -403,6 +455,24 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         webSearchEnabled: false,
         onResponseStarted: async (responseId: string) => {
           responsesApiResponseIdRef.current = responseId;
+          try {
+            await setPendingResponseMirror(pendingResponseScope, responseId);
+          } catch (error) {
+            console.error(
+              "Failed to set pending response mirror (POST /rooms/{id}/stream):",
+              error,
+            );
+          }
+        },
+        onResponseCompleted: async (_responseId: string) => {
+          try {
+            await clearPendingResponseMirror(pendingResponseScope);
+          } catch (error) {
+            console.error(
+              "Failed to clear pending response mirror on response completed (POST /rooms/{id}/stream):",
+              error,
+            );
+          }
         },
         onInvalidProviderConversationId,
       };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Room stream gates on Redis pending Responses API id before start ([SOK-659](https://linear.app/masumi/issue/SOK-659)).

- Mirror keys: `room:{id}`, `room:{id}:thread:{parent}`
- On start: poll pending id; 409 if in progress, else clear and continue (503 if status unknown)
- Set on `onResponseStarted`; clear on completed, stream finish, stream error

## Verification

- `pnpm --filter core check`
- `pnpm core:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-659](https://linear.app/masumi/issue/SOK-659/restore-room-stream-parity-with-legacy-coworker-chat)

<div><a href="https://cursor.com/agents/bc-bbae9a7f-62d4-45de-b622-2f9e2da0fc85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbae9a7f-62d4-45de-b622-2f9e2da0fc85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

