### PR TITLE
fix(chat): highlight only roster-resolved @mentions

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -39,7 +39,7 @@ describe("formatRoomMarkdownMentions", () => {
     expect(formatted).toContain('class="text-primary font-medium"');
   });
 
-  it("falls back to the raw id when the member is unknown", () => {
+  it("leaves unknown mention tokens unstyled", () => {
     const formatted = formatRoomMarkdownMentions({
       content: "@missing:ghost hey",
       coworkersById: new Map(),
@@ -48,6 +48,37 @@ describe("formatRoomMarkdownMentions", () => {
       usersBySlug: new Map(),
     });
 
-    expect(formatted).toContain("@missing");
+    expect(formatted).toBe("@missing:ghost hey");
+    expect(formatted).not.toContain("text-primary");
+  });
+
+  it("does not highlight bare @words or email local-parts", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: "ping @nobody and alice@example.com",
+      coworkersById: new Map(),
+      coworkersBySlug: new Map(),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+    });
+
+    expect(formatted).toBe("ping @nobody and alice@example.com");
+    expect(formatted).not.toContain("text-primary");
+  });
+
+  it("highlights only resolved mentions when mixed with bare @words", () => {
+    const content = `@${coworker.id}:${coworker.slug} and @nobody please`;
+    const formatted = formatRoomMarkdownMentions({
+      content,
+      coworkersById: new Map([[coworker.id, coworker]]),
+      coworkersBySlug: new Map([[coworker.slug, coworker]]),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+    });
+
+    expect(formatted).toContain(
+      '<span class="text-primary font-medium">@Elena</span>',
+    );
+    expect(formatted).toContain("and @nobody please");
+    expect(formatted.match(/text-primary/g)).toHaveLength(1);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -409,7 +409,7 @@ export function formatRoomMarkdownMentions({
 
   let formatted = "";
   let lastIndex = 0;
-  matches.forEach((match) => {
+  for (const match of matches) {
     if (match.start > lastIndex) {
       formatted += content.slice(lastIndex, match.start);
     }
@@ -417,10 +417,14 @@ export function formatRoomMarkdownMentions({
       coworkersById.get(match.id) ?? coworkersBySlug.get(match.slug);
     const user =
       usersById?.get(match.id) ?? usersBySlug?.get(match.slug) ?? undefined;
-    const displayName = coworker?.name ?? user?.name ?? match.id;
-    formatted += `<span class="text-primary font-medium">${escapeHtml(`@${displayName}`)}</span>`;
+    const displayName = coworker?.name ?? user?.name;
+    if (displayName) {
+      formatted += `<span class="text-primary font-medium">${escapeHtml(`@${displayName}`)}</span>`;
+    } else {
+      formatted += content.slice(match.start, match.end);
+    }
     lastIndex = match.end;
-  });
+  }
   if (lastIndex < content.length) {
     formatted += content.slice(lastIndex);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat message bodies were painting every `@…` regex hit purple, including bare `@words` and the domain half of emails.

**Root cause.** `formatRoomMarkdownMentions` wrapped every `parseMentions` match in `text-primary`, falling back to the raw id when no roommate resolved.

**Fix.** Emit the purple span only when the token resolves to a known coworker or human. Unresolved tokens stay plain text (same pattern as task `formatMentionsAsMarkdownLinks`).

**Verification.**
```text
# before
Expected: "ping @nobody and alice@example.com"
Received: "ping <span class=\"text-primary font-medium\">@nobody</span> and alice<span class=\"text-primary font-medium\">@example.com</span>"

# after
pnpm --filter web test 'src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts'
# 4 passed
```

Composer blur-rehydrate can still style unknown tokens via `markdownToHtml`; out of scope for this message-body fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a25a9d12-72f4-4d6e-bc26-9f472f9181b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a25a9d12-72f4-4d6e-bc26-9f472f9181b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

