### PR TITLE
fix(core): renew pending-response mirror TTL on stream lock heartbeat

### DIFF
--- a/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
+++ b/apps/core/src/helpers/coworker-pending-response-mirror.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getRedisClientMock, redisDelMock, redisGetMock, redisSetMock } =
-  vi.hoisted(() => ({
-    getRedisClientMock: vi.fn(),
-    redisDelMock: vi.fn(),
-    redisGetMock: vi.fn(),
-    redisSetMock: vi.fn(),
-  }));
+const {
+  getRedisClientMock,
+  redisDelMock,
+  redisExpireMock,
+  redisGetMock,
+  redisSetMock,
+} = vi.hoisted(() => ({
+  getRedisClientMock: vi.fn(),
+  redisDelMock: vi.fn(),
+  redisExpireMock: vi.fn(),
+  redisGetMock: vi.fn(),
+  redisSetMock: vi.fn(),
+}));
 
 vi.mock("@/lib/redis", () => ({
   getRedisClient: getRedisClientMock,
@@ -16,6 +22,7 @@ import {
   clearPendingResponseMirror,
   coworkerPendingResponseRedisKey,
   getPendingResponseMirror,
+  renewPendingResponseMirror,
   setPendingResponseMirror,
 } from "./coworker-pending-response-mirror";
 import { COWORKER_STREAM_LOCK_TTL_SECONDS } from "./coworker-stream-lock";
@@ -33,10 +40,12 @@ describe("coworker-pending-response-mirror", () => {
       get: redisGetMock,
       set: redisSetMock,
       del: redisDelMock,
+      expire: redisExpireMock,
     });
     redisGetMock.mockResolvedValue(null);
     redisSetMock.mockResolvedValue("OK");
     redisDelMock.mockResolvedValue(1);
+    redisExpireMock.mockResolvedValue(1);
   });
 
   it("builds room-scoped and thread-scoped redis keys", () => {
@@ -59,11 +68,13 @@ describe("coworker-pending-response-mirror", () => {
 
     await setPendingResponseMirror(ROOM_SCOPE, "resp_1");
     await clearPendingResponseMirror(ROOM_SCOPE);
+    await renewPendingResponseMirror(ROOM_SCOPE);
     await expect(getPendingResponseMirror(ROOM_SCOPE)).resolves.toBeNull();
 
     expect(redisSetMock).not.toHaveBeenCalled();
     expect(redisDelMock).not.toHaveBeenCalled();
     expect(redisGetMock).not.toHaveBeenCalled();
+    expect(redisExpireMock).not.toHaveBeenCalled();
   });
 
   it("sets, reads, and clears the pending response mirror for a room", async () => {
@@ -83,5 +94,27 @@ describe("coworker-pending-response-mirror", () => {
     expect(redisDelMock).toHaveBeenCalledWith(
       coworkerPendingResponseRedisKey(ROOM_SCOPE),
     );
+  });
+
+  it("renews mirror TTL via expire for room and thread scopes", async () => {
+    await renewPendingResponseMirror(ROOM_SCOPE);
+    expect(redisExpireMock).toHaveBeenCalledWith(
+      coworkerPendingResponseRedisKey(ROOM_SCOPE),
+      COWORKER_STREAM_LOCK_TTL_SECONDS,
+    );
+
+    await renewPendingResponseMirror(THREAD_SCOPE);
+    expect(redisExpireMock).toHaveBeenCalledWith(
+      coworkerPendingResponseRedisKey(THREAD_SCOPE),
+      COWORKER_STREAM_LOCK_TTL_SECONDS,
+    );
+    expect(redisSetMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows expire errors without throwing", async () => {
+    redisExpireMock.mockRejectedValueOnce(new Error("redis down"));
+    await expect(
+      renewPendingResponseMirror(ROOM_SCOPE),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/core/src/helpers/coworker-pending-response-mirror.ts
+++ b/apps/core/src/helpers/coworker-pending-response-mirror.ts
@@ -80,3 +80,28 @@ export async function clearPendingResponseMirror(
     );
   }
 }
+
+/**
+ * Refresh TTL on an existing pending mirror key. No-op when Redis is absent
+ * or the key was already cleared/expired — does not recreate the key.
+ */
+export async function renewPendingResponseMirror(
+  scope: CoworkerPendingResponseScope,
+): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  try {
+    await redis.expire(
+      coworkerPendingResponseRedisKey(scope),
+      COWORKER_STREAM_LOCK_TTL_SECONDS,
+    );
+  } catch (error) {
+    console.error(
+      "[coworker-pending-response-mirror] Failed to renew pending mirror:",
+      error,
+    );
+  }
+}

--- a/apps/core/src/helpers/coworker-stream-lock.test.ts
+++ b/apps/core/src/helpers/coworker-stream-lock.test.ts
@@ -135,4 +135,18 @@ describe("coworker-stream-lock", () => {
     expect(onRenew).toHaveBeenCalledTimes(1);
     stop();
   });
+
+  it("heartbeat skips onRenew when lock renew fails", async () => {
+    vi.useFakeTimers();
+    redisEvalMock.mockResolvedValueOnce(0);
+    const onRenew = vi.fn().mockResolvedValue(undefined);
+    const stop = startStreamLockHeartbeat("conv-1", "instance-test:token-1", {
+      onRenew,
+    });
+    await vi.advanceTimersByTimeAsync(COWORKER_STREAM_LOCK_HEARTBEAT_MS);
+
+    expect(redisEvalMock).toHaveBeenCalled();
+    expect(onRenew).not.toHaveBeenCalled();
+    stop();
+  });
 });

--- a/apps/core/src/helpers/coworker-stream-lock.test.ts
+++ b/apps/core/src/helpers/coworker-stream-lock.test.ts
@@ -122,4 +122,17 @@ describe("coworker-stream-lock", () => {
     expect(redisEvalMock).toHaveBeenCalled();
     stop();
   });
+
+  it("heartbeat invokes onRenew after lock renew", async () => {
+    vi.useFakeTimers();
+    const onRenew = vi.fn().mockResolvedValue(undefined);
+    const stop = startStreamLockHeartbeat("conv-1", "instance-test:token-1", {
+      onRenew,
+    });
+    await vi.advanceTimersByTimeAsync(COWORKER_STREAM_LOCK_HEARTBEAT_MS);
+
+    expect(redisEvalMock).toHaveBeenCalled();
+    expect(onRenew).toHaveBeenCalledTimes(1);
+    stop();
+  });
 });

--- a/apps/core/src/helpers/coworker-stream-lock.ts
+++ b/apps/core/src/helpers/coworker-stream-lock.ts
@@ -148,10 +148,12 @@ export function startStreamLockHeartbeat(
   options?: StartStreamLockHeartbeatOptions,
 ): () => void {
   const timer = setInterval(() => {
-    void renewStreamLock(internalConversationId, ownerToken);
-    if (options?.onRenew) {
-      void options.onRenew();
-    }
+    void (async () => {
+      const renewed = await renewStreamLock(internalConversationId, ownerToken);
+      if (renewed && options?.onRenew) {
+        await options.onRenew();
+      }
+    })();
   }, COWORKER_STREAM_LOCK_HEARTBEAT_MS);
 
   return () => {

--- a/apps/core/src/helpers/coworker-stream-lock.ts
+++ b/apps/core/src/helpers/coworker-stream-lock.ts
@@ -134,12 +134,24 @@ export async function releaseStreamLock(
   }
 }
 
+export interface StartStreamLockHeartbeatOptions {
+  /**
+   * Optional side effect on each heartbeat tick (e.g. renew pending-response
+   * mirror TTL). Failures inside the callback are the caller's concern.
+   */
+  onRenew?: () => void | Promise<void>;
+}
+
 export function startStreamLockHeartbeat(
   internalConversationId: string,
   ownerToken: string,
+  options?: StartStreamLockHeartbeatOptions,
 ): () => void {
   const timer = setInterval(() => {
     void renewStreamLock(internalConversationId, ownerToken);
+    if (options?.onRenew) {
+      void options.onRenew();
+    }
   }, COWORKER_STREAM_LOCK_HEARTBEAT_MS);
 
   return () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -40,6 +40,7 @@ const {
   getPendingResponseMirrorMock,
   setPendingResponseMirrorMock,
   clearPendingResponseMirrorMock,
+  renewPendingResponseMirrorMock,
   pollCoworkerResponseStatusMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
@@ -74,6 +75,7 @@ const {
   getPendingResponseMirrorMock: vi.fn(),
   setPendingResponseMirrorMock: vi.fn(),
   clearPendingResponseMirrorMock: vi.fn(),
+  renewPendingResponseMirrorMock: vi.fn(),
   pollCoworkerResponseStatusMock: vi.fn(),
 }));
 
@@ -114,6 +116,8 @@ vi.mock("@/helpers/coworker-pending-response-mirror", () => ({
     setPendingResponseMirrorMock(...args),
   clearPendingResponseMirror: (...args: unknown[]) =>
     clearPendingResponseMirrorMock(...args),
+  renewPendingResponseMirror: (...args: unknown[]) =>
+    renewPendingResponseMirrorMock(...args),
 }));
 
 vi.mock("@/helpers/coworker-response-poll", () => ({
@@ -313,6 +317,7 @@ beforeEach(() => {
   getPendingResponseMirrorMock.mockResolvedValue(null);
   setPendingResponseMirrorMock.mockResolvedValue(undefined);
   clearPendingResponseMirrorMock.mockResolvedValue(undefined);
+  renewPendingResponseMirrorMock.mockResolvedValue(undefined);
   waitUntilMock.mockImplementation((promise: Promise<unknown>) => {
     void promise;
   });
@@ -917,7 +922,20 @@ describe("POST /chats/rooms/{id}/stream", () => {
       expect(startStreamLockHeartbeatMock).toHaveBeenCalledWith(
         ROOM_ID,
         "instance-test:token-1",
+        expect.objectContaining({
+          onRenew: expect.any(Function),
+        }),
       );
+
+      const heartbeatOptions = startStreamLockHeartbeatMock.mock
+        .calls[0]![2] as {
+        onRenew: () => Promise<void>;
+      };
+      await heartbeatOptions.onRenew();
+      expect(renewPendingResponseMirrorMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        parentMessageId: null,
+      });
     });
 
     it("releases the stream lock on UI onFinish", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -18,6 +18,7 @@ import {
 import {
   clearPendingResponseMirror,
   getPendingResponseMirror,
+  renewPendingResponseMirror,
   setPendingResponseMirror,
 } from "@/helpers/coworker-pending-response-mirror";
 import { pollCoworkerResponseStatus } from "@/helpers/coworker-response-poll";
@@ -227,14 +228,16 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const streamLockOwnerToken =
       streamLock.status === "acquired" ? streamLock.ownerToken : null;
 
-    const stopHeartbeat = streamLockOwnerToken
-      ? startStreamLockHeartbeat(room.id, streamLockOwnerToken)
-      : null;
-
     const pendingResponseScope = {
       roomId: room.id,
       parentMessageId,
     };
+
+    const stopHeartbeat = streamLockOwnerToken
+      ? startStreamLockHeartbeat(room.id, streamLockOwnerToken, {
+          onRenew: () => renewPendingResponseMirror(pendingResponseScope),
+        })
+      : null;
 
     let releaseOwnedCoworkerStreamLock: (() => Promise<void>) | null =
       async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-673](https://linear.app/masumi/issue/SOK-673/renew-coworker-pending-response-mirror-ttl-for-long-room-streams).

Long coworker room streams were losing the Redis pending-response mirror after 120s because it was SET once and never renewed, while the stream lock was heartbeated. Reconnects could then start a second generation.

**Change:** `renewPendingResponseMirror` EXPIRE-renews the room/thread mirror key; room stream passes it as `onRenew` on the existing lock heartbeat (every 60s). Mirror renew runs only when lock renew succeeds. Fail-open and clear policy unchanged.

## Verification

- `pnpm --filter core check`
- `pnpm core:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-673](https://linear.app/masumi/issue/SOK-673/renew-coworker-pending-response-mirror-ttl-for-long-room-streams)

<div><a href="https://cursor.com/agents/bc-0cf18e52-bfda-4381-aa73-7a583c0825f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cf18e52-bfda-4381-aa73-7a583c0825f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

