### PR TITLE
feat(chat): add more/less expand on clamped quote bodies

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4689,7 +4689,9 @@
         "action": "Zitieren",
         "dismiss": "Zitat entfernen",
         "previewLabel": "Zitiere {author}",
-        "jump": "Zur Nachricht von {author} springen"
+        "jump": "Zur Nachricht von {author} springen",
+        "showMore": "Mehr",
+        "showLess": "Weniger"
       },
       "MentionAll": {
         "label": "Alle"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4808,7 +4808,9 @@
         "action": "Quote",
         "dismiss": "Remove quote",
         "previewLabel": "Quoting {author}",
-        "jump": "Jump to message from {author}"
+        "jump": "Jump to message from {author}",
+        "showMore": "More",
+        "showLess": "Less"
       },
       "MentionAll": {
         "label": "Everyone"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4689,7 +4689,9 @@
         "action": "Citar",
         "dismiss": "Quitar cita",
         "previewLabel": "Citando a {author}",
-        "jump": "Ir al mensaje de {author}"
+        "jump": "Ir al mensaje de {author}",
+        "showMore": "Más",
+        "showLess": "Menos"
       },
       "MentionAll": {
         "label": "Todos"

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4689,7 +4689,9 @@
         "action": "Citer",
         "dismiss": "Retirer la citation",
         "previewLabel": "Citation de {author}",
-        "jump": "Aller au message de {author}"
+        "jump": "Aller au message de {author}",
+        "showMore": "Plus",
+        "showLess": "Moins"
       },
       "MentionAll": {
         "label": "Tout le monde"

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4689,7 +4689,9 @@
         "action": "Cita",
         "dismiss": "Rimuovi citazione",
         "previewLabel": "Citando {author}",
-        "jump": "Vai al messaggio di {author}"
+        "jump": "Vai al messaggio di {author}",
+        "showMore": "Altro",
+        "showLess": "Meno"
       },
       "MentionAll": {
         "label": "Tutti"

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4689,7 +4689,9 @@
         "action": "引用",
         "dismiss": "引用を削除",
         "previewLabel": "{author} を引用中",
-        "jump": "{author} のメッセージへ移動"
+        "jump": "{author} のメッセージへ移動",
+        "showMore": "続きを表示",
+        "showLess": "折りたたむ"
       },
       "MentionAll": {
         "label": "全員"

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4689,7 +4689,9 @@
         "action": "Citar",
         "dismiss": "Remover citação",
         "previewLabel": "Citando {author}",
-        "jump": "Ir para a mensagem de {author}"
+        "jump": "Ir para a mensagem de {author}",
+        "showMore": "Mais",
+        "showLess": "Menos"
       },
       "MentionAll": {
         "label": "Todos"

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4689,7 +4689,9 @@
         "action": "Citar",
         "dismiss": "Remover citação",
         "previewLabel": "A citar {author}",
-        "jump": "Ir para a mensagem de {author}"
+        "jump": "Ir para a mensagem de {author}",
+        "showMore": "Mais",
+        "showLess": "Menos"
       },
       "MentionAll": {
         "label": "Todos"

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4689,7 +4689,9 @@
         "action": "引用",
         "dismiss": "移除引用",
         "previewLabel": "正在引用 {author}",
-        "jump": "跳转到 {author} 的消息"
+        "jump": "跳转到 {author} 的消息",
+        "showMore": "更多",
+        "showLess": "收起"
       },
       "MentionAll": {
         "label": "所有人"

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -20,6 +20,12 @@ vi.mock("next-intl", () => ({
     if (key === "jump" && values) {
       return `Jump to message from ${values.author}`;
     }
+    if (key === "showMore") {
+      return "More";
+    }
+    if (key === "showLess") {
+      return "Less";
+    }
     return key;
   },
 }));
@@ -255,33 +261,129 @@ describe("ChatMessageRow", () => {
     expect(quoteButton.textContent).toContain("line one\nline two");
   });
 
-  it("shows the full quote body without a line clamp", () => {
-    const fullSnippet =
-      "Two more things about the chat here:\nCan you please make chat drafts persistent during tab-switches. Writing a long message and losing it because I quickly wanted to check sth. in another chat is painful :) and please add @all:all tagging functionality please.";
-
-    renderRow({
-      message: userMessage({
-        content: "Reply body",
-        quote: {
-          messageId: "original-3",
-          authorName: "Phil",
-          snippet: fullSnippet,
-        },
-      }),
+  it("clamps long quotes and expands with More/Less when content overflows", async () => {
+    const user = userEvent.setup();
+    const scrollDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+    const clientDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return 120;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return 40;
+      },
     });
 
-    const quoteButton = screen.getByRole("button", {
-      name: "Jump to message from Phil",
+    try {
+      const fullSnippet =
+        "Two more things about the chat here:\nCan you please make chat drafts persistent during tab-switches. Writing a long message and losing it because I quickly wanted to check sth. in another chat is painful :) and please add @all:all tagging functionality please.";
+
+      renderRow({
+        message: userMessage({
+          content: "Reply body",
+          quote: {
+            messageId: "original-3",
+            authorName: "Phil",
+            snippet: fullSnippet,
+          },
+        }),
+      });
+
+      const jumpButton = screen.getByRole("button", {
+        name: "Jump to message from Phil",
+      });
+      expect(jumpButton.querySelector(".line-clamp-4")).not.toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "More" }));
+      expect(jumpButton.querySelector(".line-clamp-4")).toBeNull();
+      expect(screen.getByRole("button", { name: "Less" })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Less" }));
+      expect(jumpButton.querySelector(".line-clamp-4")).not.toBeNull();
+      expect(screen.getByRole("button", { name: "More" })).toBeInTheDocument();
+    } finally {
+      if (scrollDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollDescriptor,
+        );
+      }
+      if (clientDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "clientHeight",
+          clientDescriptor,
+        );
+      }
+    }
+  });
+
+  it("hides More when the clamped quote does not overflow", () => {
+    const scrollDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+    const clientDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return 20;
+      },
     });
-    const snippetHost = quoteButton.querySelector(".whitespace-pre-line");
-    expect(snippetHost).not.toBeNull();
-    expect(snippetHost?.className ?? "").not.toMatch(/line-clamp-/);
-    expect(quoteButton.textContent).toContain(
-      "Two more things about the chat here:",
-    );
-    expect(quoteButton.textContent).toContain(
-      "chat drafts persistent during tab-switches",
-    );
-    expect(quoteButton.textContent).toContain("tagging functionality please.");
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return 20;
+      },
+    });
+
+    try {
+      renderRow({
+        message: userMessage({
+          content: "Reply body",
+          quote: {
+            messageId: "original-short",
+            authorName: "Phil",
+            snippet: "short quote",
+          },
+        }),
+      });
+
+      expect(
+        screen.queryByRole("button", { name: "More" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Jump to message from Phil" }),
+      ).toBeInTheDocument();
+    } finally {
+      if (scrollDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollDescriptor,
+        );
+      }
+      if (clientDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "clientHeight",
+          clientDescriptor,
+        );
+      }
+    }
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -214,4 +214,44 @@ describe("ChatMessageRow", () => {
     );
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
+
+  it("styles @all mention tokens in quote snippets", () => {
+    renderRow({
+      message: userMessage({
+        content: "Reply body",
+        quote: {
+          messageId: "original-1",
+          authorName: "Bob",
+          snippet: "please add @all:all tagging",
+        },
+      }),
+    });
+
+    const quoteButton = screen.getByRole("button", {
+      name: "Jump to message from Bob",
+    });
+    // Markdown mock renders children as text, so the mention HTML string is visible.
+    const formatted = quoteButton.textContent ?? "";
+    expect(formatted).toContain("text-primary");
+    expect(formatted).toContain(">@all</span>");
+    expect(formatted).not.toContain("@all:all");
+  });
+
+  it("preserves newlines in multi-line quote snippets", () => {
+    renderRow({
+      message: userMessage({
+        content: "Reply body",
+        quote: {
+          messageId: "original-2",
+          authorName: "Bob",
+          snippet: "line one\nline two",
+        },
+      }),
+    });
+
+    const quoteButton = screen.getByRole("button", {
+      name: "Jump to message from Bob",
+    });
+    expect(quoteButton.textContent).toContain("line one\nline two");
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -254,4 +254,34 @@ describe("ChatMessageRow", () => {
     });
     expect(quoteButton.textContent).toContain("line one\nline two");
   });
+
+  it("shows the full quote body without a line clamp", () => {
+    const fullSnippet =
+      "Two more things about the chat here:\nCan you please make chat drafts persistent during tab-switches. Writing a long message and losing it because I quickly wanted to check sth. in another chat is painful :) and please add @all:all tagging functionality please.";
+
+    renderRow({
+      message: userMessage({
+        content: "Reply body",
+        quote: {
+          messageId: "original-3",
+          authorName: "Phil",
+          snippet: fullSnippet,
+        },
+      }),
+    });
+
+    const quoteButton = screen.getByRole("button", {
+      name: "Jump to message from Phil",
+    });
+    const snippetHost = quoteButton.querySelector(".whitespace-pre-line");
+    expect(snippetHost).not.toBeNull();
+    expect(snippetHost?.className ?? "").not.toMatch(/line-clamp-/);
+    expect(quoteButton.textContent).toContain(
+      "Two more things about the chat here:",
+    );
+    expect(quoteButton.textContent).toContain(
+      "chat drafts persistent during tab-switches",
+    );
+    expect(quoteButton.textContent).toContain("tagging functionality please.");
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -35,12 +35,17 @@ import {
   RoomMessageComposer,
   type RoomMessageComposerAttachment,
 } from "@/components/chat/room-message-composer";
+import Markdown from "@/components/markdown";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   type MentionRecordEntry,
   type NormalizedMention,
 } from "@/components/ui/mention-textarea";
+import type {
+  ChatRoomCoworkerParticipant,
+  ChatRoomUserParticipant,
+} from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { uploadComposeAttachments } from "@/lib/utils/compose-upload.client";
 import {
@@ -50,7 +55,11 @@ import {
 } from "@/lib/utils/composer-active-formats";
 import { getInitials } from "@/lib/utils/text";
 import { AiCoworkerIcon } from "./room-draft-shared";
-import type { PendingRoomQuote, RoomMentionParticipant } from "./room-helpers";
+import {
+  formatRoomMarkdownMentions,
+  type PendingRoomQuote,
+  type RoomMentionParticipant,
+} from "./room-helpers";
 
 export interface RoomComposerAttachment extends RoomMessageComposerAttachment {
   mediaType: string | null;
@@ -97,14 +106,61 @@ function RoomMentionSuggestion({
   );
 }
 
+type UserMentionLookup = Pick<ChatRoomUserParticipant, "id" | "name">;
+
+function mentionLookupMapsFromCatalog(
+  mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>,
+): {
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
+  usersById: Map<string, UserMentionLookup>;
+  usersBySlug: Map<string, UserMentionLookup>;
+} {
+  const coworkersById = new Map<string, ChatRoomCoworkerParticipant>();
+  const coworkersBySlug = new Map<string, ChatRoomCoworkerParticipant>();
+  const usersById = new Map<string, UserMentionLookup>();
+  const usersBySlug = new Map<string, UserMentionLookup>();
+
+  for (const entry of Object.values(mentions)) {
+    const data = entry.data;
+    if (!data) {
+      continue;
+    }
+    if (data.kind === "coworker") {
+      const coworker: ChatRoomCoworkerParticipant = {
+        id: data.id,
+        name: data.name,
+        slug: data.slug,
+        caption: null,
+        image: data.image,
+        presence: "offline",
+      };
+      coworkersById.set(data.id, coworker);
+      coworkersBySlug.set(data.slug, coworker);
+      continue;
+    }
+    if (data.kind === "human") {
+      const user: UserMentionLookup = { id: data.id, name: data.name };
+      usersById.set(data.id, user);
+      usersBySlug.set(data.slug, user);
+    }
+  }
+
+  return { coworkersById, coworkersBySlug, usersById, usersBySlug };
+}
+
 function PendingQuotePreview({
   quote,
   onDismiss,
+  mentions,
 }: {
   quote: PendingRoomQuote;
   onDismiss: () => void;
+  mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
 }) {
   const t = useTranslations("App.Channels.Quote");
+  const { coworkersById, coworkersBySlug, usersById, usersBySlug } =
+    mentionLookupMapsFromCatalog(mentions);
 
   return (
     <div
@@ -116,8 +172,16 @@ function PendingQuotePreview({
         <div className="text-foreground truncate text-xs font-semibold">
           {quote.authorName}
         </div>
-        <div className="text-muted-foreground line-clamp-2 text-xs leading-5">
-          {quote.snippet}
+        <div className="text-muted-foreground line-clamp-2 text-xs leading-5 whitespace-pre-line">
+          <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
+            {formatRoomMarkdownMentions({
+              content: quote.snippet,
+              coworkersById,
+              coworkersBySlug,
+              usersById,
+              usersBySlug,
+            })}
+          </Markdown>
         </div>
       </div>
       <Button
@@ -359,6 +423,7 @@ export function RoomComposer({
               <PendingQuotePreview
                 quote={pendingQuote}
                 onDismiss={onClearPendingQuote}
+                mentions={composerMentions}
               />
             ) : null}
             {formatToolbarOpen ? (

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -172,7 +172,7 @@ function PendingQuotePreview({
         <div className="text-foreground truncate text-xs font-semibold">
           {quote.authorName}
         </div>
-        <div className="text-muted-foreground line-clamp-2 text-xs leading-5 whitespace-pre-line">
+        <div className="text-muted-foreground text-xs leading-5 whitespace-pre-line">
           <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
             {formatRoomMarkdownMentions({
               content: quote.snippet,

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -172,7 +172,7 @@ function PendingQuotePreview({
         <div className="text-foreground truncate text-xs font-semibold">
           {quote.authorName}
         </div>
-        <div className="text-muted-foreground text-xs leading-5 whitespace-pre-line">
+        <div className="text-muted-foreground line-clamp-4 text-xs leading-5 whitespace-pre-line">
           <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
             {formatRoomMarkdownMentions({
               content: quote.snippet,

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -172,7 +172,7 @@ function PendingQuotePreview({
         <div className="text-foreground truncate text-xs font-semibold">
           {quote.authorName}
         </div>
-        <div className="text-muted-foreground line-clamp-4 text-xs leading-5 whitespace-pre-line">
+        <div className="text-muted-foreground line-clamp-4 text-xs leading-5">
           <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
             {formatRoomMarkdownMentions({
               content: quote.snippet,

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -7,7 +7,7 @@ import {
 } from "@sokosumi/utils";
 import { CheckCircle2, Loader2, MessageCircle, Quote } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type ReactNode } from "react";
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
 import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import Markdown from "@/components/markdown";
@@ -70,31 +70,77 @@ function MessageQuoteBlock({
   usersBySlug?: Map<string, UserMentionLookup>;
 }) {
   const t = useTranslations("App.Channels.Quote");
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const snippetRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    setExpanded(false);
+  }, [quote.messageId, quote.snippet]);
+
+  useLayoutEffect(() => {
+    const node = snippetRef.current;
+    if (!node || expanded) {
+      return;
+    }
+
+    function measureOverflow() {
+      const el = snippetRef.current;
+      if (!el) {
+        return;
+      }
+      setOverflows(el.scrollHeight > el.clientHeight + 1);
+    }
+
+    measureOverflow();
+    const observer = new ResizeObserver(measureOverflow);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [expanded, quote.snippet]);
 
   return (
-    <button
-      type="button"
-      className="border-border bg-muted/40 hover:bg-muted/70 focus-visible:ring-ring mb-1.5 w-full rounded-md border-l-2 border-l-primary/60 px-2.5 py-1.5 text-left outline-none transition-colors focus-visible:ring-2"
-      aria-label={t("jump", { author: quote.authorName })}
-      onClick={() => {
-        scrollToRoomMessageElement(quote.messageId);
-      }}
-    >
-      <div className="text-foreground truncate text-xs font-semibold">
-        {quote.authorName}
-      </div>
-      <div className="text-muted-foreground text-xs leading-5 whitespace-pre-line">
-        <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
-          {formatRoomMarkdownMentions({
-            content: quote.snippet,
-            coworkersById,
-            coworkersBySlug,
-            usersById,
-            usersBySlug,
-          })}
-        </Markdown>
-      </div>
-    </button>
+    <div className="border-border bg-muted/40 mb-1.5 w-full rounded-md border-l-2 border-l-primary/60 px-2.5 py-1.5">
+      <button
+        type="button"
+        className="hover:bg-muted/70 focus-visible:ring-ring -mx-1 w-[calc(100%+0.5rem)] rounded-sm px-1 text-left outline-none transition-colors focus-visible:ring-2"
+        aria-label={t("jump", { author: quote.authorName })}
+        onClick={() => {
+          scrollToRoomMessageElement(quote.messageId);
+        }}
+      >
+        <div className="text-foreground truncate text-xs font-semibold">
+          {quote.authorName}
+        </div>
+        <div
+          ref={snippetRef}
+          className={cn(
+            "text-muted-foreground text-xs leading-5 whitespace-pre-line",
+            expanded ? null : "line-clamp-4",
+          )}
+        >
+          <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
+            {formatRoomMarkdownMentions({
+              content: quote.snippet,
+              coworkersById,
+              coworkersBySlug,
+              usersById,
+              usersBySlug,
+            })}
+          </Markdown>
+        </div>
+      </button>
+      {expanded || overflows ? (
+        <button
+          type="button"
+          className="text-primary hover:text-primary/80 mt-0.5 text-xs font-medium outline-none focus-visible:underline"
+          onClick={() => {
+            setExpanded((current) => !current);
+          }}
+        >
+          {expanded ? t("showLess") : t("showMore")}
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -114,7 +114,7 @@ function MessageQuoteBlock({
         <div
           ref={snippetRef}
           className={cn(
-            "text-muted-foreground text-xs leading-5 whitespace-pre-line",
+            "text-muted-foreground text-xs leading-5",
             expanded ? null : "line-clamp-4",
           )}
         >

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -56,7 +56,19 @@ function formatWhoReactedLabel(
   return t("Reactions.whoReacted", { names, more });
 }
 
-function MessageQuoteBlock({ quote }: { quote: RoomMessageQuoteSnapshot }) {
+function MessageQuoteBlock({
+  quote,
+  coworkersById,
+  coworkersBySlug,
+  usersById,
+  usersBySlug,
+}: {
+  quote: RoomMessageQuoteSnapshot;
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, UserMentionLookup>;
+  usersBySlug?: Map<string, UserMentionLookup>;
+}) {
   const t = useTranslations("App.Channels.Quote");
 
   return (
@@ -71,8 +83,16 @@ function MessageQuoteBlock({ quote }: { quote: RoomMessageQuoteSnapshot }) {
       <div className="text-foreground truncate text-xs font-semibold">
         {quote.authorName}
       </div>
-      <div className="text-muted-foreground line-clamp-2 text-xs leading-5">
-        {quote.snippet}
+      <div className="text-muted-foreground line-clamp-2 text-xs leading-5 whitespace-pre-line">
+        <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
+          {formatRoomMarkdownMentions({
+            content: quote.snippet,
+            coworkersById,
+            coworkersBySlug,
+            usersById,
+            usersBySlug,
+          })}
+        </Markdown>
       </div>
     </button>
   );
@@ -417,7 +437,15 @@ export function ChatMessageRow({
           </div>
         )}
         <div className="text-foreground wrap-break-word text-sm leading-6">
-          {quote ? <MessageQuoteBlock quote={quote} /> : null}
+          {quote ? (
+            <MessageQuoteBlock
+              quote={quote}
+              coworkersById={coworkersById}
+              coworkersBySlug={coworkersBySlug}
+              usersById={usersById}
+              usersBySlug={usersBySlug}
+            />
+          ) : null}
           {isThinking ? (
             <span
               className="reasoning-text-shine text-sm leading-5"

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -83,7 +83,7 @@ function MessageQuoteBlock({
       <div className="text-foreground truncate text-xs font-semibold">
         {quote.authorName}
       </div>
-      <div className="text-muted-foreground line-clamp-2 text-xs leading-5 whitespace-pre-line">
+      <div className="text-muted-foreground text-xs leading-5 whitespace-pre-line">
         <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
           {formatRoomMarkdownMentions({
             content: quote.snippet,

--- a/packages/utils/src/__tests__/chat-room-quote-snippet.test.ts
+++ b/packages/utils/src/__tests__/chat-room-quote-snippet.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildQuoteSnippet,
-  QUOTE_SNIPPET_MAX_CHARS,
-} from "../chat-room-quote-snippet";
+import { buildQuoteSnippet } from "../chat-room-quote-snippet";
 
 describe("buildQuoteSnippet", () => {
   it("strips light markdown and collapses horizontal whitespace", () => {
@@ -33,11 +30,12 @@ describe("buildQuoteSnippet", () => {
     );
   });
 
-  it("truncates long snippets with an ellipsis", () => {
+  it("keeps the full cleaned message without truncating", () => {
     const long = `**bold** and [link](https://x.test) ${"a".repeat(300)}`;
     const snippet = buildQuoteSnippet(long);
     expect(snippet.startsWith("bold and link ")).toBe(true);
-    expect(snippet.endsWith("…")).toBe(true);
-    expect(snippet.length).toBeLessThanOrEqual(QUOTE_SNIPPET_MAX_CHARS + 1);
+    expect(snippet.endsWith("a")).toBe(true);
+    expect(snippet).not.toContain("…");
+    expect(snippet.length).toBeGreaterThan(300);
   });
 });

--- a/packages/utils/src/__tests__/chat-room-quote-snippet.test.ts
+++ b/packages/utils/src/__tests__/chat-room-quote-snippet.test.ts
@@ -5,9 +5,31 @@ import {
 } from "../chat-room-quote-snippet";
 
 describe("buildQuoteSnippet", () => {
-  it("strips light markdown and collapses whitespace", () => {
+  it("strips light markdown and collapses horizontal whitespace", () => {
     expect(buildQuoteSnippet("**hello**  [link](https://x.test)  world")).toBe(
       "hello link world",
+    );
+  });
+
+  it("preserves newlines from the original message", () => {
+    expect(
+      buildQuoteSnippet(
+        "Two more things about the chat here:\nCan you please add @all:all tagging.",
+      ),
+    ).toBe(
+      "Two more things about the chat here:\nCan you please add @all:all tagging.",
+    );
+  });
+
+  it("collapses spaces and tabs on a line without joining paragraphs", () => {
+    expect(buildQuoteSnippet("hello \t  world\n\nnext")).toBe(
+      "hello world\n\nnext",
+    );
+  });
+
+  it("leaves mention tokens intact for the render layer", () => {
+    expect(buildQuoteSnippet("ping @user-1:alice and @all:all")).toBe(
+      "ping @user-1:alice and @all:all",
     );
   });
 

--- a/packages/utils/src/chat-room-quote-snippet.ts
+++ b/packages/utils/src/chat-room-quote-snippet.ts
@@ -1,22 +1,15 @@
-/** Soft cap for room message quote preview text (composer chip + persisted snapshot). */
-export const QUOTE_SNIPPET_MAX_CHARS = 280;
-
 /**
- * Light plain-text preview for a quoted room message. Strips cheap markdown
+ * Plain-text quote body for a quoted room message. Strips cheap markdown
  * markers and collapses horizontal whitespace while preserving newlines.
  * Mention tokens stay intact; the render layer formats them for display.
+ * Returns the full cleaned message (no character truncation).
  */
 export function buildQuoteSnippet(content: string): string {
-  const flattened = content
+  return content
     .replace(/```[\s\S]*?```/g, " ")
     .replace(/`([^`]+)`/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     .replace(/[*_~>#]+/g, "")
     .replace(/[^\S\n]+/g, " ")
     .trim();
-
-  if (flattened.length > QUOTE_SNIPPET_MAX_CHARS) {
-    return `${flattened.slice(0, QUOTE_SNIPPET_MAX_CHARS)}…`;
-  }
-  return flattened;
 }

--- a/packages/utils/src/chat-room-quote-snippet.ts
+++ b/packages/utils/src/chat-room-quote-snippet.ts
@@ -3,7 +3,8 @@ export const QUOTE_SNIPPET_MAX_CHARS = 280;
 
 /**
  * Light plain-text preview for a quoted room message. Strips cheap markdown
- * markers and collapses whitespace for attribution snippets.
+ * markers and collapses horizontal whitespace while preserving newlines.
+ * Mention tokens stay intact; the render layer formats them for display.
  */
 export function buildQuoteSnippet(content: string): string {
   const flattened = content
@@ -11,7 +12,7 @@ export function buildQuoteSnippet(content: string): string {
     .replace(/`([^`]+)`/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     .replace(/[*_~>#]+/g, "")
-    .replace(/\s+/g, " ")
+    .replace(/[^\S\n]+/g, " ")
     .trim();
 
   if (flattened.length > QUOTE_SNIPPET_MAX_CHARS) {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -37,10 +37,7 @@ export {
   isOwnedCoworkerChatRoomFileUrl,
   isOwnedUserChatRoomFileUrl,
 } from "./chat-room-file-upload.js";
-export {
-  buildQuoteSnippet,
-  QUOTE_SNIPPET_MAX_CHARS,
-} from "./chat-room-quote-snippet.js";
+export { buildQuoteSnippet } from "./chat-room-quote-snippet.js";
 export {
   CHAT_UI_NON_REASONING_PART_TYPE_VALUES,
   CHAT_UI_NON_REASONING_PART_TYPES,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Room quote previews keep newlines and mention styling, clamp long bodies to 4 lines with overflow-only More/Less, and match message-body paragraph spacing.

**What changed**
- Preserve newlines in `buildQuoteSnippet`; leave mention tokens for the render layer
- Format timeline + composer quotes with `formatRoomMarkdownMentions` + `Markdown`
- Timeline quotes use `line-clamp-4` with overflow-only More/Less (jump stays separate)
- Composer pending chip uses `line-clamp-4` without expand chrome
- Dropped the 280-char soft cap so expanded quotes can show the full cleaned message
- Removed `whitespace-pre-line` on quote snippets so blank lines match the original message (Markdown alone handles breaks)

## Verification

```text
pnpm --filter @sokosumi/utils test src/__tests__/chat-room-quote-snippet.test.ts
pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
```

**Note:** Quotes persisted before the snippet-builder fix may still be flattened until re-quoted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a89a879-1fe6-4ebc-9d98-1753fc3c4201?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a89a879-1fe6-4ebc-9d98-1753fc3c4201&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

