### PR TITLE
fix(chat): rename document title from Channels to Chat

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} wurde wiederhergestellt."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4687,7 +4687,7 @@
         "restoreSuccess": "{name} was restored."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} se restauró."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} a été restauré."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} è stato ripristinato."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} を復元しました。"
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "チャット",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} foi restaurado."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "{name} foi restaurado."
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "Chat",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4568,7 +4568,7 @@
         "restoreSuccess": "已恢复 {name}。"
       },
       "Metadata": {
-        "title": "Channels",
+        "title": "聊天",
         "description": "Organization chat channels for humans and AI coworkers."
       },
       "title": "Channels",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Room and draft chat routes used `App.Channels.Metadata.title` (`Channels`), so the browser tab showed **Sokosumi - Channels**. Nav already says Chat. This updates that metadata title to **Chat** (ja/zh-Hans match `App.Chat.Metadata`) so the composed document title is **Sokosumi - Chat**.

**Who notices.** Anyone on `/chat` rooms or draft create flows. Tab title and Cursor Work Apps label now match the Chat product name.

**What changed.** `App.Channels.Metadata.title` in all 9 locale catalogs. Descriptions and `App.Channels.title` (channels list copy) unchanged.

**Verification.** Composed `App.Metadata.Title.template` + new title → `Sokosumi - Chat`. Locale values match `App.Chat.Metadata.title`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da4b5449-8307-42be-a2a4-238b1b6c4157?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da4b5449-8307-42be-a2a4-238b1b6c4157&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

