### PR TITLE
feat(chat): bold unread rooms and badge mentions only

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/get.ts
@@ -12,6 +12,7 @@ import { chatRoomSchema } from "@/schemas/chat-room.schema";
 
 import {
   getChatRoomUnreadCounts,
+  getChatRoomUnreadMentionCounts,
   mapChatRoom,
   requireChatRoomUserAccess,
 } from "../helpers";
@@ -59,16 +60,18 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       userContext.userId,
       prisma,
     );
-    const unreadCounts = await getChatRoomUnreadCounts(
-      [room.id],
-      userContext.userId,
-      prisma,
-    );
+    const [unreadCounts, unreadMentionCounts] = await Promise.all([
+      getChatRoomUnreadCounts([room.id], userContext.userId, prisma),
+      getChatRoomUnreadMentionCounts([room.id], userContext.userId, prisma),
+    ]);
 
     return ok(
       c,
       chatRoomSchema.parse(
-        mapChatRoom(room, userContext.userId, unreadCounts.get(room.id) ?? 0),
+        mapChatRoom(room, userContext.userId, {
+          unreadCount: unreadCounts.get(room.id) ?? 0,
+          unreadMentionCount: unreadMentionCounts.get(room.id) ?? 0,
+        }),
       ),
     );
   });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/read/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/read/post.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { MemberRole } from "@sokosumi/database";
+import { MemberRole, NotificationKind } from "@sokosumi/database";
 import type { RequestIdVariables } from "hono/request-id";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,39 +8,26 @@ import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import { defaultValidationHook } from "@/lib/hono";
 import type { AuthVariables } from "@/middleware/auth";
 
-import mountGetChatRoom from "./get";
+import mountMarkChatRoomRead from "./post";
 
 const {
   roomFindFirstMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
-  queryRawUnsafeMock,
-  notificationGroupByMock,
+  readStateUpsertMock,
+  notificationUpdateManyMock,
   prismaTransactionMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
-  queryRawUnsafeMock: vi.fn(),
-  notificationGroupByMock: vi.fn(),
+  readStateUpsertMock: vi.fn(),
+  notificationUpdateManyMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
-    chatRoom: {
-      findFirst: roomFindFirstMock,
-    },
-    organization: {
-      findUnique: organizationFindUniqueMock,
-    },
-    member: {
-      findUnique: memberFindUniqueMock,
-    },
-    notification: {
-      groupBy: notificationGroupByMock,
-    },
-    $queryRawUnsafe: queryRawUnsafeMock,
     $transaction: prismaTransactionMock,
   },
 }));
@@ -48,6 +35,14 @@ vi.mock("@/lib/db/prisma", () => ({
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const USER_ID = "user_123";
 const ORG_ID = "org_1";
+
+const tx = {
+  chatRoom: { findFirst: roomFindFirstMock },
+  organization: { findUnique: organizationFindUniqueMock },
+  member: { findUnique: memberFindUniqueMock },
+  chatRoomReadState: { upsert: readStateUpsertMock },
+  notification: { updateMany: notificationUpdateManyMock },
+};
 
 function createApp(authContext: AuthVariables["authContext"]) {
   const app = new OpenAPIHono<{
@@ -57,14 +52,14 @@ function createApp(authContext: AuthVariables["authContext"]) {
   });
 
   app.use("*", async (c, next) => {
-    c.set("requestId", "req_get_chat_room");
+    c.set("requestId", "req_mark_chat_room_read");
     c.set("isAuthenticated", true);
     c.set("authContext", authContext);
     return await next();
   });
 
   app.onError(errorHandler);
-  mountGetChatRoom(app as unknown as OpenAPIHonoWithAuth);
+  mountMarkChatRoomRead(app as unknown as OpenAPIHonoWithAuth);
   return app;
 }
 
@@ -105,45 +100,47 @@ function room() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  prismaTransactionMock.mockImplementation(async (cb) => cb(tx));
   roomFindFirstMock.mockResolvedValue(room());
   organizationFindUniqueMock.mockResolvedValue({ id: ORG_ID });
   memberFindUniqueMock.mockResolvedValue({ role: MemberRole.MEMBER });
-  queryRawUnsafeMock.mockResolvedValue([{ roomId: ROOM_ID, unreadCount: 2 }]);
-  notificationGroupByMock.mockResolvedValue([
-    { referenceId: ROOM_ID, _count: { _all: 1 } },
-  ]);
+  readStateUpsertMock.mockResolvedValue({});
+  notificationUpdateManyMock.mockResolvedValue({ count: 2 });
 });
 
-describe("GET /chats/rooms/{id}", () => {
-  it("returns the room without opening an interactive transaction", async () => {
-    const response = await createApp(userAuthContext).request(`/${ROOM_ID}`);
+describe("POST /chats/rooms/{id}/read", () => {
+  it("upserts lastReadAt and marks unread CHAT notifications for the room", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/read`,
+      { method: "POST" },
+    );
 
     expect(response.status).toBe(200);
-    expect(prismaTransactionMock).not.toHaveBeenCalled();
-    expect(roomFindFirstMock).toHaveBeenCalledOnce();
-    expect(organizationFindUniqueMock).toHaveBeenCalledOnce();
-    expect(memberFindUniqueMock).toHaveBeenCalledOnce();
-    expect(queryRawUnsafeMock).toHaveBeenCalledOnce();
-    expect(notificationGroupByMock).toHaveBeenCalledOnce();
+    expect(readStateUpsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          roomId_userId: { roomId: ROOM_ID, userId: USER_ID },
+        },
+      }),
+    );
+    expect(notificationUpdateManyMock).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        kind: NotificationKind.CHAT,
+        referenceId: ROOM_ID,
+        isRead: false,
+      },
+      data: expect.objectContaining({
+        isRead: true,
+        readAt: expect.any(Date),
+      }),
+    });
 
     const body = await response.json();
     expect(body.data).toMatchObject({
       id: ROOM_ID,
-      name: "Launch Room",
-      unreadCount: 2,
-      unreadMentionCount: 1,
+      unreadCount: 0,
+      unreadMentionCount: 0,
     });
-  });
-
-  it("returns 404 when the room is missing", async () => {
-    roomFindFirstMock.mockResolvedValue(null);
-
-    const response = await createApp(userAuthContext).request(`/${ROOM_ID}`);
-
-    expect(response.status).toBe(404);
-    expect(prismaTransactionMock).not.toHaveBeenCalled();
-    expect(organizationFindUniqueMock).not.toHaveBeenCalled();
-    expect(memberFindUniqueMock).not.toHaveBeenCalled();
-    expect(queryRawUnsafeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/read/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/read/post.ts
@@ -1,4 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
+import { NotificationKind } from "@sokosumi/database";
 
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -65,12 +66,30 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         },
       });
 
+      await tx.notification.updateMany({
+        where: {
+          userId: userContext.userId,
+          kind: NotificationKind.CHAT,
+          referenceId: room.id,
+          isRead: false,
+        },
+        data: {
+          isRead: true,
+          readAt,
+        },
+      });
+
       return room;
     });
 
     return ok(
       c,
-      chatRoomSchema.parse(mapChatRoom(room, userContext.userId, 0)),
+      chatRoomSchema.parse(
+        mapChatRoom(room, userContext.userId, {
+          unreadCount: 0,
+          unreadMentionCount: 0,
+        }),
+      ),
     );
   });
 }

--- a/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.ts
@@ -114,7 +114,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         userContext.userId,
         tx,
       );
-      return mapChatRoom(live, userContext.userId, 0);
+      return mapChatRoom(live, userContext.userId, {
+        unreadCount: 0,
+        unreadMentionCount: 0,
+      });
     });
 
     return ok(c, restoredChatRoomSchema.parse(restored));

--- a/apps/core/src/routes/v1/chats/rooms/auth.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/auth.test.ts
@@ -50,6 +50,9 @@ const {
       chatRoomMention: {
         findMany: vi.fn().mockResolvedValue([]),
       },
+      notification: {
+        groupBy: vi.fn().mockResolvedValue([]),
+      },
     },
   };
 });

--- a/apps/core/src/routes/v1/chats/rooms/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.test.ts
@@ -14,6 +14,7 @@ const {
   organizationFindUniqueMock,
   memberFindUniqueMock,
   messageGroupByMock,
+  notificationGroupByMock,
   queryRawUnsafeMock,
   prismaTransactionMock,
 } = vi.hoisted(() => ({
@@ -22,6 +23,7 @@ const {
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
   messageGroupByMock: vi.fn(),
+  notificationGroupByMock: vi.fn(),
   queryRawUnsafeMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
 }));
@@ -40,6 +42,9 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     chatRoomMessage: {
       groupBy: messageGroupByMock,
+    },
+    notification: {
+      groupBy: notificationGroupByMock,
     },
     $queryRawUnsafe: queryRawUnsafeMock,
     $transaction: prismaTransactionMock,
@@ -74,6 +79,7 @@ beforeEach(() => {
   roomFindManyMock.mockResolvedValue([]);
   roomCountMock.mockResolvedValue(0);
   messageGroupByMock.mockResolvedValue([]);
+  notificationGroupByMock.mockResolvedValue([]);
   queryRawUnsafeMock.mockResolvedValue([]);
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.ts
@@ -29,6 +29,7 @@ import {
   chatRoomInclude,
   getChatRoomLastMessageAts,
   getChatRoomUnreadCounts,
+  getChatRoomUnreadMentionCounts,
   mapChatRoom,
 } from "./helpers";
 
@@ -171,10 +172,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const hasMore = rows.length === takePlusOne;
     const rooms = rows.slice(0, take);
     const roomIds = rooms.map((room) => room.id);
-    const [unreadCounts, lastMessageAts] = await Promise.all([
-      getChatRoomUnreadCounts(roomIds, userContext.userId, prisma),
-      getChatRoomLastMessageAts(roomIds, prisma),
-    ]);
+    const [unreadCounts, unreadMentionCounts, lastMessageAts] =
+      await Promise.all([
+        getChatRoomUnreadCounts(roomIds, userContext.userId, prisma),
+        getChatRoomUnreadMentionCounts(roomIds, userContext.userId, prisma),
+        getChatRoomLastMessageAts(roomIds, prisma),
+      ]);
 
     // Keep DB cursor order (`updatedAt` desc). Stream/message writes bump
     // room.updatedAt; do not re-sort by lastMessageAts after `take` — that
@@ -189,18 +192,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     return ok(
       c,
-      z
-        .array(chatRoomSchema)
-        .parse(
-          rooms.map((room) =>
-            mapChatRoom(
-              room,
-              userContext.userId,
-              unreadCounts.get(room.id) ?? 0,
-              lastMessageAts.get(room.id) ?? room.updatedAt,
-            ),
-          ),
+      z.array(chatRoomSchema).parse(
+        rooms.map((room) =>
+          mapChatRoom(room, userContext.userId, {
+            unreadCount: unreadCounts.get(room.id) ?? 0,
+            unreadMentionCount: unreadMentionCounts.get(room.id) ?? 0,
+            lastActivityAt: lastMessageAts.get(room.id) ?? room.updatedAt,
+          }),
         ),
+      ),
       paginationMeta,
     );
   });

--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -1,5 +1,5 @@
-import { MemberRole } from "@sokosumi/database";
-import { describe, expect, it } from "vitest";
+import { MemberRole, NotificationKind } from "@sokosumi/database";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildDirectCoworkerRoomKey,
@@ -8,6 +8,7 @@ import {
   buildDirectRoomName,
   canManageChatRoomLifecycle,
   contentIncludesRoomAllMention,
+  getChatRoomUnreadMentionCounts,
   mapChatRoomMessage,
   mergeChatRoomMessageMetadata,
   resolveMentionedCoworkerIds,
@@ -276,6 +277,46 @@ describe("mergeChatRoomMessageMetadata", () => {
 
   it("returns null when empty and no quote", () => {
     expect(mergeChatRoomMessageMetadata(null, null)).toBeNull();
+  });
+});
+
+describe("getChatRoomUnreadMentionCounts", () => {
+  it("groups unread CHAT notifications by room referenceId", async () => {
+    const groupBy = vi.fn().mockResolvedValue([
+      { referenceId: "room-a", _count: { _all: 2 } },
+      { referenceId: "room-b", _count: { _all: 1 } },
+    ]);
+
+    const counts = await getChatRoomUnreadMentionCounts(
+      ["room-a", "room-b", "room-c"],
+      "user_1",
+      { notification: { groupBy } } as never,
+    );
+
+    expect(groupBy).toHaveBeenCalledWith({
+      by: ["referenceId"],
+      where: {
+        userId: "user_1",
+        kind: NotificationKind.CHAT,
+        isRead: false,
+        referenceId: { in: ["room-a", "room-b", "room-c"] },
+      },
+      _count: { _all: true },
+    });
+    expect(counts.get("room-a")).toBe(2);
+    expect(counts.get("room-b")).toBe(1);
+    expect(counts.has("room-c")).toBe(false);
+  });
+
+  it("returns an empty map without querying when room ids are empty", async () => {
+    const groupBy = vi.fn();
+
+    const counts = await getChatRoomUnreadMentionCounts([], "user_1", {
+      notification: { groupBy },
+    } as never);
+
+    expect(counts.size).toBe(0);
+    expect(groupBy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -1,4 +1,4 @@
-import { MemberRole, type Prisma } from "@sokosumi/database";
+import { MemberRole, NotificationKind, type Prisma } from "@sokosumi/database";
 import {
   buildQuoteSnippet,
   CHAT_PRESENCE_AFK_WINDOW_MS,
@@ -159,6 +159,36 @@ export async function getChatRoomUnreadCounts(
   return new Map(rows.map((row) => [row.roomId, Number(row.unreadCount)]));
 }
 
+/**
+ * Per-room count of unread CHAT notifications for the user.
+ * `referenceId` is the room id (see emitChatMentionNotifications).
+ */
+export async function getChatRoomUnreadMentionCounts(
+  roomIds: readonly string[],
+  userId: string,
+  tx: Prisma.TransactionClient,
+): Promise<Map<string, number>> {
+  const uniqueRoomIds = normalizeUniqueStrings(roomIds);
+  if (uniqueRoomIds.length === 0) {
+    return new Map();
+  }
+
+  const groups = await tx.notification.groupBy({
+    by: ["referenceId"],
+    where: {
+      userId,
+      kind: NotificationKind.CHAT,
+      isRead: false,
+      referenceId: { in: uniqueRoomIds },
+    },
+    _count: { _all: true },
+  });
+
+  return new Map(
+    groups.map((group) => [group.referenceId, group._count._all] as const),
+  );
+}
+
 /** Latest message time per room — used to order the sidebar by real activity. */
 export async function getChatRoomLastMessageAts(
   roomIds: readonly string[],
@@ -184,13 +214,20 @@ export async function getChatRoomLastMessageAts(
   );
 }
 
+export interface MapChatRoomAttentionOptions {
+  unreadCount?: number;
+  unreadMentionCount?: number;
+  /** Prefer latest message time when room.updatedAt lagged (legacy stream writes). */
+  lastActivityAt?: Date | null;
+}
+
 export function mapChatRoom(
   room: ChatRoomWithMembers,
   currentUserId?: string,
-  unreadCount = 0,
-  /** Prefer latest message time when room.updatedAt lagged (legacy stream writes). */
-  lastActivityAt?: Date | null,
+  attention: MapChatRoomAttentionOptions = {},
 ) {
+  const { unreadCount = 0, unreadMentionCount = 0, lastActivityAt } = attention;
+
   return {
     id: room.id,
     organizationId: room.organizationId,
@@ -203,6 +240,7 @@ export function mapChatRoom(
     createdAt: room.createdAt,
     updatedAt: lastActivityAt ?? room.updatedAt,
     unreadCount,
+    unreadMentionCount,
     userMembers: room.userMembers.map(({ user }) => ({
       id: user.id,
       name: user.name,

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -68,6 +68,11 @@ export const chatRoomSchema = z
         "Messages sent by others after the current user's read marker.",
       example: 2,
     }),
+    unreadMentionCount: z.number().int().min(0).openapi({
+      description:
+        "Unread @mention attentions for the current user in this room (CHAT notifications with referenceId=roomId). Cleared on mark-read.",
+      example: 1,
+    }),
     userMembers: z.array(chatRoomUserParticipantSchema),
     coworkerMembers: z.array(chatRoomCoworkerParticipantSchema),
   })

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -85,6 +85,7 @@ function room(
     userMembers: [],
     coworkerMembers: [],
     unreadCount: 0,
+    unreadMentionCount: 0,
   };
 }
 

--- a/apps/web/src/components/chat/__tests__/room-attention.test.ts
+++ b/apps/web/src/components/chat/__tests__/room-attention.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRoomAttention } from "../room-attention";
+
+describe("resolveRoomAttention", () => {
+  it("bolds unread rooms without a mention badge", () => {
+    expect(
+      resolveRoomAttention({
+        unreadCount: 3,
+        unreadMentionCount: 0,
+        isActive: false,
+      }),
+    ).toEqual({ bold: true, badgeCount: 0 });
+  });
+
+  it("shows a mention badge only when unreadMentionCount > 0", () => {
+    expect(
+      resolveRoomAttention({
+        unreadCount: 5,
+        unreadMentionCount: 2,
+        isActive: false,
+      }),
+    ).toEqual({ bold: true, badgeCount: 2 });
+  });
+
+  it("suppresses bold and badge when the room is active", () => {
+    expect(
+      resolveRoomAttention({
+        unreadCount: 5,
+        unreadMentionCount: 2,
+        isActive: true,
+      }),
+    ).toEqual({ bold: false, badgeCount: 0 });
+  });
+});

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -179,7 +179,7 @@ function DirectAvatarStack({
   );
 }
 
-function UnreadBadge({ count }: { count: number }) {
+function MentionBadge({ count }: { count: number }) {
   if (count <= 0) {
     return null;
   }
@@ -188,7 +188,7 @@ function UnreadBadge({ count }: { count: number }) {
 
   return (
     <span
-      aria-label={`${label} unread`}
+      aria-label={`${label} mentions`}
       className="bg-primary text-primary-foreground group-data-[collapsible=icon]:hidden inline-flex min-w-4.5 shrink-0 items-center justify-center rounded-full px-1 text-[10px] font-semibold leading-4 tabular-nums"
     >
       {label}
@@ -485,7 +485,7 @@ export function OrganizationChatList({
                           >
                             {room.name}
                           </span>
-                          <UnreadBadge count={badgeCount} />
+                          <MentionBadge count={badgeCount} />
                         </Link>
                       </SheetClose>
                     </SidebarMenuButton>
@@ -599,7 +599,7 @@ export function OrganizationChatList({
                           >
                             {label}
                           </span>
-                          <UnreadBadge count={badgeCount} />
+                          <MentionBadge count={badgeCount} />
                         </Link>
                       </SheetClose>
                     </SidebarMenuButton>

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -43,6 +43,7 @@ import {
   listOrganizationArchivedChatRoomsAction,
   listOrganizationChatRoomsAction,
 } from "./organization-chat-list.actions";
+import { resolveRoomAttention } from "./room-attention";
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
 
@@ -318,7 +319,11 @@ export function OrganizationChatList({
       setRoomRows((current) =>
         current.map((room) =>
           room.id === detail.roomId
-            ? (detail.room ?? { ...room, unreadCount: 0 })
+            ? (detail.room ?? {
+                ...room,
+                unreadCount: 0,
+                unreadMentionCount: 0,
+              })
             : room,
         ),
       );
@@ -456,7 +461,11 @@ export function OrganizationChatList({
             <SidebarMenu className="gap-0">
               {namedChannels.map((room) => {
                 const isActive = activeRoomId === room.id;
-                const unreadCount = isActive ? 0 : room.unreadCount;
+                const { bold, badgeCount } = resolveRoomAttention({
+                  unreadCount: room.unreadCount,
+                  unreadMentionCount: room.unreadMentionCount,
+                  isActive,
+                });
 
                 return (
                   <SidebarMenuItem key={room.id}>
@@ -468,8 +477,15 @@ export function OrganizationChatList({
                           href={`/chat/rooms/${room.id}`}
                         >
                           <Hash className="size-4 shrink-0" aria-hidden />
-                          <span className="flex-1 truncate">{room.name}</span>
-                          <UnreadBadge count={unreadCount} />
+                          <span
+                            className={cn(
+                              "flex-1 truncate",
+                              bold && "font-semibold text-foreground",
+                            )}
+                          >
+                            {room.name}
+                          </span>
+                          <UnreadBadge count={badgeCount} />
                         </Link>
                       </SheetClose>
                     </SidebarMenuButton>
@@ -557,7 +573,11 @@ export function OrganizationChatList({
               {directMessages.map((room) => {
                 const isActive = activeRoomId === room.id;
                 const label = getDirectRoomDisplayName(room, currentUserId);
-                const unreadCount = isActive ? 0 : room.unreadCount;
+                const { bold, badgeCount } = resolveRoomAttention({
+                  unreadCount: room.unreadCount,
+                  unreadMentionCount: room.unreadMentionCount,
+                  isActive,
+                });
                 return (
                   <SidebarMenuItem key={room.id}>
                     <SidebarMenuButton asChild isActive={isActive}>
@@ -571,10 +591,15 @@ export function OrganizationChatList({
                             room={room}
                             currentUserId={currentUserId}
                           />
-                          <span className="min-w-0 flex-1 truncate">
+                          <span
+                            className={cn(
+                              "min-w-0 flex-1 truncate",
+                              bold && "font-semibold text-foreground",
+                            )}
+                          >
                             {label}
                           </span>
-                          <UnreadBadge count={unreadCount} />
+                          <UnreadBadge count={badgeCount} />
                         </Link>
                       </SheetClose>
                     </SidebarMenuButton>

--- a/apps/web/src/components/chat/room-attention.ts
+++ b/apps/web/src/components/chat/room-attention.ts
@@ -1,0 +1,18 @@
+/**
+ * Sidebar attention chrome for a room row.
+ * Bold = unread activity; badge = unread @mentions only.
+ */
+export function resolveRoomAttention(options: {
+  unreadCount: number;
+  unreadMentionCount: number;
+  isActive: boolean;
+}): { bold: boolean; badgeCount: number } {
+  if (options.isActive) {
+    return { bold: false, badgeCount: 0 };
+  }
+
+  return {
+    bold: options.unreadCount > 0,
+    badgeCount: options.unreadMentionCount,
+  };
+}

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -4257,6 +4257,12 @@ export const ChatRoomSchema = {
             description: 'Messages sent by others after the current user\'s read marker.',
             example: 2
         },
+        unreadMentionCount: {
+            type: 'integer',
+            minimum: 0,
+            description: 'Unread @mention attentions for the current user in this room (CHAT notifications with referenceId=roomId). Cleared on mark-read.',
+            example: 1
+        },
         userMembers: {
             type: 'array',
             items: {
@@ -4282,6 +4288,7 @@ export const ChatRoomSchema = {
         'createdAt',
         'updatedAt',
         'unreadCount',
+        'unreadMentionCount',
         'userMembers',
         'coworkerMembers'
     ]

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1168,6 +1168,10 @@ export type ChatRoom = {
      * Messages sent by others after the current user's read marker.
      */
     unreadCount: number;
+    /**
+     * Unread @mention attentions for the current user in this room (CHAT notifications with referenceId=roomId). Cleared on mark-read.
+     */
+    unreadMentionCount: number;
     userMembers: Array<ChatRoomUserParticipant>;
     coworkerMembers: Array<ChatRoomCoworkerParticipant>;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slack-style sidebar attention for channels and DMs:

- Bold room name when there are unread messages (`unreadCount > 0`)
- Badge only when the user has unread @mentions (`unreadMentionCount > 0`)

`unreadMentionCount` counts unread `CHAT` notifications for that room. Marking a room read clears the read marker and those mention notifications together.

## Design

| Signal | Source | UI |
| --- | --- | --- |
| Unread messages | `ChatRoom.unreadCount` | Bold name |
| Unread @mentions | `ChatRoom.unreadMentionCount` | Numeric badge |

Chose extending `ChatRoom` over a separate mention-counts endpoint so the sidebar poll stays one DTO.

## Verification

- Core room helpers/get/read tests: 39 passed
- Web `room-attention` tests: 3 passed
- Pre-commit check + typecheck green
- CI on this PR: all checks green

Browser visual of live unread/mention chrome not exercised here (needs seeded mention traffic). Behavior covered by unit + Core route tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a359cad-4798-4bbf-8b2b-293516babae1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a359cad-4798-4bbf-8b2b-293516babae1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

