### PR TITLE
feat(chat): add GitHub emoji shortcode autocomplete to room composer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "dompurify": "3.4.12",
     "embla-carousel-react": "8.6.0",
     "fake-indexeddb": "6.2.5",
+    "gemoji": "8.1.0",
     "gravatar-url": "4.0.2",
     "happy-dom": "20.11.1",
     "humanize-duration": "3.34.0",

--- a/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
+++ b/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildMentionToken,
+  getActiveEmojiTrigger,
   getActiveTrigger,
   serializeEditorText,
   setEditorFromRaw,
@@ -57,5 +58,28 @@ describe("mention-textarea utils", () => {
       query: "wr",
       triggerStart: 6,
     });
+  });
+
+  it("activates emoji trigger for in-progress shortcode queries", () => {
+    expect(getActiveEmojiTrigger("Hello :gri", 10)).toEqual({
+      query: "gri",
+      triggerStart: 6,
+    });
+    expect(getActiveEmojiTrigger(":", 1)).toEqual({
+      query: "",
+      triggerStart: 0,
+    });
+  });
+
+  it("does not activate emoji trigger on space, @, or mid-token colon", () => {
+    expect(getActiveEmojiTrigger(":gri ", 5)).toBeNull();
+    expect(getActiveEmojiTrigger(":@user", 6)).toBeNull();
+    expect(getActiveEmojiTrigger(":smile:", 7)).toBeNull();
+    expect(getActiveEmojiTrigger("a:smile", 7)).toBeNull();
+  });
+
+  it("keeps mention trigger rejecting queries that contain colon", () => {
+    const text = "@agent-1:writer-agent";
+    expect(getActiveTrigger(text, text.length)).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/__tests__/composer-suggestions.test.ts
+++ b/apps/web/src/components/chat/__tests__/composer-suggestions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveComposerSuggestion } from "@/components/chat/composer-suggestions";
+
+describe("resolveComposerSuggestion", () => {
+  it("prefers mention when @ trigger is active", () => {
+    expect(
+      resolveComposerSuggestion("Hello @wr", 9, { mentionsAvailable: true }),
+    ).toEqual({
+      kind: "mention",
+      query: "wr",
+      triggerStart: 6,
+    });
+  });
+
+  it("does not treat serialized mention tokens as mention or emoji", () => {
+    const text = "@agent-id:slug ";
+    expect(
+      resolveComposerSuggestion(text, text.length, { mentionsAvailable: true }),
+    ).toBeNull();
+  });
+
+  it("resolves emoji shortcode when mentions unavailable", () => {
+    const result = resolveComposerSuggestion("hi :smi", 7, {
+      mentionsAvailable: false,
+    });
+    expect(result?.kind).toBe("emoji");
+    if (result?.kind === "emoji") {
+      expect(result.query).toBe("smi");
+      expect(result.triggerStart).toBe(3);
+      expect(result.matches.length).toBeGreaterThan(0);
+      expect(result.matches.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("resolves bare colon to capped emoji list", () => {
+    const result = resolveComposerSuggestion(":", 1, {
+      mentionsAvailable: false,
+    });
+    expect(result?.kind).toBe("emoji");
+    if (result?.kind === "emoji") {
+      expect(result.query).toBe("");
+      expect(result.matches.length).toBeGreaterThan(0);
+      expect(result.matches.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("skips mention branch when mentionsAvailable is false", () => {
+    expect(
+      resolveComposerSuggestion("@al", 3, { mentionsAvailable: false }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/__tests__/composer-suggestions.test.ts
+++ b/apps/web/src/components/chat/__tests__/composer-suggestions.test.ts
@@ -33,6 +33,19 @@ describe("resolveComposerSuggestion", () => {
     }
   });
 
+  it("resolves emoji shortcode when mention catalog exists but caret is on :", () => {
+    const result = resolveComposerSuggestion("hi :smi", 7, {
+      mentionsAvailable: true,
+    });
+    expect(result?.kind).toBe("emoji");
+    if (result?.kind === "emoji") {
+      expect(result.query).toBe("smi");
+      expect(result.matches.some((match) => match.name.includes("smi"))).toBe(
+        true,
+      );
+    }
+  });
+
   it("resolves bare colon to capped emoji list", () => {
     const result = resolveComposerSuggestion(":", 1, {
       mentionsAvailable: false,

--- a/apps/web/src/components/chat/composer-suggestions.ts
+++ b/apps/web/src/components/chat/composer-suggestions.ts
@@ -1,0 +1,61 @@
+import {
+  getActiveEmojiTrigger,
+  getActiveTrigger,
+} from "@/components/ui/mention-textarea-utils";
+import {
+  EMOJI_RESULT_CAP,
+  type EmojiShortcodeMatch,
+  filterEmojiShortcodes,
+} from "@/lib/utils/emoji-shortcodes";
+
+export type ComposerSuggestion =
+  | {
+      kind: "mention";
+      query: string;
+      triggerStart: number;
+    }
+  | {
+      kind: "emoji";
+      query: string;
+      triggerStart: number;
+      matches: EmojiShortcodeMatch[];
+    };
+
+export interface ComposerSuggestionContext {
+  /** When false, skip mention branch (no mention catalog). */
+  mentionsAvailable: boolean;
+}
+
+/**
+ * Which autocomplete (if any) is active at caret.
+ * Mutual exclusion: mention first when catalog exists, else emoji.
+ */
+export function resolveComposerSuggestion(
+  text: string,
+  caret: number,
+  context: ComposerSuggestionContext,
+): ComposerSuggestion | null {
+  if (context.mentionsAvailable) {
+    const mention = getActiveTrigger(text, caret);
+    if (mention) {
+      return {
+        kind: "mention",
+        query: mention.query,
+        triggerStart: mention.triggerStart,
+      };
+    }
+  }
+
+  const emojiTrigger = getActiveEmojiTrigger(text, caret);
+  if (!emojiTrigger) return null;
+
+  const matches = filterEmojiShortcodes(emojiTrigger.query, EMOJI_RESULT_CAP);
+  if (matches.length === 0) return null;
+
+  return {
+    kind: "emoji",
+    query: emojiTrigger.query,
+    triggerStart: emojiTrigger.triggerStart,
+    matches,
+  };
+}

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -12,9 +12,14 @@ import {
 import { createPortal } from "react-dom";
 
 import {
+  type ComposerSuggestion,
+  resolveComposerSuggestion,
+} from "@/components/chat/composer-suggestions";
+import {
   createMentionSpan,
   deslugifyMentionSlug,
   findPositionForOffset,
+  getActiveEmojiTrigger,
   getActiveTrigger,
   getCaretRect,
   getPopupPositionFromRect,
@@ -44,8 +49,21 @@ import {
   resolveComposerEnterAction,
   tryApplyComposerInputRuleAtCaret,
 } from "@/lib/utils/composer-wysiwyg-input-rules";
+import {
+  type EmojiShortcodeMatch,
+  matchExactEmojiShortcodeClosed,
+} from "@/lib/utils/emoji-shortcodes";
 import { normalizeUrl } from "@/lib/utils/markdown-editor-utils";
 import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
+
+type SuggestionUiState =
+  | { open: false }
+  | {
+      open: true;
+      suggestion: ComposerSuggestion;
+      position: TriggerPosition;
+      activeIndex: number;
+    };
 
 export interface ComposerWysiwygEditorHandle {
   focus: () => void;
@@ -138,11 +156,9 @@ export function ComposerWysiwygEditor<TData = unknown>({
   const manualMentionOpenRef = useRef(false);
   const onActiveFormatsChangeRef = useRef(onActiveFormatsChange);
   onActiveFormatsChangeRef.current = onActiveFormatsChange;
-  const [isOpen, setIsOpen] = useState(false);
-  const [query, setQuery] = useState<string | null>(null);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [triggerPosition, setTriggerPosition] =
-    useState<TriggerPosition | null>(null);
+  const [suggestionUi, setSuggestionUi] = useState<SuggestionUiState>({
+    open: false,
+  });
 
   const normalizedMentions = useMemo(() => {
     const entries = Object.entries(mentions);
@@ -204,13 +220,33 @@ export function ComposerWysiwygEditor<TData = unknown>({
     [keyToValue, slugToValue],
   );
 
+  const mentionQuery =
+    suggestionUi.open && suggestionUi.suggestion.kind === "mention"
+      ? suggestionUi.suggestion.query
+      : null;
+
   const filteredMentions = useMemo(() => {
-    if (query === null || query === "") return normalizedMentions;
-    const normalizedQuery = query.toLowerCase();
+    if (mentionQuery === null) return [];
+    if (mentionQuery === "") return normalizedMentions;
+    const normalizedQuery = mentionQuery.toLowerCase();
     return normalizedMentions.filter((mention) =>
       mention.value.toLowerCase().includes(normalizedQuery),
     );
-  }, [normalizedMentions, query]);
+  }, [mentionQuery, normalizedMentions]);
+
+  const emojiMatches =
+    suggestionUi.open && suggestionUi.suggestion.kind === "emoji"
+      ? suggestionUi.suggestion.matches
+      : [];
+
+  const activeIndex = suggestionUi.open ? suggestionUi.activeIndex : 0;
+  const triggerPosition = suggestionUi.open ? suggestionUi.position : null;
+  const suggestionKind = suggestionUi.open
+    ? suggestionUi.suggestion.kind
+    : null;
+  const isOpen = suggestionUi.open;
+  const visibleSuggestionCount =
+    suggestionKind === "emoji" ? emojiMatches.length : filteredMentions.length;
 
   const selectedKeys = useMemo(() => {
     const parsed = parseMentions(value);
@@ -247,28 +283,35 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
   const openSuggestions = useCallback(
     ({
-      nextQuery,
+      suggestion,
       nextTriggerPosition,
       nextActiveIndex = 0,
     }: {
-      nextQuery: string;
-      nextTriggerPosition: TriggerPosition | null;
+      suggestion: ComposerSuggestion;
+      nextTriggerPosition: TriggerPosition;
       nextActiveIndex?: number;
     }) => {
-      setQuery(nextQuery);
-      setIsOpen(true);
-      setActiveIndex(nextActiveIndex);
-      setTriggerPosition(nextTriggerPosition);
+      setSuggestionUi({
+        open: true,
+        suggestion,
+        position: nextTriggerPosition,
+        activeIndex: nextActiveIndex,
+      });
     },
     [],
   );
 
   const closeSuggestions = useCallback(() => {
-    setIsOpen(false);
-    setQuery(null);
-    setActiveIndex(0);
-    setTriggerPosition(null);
+    setSuggestionUi({ open: false });
     manualMentionOpenRef.current = false;
+  }, []);
+
+  const getSuggestionPopupPosition = useCallback((editor: HTMLElement) => {
+    const caretRect = getCaretRect(editor);
+    const fallbackRect = editor.getBoundingClientRect();
+    return caretRect
+      ? getPopupPositionFromRect(caretRect)
+      : getPopupPositionFromRect(fallbackRect);
   }, []);
 
   const syncFromEditor = useCallback(() => {
@@ -311,35 +354,52 @@ export function ComposerWysiwygEditor<TData = unknown>({
     const { text, caret } = syncFromEditor();
     publishActiveFormats();
 
+    const exactEmoji = matchExactEmojiShortcodeClosed(text, caret);
+    if (exactEmoji) {
+      const startPos = findPositionForOffset(
+        editorRef.current,
+        exactEmoji.triggerStart,
+      );
+      const endPos = findPositionForOffset(editorRef.current, exactEmoji.end);
+      const range = document.createRange();
+      range.setStart(startPos.node, startPos.offset);
+      range.setEnd(endPos.node, endPos.offset);
+      range.deleteContents();
+
+      const nextChar = text[exactEmoji.end];
+      const insert = shouldAppendTrailingSpace(nextChar)
+        ? `${exactEmoji.emoji} `
+        : exactEmoji.emoji;
+      const textNode = document.createTextNode(insert);
+      range.insertNode(textNode);
+      setCaretAfterNode(editorRef.current, textNode);
+      isInternalChange.current = true;
+      syncFromEditor();
+      closeSuggestions();
+      return;
+    }
+
     if (manualMentionOpenRef.current && normalizedMentions.length > 0) {
-      const caretRect = getCaretRect(editorRef.current);
-      const fallbackRect = editorRef.current.getBoundingClientRect();
-      const position = caretRect
-        ? getPopupPositionFromRect(caretRect)
-        : getPopupPositionFromRect(fallbackRect);
       openSuggestions({
-        nextQuery: "",
-        nextTriggerPosition: position,
+        suggestion: {
+          kind: "mention",
+          query: "",
+          triggerStart: caret,
+        },
+        nextTriggerPosition: getSuggestionPopupPosition(editorRef.current),
         nextActiveIndex: 0,
       });
       return;
     }
 
-    if (normalizedMentions.length === 0) {
-      closeSuggestions();
-      return;
-    }
+    const suggestion = resolveComposerSuggestion(text, caret, {
+      mentionsAvailable: normalizedMentions.length > 0,
+    });
 
-    const trigger = getActiveTrigger(text, caret);
-    if (trigger) {
-      const caretRect = getCaretRect(editorRef.current);
-      const fallbackRect = editorRef.current.getBoundingClientRect();
-      const position = caretRect
-        ? getPopupPositionFromRect(caretRect)
-        : getPopupPositionFromRect(fallbackRect);
+    if (suggestion) {
       openSuggestions({
-        nextQuery: trigger.query,
-        nextTriggerPosition: position,
+        suggestion,
+        nextTriggerPosition: getSuggestionPopupPosition(editorRef.current),
         nextActiveIndex: 0,
       });
       return;
@@ -348,6 +408,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
     closeSuggestions();
   }, [
     closeSuggestions,
+    getSuggestionPopupPosition,
     normalizedMentions.length,
     openSuggestions,
     publishActiveFormats,
@@ -416,6 +477,42 @@ export function ComposerWysiwygEditor<TData = unknown>({
       editorRef.current.focus();
     },
     [closeSuggestions, resolveMentionDisplay, syncFromEditor],
+  );
+
+  const insertEmojiShortcode = useCallback(
+    (match: EmojiShortcodeMatch) => {
+      if (!editorRef.current) return;
+
+      const { text, caret } = serializeEditor(editorRef.current);
+      const trigger = getActiveEmojiTrigger(text, caret);
+      if (!trigger) {
+        closeSuggestions();
+        return;
+      }
+
+      const startPos = findPositionForOffset(
+        editorRef.current,
+        trigger.triggerStart,
+      );
+      const endPos = findPositionForOffset(editorRef.current, caret);
+      const range = document.createRange();
+      range.setStart(startPos.node, startPos.offset);
+      range.setEnd(endPos.node, endPos.offset);
+      range.deleteContents();
+
+      const nextChar = text[caret];
+      const insert = shouldAppendTrailingSpace(nextChar)
+        ? `${match.emoji} `
+        : match.emoji;
+      const textNode = document.createTextNode(insert);
+      range.insertNode(textNode);
+      setCaretAfterNode(editorRef.current, textNode);
+      isInternalChange.current = true;
+      syncFromEditor();
+      closeSuggestions();
+      editorRef.current.focus();
+    },
+    [closeSuggestions, syncFromEditor],
   );
 
   const execCommand = useCallback(
@@ -559,51 +656,72 @@ export function ComposerWysiwygEditor<TData = unknown>({
     if (!editor) return;
     editor.focus();
     manualMentionOpenRef.current = true;
-    const caretRect = getCaretRect(editor);
-    const fallbackRect = editor.getBoundingClientRect();
-    const position = caretRect
-      ? getPopupPositionFromRect(caretRect)
-      : getPopupPositionFromRect(fallbackRect);
     openSuggestions({
-      nextQuery: "",
-      nextTriggerPosition: position,
+      suggestion: {
+        kind: "mention",
+        query: "",
+        triggerStart: serializeEditor(editor).caret,
+      },
+      nextTriggerPosition: getSuggestionPopupPosition(editor),
       nextActiveIndex: 0,
     });
-  }, [openSuggestions]);
+  }, [getSuggestionPopupPosition, openSuggestions]);
 
-  const getCurrentTriggerAtCaret = useCallback(() => {
+  const getLiveSuggestionAtCaret = useCallback(() => {
     if (!editorRef.current) return null;
+    if (manualMentionOpenRef.current && normalizedMentions.length > 0) {
+      return {
+        kind: "mention" as const,
+        query: "",
+        triggerStart: 0,
+      };
+    }
     const { text, caret } = serializeEditor(editorRef.current);
-    return getActiveTrigger(text, caret);
-  }, []);
+    return resolveComposerSuggestion(text, caret, {
+      mentionsAvailable: normalizedMentions.length > 0,
+    });
+  }, [normalizedMentions.length]);
 
-  const syncMentionSuggestionsWithCaret = useCallback(() => {
+  const syncSuggestionsWithCaret = useCallback(() => {
     publishActiveFormats();
-    if (!isOpen) return;
+    if (!suggestionUi.open) return;
     if (manualMentionOpenRef.current) return;
-    const trigger = getCurrentTriggerAtCaret();
-    if (!trigger) {
+    const live = getLiveSuggestionAtCaret();
+    if (!live || live.kind !== suggestionKind) {
       closeSuggestions();
     }
   }, [
     closeSuggestions,
-    getCurrentTriggerAtCaret,
-    isOpen,
+    getLiveSuggestionAtCaret,
     publishActiveFormats,
+    suggestionKind,
+    suggestionUi.open,
   ]);
+
+  const setActiveSuggestionIndex = useCallback(
+    (updater: (prev: number) => number) => {
+      setSuggestionUi((prev) => {
+        if (!prev.open) return prev;
+        return { ...prev, activeIndex: updater(prev.activeIndex) };
+      });
+    },
+    [],
+  );
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       const key = event.key.toLowerCase();
       const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
-      const currentTrigger = getCurrentTriggerAtCaret();
-      const isMentionDropdownVisible = isOpen && filteredMentions.length > 0;
-      const isCaretOnMentionTrigger =
-        Boolean(currentTrigger) || manualMentionOpenRef.current;
-      const isMentionKeyboardActive =
-        isMentionDropdownVisible && isCaretOnMentionTrigger;
+      const liveSuggestion = getLiveSuggestionAtCaret();
+      const isDropdownVisible = isOpen && visibleSuggestionCount > 0;
+      const isCaretOnLiveTrigger =
+        Boolean(liveSuggestion) || manualMentionOpenRef.current;
+      const isSuggestionKeyboardActive =
+        isDropdownVisible &&
+        isCaretOnLiveTrigger &&
+        liveSuggestion?.kind === suggestionKind;
 
-      if (isMentionKeyboardActive && !hasModifier) {
+      if (isSuggestionKeyboardActive && !hasModifier) {
         if (key === "escape") {
           event.preventDefault();
           closeSuggestions();
@@ -612,16 +730,16 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
         if (key === "arrowdown") {
           event.preventDefault();
-          setActiveIndex((prev) =>
-            prev + 1 < filteredMentions.length ? prev + 1 : 0,
+          setActiveSuggestionIndex((prev) =>
+            prev + 1 < visibleSuggestionCount ? prev + 1 : 0,
           );
           return;
         }
 
         if (key === "arrowup") {
           event.preventDefault();
-          setActiveIndex((prev) =>
-            prev - 1 >= 0 ? prev - 1 : filteredMentions.length - 1,
+          setActiveSuggestionIndex((prev) =>
+            prev - 1 >= 0 ? prev - 1 : visibleSuggestionCount - 1,
           );
           return;
         }
@@ -629,9 +747,12 @@ export function ComposerWysiwygEditor<TData = unknown>({
         if (key === "enter" || key === "tab") {
           if (event.nativeEvent.isComposing) return;
           event.preventDefault();
-          const mention = filteredMentions[activeIndex];
-          if (mention) {
-            insertMention(mention);
+          if (suggestionKind === "emoji") {
+            const match = emojiMatches[activeIndex];
+            if (match) insertEmojiShortcode(match);
+          } else {
+            const mention = filteredMentions[activeIndex];
+            if (mention) insertMention(mention);
           }
           return;
         }
@@ -671,7 +792,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
           shiftKey: event.shiftKey,
           metaKey: event.metaKey,
           ctrlKey: event.ctrlKey,
-          isMentionKeyboardActive,
+          isSuggestionKeyboardActive,
         });
 
         if (action === "ignore") return;
@@ -694,13 +815,18 @@ export function ComposerWysiwygEditor<TData = unknown>({
       activeIndex,
       applyFormat,
       closeSuggestions,
+      emojiMatches,
       filteredMentions,
-      getCurrentTriggerAtCaret,
+      getLiveSuggestionAtCaret,
       handleInput,
+      insertEmojiShortcode,
       insertMention,
       isOpen,
       onLinkShortcut,
       onSubmitShortcut,
+      setActiveSuggestionIndex,
+      suggestionKind,
+      visibleSuggestionCount,
     ],
   );
 
@@ -804,8 +930,8 @@ export function ComposerWysiwygEditor<TData = unknown>({
         suppressContentEditableWarning
         onInput={handleInput}
         onKeyDown={handleKeyDown}
-        onKeyUp={syncMentionSuggestionsWithCaret}
-        onMouseUp={syncMentionSuggestionsWithCaret}
+        onKeyUp={syncSuggestionsWithCaret}
+        onMouseUp={syncSuggestionsWithCaret}
         onBlur={handleBlur}
         data-placeholder={placeholder}
         role="textbox"
@@ -820,7 +946,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
       />
       {typeof window !== "undefined" &&
         isOpen &&
-        filteredMentions.length > 0 &&
+        visibleSuggestionCount > 0 &&
         createPortal(
           <div
             ref={listRef}
@@ -835,37 +961,68 @@ export function ComposerWysiwygEditor<TData = unknown>({
               !triggerPosition && "mt-1",
             )}
           >
-            {filteredMentions.map((mention, index) => (
-              <div
-                key={mention.key}
-                data-index={index}
-                role="option"
-                aria-selected={index === activeIndex}
-                className={cn(
-                  "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
-                  index === activeIndex && "bg-accent text-accent-foreground",
-                )}
-                onMouseDown={() => {
-                  isSelectingRef.current = true;
-                }}
-                onClick={() => {
-                  insertMention(mention);
-                  isSelectingRef.current = false;
-                }}
-                onMouseEnter={() => setActiveIndex(index)}
-              >
-                {renderMentionItem ? (
-                  renderMentionItem(mention, index === activeIndex)
-                ) : (
-                  <>
-                    <div className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                      {mention.value.charAt(0).toUpperCase()}
-                    </div>
-                    <span className="truncate">{mention.value}</span>
-                  </>
-                )}
-              </div>
-            ))}
+            {suggestionKind === "emoji"
+              ? emojiMatches.map((match, index) => (
+                  <div
+                    key={match.name}
+                    data-index={index}
+                    role="option"
+                    aria-selected={index === activeIndex}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+                      index === activeIndex &&
+                        "bg-accent text-accent-foreground",
+                    )}
+                    onMouseDown={() => {
+                      isSelectingRef.current = true;
+                    }}
+                    onClick={() => {
+                      insertEmojiShortcode(match);
+                      isSelectingRef.current = false;
+                    }}
+                    onMouseEnter={() => setActiveSuggestionIndex(() => index)}
+                  >
+                    <span
+                      className="size-6 shrink-0 text-center text-base leading-6"
+                      aria-hidden
+                    >
+                      {match.emoji}
+                    </span>
+                    <span className="truncate">:{match.name}:</span>
+                  </div>
+                ))
+              : filteredMentions.map((mention, index) => (
+                  <div
+                    key={mention.key}
+                    data-index={index}
+                    role="option"
+                    aria-selected={index === activeIndex}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+                      index === activeIndex &&
+                        "bg-accent text-accent-foreground",
+                    )}
+                    onMouseDown={() => {
+                      isSelectingRef.current = true;
+                    }}
+                    onClick={() => {
+                      insertMention(mention);
+                      isSelectingRef.current = false;
+                    }}
+                    onMouseEnter={() => setActiveSuggestionIndex(() => index)}
+                  >
+                    {renderMentionItem ? (
+                      renderMentionItem(mention, index === activeIndex)
+                    ) : (
+                      <>
+                        <div className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                          {mention.value.charAt(0).toUpperCase()}
+                        </div>
+                        <span className="truncate">{mention.value}</span>
+                      </>
+                    )}
+                  </div>
+                ))}
           </div>,
           document.body,
         )}

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -684,18 +684,43 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
   const syncSuggestionsWithCaret = useCallback(() => {
     publishActiveFormats();
-    if (!suggestionUi.open) return;
+    if (!suggestionUi.open || !editorRef.current) return;
     if (manualMentionOpenRef.current) return;
+
     const live = getLiveSuggestionAtCaret();
     if (!live || live.kind !== suggestionKind) {
       closeSuggestions();
+      return;
     }
+
+    const listLength =
+      live.kind === "emoji"
+        ? live.matches.length
+        : live.query === ""
+          ? normalizedMentions.length
+          : normalizedMentions.filter((mention) =>
+              mention.value.toLowerCase().includes(live.query.toLowerCase()),
+            ).length;
+
+    if (listLength === 0) {
+      closeSuggestions();
+      return;
+    }
+
+    openSuggestions({
+      suggestion: live,
+      nextTriggerPosition: getSuggestionPopupPosition(editorRef.current),
+      nextActiveIndex: Math.min(suggestionUi.activeIndex, listLength - 1),
+    });
   }, [
     closeSuggestions,
     getLiveSuggestionAtCaret,
+    getSuggestionPopupPosition,
+    normalizedMentions,
+    openSuggestions,
     publishActiveFormats,
     suggestionKind,
-    suggestionUi.open,
+    suggestionUi,
   ]);
 
   const setActiveSuggestionIndex = useCallback(
@@ -712,22 +737,17 @@ export function ComposerWysiwygEditor<TData = unknown>({
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       const key = event.key.toLowerCase();
       const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
-      const liveSuggestion = getLiveSuggestionAtCaret();
       const isDropdownVisible = isOpen && visibleSuggestionCount > 0;
-      const isCaretOnLiveTrigger =
-        Boolean(liveSuggestion) || manualMentionOpenRef.current;
-      const isSuggestionKeyboardActive =
-        isDropdownVisible &&
-        isCaretOnLiveTrigger &&
-        liveSuggestion?.kind === suggestionKind;
 
-      if (isSuggestionKeyboardActive && !hasModifier) {
-        if (key === "escape") {
-          event.preventDefault();
-          closeSuggestions();
-          return;
-        }
+      // Escape always dismisses while the popup is open, even if caret left the
+      // trigger (selectionchange may lag behind the key event).
+      if (isOpen && !hasModifier && key === "escape") {
+        event.preventDefault();
+        closeSuggestions();
+        return;
+      }
 
+      if (isDropdownVisible && !hasModifier) {
         if (key === "arrowdown") {
           event.preventDefault();
           setActiveSuggestionIndex((prev) =>
@@ -792,7 +812,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
           shiftKey: event.shiftKey,
           metaKey: event.metaKey,
           ctrlKey: event.ctrlKey,
-          isSuggestionKeyboardActive,
+          isSuggestionKeyboardActive: isDropdownVisible,
         });
 
         if (action === "ignore") return;
@@ -817,7 +837,6 @@ export function ComposerWysiwygEditor<TData = unknown>({
       closeSuggestions,
       emojiMatches,
       filteredMentions,
-      getLiveSuggestionAtCaret,
       handleInput,
       insertEmojiShortcode,
       insertMention,

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -377,6 +377,35 @@ export function getActiveTrigger(
   return { query, triggerStart: tokenStart };
 }
 
+const EMOJI_SHORTCODE_QUERY_PATTERN = /^[a-z0-9_+-]*$/i;
+
+/**
+ * Detect in-progress emoji shortcode at caret.
+ * Token is start/whitespace-delimited, leading `:`, query = [a-z0-9_+-]*.
+ * Does not share logic with getActiveTrigger (mentions keep rejecting `:`).
+ */
+export function getActiveEmojiTrigger(
+  text: string,
+  caret: number,
+): { query: string; triggerStart: number } | null {
+  const clampedCaret = Math.max(0, Math.min(caret, text.length));
+  if (clampedCaret === 0) return null;
+
+  let tokenStart = clampedCaret;
+  while (tokenStart > 0 && !isWhitespaceChar(text[tokenStart - 1] ?? "")) {
+    tokenStart -= 1;
+  }
+
+  if (tokenStart === clampedCaret) return null;
+  if (text[tokenStart] !== ":") return null;
+
+  const query = text.slice(tokenStart + 1, clampedCaret);
+  if (query.includes("@") || query.includes(":")) return null;
+  if (!EMOJI_SHORTCODE_QUERY_PATTERN.test(query)) return null;
+
+  return { query: query.toLowerCase(), triggerStart: tokenStart };
+}
+
 export function getPopupPositionFromRect(rect: DOMRect): TriggerPosition {
   // Measure against the visual viewport so an open virtual keyboard counts as
   // unavailable space. `interactiveWidget: "resizes-content"` shrinks the

--- a/apps/web/src/lib/utils/__tests__/composer-wysiwyg-input-rules.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-wysiwyg-input-rules.test.ts
@@ -44,7 +44,7 @@ describe("resolveComposerEnterAction", () => {
         shiftKey: false,
         metaKey: false,
         ctrlKey: false,
-        isMentionKeyboardActive: false,
+        isSuggestionKeyboardActive: false,
       }),
     ).toBe("submit");
   });
@@ -56,7 +56,7 @@ describe("resolveComposerEnterAction", () => {
         shiftKey: true,
         metaKey: false,
         ctrlKey: false,
-        isMentionKeyboardActive: false,
+        isSuggestionKeyboardActive: false,
       }),
     ).toBe("newline");
     expect(
@@ -65,7 +65,7 @@ describe("resolveComposerEnterAction", () => {
         shiftKey: false,
         metaKey: true,
         ctrlKey: false,
-        isMentionKeyboardActive: false,
+        isSuggestionKeyboardActive: false,
       }),
     ).toBe("newline");
     expect(
@@ -74,19 +74,19 @@ describe("resolveComposerEnterAction", () => {
         shiftKey: false,
         metaKey: false,
         ctrlKey: false,
-        isMentionKeyboardActive: false,
+        isSuggestionKeyboardActive: false,
       }),
     ).toBe("newline");
   });
 
-  it("ignores Enter while mention keyboard is active", () => {
+  it("ignores Enter while suggestion keyboard is active", () => {
     expect(
       resolveComposerEnterAction({
         isNarrowViewport: false,
         shiftKey: false,
         metaKey: false,
         ctrlKey: false,
-        isMentionKeyboardActive: true,
+        isSuggestionKeyboardActive: true,
       }),
     ).toBe("ignore");
   });

--- a/apps/web/src/lib/utils/__tests__/emoji-shortcodes.test.ts
+++ b/apps/web/src/lib/utils/__tests__/emoji-shortcodes.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterEmojiShortcodes,
+  matchExactEmojiShortcodeClosed,
+} from "@/lib/utils/emoji-shortcodes";
+
+describe("filterEmojiShortcodes", () => {
+  it("returns stable alphabetical top-N for empty query", () => {
+    const results = filterEmojiShortcodes("", 5);
+    expect(results).toHaveLength(5);
+    const names = results.map((row) => row.name);
+    expect(names).toEqual([...names].toSorted((a, b) => a.localeCompare(b)));
+    expect(results.every((row) => row.emoji.length > 0)).toBe(true);
+  });
+
+  it("prefers prefix matches before includes and caps results", () => {
+    const results = filterEmojiShortcodes("thumb", 20);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBeLessThanOrEqual(20);
+
+    const firstNonPrefix = results.findIndex(
+      (row) => !row.name.startsWith("thumb"),
+    );
+    if (firstNonPrefix >= 0) {
+      expect(
+        results
+          .slice(0, firstNonPrefix)
+          .every((row) => row.name.startsWith("thumb")),
+      ).toBe(true);
+      expect(
+        results
+          .slice(firstNonPrefix)
+          .every((row) => row.name.includes("thumb")),
+      ).toBe(true);
+    } else {
+      expect(results.every((row) => row.name.startsWith("thumb"))).toBe(true);
+    }
+  });
+
+  it("matches known shortcodes like smile", () => {
+    const results = filterEmojiShortcodes("smile", 20);
+    const smile = results.find((row) => row.name === "smile");
+    expect(smile?.emoji).toBeTruthy();
+  });
+
+  it("respects an explicit cap", () => {
+    expect(filterEmojiShortcodes("", 3)).toHaveLength(3);
+    expect(filterEmojiShortcodes("a", 2).length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("matchExactEmojiShortcodeClosed", () => {
+  it("returns unicode for exact :name: at caret", () => {
+    const text = "hi :smile:";
+    expect(matchExactEmojiShortcodeClosed(text, text.length)).toEqual({
+      triggerStart: 3,
+      end: text.length,
+      emoji: expect.any(String),
+    });
+    expect(
+      matchExactEmojiShortcodeClosed(text, text.length)?.emoji,
+    ).toBeTruthy();
+  });
+
+  it("returns null for unknown or incomplete shortcodes", () => {
+    expect(
+      matchExactEmojiShortcodeClosed(":not_a_real_emoji_xyz:", 22),
+    ).toBeNull();
+    expect(matchExactEmojiShortcodeClosed(":smile", 6)).toBeNull();
+    expect(matchExactEmojiShortcodeClosed("smile:", 6)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/utils/composer-wysiwyg-input-rules.ts
+++ b/apps/web/src/lib/utils/composer-wysiwyg-input-rules.ts
@@ -86,9 +86,10 @@ export function resolveComposerEnterAction(options: {
   shiftKey: boolean;
   metaKey: boolean;
   ctrlKey: boolean;
-  isMentionKeyboardActive: boolean;
+  /** True when mention or emoji suggestion keyboard owns Enter. */
+  isSuggestionKeyboardActive: boolean;
 }): ComposerEnterAction {
-  if (options.isMentionKeyboardActive) return "ignore";
+  if (options.isSuggestionKeyboardActive) return "ignore";
   if (options.shiftKey || options.metaKey || options.ctrlKey) {
     return "newline";
   }

--- a/apps/web/src/lib/utils/emoji-shortcodes.ts
+++ b/apps/web/src/lib/utils/emoji-shortcodes.ts
@@ -1,0 +1,96 @@
+import { nameToEmoji } from "gemoji";
+
+const DEFAULT_EMOJI_RESULT_CAP = 20;
+const EMOJI_QUERY_PATTERN = /^[a-z0-9_+-]*$/i;
+
+/** Public emoji row — unicode + shortcode name only. */
+export interface EmojiShortcodeMatch {
+  name: string;
+  emoji: string;
+}
+
+interface EmojiShortcodeRegistryEntry {
+  name: string;
+  emoji: string;
+}
+
+const EMOJI_SHORTCODE_REGISTRY: readonly EmojiShortcodeRegistryEntry[] =
+  Object.entries(nameToEmoji)
+    .map(([name, emoji]) => ({ name, emoji }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+const EMOJI_BY_NAME = new Map(
+  EMOJI_SHORTCODE_REGISTRY.map((entry) => [entry.name, entry.emoji]),
+);
+
+/**
+ * Pure filter over the static registry. Prefix matches first, then includes.
+ * Empty query → stable alphabetical top-N.
+ */
+export function filterEmojiShortcodes(
+  query: string,
+  cap: number = DEFAULT_EMOJI_RESULT_CAP,
+): EmojiShortcodeMatch[] {
+  const limit = Math.max(0, cap);
+  if (limit === 0) return [];
+
+  const normalizedQuery = query.toLowerCase();
+  if (normalizedQuery.length === 0) {
+    return EMOJI_SHORTCODE_REGISTRY.slice(0, limit).map((entry) => ({
+      name: entry.name,
+      emoji: entry.emoji,
+    }));
+  }
+
+  const prefixMatches: EmojiShortcodeMatch[] = [];
+  const includesMatches: EmojiShortcodeMatch[] = [];
+
+  for (const entry of EMOJI_SHORTCODE_REGISTRY) {
+    if (entry.name.startsWith(normalizedQuery)) {
+      prefixMatches.push({ name: entry.name, emoji: entry.emoji });
+      continue;
+    }
+    if (entry.name.includes(normalizedQuery)) {
+      includesMatches.push({ name: entry.name, emoji: entry.emoji });
+    }
+  }
+
+  return [...prefixMatches, ...includesMatches].slice(0, limit);
+}
+
+/**
+ * Optional: exact `:name:` just closed at caret → unicode for auto-insert.
+ */
+export function matchExactEmojiShortcodeClosed(
+  text: string,
+  caret: number,
+): { triggerStart: number; end: number; emoji: string } | null {
+  const clampedCaret = Math.max(0, Math.min(caret, text.length));
+  if (clampedCaret < 3) return null;
+  if (text[clampedCaret - 1] !== ":") return null;
+
+  let openIndex = -1;
+  for (let index = clampedCaret - 2; index >= 0; index -= 1) {
+    const char = text[index] ?? "";
+    if (char.trim() === "") break;
+    if (char === ":") {
+      openIndex = index;
+      break;
+    }
+  }
+  if (openIndex < 0) return null;
+  if (openIndex > 0 && (text[openIndex - 1] ?? "").trim() !== "") {
+    return null;
+  }
+
+  const name = text.slice(openIndex + 1, clampedCaret - 1);
+  if (name.length === 0 || !EMOJI_QUERY_PATTERN.test(name)) return null;
+  if (name.includes(":")) return null;
+
+  const emoji = EMOJI_BY_NAME.get(name.toLowerCase());
+  if (!emoji) return null;
+
+  return { triggerStart: openIndex, end: clampedCaret, emoji };
+}
+
+export { DEFAULT_EMOJI_RESULT_CAP as EMOJI_RESULT_CAP };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,22 +45,22 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 1.6.25
-        version: 1.6.25(0b0506c22665ebcac6086f903fd691fb)
+        version: 1.6.25(d58965588baf58e493842cdb9b2f8c84)
       '@better-auth/i18n':
         specifier: 1.6.25
-        version: 1.6.25(a56fb19f19e2bce016f9a4f70071dec7)
+        version: 1.6.25(faed3ee53d120c0162bec20a2b4103b2)
       '@better-auth/oauth-provider':
         specifier: 1.6.25
-        version: 1.6.25(9e01f32f3640be40e76574a70699fac9)
+        version: 1.6.25(aaae71a73bb8e9547e8ea297e0335343)
       '@better-auth/passkey':
         specifier: 1.6.25
-        version: 1.6.25(68e80ff07e2d9a54ae5a72deb82d54fe)
+        version: 1.6.25(ccec257ad15caa64e0de928ce98b2597)
       '@better-auth/prisma-adapter':
         specifier: 1.6.25
-        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@better-auth/stripe':
         specifier: 1.6.25
-        version: 1.6.25(67faaed825825990f940797240fb9511)
+        version: 1.6.25(6bca391f7a2a18cd0beaef1df73f02fd)
       '@better-auth/utils':
         specifier: 0.4.2
         version: 0.4.2
@@ -126,7 +126,7 @@ importers:
         version: 7.0.44(zod@4.4.3)
       better-auth:
         specifier: 1.6.25
-        version: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+        version: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
       cron-parser:
         specifier: 5.6.2
         version: 5.6.2
@@ -190,19 +190,19 @@ importers:
         version: 4.0.47(react@19.2.8)(zod@4.4.3)
       '@better-auth/api-key':
         specifier: 1.6.25
-        version: 1.6.25(0b0506c22665ebcac6086f903fd691fb)
+        version: 1.6.25(d58965588baf58e493842cdb9b2f8c84)
       '@better-auth/i18n':
         specifier: 1.6.25
-        version: 1.6.25(a56fb19f19e2bce016f9a4f70071dec7)
+        version: 1.6.25(faed3ee53d120c0162bec20a2b4103b2)
       '@better-auth/oauth-provider':
         specifier: 1.6.25
-        version: 1.6.25(9e01f32f3640be40e76574a70699fac9)
+        version: 1.6.25(aaae71a73bb8e9547e8ea297e0335343)
       '@better-auth/passkey':
         specifier: 1.6.25
-        version: 1.6.25(68e80ff07e2d9a54ae5a72deb82d54fe)
+        version: 1.6.25(ccec257ad15caa64e0de928ce98b2597)
       '@better-auth/stripe':
         specifier: 1.6.25
-        version: 1.6.25(67faaed825825990f940797240fb9511)
+        version: 1.6.25(6bca391f7a2a18cd0beaef1df73f02fd)
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -283,7 +283,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.25
-        version: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+        version: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -311,6 +311,9 @@ importers:
       fake-indexeddb:
         specifier: 6.2.5
         version: 6.2.5
+      gemoji:
+        specifier: 8.1.0
+        version: 8.1.0
       gravatar-url:
         specifier: 4.0.2
         version: 4.0.2
@@ -552,7 +555,7 @@ importers:
         version: 7.9.1
       '@prisma/client':
         specifier: 7.9.1
-        version: 7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sokosumi/masumi':
         specifier: workspace:*
         version: link:../masumi
@@ -6371,6 +6374,9 @@ packages:
     resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
     engines: {node: '>=18'}
 
+  gemoji@8.1.0:
+    resolution: {integrity: sha512-HA4Gx59dw2+tn+UAa7XEV4ufUKI4fH1KgcbenVA9YKSj1QJTT0xh5Mwv5HMFNN3l2OtUe3ZIfuRwSyZS5pLIWw==}
+
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
 
@@ -9774,11 +9780,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@better-auth/api-key@1.6.25(0b0506c22665ebcac6086f903fd691fb)':
+  '@better-auth/api-key@1.6.25(d58965588baf58e493842cdb9b2f8c84)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -9801,10 +9807,10 @@ snapshots:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/i18n@1.6.25(a56fb19f19e2bce016f9a4f70071dec7)':
+  '@better-auth/i18n@1.6.25(faed3ee53d120c0162bec20a2b4103b2)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
 
   '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -9823,40 +9829,40 @@ snapshots:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.25(9e01f32f3640be40e76574a70699fac9)':
+  '@better-auth/oauth-provider@1.6.25(aaae71a73bb8e9547e8ea297e0335343)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
       better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       zod: 4.4.3
 
-  '@better-auth/passkey@1.6.25(68e80ff07e2d9a54ae5a72deb82d54fe)':
+  '@better-auth/passkey@1.6.25(ccec257ad15caa64e0de928ce98b2597)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
       better-call: 1.3.7(zod@4.4.3)
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      '@prisma/client': 7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@prisma/client': 7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@better-auth/stripe@1.6.25(67faaed825825990f940797240fb9511)':
+  '@better-auth/stripe@1.6.25(6bca391f7a2a18cd0beaef1df73f02fd)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2))
       better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       stripe: 22.4.0(@types/node@24.13.3)
@@ -11001,7 +11007,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.9.1': {}
 
-  '@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.1
     optionalDependencies:
@@ -14285,14 +14291,14 @@ snapshots:
 
   baseline-browser-mapping@2.11.4: {}
 
-  better-auth@1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2)):
+  better-auth@1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(mysql2@3.15.3)(next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.40(@typescript/typescript6@6.0.2)):
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -14305,7 +14311,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      '@prisma/client': 7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@prisma/client': 7.9.1(@typescript/typescript6@6.0.2)(prisma@7.9.1(@types/react@19.2.18)(@typescript/typescript6@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       mysql2: 3.15.3
       next: 16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.22.0
@@ -15257,6 +15263,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   function-timeout@1.0.2: {}
+
+  gemoji@8.1.0: {}
 
   generate-function@2.3.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linear

https://linear.app/masumi/issue/SOK-682/chat-composer-emoji-shortcuts-shortcode

## Summary

- Room/channel/DM composer: type `:` for GitHub gemoji shortcode autocomplete
- Keyboard + click insert unicode emoji; Escape dismisses
- Shared suggestion popup with @mentions (mutual exclusion)
- Static `gemoji@8.1.0` catalog (no live GitHub fetch)
- Existing SmilePlus picker unchanged

## Spec (≤8 lines)

Typing `:` opens shortcode autocomplete filtered from gemoji. Selecting a match (or exact `:name:`) inserts unicode into the message body. Mentions and emoji share one suggestion UI via `resolveComposerSuggestion`. Out of scope: custom emoji, iamcal dialect, picker redesign, MultimodalInput.

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0)
- UI `/chat?dm=new`: typed `:smile` → listbox options → Enter → composer shows `😄`

### UI proof

![Colon autocomplete listbox](https://cursor.com/artifacts/c/art-66830788-f430-449b-a6e2-09d3b93769e8)
![Unicode emoji after insert](https://cursor.com/artifacts/c/art-5f5f7d57-9a77-44e1-bda7-ac0905728dde)

### Follow-up (merged into this PR)

- Caret move inside `:query` refreshes filtered matches
- Escape dismisses whenever the suggestion popup is open; Enter insert/ignore keys off popup visibility

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-682](https://linear.app/masumi/issue/SOK-682/chat-composer-emoji-shortcuts-shortcode)

<div><a href="https://cursor.com/agents/bc-3c041620-ddbc-41da-87d4-6267e124494a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c041620-ddbc-41da-87d4-6267e124494a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

