### PR TITLE
feat(chat): open images in an in-app viewer

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -762,6 +762,11 @@
       "placeholder": "Organisation auswählen",
       "search": "Organisationen suchen…",
       "empty": "Keine Organisationen gefunden."
+    },
+    "ImageViewer": {
+      "title": "Bild",
+      "viewImage": "Bild ansehen {fileName}",
+      "download": "Bild herunterladen"
     }
   },
   "Join": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "Bild",
       "viewImage": "Bild ansehen {fileName}",
-      "download": "Bild herunterladen"
+      "download": "Bild herunterladen",
+      "close": "Schließen"
     }
   },
   "Join": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -773,6 +773,11 @@
       "copy": "Copy",
       "copySuccess": "Copied to clipboard",
       "copyError": "Failed to copy"
+    },
+    "ImageViewer": {
+      "title": "Image",
+      "viewImage": "View image {fileName}",
+      "download": "Download image"
     }
   },
   "Join": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -777,7 +777,8 @@
     "ImageViewer": {
       "title": "Image",
       "viewImage": "View image {fileName}",
-      "download": "Download image"
+      "download": "Download image",
+      "close": "Close"
     }
   },
   "Join": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -762,6 +762,11 @@
       "placeholder": "Selecciona una organización",
       "search": "Buscar organizaciones…",
       "empty": "No se encontraron organizaciones."
+    },
+    "ImageViewer": {
+      "title": "Imagen",
+      "viewImage": "Ver imagen {fileName}",
+      "download": "Descargar imagen"
     }
   },
   "Join": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "Imagen",
       "viewImage": "Ver imagen {fileName}",
-      "download": "Descargar imagen"
+      "download": "Descargar imagen",
+      "close": "Cerrar"
     }
   },
   "Join": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "Image",
       "viewImage": "Voir l'image {fileName}",
-      "download": "Télécharger l'image"
+      "download": "Télécharger l'image",
+      "close": "Fermer"
     }
   },
   "Join": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -762,6 +762,11 @@
       "placeholder": "Sélectionner une organisation",
       "search": "Rechercher des organisations…",
       "empty": "Aucune organisation trouvée."
+    },
+    "ImageViewer": {
+      "title": "Image",
+      "viewImage": "Voir l'image {fileName}",
+      "download": "Télécharger l'image"
     }
   },
   "Join": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -762,6 +762,11 @@
       "placeholder": "Seleziona un'organizzazione",
       "search": "Cerca organizzazioni…",
       "empty": "Nessuna organizzazione trovata."
+    },
+    "ImageViewer": {
+      "title": "Immagine",
+      "viewImage": "Visualizza immagine {fileName}",
+      "download": "Scarica immagine"
     }
   },
   "Join": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "Immagine",
       "viewImage": "Visualizza immagine {fileName}",
-      "download": "Scarica immagine"
+      "download": "Scarica immagine",
+      "close": "Chiudi"
     }
   },
   "Join": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -762,6 +762,11 @@
       "placeholder": "組織を選択",
       "search": "組織を検索…",
       "empty": "組織が見つかりません。"
+    },
+    "ImageViewer": {
+      "title": "画像",
+      "viewImage": "画像を表示 {fileName}",
+      "download": "画像をダウンロード"
     }
   },
   "Join": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "画像",
       "viewImage": "画像を表示 {fileName}",
-      "download": "画像をダウンロード"
+      "download": "画像をダウンロード",
+      "close": "閉じる"
     }
   },
   "Join": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -762,6 +762,11 @@
       "placeholder": "Selecione uma organização",
       "search": "Pesquisar organizações…",
       "empty": "Nenhuma organização encontrada."
+    },
+    "ImageViewer": {
+      "title": "Imagem",
+      "viewImage": "Ver imagem {fileName}",
+      "download": "Baixar imagem"
     }
   },
   "Join": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "Imagem",
       "viewImage": "Ver imagem {fileName}",
-      "download": "Baixar imagem"
+      "download": "Baixar imagem",
+      "close": "Fechar"
     }
   },
   "Join": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -762,6 +762,11 @@
       "placeholder": "Selecione uma organização",
       "search": "Pesquisar organizações…",
       "empty": "Nenhuma organização encontrada."
+    },
+    "ImageViewer": {
+      "title": "Imagem",
+      "viewImage": "Ver imagem {fileName}",
+      "download": "Descarregar imagem"
     }
   },
   "Join": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "Imagem",
       "viewImage": "Ver imagem {fileName}",
-      "download": "Descarregar imagem"
+      "download": "Descarregar imagem",
+      "close": "Fechar"
     }
   },
   "Join": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -766,7 +766,8 @@
     "ImageViewer": {
       "title": "图片",
       "viewImage": "查看图片 {fileName}",
-      "download": "下载图片"
+      "download": "下载图片",
+      "close": "关闭"
     }
   },
   "Join": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -762,6 +762,11 @@
       "placeholder": "选择组织",
       "search": "搜索组织…",
       "empty": "未找到组织。"
+    },
+    "ImageViewer": {
+      "title": "图片",
+      "viewImage": "查看图片 {fileName}",
+      "download": "下载图片"
     }
   },
   "Join": {

--- a/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
@@ -16,6 +16,9 @@ vi.mock("next-intl", () => ({
     if (key === "download") {
       return "Download image";
     }
+    if (key === "close") {
+      return "Close";
+    }
     return key;
   },
 }));

--- a/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-generated-image-bubble.test.tsx
@@ -1,9 +1,24 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { stubPendingImageLoad } from "@/test/stub-pending-image-load";
 
 import { ChatGeneratedImageBubble } from "../chat-generated-image-bubble";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "viewImage") {
+      return `View image ${values?.fileName ?? ""}`;
+    }
+    if (key === "title") {
+      return "Image";
+    }
+    if (key === "download") {
+      return "Download image";
+    }
+    return key;
+  },
+}));
 
 describe("ChatGeneratedImageBubble", () => {
   stubPendingImageLoad();
@@ -90,5 +105,29 @@ describe("ChatGeneratedImageBubble", () => {
     });
 
     expect(link).toHaveAttribute("download", "generated-image.svg");
+  });
+
+  it("opens an image viewer when the loaded image is activated", () => {
+    render(
+      <ChatGeneratedImageBubble
+        alt="Generated image"
+        downloadLabel="Download generated image"
+        src="https://example.com/generated-image.png"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Generated image" });
+    fireEvent.load(image);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View image Generated image" }),
+    );
+
+    const viewer = screen.getByTestId("image-viewer");
+    expect(viewer).toBeInTheDocument();
+    expect(viewer.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/generated-image.png",
+    );
   });
 });

--- a/apps/web/src/components/chat/chat-generated-image-bubble.tsx
+++ b/apps/web/src/components/chat/chat-generated-image-bubble.tsx
@@ -131,6 +131,7 @@ export function ChatGeneratedImageBubble({
           alt={alt}
           title={t("title")}
           downloadLabel={downloadLabel}
+          closeLabel={t("close")}
           downloadFilename={getGeneratedImageDownloadFilename(src)}
         />
       ) : null}

--- a/apps/web/src/components/chat/chat-generated-image-bubble.tsx
+++ b/apps/web/src/components/chat/chat-generated-image-bubble.tsx
@@ -2,9 +2,11 @@
 
 import { getExtensionFromUrl } from "@sokosumi/utils";
 import { Download, ImageOff } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { ImageViewer } from "@/components/ui/image-viewer";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
@@ -52,9 +54,12 @@ export function ChatGeneratedImageBubble({
   downloadLabel,
   src,
 }: ChatGeneratedImageBubbleProps) {
+  const t = useTranslations("Components.ImageViewer");
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [isViewerOpen, setIsViewerOpen] = useState(false);
   const showSkeleton = !src || (!isLoaded && !hasError);
+  const canOpenViewer = Boolean(src) && !hasError && isLoaded;
 
   return (
     <figure className="not-prose my-3 w-full max-w-xl overflow-hidden rounded-xl border border-border bg-muted/20 shadow-sm">
@@ -67,21 +72,34 @@ export function ChatGeneratedImageBubble({
           </div>
         ) : null}
         {src ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            alt={alt}
+          <button
+            type="button"
             className={cn(
-              "size-full object-cover transition-opacity duration-300",
-              isLoaded && !hasError ? "opacity-100" : "opacity-0",
+              "absolute inset-0 block size-full disabled:cursor-default",
+              canOpenViewer ? "cursor-zoom-in" : null,
             )}
-            src={src}
-            onError={() => {
-              setHasError(true);
+            aria-label={t("viewImage", { fileName: alt })}
+            disabled={!canOpenViewer}
+            onClick={() => {
+              setIsViewerOpen(true);
             }}
-            onLoad={() => {
-              setIsLoaded(true);
-            }}
-          />
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              alt={alt}
+              className={cn(
+                "size-full object-cover transition-opacity duration-300",
+                isLoaded && !hasError ? "opacity-100" : "opacity-0",
+              )}
+              src={src}
+              onError={() => {
+                setHasError(true);
+              }}
+              onLoad={() => {
+                setIsLoaded(true);
+              }}
+            />
+          </button>
         ) : null}
         {hasError ? (
           <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
@@ -105,6 +123,17 @@ export function ChatGeneratedImageBubble({
           </Button>
         ) : null}
       </div>
+      {src && !hasError ? (
+        <ImageViewer
+          open={isViewerOpen}
+          onOpenChange={setIsViewerOpen}
+          src={src}
+          alt={alt}
+          title={t("title")}
+          downloadLabel={downloadLabel}
+          downloadFilename={getGeneratedImageDownloadFilename(src)}
+        />
+      ) : null}
     </figure>
   );
 }

--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -28,6 +28,9 @@ vi.mock("next-intl", () => ({
     if (key === "download") {
       return "Download image";
     }
+    if (key === "close") {
+      return "Close";
+    }
     return key;
   },
 }));

--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FileChipMiniPreview } from "../file-chip-mini-preview";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    src,
+  }: {
+    alt: string;
+    src: string;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "viewImage") {
+      return `View image ${values?.fileName ?? ""}`;
+    }
+    if (key === "title") {
+      return "Image";
+    }
+    if (key === "download") {
+      return "Download image";
+    }
+    return key;
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("FileChipMiniPreview", () => {
+  it("opens an image viewer instead of navigating away for image files", () => {
+    render(
+      <FileChipMiniPreview
+        url="https://blob.example.com/uploads/photo.png"
+        fileName="photo.png"
+        mediaType="image/png"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /photo\.png/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "View image photo.png" }));
+
+    expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Download image" }),
+    ).toHaveAttribute("href", "https://blob.example.com/uploads/photo.png");
+  });
+
+  it("keeps a download/open link for non-image files", () => {
+    render(
+      <FileChipMiniPreview
+        url="https://blob.example.com/uploads/notes.pdf"
+        fileName="notes.pdf"
+        mediaType="application/pdf"
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://blob.example.com/uploads/notes.pdf",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.queryByTestId("image-viewer")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/__tests__/image-viewer.test.tsx
+++ b/apps/web/src/components/ui/__tests__/image-viewer.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ImageViewer } from "../image-viewer";
 
 describe("ImageViewer", () => {
-  it("renders the image and download action when open", () => {
+  it("renders toolbar actions outside the image stage", () => {
     render(
       <ImageViewer
         open
@@ -13,15 +13,25 @@ describe("ImageViewer", () => {
         alt="Photo"
         title="View image"
         downloadLabel="Download image"
+        closeLabel="Close"
         downloadFilename="photo.png"
       />,
     );
 
     expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Photo" })).toHaveAttribute(
-      "src",
-      "https://example.com/photo.png",
+
+    const toolbar = screen.getByTestId("image-viewer-toolbar");
+    const stage = screen.getByTestId("image-viewer-stage");
+
+    expect(toolbar).toContainElement(
+      screen.getByRole("link", { name: "Download image" }),
     );
+    expect(toolbar).toContainElement(
+      screen.getByRole("button", { name: "Close" }),
+    );
+    expect(stage).toContainElement(screen.getByRole("img", { name: "Photo" }));
+    expect(stage.querySelector("a")).toBeNull();
+    expect(stage.querySelector("button")).toBeNull();
 
     const download = screen.getByRole("link", { name: "Download image" });
     expect(download).toHaveAttribute("href", "https://example.com/photo.png");
@@ -37,6 +47,7 @@ describe("ImageViewer", () => {
         alt="Photo"
         title="View image"
         downloadLabel="Download image"
+        closeLabel="Close"
       />,
     );
 

--- a/apps/web/src/components/ui/__tests__/image-viewer.test.tsx
+++ b/apps/web/src/components/ui/__tests__/image-viewer.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ImageViewer } from "../image-viewer";
+
+describe("ImageViewer", () => {
+  it("renders the image and download action when open", () => {
+    render(
+      <ImageViewer
+        open
+        onOpenChange={vi.fn()}
+        src="https://example.com/photo.png"
+        alt="Photo"
+        title="View image"
+        downloadLabel="Download image"
+        downloadFilename="photo.png"
+      />,
+    );
+
+    expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Photo" })).toHaveAttribute(
+      "src",
+      "https://example.com/photo.png",
+    );
+
+    const download = screen.getByRole("link", { name: "Download image" });
+    expect(download).toHaveAttribute("href", "https://example.com/photo.png");
+    expect(download).toHaveAttribute("download", "photo.png");
+  });
+
+  it("does not render dialog content when closed", () => {
+    render(
+      <ImageViewer
+        open={false}
+        onOpenChange={vi.fn()}
+        src="https://example.com/photo.png"
+        alt="Photo"
+        title="View image"
+        downloadLabel="Download image"
+      />,
+    );
+
+    expect(screen.queryByTestId("image-viewer")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -49,8 +49,11 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -63,10 +66,12 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {showCloseButton ? (
+          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        ) : null}
       </DialogPrimitive.Content>
     </DialogPortal>
   )

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -120,6 +120,7 @@ export function FileChipMiniPreview({
           alt={resolvedFileName}
           title={t("title")}
           downloadLabel={t("download")}
+          closeLabel={t("close")}
           downloadFilename={resolvedFileName}
         />
       ) : null}

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import Image from "next/image";
+import { getExtensionFromUrl, isImageUrl } from "@sokosumi/utils";
 import { X } from "lucide-react";
+import Image from "next/image";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
 
 import { FileTypeIcon } from "@/components/ui/file-icon";
+import { ImageViewer } from "@/components/ui/image-viewer";
 import {
   Tooltip,
   TooltipContent,
@@ -11,7 +15,6 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/utils/format-bytes";
-import {getExtensionFromUrl, isImageUrl} from "@sokosumi/utils";
 
 export interface FileChipMiniPreviewProps {
   url: string;
@@ -24,6 +27,9 @@ export interface FileChipMiniPreviewProps {
   removeLabel?: string;
 }
 
+const previewTriggerClassName =
+  "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 overflow-hidden rounded-xl border outline-none transition";
+
 export function FileChipMiniPreview({
   url,
   fileName,
@@ -34,6 +40,8 @@ export function FileChipMiniPreview({
   onRemove,
   removeLabel = "Remove file",
 }: FileChipMiniPreviewProps) {
+  const t = useTranslations("Components.ImageViewer");
+  const [isViewerOpen, setIsViewerOpen] = useState(false);
   const resolvedFileName = fileName ?? url.split("/").pop() ?? url;
   const isImage =
     mediaType?.toLowerCase().startsWith("image/") ||
@@ -46,33 +54,39 @@ export function FileChipMiniPreview({
     <div className={cn("not-prose relative inline-flex", className)}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <a
-            href={url}
-            target="_blank"
-            rel="noreferrer noopener"
-            className={cn(
-              "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 overflow-hidden rounded-xl border outline-none transition",
-              sizeClass,
-            )}
-          >
-            {isImage ? (
+          {isImage ? (
+            <button
+              type="button"
+              aria-label={t("viewImage", { fileName: resolvedFileName })}
+              className={cn(previewTriggerClassName, sizeClass)}
+              onClick={() => {
+                setIsViewerOpen(true);
+              }}
+            >
               <div className="relative size-full overflow-hidden">
-                  <Image
-                    src={url}
-                    alt={resolvedFileName}
-                    fill
-                    sizes="96px"
-                    className="object-cover object-center"
-                  />
+                <Image
+                  src={url}
+                  alt={resolvedFileName}
+                  fill
+                  sizes="96px"
+                  className="object-cover object-center"
+                />
               </div>
-            ) : (
+            </button>
+          ) : (
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className={cn(previewTriggerClassName, sizeClass)}
+            >
               <div className="text-muted-foreground flex size-full items-center justify-center">
                 <div className="flex size-8 items-center justify-center rounded-md">
                   <FileTypeIcon extension={extension || "file"} />
                 </div>
               </div>
-            )}
-          </a>
+            </a>
+          )}
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-64">
           <div className="flex flex-col">
@@ -97,6 +111,17 @@ export function FileChipMiniPreview({
           </TooltipTrigger>
           <TooltipContent side="top">{removeLabel}</TooltipContent>
         </Tooltip>
+      ) : null}
+      {isImage ? (
+        <ImageViewer
+          open={isViewerOpen}
+          onOpenChange={setIsViewerOpen}
+          src={url}
+          alt={resolvedFileName}
+          title={t("title")}
+          downloadLabel={t("download")}
+          downloadFilename={resolvedFileName}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/ui/image-viewer.tsx
+++ b/apps/web/src/components/ui/image-viewer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Download } from "lucide-react";
+import { Download, XIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -18,9 +19,13 @@ interface ImageViewerProps {
   alt: string;
   title: string;
   downloadLabel: string;
+  closeLabel: string;
   downloadFilename?: string;
   className?: string;
 }
+
+const toolbarActionClassName =
+  "size-9 rounded-full border border-border/80 bg-background text-foreground shadow-sm hover:bg-muted";
 
 export function ImageViewer({
   open,
@@ -29,30 +34,29 @@ export function ImageViewer({
   alt,
   title,
   downloadLabel,
+  closeLabel,
   downloadFilename,
   className,
 }: ImageViewerProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        showCloseButton={false}
         className={cn(
-          "bg-background/95 flex w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] flex-col gap-3 border-border/60 p-3 sm:p-4",
+          "flex w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] flex-col gap-0 overflow-hidden border-border/60 p-0",
           className,
         )}
         data-testid="image-viewer"
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">{alt}</DialogDescription>
-        <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-muted/30">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={src}
-            alt={alt}
-            className="max-h-[min(85dvh,48rem)] max-w-full object-contain"
-          />
+        <div
+          className="bg-background flex items-center justify-between gap-3 border-b border-border/60 px-3 py-2"
+          data-testid="image-viewer-toolbar"
+        >
           <Button
             asChild
-            className="absolute top-2 left-2 z-10 size-8 rounded-full border border-border/70 bg-background/85 text-foreground shadow-sm backdrop-blur hover:bg-background"
+            className={toolbarActionClassName}
             size="icon"
             variant="ghost"
           >
@@ -64,6 +68,28 @@ export function ImageViewer({
               <Download className="size-4" aria-hidden="true" />
             </a>
           </Button>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              aria-label={closeLabel}
+              className={toolbarActionClassName}
+              size="icon"
+              variant="ghost"
+            >
+              <XIcon className="size-4" aria-hidden="true" />
+            </Button>
+          </DialogClose>
+        </div>
+        <div
+          className="flex min-h-0 flex-1 items-center justify-center bg-muted/40 p-4 sm:p-6"
+          data-testid="image-viewer-stage"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={src}
+            alt={alt}
+            className="max-h-[min(80dvh,44rem)] max-w-full object-contain"
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/ui/image-viewer.tsx
+++ b/apps/web/src/components/ui/image-viewer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Download } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface ImageViewerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  src: string;
+  alt: string;
+  title: string;
+  downloadLabel: string;
+  downloadFilename?: string;
+  className?: string;
+}
+
+export function ImageViewer({
+  open,
+  onOpenChange,
+  src,
+  alt,
+  title,
+  downloadLabel,
+  downloadFilename,
+  className,
+}: ImageViewerProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          "bg-background/95 flex w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] flex-col gap-3 border-border/60 p-3 sm:p-4",
+          className,
+        )}
+        data-testid="image-viewer"
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">{alt}</DialogDescription>
+        <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-muted/30">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={src}
+            alt={alt}
+            className="max-h-[min(85dvh,48rem)] max-w-full object-contain"
+          />
+          <Button
+            asChild
+            className="absolute top-2 left-2 z-10 size-8 rounded-full border border-border/70 bg-background/85 text-foreground shadow-sm backdrop-blur hover:bg-background"
+            size="icon"
+            variant="ghost"
+          >
+            <a
+              aria-label={downloadLabel}
+              download={downloadFilename}
+              href={src}
+            >
+              <Download className="size-4" aria-hidden="true" />
+            </a>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chat images can be viewed in-app instead of being forced to download/open in a new tab.

- Click a chat image thumbnail → fullscreen dialog viewer
- Download remains available as an explicit action
- Non-image files keep their existing open/download behavior
- Shared `ImageViewer` also wired into generated image bubbles
- Action buttons sit in a top toolbar **outside** the image so they never cover content (common lightbox pattern)

## Changes

- Add `ImageViewer` dialog component with toolbar above the image stage
- Update `FileChipMiniPreview` so image attachments open the viewer
- Update `ChatGeneratedImageBubble` to use the same viewer
- Allow Dialog to hide the default overlay close button via `showCloseButton`
- Add i18n keys for the viewer
- Add unit tests covering viewer open behavior, toolbar actions, and non-image links

## Test plan

- [x] `pnpm --filter web test` on image viewer / file chip / generated image bubble tests
- [ ] Manually open a chat with an image attachment and confirm click opens viewer
- [ ] Confirm download/close controls are visible and do not overlap the image
- [ ] Confirm download still works from the viewer
- [ ] Confirm non-image attachments still download/open as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ab9e980-36bf-46a1-95f2-a626bb49fba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ab9e980-36bf-46a1-95f2-a626bb49fba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

