### PR TITLE
feat(core): scope DESIGN.md blobs by user or organization owner

### DIFF
--- a/apps/core/src/config/constants.ts
+++ b/apps/core/src/config/constants.ts
@@ -103,7 +103,4 @@ export const STORAGE = {
 
   /** Root directory for user file uploads */
   USER_UPLOADS_DIR: "users",
-
-  /** Directory for stored DESIGN.md documents */
-  DESIGN_MD_UPLOAD_DIR: "design-md",
 } as const;

--- a/apps/core/src/lib/design-md-blob.test.ts
+++ b/apps/core/src/lib/design-md-blob.test.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { uploadDesignMdContent } from "./design-md-blob";
+
+const { putMock, getEnvMock, captureExceptionMock } = vi.hoisted(() => ({
+  putMock: vi.fn(),
+  getEnvMock: vi.fn(() => ({ BLOB_READ_WRITE_TOKEN: "blob_token" })),
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@/config/env", () => ({
+  getEnv: getEnvMock,
+}));
+
+vi.mock("@vercel/blob", () => ({
+  put: putMock,
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: captureExceptionMock,
+}));
+
+describe("uploadDesignMdContent", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    getEnvMock.mockReturnValue({ BLOB_READ_WRITE_TOKEN: "blob_token" });
+  });
+
+  it("puts under design-md/users/{userId}/ with content-hash filename", async () => {
+    const content = "# Brand";
+    const hash = crypto.createHash("sha256").update(content).digest("hex");
+    putMock.mockResolvedValueOnce({
+      url: `https://blob.example/design-md/users/user_123/${hash}.md`,
+    });
+
+    const url = await uploadDesignMdContent({
+      content,
+      owner: { kind: "user", id: "user_123" },
+    });
+
+    expect(putMock).toHaveBeenCalledWith(
+      `design-md/users/user_123/${hash}.md`,
+      content,
+      expect.objectContaining({
+        access: "public",
+        contentType: "text/markdown; charset=utf-8",
+        allowOverwrite: true,
+        addRandomSuffix: false,
+        token: "blob_token",
+      }),
+    );
+    expect(url).toBe(
+      `https://blob.example/design-md/users/user_123/${hash}.md`,
+    );
+  });
+
+  it("puts under design-md/organizations/{orgId}/ with extractionId prefix", async () => {
+    const content = "# Org Brand";
+    const hash = crypto.createHash("sha256").update(content).digest("hex");
+    putMock.mockResolvedValueOnce({
+      url: `https://blob.example/design-md/organizations/org_99/55-${hash}.md`,
+    });
+
+    const url = await uploadDesignMdContent({
+      content,
+      owner: { kind: "organization", id: "org_99" },
+      extractionId: "55",
+    });
+
+    expect(putMock).toHaveBeenCalledWith(
+      `design-md/organizations/org_99/55-${hash}.md`,
+      content,
+      expect.objectContaining({
+        contentType: "text/markdown; charset=utf-8",
+        allowOverwrite: true,
+        addRandomSuffix: false,
+      }),
+    );
+    expect(url).toBe(
+      `https://blob.example/design-md/organizations/org_99/55-${hash}.md`,
+    );
+  });
+
+  it("returns null when put fails", async () => {
+    putMock.mockRejectedValueOnce(new Error("blob down"));
+
+    const url = await uploadDesignMdContent({
+      content: "# Brand",
+      owner: { kind: "user", id: "user_123" },
+    });
+
+    expect(url).toBeNull();
+    expect(captureExceptionMock).toHaveBeenCalled();
+  });
+
+  it("throws when blob token is missing", async () => {
+    getEnvMock.mockReturnValueOnce({});
+
+    await expect(
+      uploadDesignMdContent({
+        content: "# Brand",
+        owner: { kind: "user", id: "user_123" },
+      }),
+    ).rejects.toThrow("BLOB_READ_WRITE_TOKEN is not configured");
+  });
+});

--- a/apps/core/src/lib/design-md-blob.test.ts
+++ b/apps/core/src/lib/design-md-blob.test.ts
@@ -96,7 +96,7 @@ describe("uploadDesignMdContent", () => {
   });
 
   it("throws when blob token is missing", async () => {
-    getEnvMock.mockReturnValueOnce({});
+    getEnvMock.mockReturnValueOnce({ BLOB_READ_WRITE_TOKEN: "" });
 
     await expect(
       uploadDesignMdContent({

--- a/apps/core/src/lib/design-md-blob.ts
+++ b/apps/core/src/lib/design-md-blob.ts
@@ -1,10 +1,19 @@
 import crypto from "node:crypto";
 
 import * as Sentry from "@sentry/node";
+import {
+  buildOrganizationDesignMdPathname,
+  buildUserDesignMdPathname,
+} from "@sokosumi/utils";
 import { put } from "@vercel/blob";
 
-import { STORAGE } from "@/config/constants";
 import { getEnv } from "@/config/env";
+
+export interface UploadDesignMdContentOptions {
+  content: string;
+  owner: { kind: "user"; id: string } | { kind: "organization"; id: string };
+  extractionId?: string | null;
+}
 
 /**
  * Uploads DESIGN.md markdown content to blob storage and returns the public URL,
@@ -15,12 +24,14 @@ import { getEnv } from "@/config/env";
  * map a `null` result to a 503.
  *
  * The filename is content-addressed (sha256) and namespaced by `extractionId`
- * when known, so re-uploading identical content is idempotent.
+ * when known, so re-uploading identical content is idempotent. New uploads go
+ * under owner-scoped paths (`design-md/users/…` or `design-md/organizations/…`).
  */
-export async function uploadDesignMdContent(
-  content: string,
-  extractionId?: string | null,
-): Promise<string | null> {
+export async function uploadDesignMdContent({
+  content,
+  owner,
+  extractionId,
+}: UploadDesignMdContentOptions): Promise<string | null> {
   const env = getEnv();
   if (!env.BLOB_READ_WRITE_TOKEN) {
     throw new Error("BLOB_READ_WRITE_TOKEN is not configured");
@@ -30,20 +41,32 @@ export async function uploadDesignMdContent(
   const hash = crypto.createHash("sha256").update(trimmed).digest("hex");
   const fileName = extractionId ? `${extractionId}-${hash}.md` : `${hash}.md`;
 
+  let pathname: string;
+  switch (owner.kind) {
+    case "user":
+      pathname = buildUserDesignMdPathname(owner.id, fileName);
+      break;
+    case "organization":
+      pathname = buildOrganizationDesignMdPathname(owner.id, fileName);
+      break;
+    default: {
+      const _exhaustive: never = owner;
+      throw new Error(
+        `Unsupported DESIGN.md owner: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+
   try {
-    const blob = await put(
-      `${STORAGE.DESIGN_MD_UPLOAD_DIR}/${fileName}`,
-      trimmed,
-      {
-        access: "public",
-        // Must stay a non-HTML type: the blob is public and user-authored, so
-        // serving it as text/html would turn it into stored XSS.
-        contentType: "text/markdown; charset=utf-8",
-        token: env.BLOB_READ_WRITE_TOKEN,
-        allowOverwrite: true,
-        addRandomSuffix: false,
-      },
-    );
+    const blob = await put(pathname, trimmed, {
+      access: "public",
+      // Must stay a non-HTML type: the blob is public and user-authored, so
+      // serving it as text/html would turn it into stored XSS.
+      contentType: "text/markdown; charset=utf-8",
+      token: env.BLOB_READ_WRITE_TOKEN,
+      allowOverwrite: true,
+      addRandomSuffix: false,
+    });
     return blob.url;
   } catch (error) {
     Sentry.captureException(error, {

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/put.test.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/put.test.ts
@@ -137,7 +137,11 @@ describe("PUT /organizations/{id}/design-md", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(uploadDesignMdContentMock).toHaveBeenCalledWith("# Brand", "55");
+    expect(uploadDesignMdContentMock).toHaveBeenCalledWith({
+      content: "# Brand",
+      owner: { kind: "organization", id: "org_123" },
+      extractionId: "55",
+    });
     expect(updateOrganizationByIdMock).toHaveBeenCalledWith(
       "org_123",
       { metadata: expect.stringContaining("https://blob.example/org.md") },
@@ -216,7 +220,11 @@ describe("PUT /organizations/{id}/design-md", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(uploadDesignMdContentMock).toHaveBeenCalledWith("# Brand", "55");
+    expect(uploadDesignMdContentMock).toHaveBeenCalledWith({
+      content: "# Brand",
+      owner: { kind: "organization", id: "org_123" },
+      extractionId: "55",
+    });
     expect(body.data.designMd).toEqual({
       url: "https://blob.example/org.md",
       extractionId: "55",

--- a/apps/core/src/routes/v1/organizations/[id]/design-md/put.ts
+++ b/apps/core/src/routes/v1/organizations/[id]/design-md/put.ts
@@ -83,7 +83,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     let url: string | null = null;
     if (body.content !== null) {
-      url = await uploadDesignMdContent(body.content, body.extractionId);
+      url = await uploadDesignMdContent({
+        content: body.content,
+        owner: { kind: "organization", id: organization.id },
+        extractionId: body.extractionId,
+      });
       if (!url) {
         throw serviceUnavailable("Failed to store the DESIGN.md");
       }

--- a/apps/core/src/routes/v1/users/[id]/design-md/put.test.ts
+++ b/apps/core/src/routes/v1/users/[id]/design-md/put.test.ts
@@ -104,7 +104,11 @@ describe("PUT /users/{id}/design-md", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(uploadDesignMdContentMock).toHaveBeenCalledWith("# Brand", "123");
+    expect(uploadDesignMdContentMock).toHaveBeenCalledWith({
+      content: "# Brand",
+      owner: { kind: "user", id: "user_123" },
+      extractionId: "123",
+    });
     expect(updateUserMetadataMock).toHaveBeenCalledWith(
       "user_123",
       expect.stringContaining("https://blob.example/design.md"),

--- a/apps/core/src/routes/v1/users/[id]/design-md/put.ts
+++ b/apps/core/src/routes/v1/users/[id]/design-md/put.ts
@@ -77,7 +77,11 @@ export default function mount(app: OpenAPIHonoWithAuth<UserRouteVariables>) {
 
     let url: string | null = null;
     if (body.content !== null) {
-      url = await uploadDesignMdContent(body.content, body.extractionId);
+      url = await uploadDesignMdContent({
+        content: body.content,
+        owner: { kind: "user", id: resolvedUserId },
+        extractionId: body.extractionId,
+      });
       if (!url) {
         throw serviceUnavailable("Failed to store the DESIGN.md");
       }

--- a/packages/utils/src/__tests__/design-md-path.test.ts
+++ b/packages/utils/src/__tests__/design-md-path.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOrganizationDesignMdPathname,
+  buildOrganizationDesignMdPrefix,
+  buildUserDesignMdPathname,
+  buildUserDesignMdPrefix,
+} from "../design-md-path.js";
+
+const USER_ID = "user_123";
+const ORG_ID = "01960001-0001-7001-8001-000000000099";
+const HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+describe("buildUserDesignMdPrefix", () => {
+  it("returns design-md/users/{userId}/", () => {
+    expect(buildUserDesignMdPrefix(USER_ID)).toBe(
+      `design-md/users/${USER_ID}/`,
+    );
+  });
+});
+
+describe("buildOrganizationDesignMdPrefix", () => {
+  it("returns design-md/organizations/{orgId}/", () => {
+    expect(buildOrganizationDesignMdPrefix(ORG_ID)).toBe(
+      `design-md/organizations/${ORG_ID}/`,
+    );
+  });
+});
+
+describe("buildUserDesignMdPathname", () => {
+  it("appends the hash filename under the user design-md prefix", () => {
+    expect(buildUserDesignMdPathname(USER_ID, `${HASH}.md`)).toBe(
+      `design-md/users/${USER_ID}/${HASH}.md`,
+    );
+  });
+
+  it("keeps an extractionId-prefixed hash filename", () => {
+    expect(buildUserDesignMdPathname(USER_ID, `123-${HASH}.md`)).toBe(
+      `design-md/users/${USER_ID}/123-${HASH}.md`,
+    );
+  });
+});
+
+describe("buildOrganizationDesignMdPathname", () => {
+  it("appends the hash filename under the org design-md prefix", () => {
+    expect(buildOrganizationDesignMdPathname(ORG_ID, `${HASH}.md`)).toBe(
+      `design-md/organizations/${ORG_ID}/${HASH}.md`,
+    );
+  });
+
+  it("keeps an extractionId-prefixed hash filename", () => {
+    expect(buildOrganizationDesignMdPathname(ORG_ID, `55-${HASH}.md`)).toBe(
+      `design-md/organizations/${ORG_ID}/55-${HASH}.md`,
+    );
+  });
+});

--- a/packages/utils/src/design-md-path.ts
+++ b/packages/utils/src/design-md-path.ts
@@ -1,0 +1,45 @@
+const DESIGN_MD_DIR = "design-md";
+const USERS_SEGMENT = "users";
+const ORGANIZATIONS_SEGMENT = "organizations";
+
+/**
+ * Prefix for user-owned DESIGN.md blobs.
+ * Example: `design-md/users/{userId}/`
+ */
+export function buildUserDesignMdPrefix(userId: string): string {
+  return `${DESIGN_MD_DIR}/${USERS_SEGMENT}/${userId}/`;
+}
+
+/**
+ * Prefix for organization-owned DESIGN.md blobs.
+ * Example: `design-md/organizations/{organizationId}/`
+ */
+export function buildOrganizationDesignMdPrefix(
+  organizationId: string,
+): string {
+  return `${DESIGN_MD_DIR}/${ORGANIZATIONS_SEGMENT}/${organizationId}/`;
+}
+
+/**
+ * Content-hash pathname for a user DESIGN.md put (no random suffix).
+ * `fileName` is already a safe hash (optional extractionId prefix + sha256 + `.md`).
+ * Example: `design-md/users/{userId}/{extractionId-}{sha256}.md`
+ */
+export function buildUserDesignMdPathname(
+  userId: string,
+  fileName: string,
+): string {
+  return `${buildUserDesignMdPrefix(userId)}${fileName}`;
+}
+
+/**
+ * Content-hash pathname for an organization DESIGN.md put (no random suffix).
+ * `fileName` is already a safe hash (optional extractionId prefix + sha256 + `.md`).
+ * Example: `design-md/organizations/{organizationId}/{extractionId-}{sha256}.md`
+ */
+export function buildOrganizationDesignMdPathname(
+  organizationId: string,
+  fileName: string,
+): string {
+  return `${buildOrganizationDesignMdPrefix(organizationId)}${fileName}`;
+}

--- a/packages/utils/src/design-md-url.ts
+++ b/packages/utils/src/design-md-url.ts
@@ -8,6 +8,8 @@ export const DESIGN_MD_BLOB_PATH_PREFIX = "/design-md/";
 
 /**
  * True when `url` is an HTTPS public Vercel Blob URL under `/design-md/…`.
+ * Matches both legacy flat paths (`/design-md/{hash}.md`) and owner-scoped
+ * nested paths (`/design-md/users/…`, `/design-md/organizations/…`).
  * Used to stop SSRF via attacker-controlled `metadata.designMdUrl` values —
  * only Core-uploaded DESIGN.md blobs match this shape.
  */

--- a/packages/utils/src/design-md-url.ts
+++ b/packages/utils/src/design-md-url.ts
@@ -1,8 +1,8 @@
 import { isVercelBlobPublicHost } from "./entity-image-upload.js";
 
 /**
- * Blob path prefix used by Core when uploading DESIGN.md content
- * (`STORAGE.DESIGN_MD_UPLOAD_DIR` in apps/core).
+ * Blob path prefix for DESIGN.md URLs under Vercel Blob.
+ * Matches the `design-md/` root used by `design-md-path` builders.
  */
 export const DESIGN_MD_BLOB_PATH_PREFIX = "/design-md/";
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -86,6 +86,12 @@ export {
   withPreservedDesignMdMetadata,
 } from "./design-md-metadata-guard.js";
 export {
+  buildOrganizationDesignMdPathname,
+  buildOrganizationDesignMdPrefix,
+  buildUserDesignMdPathname,
+  buildUserDesignMdPrefix,
+} from "./design-md-path.js";
+export {
   DESIGN_MD_BLOB_PATH_PREFIX,
   isDesignMdBlobUrl,
 } from "./design-md-url.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://linear.app/masumi/issue/SOK-670/scope-designmd-blobs-by-user-or-organization-owner

- New DESIGN.md uploads go under `design-md/users/{userId}/…` or `design-md/organizations/{orgId}/…`
- Server `put` kept; markdown content-type and idempotent overwrite unchanged
- Path builders live in `@sokosumi/utils` (logo-style dual prefixes)
- `isDesignMdBlobUrl` still accepts legacy flat `/design-md/{hash}.md` URLs
- Removed unused `STORAGE.DESIGN_MD_UPLOAD_DIR` (root segment owned by utils builders)
- No backfill, purge, or client mint in this PR

## Verification

- `pnpm --filter @sokosumi/utils check` / `test`
- `pnpm --filter core check` / `pnpm core:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-670](https://linear.app/masumi/issue/SOK-670/scope-designmd-blobs-by-user-or-organization-owner)

<div><a href="https://cursor.com/agents/bc-19d8eb60-a329-4fe2-bf15-32998e97ec91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19d8eb60-a329-4fe2-bf15-32998e97ec91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

