### PR TITLE
feat(chat): show members roster load-failed state

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "Mitglieder konnten nicht geladen werden",
+        "membersLoadFailedDescription": "Organisationsmitglieder sind vorübergehend nicht verfügbar. Bitte versuche es gleich noch einmal.",
+        "membersLoadFailedRetry": "Erneut versuchen",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4673,6 +4673,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "Members could not be loaded",
+        "membersLoadFailedDescription": "Organization members are temporarily unavailable. Try again in a moment.",
+        "membersLoadFailedRetry": "Retry",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "No se pudieron cargar los miembros",
+        "membersLoadFailedDescription": "Los miembros de la organización no están disponibles temporalmente. Inténtalo de nuevo en un momento.",
+        "membersLoadFailedRetry": "Reintentar",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "Impossible de charger les membres",
+        "membersLoadFailedDescription": "Les membres de l'organisation sont temporairement indisponibles. Réessayez dans un instant.",
+        "membersLoadFailedRetry": "Réessayer",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "Impossibile caricare i membri",
+        "membersLoadFailedDescription": "I membri dell'organizzazione non sono temporaneamente disponibili. Riprova tra un momento.",
+        "membersLoadFailedRetry": "Riprova",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "メンバーを読み込めませんでした",
+        "membersLoadFailedDescription": "組織のメンバーを一時的に取得できません。しばらくしてからもう一度お試しください。",
+        "membersLoadFailedRetry": "再試行",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "Não foi possível carregar os membros",
+        "membersLoadFailedDescription": "Os membros da organização estão temporariamente indisponíveis. Tente novamente em instantes.",
+        "membersLoadFailedRetry": "Tentar novamente",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "Não foi possível carregar os membros",
+        "membersLoadFailedDescription": "Os membros da organização estão temporariamente indisponíveis. Tente novamente dentro de momentos.",
+        "membersLoadFailedRetry": "Tentar novamente",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4554,6 +4554,9 @@
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
         "messagesLoadFailedDescription": "Try opening this chat again in a moment.",
+        "membersLoadFailedTitle": "无法加载成员",
+        "membersLoadFailedDescription": "组织成员暂时不可用。请稍后再试。",
+        "membersLoadFailedRetry": "重试",
         "noChannelTitle": "Create a channel",
         "noChannelDescription": "Add teammates and AI coworkers, then mention coworkers when you need them."
       },

--- a/apps/web/src/app/(app)/chat/components/draft-channel.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-channel.tsx
@@ -29,16 +29,19 @@ import {
   type DirectDraftTarget,
   DirectDraftTargetList,
   filterDraftTargets,
+  MembersRosterLoadFailed,
 } from "./room-draft-shared";
 
 export function DraftChannel({
   members,
   coworkers,
   currentUserId,
+  membersLoadFailed = false,
 }: {
   members: Member[];
   coworkers: Coworker[];
   currentUserId: string;
+  membersLoadFailed?: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const router = useRouter();
@@ -257,12 +260,15 @@ export function DraftChannel({
             </div>
             {isRecipientPickerOpen ? (
               <div className="bg-popover text-popover-foreground border-border absolute top-full right-0 left-0 z-20 mt-1 max-h-72 overflow-y-auto rounded-md border p-1 shadow-lg">
+                {membersLoadFailed ? (
+                  <MembersRosterLoadFailed className="m-1 px-3 py-6" />
+                ) : null}
                 {candidateTargets.length > 0 ? (
                   <DirectDraftTargetList
                     targets={candidateTargets}
                     onSelect={addTarget}
                   />
-                ) : (
+                ) : membersLoadFailed ? null : (
                   <p className="text-muted-foreground px-3 py-4 text-sm">
                     {t("Draft.noResults")}
                   </p>

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -33,6 +33,7 @@ import {
   type DirectDraftTarget,
   DirectDraftTargetList,
   filterDraftTargets,
+  MembersRosterLoadFailed,
 } from "./room-draft-shared";
 
 export function DraftDirectMessage({
@@ -40,12 +41,14 @@ export function DraftDirectMessage({
   coworkers,
   currentUserId,
   canCreateRoomDirect,
+  membersLoadFailed = false,
 }: {
   members: Member[];
   coworkers: Coworker[];
   currentUserId: string;
   /** False in personal workspace — human 1:1 room DMs need an org. */
   canCreateRoomDirect: boolean;
+  membersLoadFailed?: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const router = useRouter();
@@ -266,12 +269,15 @@ export function DraftDirectMessage({
           </div>
           {isRecipientPickerOpen ? (
             <div className="bg-popover text-popover-foreground border-border absolute top-full right-0 left-8 z-20 mt-1 max-h-72 overflow-y-auto rounded-md border p-1 shadow-lg">
+              {membersLoadFailed ? (
+                <MembersRosterLoadFailed className="m-1 px-3 py-6" />
+              ) : null}
               {candidateTargets.length > 0 ? (
                 <DirectDraftTargetList
                   targets={candidateTargets}
                   onSelect={addTarget}
                 />
-              ) : (
+              ) : membersLoadFailed ? null : (
                 <p className="text-muted-foreground px-3 py-4 text-sm">
                   {t("Draft.noResults")}
                 </p>

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -53,7 +53,7 @@ import { Textarea } from "@/components/ui/textarea";
 import type { ChatRoom, Coworker, Member } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
-import { AiCoworkerIcon } from "./room-draft-shared";
+import { AiCoworkerIcon, MembersRosterLoadFailed } from "./room-draft-shared";
 import { toggleId } from "./room-helpers";
 
 function ParticipantCheckboxes({
@@ -63,6 +63,7 @@ function ParticipantCheckboxes({
   coworkerIds,
   onMemberIdsChange,
   onCoworkerIdsChange,
+  membersLoadFailed,
 }: {
   members: Member[];
   coworkers: Coworker[];
@@ -70,6 +71,7 @@ function ParticipantCheckboxes({
   coworkerIds: string[];
   onMemberIdsChange: (ids: string[]) => void;
   onCoworkerIdsChange: (ids: string[]) => void;
+  membersLoadFailed: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const [participantQuery, setParticipantQuery] = useState("");
@@ -125,7 +127,11 @@ function ParticipantCheckboxes({
 
       <ScrollArea className="h-[300px]">
         <div className="p-2">
-          {filteredMembers.length > 0 ? (
+          {membersLoadFailed ? (
+            <div className="pb-2">
+              <MembersRosterLoadFailed className="px-3 py-6" />
+            </div>
+          ) : filteredMembers.length > 0 ? (
             <div className="pb-2">
               <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[11px] font-medium">
                 {t("Dialog.humans")}
@@ -233,7 +239,9 @@ function ParticipantCheckboxes({
             </div>
           ) : null}
 
-          {filteredMembers.length === 0 && filteredCoworkers.length === 0 ? (
+          {!membersLoadFailed &&
+          filteredMembers.length === 0 &&
+          filteredCoworkers.length === 0 ? (
             <div className="text-muted-foreground px-4 py-12 text-center text-sm">
               {t("Draft.noResults")}
             </div>
@@ -250,6 +258,7 @@ export function EditChannelDialog({
   coworkers,
   canArchive,
   canLeave,
+  membersLoadFailed = false,
 }: {
   channel: ChatRoom;
   members: Member[];
@@ -260,6 +269,7 @@ export function EditChannelDialog({
   /** Any member can leave, except the last one: an empty roster could not be
    * archived by a remaining elevated member. */
   canLeave: boolean;
+  membersLoadFailed?: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const tActions = useTranslations("App.Channels.Actions");
@@ -394,6 +404,7 @@ export function EditChannelDialog({
                 coworkerIds={coworkerIds}
                 onMemberIdsChange={setMemberIds}
                 onCoworkerIdsChange={setCoworkerIds}
+                membersLoadFailed={membersLoadFailed}
               />
             </div>
             {canArchive || canLeave ? (

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { Bot } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import type {
   ChatRoomPresence,
   Coworker,
@@ -19,6 +21,38 @@ export function AiCoworkerIcon({ className }: { className?: string }) {
       className={cn("text-muted-foreground size-3.5 shrink-0", className)}
       aria-label={t("coworkerBadge")}
     />
+  );
+}
+
+/** Parity with rooms-client messageLoadFailed empty-state; reload re-fetches RSC props. */
+export function MembersRosterLoadFailed({ className }: { className?: string }) {
+  const t = useTranslations("App.Channels");
+  const router = useRouter();
+
+  return (
+    <div
+      className={cn(
+        "border-border/70 bg-muted/20 rounded-md border border-dashed px-5 py-10 text-center",
+        className,
+      )}
+      role="status"
+    >
+      <p className="font-medium">{t("Empty.membersLoadFailedTitle")}</p>
+      <p className="text-muted-foreground mt-1 text-sm">
+        {t("Empty.membersLoadFailedDescription")}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-4"
+        onClick={() => {
+          router.refresh();
+        }}
+      >
+        {t("Empty.membersLoadFailedRetry")}
+      </Button>
+    </div>
   );
 }
 

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -76,6 +76,8 @@ interface RoomsClientProps {
   isCreateChannelRequested: boolean;
   isNewDirectMessage: boolean;
   messageLoadFailed: boolean;
+  /** Org roster soft-fail; false for personal workspace (no org roster). */
+  membersLoadFailed: boolean;
   messages: ChatRoomMessage[];
   /** Cursor for the next older page; null when the initial page is complete. */
   messagesNextCursor: string | null;
@@ -152,6 +154,7 @@ export function RoomsClient({
   isCreateChannelRequested,
   isNewDirectMessage,
   messageLoadFailed,
+  membersLoadFailed,
   messages,
   messagesNextCursor,
 }: RoomsClientProps) {
@@ -941,6 +944,7 @@ export function RoomsClient({
               members={organizationMembers}
               coworkers={coworkers}
               currentUserId={currentUserId}
+              membersLoadFailed={membersLoadFailed}
             />
           ) : isNewDirectMessage ? (
             <DraftDirectMessage
@@ -948,6 +952,7 @@ export function RoomsClient({
               coworkers={coworkers}
               currentUserId={currentUserId}
               canCreateRoomDirect={activeOrganization != null}
+              membersLoadFailed={membersLoadFailed}
             />
           ) : selectedRoom ? (
             <>
@@ -971,6 +976,7 @@ export function RoomsClient({
                       coworkers={coworkers}
                       canArchive={canArchiveSelectedRoom}
                       canLeave={canLeaveSelectedRoom}
+                      membersLoadFailed={membersLoadFailed}
                     />
                   )}
                 </div>

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -96,6 +96,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
             isCreateChannelRequested={false}
             isNewDirectMessage
             messageLoadFailed={false}
+            membersLoadFailed={false}
             messages={[]}
             messagesNextCursor={null}
           />
@@ -124,6 +125,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
           isCreateChannelRequested={isCreateChannelRequested}
           isNewDirectMessage={isNewDirectMessage}
           messageLoadFailed={false}
+          membersLoadFailed={membersPage.failed}
           messages={[]}
           messagesNextCursor={null}
         />

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -11,8 +12,6 @@ const loadRoomMessagesMock = vi.fn();
 const redirectMock = vi.fn((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
-
-let lastRoomsClientProps: Record<string, unknown> | null = null;
 
 vi.mock("next/navigation", () => ({
   redirect: (url: string) => redirectMock(url),
@@ -54,10 +53,7 @@ vi.mock("@/app/chat/load-room-messages", () => ({
 }));
 
 vi.mock("@/app/chat/components/rooms-client", () => ({
-  RoomsClient: (props: Record<string, unknown>) => {
-    lastRoomsClientProps = props;
-    return <div data-testid="rooms-client" />;
-  },
+  RoomsClient: () => <div data-testid="rooms-client" />,
 }));
 
 import ChatRoomPage from "../page";
@@ -92,10 +88,16 @@ function room(
   };
 }
 
+function roomsClientProps(element: ReactElement) {
+  return element.props as {
+    membersLoadFailed?: boolean;
+    organizationMembers?: unknown[];
+  };
+}
+
 describe("ChatRoomPage org deep-link guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    lastRoomsClientProps = null;
     getSessionMock.mockResolvedValue({ user: { id: USER_ID } });
     loadOrganizationMembersMock.mockResolvedValue({
       members: [],
@@ -162,13 +164,13 @@ describe("ChatRoomPage org deep-link guard", () => {
     });
     getRoomMock.mockResolvedValue(room({ organizationId: ORG_A }));
 
-    const element = await ChatRoomPage({
+    const element = (await ChatRoomPage({
       params: Promise.resolve({ roomId: ROOM_ID }),
-    });
+    })) as ReactElement;
 
     expect(element).toBeTruthy();
     expect(redirectMock).not.toHaveBeenCalled();
-    expect(lastRoomsClientProps?.membersLoadFailed).toBe(false);
+    expect(roomsClientProps(element).membersLoadFailed).toBe(false);
   });
 
   it("still renders when organization members fail to load", async () => {
@@ -183,15 +185,15 @@ describe("ChatRoomPage org deep-link guard", () => {
       failed: true,
     });
 
-    const element = await ChatRoomPage({
+    const element = (await ChatRoomPage({
       params: Promise.resolve({ roomId: ROOM_ID }),
-    });
+    })) as ReactElement;
 
     expect(element).toBeTruthy();
     expect(redirectMock).not.toHaveBeenCalled();
     expect(loadOrganizationMembersMock).toHaveBeenCalledWith(ORG_A);
-    expect(lastRoomsClientProps?.membersLoadFailed).toBe(true);
-    expect(lastRoomsClientProps?.organizationMembers).toEqual([]);
+    expect(roomsClientProps(element).membersLoadFailed).toBe(true);
+    expect(roomsClientProps(element).organizationMembers).toEqual([]);
   });
 
   it("treats personal workspace as membersLoadFailed false", async () => {
@@ -200,13 +202,13 @@ describe("ChatRoomPage org deep-link guard", () => {
       room({ organizationId: null, kind: "direct" }),
     );
 
-    const element = await ChatRoomPage({
+    const element = (await ChatRoomPage({
       params: Promise.resolve({ roomId: ROOM_ID }),
-    });
+    })) as ReactElement;
 
     expect(element).toBeTruthy();
     expect(loadOrganizationMembersMock).not.toHaveBeenCalled();
-    expect(lastRoomsClientProps?.membersLoadFailed).toBe(false);
-    expect(lastRoomsClientProps?.organizationMembers).toEqual([]);
+    expect(roomsClientProps(element).membersLoadFailed).toBe(false);
+    expect(roomsClientProps(element).organizationMembers).toEqual([]);
   });
 });

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -12,6 +12,8 @@ const redirectMock = vi.fn((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
 
+let lastRoomsClientProps: Record<string, unknown> | null = null;
+
 vi.mock("next/navigation", () => ({
   redirect: (url: string) => redirectMock(url),
 }));
@@ -52,7 +54,10 @@ vi.mock("@/app/chat/load-room-messages", () => ({
 }));
 
 vi.mock("@/app/chat/components/rooms-client", () => ({
-  RoomsClient: () => <div data-testid="rooms-client" />,
+  RoomsClient: (props: Record<string, unknown>) => {
+    lastRoomsClientProps = props;
+    return <div data-testid="rooms-client" />;
+  },
 }));
 
 import ChatRoomPage from "../page";
@@ -90,6 +95,7 @@ function room(
 describe("ChatRoomPage org deep-link guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lastRoomsClientProps = null;
     getSessionMock.mockResolvedValue({ user: { id: USER_ID } });
     loadOrganizationMembersMock.mockResolvedValue({
       members: [],
@@ -162,6 +168,7 @@ describe("ChatRoomPage org deep-link guard", () => {
 
     expect(element).toBeTruthy();
     expect(redirectMock).not.toHaveBeenCalled();
+    expect(lastRoomsClientProps?.membersLoadFailed).toBe(false);
   });
 
   it("still renders when organization members fail to load", async () => {
@@ -183,5 +190,23 @@ describe("ChatRoomPage org deep-link guard", () => {
     expect(element).toBeTruthy();
     expect(redirectMock).not.toHaveBeenCalled();
     expect(loadOrganizationMembersMock).toHaveBeenCalledWith(ORG_A);
+    expect(lastRoomsClientProps?.membersLoadFailed).toBe(true);
+    expect(lastRoomsClientProps?.organizationMembers).toEqual([]);
+  });
+
+  it("treats personal workspace as membersLoadFailed false", async () => {
+    getActiveOrganizationMock.mockResolvedValue(null);
+    getRoomMock.mockResolvedValue(
+      room({ organizationId: null, kind: "direct" }),
+    );
+
+    const element = await ChatRoomPage({
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+
+    expect(element).toBeTruthy();
+    expect(loadOrganizationMembersMock).not.toHaveBeenCalled();
+    expect(lastRoomsClientProps?.membersLoadFailed).toBe(false);
+    expect(lastRoomsClientProps?.organizationMembers).toEqual([]);
   });
 });

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -96,6 +96,7 @@ export default async function ChatRoomPage({ params }: ChatRoomPageProps) {
         isCreateChannelRequested={false}
         isNewDirectMessage={false}
         messageLoadFailed={messagePage.failed}
+        membersLoadFailed={false}
         messages={messagePage.messages}
         messagesNextCursor={messagePage.nextCursor}
       />
@@ -132,6 +133,7 @@ export default async function ChatRoomPage({ params }: ChatRoomPageProps) {
       isCreateChannelRequested={false}
       isNewDirectMessage={false}
       messageLoadFailed={messagePage.failed}
+      membersLoadFailed={membersPage.failed}
       messages={messagePage.messages}
       messagesNextCursor={messagePage.nextCursor}
     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-660/show-load-failed-state-when-chat-org-member-roster-is-unavailable

- Plumb `membersPage.failed` → `RoomsClient.membersLoadFailed` on `/chat` and `/chat/rooms/[roomId]`
- Draft channel/DM pickers and edit-channel humans list show dashed load-failed + Retry (`router.refresh`)
- Coworkers stay selectable; personal workspace stays `membersLoadFailed={false}`
- Soft-fail empty roster unchanged for room viewing; edit dialog still seeds from `channel.userMembers`
- i18n under `App.Channels.Empty.membersLoadFailed*`

**Verify:** `pnpm web:check`, `pnpm web:test` (exit 0)

Happy-path UI (`/chat?create=channel` member picker):

![Create channel members picker](https://cursor.com/artifacts/c/art-56f3771b-acf6-4dfb-8895-e26359ff74c5)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| UI evidence | fail-state | Load-failed dashed UI proven by plumbing + unit props tests; live Core 500 not injected for visual fail-state capture |
| Test | drafts/edit components | No dedicated component tests for `MembersRosterLoadFailed` render (TDD skip; page prop assert covers Contract) |
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-660](https://linear.app/masumi/issue/SOK-660/show-load-failed-state-when-chat-org-member-roster-is-unavailable)

<div><a href="https://cursor.com/agents/bc-ccbe0336-d581-47aa-9e01-411d79073993?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccbe0336-d581-47aa-9e01-411d79073993&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

