### PR TITLE
feat(web): add drag-and-drop file attach to room composer

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Dateien zum Anhängen ablegen",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4726,6 +4726,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Drop files to attach",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Suelta archivos para adjuntar",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Déposez des fichiers pour les joindre",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Trascina i file per allegarli",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "ファイルをドロップして添付",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Solte arquivos para anexar",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "Largue ficheiros para anexar",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4607,6 +4607,7 @@
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",
+        "dropToAttach": "拖放文件以附加",
         "emoji": "Emoji",
         "format": "Formatting",
         "bold": "Bold",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RoomFileDropZone } from "@/app/chat/components/room-file-drop-zone";
+
+describe("RoomFileDropZone", () => {
+  it("calls onFiles when files are dropped while enabled", () => {
+    const onFiles = vi.fn();
+    render(
+      <RoomFileDropZone enabled onFiles={onFiles} label="Drop files to attach">
+        <div>room</div>
+      </RoomFileDropZone>,
+    );
+
+    const zone = screen.getByText("room").parentElement;
+    expect(zone).toBeTruthy();
+    const file = new File(["hello"], "note.txt", { type: "text/plain" });
+    fireEvent.drop(zone!, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [file],
+      },
+    });
+
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0]?.[0]).toEqual([file]);
+  });
+
+  it("ignores drops when disabled", () => {
+    const onFiles = vi.fn();
+    render(
+      <RoomFileDropZone
+        enabled={false}
+        onFiles={onFiles}
+        label="Drop files to attach"
+      >
+        <div>room</div>
+      </RoomFileDropZone>,
+    );
+
+    const zone = screen.getByText("room").parentElement;
+    fireEvent.drop(zone!, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [new File(["x"], "a.txt", { type: "text/plain" })],
+      },
+    });
+
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it("shows overlay while dragging files", () => {
+    render(
+      <RoomFileDropZone enabled onFiles={vi.fn()} label="Drop files to attach">
+        <div>room</div>
+      </RoomFileDropZone>,
+    );
+
+    const zone = screen.getByText("room").parentElement!;
+    fireEvent.dragEnter(zone, {
+      dataTransfer: { types: ["Files"], files: [] },
+    });
+
+    expect(screen.getByText("Drop files to attach")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/draft-channel.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-channel.tsx
@@ -20,7 +20,11 @@ import type { Coworker, Member } from "@/lib/clients/generated/core";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 import { formatTaskAttachmentMarkdown } from "@/lib/utils/task-attachments";
 import { getInitials } from "@/lib/utils/text";
-import { RoomComposer, type RoomComposerAttachment } from "./room-composer";
+import {
+  RoomComposer,
+  type RoomComposerAttachment,
+  type RoomComposerHandle,
+} from "./room-composer";
 import {
   AiCoworkerIcon,
   buildDirectDraftTargets,
@@ -29,6 +33,7 @@ import {
   filterDraftTargets,
   MembersRosterLoadFailed,
 } from "./room-draft-shared";
+import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
   buildRoomComposerMessageContent,
   isRoomComposerEmpty,
@@ -50,6 +55,7 @@ export function DraftChannel({
   const router = useRouter();
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const composerRef = useRef<RoomComposerHandle | null>(null);
   const [name, setName] = useState("");
   const [topic, setTopic] = useState("");
   const [recipientQuery, setRecipientQuery] = useState("");
@@ -182,7 +188,14 @@ export function DraftChannel({
   }
 
   return (
-    <>
+    <RoomFileDropZone
+      enabled
+      onFiles={(files) => {
+        composerRef.current?.attachFiles(files);
+      }}
+      label={t("Toolbar.dropToAttach")}
+      className="flex min-h-0 flex-1 flex-col"
+    >
       <header className="min-h-14 shrink-0 border-b px-5 py-2">
         <div className="space-y-2">
           <div className="flex w-full items-start gap-2">
@@ -322,6 +335,7 @@ export function DraftChannel({
       </ScrollArea>
 
       <RoomComposer
+        ref={composerRef}
         value={composerValue}
         onValueChange={setComposerValue}
         mentions={selectedMentionParticipants}
@@ -340,6 +354,6 @@ export function DraftChannel({
           isRoomComposerEmpty(composerValue, composerAttachments)
         }
       />
-    </>
+    </RoomFileDropZone>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -24,7 +24,11 @@ import type { Coworker, Member } from "@/lib/clients/generated/core";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 import { formatTaskAttachmentMarkdown } from "@/lib/utils/task-attachments";
 import { getInitials } from "@/lib/utils/text";
-import { RoomComposer, type RoomComposerAttachment } from "./room-composer";
+import {
+  RoomComposer,
+  type RoomComposerAttachment,
+  type RoomComposerHandle,
+} from "./room-composer";
 import {
   AiCoworkerIcon,
   buildDirectDraftTargets,
@@ -33,6 +37,7 @@ import {
   filterDraftTargets,
   MembersRosterLoadFailed,
 } from "./room-draft-shared";
+import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
   buildRoomComposerMessageContent,
   isRoomComposerEmpty,
@@ -56,6 +61,7 @@ export function DraftDirectMessage({
   const t = useTranslations("App.Channels");
   const router = useRouter();
   const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const composerRef = useRef<RoomComposerHandle | null>(null);
   const [recipientQuery, setRecipientQuery] = useState("");
   const [isRecipientPickerOpen, setIsRecipientPickerOpen] = useState(true);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
@@ -217,7 +223,14 @@ export function DraftDirectMessage({
   }
 
   return (
-    <>
+    <RoomFileDropZone
+      enabled
+      onFiles={(files) => {
+        composerRef.current?.attachFiles(files);
+      }}
+      label={t("Toolbar.dropToAttach")}
+      className="flex min-h-0 flex-1 flex-col"
+    >
       <header className="min-h-14 shrink-0 border-b px-5 py-2">
         <div className="relative flex w-full items-start gap-2">
           <span className="text-muted-foreground pt-2 text-sm font-medium">
@@ -324,6 +337,7 @@ export function DraftDirectMessage({
       </ScrollArea>
 
       <RoomComposer
+        ref={composerRef}
         value={composerValue}
         onValueChange={setComposerValue}
         mentions={selectedMentionParticipants}
@@ -343,6 +357,6 @@ export function DraftDirectMessage({
         }
         showMentionShortcut={selectedTargets.length > 1}
       />
-    </>
+    </RoomFileDropZone>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -5,8 +5,10 @@ import { useTranslations } from "next-intl";
 import {
   type Dispatch,
   type FormEvent,
+  type Ref,
   type SetStateAction,
   useCallback,
+  useImperativeHandle,
   useRef,
   useState,
 } from "react";
@@ -22,11 +24,6 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
-  FileUpload,
-  FileUploadDropzone,
-  FileUploadTrigger,
-} from "@/components/ui/file-upload";
-import {
   type MentionRecordEntry,
   MentionTextarea,
   type MentionTextareaHandle,
@@ -39,6 +36,11 @@ import type { RoomMentionParticipant } from "./room-helpers";
 
 export interface RoomComposerAttachment extends RoomMessageComposerAttachment {
   mediaType: string | null;
+}
+
+/** Shell drop zones call this to reuse the paperclip upload path. */
+export interface RoomComposerHandle {
+  attachFiles: (files: FileList | File[] | null) => void;
 }
 
 function RoomMentionSuggestion({
@@ -69,6 +71,7 @@ function RoomMentionSuggestion({
 }
 
 export function RoomComposer({
+  ref,
   roomId,
   value,
   onValueChange,
@@ -83,6 +86,7 @@ export function RoomComposer({
   showMentionShortcut = true,
   allowAttachments = true,
 }: {
+  ref?: Ref<RoomComposerHandle>;
   /** When set, attaches mint via room chat file endpoint. */
   roomId?: string;
   value: string;
@@ -104,10 +108,9 @@ export function RoomComposer({
   const tToolbar = useTranslations("App.Channels.Toolbar");
   const formRef = useRef<HTMLFormElement | null>(null);
   const textareaRef = useRef<MentionTextareaHandle | null>(null);
-  const attachmentTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isUploadingFilesRef = useRef(false);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
-  const [pendingUploadFiles, setPendingUploadFiles] = useState<File[]>([]);
   const composerMentions = showMentionShortcut ? mentions : {};
   const handleSelectedKeysChange = showMentionShortcut
     ? onSelectedKeysChange
@@ -115,6 +118,8 @@ export function RoomComposer({
 
   const handleFilesSelected = useCallback(
     async (files: FileList | File[] | null) => {
+      if (!allowAttachments) return;
+
       const selectedFiles = Array.from(files ?? []).filter(
         (file) => file.size > 0,
       );
@@ -159,10 +164,22 @@ export function RoomComposer({
       } finally {
         isUploadingFilesRef.current = false;
         setIsUploadingFiles(false);
-        setPendingUploadFiles([]);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
       }
     },
-    [onAttachmentsChange, roomId, tToolbar],
+    [allowAttachments, onAttachmentsChange, roomId, tToolbar],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      attachFiles: (files) => {
+        void handleFilesSelected(files);
+      },
+    }),
+    [handleFilesSelected],
   );
 
   function removeAttachment(attachment: RoomComposerAttachment) {
@@ -172,7 +189,7 @@ export function RoomComposer({
     textareaRef.current?.focus();
   }
 
-  const composer = (
+  return (
     <RoomMessageComposer
       formRef={formRef}
       onSubmit={onSubmit}
@@ -204,22 +221,34 @@ export function RoomComposer({
             </Button>
           ) : null}
           {allowAttachments ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-              title={t("Toolbar.attach")}
-              aria-label={t("Toolbar.attach")}
-              disabled={isUploadingFiles}
-              onClick={() => attachmentTriggerRef.current?.click()}
-            >
-              {isUploadingFiles ? (
-                <Loader2 className="size-4 animate-spin" aria-hidden />
-              ) : (
-                <Paperclip className="size-4" aria-hidden />
-              )}
-            </Button>
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                tabIndex={-1}
+                onChange={(event) => {
+                  void handleFilesSelected(event.currentTarget.files);
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
+                title={t("Toolbar.attach")}
+                aria-label={t("Toolbar.attach")}
+                disabled={isUploadingFiles}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {isUploadingFiles ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                ) : (
+                  <Paperclip className="size-4" aria-hidden />
+                )}
+              </Button>
+            </>
           ) : null}
           <RoomComposerEmojiPicker
             title={t("Toolbar.emoji")}
@@ -248,41 +277,5 @@ export function RoomComposer({
         renderItem={(mention) => <RoomMentionSuggestion mention={mention} />}
       />
     </RoomMessageComposer>
-  );
-
-  if (!allowAttachments) {
-    return composer;
-  }
-
-  return (
-    <FileUpload
-      value={pendingUploadFiles}
-      onValueChange={setPendingUploadFiles}
-      onAccept={(files) => {
-        void handleFilesSelected(files);
-      }}
-      multiple
-      className="w-full"
-    >
-      <FileUploadDropzone
-        // Drop only — paperclip uses FileUploadTrigger. Prevents click on
-        // textarea/toolbar from opening the file picker.
-        onClick={(event) => event.preventDefault()}
-        className="data-dragging:bg-accent/20 w-full items-stretch justify-start border-0 p-0 hover:bg-transparent"
-      >
-        {composer}
-        <FileUploadTrigger asChild>
-          <button
-            ref={attachmentTriggerRef}
-            type="button"
-            className="sr-only"
-            aria-label={t("Toolbar.attach")}
-            tabIndex={-1}
-          >
-            {t("Toolbar.attach")}
-          </button>
-        </FileUploadTrigger>
-      </FileUploadDropzone>
-    </FileUpload>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -22,6 +22,11 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
+  FileUpload,
+  FileUploadDropzone,
+  FileUploadTrigger,
+} from "@/components/ui/file-upload";
+import {
   type MentionRecordEntry,
   MentionTextarea,
   type MentionTextareaHandle,
@@ -99,22 +104,25 @@ export function RoomComposer({
   const tToolbar = useTranslations("App.Channels.Toolbar");
   const formRef = useRef<HTMLFormElement | null>(null);
   const textareaRef = useRef<MentionTextareaHandle | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const attachmentTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const isUploadingFilesRef = useRef(false);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
+  const [pendingUploadFiles, setPendingUploadFiles] = useState<File[]>([]);
   const composerMentions = showMentionShortcut ? mentions : {};
   const handleSelectedKeysChange = showMentionShortcut
     ? onSelectedKeysChange
     : undefined;
 
   const handleFilesSelected = useCallback(
-    async (files: FileList | null) => {
+    async (files: FileList | File[] | null) => {
       const selectedFiles = Array.from(files ?? []).filter(
         (file) => file.size > 0,
       );
-      if (selectedFiles.length === 0) {
+      if (selectedFiles.length === 0 || isUploadingFilesRef.current) {
         return;
       }
 
+      isUploadingFilesRef.current = true;
       setIsUploadingFiles(true);
 
       try {
@@ -149,10 +157,9 @@ export function RoomComposer({
       } catch {
         // Error toast is handled by uploadComposeAttachments.
       } finally {
+        isUploadingFilesRef.current = false;
         setIsUploadingFiles(false);
-        if (fileInputRef.current) {
-          fileInputRef.current.value = "";
-        }
+        setPendingUploadFiles([]);
       }
     },
     [onAttachmentsChange, roomId, tToolbar],
@@ -165,7 +172,7 @@ export function RoomComposer({
     textareaRef.current?.focus();
   }
 
-  return (
+  const composer = (
     <RoomMessageComposer
       formRef={formRef}
       onSubmit={onSubmit}
@@ -197,34 +204,22 @@ export function RoomComposer({
             </Button>
           ) : null}
           {allowAttachments ? (
-            <>
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                className="hidden"
-                tabIndex={-1}
-                onChange={(event) => {
-                  void handleFilesSelected(event.currentTarget.files);
-                }}
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-                title={t("Toolbar.attach")}
-                aria-label={t("Toolbar.attach")}
-                disabled={isUploadingFiles}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                {isUploadingFiles ? (
-                  <Loader2 className="size-4 animate-spin" aria-hidden />
-                ) : (
-                  <Paperclip className="size-4" aria-hidden />
-                )}
-              </Button>
-            </>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
+              title={t("Toolbar.attach")}
+              aria-label={t("Toolbar.attach")}
+              disabled={isUploadingFiles}
+              onClick={() => attachmentTriggerRef.current?.click()}
+            >
+              {isUploadingFiles ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden />
+              ) : (
+                <Paperclip className="size-4" aria-hidden />
+              )}
+            </Button>
           ) : null}
           <RoomComposerEmojiPicker
             title={t("Toolbar.emoji")}
@@ -253,5 +248,41 @@ export function RoomComposer({
         renderItem={(mention) => <RoomMentionSuggestion mention={mention} />}
       />
     </RoomMessageComposer>
+  );
+
+  if (!allowAttachments) {
+    return composer;
+  }
+
+  return (
+    <FileUpload
+      value={pendingUploadFiles}
+      onValueChange={setPendingUploadFiles}
+      onAccept={(files) => {
+        void handleFilesSelected(files);
+      }}
+      multiple
+      className="w-full"
+    >
+      <FileUploadDropzone
+        // Drop only — paperclip uses FileUploadTrigger. Prevents click on
+        // textarea/toolbar from opening the file picker.
+        onClick={(event) => event.preventDefault()}
+        className="data-dragging:bg-accent/20 w-full items-stretch justify-start border-0 p-0 hover:bg-transparent"
+      >
+        {composer}
+        <FileUploadTrigger asChild>
+          <button
+            ref={attachmentTriggerRef}
+            type="button"
+            className="sr-only"
+            aria-label={t("Toolbar.attach")}
+            tabIndex={-1}
+          >
+            {t("Toolbar.attach")}
+          </button>
+        </FileUploadTrigger>
+      </FileUploadDropzone>
+    </FileUpload>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-file-drop-zone.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-file-drop-zone.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import {
+  type DragEvent,
+  type ReactNode,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/lib/utils";
+
+function dataTransferHasFiles(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.types).includes("Files");
+}
+
+/**
+ * Room-shell file drop target: message list + composer (or draft/thread pane).
+ * Shows a light overlay while dragging files. Non-file drags are ignored.
+ */
+export function RoomFileDropZone({
+  enabled,
+  onFiles,
+  label,
+  children,
+  className,
+}: {
+  enabled: boolean;
+  onFiles: (files: File[]) => void;
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const dragDepthRef = useRef(0);
+
+  const resetDrag = useCallback(() => {
+    dragDepthRef.current = 0;
+    setIsDraggingFiles(false);
+  }, []);
+
+  const handleDragEnter = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dragDepthRef.current += 1;
+    setIsDraggingFiles(true);
+  }, []);
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dragDepthRef.current -= 1;
+    if (dragDepthRef.current <= 0) {
+      dragDepthRef.current = 0;
+      setIsDraggingFiles(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!dataTransferHasFiles(event.dataTransfer)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      resetDrag();
+      const files = Array.from(event.dataTransfer.files).filter(
+        (file) => file.size > 0,
+      );
+      if (files.length === 0) return;
+      onFiles(files);
+    },
+    [onFiles, resetDrag],
+  );
+
+  if (!enabled) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <div
+      className={cn("relative", className)}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {children}
+      {isDraggingFiles ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-accent/50"
+        >
+          <p className="bg-background text-foreground rounded-md border px-4 py-2 text-sm font-medium shadow-sm">
+            {label}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -51,7 +51,12 @@ import { getInitials } from "@/lib/utils/text";
 import { DraftChannel } from "./draft-channel";
 import { DraftDirectMessage } from "./draft-direct-message";
 import { EditChannelDialog } from "./edit-channel-dialog";
-import { RoomComposer, type RoomComposerAttachment } from "./room-composer";
+import {
+  RoomComposer,
+  type RoomComposerAttachment,
+  type RoomComposerHandle,
+} from "./room-composer";
+import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
   appendMessage,
   buildRoomComposerMessageContent,
@@ -190,6 +195,7 @@ export function RoomsClient({
   >([]);
   const [threadMentionedIds, setThreadMentionedIds] = useState<string[]>([]);
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const roomComposerRef = useRef<RoomComposerHandle | null>(null);
   const readMarkerRef = useRef<string | null>(null);
   const syncedRoomIdRef = useRef<string | null>(null);
   // RoomsClient stays mounted across /chat/rooms/[id] navigations. Async
@@ -1034,7 +1040,14 @@ export function RoomsClient({
               membersLoadFailed={membersLoadFailed}
             />
           ) : selectedRoom ? (
-            <>
+            <RoomFileDropZone
+              enabled={!isCoworkerStreamRoom}
+              onFiles={(files) => {
+                roomComposerRef.current?.attachFiles(files);
+              }}
+              label={t("Toolbar.dropToAttach")}
+              className="flex min-h-0 flex-1 flex-col"
+            >
               <header className="flex h-16 shrink-0 items-center justify-between gap-4 border-b px-6">
                 <div className="flex min-w-0 items-center gap-2">
                   {isDirectRoom ? (
@@ -1150,6 +1163,7 @@ export function RoomsClient({
               </ScrollArea>
 
               <RoomComposer
+                ref={roomComposerRef}
                 roomId={selectedRoom.id}
                 value={composerValue}
                 onValueChange={setComposerValue}
@@ -1177,7 +1191,7 @@ export function RoomsClient({
                 )}
                 allowAttachments={!isCoworkerStreamRoom}
               />
-            </>
+            </RoomFileDropZone>
           ) : (
             <div className="flex flex-1 items-center justify-center p-6">
               <div className="border-border/70 bg-muted/20 max-w-md rounded-md border border-dashed px-6 py-10 text-center">

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -2,7 +2,12 @@
 
 import { Loader2, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type Dispatch, type FormEvent, type SetStateAction } from "react";
+import {
+  type Dispatch,
+  type FormEvent,
+  type SetStateAction,
+  useRef,
+} from "react";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -11,7 +16,12 @@ import type {
   ChatRoomMessage,
   ChatRoomUserParticipant,
 } from "@/lib/clients/generated/core";
-import { RoomComposer, type RoomComposerAttachment } from "./room-composer";
+import {
+  RoomComposer,
+  type RoomComposerAttachment,
+  type RoomComposerHandle,
+} from "./room-composer";
+import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
   isMessageContinuation,
   isRoomComposerEmpty,
@@ -69,6 +79,7 @@ export function ThreadPanel({
   roomId?: string;
 }) {
   const t = useTranslations("App.Channels");
+  const threadComposerRef = useRef<RoomComposerHandle | null>(null);
 
   return (
     // Below lg the thread takes over the whole pane: side-by-side would leave
@@ -76,111 +87,121 @@ export function ThreadPanel({
     // taking its close button with it. It has its own header and close button,
     // so a full-screen takeover is self-contained.
     <aside className="bg-background absolute inset-0 z-30 flex min-h-0 w-full shrink-0 flex-col lg:static lg:z-auto lg:w-[420px] lg:border-l">
-      <header className="flex h-16 shrink-0 items-center justify-between gap-3 border-b px-4">
-        <div className="min-w-0">
-          <h2 className="truncate text-sm font-semibold">
-            {t("Thread.title")}
-          </h2>
-          <p className="text-muted-foreground truncate text-xs">
-            {t("Thread.replyCount", {
-              count: parentMessage.threadReplyCount,
-            })}
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-8 rounded-full"
-          aria-label={t("Thread.close")}
-          title={t("Thread.close")}
-          onClick={onClose}
-        >
-          <X className="size-4" aria-hidden />
-        </Button>
-      </header>
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="px-4 py-4">
-          <ChatMessageRow
-            message={parentMessage}
-            coworkersById={coworkersById}
-            coworkersBySlug={coworkersBySlug}
-            usersById={usersById}
-            usersBySlug={usersBySlug}
-            onToggleReaction={onToggleReaction}
-            showThreadButton={false}
-          />
-          <div className="my-4 border-t" />
-          {isLoading ? (
-            <div className="text-muted-foreground flex items-center gap-2 py-4 text-sm">
-              <Loader2 className="size-4 animate-spin" aria-hidden />
-              {t("Thread.loading")}
-            </div>
-          ) : (
-            <>
-              {olderNextCursor ? (
-                <div className="mb-3 flex justify-center">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    disabled={isLoadingOlder}
-                    onClick={onLoadOlder}
-                  >
-                    {isLoadingOlder ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        {t("loadingOlder")}
-                      </>
-                    ) : (
-                      t("loadOlder")
-                    )}
-                  </Button>
-                </div>
-              ) : null}
-              {replies.length > 0 ? (
-                <div className="space-y-1">
-                  {replies.map((reply, index) => (
-                    <ChatMessageRow
-                      key={reply.id}
-                      message={reply}
-                      coworkersById={coworkersById}
-                      coworkersBySlug={coworkersBySlug}
-                      usersById={usersById}
-                      usersBySlug={usersBySlug}
-                      onToggleReaction={onToggleReaction}
-                      showThreadButton={false}
-                      isContinuation={isMessageContinuation(
-                        replies[index - 1],
-                        reply,
+      <RoomFileDropZone
+        enabled={allowAttachments}
+        onFiles={(files) => {
+          threadComposerRef.current?.attachFiles(files);
+        }}
+        label={t("Toolbar.dropToAttach")}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <header className="flex h-16 shrink-0 items-center justify-between gap-3 border-b px-4">
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-semibold">
+              {t("Thread.title")}
+            </h2>
+            <p className="text-muted-foreground truncate text-xs">
+              {t("Thread.replyCount", {
+                count: parentMessage.threadReplyCount,
+              })}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 rounded-full"
+            aria-label={t("Thread.close")}
+            title={t("Thread.close")}
+            onClick={onClose}
+          >
+            <X className="size-4" aria-hidden />
+          </Button>
+        </header>
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="px-4 py-4">
+            <ChatMessageRow
+              message={parentMessage}
+              coworkersById={coworkersById}
+              coworkersBySlug={coworkersBySlug}
+              usersById={usersById}
+              usersBySlug={usersBySlug}
+              onToggleReaction={onToggleReaction}
+              showThreadButton={false}
+            />
+            <div className="my-4 border-t" />
+            {isLoading ? (
+              <div className="text-muted-foreground flex items-center gap-2 py-4 text-sm">
+                <Loader2 className="size-4 animate-spin" aria-hidden />
+                {t("Thread.loading")}
+              </div>
+            ) : (
+              <>
+                {olderNextCursor ? (
+                  <div className="mb-3 flex justify-center">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={isLoadingOlder}
+                      onClick={onLoadOlder}
+                    >
+                      {isLoadingOlder ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" />
+                          {t("loadingOlder")}
+                        </>
+                      ) : (
+                        t("loadOlder")
                       )}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <p className="text-muted-foreground py-4 text-sm">
-                  {t("Thread.empty")}
-                </p>
-              )}
-            </>
-          )}
-        </div>
-      </ScrollArea>
-      <RoomComposer
-        roomId={roomId}
-        value={replyValue}
-        onValueChange={onReplyValueChange}
-        mentions={mentionRecords}
-        onSelectedKeysChange={replyMentionedIdsChange}
-        placeholder={t("Thread.replyPlaceholder")}
-        attachments={replyAttachments}
-        onAttachmentsChange={onReplyAttachmentsChange}
-        onSubmit={onSubmitReply}
-        isSending={isSendingReply}
-        sendDisabled={isRoomComposerEmpty(replyValue, replyAttachments)}
-        showMentionShortcut={showMentionShortcut}
-        allowAttachments={allowAttachments}
-      />
+                    </Button>
+                  </div>
+                ) : null}
+                {replies.length > 0 ? (
+                  <div className="space-y-1">
+                    {replies.map((reply, index) => (
+                      <ChatMessageRow
+                        key={reply.id}
+                        message={reply}
+                        coworkersById={coworkersById}
+                        coworkersBySlug={coworkersBySlug}
+                        usersById={usersById}
+                        usersBySlug={usersBySlug}
+                        onToggleReaction={onToggleReaction}
+                        showThreadButton={false}
+                        isContinuation={isMessageContinuation(
+                          replies[index - 1],
+                          reply,
+                        )}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground py-4 text-sm">
+                    {t("Thread.empty")}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </ScrollArea>
+        <RoomComposer
+          ref={threadComposerRef}
+          roomId={roomId}
+          value={replyValue}
+          onValueChange={onReplyValueChange}
+          mentions={mentionRecords}
+          onSelectedKeysChange={replyMentionedIdsChange}
+          placeholder={t("Thread.replyPlaceholder")}
+          attachments={replyAttachments}
+          onAttachmentsChange={onReplyAttachmentsChange}
+          onSubmit={onSubmitReply}
+          isSending={isSendingReply}
+          sendDisabled={isRoomComposerEmpty(replyValue, replyAttachments)}
+          showMentionShortcut={showMentionShortcut}
+          allowAttachments={allowAttachments}
+        />
+      </RoomFileDropZone>
     </aside>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-674/add-drag-and-drop-file-attach-to-chat-composer

## Summary
- Open room / thread / draft panes act as file drop targets (not only the composer card)
- Dropped files reuse `RoomComposer.attachFiles` → `uploadComposeAttachments` (same as paperclip)
- Light “Drop files to attach” overlay while dragging files
- No drop when `allowAttachments` is off (e.g. coworker stream rooms)
- Thread panel owns its own drop → thread reply composer

## Spec (short)
Shell-level drop → same attach pipeline as paperclip; toast/progress/errors unchanged; multi-file; ignore non-file drags.

## Verification
- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0; 1945 passed)
- CI: all checks green
- UI: `/chat?dm=new` shell dropzone wraps header + body + composer (`shellContainsHeader` + `shellContainsComposer`)

![Draft DM shell with attach composer](https://cursor.com/artifacts/c/art-72dad9d2-aa70-4dac-acc5-aa3059abd019)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| defect | `room-file-drop-zone.test.tsx` | Tests cover drop/disabled/overlay; no case for non-file drag ignored |
| Spec | thread + main panes | Desktop with thread open: drop on main pane still attaches to main composer (thread has its own zone) — intentional
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-674](https://linear.app/masumi/issue/SOK-674/add-drag-and-drop-file-attach-to-chat-composer)

<div><a href="https://cursor.com/agents/bc-56f931eb-7fbf-430b-afa8-c76cdb7ddbad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56f931eb-7fbf-430b-afa8-c76cdb7ddbad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

