### PR TITLE
fix(chat): tighten spacing between consecutive same-sender messages

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -64,27 +64,37 @@ function userMessage(
   };
 }
 
-function renderContinuation(message: ChatRoomMessage = userMessage()) {
+function renderRow({
+  message = userMessage(),
+  isContinuation = false,
+}: {
+  message?: ChatRoomMessage;
+  isContinuation?: boolean;
+} = {}) {
   render(
     <ChatMessageRow
       message={message}
       coworkersById={new Map()}
       coworkersBySlug={new Map()}
       onToggleReaction={vi.fn()}
-      isContinuation
+      isContinuation={isContinuation}
     />,
   );
 }
 
+function renderContinuation(message: ChatRoomMessage = userMessage()) {
+  renderRow({ message, isContinuation: true });
+}
+
 describe("ChatMessageRow", () => {
   it("keeps sender attribution on continuation rows", () => {
-    renderContinuation();
+    renderRow({ isContinuation: true });
 
     expect(screen.getByRole("article", { name: "Ada" })).toBeInTheDocument();
   });
 
   it("keeps continuation timestamps on one line", () => {
-    renderContinuation();
+    renderRow({ isContinuation: true });
 
     expect(screen.getByRole("time")).toHaveClass("whitespace-nowrap");
   });
@@ -133,5 +143,23 @@ describe("ChatMessageRow", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       "Ada, Bob, Carol, and 2 more",
     );
+  });
+
+  it("keeps continuation rows tight so same-sender bursts stay dense", () => {
+    renderRow({ isContinuation: true });
+
+    const article = screen.getByRole("article", { name: "Ada" });
+    expect(article).toHaveClass("py-0.5");
+    expect(article).not.toHaveClass("py-2.5");
+    expect(article).not.toHaveClass("mt-3");
+  });
+
+  it("separates author groups with top margin instead of fat vertical padding", () => {
+    renderRow({ isContinuation: false });
+
+    const article = screen.getByRole("article");
+    expect(article).toHaveClass("mt-3");
+    expect(article).toHaveClass("pb-0.5");
+    expect(article).not.toHaveClass("py-2.5");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -76,7 +76,7 @@ function ChannelMarkdownSegment({
   }
 
   return (
-    <Markdown className="prose-p:my-0 prose-p:leading-7 prose-ul:my-1 prose-ol:my-1 prose-pre:my-2">
+    <Markdown className="prose-p:my-0 prose-p:leading-6 prose-ul:my-1 prose-ol:my-1 prose-pre:my-2">
       {formatRoomMarkdownMentions({
         content,
         coworkersById,
@@ -369,11 +369,11 @@ export function ChatMessageRow({
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
         "group relative -mx-2 flex gap-3.5 rounded-md pr-20 pl-2 transition-colors hover:bg-muted/45",
-        isContinuation ? "min-h-8 py-0.5" : "min-h-11 py-2.5",
+        isContinuation ? "min-h-0 py-0.5" : "mt-3 min-h-0 pt-1 pb-0.5",
       )}
     >
       {isContinuation ? (
-        <div className="flex w-8 shrink-0 justify-center pt-1">
+        <div className="flex w-8 shrink-0 justify-center pt-0.5">
           <time
             dateTime={createdAtIso}
             className="text-muted-foreground whitespace-nowrap text-[10px] leading-4 tabular-nums opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
@@ -391,7 +391,12 @@ export function ChatMessageRow({
           </AvatarFallback>
         </Avatar>
       )}
-      <div className="min-w-0 flex-1 space-y-1.5">
+      <div
+        className={cn(
+          "min-w-0 flex-1",
+          isContinuation ? "space-y-1" : "space-y-1.5",
+        )}
+      >
         {isContinuation ? null : (
           <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
             <span className="truncate text-sm font-semibold">
@@ -407,7 +412,7 @@ export function ChatMessageRow({
             </time>
           </div>
         )}
-        <div className="text-foreground wrap-break-word text-sm leading-7">
+        <div className="text-foreground wrap-break-word text-sm leading-6">
           {isThinking ? (
             <span
               className="reasoning-text-shine text-sm leading-5"

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -158,7 +158,7 @@ export function ThreadPanel({
                   </div>
                 ) : null}
                 {replies.length > 0 ? (
-                  <div className="space-y-1">
+                  <div className="flex flex-col">
                     {replies.map((reply, index) => (
                       <ChatMessageRow
                         key={reply.id}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same-sender chat bursts were still airy after Slack-style grouping (SOK-677): lead rows kept `py-2.5`, so the gap into a continuation nearly matched the gap into the next author group.

**Change**
- Lead rows: `mt-3 pt-1 pb-0.5` (group separation on top margin)
- Continuations: `min-h-0 py-0.5` (dense within a burst)
- Slightly tighter body leading (`leading-6`)
- Thread reply list drops extra `space-y-1` so spacing matches the room

**Verify**
- `pnpm --filter web test` on `room-message-row` (6 tests, exit 0) including reaction tooltip tests from main
- `pnpm --filter web check` (exit 0)
- Browser: seeded consecutive Alice messages → text-to-text gap **4px** (was ~12px lead→continuation)

Rebased onto latest `main` (includes #3491 who-reacted).

![After: dense same-sender burst](https://cursor.com/artifacts/c/art-323f6bd4-ca0d-49b3-8424-71d9b0dd8e04)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7677b15-5cb1-4a15-8d14-26a2127423b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7677b15-5cb1-4a15-8d14-26a2127423b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

