### PR TITLE
feat(chat): add @all mention for room humans

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   buildDirectRoomKey,
   buildDirectRoomName,
   canManageChatRoomLifecycle,
+  contentIncludesRoomAllMention,
   mapChatRoomMessage,
   mergeChatRoomMessageMetadata,
   resolveMentionedCoworkerIds,
@@ -76,6 +77,88 @@ describe("resolveMentionedUserIds", () => {
         excludeUserId: "user_self",
       }),
     ).toEqual(["user_alice", "user_bob"]);
+  });
+
+  it("expands @all:all to all room users except the author", () => {
+    expect(
+      resolveMentionedUserIds({
+        content: "@all:all can someone take a look?",
+        roomUsers,
+        excludeUserId: "user_self",
+      }).toSorted(),
+    ).toEqual(["user_alice", "user_bob"].toSorted());
+  });
+
+  it("expands bare @all to all room users except the author", () => {
+    expect(
+      resolveMentionedUserIds({
+        content: "@all please sync",
+        roomUsers,
+        excludeUserId: "user_self",
+      }).toSorted(),
+    ).toEqual(["user_alice", "user_bob"].toSorted());
+  });
+
+  it("does not expand @allison as a room-all mention", () => {
+    const mentioned = resolveMentionedUserIds({
+      content: "@allison can you check?",
+      roomUsers: [...roomUsers, { id: "user_allison", name: "Allison Lee" }],
+      excludeUserId: "user_self",
+    });
+    expect(mentioned).not.toContain("user_alice");
+    expect(mentioned).not.toContain("user_bob");
+  });
+
+  it("does not expand case variants like @ALL", () => {
+    expect(
+      resolveMentionedUserIds({
+        content: "@ALL please sync",
+        roomUsers,
+        excludeUserId: "user_self",
+      }),
+    ).toEqual([]);
+  });
+
+  it("merges @all expansion with explicit user ids", () => {
+    expect(
+      resolveMentionedUserIds({
+        content: "@all:all and also hello",
+        explicitUserIds: ["user_alice"],
+        roomUsers,
+        excludeUserId: "user_self",
+      }).toSorted(),
+    ).toEqual(["user_alice", "user_bob"].toSorted());
+  });
+
+  it("excludes the author from @all expansion", () => {
+    const mentioned = resolveMentionedUserIds({
+      content: "@all:all",
+      roomUsers,
+      excludeUserId: "user_self",
+    });
+    expect(mentioned).not.toContain("user_self");
+    expect(mentioned.toSorted()).toEqual(["user_alice", "user_bob"].toSorted());
+  });
+
+  it("only returns human room user ids for @all (never coworker ids)", () => {
+    const mentioned = resolveMentionedUserIds({
+      content: "@all:all",
+      explicitUserIds: ["coworker_elena", "all"],
+      roomUsers,
+      excludeUserId: "user_self",
+    });
+    expect(mentioned.toSorted()).toEqual(["user_alice", "user_bob"].toSorted());
+    expect(mentioned).not.toContain("coworker_elena");
+    expect(mentioned).not.toContain("all");
+  });
+});
+
+describe("contentIncludesRoomAllMention", () => {
+  it("detects persist and bare tokens with word boundaries", () => {
+    expect(contentIncludesRoomAllMention("@all:all hey")).toBe(true);
+    expect(contentIncludesRoomAllMention("ping @all")).toBe(true);
+    expect(contentIncludesRoomAllMention("@allison")).toBe(false);
+    expect(contentIncludesRoomAllMention("@all:other")).toBe(false);
   });
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -853,11 +853,29 @@ export function resolveMentionedCoworkerIds(params: {
   return [...mentionedIds].filter((coworkerId) => allowedIds.has(coworkerId));
 }
 
+/** Catalog / content sentinel for room-wide @all. Not a user UUID. */
+export const ROOM_MENTION_ALL_ID = "all" as const;
+
+/**
+ * True when content includes a room-all mention: persist token `@all:all` or
+ * bare `@all` at a word boundary. Must not match `@allison` or `@all:other`.
+ */
+export function contentIncludesRoomAllMention(content: string): boolean {
+  if (/(?:^|\s)@all:all(?=$|[\s.,!?;:])/.test(content)) {
+    return true;
+  }
+  // Bare form must not treat `@all:other` as a match (colon form handled above).
+  return /(?:^|\s)@all(?=$|[\s.,!?;])/.test(content);
+}
+
 /**
  * Resolve human @mentions for a room message. Candidates must already be room
  * members. The author is always excluded. Unlike coworkers, these IDs do not
  * create ChatRoomMention rows or trigger AI dispatch — they address humans via
  * content tokens; callers emit in-app notifications after the message commits.
+ *
+ * When content includes `@all` / `@all:all`, every room human except the author
+ * is included. Explicit id `"all"` is ignored (not a room user).
  */
 export function resolveMentionedUserIds(params: {
   content: string;
@@ -870,15 +888,21 @@ export function resolveMentionedUserIds(params: {
     params.roomUsers.map((user) => user.id).filter((id) => id !== excluded),
   );
   const mentionedIds = new Set(
-    normalizeUniqueStrings(params.explicitUserIds ?? []).filter((id) =>
-      roomUserIds.has(id),
+    normalizeUniqueStrings(params.explicitUserIds ?? []).filter(
+      (id) => id !== ROOM_MENTION_ALL_ID && roomUserIds.has(id),
     ),
   );
+
+  if (contentIncludesRoomAllMention(params.content)) {
+    for (const userId of roomUserIds) {
+      mentionedIds.add(userId);
+    }
+  }
 
   const idTokenRegex = /@([^\s:]+):([^\s]+)/g;
   for (const match of params.content.matchAll(idTokenRegex)) {
     const id = match[1];
-    if (id && roomUserIds.has(id)) {
+    if (id && id !== ROOM_MENTION_ALL_ID && roomUserIds.has(id)) {
       mentionedIds.add(id);
     }
   }
@@ -889,6 +913,10 @@ export function resolveMentionedUserIds(params: {
     }
     const aliases = new Set([slugifyRoomName(user.name)]);
     for (const alias of aliases) {
+      // Reserved `@all` is owned by contentIncludesRoomAllMention, not name alias.
+      if (alias === ROOM_MENTION_ALL_ID) {
+        continue;
+      }
       const aliasRegex = new RegExp(
         `(^|\\s)@${escapeRegExp(alias)}(?=$|[\\s.,!?;:])`,
         "i",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4674,6 +4674,9 @@
         "dismiss": "Zitat entfernen",
         "previewLabel": "Zitiere {author}",
         "jump": "Zur Nachricht von {author} springen"
+      },
+      "MentionAll": {
+        "label": "Alle"
       }
     }
   },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4793,6 +4793,9 @@
         "dismiss": "Remove quote",
         "previewLabel": "Quoting {author}",
         "jump": "Jump to message from {author}"
+      },
+      "MentionAll": {
+        "label": "Everyone"
       }
     }
   },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4674,6 +4674,9 @@
         "dismiss": "Quitar cita",
         "previewLabel": "Citando a {author}",
         "jump": "Ir al mensaje de {author}"
+      },
+      "MentionAll": {
+        "label": "Todos"
       }
     }
   },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4674,6 +4674,9 @@
         "dismiss": "Retirer la citation",
         "previewLabel": "Citation de {author}",
         "jump": "Aller au message de {author}"
+      },
+      "MentionAll": {
+        "label": "Tout le monde"
       }
     }
   },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4674,6 +4674,9 @@
         "dismiss": "Rimuovi citazione",
         "previewLabel": "Citando {author}",
         "jump": "Vai al messaggio di {author}"
+      },
+      "MentionAll": {
+        "label": "Tutti"
       }
     }
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4674,6 +4674,9 @@
         "dismiss": "引用を削除",
         "previewLabel": "{author} を引用中",
         "jump": "{author} のメッセージへ移動"
+      },
+      "MentionAll": {
+        "label": "全員"
       }
     }
   },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4674,6 +4674,9 @@
         "dismiss": "Remover citação",
         "previewLabel": "Citando {author}",
         "jump": "Ir para a mensagem de {author}"
+      },
+      "MentionAll": {
+        "label": "Todos"
       }
     }
   },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4674,6 +4674,9 @@
         "dismiss": "Remover citação",
         "previewLabel": "A citar {author}",
         "jump": "Ir para a mensagem de {author}"
+      },
+      "MentionAll": {
+        "label": "Todos"
       }
     }
   },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4674,6 +4674,9 @@
         "dismiss": "移除引用",
         "previewLabel": "正在引用 {author}",
         "jump": "跳转到 {author} 的消息"
+      },
+      "MentionAll": {
+        "label": "所有人"
       }
     }
   },

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -4,7 +4,14 @@ import type {
   ChatRoomCoworkerParticipant,
   ChatRoomUserParticipant,
 } from "@/lib/clients/generated/core";
-import { formatRoomMarkdownMentions } from "../room-helpers";
+import {
+  buildRoomAllMentionRecord,
+  formatRoomMarkdownMentions,
+  ROOM_MENTION_ALL_ID,
+  ROOM_MENTION_ALL_SLUG,
+  ROOM_MENTION_ALL_TOKEN,
+  shouldIncludeRoomAllMention,
+} from "../room-helpers";
 
 const coworker: ChatRoomCoworkerParticipant = {
   id: "cow_1",
@@ -49,5 +56,86 @@ describe("formatRoomMarkdownMentions", () => {
     });
 
     expect(formatted).toContain("@missing");
+  });
+
+  it("renders @all:all as an @all chip without member lookup", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `${ROOM_MENTION_ALL_TOKEN} please look`,
+      coworkersById: new Map(),
+      coworkersBySlug: new Map(),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+    });
+
+    expect(formatted).toContain(">@all</span>");
+    expect(formatted).not.toContain("@all:all");
+  });
+});
+
+describe("buildRoomAllMentionRecord", () => {
+  it("builds a synthetic catalog entry keyed as all", () => {
+    const record = buildRoomAllMentionRecord();
+    expect(record.slug).toBe(ROOM_MENTION_ALL_SLUG);
+    expect(record.data).toEqual({
+      kind: "all",
+      id: ROOM_MENTION_ALL_ID,
+      name: ROOM_MENTION_ALL_ID,
+      slug: ROOM_MENTION_ALL_SLUG,
+      image: null,
+    });
+  });
+});
+
+describe("shouldIncludeRoomAllMention", () => {
+  it("includes @all for channels with another human", () => {
+    expect(
+      shouldIncludeRoomAllMention(
+        {
+          kind: "channel",
+          userMembers: [{ id: "self" }, { id: "alice" }],
+          coworkerMembers: [],
+        },
+        "self",
+      ),
+    ).toBe(true);
+  });
+
+  it("hides @all when the author is the only human", () => {
+    expect(
+      shouldIncludeRoomAllMention(
+        {
+          kind: "channel",
+          userMembers: [{ id: "self" }],
+          coworkerMembers: [{ id: "cow_1" }],
+        },
+        "self",
+      ),
+    ).toBe(false);
+  });
+
+  it("hides @all for 1:1 directs even with another human", () => {
+    expect(
+      shouldIncludeRoomAllMention(
+        {
+          kind: "direct",
+          userMembers: [{ id: "self" }, { id: "alice" }],
+          coworkerMembers: [],
+        },
+        "self",
+      ),
+    ).toBe(false);
+  });
+
+  it("includes @all for group directs with another human", () => {
+    expect(
+      shouldIncludeRoomAllMention(
+        {
+          kind: "direct",
+          userMembers: [{ id: "self" }, { id: "alice" }, { id: "bob" }],
+          coworkerMembers: [],
+        },
+        "self",
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/draft-channel.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-channel.tsx
@@ -35,9 +35,12 @@ import {
 } from "./room-draft-shared";
 import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
+  buildRoomAllMentionRecord,
   buildRoomComposerMessageContent,
   isRoomComposerEmpty,
+  ROOM_MENTION_ALL_ID,
   type RoomMentionParticipant,
+  shouldIncludeRoomAllMention,
 } from "./room-helpers";
 
 export function DraftChannel({
@@ -85,30 +88,44 @@ export function DraftChannel({
   const selectedMentionParticipants = useMemo<
     Record<string, MentionRecordEntry<RoomMentionParticipant>>
   >(() => {
-    return Object.fromEntries(
-      selectedTargets.map((target) => {
-        const slug =
-          target.kind === "coworker"
-            ? (target.slug ?? target.id)
-            : slugifyMentionValue(target.name);
-        const participant: RoomMentionParticipant = {
-          kind: target.kind,
-          id: target.id,
-          name: target.name,
+    const entries = selectedTargets.map((target) => {
+      const slug =
+        target.kind === "coworker"
+          ? (target.slug ?? target.id)
+          : slugifyMentionValue(target.name);
+      const participant: RoomMentionParticipant = {
+        kind: target.kind,
+        id: target.id,
+        name: target.name,
+        slug,
+        image: target.image,
+      };
+      return [
+        target.id,
+        {
+          value: target.name,
           slug,
-          image: target.image,
-        };
-        return [
-          target.id,
-          {
-            value: target.name,
-            slug,
-            data: participant,
-          },
-        ];
-      }),
-    );
-  }, [selectedTargets]);
+          data: participant,
+        },
+      ] as const;
+    });
+    const draftRoom = {
+      kind: "channel" as const,
+      userMembers: [
+        { id: currentUserId },
+        ...selectedTargets
+          .filter((target) => target.kind === "human")
+          .map((target) => ({ id: target.id })),
+      ],
+      coworkerMembers: selectedTargets.filter(
+        (target) => target.kind === "coworker",
+      ),
+    };
+    if (shouldIncludeRoomAllMention(draftRoom, currentUserId)) {
+      entries.unshift([ROOM_MENTION_ALL_ID, buildRoomAllMentionRecord()]);
+    }
+    return Object.fromEntries(entries);
+  }, [currentUserId, selectedTargets]);
   const selectedMemberUserIds = selectedTargets
     .filter((target) => target.kind === "human")
     .map((target) => target.id);

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -39,9 +39,12 @@ import {
 } from "./room-draft-shared";
 import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
+  buildRoomAllMentionRecord,
   buildRoomComposerMessageContent,
   isRoomComposerEmpty,
+  ROOM_MENTION_ALL_ID,
   type RoomMentionParticipant,
+  shouldIncludeRoomAllMention,
 } from "./room-helpers";
 
 export function DraftDirectMessage({
@@ -89,30 +92,44 @@ export function DraftDirectMessage({
   const selectedMentionParticipants = useMemo<
     Record<string, MentionRecordEntry<RoomMentionParticipant>>
   >(() => {
-    return Object.fromEntries(
-      selectedTargets.map((target) => {
-        const slug =
-          target.kind === "coworker"
-            ? (target.slug ?? target.id)
-            : slugifyMentionValue(target.name);
-        const participant: RoomMentionParticipant = {
-          kind: target.kind,
-          id: target.id,
-          name: target.name,
+    const entries = selectedTargets.map((target) => {
+      const slug =
+        target.kind === "coworker"
+          ? (target.slug ?? target.id)
+          : slugifyMentionValue(target.name);
+      const participant: RoomMentionParticipant = {
+        kind: target.kind,
+        id: target.id,
+        name: target.name,
+        slug,
+        image: target.image,
+      };
+      return [
+        target.id,
+        {
+          value: target.name,
           slug,
-          image: target.image,
-        };
-        return [
-          target.id,
-          {
-            value: target.name,
-            slug,
-            data: participant,
-          },
-        ];
-      }),
-    );
-  }, [selectedTargets]);
+          data: participant,
+        },
+      ] as const;
+    });
+    const draftRoom = {
+      kind: "direct" as const,
+      userMembers: [
+        { id: currentUserId },
+        ...selectedTargets
+          .filter((target) => target.kind === "human")
+          .map((target) => ({ id: target.id })),
+      ],
+      coworkerMembers: selectedTargets.filter(
+        (target) => target.kind === "coworker",
+      ),
+    };
+    if (shouldIncludeRoomAllMention(draftRoom, currentUserId)) {
+      entries.unshift([ROOM_MENTION_ALL_ID, buildRoomAllMentionRecord()]);
+    }
+    return Object.fromEntries(entries);
+  }, [currentUserId, selectedTargets]);
   const selectedMemberUserIds = selectedTargets
     .filter((target) => target.kind === "human")
     .map((target) => target.id);

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ALargeSmall, AtSign, Loader2, Paperclip, X } from "lucide-react";
+import {
+  ALargeSmall,
+  AtSign,
+  Loader2,
+  Paperclip,
+  Users,
+  X,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   type Dispatch,
@@ -59,18 +66,27 @@ function RoomMentionSuggestion({
 }: {
   mention: NormalizedMention<RoomMentionParticipant>;
 }) {
+  const t = useTranslations("App.Channels");
   const isCoworker = mention.data?.kind === "coworker";
+  const isAll = mention.data?.kind === "all";
+  const displayName = isAll ? t("MentionAll.label") : mention.value;
   return (
     <>
-      <Avatar className="size-6">
-        <AvatarImage src={mention.data?.image ?? undefined} alt="" />
-        <AvatarFallback className="text-[10px]">
-          {getInitials(mention.value)}
-        </AvatarFallback>
-      </Avatar>
+      {isAll ? (
+        <div className="bg-muted flex size-6 items-center justify-center rounded-full">
+          <Users className="text-muted-foreground size-3.5" aria-hidden />
+        </div>
+      ) : (
+        <Avatar className="size-6">
+          <AvatarImage src={mention.data?.image ?? undefined} alt="" />
+          <AvatarFallback className="text-[10px]">
+            {getInitials(mention.value)}
+          </AvatarFallback>
+        </Avatar>
+      )}
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-1.5">
-          <span className="truncate font-medium">{mention.value}</span>
+          <span className="truncate font-medium">{displayName}</span>
           {isCoworker ? <AiCoworkerIcon /> : null}
         </div>
         <div className="text-muted-foreground truncate text-xs">

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -25,13 +25,48 @@ export interface RoomParticipantPreview {
   kind: "human" | "coworker";
 }
 
-/** Shared mention-picker payload for humans and coworkers in room composers. */
+/** Catalog / chip key for room-wide @all. Not a user UUID. */
+export const ROOM_MENTION_ALL_ID = "all" as const;
+
+/** Slug half of the persist token `@all:all`. */
+export const ROOM_MENTION_ALL_SLUG = "all" as const;
+
+/** Persist form written by the wysiwyg serializer (`@key:slug`). */
+export const ROOM_MENTION_ALL_TOKEN = "@all:all" as const;
+
+/** Bare form accepted when users type/paste without the `:slug` suffix. */
+export const ROOM_MENTION_ALL_BARE = "@all" as const;
+
+export function isRoomMentionAllId(id: string): boolean {
+  return id === ROOM_MENTION_ALL_ID;
+}
+
+/** Shared mention-picker payload for humans, coworkers, and synthetic @all. */
 export interface RoomMentionParticipant {
-  kind: "human" | "coworker";
+  kind: "human" | "coworker" | "all";
   id: string;
   name: string;
   slug: string;
   image: string | null;
+}
+
+/** Synthetic catalog row for the @all picker entry. */
+export function buildRoomAllMentionRecord(): {
+  value: string;
+  slug: string;
+  data: RoomMentionParticipant;
+} {
+  return {
+    value: ROOM_MENTION_ALL_ID,
+    slug: ROOM_MENTION_ALL_SLUG,
+    data: {
+      kind: "all",
+      id: ROOM_MENTION_ALL_ID,
+      name: ROOM_MENTION_ALL_ID,
+      slug: ROOM_MENTION_ALL_SLUG,
+      image: null,
+    },
+  };
 }
 
 export function appendComposerBlock(value: string, block: string): string {
@@ -311,11 +346,33 @@ export function shouldShowChatRoomThreadButton(options: {
 }
 
 /** Direct rooms: @ only when the roster has more than two people (incl. you). */
-export function shouldShowRoomMentionShortcut(room: ChatRoom): boolean {
+export function shouldShowRoomMentionShortcut(room: {
+  kind: string;
+  userMembers: readonly unknown[];
+  coworkerMembers: readonly unknown[];
+}): boolean {
   if (room.kind !== "direct") {
     return true;
   }
   return room.userMembers.length + room.coworkerMembers.length > 2;
+}
+
+/**
+ * Offer @all when mentions already work and at least one other human can be
+ * notified (room humans excluding the author).
+ */
+export function shouldIncludeRoomAllMention(
+  room: {
+    kind: string;
+    userMembers: ReadonlyArray<{ id: string }>;
+    coworkerMembers: readonly unknown[];
+  },
+  currentUserId: string,
+): boolean {
+  if (!shouldShowRoomMentionShortcut(room)) {
+    return false;
+  }
+  return room.userMembers.some((member) => member.id !== currentUserId);
 }
 
 export function formatDirectParticipantNames(
@@ -412,6 +469,11 @@ export function formatRoomMarkdownMentions({
   matches.forEach((match) => {
     if (match.start > lastIndex) {
       formatted += content.slice(lastIndex, match.start);
+    }
+    if (isRoomMentionAllId(match.id)) {
+      formatted += `<span class="text-primary font-medium">${escapeHtml(ROOM_MENTION_ALL_BARE)}</span>`;
+      lastIndex = match.end;
+      return;
     }
     const coworker =
       coworkersById.get(match.id) ?? coworkersBySlug.get(match.slug);

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -466,23 +466,19 @@ export function formatRoomMarkdownMentions({
 
   let formatted = "";
   let lastIndex = 0;
-  matches.forEach((match) => {
+  for (const match of matches) {
     if (match.start > lastIndex) {
       formatted += content.slice(lastIndex, match.start);
     }
-    if (isRoomMentionAllId(match.id)) {
-      formatted += `<span class="text-primary font-medium">${escapeHtml(ROOM_MENTION_ALL_BARE)}</span>`;
-      lastIndex = match.end;
-      return;
-    }
-    const coworker =
-      coworkersById.get(match.id) ?? coworkersBySlug.get(match.slug);
-    const user =
-      usersById?.get(match.id) ?? usersBySlug?.get(match.slug) ?? undefined;
-    const displayName = coworker?.name ?? user?.name ?? match.id;
+    const displayName = isRoomMentionAllId(match.id)
+      ? ROOM_MENTION_ALL_ID
+      : ((coworkersById.get(match.id) ?? coworkersBySlug.get(match.slug))
+          ?.name ??
+        (usersById?.get(match.id) ?? usersBySlug?.get(match.slug))?.name ??
+        match.id);
     formatted += `<span class="text-primary font-medium">${escapeHtml(`@${displayName}`)}</span>`;
     lastIndex = match.end;
-  });
+  }
   if (lastIndex < content.length) {
     formatted += content.slice(lastIndex);
   }

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -59,6 +59,7 @@ import {
 import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
   appendMessage,
+  buildRoomAllMentionRecord,
   buildRoomComposerMessageContent,
   getRoomDisplayName,
   getRoomParticipantPreviews,
@@ -69,7 +70,9 @@ import {
   type PendingRoomQuote,
   pendingQuoteFromMessage,
   presenceLabel,
+  ROOM_MENTION_ALL_ID,
   type RoomMentionParticipant,
+  shouldIncludeRoomAllMention,
   shouldShowChatRoomThreadButton,
   shouldShowRoomMentionShortcut,
   shouldUseCoworkerRoomStream,
@@ -501,7 +504,18 @@ export function RoomsClient({
         ] as const;
       },
     );
-    return Object.fromEntries([...humanEntries, ...coworkerEntries]);
+    const entries = [...humanEntries, ...coworkerEntries];
+    if (
+      selectedRoom &&
+      shouldIncludeRoomAllMention(selectedRoom, currentUserId)
+    ) {
+      // Pin @all first so the picker surfaces it above long member lists.
+      entries.unshift([
+        ROOM_MENTION_ALL_ID,
+        buildRoomAllMentionRecord(),
+      ] as const);
+    }
+    return Object.fromEntries(entries);
   }, [currentUserId, selectedRoom]);
 
   function partitionMentionIds(selectedKeys: string[]): {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `@all` tagging in room chat so users can notify every human room member (except themselves) in one mention.

Follows up the deferred `@everyone` / role-mention out-of-scope note from [SOK-676](https://linear.app/masumi/issue/SOK-676/mention-humans-in-chat-rooms) / [SOK-680](https://linear.app/masumi/issue/SOK-680/notify-humans-when-they-are-mentioned-in-chat-rooms).

### Behavior

- Picker shows **Everyone** (`@all`) in channels and multi-party rooms when at least one other human is present
- Message body keeps `@all:all` (bare `@all` also accepted)
- Core expands the token to all room `userMembers` except the author
- Reuses existing `NotificationKind.CHAT` mention notifications
- Does **not** create coworker `ChatRoomMention` rows or AI dispatch

### Design choice

Content-token-only expansion owned by Core (no new OpenAPI field, no client-side ID fan-out). Chosen over a `mentionAll` flag and over dual client+Core expand after parallel design arena.

## Verification

- `pnpm --filter core test src/routes/v1/chats/rooms/helpers.test.ts` (26 passed)
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts` (8 passed)
- `pnpm check` + `pnpm typecheck` (pre-commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-811dc0b4-dcbd-41ff-a78a-223f6dbdcbcb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-811dc0b4-dcbd-41ff-a78a-223f6dbdcbcb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

