### PR TITLE
fix(chat): enable show formatting by default in room composer

### DIFF
--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -131,8 +131,8 @@ export function RoomComposer({
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linkInitialText, setLinkInitialText] = useState("");
   const [linkInitialUrl, setLinkInitialUrl] = useState("");
-  /** Slack Aa toggle: formatting strip above the editor. */
-  const [formatToolbarOpen, setFormatToolbarOpen] = useState(false);
+  /** Slack Aa toggle: formatting strip above the editor. Starts open by default. */
+  const [formatToolbarOpen, setFormatToolbarOpen] = useState(true);
   const [activeFormats, setActiveFormats] = useState<ComposerActiveFormats>(
     EMPTY_COMPOSER_ACTIVE_FORMATS,
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [SOK-681](https://linear.app/masumi/issue/SOK-681/enable-show-formatting-by-default-in-chat-composer).

- Room chat composer mounts with Show Formatting on (`formatToolbarOpen` defaults to `true`).
- Aa toggle still hides and shows the formatting strip.
- No persistence across sessions (remount resets to on).
- Scope: room/channel composers only; welcome/multimodal and toolbar contents unchanged.

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-681](https://linear.app/masumi/issue/SOK-681/enable-show-formatting-by-default-in-chat-composer)

<div><a href="https://cursor.com/agents/bc-53d9bdeb-6fdd-4fe9-8a2c-a0f71bbcc00c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53d9bdeb-6fdd-4fe9-8a2c-a0f71bbcc00c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

