### PR TITLE
fix(web): skip sidebar Cmd/Ctrl+B while typing

### DIFF
--- a/apps/web/src/app/(app)/components/history-search-dialog-provider.tsx
+++ b/apps/web/src/app/(app)/components/history-search-dialog-provider.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { HistorySearchDialog } from "@/app/components/history-search-dialog";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
+import { isEditableKeyboardTarget } from "@/lib/utils/is-editable-keyboard-target";
 
 interface HistorySearchContextValue {
   openHistorySearch: () => void;
@@ -53,12 +54,8 @@ export function HistorySearchDialogProvider({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const target = event.target;
-      if (target instanceof HTMLElement) {
-        const tag = target.tagName;
-        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
-          return;
-        }
+      if (isEditableKeyboardTarget(event.target)) {
+        return;
       }
 
       if (

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -7,6 +7,7 @@ import { PanelLeftIcon } from "lucide-react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { isEditableKeyboardTarget } from "@/lib/utils/is-editable-keyboard-target";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -100,6 +101,9 @@ function SidebarProvider({
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
         (event.metaKey || event.ctrlKey)
       ) {
+        if (isEditableKeyboardTarget(event.target)) {
+          return;
+        }
         event.preventDefault();
         toggleSidebar();
       }

--- a/apps/web/src/lib/utils/__tests__/is-editable-keyboard-target.test.ts
+++ b/apps/web/src/lib/utils/__tests__/is-editable-keyboard-target.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { isEditableKeyboardTarget } from "@/lib/utils/is-editable-keyboard-target";
+
+describe("isEditableKeyboardTarget", () => {
+  it("returns false for null and non-elements", () => {
+    expect(isEditableKeyboardTarget(null)).toBe(false);
+    expect(isEditableKeyboardTarget(document.createTextNode("x"))).toBe(false);
+  });
+
+  it("returns true for input, textarea, and select", () => {
+    expect(isEditableKeyboardTarget(document.createElement("input"))).toBe(
+      true,
+    );
+    expect(isEditableKeyboardTarget(document.createElement("textarea"))).toBe(
+      true,
+    );
+    expect(isEditableKeyboardTarget(document.createElement("select"))).toBe(
+      true,
+    );
+  });
+
+  it("returns true for contentEditable elements (chat composer)", () => {
+    const editor = document.createElement("div");
+    editor.contentEditable = "true";
+    expect(isEditableKeyboardTarget(editor)).toBe(true);
+  });
+
+  it("returns true for descendants of contentEditable", () => {
+    const editor = document.createElement("div");
+    editor.contentEditable = "true";
+    const child = document.createElement("strong");
+    editor.appendChild(child);
+    document.body.appendChild(editor);
+    expect(isEditableKeyboardTarget(child)).toBe(true);
+    editor.remove();
+  });
+
+  it("returns false for ordinary buttons and links", () => {
+    expect(isEditableKeyboardTarget(document.createElement("button"))).toBe(
+      false,
+    );
+    expect(isEditableKeyboardTarget(document.createElement("a"))).toBe(false);
+  });
+});

--- a/apps/web/src/lib/utils/is-editable-keyboard-target.ts
+++ b/apps/web/src/lib/utils/is-editable-keyboard-target.ts
@@ -1,8 +1,22 @@
-/**
- * Whether a keyboard event target is a text-editing surface.
- * Global shortcuts should skip these so editor bindings (e.g. Cmd+B bold) win.
- */
-export function isEditableKeyboardTarget(_target: EventTarget | null): boolean {
-  // Stub: failing repro before the editable-target guard lands.
+export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+    return true;
+  }
+
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  if (
+    target.closest('[contenteditable=""], [contenteditable="true"]') !== null
+  ) {
+    return true;
+  }
+
   return false;
 }

--- a/apps/web/src/lib/utils/is-editable-keyboard-target.ts
+++ b/apps/web/src/lib/utils/is-editable-keyboard-target.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether a keyboard event target is a text-editing surface.
+ * Global shortcuts should skip these so editor bindings (e.g. Cmd+B bold) win.
+ */
+export function isEditableKeyboardTarget(_target: EventTarget | null): boolean {
+  // Stub: failing repro before the editable-target guard lands.
+  return false;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cmd/Ctrl+B in chat was toggling the sidebar and fighting bold formatting.

**Cause.** Shadcn `SidebarProvider` listens on `window` for Meta/Ctrl+B and always toggles. Chat composers also bind the same chord for bold. `preventDefault` in the editor does not stop the window listener.

**Fix.** Skip the sidebar shortcut when the event target is an editable surface (`input` / `textarea` / `select` / `contenteditable`, including nested formatting). Same pattern history search already used for Cmd/Ctrl+K. Shared helper: `isEditableKeyboardTarget`. Shortcut stays `b` outside editors.

**Verification.**
- Failing then passing unit tests for the helper (commits ordered that way).
- Browser on `/chat`: Ctrl+B in the composer leaves the sidebar expanded; Ctrl+B on a non-editable target still collapses it.

![Composer Ctrl+B keeps sidebar expanded](https://cursor.com/artifacts/c/art-edf66ab4-0151-4df3-8a55-f81c8b182a63)
![Outside composer Ctrl+B still toggles sidebar](https://cursor.com/artifacts/c/art-ec607699-ee54-42b5-9b2a-66400bc518fa)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97cd6cd4-c67f-4ba0-b615-526ab195068c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97cd6cd4-c67f-4ba0-b615-526ab195068c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

