### PR TITLE
fix(chat): tighten message list bottom padding

### DIFF
--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1193,7 +1193,7 @@ export function RoomsClient({
               <ScrollArea ref={scrollerRef} className="min-h-0 flex-1">
                 <div
                   ref={contentRef}
-                  className="flex w-full flex-col px-5 pt-6 pb-8"
+                  className="flex w-full flex-col px-5 pt-6 pb-3"
                 >
                   {messageLoadFailed ? (
                     <div className="border-border/70 bg-muted/20 rounded-md border border-dashed px-5 py-10 text-center">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening a channel that fills the viewport still left a small scroll nudge. The format toolbar looked guilty, but it sits outside the message scroller.

## Root cause

Message list content used `pb-8` (~32px) inside the ScrollArea. Stick-to-bottom pins to the true content end, so that empty inset stayed scrollable.

## Fix

Trim list bottom padding from `pb-8` to `pb-3` in `rooms-client.tsx`. Toolbar unchanged.

## Verification

- Seeded a full `#Sokosumi` room and measured Radix viewport metrics in the browser
- Before: `paddingBottom` 32px, `scrollHeight` 1552
- After: `paddingBottom` 12px, `scrollHeight` 1532 (−20px), still pinned (`distanceFromBottom` 0)
- Hiding the format strip only grew `clientHeight` (sibling layout); it does not add list `scrollHeight`

![Before](https://cursor.com/artifacts/c/art-d89fcf6a-b4ab-4925-a381-2d94502527f6)
![After](https://cursor.com/artifacts/c/art-41470b54-dc25-4bf5-8544-a89519afc273)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bffbe89c-02c2-4958-a08c-c95d8c9ecdee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bffbe89c-02c2-4958-a08c-c95d8c9ecdee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

