### PR TITLE
fix(chat): treat Cmd/Ctrl+Enter as newline in composers

### DIFF
--- a/apps/web/src/components/chat/__tests__/prompt-input.test.tsx
+++ b/apps/web/src/components/chat/__tests__/prompt-input.test.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from "@/components/chat/prompt-input";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+function StatefulPromptComposer({
+  onSubmit,
+  allowEnterToSubmitOnMobile,
+}: {
+  onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
+  allowEnterToSubmitOnMobile?: boolean;
+}) {
+  const [value, setValue] = useState("hello");
+
+  return (
+    <PromptInput
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit?.(event);
+      }}
+    >
+      <PromptInputTextarea
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        allowEnterToSubmitOnMobile={allowEnterToSubmitOnMobile}
+      />
+      <PromptInputSubmit />
+    </PromptInput>
+  );
+}
+
+describe("PromptInputTextarea", () => {
+  it("submits on plain Enter", () => {
+    const onSubmit = vi.fn();
+
+    render(<StatefulPromptComposer onSubmit={onSubmit} />);
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not submit on Shift+Enter", () => {
+    const onSubmit = vi.fn();
+
+    render(<StatefulPromptComposer onSubmit={onSubmit} />);
+
+    fireEvent.keyDown(screen.getByRole("textbox"), {
+      key: "Enter",
+      shiftKey: true,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("inserts a newline on Cmd+Enter without submitting", () => {
+    const onSubmit = vi.fn();
+
+    render(<StatefulPromptComposer onSubmit={onSubmit} />);
+
+    const textarea = screen.getByRole("textbox");
+    textarea.focus();
+    (textarea as HTMLTextAreaElement).setSelectionRange(5, 5);
+
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect((textarea as HTMLTextAreaElement).value).toBe("hello\n");
+  });
+
+  it("inserts a newline on Ctrl+Enter without submitting", () => {
+    const onSubmit = vi.fn();
+
+    render(<StatefulPromptComposer onSubmit={onSubmit} />);
+
+    const textarea = screen.getByRole("textbox");
+    textarea.focus();
+    (textarea as HTMLTextAreaElement).setSelectionRange(5, 5);
+
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect((textarea as HTMLTextAreaElement).value).toBe("hello\n");
+  });
+
+  it("does not submit on Enter on a narrow viewport when mobile submit is disabled", () => {
+    const onSubmit = vi.fn();
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+
+    try {
+      render(
+        <StatefulPromptComposer
+          onSubmit={onSubmit}
+          allowEnterToSubmitOnMobile={false}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+});

--- a/apps/web/src/components/chat/prompt-input.tsx
+++ b/apps/web/src/components/chat/prompt-input.tsx
@@ -4,6 +4,7 @@ import type { ChatStatus } from "ai";
 import { Loader2Icon, SendIcon, SquareIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type {
+  ChangeEvent,
   ComponentProps,
   HTMLAttributes,
   KeyboardEventHandler,
@@ -33,6 +34,31 @@ export type PromptInputTextareaProps = ComponentProps<typeof Textarea> & {
   resizeOnNewLinesOnly?: boolean;
 };
 
+function insertNewlineAtCursor(
+  el: HTMLTextAreaElement,
+  onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void,
+) {
+  const start = el.selectionStart ?? 0;
+  const end = el.selectionEnd ?? 0;
+  const nextValue = `${el.value.slice(0, start)}\n${el.value.slice(end)}`;
+  const nextCaret = start + 1;
+
+  // Controlled inputs: React may ignore DOM `.value` writes, so pass the
+  // next value on the synthetic event instead of reading it back from `el`.
+  const valueTarget = { value: nextValue } as HTMLTextAreaElement;
+  onChange?.({
+    target: valueTarget,
+    currentTarget: valueTarget,
+  } as ChangeEvent<HTMLTextAreaElement>);
+
+  // Restore caret after React commits the controlled update when possible.
+  requestAnimationFrame(() => {
+    if (el.value === nextValue) {
+      el.setSelectionRange(nextCaret, nextCaret);
+    }
+  });
+}
+
 export const PromptInputTextarea = ({
   allowEnterToSubmitOnMobile = true,
   onChange,
@@ -53,7 +79,15 @@ export const PromptInputTextarea = ({
         return;
       }
 
+      // Shift+Enter: browser default inserts a newline.
       if (e.shiftKey) {
+        return;
+      }
+
+      // Cmd/Ctrl+Enter: browsers do not insert a newline by default.
+      if (e.metaKey || e.ctrlKey) {
+        e.preventDefault();
+        insertNewlineAtCursor(e.currentTarget, onChange);
         return;
       }
 
@@ -95,9 +129,9 @@ export const PromptInputTextarea = ({
       )}
       name="message"
       onChange={onChange}
-      onKeyDown={handleKeyDown}
       placeholder={resolvedPlaceholder}
       {...props}
+      onKeyDown={handleKeyDown}
     />
   );
 };

--- a/apps/web/src/components/ui/__tests__/mention-textarea.test.tsx
+++ b/apps/web/src/components/ui/__tests__/mention-textarea.test.tsx
@@ -168,6 +168,42 @@ describe("MentionTextarea", () => {
     expect(onSubmitShortcut).not.toHaveBeenCalled();
   });
 
+  it("keeps Cmd+Enter for multiline input", () => {
+    const onSubmitShortcut = vi.fn();
+
+    render(
+      <StatefulMentionTextarea
+        submitOnEnter
+        onSubmitShortcut={onSubmitShortcut}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("textbox"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(onSubmitShortcut).not.toHaveBeenCalled();
+  });
+
+  it("keeps Ctrl+Enter for multiline input", () => {
+    const onSubmitShortcut = vi.fn();
+
+    render(
+      <StatefulMentionTextarea
+        submitOnEnter
+        onSubmitShortcut={onSubmitShortcut}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("textbox"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    expect(onSubmitShortcut).not.toHaveBeenCalled();
+  });
+
   it("opens mention suggestions from the imperative handle", () => {
     const onChange = vi.fn();
 

--- a/apps/web/src/components/ui/mention-textarea.tsx
+++ b/apps/web/src/components/ui/mention-textarea.tsx
@@ -693,7 +693,13 @@ function MentionTextareaInner<TData = unknown>(
           typeof window !== "undefined" && window.innerWidth < 768;
         const submitsOnEnter =
           submitOnEnter && (allowEnterToSubmitOnMobile || !isNarrowViewport);
-        if (submitsOnEnter && !event.shiftKey) {
+        // Shift / Cmd / Ctrl + Enter insert a line break instead of submitting.
+        if (
+          submitsOnEnter &&
+          !event.shiftKey &&
+          !event.metaKey &&
+          !event.ctrlKey
+        ) {
           onSubmitShortcut?.();
           return;
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-675](https://linear.app/masumi/issue/SOK-675/enable-cmdctrlenter-as-newline-in-chat-composer)

## Summary
- Cmd/Ctrl+Enter inserts a newline (does not submit) in shared chat composers
- Enter still sends; Shift+Enter still newline; mobile Enter policy unchanged
- Updated `PromptInputTextarea` (multimodal / PA) and `MentionTextarea` (room)
- Unit tests cover both surfaces

## Verification
- `pnpm web:check` — exit 0
- `pnpm web:test` — exit 0
- CI — all checks green
- Manual: `/chat` Ctrl+Enter inserts newlines without submit

## UI evidence
![Chat landing composer](https://cursor.com/artifacts/c/art-b2298b6f-7f0b-4225-a2c8-4e285f5ad094)
![Ctrl+Enter multiline draft](https://cursor.com/artifacts/c/art-eef5e9e6-78af-4a25-ab58-0e217493c218)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-675](https://linear.app/masumi/issue/SOK-675/enable-cmdctrlenter-as-newline-in-chat-composer)

<div><a href="https://cursor.com/agents/bc-005d3aef-77c5-418a-9937-bd0c0dc75a41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-005d3aef-77c5-418a-9937-bd0c0dc75a41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

