### PR TITLE
docs(verify-sokosumi): document localhost cookie-domain trap and auth drive fallbacks

### DIFF
--- a/.cursor/skills/verify-sokosumi/SKILL.md
+++ b/.cursor/skills/verify-sokosumi/SKILL.md
@@ -23,9 +23,11 @@ Preconditions before launch:
 - Node **24.x** on `PATH` (`node -v`)
 - `pnpm install` already done
 - Workspace packages built at least once (`pnpm packages:build`) — Core imports compiled `@sokosumi/utils` / `@sokosumi/database` exports
-- `apps/web/.env` and `apps/core/.env` present (copy from `.env.example` if missing; replace placeholders with non-empty dummies that pass Zod — see AGENTS.md cloud notes). `POSTMARK_FROM_EMAIL` must be a valid email; `HERMES_ORCH_BASE_URL` a valid URL; Ably keys any non-empty string
+- `apps/web/.env` and `apps/core/.env` present (copy from `.env.example` if missing). **Do not leave angle-bracket placeholders** (`<your-…>`) — Zod rejects them. Use non-empty dummies that pass validation (see AGENTS.md cloud notes): `POSTMARK_FROM_EMAIL` = valid email; `HERMES_ORCH_BASE_URL` = valid URL; Ably keys any non-empty string; Blob/Postmark/OAuth secrets any non-empty dummy
 - `APP_SIGNING_SECRET` (web) equals `BETTER_AUTH_SECRET` (core)
+- **`BETTER_AUTH_COOKIE_DOMAIN` must be unset / commented out for localhost.** Core `.env.example` sets `BETTER_AUTH_COOKIE_DOMAIN="sokosumi.com"` for production-shaped deploys — if that value is copied into local `.env`, session cookies are scoped to `.sokosumi.com` and **email/password login appears to succeed but the browser never keeps a session on `localhost`**. `doctor` fails when this trap is present
 - Database reachable (Neon agent branch, or local Postgres). Prefer `with-db.mjs` when an agent branch is provisioned. Run `node scripts/cloud-agent-db/provision.mjs` when `NEON_API_KEY` + `NEON_PROJECT_ID` are set and `.cursor/cloud-agent-db.env` is missing
+- `agent-browser` on `PATH` (global `npm i -g agent-browser` then `agent-browser install` for Chromium). Not a workspace dependency
 
 ### Cursor agent session (required pattern)
 
@@ -76,6 +78,8 @@ Optional Core-only smoke:
 
 Harness: **agent-browser** (see `.agents/skills/agent-browser/SKILL.md` and `apps/web/AGENTS.md` Browser Automation). No Playwright/Cypress in this repo.
 
+Cloud Agent **computer-use** (GUI browser subagent) is a fallback when `agent-browser` is unavailable — **same auth and env rules apply**. Prefer agent-browser; computer-use is more likely to mis-click OAuth/passkey chrome at the top of `/signin`.
+
 Session reuse:
 
 ```bash
@@ -84,7 +88,9 @@ export AGENT_BROWSER_SESSION_NAME=sokosumi
 
 Stable auth selectors: `[data-testid="auth-field-email"]`, `[data-testid="auth-field-currentPassword"]`, `[data-testid="auth-submit"]`.
 
-**Login rule:** fill fields, then **press Enter** — do not rely on clicking submit. react-hook-form can race a programmatic click.
+**Login rule:** fill email/password fields only, then **press Enter** — do not click submit, Google, Microsoft, Passkey, or Magic Link. react-hook-form can race a programmatic click; social/passkey controls sit **above** the password form and steal automation focus.
+
+If UI login leaves you on `/signin` or bounces back after a “success” (classic `BETTER_AUTH_COOKIE_DOMAIN` trap, or passkey/OAuth interference), fix env first, then use the Core cookie bootstrap in [sign-in.md](./features/sign-in.md). API bootstrap alone is not UI proof — reopen a protected page in the browser after injecting cookies.
 
 Credentials (pick one):
 
@@ -95,7 +101,7 @@ Credentials (pick one):
 | Local signup | unique `*@sokosumi.test` via `/signup` | choose once | Empty/local DB without fixtures |
 | Coworker vault | `agent-browser auth save sokosumi …` | machine-local | Personal accounts — never commit |
 
-OAuth and magic-link do **not** work with placeholder credentials. Skip those paths.
+OAuth, magic-link, and passkey do **not** work with placeholder credentials. Skip those paths.
 
 API drive (secondary): `curl` against Core with session cookies from the browser when needed; public smoke is OpenAPI JSON only.
 
@@ -145,7 +151,10 @@ Default ports **3000** (web) and **8787** (core) are shared. Second concurrent v
 ## Gotchas (always)
 
 - Ambient `DATABASE_URL` can override `.env` — use `with-db.mjs` when `.cursor/cloud-agent-db.env` exists
-- Empty local catalog: `/agents` or `GET /v1/agents` may fail until `credit_cost` rows exist
+- **`BETTER_AUTH_COOKIE_DOMAIN=sokosumi.com` (or any production domain) on localhost** → cookies never stick; disable it before blaming the form
+- Copying `.env.example` without replacing `<…>` placeholders → Core/Web fail Zod at boot (“missing env”)
+- Empty local catalog: `/agents` soft-empty (“No agents available”) or Core 500 until `credit_cost` rows exist
 - Ably placeholders break realtime chat UI
 - Fixtures exist only on agent Neon branches, not production/`main`
 - Node **24.x** required
+- `/signin` shows Google / Microsoft / Passkey / Magic Link **above** the password form — automation must target `[data-testid="auth-field-*"]` only

--- a/.cursor/skills/verify-sokosumi/bin/verify-sokosumi
+++ b/.cursor/skills/verify-sokosumi/bin/verify-sokosumi
@@ -142,6 +142,37 @@ function run_dev_web() {
   run_dev web
 }
 
+function cookie_domain_trap() {
+  # Fail doctor when Core local .env scopes cookies to a production host.
+  # Matches assigned values only; comments and empty assignments are OK.
+  local env_file="$REPO_ROOT/apps/core/.env"
+  if [[ ! -f "$env_file" ]]; then
+    echo "cookie_domain=unset (no apps/core/.env)"
+    return 0
+  fi
+  local line value
+  line="$(
+    grep -E '^[[:space:]]*BETTER_AUTH_COOKIE_DOMAIN=' "$env_file" | tail -n 1 || true
+  )"
+  if [[ -z "$line" ]]; then
+    echo "cookie_domain=unset"
+    return 0
+  fi
+  value="${line#*=}"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  value="$(echo "$value" | tr -d '[:space:]')"
+  if [[ -z "$value" ]]; then
+    echo "cookie_domain=empty"
+    return 0
+  fi
+  echo "cookie_domain=$value"
+  echo "doctor fail: BETTER_AUTH_COOKIE_DOMAIN=$value breaks localhost sessions — comment it out in apps/core/.env and restart Core"
+  return 1
+}
+
 function doctor() {
   local ok=1
   local core_code web_code
@@ -158,6 +189,10 @@ function doctor() {
   fi
   if [[ ! "$web_code" =~ ^[23] ]]; then
     echo "doctor fail: Web /signin not healthy"
+    ok=0
+  fi
+
+  if ! cookie_domain_trap; then
     ok=0
   fi
 

--- a/.cursor/skills/verify-sokosumi/features/README.md
+++ b/.cursor/skills/verify-sokosumi/features/README.md
@@ -9,6 +9,7 @@ Maintained source for verifying user-facing Sokosumi behavior. Read this index b
 - Export `AGENT_BROWSER_SESSION_NAME=sokosumi`.
 - Prefer fixture `alice@sokosumi.test` / `Password123!` on cloud-agent Neon branches; otherwise create a disposable user (see [Sign up](./sign-up.md)).
 - Use **`localhost`**, not `127.0.0.1`, for browser URLs (Better Auth origin/cookies).
+- Confirm `BETTER_AUTH_COOKIE_DOMAIN` is unset in `apps/core/.env` before login; `doctor` fails when it is set.
 - Never drive an instance that was not started by this verification run.
 - Put proof under `.cursor/verify-sokosumi-artifacts/<feature-id>/` (gitignored). Cleanup must keep those files.
 
@@ -16,9 +17,10 @@ Maintained source for verifying user-facing Sokosumi behavior. Read this index b
 
 - Start every recipe from the baseline state unless its preconditions say otherwise.
 - Prefer `data-testid` and accessible names over CSS position or coordinates.
-- Sign-in: fill email/password, then `agent-browser press Enter` (do not click submit).
+- Sign-in: fill email/password testids only, then `agent-browser press Enter` (do not click submit or OAuth/passkey/magic-link).
 - Re-snapshot after navigation (`agent-browser snapshot -i`).
 - Treat Ably/chat realtime failures as environment gaps unless the feature under test is chat messaging.
+- Prefer `agent-browser`. Cloud Agent computer-use is allowed with the same rules when the CLI harness is unavailable.
 
 ## Proof and skip reporting
 

--- a/.cursor/skills/verify-sokosumi/features/browse-agents.md
+++ b/.cursor/skills/verify-sokosumi/features/browse-agents.md
@@ -25,11 +25,11 @@ Preconditions:
 - **Open catalog.** Run `agent-browser open http://localhost:3000/agents` then `agent-browser wait --load networkidle` and `agent-browser snapshot -i`. Page is `/agents` and not `/signin`.
 - **Healthy list.** Snapshot shows one or more agent links/cards under “Browse all agents”. Note one agent name and its `href` (e.g. `agent-browser get attr @ref href`).
 - **Open detail.** Scroll the catalog link into view (`scrollintoview`), then click it. URL matches `/agents/<id>` (optional `/jobs` child). Detail heading matches the agent name. If the click no-ops (list still visible), open the noted `href` directly — still valid after discovering it from the list.
-- **Empty/error path.** If the page errors or shows no agents, capture screenshot + snapshot and stop. Report unmet catalog precondition — do not invent hire/job success.
+- **Empty/error path.** If the page shows **No agents available** (web soft-empty when Core `GET /v1/agents` 500s for missing `credit_cost`) or a hard error, capture screenshot + snapshot and stop. Report unmet catalog precondition — do not invent hire/job success.
 - **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/browse-agents` then screenshot + `snapshot -i` for list and (if reached) detail under that directory.
 
 ## Gotchas
 
-- Catalog depends on Core `GET /v1/agents` and credit-cost rows; local empty DB often fails here even when auth works.
+- Catalog depends on Core `GET /v1/agents` and credit-cost rows; local empty DB often soft-fails to **No agents available** (Core still 500) even when auth works.
 - Do not treat a marketing/landing redirect as catalog proof.
 - Hire/run-job flows are out of scope for this feature file — list + detail only.

--- a/.cursor/skills/verify-sokosumi/features/sign-in.md
+++ b/.cursor/skills/verify-sokosumi/features/sign-in.md
@@ -22,16 +22,34 @@ Preconditions:
 - Credentials available: fixture `alice@sokosumi.test` / `Password123!`, or a coworker vault `agent-browser auth login sokosumi`, or a user created via [Sign up](./sign-up.md).
 - `AGENT_BROWSER_SESSION_NAME=sokosumi` is set.
 
-- **Open form.** Run `agent-browser open http://localhost:3000/signin` then `agent-browser snapshot -i`. The page exposes `[data-testid="auth-field-email"]` and `[data-testid="auth-field-currentPassword"]` (locale may label fields `E-Mail` / `Passwort`).
-- **Fill credentials.** Either `agent-browser auth login sokosumi` (vault) or `agent-browser fill '[data-testid="auth-field-email"]' "<email>"` and `agent-browser fill '[data-testid="auth-field-currentPassword"]' "<password>"`.
-- **Submit.** Wait briefly after fill, then `agent-browser press Enter` and `agent-browser wait --load networkidle`. URL leaves `/signin` (typically `/chat`). Snapshot shows authenticated chrome (e.g. welcome heading, nav links).
+- **Open form.** Run `agent-browser open http://localhost:3000/signin` then `agent-browser snapshot -i`. The page exposes `[data-testid="auth-field-email"]` and `[data-testid="auth-field-currentPassword"]` (locale may label fields `E-Mail` / `Passwort`). Google / Microsoft / Passkey / Magic Link sit **above** the password form — ignore them.
+- **Fill credentials.** Either `agent-browser auth login sokosumi` (vault) or `agent-browser fill '[data-testid="auth-field-email"]' "<email>"` and `agent-browser fill '[data-testid="auth-field-currentPassword"]' "<password>"`. Prefer CSS testids over snapshot refs so OAuth buttons are not selected by accident.
+- **Submit.** Wait briefly after fill, then `agent-browser press Enter` and `agent-browser wait --load networkidle`. URL leaves `/signin` (client often hits `/` then lands on `/chat`). Snapshot shows authenticated chrome (e.g. welcome heading, nav links).
 - **Persist.** Run `agent-browser open http://localhost:3000/agents` then `agent-browser wait --load networkidle`. URL stays on `/agents` (not bounced to `/signin`).
 - **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/sign-in`, save `snapshot -i` to `after-login.snapshot.txt`, run `agent-browser screenshot`, copy newest `~/.agent-browser/tmp/screenshots/*.png` to `after-login.png`. Artifacts show authenticated UI, not the sign-in form.
+
+### Cookie bootstrap when UI login fails
+
+Use when Enter-submit stays on `/signin`, or the app briefly leaves `/signin` then bounces back (almost always `BETTER_AUTH_COOKIE_DOMAIN` still set, or OAuth/passkey stole the interaction). Fix Core env first (`BETTER_AUTH_COOKIE_DOMAIN` commented out), restart Core, retry UI. If UI still fails after env fix:
+
+```bash
+# Capture Set-Cookie headers from Core Better Auth
+curl -si -X POST "http://localhost:8787/auth/sign-in/email" \
+  -H 'content-type: application/json' \
+  -H 'origin: http://localhost:3000' \
+  -d '{"email":"alice@sokosumi.test","password":"Password123!"}' \
+  | tee .cursor/verify-sokosumi-artifacts/sign-in/core-signin.headers.txt
+```
+
+Require HTTP 200. Inject the session cookie(s) into the agent-browser (or computer-use) profile for `http://localhost:3000`, then `agent-browser open http://localhost:3000/agents` and prove the session. **API bootstrap alone is not UI sign-in proof** — only unlocks the rest of the map after a failed UI path; record that the UI path failed and why.
+
+Computer-use note: same recipe. Prefer clicking only inside the password form; Google/Microsoft/Passkey/Magic Link sit above it and often capture the first click.
 
 ## Gotchas
 
 - Clicking `[data-testid="auth-submit"]` after vault fill can no-op; always submit with Enter after a short wait.
-- OAuth buttons are not valid verification paths with placeholder credentials.
+- OAuth, magic-link, and passkey are not valid verification paths with placeholder credentials. Passkey also runs conditional mediation (`autoFill`) when the browser supports it — that can steal focus from the email field (`autoComplete="username webauthn"`).
 - Wrong password leaves the user on `/signin`; do not treat a soft error toast alone as success.
 - Fixtures exist only on cloud-agent Neon branches — otherwise use [Sign up](./sign-up.md) first.
 - `127.0.0.1` can break auth cookies/origin; stick to `localhost`.
+- `BETTER_AUTH_COOKIE_DOMAIN` set to a production host (default in Core `.env.example`) breaks localhost sessions — comment it out before driving.

--- a/.cursor/skills/verify-sokosumi/features/sign-up.md
+++ b/.cursor/skills/verify-sokosumi/features/sign-up.md
@@ -43,8 +43,9 @@ Require HTTP 200 and a `user.email` in the body. Do **not** count API signup alo
 
 ## Gotchas
 
+- Already-authenticated sessions redirect `/signup` into the app (`/chat`). Clear cookies or sign out before driving the form.
 - Email verification is off in local/core config — do not wait for a verification email. A “confirm email” banner after login is OK.
-- OAuth signup paths are invalid with placeholder credentials.
+- OAuth and magic-link signup paths are invalid with placeholder credentials.
 - Do not reuse an email that already exists; pick a fresh address per run.
 - On cloud-agent branches, prefer fixtures over signup unless testing signup itself.
 - Origin must be `http://localhost:3000` for Core auth API calls (`INVALID_ORIGIN` otherwise).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maintain pass on `verify-sokosumi` after localhost auth/env failures that blocked computer-use verification.

- **`doctor`** fails when `BETTER_AUTH_COOKIE_DOMAIN` is set in `apps/core/.env` (classic trap from copying `.env.example` — cookies never stick on `localhost`).
- Skill + feature map document: angle-bracket placeholder env, cookie-domain unset rule, OAuth/passkey chrome above the password form, computer-use vs `agent-browser`, and Core `POST /auth/sign-in/email` cookie bootstrap when UI login fails.
- Soft catalog empty copy + signed-in `/signup` redirect gotchas aligned with source.

## Live coverage

Drove every mapped feature on an owned `verify-sokosumi launch` instance (Neon agent DB, `alice@sokosumi.test`):

| Feature | Result |
| --- | --- |
| sign-in | UI Enter → `/chat`; persist `/agents`; Core sign-in Set-Cookie 200 |
| browse-agents | list + detail |
| chat-landing | welcome shell |
| tasks-board | Tasks/Jobs tabs |
| projects | empty state |
| jobs-history | empty state |
| sign-up | form after cookie clear; Register disabled until terms |

![Post sign-in chat](https://cursor.com/artifacts/c/art-44d83f97-192d-4c9d-9172-3194a48e2b82)
![Sign-up form logged out](https://cursor.com/artifacts/c/art-372defb4-52a7-483d-b26a-497d0b21e7b1)

## Scope

Only `.cursor/skills/verify-sokosumi/**` — no product code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92656614-226f-4bf6-8327-5eab1c3b2f0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92656614-226f-4bf6-8327-5eab1c3b2f0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

