### PR TITLE
feat(web): sort active channels by recent activity like DMs

### DIFF
--- a/apps/web/src/components/chat/__tests__/chat-room-activity-sort.test.ts
+++ b/apps/web/src/components/chat/__tests__/chat-room-activity-sort.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { compareChatRoomsByRecentActivity } from "../chat-room-activity-sort";
+
+describe("compareChatRoomsByRecentActivity", () => {
+  it("sorts newer updatedAt first so channels bump like DMs", () => {
+    const older = {
+      id: "alpha",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const newer = {
+      id: "zeta",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    };
+
+    // Alphabetical-by-name would put alpha before zeta; activity wins.
+    expect(
+      [older, newer].sort(compareChatRoomsByRecentActivity).map((r) => r.id),
+    ).toEqual(["zeta", "alpha"]);
+  });
+
+  it("ties equal updatedAt by id ascending", () => {
+    const stamp = "2026-03-15T12:00:00.000Z";
+    const a = { id: "room-b", updatedAt: stamp };
+    const b = { id: "room-a", updatedAt: stamp };
+
+    expect(
+      [a, b].sort(compareChatRoomsByRecentActivity).map((r) => r.id),
+    ).toEqual(["room-a", "room-b"]);
+  });
+
+  it("accepts ISO string timestamps like ChatRoom DTO", () => {
+    const a = {
+      id: "a",
+      updatedAt: "2026-02-01T10:00:00.000Z",
+    };
+    const b = {
+      id: "b",
+      updatedAt: "2026-02-01T11:00:00.000Z",
+    };
+
+    expect(compareChatRoomsByRecentActivity(a, b)).toBeGreaterThan(0);
+    expect(compareChatRoomsByRecentActivity(b, a)).toBeLessThan(0);
+  });
+});

--- a/apps/web/src/components/chat/chat-room-activity-sort.ts
+++ b/apps/web/src/components/chat/chat-room-activity-sort.ts
@@ -1,0 +1,17 @@
+export interface ChatRoomActivitySortKey {
+  id: string;
+  updatedAt: string | Date;
+}
+
+/** Newest activity first; stable id tie-break. Shared by channels and DMs. */
+export function compareChatRoomsByRecentActivity(
+  a: ChatRoomActivitySortKey,
+  b: ChatRoomActivitySortKey,
+): number {
+  const byActivity =
+    new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  if (byActivity !== 0) {
+    return byActivity;
+  }
+  return a.id.localeCompare(b.id);
+}

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -38,6 +38,7 @@ import {
 import type { ChatRoom, ChatRoomPresence } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
+import { compareChatRoomsByRecentActivity } from "./chat-room-activity-sort";
 import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "./organization-chat-events";
 import {
   listOrganizationArchivedChatRoomsAction,
@@ -421,18 +422,9 @@ export function OrganizationChatList({
       }
     }
 
-    // Channels: A–Z. DMs: most recent activity first (`updatedAt` bumps on send).
-    namedChannels.sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
-    );
-    directMessages.sort((a, b) => {
-      const byActivity =
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      if (byActivity !== 0) {
-        return byActivity;
-      }
-      return a.id.localeCompare(b.id);
-    });
+    // Active channels and DMs: most recent activity first (`updatedAt` bumps on send).
+    namedChannels.sort(compareChatRoomsByRecentActivity);
+    directMessages.sort(compareChatRoomsByRecentActivity);
 
     return { directMessages, namedChannels };
   }, [roomRows]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Active channels in the org chat sidebar now rise on recent activity the same way DMs already do.

**Change.** Extract `compareChatRoomsByRecentActivity` and use it for both active channels and DMs (`updatedAt` desc, `id` asc). Archived channels stay A–Z.

**Why.** Users expect a channel with new traffic to float like an active DM. Unread chrome was already shared; only sort order differed.

**Verification.**
- `pnpm --filter web test src/components/chat/__tests__/chat-room-activity-sort.test.ts`
- `pnpm --filter web test src/components/chat/__tests__/room-attention.test.ts`
- Husky `pnpm check && pnpm typecheck` on commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78731453-f001-483b-9f8d-aea6458b9236?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78731453-f001-483b-9f8d-aea6458b9236&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

