### PR TITLE
feat(web): add shared compose file upload helper

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "Hochladen von {fileName}",
+        "uploadingFiles": "Hochladen von {count} Dateien",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4727,6 +4727,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "Uploading {fileName}",
+        "uploadingFiles": "Uploading {count} files",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "Subiendo {fileName}",
+        "uploadingFiles": "Subiendo {count} archivos",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "Téléversement de {fileName}",
+        "uploadingFiles": "Téléversement de {count} fichiers",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "Caricamento di {fileName}",
+        "uploadingFiles": "Caricamento di {count} file",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "{fileName} をアップロード中",
+        "uploadingFiles": "{count} 件のファイルをアップロード中",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "Enviando {fileName}",
+        "uploadingFiles": "Enviando {count} arquivos",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "A enviar {fileName}",
+        "uploadingFiles": "A enviar {count} ficheiros",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4608,6 +4608,8 @@
         "format": "Formatting",
         "bold": "Bold",
         "uploading": "{count, plural, one {Uploading file} other {Uploading files}}",
+        "uploadingFile": "正在上传 {fileName}",
+        "uploadingFiles": "正在上传 {count} 个文件",
         "uploaded": "{count, plural, one {File uploaded} other {Files uploaded}}",
         "uploadFailed": "File upload failed",
         "removeAttachment": "Remove {name}",

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
+import { getTaskAttachmentUploadLabelTemplate } from "@/app/tasks/components/task-attachment-upload-labels";
 import {
   ROOM_COMPOSER_TEXTAREA_CLASSNAME,
   ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME,
@@ -27,16 +28,12 @@ import {
   type NormalizedMention,
 } from "@/components/ui/mention-textarea";
 import type { ChatRoomCoworkerParticipant } from "@/lib/clients/generated/core";
+import { uploadComposeAttachments } from "@/lib/utils/compose-upload.client";
 import {
   formatTaskAttachmentMarkdown,
   removeTaskAttachmentLinks,
-  sanitizeTaskAttachmentLabel,
 } from "@/lib/utils/task-attachments";
 import { getInitials } from "@/lib/utils/text";
-import {
-  getUserFileUploadErrorMessage,
-  uploadUserFileDirect,
-} from "@/lib/utils/user-file-upload.client";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import { appendComposerBlock } from "./room-helpers";
 
@@ -100,6 +97,7 @@ export function RoomComposer({
   allowAttachments?: boolean;
 }) {
   const t = useTranslations("App.Channels");
+  const tToolbar = useTranslations("App.Channels.Toolbar");
   const formRef = useRef<HTMLFormElement | null>(null);
   const textareaRef = useRef<MentionTextareaHandle | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -119,23 +117,29 @@ export function RoomComposer({
       }
 
       setIsUploadingFiles(true);
-      const toastId = toast.loading(
-        t("Toolbar.uploading", { count: selectedFiles.length }),
-      );
 
       try {
-        const uploadedAttachments: RoomComposerAttachment[] = [];
-        for (const file of selectedFiles) {
-          const uploaded = await uploadUserFileDirect(file);
-          uploadedAttachments.push({
-            url: uploaded.publicUrl,
-            fileName: sanitizeTaskAttachmentLabel(
-              file.name,
-              t("Toolbar.attachmentFallback"),
+        const uploaded = await uploadComposeAttachments(selectedFiles, {
+          labels: {
+            uploadingFile: getTaskAttachmentUploadLabelTemplate(
+              tToolbar,
+              "uploadingFile",
             ),
-            mediaType: file.type || null,
-          });
-        }
+            uploadingFiles: getTaskAttachmentUploadLabelTemplate(
+              tToolbar,
+              "uploadingFiles",
+            ),
+            uploadError: tToolbar("uploadFailed"),
+          },
+          fallbackFileName: tToolbar("attachmentFallback"),
+        });
+        const uploadedAttachments: RoomComposerAttachment[] = uploaded.map(
+          (result) => ({
+            url: result.publicUrl,
+            fileName: result.fileName,
+            mediaType: result.mediaType,
+          }),
+        );
 
         const attachmentMarkdown = uploadedAttachments
           .map((attachment) =>
@@ -147,14 +151,10 @@ export function RoomComposer({
           appendComposerBlock(current, attachmentMarkdown),
         );
         toast.success(
-          t("Toolbar.uploaded", { count: uploadedAttachments.length }),
-          { id: toastId },
+          tToolbar("uploaded", { count: uploadedAttachments.length }),
         );
-      } catch (error) {
-        toast.error(
-          getUserFileUploadErrorMessage(error, t("Toolbar.uploadFailed")),
-          { id: toastId },
-        );
+      } catch {
+        // Error toast is handled by uploadComposeAttachments.
       } finally {
         setIsUploadingFiles(false);
         if (fileInputRef.current) {
@@ -162,7 +162,7 @@ export function RoomComposer({
         }
       }
     },
-    [onAttachmentsChange, onValueChange, t],
+    [onAttachmentsChange, onValueChange, tToolbar],
   );
 
   function removeAttachment(attachment: RoomComposerAttachment) {

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/lib/constants/channel-icons";
 import { cn } from "@/lib/utils";
 import { formatCreditsForDisplay } from "@/lib/utils/credits";
+import { createFileUploadProgressToast } from "@/lib/utils/file-upload-progress-toast";
 import { formatMentionsAsMarkdownLinks } from "@/lib/utils/mention-parser";
 import {
   extractTaskAttachmentUrls,
@@ -62,7 +63,6 @@ import { getFileNameFromUrl } from "@/lib/utils/url";
 import { getUserFileUploadErrorMessage } from "@/lib/utils/user-file-upload.client";
 import { MarkdownEditor, type MarkdownEditorHandle } from "./markdown-editor";
 import { getTaskAttachmentUploadLabelTemplate } from "./task-attachment-upload-labels";
-import { createTaskAttachmentUploadToast } from "./task-attachment-upload-toast";
 import {
   getTaskStatusBorderColorClass,
   getTaskStatusDotColorClass,
@@ -282,7 +282,7 @@ export function TaskActivitySection({
   const handleAttachFiles = async (files: File[]) => {
     if (files.length === 0) return;
 
-    const uploadToast = createTaskAttachmentUploadToast({
+    const uploadToast = createFileUploadProgressToast({
       files,
       labels: {
         uploadingFile: getTaskAttachmentUploadLabelTemplate(t, "uploadingFile"),

--- a/apps/web/src/app/(app)/tasks/components/task-form.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-form.tsx
@@ -44,6 +44,7 @@ import { getDefaultTimezone } from "@/lib/schedules/timezones";
 import type { CoworkerOption } from "@/lib/types/coworker";
 import type { TaskScheduleSelection } from "@/lib/types/task-schedule";
 import { cn } from "@/lib/utils";
+import { uploadComposeAttachments } from "@/lib/utils/compose-upload.client";
 import { getScheduleIcon } from "@/lib/utils/schedule-icon";
 import {
   createDesignMdDismissedState,
@@ -53,18 +54,12 @@ import {
   isDesignMdAttachmentSkipped,
   markDesignMdDismissed,
   removeTaskAttachmentLinks,
-  sanitizeTaskAttachmentLabel,
   seedTaskDescriptionWithDesignMd,
   syncDesignMdDismissedState,
   type TaskDesignMdAttachmentSeed,
 } from "@/lib/utils/task-attachments";
 import { metadataToSelection } from "@/lib/utils/task-schedule";
-import {
-  getUserFileUploadErrorMessage,
-  uploadUserFileDirect,
-} from "@/lib/utils/user-file-upload.client";
 import { MarkdownEditor, type MarkdownEditorHandle } from "./markdown-editor";
-import { createTaskAttachmentUploadToast } from "./task-attachment-upload-toast";
 import { TaskCreatedCelebration } from "./task-created-celebration";
 import { TaskFormModalHeaderStart } from "./task-form-modal";
 import { TaskProjectSelect } from "./task-project-select";
@@ -550,50 +545,38 @@ export function TaskForm({
     async (files: File[]) => {
       if (files.length === 0) return;
 
-      const uploadToast = createTaskAttachmentUploadToast({
-        files,
-        labels: {
-          uploadingFile: labels.uploadingFile,
-          uploadingFiles: labels.uploadingFiles,
-        },
-      });
-
       const controller = new AbortController();
       activeUploadControllersRef.current.add(controller);
       setUploadingAttachmentsCount((count) => count + 1);
       try {
-        for (const [index, file] of files.entries()) {
-          const uploaded = await uploadUserFileDirect(file, {
-            abortSignal: controller.signal,
-            onUploadProgress: (progress) => {
-              uploadToast.updateFileProgress(index, progress);
-            },
-          });
-          uploadToast.markFileComplete(index);
-          const safeName = sanitizeTaskAttachmentLabel(file.name, "file");
+        const uploaded = await uploadComposeAttachments(files, {
+          abortSignal: controller.signal,
+          labels: {
+            uploadingFile: labels.uploadingFile,
+            uploadingFiles: labels.uploadingFiles,
+            uploadError: labels.uploadFileError ?? "Failed to upload file",
+          },
+        });
+        for (const result of uploaded) {
           if (markdownEditorRef.current) {
-            markdownEditorRef.current.insertLink(safeName, uploaded.publicUrl);
+            markdownEditorRef.current.insertLink(
+              result.fileName,
+              result.publicUrl,
+            );
             markdownEditorRef.current.insertText("\n");
             continue;
           }
           const markdownLink = formatTaskAttachmentMarkdown(
-            safeName,
-            uploaded.publicUrl,
+            result.fileName,
+            result.publicUrl,
           );
           setDescription(
             (prev) =>
               `${prev}${prev.endsWith("\n") ? "" : "\n"}${markdownLink}`,
           );
         }
-        uploadToast.dismiss();
-      } catch (error) {
-        uploadToast.dismiss();
-        toast.error(
-          getUserFileUploadErrorMessage(
-            error,
-            labels.uploadFileError ?? "Failed to upload file",
-          ),
-        );
+      } catch {
+        // Error toast is handled by uploadComposeAttachments.
       } finally {
         activeUploadControllersRef.current.delete(controller);
         setPendingUploadFiles([]);

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -5,7 +5,6 @@ import {
   chatModelSupportsImageGeneration,
   chatModelSupportsImageInput,
 } from "@sokosumi/chat";
-import { resolveUserUploadContentType } from "@sokosumi/utils";
 import type { UIMessage } from "ai";
 import { ImagePlus, Loader2, Paperclip, Plus, X } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -19,7 +18,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
 import {
   filterCoworkersForComposeKind,
   findDefaultCoworker,
@@ -32,7 +30,6 @@ import type {
   Coworker,
 } from "@/app/chat/utils/types";
 import { getTaskAttachmentUploadLabelTemplate } from "@/app/tasks/components/task-attachment-upload-labels";
-import { createTaskAttachmentUploadToast } from "@/app/tasks/components/task-attachment-upload-toast";
 import { CoworkerGalleryCard } from "@/components/agents/coworker-gallery-card";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
@@ -54,13 +51,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { uploadComposeAttachments } from "@/lib/utils/compose-upload.client";
 import { getCoworkerMetadataChannels } from "@/lib/utils/coworker-channels";
-import { sanitizeTaskAttachmentLabel } from "@/lib/utils/task-attachments";
-import {
-  getUserFileUploadErrorMessage,
-  type UserFileUploadProgress,
-  uploadUserFileDirect,
-} from "@/lib/utils/user-file-upload.client";
 import { CoworkerAvatarWithSkeleton } from "./coworker-avatar";
 import CoworkerSelector from "./coworker-selector";
 import { ArrowUpIcon, StopIcon } from "./icons";
@@ -370,47 +362,30 @@ function PureMultimodalInput({
     async (files: File[]) => {
       if (files.length === 0 || !supportsChatImageInput) return;
 
-      const uploadToast = createTaskAttachmentUploadToast({
-        files,
-        labels: {
-          uploadingFile: taskUploadingFileLabel,
-          uploadingFiles: taskUploadingFilesLabel,
-        },
-      });
-
       const controller = new AbortController();
       activeUploadControllersRef.current.add(controller);
       setUploadingAttachmentsCount((count) => count + 1);
 
       try {
-        for (const [index, file] of files.entries()) {
-          const uploadOptions = {
-            abortSignal: controller.signal,
-            onUploadProgress: (progress: UserFileUploadProgress) => {
-              uploadToast.updateFileProgress(index, progress);
-            },
-          };
-
-          const mediaType = resolveUserUploadContentType(file.name, file.type);
-          const uploaded = await uploadUserFileDirect(file, uploadOptions);
-          uploadToast.markFileComplete(index);
-          setChatFileParts((parts) => [
-            ...parts,
-            {
-              type: "file",
-              url: uploaded.publicUrl,
-              mediaType: mediaType ?? file.type,
-              filename: sanitizeTaskAttachmentLabel(file.name, "file"),
-            },
-          ]);
-        }
-
-        uploadToast.dismiss();
-      } catch (error) {
-        uploadToast.dismiss();
-        toast.error(
-          getUserFileUploadErrorMessage(error, taskUploadFileErrorLabel),
-        );
+        const uploaded = await uploadComposeAttachments(files, {
+          abortSignal: controller.signal,
+          labels: {
+            uploadingFile: taskUploadingFileLabel,
+            uploadingFiles: taskUploadingFilesLabel,
+            uploadError: taskUploadFileErrorLabel,
+          },
+        });
+        setChatFileParts((parts) => [
+          ...parts,
+          ...uploaded.map((result) => ({
+            type: "file" as const,
+            url: result.publicUrl,
+            mediaType: result.mediaType ?? result.file.type,
+            filename: result.fileName,
+          })),
+        ]);
+      } catch {
+        // Error toast is handled by uploadComposeAttachments.
       } finally {
         activeUploadControllersRef.current.delete(controller);
         setPendingUploadFiles([]);

--- a/apps/web/src/lib/utils/__tests__/compose-upload.client.test.ts
+++ b/apps/web/src/lib/utils/__tests__/compose-upload.client.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  uploadUserFileDirectMock,
+  createFileUploadProgressToastMock,
+  toastErrorMock,
+  toastDismissMock,
+  updateFileProgressMock,
+  markFileCompleteMock,
+  dismissMock,
+} = vi.hoisted(() => ({
+  uploadUserFileDirectMock: vi.fn(),
+  createFileUploadProgressToastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastDismissMock: vi.fn(),
+  updateFileProgressMock: vi.fn(),
+  markFileCompleteMock: vi.fn(),
+  dismissMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+    dismiss: (...args: unknown[]) => toastDismissMock(...args),
+  },
+}));
+
+vi.mock("@/lib/utils/file-upload-progress-toast", () => ({
+  createFileUploadProgressToast: (...args: unknown[]) =>
+    createFileUploadProgressToastMock(...args),
+}));
+
+vi.mock("@/lib/utils/user-file-upload.client", () => ({
+  getUserFileUploadErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback,
+  uploadUserFileDirect: (...args: unknown[]) =>
+    uploadUserFileDirectMock(...args),
+}));
+
+import { uploadComposeAttachments } from "@/lib/utils/compose-upload.client";
+
+describe("uploadComposeAttachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createFileUploadProgressToastMock.mockReturnValue({
+      updateFileProgress: updateFileProgressMock,
+      markFileComplete: markFileCompleteMock,
+      dismiss: dismissMock,
+    });
+  });
+
+  it("returns empty array without toast when no files", async () => {
+    await expect(
+      uploadComposeAttachments([], {
+        labels: {
+          uploadingFile: "Uploading {fileName}",
+          uploadingFiles: "Uploading {count} files",
+          uploadError: "Failed",
+        },
+      }),
+    ).resolves.toEqual([]);
+
+    expect(createFileUploadProgressToastMock).not.toHaveBeenCalled();
+    expect(uploadUserFileDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("uploads files with progress toast and returns compose results", async () => {
+    const file = new File(["hello"], "note.txt", { type: "text/plain" });
+    uploadUserFileDirectMock.mockImplementation(
+      async (
+        _file: File,
+        options?: {
+          onUploadProgress?: (progress: {
+            loaded: number;
+            total: number;
+            percentage: number;
+          }) => void;
+        },
+      ) => {
+        options?.onUploadProgress?.({
+          loaded: 5,
+          total: 5,
+          percentage: 100,
+        });
+        return { publicUrl: "https://blob.example/note.txt" };
+      },
+    );
+
+    const results = await uploadComposeAttachments([file], {
+      labels: {
+        uploadingFile: "Uploading {fileName}",
+        uploadingFiles: "Uploading {count} files",
+        uploadError: "Failed",
+      },
+      fallbackFileName: "attachment",
+    });
+
+    expect(createFileUploadProgressToastMock).toHaveBeenCalledWith({
+      files: [file],
+      labels: {
+        uploadingFile: "Uploading {fileName}",
+        uploadingFiles: "Uploading {count} files",
+      },
+    });
+    expect(uploadUserFileDirectMock).toHaveBeenCalledTimes(1);
+    expect(updateFileProgressMock).toHaveBeenCalledWith(0, {
+      loaded: 5,
+      total: 5,
+      percentage: 100,
+    });
+    expect(markFileCompleteMock).toHaveBeenCalledWith(0);
+    expect(dismissMock).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([
+      {
+        publicUrl: "https://blob.example/note.txt",
+        fileName: "note.txt",
+        mediaType: "text/plain",
+        file,
+      },
+    ]);
+  });
+
+  it("shows error toast, dismisses progress, and rethrows on failure", async () => {
+    const file = new File(["hello"], "note.txt", { type: "text/plain" });
+    uploadUserFileDirectMock.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      uploadComposeAttachments([file], {
+        labels: {
+          uploadingFile: "Uploading {fileName}",
+          uploadingFiles: "Uploading {count} files",
+          uploadError: "Upload failed",
+        },
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(dismissMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).toHaveBeenCalledWith("boom");
+  });
+});

--- a/apps/web/src/lib/utils/__tests__/file-upload-progress-toast.test.tsx
+++ b/apps/web/src/lib/utils/__tests__/file-upload-progress-toast.test.tsx
@@ -14,7 +14,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { createTaskAttachmentUploadToast } from "../task-attachment-upload-toast";
+import { createFileUploadProgressToast } from "@/lib/utils/file-upload-progress-toast";
 
 interface ToastElementProps {
   items: Array<{
@@ -35,7 +35,7 @@ function getLatestToastElement(): ReactElement<ToastElementProps> {
   return renderToast?.("toast-id") as ReactElement<ToastElementProps>;
 }
 
-describe("task-attachment-upload-toast", () => {
+describe("file-upload-progress-toast", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -47,7 +47,7 @@ describe("task-attachment-upload-toast", () => {
     const secondFile = new File(["efgh"], "second.pdf", {
       type: "application/pdf",
     });
-    const uploadToast = createTaskAttachmentUploadToast({
+    const uploadToast = createFileUploadProgressToast({
       files: [firstFile, secondFile],
       labels: {
         uploadingFile: "Uploading {fileName}",
@@ -109,7 +109,7 @@ describe("task-attachment-upload-toast", () => {
   });
 
   it("keeps the toast shell from blocking parent scrolling", () => {
-    const uploadToast = createTaskAttachmentUploadToast({
+    const uploadToast = createFileUploadProgressToast({
       files: [new File(["abcd"], "first.pdf", { type: "application/pdf" })],
       labels: {
         uploadingFile: "Uploading {fileName}",

--- a/apps/web/src/lib/utils/compose-upload.client.ts
+++ b/apps/web/src/lib/utils/compose-upload.client.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { resolveUserUploadContentType } from "@sokosumi/utils";
+import { toast } from "sonner";
+import {
+  createFileUploadProgressToast,
+  type FileUploadProgressToastLabels,
+} from "@/lib/utils/file-upload-progress-toast";
+import { sanitizeTaskAttachmentLabel } from "@/lib/utils/task-attachments";
+import {
+  getUserFileUploadErrorMessage,
+  type UploadUserFileDirectOptions,
+  uploadUserFileDirect,
+} from "@/lib/utils/user-file-upload.client";
+
+export interface ComposeUploadLabels extends FileUploadProgressToastLabels {
+  uploadError: string;
+}
+
+export interface ComposeUploadResult {
+  publicUrl: string;
+  fileName: string;
+  mediaType: string | null;
+  file: File;
+}
+
+export interface UploadComposeAttachmentsOptions {
+  labels: ComposeUploadLabels;
+  abortSignal?: AbortSignal;
+  allowedContentTypes?: UploadUserFileDirectOptions["allowedContentTypes"];
+  maxSizeBytes?: UploadUserFileDirectOptions["maxSizeBytes"];
+  fallbackFileName?: string;
+}
+
+/**
+ * Shared compose attach helper: progress toast + error toast → public URLs.
+ * Backing mint is `uploadUserFileDirect` (user-owned blobs). Callers insert
+ * URLs into markdown/message content. No parent file row is created.
+ */
+export async function uploadComposeAttachments(
+  files: File[],
+  options: UploadComposeAttachmentsOptions,
+): Promise<ComposeUploadResult[]> {
+  if (files.length === 0) {
+    return [];
+  }
+
+  const uploadToast = createFileUploadProgressToast({
+    files,
+    labels: {
+      uploadingFile: options.labels.uploadingFile,
+      uploadingFiles: options.labels.uploadingFiles,
+    },
+  });
+
+  try {
+    const results: ComposeUploadResult[] = [];
+
+    for (const [index, file] of files.entries()) {
+      const uploaded = await uploadUserFileDirect(file, {
+        abortSignal: options.abortSignal,
+        allowedContentTypes: options.allowedContentTypes,
+        maxSizeBytes: options.maxSizeBytes,
+        onUploadProgress: (progress) => {
+          uploadToast.updateFileProgress(index, progress);
+        },
+      });
+      uploadToast.markFileComplete(index);
+
+      const resolvedMediaType =
+        resolveUserUploadContentType(file.name, file.type) ??
+        (file.type || null);
+
+      results.push({
+        publicUrl: uploaded.publicUrl,
+        fileName: sanitizeTaskAttachmentLabel(
+          file.name,
+          options.fallbackFileName ?? "file",
+        ),
+        mediaType: resolvedMediaType,
+        file,
+      });
+    }
+
+    uploadToast.dismiss();
+    return results;
+  } catch (error) {
+    uploadToast.dismiss();
+    toast.error(
+      getUserFileUploadErrorMessage(error, options.labels.uploadError),
+    );
+    throw error;
+  }
+}

--- a/apps/web/src/lib/utils/file-upload-progress-toast.tsx
+++ b/apps/web/src/lib/utils/file-upload-progress-toast.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { Progress } from "@/components/ui/progress";
 import { formatBytes } from "@/lib/utils/format-bytes";
 
-interface TaskAttachmentUploadToastItem {
+interface FileUploadProgressToastItem {
   id: string;
   name: string;
   total: number;
@@ -13,40 +13,37 @@ interface TaskAttachmentUploadToastItem {
   percentage: number;
 }
 
-export interface TaskAttachmentUploadToastLabels {
+export interface FileUploadProgressToastLabels {
   uploadingFile: string;
   uploadingFiles: string;
 }
 
-export interface TaskAttachmentUploadProgress {
+export interface FileUploadProgress {
   loaded: number;
   total: number;
   percentage: number;
 }
 
-export interface TaskAttachmentUploadToastController {
-  updateFileProgress: (
-    fileIndex: number,
-    progress: TaskAttachmentUploadProgress,
-  ) => void;
+export interface FileUploadProgressToastController {
+  updateFileProgress: (fileIndex: number, progress: FileUploadProgress) => void;
   markFileComplete: (fileIndex: number) => void;
   dismiss: () => void;
 }
 
-interface TaskAttachmentUploadToastContentProps {
+interface FileUploadProgressToastContentProps {
   title: string;
-  items: TaskAttachmentUploadToastItem[];
+  items: FileUploadProgressToastItem[];
   totalLoaded: number;
   totalBytes: number;
   totalPercentage: number;
 }
 
-interface CreateTaskAttachmentUploadToastOptions {
+interface CreateFileUploadProgressToastOptions {
   files: File[];
-  labels: TaskAttachmentUploadToastLabels;
+  labels: FileUploadProgressToastLabels;
 }
 
-const TASK_ATTACHMENT_UPLOAD_TOAST_CLASS_NAMES = {
+const FILE_UPLOAD_PROGRESS_TOAST_CLASS_NAMES = {
   toast: "!pointer-events-none !touch-auto",
   content: "pointer-events-none",
   title: "pointer-events-none",
@@ -73,25 +70,19 @@ function clampLoadedBytes(loaded: number, total: number): number {
   return Math.max(0, Math.min(loaded, total));
 }
 
-function getAggregateTotalBytes(
-  items: TaskAttachmentUploadToastItem[],
-): number {
+function getAggregateTotalBytes(items: FileUploadProgressToastItem[]): number {
   return items.reduce((sum, item) => sum + item.total, 0);
 }
 
-function getAggregateLoadedBytes(
-  items: TaskAttachmentUploadToastItem[],
-): number {
+function getAggregateLoadedBytes(items: FileUploadProgressToastItem[]): number {
   return items.reduce((sum, item) => sum + item.loaded, 0);
 }
 
 function updateToastItem(
-  items: TaskAttachmentUploadToastItem[],
+  items: FileUploadProgressToastItem[],
   itemIndex: number,
-  updater: (
-    item: TaskAttachmentUploadToastItem,
-  ) => TaskAttachmentUploadToastItem,
-): TaskAttachmentUploadToastItem[] | null {
+  updater: (item: FileUploadProgressToastItem) => FileUploadProgressToastItem,
+): FileUploadProgressToastItem[] | null {
   const item = items[itemIndex];
   if (!item) {
     return null;
@@ -103,18 +94,18 @@ function updateToastItem(
 }
 
 function createToastId(): string {
-  return `task-attachment-upload-${Date.now()}-${Math.round(
+  return `file-upload-progress-${Date.now()}-${Math.round(
     Math.random() * 1_000_000,
   )}`;
 }
 
-function TaskAttachmentUploadToastContent({
+function FileUploadProgressToastContent({
   title,
   items,
   totalLoaded,
   totalBytes,
   totalPercentage,
-}: TaskAttachmentUploadToastContentProps) {
+}: FileUploadProgressToastContentProps) {
   return (
     <div className="pointer-events-none flex min-w-80 max-w-sm flex-col gap-3 rounded-lg border border-border bg-card-background p-4 text-foreground shadow-lg">
       <div className="space-y-1">
@@ -150,13 +141,13 @@ function TaskAttachmentUploadToastContent({
   );
 }
 
-export function createTaskAttachmentUploadToast({
+export function createFileUploadProgressToast({
   files,
   labels,
-}: CreateTaskAttachmentUploadToastOptions): TaskAttachmentUploadToastController {
+}: CreateFileUploadProgressToastOptions): FileUploadProgressToastController {
   const toastId = createToastId();
   // Keep items immutable so React Compiler sees each per-file update.
-  let items: TaskAttachmentUploadToastItem[] = files.map((file, index) => ({
+  let items: FileUploadProgressToastItem[] = files.map((file, index) => ({
     id: `${index}-${file.name}-${file.size}`,
     name: file.name,
     total: file.size,
@@ -181,7 +172,7 @@ export function createTaskAttachmentUploadToast({
 
     toast.custom(
       () => (
-        <TaskAttachmentUploadToastContent
+        <FileUploadProgressToastContent
           title={title}
           items={items}
           totalLoaded={totalLoaded}
@@ -193,7 +184,7 @@ export function createTaskAttachmentUploadToast({
         id: toastId,
         duration: Infinity,
         dismissible: false,
-        classNames: TASK_ATTACHMENT_UPLOAD_TOAST_CLASS_NAMES,
+        classNames: FILE_UPLOAD_PROGRESS_TOAST_CLASS_NAMES,
       },
     );
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-672/add-shared-compose-file-upload-helper-for-markdownchat-attachments

## Summary
- Add `uploadComposeAttachments` for compose attach-into-content (toast/progress/error → public URL)
- Move progress toast to shared `file-upload-progress-toast`
- Wire task description paperclip, chat multimodal input, and room composer
- Keep activity attaches on `uploadTaskAttachment`; logos unchanged

## Verification
- `pnpm web:check`
- `pnpm web:test`

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Spec / UI | `/tasks`, `/chat` | Full route screenshots skipped (no local DB/.env in this agent VM). Upload toast UX covered by unit tests (`file-upload-progress-toast`, `task-form` attach tests). |
| defect | `App.Channels.Toolbar.uploading` | ICU `uploading` key may be unused after room composer switched to progress templates; safe to remove in follow-up. |
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-672](https://linear.app/masumi/issue/SOK-672/add-shared-compose-file-upload-helper-for-markdownchat-attachments)

<div><a href="https://cursor.com/agents/bc-da452bc0-a089-41c0-aa41-2e0ee6371593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da452bc0-a089-41c0-aa41-2e0ee6371593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

