### PR TITLE
fix(chat): flip mention suggestions above caret with dynamic height

### DIFF
--- a/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
+++ b/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
@@ -1,11 +1,41 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import {
   buildMentionToken,
   getActiveEmojiTrigger,
   getActiveTrigger,
+  getPopupPositionFromRect,
+  POPUP_HEIGHT_PX,
   serializeEditorText,
   setEditorFromRaw,
 } from "@/components/ui/mention-textarea-utils";
+
+function stubViewport(height: number) {
+  vi.stubGlobal("visualViewport", undefined);
+  vi.stubGlobal("innerHeight", height);
+  vi.stubGlobal("innerWidth", 1280);
+}
+
+function rectNearBottom(options: {
+  top: number;
+  bottom: number;
+  left?: number;
+}): DOMRect {
+  const left = options.left ?? 80;
+  return {
+    x: left,
+    y: options.top,
+    top: options.top,
+    bottom: options.bottom,
+    left,
+    right: left + 20,
+    width: 20,
+    height: options.bottom - options.top,
+    toJSON() {
+      return this;
+    },
+  };
+}
 
 describe("mention-textarea utils", () => {
   it("round-trips mention markup with friendly labels", () => {
@@ -81,5 +111,32 @@ describe("mention-textarea utils", () => {
   it("keeps mention trigger rejecting queries that contain colon", () => {
     const text = "@agent-1:writer-agent";
     expect(getActiveTrigger(text, text.length)).toBeNull();
+  });
+
+  describe("getPopupPositionFromRect", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("opens above when below cannot fit preferred height and above has more room", () => {
+      stubViewport(800);
+      const position = getPopupPositionFromRect(
+        rectNearBottom({ top: 600, bottom: 620 }),
+      );
+
+      // belowSpace ≈ 172 (< 240 preferred), aboveSpace ≈ 592
+      expect(position.side).toBe("top");
+      expect(position.maxHeight).toBeGreaterThanOrEqual(80);
+      expect(position.maxHeight).toBeLessThanOrEqual(POPUP_HEIGHT_PX);
+    });
+
+    it("stays below when there is room for the preferred height", () => {
+      stubViewport(800);
+      const position = getPopupPositionFromRect(
+        rectNearBottom({ top: 200, bottom: 220 }),
+      );
+
+      expect(position.side).toBe("bottom");
+    });
   });
 });

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -57,8 +57,10 @@ describe("ComposerWysiwygEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: "open-mentions" }));
 
     const listbox = screen.getByRole("listbox");
-    expect(listbox).toHaveStyle({ maxHeight: "120px" });
-    expect(listbox.className).toContain("-translate-y-full");
+    expect(listbox).toHaveStyle({
+      maxHeight: "120px",
+      transform: "translateY(-100%)",
+    });
     expect(getPopupPositionFromRect).toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -1,10 +1,67 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { ComposerWysiwygEditor } from "@/components/chat/composer-wysiwyg-editor";
+import {
+  ComposerWysiwygEditor,
+  type ComposerWysiwygEditorHandle,
+} from "@/components/chat/composer-wysiwyg-editor";
+
+const getPopupPositionFromRect = vi.hoisted(() =>
+  vi.fn(() => ({
+    top: 400,
+    left: 80,
+    side: "top" as const,
+    maxHeight: 120,
+  })),
+);
+
+vi.mock("@/components/ui/mention-textarea-utils", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/ui/mention-textarea-utils")
+    >();
+  return {
+    ...actual,
+    getPopupPositionFromRect,
+  };
+});
 
 describe("ComposerWysiwygEditor", () => {
+  it("applies top-side flip and dynamic maxHeight to the mention listbox", () => {
+    function Harness() {
+      const editorRef = useRef<ComposerWysiwygEditorHandle>(null);
+      const [value, setValue] = useState("");
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => editorRef.current?.openMentions()}
+          >
+            open-mentions
+          </button>
+          <ComposerWysiwygEditor
+            ref={editorRef}
+            value={value}
+            onChange={setValue}
+            mentions={{
+              alice: { value: "Alice" },
+              bob: { value: "Bob" },
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open-mentions" }));
+
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toHaveStyle({ maxHeight: "120px" });
+    expect(listbox.className).toContain("-translate-y-full");
+    expect(getPopupPositionFromRect).toHaveBeenCalled();
+  });
+
   it("submits on plain Enter on desktop and newlines on Shift+Enter", () => {
     const onSubmitShortcut = vi.fn();
 

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -1002,13 +1002,16 @@ export function ComposerWysiwygEditor<TData = unknown>({
                     top: triggerPosition.top,
                     left: triggerPosition.left,
                     maxHeight: triggerPosition.maxHeight,
+                    // `transform` (not Tailwind translate): fixed portals need it.
+                    ...(triggerPosition.side === "top"
+                      ? { transform: "translateY(-100%)" }
+                      : {}),
                   }
                 : { top: VIEWPORT_PADDING_PX, left: VIEWPORT_PADDING_PX }
             }
             className={cn(
               "bg-popover text-popover-foreground fixed z-50 w-72 overflow-y-auto rounded-md border p-1 shadow-md",
               !triggerPosition && "mt-1 max-h-60",
-              triggerPosition?.side === "top" && "-translate-y-full",
             )}
           >
             {suggestionKind === "emoji"

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -998,12 +998,17 @@ export function ComposerWysiwygEditor<TData = unknown>({
             role="listbox"
             style={
               triggerPosition
-                ? { top: triggerPosition.top, left: triggerPosition.left }
+                ? {
+                    top: triggerPosition.top,
+                    left: triggerPosition.left,
+                    maxHeight: triggerPosition.maxHeight,
+                  }
                 : { top: VIEWPORT_PADDING_PX, left: VIEWPORT_PADDING_PX }
             }
             className={cn(
-              "bg-popover text-popover-foreground fixed z-50 max-h-60 w-72 overflow-y-auto rounded-md border p-1 shadow-md",
-              !triggerPosition && "mt-1",
+              "bg-popover text-popover-foreground fixed z-50 w-72 overflow-y-auto rounded-md border p-1 shadow-md",
+              !triggerPosition && "mt-1 max-h-60",
+              triggerPosition?.side === "top" && "-translate-y-full",
             )}
           >
             {suggestionKind === "emoji"

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -428,10 +428,11 @@ export function getPopupPositionFromRect(rect: DOMRect): TriggerPosition {
   const viewportWidth = visual ? visual.width : window.innerWidth;
   const belowSpace = viewportBottom - rect.bottom - VIEWPORT_PADDING_PX;
   const aboveSpace = rect.top - viewportTop - VIEWPORT_PADDING_PX;
+  // Prefer above when the preferred popup height cannot fit below and there is
+  // more room above (bottom composers). Cap used to be min(240, 96), which kept
+  // lists growing into a thin strip under the caret with little scroll room.
   const side =
-    belowSpace < Math.min(POPUP_HEIGHT_PX, 96) && aboveSpace > belowSpace
-      ? "top"
-      : "bottom";
+    belowSpace < POPUP_HEIGHT_PX && aboveSpace > belowSpace ? "top" : "bottom";
   const maxHeight = Math.min(
     POPUP_HEIGHT_PX,
     Math.max(80, side === "top" ? aboveSpace - 4 : belowSpace - 4),

--- a/apps/web/src/components/ui/mention-textarea.tsx
+++ b/apps/web/src/components/ui/mention-textarea.tsx
@@ -892,13 +892,13 @@ function MentionTextareaInner<TData = unknown>(
                     top: popupPosition.top,
                     left: popupPosition.left,
                     maxHeight: popupPosition.maxHeight,
+                    ...(popupPosition.side === "top"
+                      ? { transform: "translateY(-100%)" }
+                      : {}),
                   }
                 : undefined
             }
-            className={cn(
-              "bg-popover text-popover-foreground fixed z-50 w-72 overflow-y-auto rounded-md border p-1 shadow-md",
-              popupPosition?.side === "top" && "-translate-y-full",
-            )}
+            className="bg-popover text-popover-foreground fixed z-50 w-72 overflow-y-auto rounded-md border p-1 shadow-md"
           >
             {filteredMentions.map((mention, index) => (
               <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Chat `@` mention list sat cramped under the bottom composer. Two gaps stacked:

1. `ComposerWysiwygEditor` ignored `side` / `maxHeight` from `getPopupPositionFromRect` (hard `max-h-60` only).
2. Flip only ran when below-space was under 96px, so the list often stayed below the caret in a thin strip.
3. Tailwind `-translate-y-full` uses the CSS `translate` property, which did not move `position: fixed` portals in Chromium.

Emoji toolbar picker looked fine because Radix Popover flips into the message history.

## Fix

- Apply `maxHeight` and `transform: translateY(-100%)` when `side === "top"` (same for `MentionTextarea`).
- Flip when below cannot fit the preferred 240px height and above has more room.

## Verification

```bash
pnpm --filter web test \
  src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx \
  src/components/__tests__/mention-textarea-utils.test.ts
```

Browser (local `#mention-fix` as alice): typed `@` → People list opens **above** the caret with room to scroll.

![Mention list opens above caret](https://cursor.com/artifacts/c/art-8d86470c-0d8e-4d45-a80a-a9fcf5c6590a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92656614-226f-4bf6-8327-5eab1c3b2f0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92656614-226f-4bf6-8327-5eab1c3b2f0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

