### PR TITLE
fix(chat): hide message actions on touch until overflow

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Nachrichtenaktionen",
         "sectionTitle": "Kanal verwalten",
         "leave": "Kanal verlassen",
         "archive": "Kanal archivieren",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4670,6 +4670,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Message actions",
         "sectionTitle": "Manage channel",
         "leave": "Leave channel",
         "archive": "Archive channel",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Acciones del mensaje",
         "sectionTitle": "Gestionar canal",
         "leave": "Salir del canal",
         "archive": "Archivar canal",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Actions du message",
         "sectionTitle": "Gérer le canal",
         "leave": "Quitter le canal",
         "archive": "Archiver le canal",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Azioni del messaggio",
         "sectionTitle": "Gestisci il canale",
         "leave": "Abbandona il canale",
         "archive": "Archivia il canale",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "メッセージ操作",
         "sectionTitle": "チャンネルの管理",
         "leave": "チャンネルから退出",
         "archive": "チャンネルをアーカイブ",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Ações da mensagem",
         "sectionTitle": "Gerenciar canal",
         "leave": "Sair do canal",
         "archive": "Arquivar canal",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "Ações da mensagem",
         "sectionTitle": "Gerenciar canal",
         "leave": "Sair do canal",
         "archive": "Arquivar canal",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4551,6 +4551,7 @@
     },
     "Channels": {
       "Actions": {
+        "more": "消息操作",
         "sectionTitle": "管理频道",
         "leave": "退出频道",
         "archive": "归档频道",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -210,6 +210,27 @@ describe("ChatMessageRow", () => {
     ).toBeInTheDocument();
   });
 
+  it("closes touch message actions on outside pointerdown", async () => {
+    const user = userEvent.setup();
+    renderRow({ onQuote: vi.fn() });
+
+    await user.click(
+      touchActions().getByRole("button", { name: "Actions.more" }),
+    );
+    expect(
+      touchActions().getByRole("button", { name: "Quote.action" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("article"));
+
+    expect(
+      touchActions().queryByRole("button", { name: "Quote.action" }),
+    ).not.toBeInTheDocument();
+    expect(
+      touchActions().getByRole("button", { name: "Actions.more" }),
+    ).toBeInTheDocument();
+  });
+
   it("shows Quote action and calls onQuote", async () => {
     const user = userEvent.setup();
     const onQuote = vi.fn();

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -45,6 +45,14 @@ vi.mock("@/components/ui/tooltip", () => ({
   ),
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
+
+function touchActions() {
+  const node = document.querySelector('[data-message-actions="touch"]');
+  if (!(node instanceof HTMLElement)) {
+    throw new Error("Touch message actions chrome missing");
+  }
+  return within(node);
+}
 
 function userMessage(
   overrides: Partial<ChatRoomMessage> = {},
@@ -185,15 +193,45 @@ describe("ChatMessageRow", () => {
     expect(article).toHaveAttribute("data-message-id", "message-1");
   });
 
+  it("hides Quote on touch until message actions overflow opens", async () => {
+    const user = userEvent.setup();
+    const onQuote = vi.fn();
+    renderRow({ onQuote });
+
+    expect(
+      touchActions().queryByRole("button", { name: "Quote.action" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      touchActions().getByRole("button", { name: "Actions.more" }),
+    );
+    expect(
+      touchActions().getByRole("button", { name: "Quote.action" }),
+    ).toBeInTheDocument();
+  });
+
   it("shows Quote action and calls onQuote", async () => {
     const user = userEvent.setup();
     const onQuote = vi.fn();
     renderRow({ onQuote });
 
-    await user.click(screen.getByRole("button", { name: "Quote.action" }));
+    await user.click(
+      touchActions().getByRole("button", { name: "Actions.more" }),
+    );
+    await user.click(
+      touchActions().getByRole("button", { name: "Quote.action" }),
+    );
     expect(onQuote).toHaveBeenCalledWith(
       expect.objectContaining({ id: "message-1" }),
     );
+  });
+
+  it("reserves hover-only right gutter on article", () => {
+    renderRow();
+
+    const article = screen.getByRole("article");
+    expect(article.className).toContain("[@media(hover:hover)]:pr-20");
+    expect(article.className.split(/\s+/)).not.toContain("pr-20");
   });
 
   it("renders quote snapshot from DTO and soft-fails jump when target missing", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -45,14 +45,6 @@ vi.mock("@/components/ui/tooltip", () => ({
   ),
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
-
-function touchActions() {
-  const node = document.querySelector('[data-message-actions="touch"]');
-  if (!(node instanceof HTMLElement)) {
-    throw new Error("Touch message actions chrome missing");
-  }
-  return within(node);
-}
 
 function userMessage(
   overrides: Partial<ChatRoomMessage> = {},
@@ -193,58 +185,76 @@ describe("ChatMessageRow", () => {
     expect(article).toHaveAttribute("data-message-id", "message-1");
   });
 
-  it("hides Quote on touch until message actions overflow opens", async () => {
+  it("keeps Quote out of the sheet until message actions open", async () => {
     const user = userEvent.setup();
     const onQuote = vi.fn();
     renderRow({ onQuote });
 
-    expect(
-      touchActions().queryByRole("button", { name: "Quote.action" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    await user.click(
-      touchActions().getByRole("button", { name: "Actions.more" }),
-    );
+    const openActions = screen.getByRole("button", { name: "Actions.more" });
+    expect(openActions).toHaveClass("sr-only");
+    await user.click(openActions);
+
+    const sheet = screen.getByRole("dialog");
     expect(
-      touchActions().getByRole("button", { name: "Quote.action" }),
+      within(sheet).getByRole("button", { name: "Quote.action" }),
     ).toBeInTheDocument();
   });
 
-  it("closes touch message actions on outside pointerdown", async () => {
-    const user = userEvent.setup();
-    renderRow({ onQuote: vi.fn() });
-
-    await user.click(
-      touchActions().getByRole("button", { name: "Actions.more" }),
-    );
-    expect(
-      touchActions().getByRole("button", { name: "Quote.action" }),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("article"));
-
-    expect(
-      touchActions().queryByRole("button", { name: "Quote.action" }),
-    ).not.toBeInTheDocument();
-    expect(
-      touchActions().getByRole("button", { name: "Actions.more" }),
-    ).toBeInTheDocument();
-  });
-
-  it("shows Quote action and calls onQuote", async () => {
+  it("shows Quote action in the sheet and calls onQuote", async () => {
     const user = userEvent.setup();
     const onQuote = vi.fn();
     renderRow({ onQuote });
 
+    await user.click(screen.getByRole("button", { name: "Actions.more" }));
     await user.click(
-      touchActions().getByRole("button", { name: "Actions.more" }),
-    );
-    await user.click(
-      touchActions().getByRole("button", { name: "Quote.action" }),
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Quote.action",
+      }),
     );
     expect(onQuote).toHaveBeenCalledWith(
       expect.objectContaining({ id: "message-1" }),
     );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens message actions sheet after long-press when hover is unavailable", async () => {
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+    try {
+      vi.useFakeTimers();
+      renderRow({ onQuote: vi.fn() });
+      const article = screen.getByRole("article");
+
+      await act(async () => {
+        article.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 10,
+            clientY: 10,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+      matchMediaSpy.mockRestore();
+    }
   });
 
   it("reserves hover-only right gutter on article", () => {

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -347,6 +347,7 @@ function MessageActions({
 }) {
   const t = useTranslations("App.Channels");
   const [open, setOpen] = useState(false);
+  const touchRootRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) {
@@ -359,9 +360,29 @@ function MessageActions({
       }
     }
 
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      if (touchRootRef.current?.contains(target)) {
+        return;
+      }
+      // EmojiPicker Popover portals outside the touch root.
+      if (
+        target instanceof Element &&
+        target.closest('[data-slot="popover-content"]')
+      ) {
+        return;
+      }
+      setOpen(false);
+    }
+
     document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("pointerdown", handlePointerDown);
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [open]);
 
@@ -386,6 +407,7 @@ function MessageActions({
         <MessageActionControls {...controlProps} />
       </div>
       <div
+        ref={touchRootRef}
         data-message-actions="touch"
         className="absolute top-1.5 right-2 flex [@media(hover:hover)]:hidden"
       >

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -5,9 +5,21 @@ import {
   isFileLikeUrl,
   unescapeMarkdownLinkUrl,
 } from "@sokosumi/utils";
-import { CheckCircle2, Loader2, MessageCircle, Quote } from "lucide-react";
+import {
+  CheckCircle2,
+  Loader2,
+  MessageCircle,
+  MoreHorizontal,
+  Quote,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import Markdown from "@/components/markdown";
@@ -248,6 +260,76 @@ function ChannelMessageText({
   return <>{nodes}</>;
 }
 
+function MessageActionControls({
+  message,
+  onToggleReaction,
+  onOpenThread,
+  onQuote,
+  showThreadButton,
+  showQuoteButton,
+  onAfterAction,
+}: {
+  message: ChatRoomMessage;
+  onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
+  onOpenThread?: (message: ChatRoomMessage) => void;
+  onQuote?: (message: ChatRoomMessage) => void;
+  showThreadButton: boolean;
+  showQuoteButton: boolean;
+  onAfterAction?: () => void;
+}) {
+  const t = useTranslations("App.Channels");
+
+  return (
+    <>
+      <EmojiPicker
+        title={t("Reactions.add")}
+        ariaLabel={t("Reactions.add")}
+        align="end"
+        triggerClassName="size-9 rounded-full sm:size-7"
+        onPick={(emoji) => {
+          onToggleReaction(message, emoji);
+          onAfterAction?.();
+        }}
+      />
+      {showQuoteButton && onQuote ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-9 rounded-full sm:size-7"
+          title={t("Quote.action")}
+          aria-label={t("Quote.action")}
+          onClick={() => {
+            onQuote(message);
+            onAfterAction?.();
+          }}
+        >
+          <Quote className="size-4" aria-hidden />
+        </Button>
+      ) : null}
+      {showThreadButton && onOpenThread ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-9 rounded-full sm:size-7"
+          title={t("Thread.open")}
+          aria-label={t("Thread.open")}
+          onClick={() => {
+            onOpenThread(message);
+            onAfterAction?.();
+          }}
+        >
+          <MessageCircle className="size-4" aria-hidden />
+        </Button>
+      ) : null}
+    </>
+  );
+}
+
+const messageActionsPillClassName =
+  "border-border bg-background absolute top-1.5 right-2 flex items-center gap-0.5 rounded-full border p-0.5 shadow-sm";
+
 function MessageActions({
   message,
   onToggleReaction,
@@ -264,43 +346,75 @@ function MessageActions({
   showQuoteButton: boolean;
 }) {
   const t = useTranslations("App.Channels");
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const controlProps = {
+    message,
+    onToggleReaction,
+    onOpenThread,
+    onQuote,
+    showThreadButton,
+    showQuoteButton,
+  };
 
   return (
-    <div className="border-border bg-background absolute top-1.5 right-2 flex items-center gap-0.5 rounded-full border p-0.5 shadow-sm transition-opacity focus-within:opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100">
-      <EmojiPicker
-        title={t("Reactions.add")}
-        ariaLabel={t("Reactions.add")}
-        align="end"
-        triggerClassName="size-9 rounded-full sm:size-7"
-        onPick={(emoji) => onToggleReaction(message, emoji)}
-      />
-      {showQuoteButton && onQuote ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-9 rounded-full sm:size-7"
-          title={t("Quote.action")}
-          aria-label={t("Quote.action")}
-          onClick={() => onQuote(message)}
-        >
-          <Quote className="size-4" aria-hidden />
-        </Button>
-      ) : null}
-      {showThreadButton && onOpenThread ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-9 rounded-full sm:size-7"
-          title={t("Thread.open")}
-          aria-label={t("Thread.open")}
-          onClick={() => onOpenThread(message)}
-        >
-          <MessageCircle className="size-4" aria-hidden />
-        </Button>
-      ) : null}
-    </div>
+    <>
+      <div
+        data-message-actions="hover"
+        className={cn(
+          messageActionsPillClassName,
+          "hidden transition-opacity focus-within:opacity-100 [@media(hover:hover)]:flex [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
+        )}
+      >
+        <MessageActionControls {...controlProps} />
+      </div>
+      <div
+        data-message-actions="touch"
+        className="absolute top-1.5 right-2 flex [@media(hover:hover)]:hidden"
+      >
+        {open ? (
+          <div className={cn(messageActionsPillClassName, "static")}>
+            <MessageActionControls
+              {...controlProps}
+              onAfterAction={() => {
+                setOpen(false);
+              }}
+            />
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="border-border bg-background size-9 rounded-full border shadow-sm sm:size-7"
+            title={t("Actions.more")}
+            aria-label={t("Actions.more")}
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            <MoreHorizontal className="size-4" aria-hidden />
+          </Button>
+        )}
+      </div>
+    </>
   );
 }
 
@@ -438,7 +552,7 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        "group relative -mx-2 flex gap-3.5 rounded-md pr-20 pl-2 transition-colors hover:bg-muted/45",
+        "group relative -mx-2 flex gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
         isContinuation ? "min-h-0 py-0.5" : "mt-3 min-h-0 pt-1 pb-0.5",
       )}
     >

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -5,17 +5,12 @@ import {
   isFileLikeUrl,
   unescapeMarkdownLinkUrl,
 } from "@sokosumi/utils";
-import {
-  CheckCircle2,
-  Loader2,
-  MessageCircle,
-  MoreHorizontal,
-  Quote,
-} from "lucide-react";
+import { CheckCircle2, Loader2, MessageCircle, Quote } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
-  useEffect,
+  type PointerEvent as ReactPointerEvent,
   useLayoutEffect,
   useRef,
   useState,
@@ -26,6 +21,13 @@ import Markdown from "@/components/markdown";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import {
   Tooltip,
   TooltipContent,
@@ -260,6 +262,78 @@ function ChannelMessageText({
   return <>{nodes}</>;
 }
 
+const QUICK_MESSAGE_REACTIONS = ["👍", "❤️", "😂", "🎉", "👀"] as const;
+const LONG_PRESS_DELAY_MS = 450;
+const LONG_PRESS_MOVE_TOLERANCE_PX = 12;
+
+function devicePrefersHover(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+  return window.matchMedia("(hover: hover)").matches;
+}
+
+function useLongPress(onLongPress: () => void): {
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerUp: () => void;
+  onPointerCancel: () => void;
+  onContextMenu: (event: ReactMouseEvent<HTMLElement>) => void;
+} {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+
+  function clearTimer() {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startRef.current = null;
+  }
+
+  return {
+    onPointerDown(event) {
+      if (event.button !== 0) {
+        return;
+      }
+      if (devicePrefersHover()) {
+        return;
+      }
+      clearTimer();
+      startRef.current = { x: event.clientX, y: event.clientY };
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        startRef.current = null;
+        onLongPress();
+      }, LONG_PRESS_DELAY_MS);
+    },
+    onPointerMove(event) {
+      if (!startRef.current || timerRef.current === null) {
+        return;
+      }
+      const deltaX = event.clientX - startRef.current.x;
+      const deltaY = event.clientY - startRef.current.y;
+      if (
+        deltaX * deltaX + deltaY * deltaY >
+        LONG_PRESS_MOVE_TOLERANCE_PX * LONG_PRESS_MOVE_TOLERANCE_PX
+      ) {
+        clearTimer();
+      }
+    },
+    onPointerUp() {
+      clearTimer();
+    },
+    onPointerCancel() {
+      clearTimer();
+    },
+    onContextMenu(event) {
+      if (!devicePrefersHover()) {
+        event.preventDefault();
+      }
+    },
+  };
+}
+
 function MessageActionControls({
   message,
   onToggleReaction,
@@ -345,98 +419,133 @@ function MessageActions({
   showThreadButton: boolean;
   showQuoteButton: boolean;
 }) {
+  return (
+    <div
+      data-message-actions="hover"
+      className={cn(
+        messageActionsPillClassName,
+        "hidden transition-opacity focus-within:opacity-100 [@media(hover:hover)]:flex [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
+      )}
+    >
+      <MessageActionControls
+        message={message}
+        onToggleReaction={onToggleReaction}
+        onOpenThread={onOpenThread}
+        onQuote={onQuote}
+        showThreadButton={showThreadButton}
+        showQuoteButton={showQuoteButton}
+      />
+    </div>
+  );
+}
+
+function TouchMessageActionsSheet({
+  open,
+  onOpenChange,
+  message,
+  onToggleReaction,
+  onOpenThread,
+  onQuote,
+  showThreadButton,
+  showQuoteButton,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  message: ChatRoomMessage;
+  onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
+  onOpenThread?: (message: ChatRoomMessage) => void;
+  onQuote?: (message: ChatRoomMessage) => void;
+  showThreadButton: boolean;
+  showQuoteButton: boolean;
+}) {
   const t = useTranslations("App.Channels");
-  const [open, setOpen] = useState(false);
-  const touchRootRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-
-    function handlePointerDown(event: PointerEvent) {
-      const target = event.target;
-      if (!(target instanceof Node)) {
-        return;
-      }
-      if (touchRootRef.current?.contains(target)) {
-        return;
-      }
-      // EmojiPicker Popover portals outside the touch root.
-      if (
-        target instanceof Element &&
-        target.closest('[data-slot="popover-content"]')
-      ) {
-        return;
-      }
-      setOpen(false);
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("pointerdown", handlePointerDown);
-    };
-  }, [open]);
-
-  const controlProps = {
-    message,
-    onToggleReaction,
-    onOpenThread,
-    onQuote,
-    showThreadButton,
-    showQuoteButton,
-  };
+  function runAndClose(action: () => void) {
+    action();
+    onOpenChange(false);
+  }
 
   return (
-    <>
-      <div
-        data-message-actions="hover"
-        className={cn(
-          messageActionsPillClassName,
-          "hidden transition-opacity focus-within:opacity-100 [@media(hover:hover)]:flex [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
-        )}
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        showCloseButton={false}
+        className="gap-0 rounded-t-2xl pb-[max(1rem,env(safe-area-inset-bottom))]"
       >
-        <MessageActionControls {...controlProps} />
-      </div>
-      <div
-        ref={touchRootRef}
-        data-message-actions="touch"
-        className="absolute top-1.5 right-2 flex [@media(hover:hover)]:hidden"
-      >
-        {open ? (
-          <div className={cn(messageActionsPillClassName, "static")}>
-            <MessageActionControls
-              {...controlProps}
-              onAfterAction={() => {
-                setOpen(false);
+        <SheetHeader className="items-center gap-2 pt-3 pb-2">
+          <div
+            className="bg-muted h-1 w-10 shrink-0 rounded-full"
+            aria-hidden
+          />
+          <SheetTitle>{t("Actions.more")}</SheetTitle>
+          <SheetDescription className="sr-only">
+            {t("Actions.more")}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex flex-wrap items-center justify-center gap-2 px-4 pb-4">
+          {QUICK_MESSAGE_REACTIONS.map((emoji) => (
+            <Button
+              key={emoji}
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-11 rounded-full text-xl"
+              aria-label={t("Reactions.toggle", { emoji })}
+              onClick={() => {
+                runAndClose(() => {
+                  onToggleReaction(message, emoji);
+                });
               }}
-            />
-          </div>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="border-border bg-background size-9 rounded-full border shadow-sm sm:size-7"
-            title={t("Actions.more")}
-            aria-label={t("Actions.more")}
-            onClick={() => {
-              setOpen(true);
+            >
+              <span aria-hidden>{emoji}</span>
+            </Button>
+          ))}
+          <EmojiPicker
+            title={t("Reactions.add")}
+            ariaLabel={t("Reactions.add")}
+            align="center"
+            triggerClassName="size-11 rounded-full"
+            onPick={(emoji) => {
+              runAndClose(() => {
+                onToggleReaction(message, emoji);
+              });
             }}
-          >
-            <MoreHorizontal className="size-4" aria-hidden />
-          </Button>
-        )}
-      </div>
-    </>
+          />
+        </div>
+        <div className="border-border flex flex-col gap-1 border-t px-2 py-2">
+          {showQuoteButton && onQuote ? (
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-11 justify-start gap-3 px-3"
+              onClick={() => {
+                runAndClose(() => {
+                  onQuote(message);
+                });
+              }}
+            >
+              <Quote className="size-4 shrink-0" aria-hidden />
+              {t("Quote.action")}
+            </Button>
+          ) : null}
+          {showThreadButton && onOpenThread ? (
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-11 justify-start gap-3 px-3"
+              onClick={() => {
+                runAndClose(() => {
+                  onOpenThread(message);
+                });
+              }}
+            >
+              <MessageCircle className="size-4 shrink-0" aria-hidden />
+              {t("Thread.open")}
+            </Button>
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }
 
@@ -557,6 +666,7 @@ export function ChatMessageRow({
   isContinuation?: boolean;
 }) {
   const tChat = useTranslations("App.Chat.Chat");
+  const tChannels = useTranslations("App.Channels");
   const sender = messageSender(message);
   const isStreamOverlay = message.id.startsWith("stream:");
   const isThinking =
@@ -567,6 +677,10 @@ export function ChatMessageRow({
   const createdAtIso = new Date(message.createdAt).toISOString();
   const canQuote = showQuoteButton && Boolean(onQuote) && !isStreamOverlay;
   const quote = message.quote;
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const longPress = useLongPress(() => {
+    setSheetOpen(true);
+  });
 
   return (
     <article
@@ -577,6 +691,7 @@ export function ChatMessageRow({
         "group relative -mx-2 flex gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
         isContinuation ? "min-h-0 py-0.5" : "mt-3 min-h-0 pt-1 pb-0.5",
       )}
+      {...(isThinking ? {} : longPress)}
     >
       {isContinuation ? (
         <div className="flex w-8 shrink-0 justify-center pt-0.5">
@@ -655,14 +770,35 @@ export function ChatMessageRow({
         />
       </div>
       {!isThinking ? (
-        <MessageActions
-          message={message}
-          onToggleReaction={onToggleReaction}
-          onOpenThread={onOpenThread}
-          onQuote={onQuote}
-          showThreadButton={showThreadButton}
-          showQuoteButton={canQuote}
-        />
+        <>
+          <MessageActions
+            message={message}
+            onToggleReaction={onToggleReaction}
+            onOpenThread={onOpenThread}
+            onQuote={onQuote}
+            showThreadButton={showThreadButton}
+            showQuoteButton={canQuote}
+          />
+          <button
+            type="button"
+            className="sr-only"
+            onClick={() => {
+              setSheetOpen(true);
+            }}
+          >
+            {tChannels("Actions.more")}
+          </button>
+          <TouchMessageActionsSheet
+            open={sheetOpen}
+            onOpenChange={setSheetOpen}
+            message={message}
+            onToggleReaction={onToggleReaction}
+            onOpenThread={onOpenThread}
+            onQuote={onQuote}
+            showThreadButton={showThreadButton}
+            showQuoteButton={canQuote}
+          />
+        </>
       ) : null}
     </article>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-692](https://linear.app/masumi/issue/SOK-692/hide-per-message-action-icons-on-touch-until-invoked).

On no-hover (touch) devices, message rows have **no** persistent action chrome. Long-press opens a bottom Sheet with quick reactions, full emoji picker, quote, and thread. Desktop hover-reveal is unchanged. Right gutter (`pr-20`) is hover-only.

## Spec

- Touch default: zero per-message action icons / ⋯
- Touch invoke: long-press → bottom Sheet (Buzz-style)
- Desktop: existing `@media(hover:hover)` hover + `focus-within` unchanged
- A11y: `sr-only` “Message actions” opens the same sheet
- Same react / quote / thread set; no new features
- Callers unchanged

## Verification

- `pnpm web:check` / room-message-row tests / typecheck (exit 0)
- CI green
- Visual (mobile 390): no ⋯ on rows

![Touch message row with no overflow chrome](https://cursor.com/artifacts/c/art-8a1a784c-a727-452e-9005-d22070630049)

### Principles

- **Experience First:** sheet-only matches Slack/Teams/Buzz; no ⋯ column
- **Subtract Before You Add:** removed overflow expand path before adding Sheet
- **Redesign from First Principles:** touch invoke is long-press sheet, not a shrunk icon row
- **Prove It Works:** unit tests for sheet + long-press; collapsed visual on mobile viewport

### Review notes

| Area | Finding |
|------|---------|
| DevTools | Chrome responsive mode still reports `(hover: hover)`, so long-press won’t fire there; real phones / `(hover: none)` do. Use real device or touch-emulation that flips the media query. |
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-692](https://linear.app/masumi/issue/SOK-692/hide-per-message-action-icons-on-touch-until-invoked)

<div><a href="https://cursor.com/agents/bc-a9368b4d-8cab-4437-b7a7-ed7b88f8b5f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9368b4d-8cab-4437-b7a7-ed7b88f8b5f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

