### PR TITLE
feat(chat): persist unsent compose drafts in localStorage

### DIFF
--- a/apps/web/src/app/(app)/chat/components/draft-channel.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-channel.tsx
@@ -12,6 +12,11 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { sendNewChannelMessageAction } from "@/app/chat/actions";
+import { usePersistComposeDraft } from "@/app/chat/hooks/use-compose-draft";
+import {
+  type ComposeDraft,
+  composeDraftKey,
+} from "@/app/chat/utils/compose-draft-storage";
 import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
@@ -67,6 +72,31 @@ export function DraftChannel({
   >([]);
   const [mentionedIds, setMentionedIds] = useState<string[]>([]);
   const [isCreating, startCreatingTransition] = useTransition();
+  const composeDraft = useMemo<ComposeDraft>(
+    () => ({
+      text: composerValue,
+      attachments: composerAttachments.map((attachment) => ({
+        url: attachment.url,
+        fileName: attachment.fileName,
+        ...(attachment.mediaType ? { mediaType: attachment.mediaType } : {}),
+      })),
+    }),
+    [composerValue, composerAttachments],
+  );
+  const { clearDraft } = usePersistComposeDraft({
+    key: composeDraftKey.draftChannel(),
+    draft: composeDraft,
+    onHydrate: (draft) => {
+      setComposerValue(draft.text);
+      setComposerAttachments(
+        draft.attachments.map((attachment) => ({
+          url: attachment.url,
+          fileName: attachment.fileName,
+          mediaType: attachment.mediaType ?? null,
+        })),
+      );
+    },
+  });
   const targets = useMemo(
     () => buildDirectDraftTargets(members, coworkers, currentUserId),
     [members, coworkers, currentUserId],
@@ -182,6 +212,7 @@ export function DraftChannel({
       setComposerValue("");
       setComposerAttachments([]);
       setMentionedIds([]);
+      clearDraft();
       notifyOrganizationChatRoomsChanged(result.data.room);
       router.replace(`/chat/rooms/${result.data.room.id}`);
     });

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -15,6 +15,11 @@ import {
   ensureCoworkerDirectRoomAction,
   sendNewDirectMessageAction,
 } from "@/app/chat/actions";
+import { usePersistComposeDraft } from "@/app/chat/hooks/use-compose-draft";
+import {
+  type ComposeDraft,
+  composeDraftKey,
+} from "@/app/chat/utils/compose-draft-storage";
 import { stashPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
 import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -71,6 +76,31 @@ export function DraftDirectMessage({
   >([]);
   const [mentionedIds, setMentionedIds] = useState<string[]>([]);
   const [isSending, startSendingTransition] = useTransition();
+  const composeDraft = useMemo<ComposeDraft>(
+    () => ({
+      text: composerValue,
+      attachments: composerAttachments.map((attachment) => ({
+        url: attachment.url,
+        fileName: attachment.fileName,
+        ...(attachment.mediaType ? { mediaType: attachment.mediaType } : {}),
+      })),
+    }),
+    [composerValue, composerAttachments],
+  );
+  const { clearDraft } = usePersistComposeDraft({
+    key: composeDraftKey.draftDm(),
+    draft: composeDraft,
+    onHydrate: (draft) => {
+      setComposerValue(draft.text);
+      setComposerAttachments(
+        draft.attachments.map((attachment) => ({
+          url: attachment.url,
+          fileName: attachment.fileName,
+          mediaType: attachment.mediaType ?? null,
+        })),
+      );
+    },
+  });
   const targets = useMemo(
     () => buildDirectDraftTargets(members, coworkers, currentUserId),
     [members, coworkers, currentUserId],
@@ -180,6 +210,7 @@ export function DraftDirectMessage({
         setComposerValue("");
         setComposerAttachments([]);
         setMentionedIds([]);
+        clearDraft();
         notifyOrganizationChatRoomsChanged(roomResult.data);
         router.replace(`/chat/rooms/${roomResult.data.id}`);
       });
@@ -217,6 +248,7 @@ export function DraftDirectMessage({
       setComposerValue("");
       setComposerAttachments([]);
       setMentionedIds([]);
+      clearDraft();
       notifyOrganizationChatRoomsChanged(result.data.room);
       router.replace(`/chat/rooms/${result.data.room.id}`);
     });

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/app/chat/hooks/use-coworker-direct-room-stream";
 import {
   type ComposeDraft,
+  clearComposeDraft,
   composeDraftKey,
 } from "@/app/chat/utils/compose-draft-storage";
 import { formatDaySeparator } from "@/app/chat/utils/date-utils";
@@ -206,6 +207,20 @@ export function RoomsClient({
   const [threadMentionedIds, setThreadMentionedIds] = useState<string[]>([]);
   const [pendingThreadQuote, setPendingThreadQuote] =
     useState<PendingRoomQuote | null>(null);
+  const composeSurfaceEpoch = `${selectedRoomId}:${isNewDirectMessage}:${isCreateChannelRequested}`;
+  const [syncedComposeSurfaceEpoch, setSyncedComposeSurfaceEpoch] =
+    useState(composeSurfaceEpoch);
+  if (composeSurfaceEpoch !== syncedComposeSurfaceEpoch) {
+    setSyncedComposeSurfaceEpoch(composeSurfaceEpoch);
+    setMentionedIds([]);
+    setPendingQuote(null);
+    setThreadParentMessage(null);
+    setThreadMessages([]);
+    setThreadComposerValue("");
+    setThreadComposerAttachments([]);
+    setThreadMentionedIds([]);
+    setPendingThreadQuote(null);
+  }
 
   const channelComposeDraftKey =
     selectedRoomId != null && !isNewDirectMessage && !isCreateChannelRequested
@@ -603,17 +618,6 @@ export function RoomsClient({
         : current,
     );
   }, [messages, messagesNextCursor, selectedRoomId]);
-
-  useEffect(() => {
-    setMentionedIds([]);
-    setPendingQuote(null);
-    setThreadParentMessage(null);
-    setThreadMessages([]);
-    setThreadComposerValue("");
-    setThreadComposerAttachments([]);
-    setThreadMentionedIds([]);
-    setPendingThreadQuote(null);
-  }, [selectedRoomId, isNewDirectMessage, isCreateChannelRequested]);
 
   // Scroll on room switch or when the newest message changes — not when
   // an older page is prepended (length grows, last id stays the same).
@@ -1036,6 +1040,7 @@ export function RoomsClient({
 
     const { mentionedCoworkerIds, mentionedUserIds } =
       partitionMentionIds(mentionedIds);
+    const sentChannelDraftKey = composeDraftKey.room(roomId);
     startSendingTransition(async () => {
       const result = await sendRoomMessageAction(
         roomId,
@@ -1050,15 +1055,16 @@ export function RoomsClient({
         toast.error(result.message);
         return;
       }
+      clearComposeDraft(sentChannelDraftKey);
       if (!isStillSelectedRoom(roomId)) {
         return;
       }
+      clearChannelComposeDraft();
       setMessagesState((current) => appendMessage(current, result.data));
       setComposerValue("");
       setComposerAttachments([]);
       setMentionedIds([]);
       setPendingQuote(null);
-      clearChannelComposeDraft();
     });
   }
 
@@ -1090,6 +1096,7 @@ export function RoomsClient({
 
     const { mentionedCoworkerIds, mentionedUserIds } =
       partitionMentionIds(threadMentionedIds);
+    const sentThreadDraftKey = composeDraftKey.thread(roomId, parentMessageId);
     startSendingThreadReplyTransition(async () => {
       const result = await sendRoomMessageAction(
         roomId,
@@ -1105,17 +1112,18 @@ export function RoomsClient({
         toast.error(result.message);
         return;
       }
+      clearComposeDraft(sentThreadDraftKey);
       if (!isStillSelectedRoom(roomId)) {
         return;
       }
 
+      clearThreadComposeDraft();
       setThreadMessages((current) => [...current, result.data]);
       updateParentThreadPreview(parentMessageId, result.data);
       setThreadComposerValue("");
       setThreadComposerAttachments([]);
       setThreadMentionedIds([]);
       setPendingThreadQuote(null);
-      clearThreadComposeDraft();
     });
   }
 

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -20,10 +20,15 @@ import {
   toggleMessageReactionAction,
 } from "@/app/chat/actions";
 import DaySeparator from "@/app/chat/components/day-separator";
+import { usePersistComposeDraft } from "@/app/chat/hooks/use-compose-draft";
 import {
   readStoredStreamParentMessageId,
   useCoworkerDirectRoomStream,
 } from "@/app/chat/hooks/use-coworker-direct-room-stream";
+import {
+  type ComposeDraft,
+  composeDraftKey,
+} from "@/app/chat/utils/compose-draft-storage";
 import { formatDaySeparator } from "@/app/chat/utils/date-utils";
 import {
   mergeMessagesWithStreamOverlay,
@@ -201,6 +206,66 @@ export function RoomsClient({
   const [threadMentionedIds, setThreadMentionedIds] = useState<string[]>([]);
   const [pendingThreadQuote, setPendingThreadQuote] =
     useState<PendingRoomQuote | null>(null);
+
+  const channelComposeDraftKey =
+    selectedRoomId != null && !isNewDirectMessage && !isCreateChannelRequested
+      ? composeDraftKey.room(selectedRoomId)
+      : null;
+  const threadComposeDraftKey =
+    selectedRoomId != null && threadParentMessage != null
+      ? composeDraftKey.thread(selectedRoomId, threadParentMessage.id)
+      : null;
+  const channelComposeDraft = useMemo<ComposeDraft>(
+    () => ({
+      text: composerValue,
+      attachments: composerAttachments.map((attachment) => ({
+        url: attachment.url,
+        fileName: attachment.fileName,
+        ...(attachment.mediaType ? { mediaType: attachment.mediaType } : {}),
+      })),
+    }),
+    [composerValue, composerAttachments],
+  );
+  const threadComposeDraft = useMemo<ComposeDraft>(
+    () => ({
+      text: threadComposerValue,
+      attachments: threadComposerAttachments.map((attachment) => ({
+        url: attachment.url,
+        fileName: attachment.fileName,
+        ...(attachment.mediaType ? { mediaType: attachment.mediaType } : {}),
+      })),
+    }),
+    [threadComposerValue, threadComposerAttachments],
+  );
+  const { clearDraft: clearChannelComposeDraft } = usePersistComposeDraft({
+    key: channelComposeDraftKey,
+    draft: channelComposeDraft,
+    onHydrate: (draft) => {
+      setComposerValue(draft.text);
+      setComposerAttachments(
+        draft.attachments.map((attachment) => ({
+          url: attachment.url,
+          fileName: attachment.fileName,
+          mediaType: attachment.mediaType ?? null,
+        })),
+      );
+    },
+  });
+  const { clearDraft: clearThreadComposeDraft } = usePersistComposeDraft({
+    key: threadComposeDraftKey,
+    draft: threadComposeDraft,
+    onHydrate: (draft) => {
+      setThreadComposerValue(draft.text);
+      setThreadComposerAttachments(
+        draft.attachments.map((attachment) => ({
+          url: attachment.url,
+          fileName: attachment.fileName,
+          mediaType: attachment.mediaType ?? null,
+        })),
+      );
+    },
+  });
+
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const roomComposerRef = useRef<RoomComposerHandle | null>(null);
   const readMarkerRef = useRef<string | null>(null);
@@ -540,8 +605,6 @@ export function RoomsClient({
   }, [messages, messagesNextCursor, selectedRoomId]);
 
   useEffect(() => {
-    setComposerValue("");
-    setComposerAttachments([]);
     setMentionedIds([]);
     setPendingQuote(null);
     setThreadParentMessage(null);
@@ -966,6 +1029,7 @@ export function RoomsClient({
       setComposerAttachments([]);
       setMentionedIds([]);
       setPendingQuote(null);
+      clearChannelComposeDraft();
       sendStreamMessage(content);
       return;
     }
@@ -994,6 +1058,7 @@ export function RoomsClient({
       setComposerAttachments([]);
       setMentionedIds([]);
       setPendingQuote(null);
+      clearChannelComposeDraft();
     });
   }
 
@@ -1018,6 +1083,7 @@ export function RoomsClient({
       setThreadComposerAttachments([]);
       setThreadMentionedIds([]);
       setPendingThreadQuote(null);
+      clearThreadComposeDraft();
       sendStreamMessage(content, { parentMessageId });
       return;
     }
@@ -1049,6 +1115,7 @@ export function RoomsClient({
       setThreadComposerAttachments([]);
       setThreadMentionedIds([]);
       setPendingThreadQuote(null);
+      clearThreadComposeDraft();
     });
   }
 

--- a/apps/web/src/app/(app)/chat/hooks/use-compose-draft.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-compose-draft.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useEffectEvent, useRef } from "react";
+import {
+  type ComposeDraft,
+  clearComposeDraft,
+  EMPTY_COMPOSE_DRAFT,
+  getComposeDraft,
+  setComposeDraft,
+} from "@/app/chat/utils/compose-draft-storage";
+
+const DEFAULT_DEBOUNCE_MS = 300;
+
+export function usePersistComposeDraft({
+  key,
+  draft,
+  onHydrate,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}: {
+  key: string | null;
+  draft: ComposeDraft;
+  onHydrate: (draft: ComposeDraft) => void;
+  debounceMs?: number;
+}): { clearDraft: () => void } {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingKeyRef = useRef<string | null>(null);
+  const pendingDraftRef = useRef<ComposeDraft | null>(null);
+  const skipNextPersistRef = useRef(false);
+  const keyRef = useRef(key);
+  const hydrate = useEffectEvent(onHydrate);
+
+  const cancelDebounce = useCallback(() => {
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingKeyRef.current = null;
+    pendingDraftRef.current = null;
+  }, []);
+
+  const flushPending = useCallback(() => {
+    if (pendingKeyRef.current != null && pendingDraftRef.current != null) {
+      setComposeDraft(pendingKeyRef.current, pendingDraftRef.current);
+    }
+    cancelDebounce();
+  }, [cancelDebounce]);
+
+  useEffect(() => {
+    const previousKey = keyRef.current;
+    if (previousKey !== key) {
+      flushPending();
+      keyRef.current = key;
+    }
+
+    if (key == null) {
+      return;
+    }
+
+    skipNextPersistRef.current = true;
+    hydrate(getComposeDraft(key) ?? EMPTY_COMPOSE_DRAFT);
+  }, [key, flushPending]);
+
+  useEffect(() => {
+    if (key == null) {
+      return;
+    }
+    if (skipNextPersistRef.current) {
+      skipNextPersistRef.current = false;
+      return;
+    }
+
+    pendingKeyRef.current = key;
+    pendingDraftRef.current = draft;
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      if (pendingKeyRef.current != null && pendingDraftRef.current != null) {
+        setComposeDraft(pendingKeyRef.current, pendingDraftRef.current);
+      }
+      timerRef.current = null;
+      pendingKeyRef.current = null;
+      pendingDraftRef.current = null;
+    }, debounceMs);
+  }, [key, draft, debounceMs]);
+
+  useEffect(() => {
+    return () => {
+      flushPending();
+    };
+  }, [flushPending]);
+
+  const clearDraft = useCallback(() => {
+    cancelDebounce();
+    if (key != null) {
+      clearComposeDraft(key);
+    }
+  }, [cancelDebounce, key]);
+
+  return { clearDraft };
+}

--- a/apps/web/src/app/(app)/chat/utils/__tests__/compose-draft-storage.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/compose-draft-storage.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearComposeDraft,
+  composeDraftKey,
+  getComposeDraft,
+  setComposeDraft,
+} from "../compose-draft-storage";
+
+describe("compose-draft-storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("builds surface keys", () => {
+    expect(composeDraftKey.room("room-1")).toBe(
+      "sokosumi:compose-draft:v1:room:room-1",
+    );
+    expect(composeDraftKey.thread("room-1", "msg-2")).toBe(
+      "sokosumi:compose-draft:v1:thread:room-1:msg-2",
+    );
+    expect(composeDraftKey.welcome()).toBe("sokosumi:compose-draft:v1:welcome");
+    expect(composeDraftKey.draftDm()).toBe(
+      "sokosumi:compose-draft:v1:draft-dm",
+    );
+    expect(composeDraftKey.draftChannel()).toBe(
+      "sokosumi:compose-draft:v1:draft-channel",
+    );
+  });
+
+  it("roundtrips text and attachments", () => {
+    const key = composeDraftKey.room("room-1");
+    setComposeDraft(key, {
+      text: "hello",
+      attachments: [
+        {
+          url: "https://cdn.example/a.png",
+          fileName: "a.png",
+          mediaType: "image/png",
+        },
+      ],
+    });
+
+    expect(getComposeDraft(key)).toEqual({
+      text: "hello",
+      attachments: [
+        {
+          url: "https://cdn.example/a.png",
+          fileName: "a.png",
+          mediaType: "image/png",
+        },
+      ],
+    });
+  });
+
+  it("removes the key when draft is empty", () => {
+    const key = composeDraftKey.draftDm();
+    setComposeDraft(key, { text: "keep", attachments: [] });
+    expect(window.localStorage.getItem(key)).not.toBeNull();
+
+    setComposeDraft(key, { text: "  ", attachments: [] });
+    expect(window.localStorage.getItem(key)).toBeNull();
+    expect(getComposeDraft(key)).toBeNull();
+  });
+
+  it("clearComposeDraft removes the key", () => {
+    const key = composeDraftKey.draftChannel();
+    setComposeDraft(key, { text: "draft", attachments: [] });
+    clearComposeDraft(key);
+    expect(window.localStorage.getItem(key)).toBeNull();
+  });
+
+  it("migrates legacy chat-input once into welcome", () => {
+    window.localStorage.setItem("chat-input", JSON.stringify("legacy text"));
+
+    const welcomeKey = composeDraftKey.welcome();
+    expect(getComposeDraft(welcomeKey)).toEqual({
+      text: "legacy text",
+      attachments: [],
+    });
+    expect(window.localStorage.getItem("chat-input")).toBeNull();
+
+    setComposeDraft(welcomeKey, { text: "new draft", attachments: [] });
+    window.localStorage.setItem("chat-input", JSON.stringify("ignored"));
+    expect(getComposeDraft(welcomeKey)).toEqual({
+      text: "new draft",
+      attachments: [],
+    });
+  });
+
+  it("does not migrate empty legacy chat-input text", () => {
+    window.localStorage.setItem("chat-input", JSON.stringify(""));
+    expect(getComposeDraft(composeDraftKey.welcome())).toBeNull();
+    expect(window.localStorage.getItem("chat-input")).toBeNull();
+  });
+
+  it("returns null for corrupt JSON", () => {
+    const key = composeDraftKey.room("room-1");
+    window.localStorage.setItem(key, "{not-json");
+    expect(getComposeDraft(key)).toBeNull();
+  });
+
+  it("returns null for invalid draft shape", () => {
+    const key = composeDraftKey.room("room-1");
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({ text: 1, attachments: [] }),
+    );
+    expect(getComposeDraft(key)).toBeNull();
+  });
+
+  it("soft-fails when localStorage throws", () => {
+    const key = composeDraftKey.room("room-1");
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(getComposeDraft(key)).toBeNull();
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() =>
+      setComposeDraft(key, { text: "x", attachments: [] }),
+    ).not.toThrow();
+
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => clearComposeDraft(key)).not.toThrow();
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/compose-draft-storage.ts
+++ b/apps/web/src/app/(app)/chat/utils/compose-draft-storage.ts
@@ -148,7 +148,7 @@ export function setComposeDraft(key: string, draft: ComposeDraft): void {
       }),
     );
   } catch {
-    // Quota / private mode — compose must keep working.
+    // Best-effort: quota / private mode must not break compose.
   }
 }
 

--- a/apps/web/src/app/(app)/chat/utils/compose-draft-storage.ts
+++ b/apps/web/src/app/(app)/chat/utils/compose-draft-storage.ts
@@ -1,0 +1,164 @@
+export interface ComposeDraftAttachment {
+  url: string;
+  fileName: string;
+  mediaType?: string;
+}
+
+export interface ComposeDraft {
+  text: string;
+  attachments: ComposeDraftAttachment[];
+}
+
+const DRAFT_KEY_PREFIX = "sokosumi:compose-draft:v1:";
+const LEGACY_CHAT_INPUT_KEY = "chat-input";
+
+export const EMPTY_COMPOSE_DRAFT: ComposeDraft = {
+  text: "",
+  attachments: [],
+};
+
+export const composeDraftKey = {
+  room(id: string): string {
+    return `${DRAFT_KEY_PREFIX}room:${id}`;
+  },
+  thread(roomId: string, parentId: string): string {
+    return `${DRAFT_KEY_PREFIX}thread:${roomId}:${parentId}`;
+  },
+  welcome(): string {
+    return `${DRAFT_KEY_PREFIX}welcome`;
+  },
+  draftDm(): string {
+    return `${DRAFT_KEY_PREFIX}draft-dm`;
+  },
+  draftChannel(): string {
+    return `${DRAFT_KEY_PREFIX}draft-channel`;
+  },
+};
+
+function isComposeDraftAttachment(
+  value: unknown,
+): value is ComposeDraftAttachment {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const attachment = value as ComposeDraftAttachment;
+  if (typeof attachment.url !== "string") {
+    return false;
+  }
+  if (typeof attachment.fileName !== "string") {
+    return false;
+  }
+  if (
+    attachment.mediaType !== undefined &&
+    typeof attachment.mediaType !== "string"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function parseComposeDraft(raw: string): ComposeDraft | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed == null || typeof parsed !== "object") {
+      return null;
+    }
+    const draft = parsed as ComposeDraft;
+    if (typeof draft.text !== "string") {
+      return null;
+    }
+    if (!Array.isArray(draft.attachments)) {
+      return null;
+    }
+    if (!draft.attachments.every(isComposeDraftAttachment)) {
+      return null;
+    }
+    return {
+      text: draft.text,
+      attachments: draft.attachments.map((attachment) => ({
+        url: attachment.url,
+        fileName: attachment.fileName,
+        ...(attachment.mediaType !== undefined
+          ? { mediaType: attachment.mediaType }
+          : {}),
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isEmptyComposeDraft(draft: ComposeDraft): boolean {
+  return draft.text.trim().length === 0 && draft.attachments.length === 0;
+}
+
+function migrateLegacyChatInput(): ComposeDraft | null {
+  try {
+    const legacy = window.localStorage.getItem(LEGACY_CHAT_INPUT_KEY);
+    if (legacy == null) {
+      return null;
+    }
+    window.localStorage.removeItem(LEGACY_CHAT_INPUT_KEY);
+    try {
+      const text: unknown = JSON.parse(legacy);
+      if (typeof text !== "string" || text.length === 0) {
+        return null;
+      }
+      return { text, attachments: [] };
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+export function getComposeDraft(key: string): ComposeDraft | null {
+  try {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    const raw = window.localStorage.getItem(key);
+    if (raw != null) {
+      return parseComposeDraft(raw);
+    }
+    if (key === composeDraftKey.welcome()) {
+      return migrateLegacyChatInput();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function setComposeDraft(key: string, draft: ComposeDraft): void {
+  try {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (isEmptyComposeDraft(draft)) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        text: draft.text,
+        attachments: draft.attachments,
+      }),
+    );
+  } catch {
+    // Quota / private mode — compose must keep working.
+  }
+}
+
+export function clearComposeDraft(key: string): void {
+  try {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.removeItem(key);
+  } catch {
+    // Quota / private mode — compose must keep working.
+  }
+}

--- a/apps/web/src/components/chat/__tests__/multimodal-input.test.tsx
+++ b/apps/web/src/components/chat/__tests__/multimodal-input.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { type UIMessage } from "ai";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
+import {
+  composeDraftKey,
+  setComposeDraft,
+} from "@/app/chat/utils/compose-draft-storage";
 import type {
   ChatComposeMessage,
   ChatComposeSubmitOptions,
@@ -235,5 +238,24 @@ describe("MultimodalInput", () => {
         imageGeneration: true,
       }),
     );
+  });
+
+  it("hydrates welcome draft from localStorage and clears it on successful send", async () => {
+    setComposeDraft(composeDraftKey.welcome(), {
+      text: "restored draft",
+      attachments: [],
+    });
+
+    const onSendMessage = vi.fn().mockResolvedValue(true);
+    render(<WelcomeMultimodalInput onSendMessage={onSendMessage} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveValue("restored draft");
+    });
+
+    fireEvent.click(screen.getByTestId("send-button"));
+
+    await waitFor(() => expect(onSendMessage).toHaveBeenCalledTimes(1));
+    expect(window.localStorage.getItem(composeDraftKey.welcome())).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -18,6 +18,11 @@ import {
   useRef,
   useState,
 } from "react";
+import { usePersistComposeDraft } from "@/app/chat/hooks/use-compose-draft";
+import {
+  type ComposeDraft,
+  composeDraftKey,
+} from "@/app/chat/utils/compose-draft-storage";
 import {
   filterCoworkersForComposeKind,
   findDefaultCoworker,
@@ -286,52 +291,33 @@ function PureMultimodalInput({
     }
   }, []);
 
-  // Simple localStorage hook replacement
-  const getLocalStorageValue = useCallback(
-    (key: string, defaultValue: string) => {
-      if (typeof window === "undefined") return defaultValue;
-      try {
-        const item = window.localStorage.getItem(key);
-        return item ? JSON.parse(item) : defaultValue;
-      } catch {
-        return defaultValue;
-      }
-    },
-    [],
+  const composeDraft = useMemo<ComposeDraft>(
+    () => ({
+      text: input,
+      attachments: chatFileParts.map((part) => ({
+        url: part.url,
+        fileName: part.filename ?? "file",
+        ...(part.mediaType ? { mediaType: part.mediaType } : {}),
+      })),
+    }),
+    [input, chatFileParts],
   );
-
-  const setLocalStorageValue = useCallback((key: string, value: string) => {
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, []);
-
-  const [localStorageInput] = useState(() =>
-    getLocalStorageValue("chat-input", ""),
-  );
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      const domValue = textareaRef.current.value;
-      // Prefer DOM value over localStorage to handle hydration
-      const finalValue = domValue || localStorageInput || "";
-      setInput(finalValue);
+  const { clearDraft } = usePersistComposeDraft({
+    key: composeDraftKey.welcome(),
+    draft: composeDraft,
+    onHydrate: (draft) => {
+      setInput(draft.text);
+      setChatFileParts(
+        draft.attachments.map((attachment) => ({
+          type: "file" as const,
+          url: attachment.url,
+          filename: attachment.fileName,
+          mediaType: attachment.mediaType ?? "application/octet-stream",
+        })),
+      );
       adjustHeight();
-      return;
-    }
-    if (localStorageInput) {
-      setInput((prev) => (prev ? prev : localStorageInput));
-    }
-    // Only run once after hydration
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    setLocalStorageValue("chat-input", input);
-  }, [input, setLocalStorageValue]);
+    },
+  });
 
   const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(event.target.value);
@@ -471,7 +457,7 @@ function PureMultimodalInput({
       );
     }
 
-    setLocalStorageValue("chat-input", "");
+    clearDraft();
     resetHeight();
     setInput("");
     setChatFileParts([]);
@@ -483,13 +469,13 @@ function PureMultimodalInput({
   }, [
     blurOnSendOnMobile,
     chatFileParts,
+    clearDraft,
     effectiveImageGenerationEnabled,
     input,
     onSendMessage,
     resetHeight,
     selectedCoworker,
     setInput,
-    setLocalStorageValue,
     sendMessage,
     width,
   ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://linear.app/masumi/issue/SOK-686/persist-unsent-chat-compose-drafts-when-navigating-away

Unsent chat compose text and uploaded attachment URL chips now restore from browser `localStorage` when the user returns to the same surface (room, thread, welcome, draft DM, draft channel).

## Spec summary

- Client-only `localStorage` keys `sokosumi:compose-draft:v1:<surface>`
- Shared storage util + `usePersistComposeDraft` thin sync; parents keep React state
- Clear draft on successful send (stream optimistic clear / POST ok, keyed by sent surface)
- Welcome migrates legacy `"chat-input"` once; `pending-room-message` unchanged
- Mentions/quotes and never-uploaded Files out of v1

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0)

Supersedes closed #3509 (same commits; reopened to restore missing Actions workflow triggers).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-686](https://linear.app/masumi/issue/SOK-686/persist-unsent-chat-compose-drafts-when-navigating-away)

<div><a href="https://cursor.com/agents/bc-7a2cdc13-8456-48ae-8669-d210ee1e8cd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a2cdc13-8456-48ae-8669-d210ee1e8cd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

