### PR TITLE
feat(chat): add Slack-style emoji picker on gemoji catalog

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -26,6 +26,22 @@
       "description": "Wir haben derzeit Probleme mit der Ausführung von Jobs, die durch technische Störungen bei einem unserer Drittanbieter verursacht werden. Keine Sorge – alles wird in Kürze wieder normal funktionieren.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Emoji suchen",
+      "frequentlyUsed": "Häufig verwendet",
+      "noResults": "Keine Emojis gefunden",
+      "categories": {
+        "smileysEmotion": "Smileys & Emotionen",
+        "peopleBody": "Personen & Körper",
+        "animalsNature": "Tiere & Natur",
+        "foodDrink": "Essen & Trinken",
+        "travelPlaces": "Reisen & Orte",
+        "activities": "Aktivitäten",
+        "objects": "Objekte",
+        "symbols": "Symbole",
+        "flags": "Flaggen"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Link in Zwischenablage kopiert",
       "copyError": "Link konnte nicht kopiert werden"

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Emoji suchen",
+      "searchPlaceholder": "Alle Emojis suchen",
       "frequentlyUsed": "Häufig verwendet",
       "noResults": "Keine Emojis gefunden",
       "categories": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Search emoji",
+      "searchPlaceholder": "Search all emoji",
       "frequentlyUsed": "Frequently used",
       "noResults": "No emoji found",
       "categories": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -26,6 +26,22 @@
       "description": "We currently encounter issues with the execution of jobs due to technical issues with one of our third party providers. Don't worry everything will be back to normal in a bit.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Search emoji",
+      "frequentlyUsed": "Frequently used",
+      "noResults": "No emoji found",
+      "categories": {
+        "smileysEmotion": "Smileys & Emotion",
+        "peopleBody": "People & Body",
+        "animalsNature": "Animals & Nature",
+        "foodDrink": "Food & Drink",
+        "travelPlaces": "Travel & Places",
+        "activities": "Activities",
+        "objects": "Objects",
+        "symbols": "Symbols",
+        "flags": "Flags"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Link copied to clipboard",
       "copyError": "Failed to copy link"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -26,6 +26,22 @@
       "description": "Actualmente experimentamos problemas con la ejecución de jobs debido a fallos técnicos de uno de nuestros proveedores externos. No te preocupes, todo volverá a la normalidad pronto.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Buscar emoji",
+      "frequentlyUsed": "Usados con frecuencia",
+      "noResults": "No se encontraron emojis",
+      "categories": {
+        "smileysEmotion": "Emoticonos y emociones",
+        "peopleBody": "Personas y cuerpo",
+        "animalsNature": "Animales y naturaleza",
+        "foodDrink": "Comida y bebida",
+        "travelPlaces": "Viajes y lugares",
+        "activities": "Actividades",
+        "objects": "Objetos",
+        "symbols": "Símbolos",
+        "flags": "Banderas"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Enlace copiado al portapapeles",
       "copyError": "No se pudo copiar el enlace"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Buscar emoji",
+      "searchPlaceholder": "Buscar todos los emojis",
       "frequentlyUsed": "Usados con frecuencia",
       "noResults": "No se encontraron emojis",
       "categories": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -26,6 +26,22 @@
       "description": "Nous rencontrons actuellement des problèmes d’exécution des jobs en raison de difficultés techniques chez l’un de nos fournisseurs tiers. Ne vous inquiétez pas, tout reviendra à la normale sous peu.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Rechercher un emoji",
+      "frequentlyUsed": "Utilisés fréquemment",
+      "noResults": "Aucun emoji trouvé",
+      "categories": {
+        "smileysEmotion": "Smileys et émotions",
+        "peopleBody": "Personnes et corps",
+        "animalsNature": "Animaux et nature",
+        "foodDrink": "Nourriture et boissons",
+        "travelPlaces": "Voyages et lieux",
+        "activities": "Activités",
+        "objects": "Objets",
+        "symbols": "Symboles",
+        "flags": "Drapeaux"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Lien copié dans le presse-papiers",
       "copyError": "Échec de la copie du lien"

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Rechercher un emoji",
+      "searchPlaceholder": "Rechercher tous les emojis",
       "frequentlyUsed": "Utilisés fréquemment",
       "noResults": "Aucun emoji trouvé",
       "categories": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -26,6 +26,22 @@
       "description": "Stiamo riscontrando problemi nell’esecuzione dei job a causa di difficoltà tecniche con uno dei nostri fornitori terzi. Non preoccuparti, tornerà tutto alla normalità a breve.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Cerca emoji",
+      "frequentlyUsed": "Usati di frequente",
+      "noResults": "Nessuna emoji trovata",
+      "categories": {
+        "smileysEmotion": "Faccine ed emozioni",
+        "peopleBody": "Persone e corpo",
+        "animalsNature": "Animali e natura",
+        "foodDrink": "Cibo e bevande",
+        "travelPlaces": "Viaggi e luoghi",
+        "activities": "Attività",
+        "objects": "Oggetti",
+        "symbols": "Simboli",
+        "flags": "Bandiere"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Link copiato negli appunti",
       "copyError": "Impossibile copiare il link"

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Cerca emoji",
+      "searchPlaceholder": "Cerca tutte le emoji",
       "frequentlyUsed": "Usati di frequente",
       "noResults": "Nessuna emoji trovata",
       "categories": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -26,6 +26,22 @@
       "description": "現在、外部プロバイダーの技術的な問題によりジョブの実行に不具合が発生しています。ご安心ください。まもなく通常どおりご利用いただけます。",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "絵文字を検索",
+      "frequentlyUsed": "よく使う絵文字",
+      "noResults": "絵文字が見つかりません",
+      "categories": {
+        "smileysEmotion": "笑顔と感情",
+        "peopleBody": "人と体",
+        "animalsNature": "動物と自然",
+        "foodDrink": "食べ物と飲み物",
+        "travelPlaces": "旅行と場所",
+        "activities": "アクティビティ",
+        "objects": "物",
+        "symbols": "記号",
+        "flags": "旗"
+      }
+    },
     "ShareButton": {
       "linkCopied": "リンクをクリップボードにコピーしました",
       "copyError": "リンクのコピーに失敗しました"

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "絵文字を検索",
+      "searchPlaceholder": "すべての絵文字を検索",
       "frequentlyUsed": "よく使う絵文字",
       "noResults": "絵文字が見つかりません",
       "categories": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Pesquisar emoji",
+      "searchPlaceholder": "Pesquisar todos os emojis",
       "frequentlyUsed": "Usados com frequência",
       "noResults": "Nenhum emoji encontrado",
       "categories": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -26,6 +26,22 @@
       "description": "No momento, estamos com problemas na execução de jobs devido a dificuldades técnicas com um de nossos provedores terceiros. Não se preocupe: em breve tudo voltará ao normal.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Pesquisar emoji",
+      "frequentlyUsed": "Usados com frequência",
+      "noResults": "Nenhum emoji encontrado",
+      "categories": {
+        "smileysEmotion": "Smileys e emoções",
+        "peopleBody": "Pessoas e corpo",
+        "animalsNature": "Animais e natureza",
+        "foodDrink": "Comida e bebida",
+        "travelPlaces": "Viagens e lugares",
+        "activities": "Atividades",
+        "objects": "Objetos",
+        "symbols": "Símbolos",
+        "flags": "Bandeiras"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Link copiado para a área de transferência",
       "copyError": "Falha ao copiar o link"

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -27,7 +27,7 @@
       "confirm": "OK"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "Pesquisar emoji",
+      "searchPlaceholder": "Pesquisar todos os emojis",
       "frequentlyUsed": "Usados com frequência",
       "noResults": "Nenhum emoji encontrado",
       "categories": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -26,6 +26,22 @@
       "description": "Estamos a enfrentar problemas na execução de jobs devido a dificuldades técnicas com um dos nossos fornecedores terceiros. Não se preocupe, tudo voltará ao normal em breve.",
       "confirm": "OK"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "Pesquisar emoji",
+      "frequentlyUsed": "Usados com frequência",
+      "noResults": "Nenhum emoji encontrado",
+      "categories": {
+        "smileysEmotion": "Smileys e emoções",
+        "peopleBody": "Pessoas e corpo",
+        "animalsNature": "Animais e natureza",
+        "foodDrink": "Comida e bebida",
+        "travelPlaces": "Viagens e locais",
+        "activities": "Atividades",
+        "objects": "Objetos",
+        "symbols": "Símbolos",
+        "flags": "Bandeiras"
+      }
+    },
     "ShareButton": {
       "linkCopied": "Link copiado para a área de transferência",
       "copyError": "Falha ao copiar o link"

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -27,7 +27,7 @@
       "confirm": "确定"
     },
     "EmojiPicker": {
-      "searchPlaceholder": "搜索表情",
+      "searchPlaceholder": "搜索全部表情",
       "frequentlyUsed": "常用表情",
       "noResults": "未找到表情",
       "categories": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -26,6 +26,22 @@
       "description": "由于某个第三方服务提供商的技术问题，我们目前在任务执行方面遇到了一些问题。请放心，稍后将恢复正常。",
       "confirm": "确定"
     },
+    "EmojiPicker": {
+      "searchPlaceholder": "搜索表情",
+      "frequentlyUsed": "常用表情",
+      "noResults": "未找到表情",
+      "categories": {
+        "smileysEmotion": "表情与情感",
+        "peopleBody": "人物与身体",
+        "animalsNature": "动物与自然",
+        "foodDrink": "食物与饮料",
+        "travelPlaces": "旅行与地点",
+        "activities": "活动",
+        "objects": "物品",
+        "symbols": "符号",
+        "flags": "旗帜"
+      }
+    },
     "ShareButton": {
       "linkCopied": "链接已复制到剪贴板",
       "copyError": "复制链接失败"

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -5,26 +5,15 @@ import {
   isFileLikeUrl,
   unescapeMarkdownLinkUrl,
 } from "@sokosumi/utils";
-import {
-  CheckCircle2,
-  Loader2,
-  MessageCircle,
-  Quote,
-  SmilePlus,
-} from "lucide-react";
+import { CheckCircle2, Loader2, MessageCircle, Quote } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type ReactNode, useState } from "react";
-import { ROOM_COMPOSER_EMOJIS } from "@/components/chat/room-message-composer";
+import { type ReactNode } from "react";
+import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import Markdown from "@/components/markdown";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import {
   Tooltip,
   TooltipContent,
@@ -193,50 +182,6 @@ function ChannelMessageText({
   return <>{nodes}</>;
 }
 
-function MessageEmojiPicker({
-  onSelect,
-  label,
-}: {
-  onSelect: (emoji: string) => void;
-  label: string;
-}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-9 rounded-full sm:size-7"
-          title={label}
-          aria-label={label}
-        >
-          <SmilePlus className="size-4" aria-hidden />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-auto p-2">
-        <div className="grid grid-cols-6 gap-1">
-          {ROOM_COMPOSER_EMOJIS.map((emoji) => (
-            <button
-              key={emoji}
-              type="button"
-              className="hover:bg-muted focus-visible:ring-ring flex size-8 items-center justify-center rounded-md text-lg outline-none transition focus-visible:ring-2"
-              onClick={() => {
-                onSelect(emoji);
-                setOpen(false);
-              }}
-            >
-              {emoji}
-            </button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
 function MessageActions({
   message,
   onToggleReaction,
@@ -256,9 +201,12 @@ function MessageActions({
 
   return (
     <div className="border-border bg-background absolute top-1.5 right-2 flex items-center gap-0.5 rounded-full border p-0.5 shadow-sm transition-opacity focus-within:opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100">
-      <MessageEmojiPicker
-        label={t("Reactions.add")}
-        onSelect={(emoji) => onToggleReaction(message, emoji)}
+      <EmojiPicker
+        title={t("Reactions.add")}
+        ariaLabel={t("Reactions.add")}
+        align="end"
+        triggerClassName="size-9 rounded-full sm:size-7"
+        onPick={(emoji) => onToggleReaction(message, emoji)}
       />
       {showQuoteButton && onQuote ? (
         <Button

--- a/apps/web/src/components/chat/emoji-picker.tsx
+++ b/apps/web/src/components/chat/emoji-picker.tsx
@@ -2,7 +2,7 @@
 
 import { SmilePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffectEvent, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,8 +11,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 import {
   type EmojiCatalogEntry,
+  type EmojiCategoryId,
   FREQUENTLY_USED_SECTION_ID,
   listEmojiCatalogSections,
   listEmojiCategories,
@@ -22,6 +24,12 @@ import {
 
 const FREQUENTLY_USED_STORAGE_KEY = "sokosumi.emoji-picker.recent.v1";
 const FREQUENTLY_USED_NAV_EMOJI = "🕒";
+const SEARCH_NAV_ID = "search" as const;
+
+type NavTargetId =
+  | typeof SEARCH_NAV_ID
+  | typeof FREQUENTLY_USED_SECTION_ID
+  | EmojiCategoryId;
 
 export interface EmojiPickerProps {
   onPick: (emoji: string) => void;
@@ -72,6 +80,34 @@ function EmojiGridButton({
   );
 }
 
+function NavButton({
+  label,
+  active,
+  onClick,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "hover:bg-muted focus-visible:ring-ring flex size-8 shrink-0 items-center justify-center rounded-md text-base outline-none focus-visible:ring-2",
+        active && "bg-muted ring-primary ring-1",
+      )}
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
 export function EmojiPicker({
   onPick,
   title,
@@ -83,6 +119,8 @@ export function EmojiPicker({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [frequentlyUsed, setFrequentlyUsed] = useState<string[]>([]);
+  const [activeNavId, setActiveNavId] =
+    useState<NavTargetId>("smileys-emotion");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -98,15 +136,23 @@ export function EmojiPicker({
     : listEmojiCatalogSections({ frequentlyUsed });
   const showFrequentlyUsedNav = frequentlyUsed.length > 0;
 
-  useEffect(() => {
-    if (!open) return;
-    setFrequentlyUsed(readFrequentlyUsedEmojis());
-    setQuery("");
-    const frame = requestAnimationFrame(() => {
+  const focusSearch = useEffectEvent(() => {
+    requestAnimationFrame(() => {
       searchInputRef.current?.focus();
     });
-    return () => cancelAnimationFrame(frame);
-  }, [open]);
+  });
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) return;
+    const recent = readFrequentlyUsedEmojis();
+    setFrequentlyUsed(recent);
+    setQuery("");
+    setActiveNavId(
+      recent.length > 0 ? FREQUENTLY_USED_SECTION_ID : "smileys-emotion",
+    );
+    focusSearch();
+  }
 
   function handlePick(emoji: string) {
     const next = recordFrequentlyUsedEmoji(frequentlyUsed, emoji);
@@ -116,14 +162,23 @@ export function EmojiPicker({
     setOpen(false);
   }
 
-  function handleScrollToSection(sectionId: string) {
+  function handleScrollToSection(sectionId: NavTargetId) {
+    if (sectionId === SEARCH_NAV_ID) {
+      setActiveNavId(SEARCH_NAV_ID);
+      focusSearch();
+      return;
+    }
+    setQuery("");
+    setActiveNavId(sectionId);
     const target = sectionRefs.current.get(sectionId);
     if (!target) return;
     target.scrollIntoView({ block: "start", behavior: "smooth" });
   }
 
+  const resolvedActiveNavId = isSearching ? SEARCH_NAV_ID : activeNavId;
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -140,47 +195,51 @@ export function EmojiPicker({
         align={align}
         className="flex max-h-[360px] w-80 flex-col overflow-hidden p-0"
       >
+        <nav className="border-border flex shrink-0 gap-0.5 overflow-x-auto border-b px-1.5 py-1">
+          <NavButton
+            label={t("searchPlaceholder")}
+            active={resolvedActiveNavId === SEARCH_NAV_ID}
+            onClick={() => handleScrollToSection(SEARCH_NAV_ID)}
+          >
+            🔍
+          </NavButton>
+          {showFrequentlyUsedNav ? (
+            <NavButton
+              label={t("frequentlyUsed")}
+              active={resolvedActiveNavId === FREQUENTLY_USED_SECTION_ID}
+              onClick={() => handleScrollToSection(FREQUENTLY_USED_SECTION_ID)}
+            >
+              {FREQUENTLY_USED_NAV_EMOJI}
+            </NavButton>
+          ) : null}
+          {categories.map((category) => (
+            <NavButton
+              key={category.id}
+              label={t(`categories.${category.messageKey}`)}
+              active={resolvedActiveNavId === category.id}
+              onClick={() => handleScrollToSection(category.id)}
+            >
+              {category.navEmoji}
+            </NavButton>
+          ))}
+        </nav>
+
         <div className="border-border border-b p-2">
           <Input
             ref={searchInputRef}
             type="search"
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              if (event.target.value.trim().length > 0) {
+                setActiveNavId(SEARCH_NAV_ID);
+              }
+            }}
             placeholder={t("searchPlaceholder")}
             aria-label={t("searchPlaceholder")}
             className="h-8"
           />
         </div>
-
-        {!isSearching ? (
-          <nav className="border-border flex shrink-0 gap-0.5 overflow-x-auto border-b px-1.5 py-1">
-            {showFrequentlyUsedNav ? (
-              <button
-                type="button"
-                className="hover:bg-muted focus-visible:ring-ring flex size-8 shrink-0 items-center justify-center rounded-md text-base outline-none focus-visible:ring-2"
-                title={t("frequentlyUsed")}
-                aria-label={t("frequentlyUsed")}
-                onClick={() =>
-                  handleScrollToSection(FREQUENTLY_USED_SECTION_ID)
-                }
-              >
-                {FREQUENTLY_USED_NAV_EMOJI}
-              </button>
-            ) : null}
-            {categories.map((category) => (
-              <button
-                key={category.id}
-                type="button"
-                className="hover:bg-muted focus-visible:ring-ring flex size-8 shrink-0 items-center justify-center rounded-md text-base outline-none focus-visible:ring-2"
-                title={t(`categories.${category.messageKey}`)}
-                aria-label={t(`categories.${category.messageKey}`)}
-                onClick={() => handleScrollToSection(category.id)}
-              >
-                {category.navEmoji}
-              </button>
-            ))}
-          </nav>
-        ) : null}
 
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-2">
           {isSearching ? (

--- a/apps/web/src/components/chat/emoji-picker.tsx
+++ b/apps/web/src/components/chat/emoji-picker.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { SmilePlus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  type EmojiCatalogEntry,
+  FREQUENTLY_USED_SECTION_ID,
+  listEmojiCatalogSections,
+  listEmojiCategories,
+  recordFrequentlyUsedEmoji,
+  searchEmojiCatalog,
+} from "@/lib/utils/emoji-shortcodes";
+
+const FREQUENTLY_USED_STORAGE_KEY = "sokosumi.emoji-picker.recent.v1";
+const FREQUENTLY_USED_NAV_EMOJI = "🕒";
+
+export interface EmojiPickerProps {
+  onPick: (emoji: string) => void;
+  title: string;
+  ariaLabel: string;
+  align?: "start" | "end" | "center";
+  triggerClassName?: string;
+}
+
+function readFrequentlyUsedEmojis(): string[] {
+  try {
+    const raw = localStorage.getItem(FREQUENTLY_USED_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return [];
+  }
+}
+
+function writeFrequentlyUsedEmojis(emojis: string[]): void {
+  try {
+    localStorage.setItem(FREQUENTLY_USED_STORAGE_KEY, JSON.stringify(emojis));
+  } catch {
+    // Incognito / blocked storage — ignore.
+  }
+}
+
+function EmojiGridButton({
+  entry,
+  onPick,
+}: {
+  entry: EmojiCatalogEntry;
+  onPick: (emoji: string) => void;
+}) {
+  const primaryName = entry.names[0] ?? entry.description;
+  return (
+    <button
+      type="button"
+      title={`:${primaryName}:`}
+      aria-label={entry.description || primaryName}
+      className="hover:bg-muted focus-visible:ring-ring flex size-8 items-center justify-center rounded-md text-lg outline-none transition focus-visible:ring-2"
+      onClick={() => onPick(entry.emoji)}
+    >
+      {entry.emoji}
+    </button>
+  );
+}
+
+export function EmojiPicker({
+  onPick,
+  title,
+  ariaLabel,
+  align = "start",
+  triggerClassName,
+}: EmojiPickerProps) {
+  const t = useTranslations("Components.EmojiPicker");
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [frequentlyUsed, setFrequentlyUsed] = useState<string[]>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  const categories = listEmojiCategories();
+  const categoryLabelById = new Map(
+    categories.map((category) => [category.id, category.messageKey]),
+  );
+  const trimmedQuery = query.trim();
+  const isSearching = trimmedQuery.length > 0;
+  const searchResults = isSearching ? searchEmojiCatalog(trimmedQuery) : [];
+  const sections = isSearching
+    ? []
+    : listEmojiCatalogSections({ frequentlyUsed });
+  const showFrequentlyUsedNav = frequentlyUsed.length > 0;
+
+  useEffect(() => {
+    if (!open) return;
+    setFrequentlyUsed(readFrequentlyUsedEmojis());
+    setQuery("");
+    const frame = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  function handlePick(emoji: string) {
+    const next = recordFrequentlyUsedEmoji(frequentlyUsed, emoji);
+    setFrequentlyUsed(next);
+    writeFrequentlyUsedEmojis(next);
+    onPick(emoji);
+    setOpen(false);
+  }
+
+  function handleScrollToSection(sectionId: string) {
+    const target = sectionRefs.current.get(sectionId);
+    if (!target) return;
+    target.scrollIntoView({ block: "start", behavior: "smooth" });
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={triggerClassName}
+          title={title}
+          aria-label={ariaLabel}
+        >
+          <SmilePlus className="size-4" aria-hidden />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align={align}
+        className="flex max-h-[360px] w-80 flex-col overflow-hidden p-0"
+      >
+        <div className="border-border border-b p-2">
+          <Input
+            ref={searchInputRef}
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t("searchPlaceholder")}
+            aria-label={t("searchPlaceholder")}
+            className="h-8"
+          />
+        </div>
+
+        {!isSearching ? (
+          <nav className="border-border flex shrink-0 gap-0.5 overflow-x-auto border-b px-1.5 py-1">
+            {showFrequentlyUsedNav ? (
+              <button
+                type="button"
+                className="hover:bg-muted focus-visible:ring-ring flex size-8 shrink-0 items-center justify-center rounded-md text-base outline-none focus-visible:ring-2"
+                title={t("frequentlyUsed")}
+                aria-label={t("frequentlyUsed")}
+                onClick={() =>
+                  handleScrollToSection(FREQUENTLY_USED_SECTION_ID)
+                }
+              >
+                {FREQUENTLY_USED_NAV_EMOJI}
+              </button>
+            ) : null}
+            {categories.map((category) => (
+              <button
+                key={category.id}
+                type="button"
+                className="hover:bg-muted focus-visible:ring-ring flex size-8 shrink-0 items-center justify-center rounded-md text-base outline-none focus-visible:ring-2"
+                title={t(`categories.${category.messageKey}`)}
+                aria-label={t(`categories.${category.messageKey}`)}
+                onClick={() => handleScrollToSection(category.id)}
+              >
+                {category.navEmoji}
+              </button>
+            ))}
+          </nav>
+        ) : null}
+
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-2">
+          {isSearching ? (
+            searchResults.length === 0 ? (
+              <p className="text-muted-foreground px-1 py-6 text-center text-sm">
+                {t("noResults")}
+              </p>
+            ) : (
+              <div className="grid grid-cols-8 gap-0.5">
+                {searchResults.map((entry) => (
+                  <EmojiGridButton
+                    key={entry.emoji}
+                    entry={entry}
+                    onPick={handlePick}
+                  />
+                ))}
+              </div>
+            )
+          ) : (
+            <div className="flex flex-col gap-3">
+              {sections.map((section) => {
+                const messageKey =
+                  section.categoryId === null
+                    ? null
+                    : categoryLabelById.get(section.categoryId);
+                const heading =
+                  section.id === FREQUENTLY_USED_SECTION_ID || !messageKey
+                    ? t("frequentlyUsed")
+                    : t(`categories.${messageKey}`);
+
+                return (
+                  <section
+                    key={section.id}
+                    ref={(node) => {
+                      if (node) sectionRefs.current.set(section.id, node);
+                      else sectionRefs.current.delete(section.id);
+                    }}
+                    className="[content-visibility:auto]"
+                  >
+                    <h3 className="text-muted-foreground mb-1 px-1 text-xs font-medium tracking-wide uppercase">
+                      {heading}
+                    </h3>
+                    <div className="grid grid-cols-8 gap-0.5">
+                      {section.emojis.map((entry) => (
+                        <EmojiGridButton
+                          key={entry.emoji}
+                          entry={entry}
+                          onPick={handlePick}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/chat/room-message-composer.tsx
+++ b/apps/web/src/components/chat/room-message-composer.tsx
@@ -1,32 +1,12 @@
 "use client";
 
-import { ArrowUp, Loader2, SmilePlus } from "lucide-react";
-import { type FormEvent, type ReactNode, type Ref, useState } from "react";
+import { ArrowUp, Loader2 } from "lucide-react";
+import { type FormEvent, type ReactNode, type Ref } from "react";
 
+import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-
-/** Shared emoji set for room composers and message reaction pickers. */
-export const ROOM_COMPOSER_EMOJIS = [
-  "👍",
-  "❤️",
-  "😂",
-  "🎉",
-  "🙏",
-  "🔥",
-  "✅",
-  "👀",
-  "💯",
-  "🚀",
-  "🙂",
-  "😅",
-] as const;
 
 export const ROOM_COMPOSER_TEXTAREA_CLASSNAME =
   "max-h-40 min-h-20 resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 py-3 text-base ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-sm";
@@ -160,39 +140,13 @@ export function RoomComposerEmojiPicker({
   title,
   ariaLabel,
 }: RoomComposerEmojiPickerProps) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-          title={title}
-          aria-label={ariaLabel}
-        >
-          <SmilePlus className="size-4" aria-hidden />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-auto p-2">
-        <div className="grid grid-cols-6 gap-1">
-          {ROOM_COMPOSER_EMOJIS.map((emoji) => (
-            <button
-              key={emoji}
-              type="button"
-              className="hover:bg-muted focus-visible:ring-ring flex size-10 items-center justify-center rounded-md text-lg outline-none transition focus-visible:ring-2 sm:size-8"
-              onClick={() => {
-                onPick(emoji);
-                setOpen(false);
-              }}
-            >
-              {emoji}
-            </button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
+    <EmojiPicker
+      onPick={onPick}
+      title={title}
+      ariaLabel={ariaLabel}
+      align="start"
+      triggerClassName={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
+    />
   );
 }

--- a/apps/web/src/lib/utils/__tests__/emoji-shortcodes.test.ts
+++ b/apps/web/src/lib/utils/__tests__/emoji-shortcodes.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   filterEmojiShortcodes,
+  listEmojiCategories,
+  listEmojisByCategory,
   matchExactEmojiShortcodeClosed,
+  recordFrequentlyUsedEmoji,
+  searchEmojiCatalog,
 } from "@/lib/utils/emoji-shortcodes";
 
 describe("filterEmojiShortcodes", () => {
@@ -69,5 +73,82 @@ describe("matchExactEmojiShortcodeClosed", () => {
     ).toBeNull();
     expect(matchExactEmojiShortcodeClosed(":smile", 6)).toBeNull();
     expect(matchExactEmojiShortcodeClosed("smile:", 6)).toBeNull();
+  });
+});
+
+describe("emoji catalog categories", () => {
+  it("lists gemoji's 9 categories in order", () => {
+    const categories = listEmojiCategories();
+    expect(categories).toHaveLength(9);
+    expect(categories.map((category) => category.id)).toEqual([
+      "smileys-emotion",
+      "people-body",
+      "animals-nature",
+      "food-drink",
+      "travel-places",
+      "activities",
+      "objects",
+      "symbols",
+      "flags",
+    ]);
+    expect(categories.every((category) => category.navEmoji.length > 0)).toBe(
+      true,
+    );
+    expect(categories.every((category) => category.messageKey.length > 0)).toBe(
+      true,
+    );
+  });
+
+  it("returns smileys for smileys-emotion", () => {
+    const smileys = listEmojisByCategory("smileys-emotion");
+    expect(smileys.length).toBeGreaterThan(0);
+    expect(
+      smileys.every((entry) => entry.categoryId === "smileys-emotion"),
+    ).toBe(true);
+  });
+});
+
+describe("searchEmojiCatalog", () => {
+  it("finds smile by name and grinning by tag", () => {
+    const results = searchEmojiCatalog("smile", { cap: 40 });
+    expect(results.some((entry) => entry.names.includes("smile"))).toBe(true);
+    expect(results.some((entry) => entry.names.includes("grinning"))).toBe(
+      true,
+    );
+  });
+
+  it("finds thumbsup by alias name", () => {
+    const results = searchEmojiCatalog("thumbsup", { cap: 20 });
+    const thumbs = results.find((entry) => entry.names.includes("thumbsup"));
+    expect(thumbs?.emoji).toBe("👍");
+  });
+
+  it("returns alphabetical slice for empty query", () => {
+    const results = searchEmojiCatalog("", { cap: 5 });
+    expect(results).toHaveLength(5);
+    const primaryNames = results.map((entry) => entry.names[0] ?? "");
+    expect(primaryNames).toEqual(
+      [...primaryNames].toSorted((a, b) => a.localeCompare(b)),
+    );
+  });
+});
+
+describe("recordFrequentlyUsedEmoji", () => {
+  it("prepends MRU, dedupes, and caps", () => {
+    expect(recordFrequentlyUsedEmoji(["😀", "🎉"], "👍", 24)).toEqual([
+      "👍",
+      "😀",
+      "🎉",
+    ]);
+    expect(recordFrequentlyUsedEmoji(["😀", "👍", "🎉"], "👍", 24)).toEqual([
+      "👍",
+      "😀",
+      "🎉",
+    ]);
+    expect(recordFrequentlyUsedEmoji(["😀", "🎉", "🔥"], "👍", 3)).toEqual([
+      "👍",
+      "😀",
+      "🎉",
+    ]);
   });
 });

--- a/apps/web/src/lib/utils/__tests__/emoji-shortcodes.test.ts
+++ b/apps/web/src/lib/utils/__tests__/emoji-shortcodes.test.ts
@@ -123,13 +123,21 @@ describe("searchEmojiCatalog", () => {
     expect(thumbs?.emoji).toBe("👍");
   });
 
-  it("returns alphabetical slice for empty query", () => {
+  it("returns alphabetical slice for empty query when capped", () => {
     const results = searchEmojiCatalog("", { cap: 5 });
     expect(results).toHaveLength(5);
     const primaryNames = results.map((entry) => entry.names[0] ?? "");
     expect(primaryNames).toEqual(
       [...primaryNames].toSorted((a, b) => a.localeCompare(b)),
     );
+  });
+
+  it("returns all ranked matches when cap is omitted", () => {
+    const capped = searchEmojiCatalog("a", { cap: 5 });
+    const uncapped = searchEmojiCatalog("a");
+    expect(capped.length).toBeLessThanOrEqual(5);
+    expect(uncapped.length).toBeGreaterThan(capped.length);
+    expect(uncapped.slice(0, capped.length)).toEqual(capped);
   });
 });
 

--- a/apps/web/src/lib/utils/emoji-shortcodes.ts
+++ b/apps/web/src/lib/utils/emoji-shortcodes.ts
@@ -232,13 +232,15 @@ export function listEmojiCatalogSections(
 
 /**
  * Ranked catalog search: name-prefix > name-includes > tag/description.
- * Empty query → stable alphabetical top-N (by primary name).
+ * Empty query → stable alphabetical list (capped only when `cap` is set).
+ * Omit `cap` to return all ranked matches.
  */
 export function searchEmojiCatalog(
   query: string,
   options: SearchEmojiCatalogOptions = {},
 ): EmojiCatalogEntry[] {
-  const limit = Math.max(0, options.cap ?? DEFAULT_EMOJI_RESULT_CAP);
+  const hasCap = options.cap !== undefined;
+  const limit = hasCap ? Math.max(0, options.cap ?? 0) : null;
   if (limit === 0) return [];
 
   const source = options.categoryId
@@ -247,9 +249,10 @@ export function searchEmojiCatalog(
 
   const normalizedQuery = query.toLowerCase().trim();
   if (normalizedQuery.length === 0) {
-    return [...source]
-      .toSorted((a, b) => (a.names[0] ?? "").localeCompare(b.names[0] ?? ""))
-      .slice(0, limit);
+    const sorted = [...source].toSorted((a, b) =>
+      (a.names[0] ?? "").localeCompare(b.names[0] ?? ""),
+    );
+    return limit === null ? sorted : sorted.slice(0, limit);
   }
 
   const prefixMatches: EmojiCatalogEntry[] = [];
@@ -273,11 +276,12 @@ export function searchEmojiCatalog(
     }
   }
 
-  return [
+  const ranked = [
     ...prefixMatches,
     ...includesMatches,
     ...tagOrDescriptionMatches,
-  ].slice(0, limit);
+  ];
+  return limit === null ? ranked : ranked.slice(0, limit);
 }
 
 /**

--- a/apps/web/src/lib/utils/emoji-shortcodes.ts
+++ b/apps/web/src/lib/utils/emoji-shortcodes.ts
@@ -1,7 +1,9 @@
-import { nameToEmoji } from "gemoji";
+import { gemoji } from "gemoji";
 
 const DEFAULT_EMOJI_RESULT_CAP = 20;
+const DEFAULT_FREQUENTLY_USED_CAP = 24;
 const EMOJI_QUERY_PATTERN = /^[a-z0-9_+-]*$/i;
+const FREQUENTLY_USED_SECTION_ID = "frequently-used" as const;
 
 /** Public emoji row — unicode + shortcode name only. */
 export interface EmojiShortcodeMatch {
@@ -9,22 +11,278 @@ export interface EmojiShortcodeMatch {
   emoji: string;
 }
 
-interface EmojiShortcodeRegistryEntry {
-  name: string;
-  emoji: string;
+export type EmojiCategoryId =
+  | "smileys-emotion"
+  | "people-body"
+  | "animals-nature"
+  | "food-drink"
+  | "travel-places"
+  | "activities"
+  | "objects"
+  | "symbols"
+  | "flags";
+
+export interface EmojiCategoryMeta {
+  id: EmojiCategoryId;
+  gemojiCategory: string;
+  navEmoji: string;
+  messageKey: string;
 }
 
-const EMOJI_SHORTCODE_REGISTRY: readonly EmojiShortcodeRegistryEntry[] =
-  Object.entries(nameToEmoji)
-    .map(([name, emoji]) => ({ name, emoji }))
-    .toSorted((a, b) => a.name.localeCompare(b.name));
+export interface EmojiCatalogEntry {
+  emoji: string;
+  names: readonly string[];
+  tags: readonly string[];
+  description: string;
+  categoryId: EmojiCategoryId;
+}
 
-const EMOJI_BY_NAME = new Map(
-  EMOJI_SHORTCODE_REGISTRY.map((entry) => [entry.name, entry.emoji]),
+export interface EmojiCatalogSection {
+  id: EmojiCategoryId | typeof FREQUENTLY_USED_SECTION_ID;
+  categoryId: EmojiCategoryId | null;
+  emojis: readonly EmojiCatalogEntry[];
+}
+
+interface EmojiCategoryDefinition {
+  id: EmojiCategoryId;
+  gemojiCategory: string;
+  navEmoji: string;
+  messageKey: string;
+}
+
+interface SearchEmojiCatalogOptions {
+  cap?: number;
+  categoryId?: EmojiCategoryId;
+}
+
+interface ListEmojiCatalogSectionsOptions {
+  frequentlyUsed?: string[];
+}
+
+const EMOJI_CATEGORY_DEFINITIONS: readonly EmojiCategoryDefinition[] = [
+  {
+    id: "smileys-emotion",
+    gemojiCategory: "Smileys & Emotion",
+    navEmoji: "😀",
+    messageKey: "smileysEmotion",
+  },
+  {
+    id: "people-body",
+    gemojiCategory: "People & Body",
+    navEmoji: "👋",
+    messageKey: "peopleBody",
+  },
+  {
+    id: "animals-nature",
+    gemojiCategory: "Animals & Nature",
+    navEmoji: "🐵",
+    messageKey: "animalsNature",
+  },
+  {
+    id: "food-drink",
+    gemojiCategory: "Food & Drink",
+    navEmoji: "🍇",
+    messageKey: "foodDrink",
+  },
+  {
+    id: "travel-places",
+    gemojiCategory: "Travel & Places",
+    navEmoji: "🌍",
+    messageKey: "travelPlaces",
+  },
+  {
+    id: "activities",
+    gemojiCategory: "Activities",
+    navEmoji: "🎃",
+    messageKey: "activities",
+  },
+  {
+    id: "objects",
+    gemojiCategory: "Objects",
+    navEmoji: "👓",
+    messageKey: "objects",
+  },
+  {
+    id: "symbols",
+    gemojiCategory: "Symbols",
+    navEmoji: "🏧",
+    messageKey: "symbols",
+  },
+  {
+    id: "flags",
+    gemojiCategory: "Flags",
+    navEmoji: "🏁",
+    messageKey: "flags",
+  },
+];
+
+const CATEGORY_BY_GEMOJI = new Map(
+  EMOJI_CATEGORY_DEFINITIONS.map((definition) => [
+    definition.gemojiCategory,
+    definition,
+  ]),
 );
 
+const EMOJI_CATEGORIES: readonly EmojiCategoryMeta[] =
+  EMOJI_CATEGORY_DEFINITIONS.map(
+    ({ id, gemojiCategory, navEmoji, messageKey }) => ({
+      id,
+      gemojiCategory,
+      navEmoji,
+      messageKey,
+    }),
+  );
+
+function buildEmojiCatalog(): {
+  catalog: readonly EmojiCatalogEntry[];
+  byCategory: ReadonlyMap<EmojiCategoryId, readonly EmojiCatalogEntry[]>;
+  byEmoji: ReadonlyMap<string, EmojiCatalogEntry>;
+  shortcodeRegistry: readonly EmojiShortcodeMatch[];
+  emojiByName: ReadonlyMap<string, string>;
+} {
+  const byEmoji = new Map<string, EmojiCatalogEntry>();
+  const byCategoryBuckets = new Map<EmojiCategoryId, EmojiCatalogEntry[]>(
+    EMOJI_CATEGORY_DEFINITIONS.map((definition) => [definition.id, []]),
+  );
+
+  for (const entry of gemoji) {
+    const category = CATEGORY_BY_GEMOJI.get(entry.category);
+    if (!category) continue;
+    if (byEmoji.has(entry.emoji)) continue;
+
+    const catalogEntry: EmojiCatalogEntry = {
+      emoji: entry.emoji,
+      names: entry.names,
+      tags: entry.tags,
+      description: entry.description,
+      categoryId: category.id,
+    };
+    byEmoji.set(entry.emoji, catalogEntry);
+    byCategoryBuckets.get(category.id)?.push(catalogEntry);
+  }
+
+  const catalog = EMOJI_CATEGORY_DEFINITIONS.flatMap(
+    (definition) => byCategoryBuckets.get(definition.id) ?? [],
+  );
+
+  const shortcodeRegistry = catalog
+    .flatMap((entry) =>
+      entry.names.map((name) => ({ name, emoji: entry.emoji })),
+    )
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  const emojiByName = new Map(
+    shortcodeRegistry.map((entry) => [entry.name, entry.emoji]),
+  );
+
+  const byCategory = new Map<EmojiCategoryId, readonly EmojiCatalogEntry[]>(
+    EMOJI_CATEGORY_DEFINITIONS.map((definition) => [
+      definition.id,
+      byCategoryBuckets.get(definition.id) ?? [],
+    ]),
+  );
+
+  return { catalog, byCategory, byEmoji, shortcodeRegistry, emojiByName };
+}
+
+const {
+  catalog: EMOJI_CATALOG,
+  byCategory: EMOJIS_BY_CATEGORY,
+  byEmoji: EMOJI_BY_GLYPH,
+  shortcodeRegistry: EMOJI_SHORTCODE_REGISTRY,
+  emojiByName: EMOJI_BY_NAME,
+} = buildEmojiCatalog();
+
+export function listEmojiCategories(): readonly EmojiCategoryMeta[] {
+  return EMOJI_CATEGORIES;
+}
+
+export function listEmojisByCategory(
+  categoryId: EmojiCategoryId,
+): readonly EmojiCatalogEntry[] {
+  return EMOJIS_BY_CATEGORY.get(categoryId) ?? [];
+}
+
+export function listEmojiCatalogSections(
+  options: ListEmojiCatalogSectionsOptions = {},
+): EmojiCatalogSection[] {
+  const sections: EmojiCatalogSection[] = [];
+  const frequentlyUsed = resolveFrequentlyUsedEmojis(
+    options.frequentlyUsed ?? [],
+  );
+
+  if (frequentlyUsed.length > 0) {
+    sections.push({
+      id: FREQUENTLY_USED_SECTION_ID,
+      categoryId: null,
+      emojis: frequentlyUsed,
+    });
+  }
+
+  for (const category of EMOJI_CATEGORIES) {
+    sections.push({
+      id: category.id,
+      categoryId: category.id,
+      emojis: listEmojisByCategory(category.id),
+    });
+  }
+
+  return sections;
+}
+
 /**
- * Pure filter over the static registry. Prefix matches first, then includes.
+ * Ranked catalog search: name-prefix > name-includes > tag/description.
+ * Empty query → stable alphabetical top-N (by primary name).
+ */
+export function searchEmojiCatalog(
+  query: string,
+  options: SearchEmojiCatalogOptions = {},
+): EmojiCatalogEntry[] {
+  const limit = Math.max(0, options.cap ?? DEFAULT_EMOJI_RESULT_CAP);
+  if (limit === 0) return [];
+
+  const source = options.categoryId
+    ? listEmojisByCategory(options.categoryId)
+    : EMOJI_CATALOG;
+
+  const normalizedQuery = query.toLowerCase().trim();
+  if (normalizedQuery.length === 0) {
+    return [...source]
+      .toSorted((a, b) => (a.names[0] ?? "").localeCompare(b.names[0] ?? ""))
+      .slice(0, limit);
+  }
+
+  const prefixMatches: EmojiCatalogEntry[] = [];
+  const includesMatches: EmojiCatalogEntry[] = [];
+  const tagOrDescriptionMatches: EmojiCatalogEntry[] = [];
+
+  for (const entry of source) {
+    if (entry.names.some((name) => name.startsWith(normalizedQuery))) {
+      prefixMatches.push(entry);
+      continue;
+    }
+    if (entry.names.some((name) => name.includes(normalizedQuery))) {
+      includesMatches.push(entry);
+      continue;
+    }
+    if (
+      entry.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery)) ||
+      entry.description.toLowerCase().includes(normalizedQuery)
+    ) {
+      tagOrDescriptionMatches.push(entry);
+    }
+  }
+
+  return [
+    ...prefixMatches,
+    ...includesMatches,
+    ...tagOrDescriptionMatches,
+  ].slice(0, limit);
+}
+
+/**
+ * Autocomplete filter over shortcode names (all aliases).
+ * Thin map of name-ranked shortcodes → `{ name, emoji }`.
  * Empty query → stable alphabetical top-N.
  */
 export function filterEmojiShortcodes(
@@ -93,4 +351,39 @@ export function matchExactEmojiShortcodeClosed(
   return { triggerStart: openIndex, end: clampedCaret, emoji };
 }
 
-export { DEFAULT_EMOJI_RESULT_CAP as EMOJI_RESULT_CAP };
+/** MRU prepend + dedupe; newest first. Pure — no storage. */
+export function recordFrequentlyUsedEmoji(
+  current: readonly string[],
+  emoji: string,
+  cap: number = DEFAULT_FREQUENTLY_USED_CAP,
+): string[] {
+  const limit = Math.max(0, cap);
+  if (limit === 0 || emoji.length === 0) return [];
+
+  const next = [emoji, ...current.filter((item) => item !== emoji)];
+  return next.slice(0, limit);
+}
+
+/** Resolve stored glyphs to catalog entries; drop unknown / duplicates. */
+export function resolveFrequentlyUsedEmojis(
+  stored: readonly string[],
+): EmojiCatalogEntry[] {
+  const resolved: EmojiCatalogEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const emoji of stored) {
+    if (seen.has(emoji)) continue;
+    const entry = EMOJI_BY_GLYPH.get(emoji);
+    if (!entry) continue;
+    seen.add(emoji);
+    resolved.push(entry);
+  }
+
+  return resolved;
+}
+
+export {
+  DEFAULT_EMOJI_RESULT_CAP as EMOJI_RESULT_CAP,
+  DEFAULT_FREQUENTLY_USED_CAP as FREQUENTLY_USED_EMOJI_CAP,
+  FREQUENTLY_USED_SECTION_ID,
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to SOK-682 colon shortcodes. Composer toolbar and reaction pickers no longer use a hardcoded 12-emoji grid.

### What changed
- Expanded `emoji-shortcodes.ts` into a gemoji-backed catalog (categories, search, frequently used helpers)
- Shared Slack-style `EmojiPicker`: category nav, search, scrollable sections, frequently used (localStorage)
- Wired into room composer, multimodal composer, and message reaction picker
- Removed `ROOM_COMPOSER_EMOJIS`

### Out of scope
- Skin tone selector
- Custom / workspace emoji
- Changing colon autocomplete UX (still shares the same catalog)

### Verification
- `pnpm --filter web test src/lib/utils/__tests__/emoji-shortcodes.test.ts`
- `pnpm --filter web typecheck`
- `pnpm check`

### Conflict resolution
- Rebased onto `main`
- Kept quote-message imports (`Quote`) from #3500
- Dropped unused `SmilePlus` (picker owns trigger icon)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52ae43c3-2f4a-4a7e-897d-12add9629116?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52ae43c3-2f4a-4a7e-897d-12add9629116&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

