### PR TITLE
feat(chat): section room mention picker into people and coworkers

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "Alle"
+      },
+      "MentionSections": {
+        "people": "Personen",
+        "coworkers": "Coworkers"
       }
     }
   },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4831,6 +4831,10 @@
       },
       "MentionAll": {
         "label": "Everyone"
+      },
+      "MentionSections": {
+        "people": "People",
+        "coworkers": "Coworkers"
       }
     }
   },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "Todos"
+      },
+      "MentionSections": {
+        "people": "Personas",
+        "coworkers": "Coworkers"
       }
     }
   },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "Tout le monde"
+      },
+      "MentionSections": {
+        "people": "Personnes",
+        "coworkers": "Collègues"
       }
     }
   },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "Tutti"
+      },
+      "MentionSections": {
+        "people": "Persone",
+        "coworkers": "Coworker"
       }
     }
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "全員"
+      },
+      "MentionSections": {
+        "people": "メンバー",
+        "coworkers": "コワーカー"
       }
     }
   },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "Todos"
+      },
+      "MentionSections": {
+        "people": "Pessoas",
+        "coworkers": "Coworkers"
       }
     }
   },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "Todos"
+      },
+      "MentionSections": {
+        "people": "Pessoas",
+        "coworkers": "Coworkers"
       }
     }
   },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4712,6 +4712,10 @@
       },
       "MentionAll": {
         "label": "所有人"
+      },
+      "MentionSections": {
+        "people": "成员",
+        "coworkers": "协作伙伴"
       }
     }
   },

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { NormalizedMention } from "@/components/ui/mention-textarea-utils";
 import type {
   ChatRoomCoworkerParticipant,
   ChatRoomUserParticipant,
@@ -7,9 +8,11 @@ import type {
 import {
   buildRoomAllMentionRecord,
   formatRoomMarkdownMentions,
+  partitionRoomMentionSuggestions,
   ROOM_MENTION_ALL_ID,
   ROOM_MENTION_ALL_SLUG,
   ROOM_MENTION_ALL_TOKEN,
+  type RoomMentionParticipant,
   shouldIncludeRoomAllMention,
 } from "../room-helpers";
 
@@ -29,6 +32,19 @@ const human: ChatRoomUserParticipant = {
   image: null,
   presence: "online",
 };
+
+const LABELS = { peopleLabel: "People", coworkersLabel: "Coworkers" };
+
+function mention(
+  partial: Omit<NormalizedMention<RoomMentionParticipant>, "slug"> & {
+    slug?: string;
+  },
+): NormalizedMention<RoomMentionParticipant> {
+  return {
+    slug: partial.slug ?? partial.key,
+    ...partial,
+  };
+}
 
 describe("formatRoomMarkdownMentions", () => {
   it("renders coworker and human mention chips from tokens", () => {
@@ -181,5 +197,114 @@ describe("shouldIncludeRoomAllMention", () => {
         "self",
       ),
     ).toBe(true);
+  });
+});
+
+describe("partitionRoomMentionSuggestions", () => {
+  const allMention = mention({
+    key: ROOM_MENTION_ALL_ID,
+    value: "Everyone",
+    slug: ROOM_MENTION_ALL_SLUG,
+    data: {
+      kind: "all",
+      id: ROOM_MENTION_ALL_ID,
+      name: "Everyone",
+      slug: ROOM_MENTION_ALL_SLUG,
+      image: null,
+    },
+  });
+
+  const humanMention = mention({
+    key: human.id,
+    value: human.name,
+    slug: "alice-smith",
+    data: {
+      kind: "human",
+      id: human.id,
+      name: human.name,
+      slug: "alice-smith",
+      image: null,
+    },
+  });
+
+  const coworkerMention = mention({
+    key: coworker.id,
+    value: coworker.name,
+    slug: coworker.slug,
+    data: {
+      kind: "coworker",
+      id: coworker.id,
+      name: coworker.name,
+      slug: coworker.slug,
+      image: null,
+    },
+  });
+
+  it("puts @all and humans in People, coworkers in Coworkers", () => {
+    const groups = partitionRoomMentionSuggestions(
+      [allMention, humanMention, coworkerMention],
+      LABELS,
+    );
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ id: "people", label: "People" });
+    expect(groups[0]?.items.map((item) => item.key)).toEqual([
+      ROOM_MENTION_ALL_ID,
+      human.id,
+    ]);
+    expect(groups[1]).toMatchObject({ id: "coworkers", label: "Coworkers" });
+    expect(groups[1]?.items.map((item) => item.key)).toEqual([coworker.id]);
+  });
+
+  it("omits empty sections after filter", () => {
+    expect(
+      partitionRoomMentionSuggestions([humanMention], LABELS).map((g) => g.id),
+    ).toEqual(["people"]);
+    expect(
+      partitionRoomMentionSuggestions([coworkerMention], LABELS).map(
+        (g) => g.id,
+      ),
+    ).toEqual(["coworkers"]);
+    expect(partitionRoomMentionSuggestions([], LABELS)).toEqual([]);
+  });
+
+  it("keeps People above Coworkers when both non-empty", () => {
+    const groups = partitionRoomMentionSuggestions(
+      [coworkerMention, humanMention],
+      LABELS,
+    );
+    expect(groups.map((g) => g.id)).toEqual(["people", "coworkers"]);
+  });
+
+  it("preserves within-People filter order (@all stays first when present)", () => {
+    const bob = mention({
+      key: "user_2",
+      value: "Bob",
+      slug: "bob",
+      data: {
+        kind: "human",
+        id: "user_2",
+        name: "Bob",
+        slug: "bob",
+        image: null,
+      },
+    });
+    const groups = partitionRoomMentionSuggestions(
+      [allMention, bob, humanMention, coworkerMention],
+      LABELS,
+    );
+    expect(groups[0]?.items.map((item) => item.key)).toEqual([
+      ROOM_MENTION_ALL_ID,
+      "user_2",
+      human.id,
+    ]);
+  });
+
+  it("treats mentions without data/kind as People (safe fallback)", () => {
+    const unknown = mention({ key: "x", value: "Unknown" });
+    const groups = partitionRoomMentionSuggestions([unknown], LABELS);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.id).toBe("people");
+    expect(groups[0]?.items).toEqual([unknown]);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -50,7 +50,11 @@ import {
 } from "@/lib/utils/composer-active-formats";
 import { getInitials } from "@/lib/utils/text";
 import { AiCoworkerIcon } from "./room-draft-shared";
-import type { PendingRoomQuote, RoomMentionParticipant } from "./room-helpers";
+import {
+  type PendingRoomQuote,
+  partitionRoomMentionSuggestions,
+  type RoomMentionParticipant,
+} from "./room-helpers";
 
 export interface RoomComposerAttachment extends RoomMessageComposerAttachment {
   mediaType: string | null;
@@ -459,6 +463,12 @@ export function RoomComposer({
             formatToolbarOpen ? handleActiveFormatsChange : undefined
           }
           className={ROOM_COMPOSER_TEXTAREA_CLASSNAME}
+          groupMentions={(filtered) =>
+            partitionRoomMentionSuggestions(filtered, {
+              peopleLabel: t("MentionSections.people"),
+              coworkersLabel: t("MentionSections.coworkers"),
+            })
+          }
           renderMentionItem={(mention) => (
             <RoomMentionSuggestion mention={mention} />
           )}

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -1,5 +1,9 @@
 import { buildQuoteSnippet } from "@sokosumi/utils";
 import type {
+  MentionSuggestionGroup,
+  NormalizedMention,
+} from "@/components/ui/mention-textarea-utils";
+import type {
   ChatRoom,
   ChatRoomCoworkerParticipant,
   ChatRoomMessage,
@@ -67,6 +71,44 @@ export function buildRoomAllMentionRecord(label: string): {
       image: null,
     },
   };
+}
+
+/**
+ * Partition filtered room mention suggestions into People (humans + @all)
+ * and Coworkers. Omits empty sections. Preserves within-section filter order.
+ */
+export function partitionRoomMentionSuggestions(
+  filtered: NormalizedMention<RoomMentionParticipant>[],
+  labels: { peopleLabel: string; coworkersLabel: string },
+): MentionSuggestionGroup<RoomMentionParticipant>[] {
+  const people: NormalizedMention<RoomMentionParticipant>[] = [];
+  const coworkers: NormalizedMention<RoomMentionParticipant>[] = [];
+
+  for (const mention of filtered) {
+    if (mention.data?.kind === "coworker") {
+      coworkers.push(mention);
+    } else {
+      // human | all | missing kind → People (safe fallback for humans-shaped rows)
+      people.push(mention);
+    }
+  }
+
+  const groups: MentionSuggestionGroup<RoomMentionParticipant>[] = [];
+  if (people.length > 0) {
+    groups.push({
+      id: "people",
+      label: labels.peopleLabel,
+      items: people,
+    });
+  }
+  if (coworkers.length > 0) {
+    groups.push({
+      id: "coworkers",
+      label: labels.coworkersLabel,
+      items: coworkers,
+    });
+  }
+  return groups;
 }
 
 export function appendComposerBlock(value: string, block: string): string {

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -25,6 +25,7 @@ import {
   getPopupPositionFromRect,
   MENTION_CLASSNAME,
   type MentionRecordEntry,
+  type MentionSuggestionGroup,
   type NormalizedMention,
   serializeEditor,
   setCaretAfterNode,
@@ -90,6 +91,10 @@ interface ComposerWysiwygEditorProps<TData = unknown> {
     mention: NormalizedMention<TData>,
     isActive: boolean,
   ) => ReactNode;
+  /** When set, mention popup renders section headers; keyboard uses flat items only. */
+  groupMentions?: (
+    filtered: NormalizedMention<TData>[],
+  ) => MentionSuggestionGroup<TData>[];
 }
 
 const EDITOR_PROSE_CLASSNAME = cn(
@@ -147,6 +152,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
   onActiveFormatsChange,
   onSelectedKeysChange,
   renderMentionItem,
+  groupMentions,
 }: ComposerWysiwygEditorProps<TData>) {
   const editorRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -236,6 +242,18 @@ export function ComposerWysiwygEditor<TData = unknown>({
     );
   }, [mentionQuery, normalizedMentions]);
 
+  const mentionGroups = useMemo(() => {
+    if (!groupMentions || mentionQuery === null) return null;
+    return groupMentions(filteredMentions);
+  }, [filteredMentions, groupMentions, mentionQuery]);
+
+  const selectableMentions = useMemo(() => {
+    if (mentionGroups) {
+      return mentionGroups.flatMap((group) => group.items);
+    }
+    return filteredMentions;
+  }, [filteredMentions, mentionGroups]);
+
   const emojiMatches =
     suggestionUi.open && suggestionUi.suggestion.kind === "emoji"
       ? suggestionUi.suggestion.matches
@@ -248,7 +266,9 @@ export function ComposerWysiwygEditor<TData = unknown>({
     : null;
   const isOpen = suggestionUi.open;
   const visibleSuggestionCount =
-    suggestionKind === "emoji" ? emojiMatches.length : filteredMentions.length;
+    suggestionKind === "emoji"
+      ? emojiMatches.length
+      : selectableMentions.length;
 
   const selectedKeys = useMemo(() => {
     const parsed = parseMentions(value);
@@ -777,7 +797,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
             const match = emojiMatches[activeIndex];
             if (match) insertEmojiShortcode(match);
           } else {
-            const mention = filteredMentions[activeIndex];
+            const mention = selectableMentions[activeIndex];
             if (mention) insertMention(mention);
           }
           return;
@@ -842,13 +862,13 @@ export function ComposerWysiwygEditor<TData = unknown>({
       applyFormat,
       closeSuggestions,
       emojiMatches,
-      filteredMentions,
       handleInput,
       insertEmojiShortcode,
       insertMention,
       isOpen,
       onLinkShortcut,
       onSubmitShortcut,
+      selectableMentions,
       setActiveSuggestionIndex,
       suggestionKind,
       visibleSuggestionCount,
@@ -1016,38 +1036,95 @@ export function ComposerWysiwygEditor<TData = unknown>({
                     <span className="truncate">:{match.name}:</span>
                   </div>
                 ))
-              : filteredMentions.map((mention, index) => (
-                  <div
-                    key={mention.key}
-                    data-index={index}
-                    role="option"
-                    aria-selected={index === activeIndex}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
-                      index === activeIndex &&
-                        "bg-accent text-accent-foreground",
-                    )}
-                    onMouseDown={() => {
-                      isSelectingRef.current = true;
-                    }}
-                    onClick={() => {
-                      insertMention(mention);
-                      isSelectingRef.current = false;
-                    }}
-                    onMouseEnter={() => setActiveSuggestionIndex(() => index)}
-                  >
-                    {renderMentionItem ? (
-                      renderMentionItem(mention, index === activeIndex)
-                    ) : (
-                      <>
-                        <div className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                          {mention.value.charAt(0).toUpperCase()}
+              : mentionGroups
+                ? (() => {
+                    let optionIndex = 0;
+                    return mentionGroups.map((group) => (
+                      <div key={group.id}>
+                        <div
+                          role="presentation"
+                          className="text-muted-foreground px-2 py-1.5 text-xs font-medium"
+                        >
+                          {group.label}
                         </div>
-                        <span className="truncate">{mention.value}</span>
-                      </>
-                    )}
-                  </div>
-                ))}
+                        {group.items.map((mention) => {
+                          const index = optionIndex;
+                          optionIndex += 1;
+                          return (
+                            <div
+                              key={mention.key}
+                              data-index={index}
+                              role="option"
+                              aria-selected={index === activeIndex}
+                              className={cn(
+                                "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+                                index === activeIndex &&
+                                  "bg-accent text-accent-foreground",
+                              )}
+                              onMouseDown={() => {
+                                isSelectingRef.current = true;
+                              }}
+                              onClick={() => {
+                                insertMention(mention);
+                                isSelectingRef.current = false;
+                              }}
+                              onMouseEnter={() =>
+                                setActiveSuggestionIndex(() => index)
+                              }
+                            >
+                              {renderMentionItem ? (
+                                renderMentionItem(
+                                  mention,
+                                  index === activeIndex,
+                                )
+                              ) : (
+                                <>
+                                  <div className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                                    {mention.value.charAt(0).toUpperCase()}
+                                  </div>
+                                  <span className="truncate">
+                                    {mention.value}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ));
+                  })()
+                : selectableMentions.map((mention, index) => (
+                    <div
+                      key={mention.key}
+                      data-index={index}
+                      role="option"
+                      aria-selected={index === activeIndex}
+                      className={cn(
+                        "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+                        index === activeIndex &&
+                          "bg-accent text-accent-foreground",
+                      )}
+                      onMouseDown={() => {
+                        isSelectingRef.current = true;
+                      }}
+                      onClick={() => {
+                        insertMention(mention);
+                        isSelectingRef.current = false;
+                      }}
+                      onMouseEnter={() => setActiveSuggestionIndex(() => index)}
+                    >
+                      {renderMentionItem ? (
+                        renderMentionItem(mention, index === activeIndex)
+                      ) : (
+                        <>
+                          <div className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                            {mention.value.charAt(0).toUpperCase()}
+                          </div>
+                          <span className="truncate">{mention.value}</span>
+                        </>
+                      )}
+                    </div>
+                  ))}
           </div>,
           document.body,
         )}

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -15,6 +15,13 @@ export interface NormalizedMention<TData = unknown> {
   data?: TData;
 }
 
+/** Optional sectioned mention picker groups (e.g. People / Coworkers). */
+export interface MentionSuggestionGroup<TData = unknown> {
+  id: string;
+  label: string;
+  items: NormalizedMention<TData>[];
+}
+
 export interface TriggerPosition {
   top: number;
   left: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [SOK-687](https://linear.app/masumi/issue/SOK-687/sectioned-mention-picker-for-humans-and-coworkers).

Room `@` mention picker groups suggestions into **People** (humans + `@all`) and **Coworkers**. `@all` stays humans-only notify semantics. Empty sections hide after filter. Keyboard nav skips section headers.

## Spec summary

- Optional `groupMentions` on `ComposerWysiwygEditor`; room wires `partitionRoomMentionSuggestions`
- People = `human` | `all`; Coworkers = `coworker`; Core dispatch unchanged
- i18n: `App.Channels.MentionSections.people` / `.coworkers` (all locales)
- Unit tests cover partition Contract

## Verification

- `pnpm web:check`
- `pnpm web:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-687](https://linear.app/masumi/issue/SOK-687/sectioned-mention-picker-for-humans-and-coworkers)

<div><a href="https://cursor.com/agents/bc-d63ab325-52ac-426a-99c5-efd0d05c7d5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d63ab325-52ac-426a-99c5-efd0d05c7d5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

