### PR TITLE
feat(chat): paste clipboard files into room composer attach path

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx
@@ -142,4 +142,31 @@ describe("RoomFileDropZone", () => {
 
     expect(onFiles).not.toHaveBeenCalled();
   });
+
+  it("handles paste bubbled from a nested contentEditable", () => {
+    const onFiles = vi.fn();
+    render(
+      <RoomFileDropZone enabled onFiles={onFiles} label="Drop files to attach">
+        <div contentEditable role="textbox">
+          composer
+        </div>
+      </RoomFileDropZone>,
+    );
+
+    const editor = screen.getByRole("textbox");
+    const file = new File(["img"], "paste.png", { type: "image/png" });
+    fireEvent.paste(editor, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0]?.[0]).toEqual([file]);
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx
@@ -62,4 +62,84 @@ describe("RoomFileDropZone", () => {
 
     expect(screen.getByText("Drop files to attach")).toBeInTheDocument();
   });
+
+  it("calls onFiles when a clipboard file is pasted while enabled", () => {
+    const onFiles = vi.fn();
+    render(
+      <RoomFileDropZone enabled onFiles={onFiles} label="Drop files to attach">
+        <div>room</div>
+      </RoomFileDropZone>,
+    );
+
+    const zone = screen.getByText("room").parentElement!;
+    const file = new File(["img"], "paste.png", { type: "image/png" });
+    fireEvent.paste(zone, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0]?.[0]).toEqual([file]);
+  });
+
+  it("leaves text paste alone when clipboard has no file items", () => {
+    const onFiles = vi.fn();
+    render(
+      <RoomFileDropZone enabled onFiles={onFiles} label="Drop files to attach">
+        <div>room</div>
+      </RoomFileDropZone>,
+    );
+
+    const zone = screen.getByText("room").parentElement!;
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: [
+          {
+            kind: "string",
+            getAsFile: () => null,
+          },
+        ],
+      },
+    });
+
+    const prevented = !zone.dispatchEvent(event);
+
+    expect(onFiles).not.toHaveBeenCalled();
+    expect(prevented).toBe(false);
+  });
+
+  it("ignores paste when disabled", () => {
+    const onFiles = vi.fn();
+    render(
+      <RoomFileDropZone
+        enabled={false}
+        onFiles={onFiles}
+        label="Drop files to attach"
+      >
+        <div>room</div>
+      </RoomFileDropZone>,
+    );
+
+    const zone = screen.getByText("room").parentElement!;
+    fireEvent.paste(zone, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            getAsFile: () =>
+              new File(["img"], "paste.png", { type: "image/png" }),
+          },
+        ],
+      },
+    });
+
+    expect(onFiles).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/room-file-drop-zone.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-file-drop-zone.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type ClipboardEvent,
   type DragEvent,
   type ReactNode,
   useCallback,
@@ -13,9 +14,23 @@ function dataTransferHasFiles(dataTransfer: DataTransfer): boolean {
   return Array.from(dataTransfer.types).includes("Files");
 }
 
+function filesFromClipboard(clipboardData: DataTransfer | null): File[] {
+  const items = clipboardData?.items;
+  if (!items) return [];
+
+  const files: File[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item?.kind !== "file") continue;
+    const file = item.getAsFile();
+    if (file && file.size > 0) files.push(file);
+  }
+  return files;
+}
+
 /**
- * Room-shell file drop target: message list + composer (or draft/thread pane).
- * Shows a light overlay while dragging files. Non-file drags are ignored.
+ * Room-shell file drop/paste target: message list + composer (or draft/thread pane).
+ * Shows a light overlay while dragging files. Non-file drags/pastes are ignored.
  */
 export function RoomFileDropZone({
   enabled,
@@ -79,6 +94,17 @@ export function RoomFileDropZone({
     [onFiles, resetDrag],
   );
 
+  const handlePaste = useCallback(
+    (event: ClipboardEvent<HTMLDivElement>) => {
+      const files = filesFromClipboard(event.clipboardData);
+      if (files.length === 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onFiles(files);
+    },
+    [onFiles],
+  );
+
   if (!enabled) {
     return <div className={className}>{children}</div>;
   }
@@ -90,6 +116,7 @@ export function RoomFileDropZone({
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
+      onPaste={handlePaste}
     >
       {children}
       {isDraggingFiles ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Room chat users can paste clipboard images/files into the composer attach path (same as paperclip and drag-and-drop).

## Changes

- Extend `RoomFileDropZone` with paste handling that feeds the existing `onFiles` → `attachFiles` → `uploadComposeAttachments` pipeline
- Text-only paste is left alone (no `preventDefault` without file items)
- Disabled drop zones ignore paste attach
- Tests cover enabled paste, text-only paste, disabled paste, and paste bubbling from nested `contentEditable` (composer focus)

## Why this shape

Welcome/multimodal chat already pastes via `FileUploadDropzone`. Room chat used a separate drop shell without paste. Extending that shell keeps one attach path for paperclip, drop, and paste across room / thread / draft surfaces.

## Verification

```bash
pnpm --filter web test 'src/app/(app)/chat/components/__tests__/room-file-drop-zone.test.tsx'
```

7/7 passed.

## Manual check

1. Open a room chat with attachments enabled
2. Copy an image, focus the composer, paste
3. Confirm upload toast and attachment chip; send and confirm markdown link
4. Paste plain text and confirm it still inserts into the composer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e0301d1-4a81-41ec-8ab6-e31e7a9392b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e0301d1-4a81-41ec-8ab6-e31e7a9392b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

