### PR TITLE
fix(chat): swipe down to dismiss message actions sheet

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -219,6 +219,52 @@ describe("ChatMessageRow", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("dismisses the sheet when swiped down past the threshold", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderRow({ onQuote: vi.fn() });
+      await user.click(screen.getByRole("button", { name: "Actions.more" }));
+
+      const sheet = screen.getByRole("dialog");
+      const handle = sheet.querySelector("[data-sheet-swipe-handle]");
+      expect(handle).toBeTruthy();
+
+      await act(async () => {
+        handle!.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            pointerId: 1,
+            clientX: 40,
+            clientY: 20,
+          }),
+        );
+        sheet.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            pointerId: 1,
+            clientX: 40,
+            clientY: 140,
+          }),
+        );
+        sheet.dispatchEvent(
+          new PointerEvent("pointerup", {
+            bubbles: true,
+            pointerId: 1,
+            clientX: 40,
+            clientY: 140,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(200);
+      });
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("opens message actions sheet after long-press when hover is unavailable", async () => {
     const matchMediaSpy = vi
       .spyOn(window, "matchMedia")

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -11,6 +11,9 @@ import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -439,6 +442,131 @@ function MessageActions({
   );
 }
 
+const SHEET_SWIPE_DISMISS_PX = 80;
+const SHEET_SWIPE_DRAG_START_PX = 8;
+
+function isSheetSwipeInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest(
+      "button, a, input, textarea, [role='button'], [data-slot='popover-content']",
+    ),
+  );
+}
+
+function useBottomSheetSwipeDismiss(
+  open: boolean,
+  onDismiss: () => void,
+): {
+  contentRef: RefObject<HTMLDivElement | null>;
+  swipeHandlers: {
+    onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  };
+} {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    pointerId: number | null;
+    startY: number;
+    dragging: boolean;
+    dismissing: boolean;
+  }>({
+    pointerId: null,
+    startY: 0,
+    dragging: false,
+    dismissing: false,
+  });
+
+  const resetTransform = useCallback(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    el.style.transform = "";
+    el.style.transition = "";
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      dragRef.current = {
+        pointerId: null,
+        startY: 0,
+        dragging: false,
+        dismissing: false,
+      };
+      resetTransform();
+    }
+  }, [open, resetTransform]);
+
+  function finishPointer(event: ReactPointerEvent<HTMLDivElement>) {
+    const drag = dragRef.current;
+    if (drag.pointerId !== event.pointerId || drag.dismissing) return;
+
+    const dy = Math.max(0, event.clientY - drag.startY);
+    drag.pointerId = null;
+    const el = contentRef.current;
+    if (!el) return;
+
+    if (drag.dragging && dy >= SHEET_SWIPE_DISMISS_PX) {
+      drag.dismissing = true;
+      el.style.transition = "transform 180ms ease-out";
+      el.style.transform = "translateY(100%)";
+      window.setTimeout(() => {
+        onDismiss();
+        resetTransform();
+        drag.dismissing = false;
+        drag.dragging = false;
+      }, 180);
+      return;
+    }
+
+    el.style.transition = "transform 200ms ease-out";
+    el.style.transform = "translateY(0)";
+    window.setTimeout(() => {
+      if (!drag.dismissing) resetTransform();
+    }, 200);
+    drag.dragging = false;
+  }
+
+  return {
+    contentRef,
+    swipeHandlers: {
+      onPointerDown(event) {
+        if (event.button !== 0) return;
+        if (dragRef.current.dismissing) return;
+        const fromHandle = Boolean(
+          event.target instanceof Element &&
+            event.target.closest("[data-sheet-swipe-handle]"),
+        );
+        if (!fromHandle && isSheetSwipeInteractiveTarget(event.target)) return;
+
+        dragRef.current = {
+          pointerId: event.pointerId,
+          startY: event.clientY,
+          dragging: false,
+          dismissing: false,
+        };
+        event.currentTarget.setPointerCapture(event.pointerId);
+      },
+      onPointerMove(event) {
+        const drag = dragRef.current;
+        if (drag.pointerId !== event.pointerId || drag.dismissing) return;
+
+        const dy = Math.max(0, event.clientY - drag.startY);
+        if (dy > SHEET_SWIPE_DRAG_START_PX) drag.dragging = true;
+        if (!drag.dragging) return;
+
+        const el = contentRef.current;
+        if (!el) return;
+        el.style.transition = "none";
+        el.style.transform = `translateY(${dy}px)`;
+      },
+      onPointerUp: finishPointer,
+      onPointerCancel: finishPointer,
+    },
+  };
+}
+
 function TouchMessageActionsSheet({
   open,
   onOpenChange,
@@ -459,6 +587,9 @@ function TouchMessageActionsSheet({
   showQuoteButton: boolean;
 }) {
   const t = useTranslations("App.Channels");
+  const { contentRef, swipeHandlers } = useBottomSheetSwipeDismiss(open, () => {
+    onOpenChange(false);
+  });
 
   function runAndClose(action: () => void) {
     action();
@@ -468,15 +599,22 @@ function TouchMessageActionsSheet({
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
+        ref={contentRef}
         side="bottom"
         showCloseButton={false}
-        className="gap-0 rounded-t-2xl pb-[max(1rem,env(safe-area-inset-bottom))]"
+        className="gap-0 rounded-t-2xl touch-none pb-[max(1rem,env(safe-area-inset-bottom))]"
+        {...swipeHandlers}
       >
-        <SheetHeader className="items-center gap-2 pt-3 pb-2">
+        <SheetHeader className="items-center gap-2 pt-1 pb-2">
           <div
-            className="bg-muted h-1 w-10 shrink-0 rounded-full"
-            aria-hidden
-          />
+            data-sheet-swipe-handle
+            className="flex w-full cursor-grab justify-center py-3 active:cursor-grabbing"
+          >
+            <div
+              className="bg-muted-foreground/40 h-1.5 w-12 shrink-0 rounded-full"
+              aria-hidden
+            />
+          </div>
           <SheetTitle>{t("Actions.more")}</SheetTitle>
           <SheetDescription className="sr-only">
             {t("Actions.more")}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#3522](https://github.com/masumi-network/sokosumi/pull/3522) / [SOK-692](https://linear.app/masumi/issue/SOK-692/hide-per-message-action-icons-on-touch-until-invoked).

Radix `Sheet` (Dialog) has no built-in swipe-to-dismiss. Message actions bottom sheet now tracks pointer drag so mobile users can swipe it closed.

## Behavior

- Drag from the grab handle always starts swipe
- Drag from sheet body works too; buttons / emoji picker skipped so taps still work
- Past ~80px down → animate out and close
- Short drag → snap back
- Backdrop tap / Escape / picking an action still dismiss

## Verification

- `pnpm --filter web test` on `room-message-row.test.tsx` (17 passed, includes swipe dismiss)
- Pre-commit `pnpm check` + typecheck on cherry-pick commit
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-692](https://linear.app/masumi/issue/SOK-692/hide-per-message-action-icons-on-touch-until-invoked)

<div><a href="https://cursor.com/agents/bc-a9368b4d-8cab-4437-b7a7-ed7b88f8b5f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9368b4d-8cab-4437-b7a7-ed7b88f8b5f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

