### PR TITLE
feat(chat): group consecutive same-sender messages

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-message-grouping.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-message-grouping.test.ts
@@ -141,6 +141,13 @@ describe("isMessageContinuation", () => {
     expect(isMessageContinuation(previous, beyondGap)).toBe(false);
   });
 
+  it("is false when the current timestamp precedes the previous message", () => {
+    const previous = userMessage("m1", "2026-07-01T12:04:00.000Z");
+    const current = userMessage("m2", "2026-07-01T12:00:00.000Z");
+
+    expect(isMessageContinuation(previous, current)).toBe(false);
+  });
+
   it("is false across day boundaries even within the gap", () => {
     const previous = userMessage(
       "m1",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-message-grouping.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-message-grouping.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import {
+  isMessageContinuation,
+  MESSAGE_GROUP_GAP_MS,
+  messageSenderKey,
+} from "../room-helpers";
+
+function baseMessage(
+  overrides: Partial<ChatRoomMessage> &
+    Pick<ChatRoomMessage, "id" | "createdAt" | "sender">,
+): ChatRoomMessage {
+  return {
+    roomId: "room-1",
+    parentMessageId: null,
+    content: "hi",
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function userMessage(
+  id: string,
+  createdAt: string,
+  userId = "user-1",
+): ChatRoomMessage {
+  return baseMessage({
+    id,
+    createdAt: new Date(createdAt),
+    sender: {
+      type: "user",
+      user: {
+        id: userId,
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+  });
+}
+
+function coworkerMessage(
+  id: string,
+  createdAt: string,
+  coworkerId = "cow-1",
+): ChatRoomMessage {
+  return baseMessage({
+    id,
+    createdAt: new Date(createdAt),
+    sender: {
+      type: "coworker",
+      coworker: {
+        id: coworkerId,
+        name: "Jamal",
+        slug: "jamal",
+        caption: null,
+        image: null,
+        presence: "online",
+      },
+    },
+  });
+}
+
+function unknownMessage(id: string, createdAt: string): ChatRoomMessage {
+  return baseMessage({
+    id,
+    createdAt: new Date(createdAt),
+    sender: { type: "unknown" },
+  });
+}
+
+describe("messageSenderKey", () => {
+  it("keys users and coworkers by type and id", () => {
+    expect(
+      messageSenderKey(userMessage("m1", "2026-07-01T12:00:00.000Z")),
+    ).toBe("user:user-1");
+    expect(
+      messageSenderKey(coworkerMessage("m2", "2026-07-01T12:00:00.000Z")),
+    ).toBe("coworker:cow-1");
+  });
+
+  it("returns null for unknown senders", () => {
+    expect(
+      messageSenderKey(unknownMessage("m3", "2026-07-01T12:00:00.000Z")),
+    ).toBeNull();
+  });
+});
+
+describe("isMessageContinuation", () => {
+  it("is false when there is no previous message", () => {
+    expect(
+      isMessageContinuation(
+        undefined,
+        userMessage("m1", "2026-07-01T12:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true for same sender within the gap on the same day", () => {
+    const previous = userMessage("m1", "2026-07-01T12:00:00.000Z");
+    const current = userMessage("m2", "2026-07-01T12:04:00.000Z");
+    expect(isMessageContinuation(previous, current)).toBe(true);
+  });
+
+  it("is false when sender identity differs even if display names match", () => {
+    const previous = userMessage("m1", "2026-07-01T12:00:00.000Z", "user-1");
+    const current = userMessage("m2", "2026-07-01T12:01:00.000Z", "user-2");
+    expect(isMessageContinuation(previous, current)).toBe(false);
+  });
+
+  it("is false across user vs coworker even with close timestamps", () => {
+    const previous = userMessage("m1", "2026-07-01T12:00:00.000Z");
+    const current = coworkerMessage("m2", "2026-07-01T12:01:00.000Z");
+    expect(isMessageContinuation(previous, current)).toBe(false);
+  });
+
+  it("is false when the time gap is at or beyond the default threshold", () => {
+    const previous = userMessage("m1", "2026-07-01T12:00:00.000Z");
+    const atGap = userMessage(
+      "m2",
+      new Date(
+        new Date("2026-07-01T12:00:00.000Z").getTime() + MESSAGE_GROUP_GAP_MS,
+      ).toISOString(),
+    );
+    const beyondGap = userMessage(
+      "m3",
+      new Date(
+        new Date("2026-07-01T12:00:00.000Z").getTime() +
+          MESSAGE_GROUP_GAP_MS +
+          1,
+      ).toISOString(),
+    );
+    expect(isMessageContinuation(previous, atGap)).toBe(false);
+    expect(isMessageContinuation(previous, beyondGap)).toBe(false);
+  });
+
+  it("is false across day boundaries even within the gap", () => {
+    const previous = userMessage(
+      "m1",
+      new Date(2026, 6, 1, 23, 58, 0).toISOString(),
+    );
+    const current = userMessage(
+      "m2",
+      new Date(2026, 6, 2, 0, 1, 0).toISOString(),
+    );
+    expect(isMessageContinuation(previous, current)).toBe(false);
+  });
+
+  it("never continues unknown senders", () => {
+    const previous = unknownMessage("m1", "2026-07-01T12:00:00.000Z");
+    const current = unknownMessage("m2", "2026-07-01T12:01:00.000Z");
+    expect(isMessageContinuation(previous, current)).toBe(false);
+  });
+
+  it("honors a custom gapMs option", () => {
+    const previous = userMessage("m1", "2026-07-01T12:00:00.000Z");
+    const current = userMessage("m2", "2026-07-01T12:02:00.000Z");
+    expect(isMessageContinuation(previous, current, { gapMs: 60_000 })).toBe(
+      false,
+    );
+    expect(isMessageContinuation(previous, current, { gapMs: 180_000 })).toBe(
+      true,
+    );
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import { ChatMessageRow } from "../room-message-row";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/components/markdown", () => ({
+  default: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/jobs/job-details/file-chip-with-metadata", () => ({
+  FileChipMiniPreviewWithMetadata: () => null,
+}));
+
+function userMessage(): ChatRoomMessage {
+  return {
+    id: "message-1",
+    roomId: "room-1",
+    parentMessageId: null,
+    content: "Hello",
+    createdAt: new Date("2026-07-01T14:35:00.000Z"),
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+  };
+}
+
+function renderContinuation() {
+  render(
+    <ChatMessageRow
+      message={userMessage()}
+      coworkersById={new Map()}
+      coworkersBySlug={new Map()}
+      onToggleReaction={vi.fn()}
+      isContinuation
+    />,
+  );
+}
+
+describe("ChatMessageRow", () => {
+  it("keeps sender attribution on continuation rows", () => {
+    renderContinuation();
+
+    expect(screen.getByRole("article", { name: "Ada" })).toBeInTheDocument();
+  });
+
+  it("keeps continuation timestamps on one line", () => {
+    renderContinuation();
+
+    expect(screen.getByRole("time")).toHaveClass("whitespace-nowrap");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -107,6 +107,9 @@ export function toggleId(
   return ids.filter((item) => item !== id);
 }
 
+/** Slack-like gap before a same-sender burst starts a new full header. */
+export const MESSAGE_GROUP_GAP_MS = 5 * 60 * 1000;
+
 export function messageSender(message: ChatRoomMessage) {
   if (message.sender.type === "user") {
     return {
@@ -127,6 +130,54 @@ export function messageSender(message: ChatRoomMessage) {
     image: null,
     kind: "unknown" as const,
   };
+}
+
+/** Stable sender identity for grouping; null when identity is unknown. */
+export function messageSenderKey(message: ChatRoomMessage): string | null {
+  if (message.sender.type === "user") {
+    return `user:${message.sender.user.id}`;
+  }
+  if (message.sender.type === "coworker") {
+    return `coworker:${message.sender.coworker.id}`;
+  }
+  return null;
+}
+
+/**
+ * True when `current` should render as a Slack-style continuation of `previous`
+ * (omit avatar / name / primary timestamp).
+ */
+export function isMessageContinuation(
+  previous: ChatRoomMessage | undefined,
+  current: ChatRoomMessage,
+  options?: { gapMs?: number },
+): boolean {
+  if (!previous) {
+    return false;
+  }
+
+  const previousKey = messageSenderKey(previous);
+  const currentKey = messageSenderKey(current);
+  if (!previousKey || !currentKey || previousKey !== currentKey) {
+    return false;
+  }
+
+  if (messageDayKey(previous.createdAt) !== messageDayKey(current.createdAt)) {
+    return false;
+  }
+
+  const gapMs = options?.gapMs ?? MESSAGE_GROUP_GAP_MS;
+  const previousTime = new Date(previous.createdAt).getTime();
+  const currentTime = new Date(current.createdAt).getTime();
+  if (
+    !Number.isFinite(previousTime) ||
+    !Number.isFinite(currentTime) ||
+    currentTime - previousTime >= gapMs
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 export function formatMessageTime(value: Date | string): string {

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -172,6 +172,7 @@ export function isMessageContinuation(
   if (
     !Number.isFinite(previousTime) ||
     !Number.isFinite(currentTime) ||
+    currentTime < previousTime ||
     currentTime - previousTime >= gapMs
   ) {
     return false;

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -302,6 +302,7 @@ export function ChatMessageRow({
   onToggleReaction,
   onOpenThread,
   showThreadButton = true,
+  isContinuation = false,
 }: {
   message: ChatRoomMessage;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -311,6 +312,8 @@ export function ChatMessageRow({
   onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
   onOpenThread?: (message: ChatRoomMessage) => void;
   showThreadButton?: boolean;
+  /** Slack-style continuation: omit avatar / name / primary timestamp. */
+  isContinuation?: boolean;
 }) {
   const tChat = useTranslations("App.Chat.Chat");
   const sender = messageSender(message);
@@ -319,26 +322,51 @@ export function ChatMessageRow({
     isStreamOverlay &&
     message.sender.type === "coworker" &&
     message.content.trim().length === 0;
+  const formattedTime = formatMessageTime(message.createdAt);
+  const createdAtIso = new Date(message.createdAt).toISOString();
 
   return (
-    <article className="group relative -mx-2 flex min-h-11 gap-3.5 rounded-md py-2.5 pr-20 pl-2 transition-colors hover:bg-muted/45">
-      <Avatar className="mt-0.5 size-8 shrink-0">
-        <AvatarImage src={sender.image ?? undefined} alt="" />
-        <AvatarFallback className="text-xs">
-          {getInitials(sender.name)}
-        </AvatarFallback>
-      </Avatar>
-      <div className="min-w-0 flex-1 space-y-1.5">
-        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
-          <span className="truncate text-sm font-semibold">{sender.name}</span>
-          {sender.kind === "coworker" ? <AiCoworkerIcon /> : null}
+    <article
+      className={cn(
+        "group relative -mx-2 flex gap-3.5 rounded-md pr-20 pl-2 transition-colors hover:bg-muted/45",
+        isContinuation ? "min-h-8 py-0.5" : "min-h-11 py-2.5",
+      )}
+    >
+      {isContinuation ? (
+        <div className="flex w-8 shrink-0 justify-center pt-1">
           <time
-            className="text-muted-foreground text-xs"
+            dateTime={createdAtIso}
+            className="text-muted-foreground text-[10px] leading-4 tabular-nums opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+            title={formattedTime}
             suppressHydrationWarning
           >
-            {formatMessageTime(message.createdAt)}
+            {formattedTime}
           </time>
         </div>
+      ) : (
+        <Avatar className="mt-0.5 size-8 shrink-0">
+          <AvatarImage src={sender.image ?? undefined} alt="" />
+          <AvatarFallback className="text-xs">
+            {getInitials(sender.name)}
+          </AvatarFallback>
+        </Avatar>
+      )}
+      <div className="min-w-0 flex-1 space-y-1.5">
+        {isContinuation ? null : (
+          <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
+            <span className="truncate text-sm font-semibold">
+              {sender.name}
+            </span>
+            {sender.kind === "coworker" ? <AiCoworkerIcon /> : null}
+            <time
+              dateTime={createdAtIso}
+              className="text-muted-foreground text-xs"
+              suppressHydrationWarning
+            >
+              {formattedTime}
+            </time>
+          </div>
+        )}
         <div className="text-foreground wrap-break-word text-sm leading-7">
           {isThinking ? (
             <span

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -327,6 +327,7 @@ export function ChatMessageRow({
 
   return (
     <article
+      aria-label={isContinuation ? sender.name : undefined}
       className={cn(
         "group relative -mx-2 flex gap-3.5 rounded-md pr-20 pl-2 transition-colors hover:bg-muted/45",
         isContinuation ? "min-h-8 py-0.5" : "min-h-11 py-2.5",
@@ -336,7 +337,7 @@ export function ChatMessageRow({
         <div className="flex w-8 shrink-0 justify-center pt-1">
           <time
             dateTime={createdAtIso}
-            className="text-muted-foreground text-[10px] leading-4 tabular-nums opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+            className="text-muted-foreground whitespace-nowrap text-[10px] leading-4 tabular-nums opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             title={formattedTime}
             suppressHydrationWarning
           >

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -58,6 +58,7 @@ import {
   getRoomDisplayName,
   getRoomParticipantPreviews,
   hasPendingCoworkerMention,
+  isMessageContinuation,
   isRoomComposerEmpty,
   messageDayKey,
   presenceLabel,
@@ -1136,6 +1137,10 @@ export function RoomsClient({
                             room: selectedRoom,
                             isStreamOverlay,
                           })}
+                          isContinuation={
+                            !showDaySeparator &&
+                            isMessageContinuation(previousMessage, message)
+                          }
                         />
                       </div>
                     );

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/lib/clients/generated/core";
 import { RoomComposer, type RoomComposerAttachment } from "./room-composer";
 import {
+  isMessageContinuation,
   isRoomComposerEmpty,
   type RoomMentionParticipant,
 } from "./room-helpers";
@@ -139,7 +140,7 @@ export function ThreadPanel({
               ) : null}
               {replies.length > 0 ? (
                 <div className="space-y-1">
-                  {replies.map((reply) => (
+                  {replies.map((reply, index) => (
                     <ChatMessageRow
                       key={reply.id}
                       message={reply}
@@ -149,6 +150,10 @@ export function ThreadPanel({
                       usersBySlug={usersBySlug}
                       onToggleReaction={onToggleReaction}
                       showThreadButton={false}
+                      isContinuation={isMessageContinuation(
+                        replies[index - 1],
+                        reply,
+                      )}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://linear.app/masumi/issue/SOK-677/slack-style-consecutive-message-grouping-in-chat-rooms

- Same-sender bursts in room + thread reply lists omit avatar/name/primary timestamp (Slack-style).
- New full header when sender changes, ≥5 min gap, or new day.
- Continuation rows keep gutter timestamp on hover/focus for discoverability.
- Client-only; no API/schema change.

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0; includes new grouping helper tests)
- CI green (Biome, Typecheck, Build, Test Web/Core/Packages, Validate PR Title)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-677](https://linear.app/masumi/issue/SOK-677/slack-style-consecutive-message-grouping-in-chat-rooms)

<div><a href="https://cursor.com/agents/bc-6a3521db-9f82-43f8-a064-13b3f9935140?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a3521db-9f82-43f8-a064-13b3f9935140&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

