### PR TITLE
feat(web): render markdown emoticons as emoji

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -94,6 +94,7 @@
     "rehype-highlight": "7.0.2",
     "rehype-raw": "7.0.0",
     "remark-breaks": "4.0.0",
+    "remark-emoji": "5.0.2",
     "remark-frontmatter": "5.0.0",
     "remark-gfm": "4.0.1",
     "remark-math": "6.0.0",

--- a/apps/web/src/components/__tests__/markdown-emoticons.test.tsx
+++ b/apps/web/src/components/__tests__/markdown-emoticons.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Markdown from "@/components/markdown";
+
+vi.mock("rehype-raw", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("rehype-highlight", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe("Markdown emoticon rendering", () => {
+  it("converts wink emoticons to 😉", () => {
+    const { container: winkFull } = render(<Markdown>{";-)"}</Markdown>);
+    const { container: winkShort } = render(<Markdown>{";)"}</Markdown>);
+
+    expect(winkFull.textContent).toContain("😉");
+    expect(winkShort.textContent).toContain("😉");
+    expect(winkFull.textContent).not.toContain(";-)");
+    expect(winkShort.textContent).not.toContain(";)");
+  });
+
+  it("converts smile emoticons to 😃", () => {
+    const { container: smileFull } = render(<Markdown>{":-)"}</Markdown>);
+    const { container: smileShort } = render(<Markdown>{":)"}</Markdown>);
+
+    expect(smileFull.textContent).toContain("😃");
+    expect(smileShort.textContent).toContain("😃");
+    expect(smileFull.textContent).not.toContain(":-)");
+    expect(smileShort.textContent).not.toContain(":)");
+  });
+
+  it("does not convert emoticons inside fenced code blocks", () => {
+    const { container } = render(<Markdown>{"```\n;-) :)\n```"}</Markdown>);
+
+    expect(container.textContent).toContain(";-)");
+    expect(container.textContent).toContain(":)");
+    expect(container.textContent).not.toContain("😉");
+    expect(container.textContent).not.toContain("😃");
+  });
+
+  it("converts :dog: shortcodes to 🐶", () => {
+    const { container } = render(<Markdown>{":dog:"}</Markdown>);
+
+    expect(container.textContent).toContain("🐶");
+    expect(container.textContent).not.toContain(":dog:");
+  });
+});

--- a/apps/web/src/components/__tests__/markdown.test.tsx
+++ b/apps/web/src/components/__tests__/markdown.test.tsx
@@ -24,6 +24,11 @@ vi.mock("remark-breaks", () => ({
   default: () => null,
 }));
 
+vi.mock("remark-emoji", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 vi.mock("react-markdown", () => ({
   __esModule: true,
   default: ({

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
 import remarkBreaks from "remark-breaks";
+import remarkEmoji from "remark-emoji";
 import remarkGfm from "remark-gfm";
 
 import { applyMarkdownHighlighting } from "@/components/markdown-highlight";
@@ -130,7 +131,11 @@ export default function Markdown({
   return (
     <div className={cn(baseTypographyClassName, className)}>
       <ReactMarkdown
-        remarkPlugins={[remarkBreaks, remarkGfm]}
+        remarkPlugins={[
+          remarkBreaks,
+          remarkGfm,
+          [remarkEmoji, { emoticon: true }],
+        ]}
         rehypePlugins={[rehypeRaw, [rehypeHighlight, { detect: true }]]}
         components={components}
       >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       remark-breaks:
         specifier: 4.0.0
         version: 4.0.0
+      remark-emoji:
+        specifier: 5.0.2
+        version: 5.0.2
       remark-frontmatter:
         specifier: 5.0.0
         version: 5.0.0(supports-color@8.1.1)
@@ -5527,6 +5530,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -6113,6 +6120,12 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  emoticon@4.1.0:
+    resolution: {integrity: sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -7623,6 +7636,10 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -8375,6 +8392,10 @@ packages:
       '@types/mdast':
         optional: true
 
+  remark-emoji@5.0.2:
+    resolution: {integrity: sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==}
+    engines: {node: '>=18'}
+
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
@@ -8622,6 +8643,10 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
 
   slugify@1.6.9:
     resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
@@ -9073,6 +9098,10 @@ packages:
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -14413,6 +14442,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  char-regex@1.0.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -14986,6 +15017,10 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emojilib@2.4.0: {}
+
+  emoticon@4.1.0: {}
 
   empathic@2.0.0: {}
 
@@ -16896,6 +16931,13 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -17808,6 +17850,14 @@ snapshots:
       - micromark
       - micromark-util-types
 
+  remark-emoji@5.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      emoticon: 4.1.0
+      mdast-util-find-and-replace: 3.0.2
+      node-emoji: 2.2.0
+      unified: 11.0.5
+
   remark-frontmatter@5.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
@@ -18157,6 +18207,10 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
 
   slugify@1.6.9: {}
 
@@ -18590,6 +18644,8 @@ snapshots:
   undici@6.27.0: {}
 
   undici@7.29.0: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat markdown now turns ASCII smiles into emoji at render time.

### What
- Add pinned `remark-emoji@5.0.2` to web
- Enable `{ emoticon: true }` on the shared `Markdown` component (`react-markdown` remark pipeline)
- Leave stored message text unchanged

### Why this package
Sokosumi already uses remark (`react-markdown` + GFM). `remark-emoji` fits that stack and keeps the emoticon map maintained upstream (via wooorm `emoticon`).

### Examples
| Input | Rendered |
| --- | --- |
| `;-)` / `;)` | 😉 |
| `:-)` / `:)` | 😃 |
| `:dog:` | 🐶 |
| fenced code with `;-)` | unchanged |

### Verification
- `pnpm --filter web test src/components/__tests__/markdown.test.tsx src/components/__tests__/markdown-emoticons.test.tsx`
- Biome check on touched files

### Open risk
The emoticon set is broad. Watch false positives in URLs / odd punctuation after ship. Code fences stay literal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11214c8a-8975-4486-b837-91118ed5291b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11214c8a-8975-4486-b837-91118ed5291b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

