### PR TITLE
fix(chat): keep format toolbar closed by default on mobile

### DIFF
--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -42,6 +42,8 @@ import {
   type MentionRecordEntry,
   type NormalizedMention,
 } from "@/components/ui/mention-textarea";
+import { MOBILE_BREAKPOINT } from "@/hooks/use-mobile";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import type {
   ChatRoomCoworkerParticipant,
   ChatRoomUserParticipant,
@@ -255,8 +257,11 @@ export function RoomComposer({
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linkInitialText, setLinkInitialText] = useState("");
   const [linkInitialUrl, setLinkInitialUrl] = useState("");
-  /** Slack Aa toggle: formatting strip above the editor. Starts open by default. */
-  const [formatToolbarOpen, setFormatToolbarOpen] = useState(true);
+  /**
+   * Slack Aa toggle: formatting strip above the editor.
+   * SSR + first paint start closed (hydration-safe). Desktop opens once on mount.
+   */
+  const [formatToolbarOpen, setFormatToolbarOpen] = useState(false);
   const [activeFormats, setActiveFormats] = useState<ComposerActiveFormats>(
     EMPTY_COMPOSER_ACTIVE_FORMATS,
   );
@@ -266,6 +271,13 @@ export function RoomComposer({
   const handleSelectedKeysChange = showMentionShortcut
     ? onSelectedKeysChange
     : undefined;
+
+  // Desktop default open (SOK-681); mobile stays closed. No resize re-apply.
+  useMountEffect(() => {
+    if (window.innerWidth >= MOBILE_BREAKPOINT) {
+      setFormatToolbarOpen(true);
+    }
+  });
 
   // After paint so the format strip / quote chip have height before scroll.
   useEffect(() => {

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+export const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-688/keep-the-chat-format-toolbar-closed-by-default-on-mobile

## Spec
- Mobile (&lt;768): format toolbar closed on load
- Desktop (≥768): open once on mount after hydrate
- SSR + first paint start `false` (hydration-safe)
- Aa toggle unchanged; no resize re-apply; no persistence
- Welcome/multimodal composer out of scope

## Verify
- `pnpm web:check` ✅
- `pnpm web:test` ✅ (339 files / 2096 passed)
- CI green
- UI (`/chat?dm=new` RoomComposer): mobile closed; Aa opens; desktop open

### Mobile closed by default
![Mobile format toolbar closed](https://cursor.com/artifacts/c/art-3cc6519c-f604-4568-bc51-d67211974151)

### Mobile after Aa toggle
![Mobile format toolbar opened via Aa](https://cursor.com/artifacts/c/art-eeb9c689-b2d3-4bde-8e4d-de46089f0d28)

### Desktop open by default
![Desktop format toolbar open](https://cursor.com/artifacts/c/art-1d9de93a-3984-492d-9078-776f7477d713)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-688](https://linear.app/masumi/issue/SOK-688/keep-the-chat-format-toolbar-closed-by-default-on-mobile)

<div><a href="https://cursor.com/agents/bc-0b1c2450-c17a-4cbf-be76-92fa14c94571?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b1c2450-c17a-4cbf-be76-92fa14c94571&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

