### PR TITLE
feat(core): allow multi-human group direct rooms

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.test.ts
@@ -41,7 +41,9 @@ vi.mock("@/lib/db/prisma", () => ({
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const USER_ID = "user_123";
 const OTHER_USER_ID = "user_456";
+const THIRD_USER_ID = "user_789";
 const ORG_ID = "org_1";
+const GROUP_DIRECT_KEY = "direct:v2:user:user_123:user:user_456:user:user_789";
 
 const tx = {
   chatRoom: {
@@ -388,20 +390,244 @@ describe("POST /chats/rooms", () => {
     expect(roomCreateMock).not.toHaveBeenCalled();
   });
 
-  it("rejects group direct targets with 400", async () => {
+  it("creates a multi-human group direct with 201 and direct:v2 key", async () => {
+    const created = directRoom({
+      name: "Bob, Carol",
+      slug: "bob-carol",
+      directKey: GROUP_DIRECT_KEY,
+      userMembers: [
+        {
+          user: {
+            id: USER_ID,
+            name: "Ada",
+            email: "ada@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          user: {
+            id: OTHER_USER_ID,
+            name: "Bob",
+            email: "bob@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          user: {
+            id: THIRD_USER_ID,
+            name: "Carol",
+            email: "carol@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+      ],
+    });
+    roomFindFirstMock.mockResolvedValueOnce(null);
+    roomCreateMock.mockResolvedValueOnce(created);
+    userFindManyMock.mockResolvedValue([
+      { id: OTHER_USER_ID, name: "Bob", email: "bob@example.com" },
+      { id: THIRD_USER_ID, name: "Carol", email: "carol@example.com" },
+    ]);
+
     const app = createApp(userAuthContext);
     const response = await app.request("/", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         kind: "direct",
-        memberUserIds: [OTHER_USER_ID, "user_789"],
+        memberUserIds: [OTHER_USER_ID, THIRD_USER_ID],
+        coworkerIds: [],
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.data.kind).toBe("direct");
+    expect(body.data.directKey).toBe(GROUP_DIRECT_KEY);
+    expect(body.data.directKey.startsWith("direct:v2:")).toBe(true);
+    expect(
+      body.data.userMembers.map((m: { id: string }) => m.id).sort(),
+    ).toEqual([USER_ID, OTHER_USER_ID, THIRD_USER_ID].sort());
+    expect(roomCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kind: "direct",
+          directKey: GROUP_DIRECT_KEY,
+          userMembers: {
+            create: expect.arrayContaining([
+              { userId: USER_ID },
+              { userId: OTHER_USER_ID },
+              { userId: THIRD_USER_ID },
+            ]),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("returns the same group direct room for the same member set with 200", async () => {
+    const existing = directRoom({
+      name: "Bob, Carol",
+      slug: "bob-carol",
+      directKey: GROUP_DIRECT_KEY,
+      userMembers: [
+        {
+          user: {
+            id: USER_ID,
+            name: "Ada",
+            email: "ada@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          user: {
+            id: OTHER_USER_ID,
+            name: "Bob",
+            email: "bob@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          user: {
+            id: THIRD_USER_ID,
+            name: "Carol",
+            email: "carol@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+      ],
+    });
+    roomFindFirstMock.mockResolvedValueOnce(null);
+    roomCreateMock.mockResolvedValueOnce(existing);
+
+    userFindManyMock.mockResolvedValue([
+      { id: OTHER_USER_ID, name: "Bob", email: "bob@example.com" },
+      { id: THIRD_USER_ID, name: "Carol", email: "carol@example.com" },
+    ]);
+
+    const app = createApp(userAuthContext);
+    const createResponse = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "direct",
+        memberUserIds: [OTHER_USER_ID, THIRD_USER_ID],
+      }),
+    });
+    expect(createResponse.status).toBe(201);
+
+    roomFindFirstMock.mockResolvedValueOnce(existing);
+
+    const getResponse = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "direct",
+        memberUserIds: [THIRD_USER_ID, OTHER_USER_ID],
+      }),
+    });
+
+    expect(getResponse.status).toBe(200);
+    const getBody = await getResponse.json();
+    expect(getBody.data.id).toBe(ROOM_ID);
+    expect(getBody.data.directKey).toBe(GROUP_DIRECT_KEY);
+    expect(roomCreateMock).toHaveBeenCalledTimes(1);
+    expect(roomFindFirstMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: ORG_ID,
+          directKey: GROUP_DIRECT_KEY,
+          archivedAt: null,
+        }),
+      }),
+    );
+  });
+
+  it("uses an order-independent directKey for multi-human group directs", async () => {
+    const created = directRoom({
+      name: "Bob, Carol",
+      slug: "bob-carol",
+      directKey: GROUP_DIRECT_KEY,
+      userMembers: [
+        {
+          user: {
+            id: USER_ID,
+            name: "Ada",
+            email: "ada@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          user: {
+            id: OTHER_USER_ID,
+            name: "Bob",
+            email: "bob@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          user: {
+            id: THIRD_USER_ID,
+            name: "Carol",
+            email: "carol@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+      ],
+    });
+    roomFindFirstMock.mockResolvedValueOnce(null);
+    roomCreateMock.mockResolvedValueOnce(created);
+    userFindManyMock.mockResolvedValue([
+      { id: THIRD_USER_ID, name: "Carol", email: "carol@example.com" },
+      { id: OTHER_USER_ID, name: "Bob", email: "bob@example.com" },
+    ]);
+
+    const app = createApp(userAuthContext);
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "direct",
+        memberUserIds: [THIRD_USER_ID, OTHER_USER_ID],
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(roomCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          directKey: GROUP_DIRECT_KEY,
+        }),
+      }),
+    );
+  });
+
+  it("rejects multi-human group direct without an active organization with 400", async () => {
+    const app = createApp({
+      ...userAuthContext,
+      organizationId: null,
+    });
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "direct",
+        memberUserIds: [OTHER_USER_ID, THIRD_USER_ID],
       }),
     });
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe(
-      "Direct messages are 1:1. Pick one member or one coworker.",
+      "Switch to an organization to message a teammate.",
     );
     expect(roomCreateMock).not.toHaveBeenCalled();
   });
@@ -420,7 +646,25 @@ describe("POST /chats/rooms", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe(
-      "Direct messages are 1:1. Pick one member or one coworker.",
+      "Group direct messages cannot include coworkers.",
+    );
+    expect(roomCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects multi-coworker direct targets with 400", async () => {
+    const app = createApp(userAuthContext);
+    const response = await app.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "direct",
+        coworkerIds: ["cow_123", "cow_456"],
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe(
+      "Direct messages support one coworker only.",
     );
     expect(roomCreateMock).not.toHaveBeenCalled();
   });

--- a/apps/core/src/routes/v1/chats/rooms/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.ts
@@ -43,7 +43,7 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/",
     description:
-      'Create a chat room. `kind: "channel"` requires an active organization. `kind: "direct"` creates or returns a 1:1 room scoped to the active organization when one is set. Coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.',
+      'Create a chat room. `kind: "channel"` requires an active organization. `kind: "direct"` creates or returns a direct room (1:1 or multi-human group) scoped to the active organization when one is set. Coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.',
     tags: ["Chat Rooms"],
     request: {
       body: {
@@ -82,7 +82,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       const direct = await createOrGetDirectRoom({
         // Both kinds respect activeOrganization when present.
         // Coworker 1:1 may be personal (null) with no active org.
-        // Human 1:1 always requires an active org.
+        // Human directs (1:1 or group) always require an active org.
         organizationId: userContext.organizationId,
         currentUserId: userContext.userId,
         memberUserIds: body.memberUserIds ?? [],
@@ -153,13 +153,73 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 }
 
 /**
+ * Valid direct create targets: human-direct (≥1 humans, no coworkers) or
+ * coworker-1to1 (exactly one coworker, no humans). Mix / multi-coworker /
+ * empty are invalid.
+ */
+type DirectCreateShape =
+  | {
+      kind: "human-direct";
+      memberUserIds: string[];
+      coworkerIds: [];
+    }
+  | {
+      kind: "coworker-1to1";
+      memberUserIds: [];
+      coworkerIds: [string];
+    };
+
+function parseDirectCreateShape(params: {
+  currentUserId: string;
+  memberUserIds: readonly string[];
+  coworkerIds: readonly string[];
+}): DirectCreateShape {
+  const memberUserIds = normalizeUniqueStrings(params.memberUserIds);
+  const coworkerIds = normalizeUniqueStrings(params.coworkerIds);
+
+  if (memberUserIds.includes(params.currentUserId)) {
+    throw badRequest("Choose another organization member");
+  }
+
+  if (memberUserIds.length === 0 && coworkerIds.length === 0) {
+    throw badRequest("Choose a direct message target");
+  }
+
+  if (memberUserIds.length > 0 && coworkerIds.length > 0) {
+    throw badRequest("Group direct messages cannot include coworkers.");
+  }
+
+  if (coworkerIds.length > 1) {
+    throw badRequest("Direct messages support one coworker only.");
+  }
+
+  if (memberUserIds.length >= 1 && coworkerIds.length === 0) {
+    return {
+      kind: "human-direct",
+      memberUserIds,
+      coworkerIds: [],
+    };
+  }
+
+  if (memberUserIds.length === 0 && coworkerIds.length === 1) {
+    return {
+      kind: "coworker-1to1",
+      memberUserIds: [],
+      coworkerIds: [coworkerIds[0]],
+    };
+  }
+
+  throw badRequest("Choose a direct message target");
+}
+
+/**
  * Direct rooms are addressed by their participant set, so creation is
  * create-or-get: two clients opening the same conversation must land on one
  * room instead of racing into duplicates.
  *
  * Rooms inherit `organizationId` from the active organization when set.
  * Coworker 1:1 may still be personal (`organizationId` null) with no active
- * org. Human 1:1 always requires an active organization.
+ * org. Human directs (1:1 or group) always require an active organization.
  */
 async function createOrGetDirectRoom(params: {
   organizationId: string | null;
@@ -168,35 +228,17 @@ async function createOrGetDirectRoom(params: {
   coworkerIds: readonly string[];
 }): Promise<{ room: ChatRoom; created: boolean }> {
   const { currentUserId } = params;
-  const requestedMemberUserIds = normalizeUniqueStrings(params.memberUserIds);
-  const requestedCoworkerIds = normalizeUniqueStrings(params.coworkerIds);
-
-  if (requestedMemberUserIds.includes(currentUserId)) {
-    throw badRequest("Choose another organization member");
-  }
-
-  if (
-    requestedMemberUserIds.length === 0 &&
-    requestedCoworkerIds.length === 0
-  ) {
-    throw badRequest("Choose a direct message target");
-  }
-
-  // Direct rooms are 1:1 for now (one other human XOR one coworker).
-  // Group directs (multi-human / human+coworker) are a follow-up.
-  const isOneToOneHuman =
-    requestedMemberUserIds.length === 1 && requestedCoworkerIds.length === 0;
-  const isOneToOneCoworker =
-    requestedMemberUserIds.length === 0 && requestedCoworkerIds.length === 1;
-  if (!isOneToOneHuman && !isOneToOneCoworker) {
-    throw badRequest(
-      "Direct messages are 1:1. Pick one member or one coworker.",
-    );
-  }
+  const shape = parseDirectCreateShape({
+    currentUserId,
+    memberUserIds: params.memberUserIds,
+    coworkerIds: params.coworkerIds,
+  });
+  const requestedMemberUserIds = shape.memberUserIds;
+  const requestedCoworkerIds = shape.coworkerIds;
 
   const roomOrganizationId = params.organizationId;
 
-  if (isOneToOneHuman && !roomOrganizationId) {
+  if (shape.kind === "human-direct" && !roomOrganizationId) {
     throw badRequest("Switch to an organization to message a teammate.");
   }
 

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -118,7 +118,7 @@ export const createChatRoomRequestSchema = z
     z.object({
       kind: z.literal("direct").openapi({
         description:
-          "Creates or returns a 1:1 direct room (one organization member XOR one coworker) scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization. Group directs are not supported yet.",
+          "Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization.",
       }),
       memberUserIds: roomMemberUserIdsSchema,
       coworkerIds: roomCoworkerIdsSchema,

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "Empfänger hinzufügen, um zu starten",
-        "oneToOneOnlyError": "Direktnachrichten sind 1:1. Wähle ein Mitglied oder einen Coworker.",
-        "searchPlaceholderReplace": "Empfänger ersetzen"
+        "searchPlaceholderReplace": "Empfänger ersetzen",
+        "groupDirectHumansOnly": "Gruppendirektnachrichten sind nur für Menschen.",
+        "groupDirectNoCoworkersError": "Gruppendirektnachrichten können keine Coworker enthalten.",
+        "coworkerDirectOneToOneOnly": "Coworker-Direktnachrichten sind 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4740,10 +4740,12 @@
         "ready": "Recipient selected",
         "chooseRecipientError": "Choose a recipient.",
         "organizationRequiredForGroup": "Switch to an organization to message a teammate.",
-        "oneToOneOnlyError": "Direct messages are 1:1. Pick one member or one coworker.",
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
-        "composerPlaceholderNoRecipients": "Add a recipient to start"
+        "composerPlaceholderNoRecipients": "Add a recipient to start",
+        "groupDirectHumansOnly": "Group direct messages are humans only.",
+        "groupDirectNoCoworkersError": "Group direct messages cannot include coworkers.",
+        "coworkerDirectOneToOneOnly": "Coworker direct messages are 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "Añade un destinatario para empezar",
-        "oneToOneOnlyError": "Los mensajes directos son 1:1. Elige un miembro o un coworker.",
-        "searchPlaceholderReplace": "Reemplazar destinatario"
+        "searchPlaceholderReplace": "Reemplazar destinatario",
+        "groupDirectHumansOnly": "Los mensajes directos de grupo son solo entre personas.",
+        "groupDirectNoCoworkersError": "Los mensajes directos de grupo no pueden incluir coworkers.",
+        "coworkerDirectOneToOneOnly": "Los mensajes directos con coworkers son 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "Ajoutez un destinataire pour commencer",
-        "oneToOneOnlyError": "Les messages directs sont en 1:1. Choisissez un membre ou un coworker.",
-        "searchPlaceholderReplace": "Remplacer le destinataire"
+        "searchPlaceholderReplace": "Remplacer le destinataire",
+        "groupDirectHumansOnly": "Les messages directs de groupe sont réservés aux humains.",
+        "groupDirectNoCoworkersError": "Les messages directs de groupe ne peuvent pas inclure de coworkers.",
+        "coworkerDirectOneToOneOnly": "Les messages directs avec un coworker sont en 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "Aggiungi un destinatario per iniziare",
-        "oneToOneOnlyError": "I messaggi diretti sono 1:1. Scegli un membro o un coworker.",
-        "searchPlaceholderReplace": "Sostituisci destinatario"
+        "searchPlaceholderReplace": "Sostituisci destinatario",
+        "groupDirectHumansOnly": "I messaggi diretti di gruppo sono solo tra persone.",
+        "groupDirectNoCoworkersError": "I messaggi diretti di gruppo non possono includere coworker.",
+        "coworkerDirectOneToOneOnly": "I messaggi diretti con coworker sono 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "宛先を追加して開始",
-        "oneToOneOnlyError": "ダイレクトメッセージは1対1です。メンバーまたはコワーカーを1人選んでください。",
-        "searchPlaceholderReplace": "宛先を差し替え"
+        "searchPlaceholderReplace": "宛先を差し替え",
+        "groupDirectHumansOnly": "グループのダイレクトメッセージは人間のみです。",
+        "groupDirectNoCoworkersError": "グループのダイレクトメッセージにコワーカーは含められません。",
+        "coworkerDirectOneToOneOnly": "コワーカーとのダイレクトメッセージは1対1です。"
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "Adicione um destinatário para começar",
-        "oneToOneOnlyError": "Mensagens diretas são 1:1. Escolha um membro ou um coworker.",
-        "searchPlaceholderReplace": "Substituir destinatário"
+        "searchPlaceholderReplace": "Substituir destinatário",
+        "groupDirectHumansOnly": "Mensagens diretas em grupo são apenas entre pessoas.",
+        "groupDirectNoCoworkersError": "Mensagens diretas em grupo não podem incluir coworkers.",
+        "coworkerDirectOneToOneOnly": "Mensagens diretas com coworkers são 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "Adiciona um destinatário para começar",
-        "oneToOneOnlyError": "As mensagens diretas são 1:1. Escolhe um membro ou um coworker.",
-        "searchPlaceholderReplace": "Substituir destinatário"
+        "searchPlaceholderReplace": "Substituir destinatário",
+        "groupDirectHumansOnly": "As mensagens diretas de grupo são só entre pessoas.",
+        "groupDirectNoCoworkersError": "As mensagens diretas de grupo não podem incluir coworkers.",
+        "coworkerDirectOneToOneOnly": "As mensagens diretas com coworkers são 1:1."
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4623,8 +4623,10 @@
         "removeRecipient": "Remove {name}",
         "composerPlaceholder": "Write the first message",
         "composerPlaceholderNoRecipients": "添加收件人后开始",
-        "oneToOneOnlyError": "私信目前仅为一对一。请选择一位成员或一位同事。",
-        "searchPlaceholderReplace": "更换收件人"
+        "searchPlaceholderReplace": "更换收件人",
+        "groupDirectHumansOnly": "群组私信仅限真人成员。",
+        "groupDirectNoCoworkersError": "群组私信不能包含同事。",
+        "coworkerDirectOneToOneOnly": "与同事的私信仅支持一对一。"
       },
       "Toolbar": {
         "mention": "Mention coworker",

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { directCreateShapeError } from "@/app/chat/utils/direct-create-shape";
 import { CoreApiRequestError } from "@/lib/clients/core.client";
 import type { ChatRoom, ChatRoomMessage } from "@/lib/clients/generated/core";
 import { chatRoomService, userService } from "@/lib/services";
@@ -63,22 +64,6 @@ function cleanIds(value: string[] | null | undefined): string[] {
   );
 }
 
-/** Direct rooms are 1:1 only until group DM ships. */
-function oneToOneDirectError(
-  memberUserIds: readonly string[],
-  coworkerIds: readonly string[],
-): string | null {
-  const isOneHuman = memberUserIds.length === 1 && coworkerIds.length === 0;
-  const isOneCoworker = memberUserIds.length === 0 && coworkerIds.length === 1;
-  if (isOneHuman || isOneCoworker) {
-    return null;
-  }
-  if (memberUserIds.length + coworkerIds.length === 0) {
-    return "Choose at least one direct message target.";
-  }
-  return "Direct messages are 1:1. Pick one member or one coworker.";
-}
-
 function actionErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof CoreApiRequestError) {
     return error.message;
@@ -134,14 +119,14 @@ export async function createDirectRoomAction(
     ...(input.coworkerIds ?? []),
   ]);
 
-  const oneToOneError = oneToOneDirectError(memberUserIds, coworkerIds);
-  if (oneToOneError) {
-    return { ok: false, message: oneToOneError };
+  const shapeError = directCreateShapeError(memberUserIds, coworkerIds);
+  if (shapeError) {
+    return { ok: false, message: shapeError };
   }
 
-  // Human 1:1 needs an org (teammate roster). Coworker 1:1 uses active org
-  // when set; Core stores null only with no active organization.
-  if (memberUserIds.length === 1) {
+  // Human directs (1:1 or group) need an org (teammate roster). Coworker 1:1
+  // uses active org when set; Core stores null only with no active organization.
+  if (memberUserIds.length >= 1) {
     const activeOrganization = await userService.getActiveOrganization();
     if (!activeOrganization) {
       return { ok: false, message: "Select an organization first." };
@@ -204,9 +189,9 @@ export async function sendNewDirectMessageAction(
 
   const memberUserIds = cleanIds(input.memberUserIds);
   const coworkerIds = cleanIds(input.coworkerIds);
-  const oneToOneError = oneToOneDirectError(memberUserIds, coworkerIds);
-  if (oneToOneError) {
-    return { ok: false, message: oneToOneError };
+  const shapeError = directCreateShapeError(memberUserIds, coworkerIds);
+  if (shapeError) {
+    return { ok: false, message: shapeError };
   }
 
   const cleanContent = cleanString(input.content);

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -54,7 +54,7 @@ export function DraftDirectMessage({
   members: Member[];
   coworkers: Coworker[];
   currentUserId: string;
-  /** False in personal workspace — human 1:1 room DMs need an org. */
+  /** False in personal workspace — human 1:1 / group room DMs need an org. */
   canCreateRoomDirect: boolean;
   membersLoadFailed?: boolean;
 }) {
@@ -127,10 +127,37 @@ export function DraftDirectMessage({
     () => new Set(selectedMemberUserIds),
     [selectedMemberUserIds],
   );
+  const hasSelectedHumans = selectedMemberUserIds.length > 0;
+  const hasSelectedCoworker = selectedCoworkerIds.length > 0;
+  const crossKindDisabledReason = hasSelectedHumans
+    ? t("Draft.groupDirectHumansOnly")
+    : hasSelectedCoworker
+      ? t("Draft.coworkerDirectOneToOneOnly")
+      : undefined;
+
+  function isTargetDisabled(target: DirectDraftTarget): boolean {
+    if (hasSelectedHumans && target.kind === "coworker") {
+      return true;
+    }
+    if (hasSelectedCoworker && target.kind === "human") {
+      return true;
+    }
+    return false;
+  }
 
   function addTarget(target: DirectDraftTarget) {
-    // Direct messages are 1:1 until group DM ships — selecting replaces.
-    setSelectedKeys([target.key]);
+    if (isTargetDisabled(target)) {
+      return;
+    }
+    if (target.kind === "coworker") {
+      // Coworker DMs stay replace-to-solo (1:1).
+      setSelectedKeys([target.key]);
+    } else {
+      // Humans accumulate for 1:1 or multi-human group DMs.
+      setSelectedKeys((current) =>
+        current.includes(target.key) ? current : [...current, target.key],
+      );
+    }
     setRecipientQuery("");
     setIsRecipientPickerOpen(true);
     window.requestAnimationFrame(() => searchInputRef.current?.focus());
@@ -186,13 +213,23 @@ export function DraftDirectMessage({
       return;
     }
 
-    if (!canCreateRoomDirect) {
-      toast.error(t("Draft.organizationRequiredForGroup"));
+    if (selectedMemberUserIds.length > 0 && selectedCoworkerIds.length > 0) {
+      toast.error(t("Draft.groupDirectNoCoworkersError"));
       return;
     }
 
-    if (selectedMemberUserIds.length !== 1 || selectedCoworkerIds.length > 0) {
-      toast.error(t("Draft.oneToOneOnlyError"));
+    if (selectedCoworkerIds.length > 1) {
+      toast.error(t("Draft.coworkerDirectOneToOneOnly"));
+      return;
+    }
+
+    if (selectedMemberUserIds.length === 0) {
+      toast.error(t("Draft.chooseRecipientError"));
+      return;
+    }
+
+    if (!canCreateRoomDirect) {
+      toast.error(t("Draft.organizationRequiredForGroup"));
       return;
     }
 
@@ -221,6 +258,10 @@ export function DraftDirectMessage({
       router.replace(`/chat/rooms/${result.data.room.id}`);
     });
   }
+
+  const firstEnabledCandidate = candidateTargets.find(
+    (target) => !isTargetDisabled(target),
+  );
 
   return (
     <RoomFileDropZone
@@ -283,9 +324,9 @@ export function DraftDirectMessage({
                   window.setTimeout(() => setIsRecipientPickerOpen(false), 120);
                 }}
                 onKeyDown={(event) => {
-                  if (event.key === "Enter" && candidateTargets[0]) {
+                  if (event.key === "Enter" && firstEnabledCandidate) {
                     event.preventDefault();
-                    addTarget(candidateTargets[0]);
+                    addTarget(firstEnabledCandidate);
                   }
                   if (
                     event.key === "Backspace" &&
@@ -298,7 +339,9 @@ export function DraftDirectMessage({
                 placeholder={
                   selectedTargets.length === 0
                     ? t("Draft.searchPlaceholder")
-                    : t("Draft.searchPlaceholderReplace")
+                    : hasSelectedHumans
+                      ? t("Draft.searchPlaceholderMore")
+                      : t("Draft.searchPlaceholderReplace")
                 }
                 className="placeholder:text-muted-foreground h-9 w-full bg-transparent pr-2 pl-6 text-base outline-none md:text-sm"
               />
@@ -313,6 +356,8 @@ export function DraftDirectMessage({
                 <DirectDraftTargetList
                   targets={candidateTargets}
                   onSelect={addTarget}
+                  isTargetDisabled={isTargetDisabled}
+                  disabledReason={crossKindDisabledReason}
                 />
               ) : membersLoadFailed ? null : (
                 <p className="text-muted-foreground px-3 py-4 text-sm">

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -5,6 +5,11 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type {
   ChatRoomPresence,
   Coworker,
@@ -122,16 +127,31 @@ export function filterDraftTargets(
 export function DirectDraftTargetRow({
   target,
   onSelect,
+  disabled = false,
+  disabledReason,
 }: {
   target: DirectDraftTarget;
   onSelect: (target: DirectDraftTarget) => void;
+  disabled?: boolean;
+  disabledReason?: string;
 }) {
-  return (
+  const row = (
     <button
       type="button"
-      className="hover:bg-muted/70 flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors"
+      disabled={disabled}
+      aria-disabled={disabled || undefined}
+      title={disabled ? disabledReason : undefined}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors",
+        disabled
+          ? "text-muted-foreground cursor-not-allowed opacity-50"
+          : "hover:bg-muted/70",
+      )}
       onMouseDown={(event) => {
         event.preventDefault();
+        if (disabled) {
+          return;
+        }
         onSelect(target);
       }}
     >
@@ -154,14 +174,33 @@ export function DirectDraftTargetRow({
       </span>
     </button>
   );
+
+  if (!disabled || !disabledReason) {
+    return row;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="block w-full">{row}</span>
+      </TooltipTrigger>
+      <TooltipContent side="left" sideOffset={6}>
+        {disabledReason}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function DirectDraftTargetList({
   targets,
   onSelect,
+  isTargetDisabled,
+  disabledReason,
 }: {
   targets: readonly DirectDraftTarget[];
   onSelect: (target: DirectDraftTarget) => void;
+  isTargetDisabled?: (target: DirectDraftTarget) => boolean;
+  disabledReason?: string;
 }) {
   const t = useTranslations("App.Channels");
   const humans = targets.filter((target) => target.kind === "human");
@@ -179,13 +218,18 @@ export function DirectDraftTargetList({
               {t("Dialog.humans")}
             </div>
           ) : null}
-          {humans.map((target) => (
-            <DirectDraftTargetRow
-              key={target.key}
-              target={target}
-              onSelect={onSelect}
-            />
-          ))}
+          {humans.map((target) => {
+            const disabled = isTargetDisabled?.(target) ?? false;
+            return (
+              <DirectDraftTargetRow
+                key={target.key}
+                target={target}
+                onSelect={onSelect}
+                disabled={disabled}
+                disabledReason={disabled ? disabledReason : undefined}
+              />
+            );
+          })}
         </div>
       ) : null}
       {coworkerTargets.length > 0 ? (
@@ -195,13 +239,18 @@ export function DirectDraftTargetList({
               {t("Dialog.coworkers")}
             </div>
           ) : null}
-          {coworkerTargets.map((target) => (
-            <DirectDraftTargetRow
-              key={target.key}
-              target={target}
-              onSelect={onSelect}
-            />
-          ))}
+          {coworkerTargets.map((target) => {
+            const disabled = isTargetDisabled?.(target) ?? false;
+            return (
+              <DirectDraftTargetRow
+                key={target.key}
+                target={target}
+                onSelect={onSelect}
+                disabled={disabled}
+                disabledReason={disabled ? disabledReason : undefined}
+              />
+            );
+          })}
         </div>
       ) : null}
     </>

--- a/apps/web/src/app/(app)/chat/utils/__tests__/direct-create-shape.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/direct-create-shape.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { directCreateShapeError } from "@/app/chat/utils/direct-create-shape";
+
+describe("directCreateShapeError", () => {
+  it("allows one or more humans with no coworkers", () => {
+    expect(directCreateShapeError(["u1"], [])).toBeNull();
+    expect(directCreateShapeError(["u1", "u2"], [])).toBeNull();
+  });
+
+  it("allows a single coworker with no humans", () => {
+    expect(directCreateShapeError([], ["c1"])).toBeNull();
+  });
+
+  it("rejects empty targets", () => {
+    expect(directCreateShapeError([], [])).toBe(
+      "Choose a direct message target",
+    );
+  });
+
+  it("rejects mixed human and coworker targets", () => {
+    expect(directCreateShapeError(["u1"], ["c1"])).toBe(
+      "Group direct messages cannot include coworkers.",
+    );
+    expect(directCreateShapeError(["u1", "u2"], ["c1"])).toBe(
+      "Group direct messages cannot include coworkers.",
+    );
+  });
+
+  it("rejects multiple coworkers", () => {
+    expect(directCreateShapeError([], ["c1", "c2"])).toBe(
+      "Direct messages support one coworker only.",
+    );
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/direct-create-shape.ts
+++ b/apps/web/src/app/(app)/chat/utils/direct-create-shape.ts
@@ -1,0 +1,30 @@
+/**
+ * Mirrors Core `parseDirectCreateShape` predicates for web-side validation
+ * before calling create/send direct actions. Messages match Core when possible.
+ */
+export function directCreateShapeError(
+  memberUserIds: readonly string[],
+  coworkerIds: readonly string[],
+): string | null {
+  if (memberUserIds.length === 0 && coworkerIds.length === 0) {
+    return "Choose a direct message target";
+  }
+
+  if (memberUserIds.length > 0 && coworkerIds.length > 0) {
+    return "Group direct messages cannot include coworkers.";
+  }
+
+  if (coworkerIds.length > 1) {
+    return "Direct messages support one coworker only.";
+  }
+
+  if (memberUserIds.length >= 1 && coworkerIds.length === 0) {
+    return null;
+  }
+
+  if (memberUserIds.length === 0 && coworkerIds.length === 1) {
+    return null;
+  }
+
+  return "Choose a direct message target";
+}

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -4492,7 +4492,7 @@ export const CreateChatRoomRequestSchema = {
                     enum: [
                         'direct'
                     ],
-                    description: 'Creates or returns a 1:1 direct room (one organization member XOR one coworker) scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization. Group directs are not supported yet.'
+                    description: 'Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization.'
                 },
                 memberUserIds: {
                     type: 'array',

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -386,7 +386,7 @@ export const getChatsRooms = <ThrowOnError extends boolean = false>(options?: Op
 });
 
 /**
- * Create a chat room. `kind: "channel"` requires an active organization. `kind: "direct"` creates or returns a 1:1 room scoped to the active organization when one is set. Coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.
+ * Create a chat room. `kind: "channel"` requires an active organization. `kind: "direct"` creates or returns a direct room (1:1 or multi-human group) scoped to the active organization when one is set. Coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.
  */
 export const postChatsRooms = <ThrowOnError extends boolean = false>(options?: Options<PostChatsRoomsData, ThrowOnError>): RequestResult<PostChatsRoomsResponses, PostChatsRoomsErrors, ThrowOnError> => (options?.client ?? client).post<PostChatsRoomsResponses, PostChatsRoomsErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsResponseTransformer,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1243,7 +1243,7 @@ export type CreateChatRoomRequest = {
     coworkerIds?: Array<string>;
 } | {
     /**
-     * Creates or returns a 1:1 direct room (one organization member XOR one coworker) scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization. Group directs are not supported yet.
+     * Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization.
      */
     kind: 'direct';
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linear

https://linear.app/masumi/issue/SOK-685/multi-human-group-direct-messages

## Summary

Org members can create-or-get **multi-human group direct rooms** (≥2 other humans + self). Same participant set → same `directKey` (`direct:v2:…`). 1:1 human and 1:1 coworker directs unchanged. Coworkers rejected in group directs. Fixed participant set for v1.

## Spec (≤8 lines)

- Core: `DirectCreateShape` allows N≥1 humans / XOR one coworker; mix → 400
- Web: multi-select humans; cross-kind picker disable; mirror validation
- List titles/avatars already group-ready; leave/rename/archive still blocked
- No stream/AI path for group directs (no coworkers in room)
- Out of scope: coworkers in groups, channel↔direct, personal multi-human, mutations after create

## Verification

- `pnpm --filter core check` / `pnpm core:test` — pass
- `pnpm web:check` / `pnpm web:test` — pass
- UI `/chat?dm=new`: multi-select Bob+Admin, coworkers disabled, room created with `direct:v2` key, sidebar title “Bob Agent, Admin Agent”
- CI: all required checks green

![DM picker with humans](https://cursor.com/artifacts/c/art-48ddbff2-48ec-49da-b8bd-bf4a0404e61e)
![Multi-selected humans, coworkers disabled](https://cursor.com/artifacts/c/art-fbdc4727-a41e-4b8e-9d03-1f7948cc781f)
![Group direct room open](https://cursor.com/artifacts/c/art-a5d5dfec-189b-4d6d-9477-4ffe68b76ff7)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-685](https://linear.app/masumi/issue/SOK-685/multi-human-group-direct-messages)

<div><a href="https://cursor.com/agents/bc-6ff33717-ecdf-45b0-85ba-f8a6aef51dbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ff33717-ecdf-45b0-85ba-f8a6aef51dbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

