### PR TITLE
feat(core): store imported job result blobs under jobs/{jobId}

### DIFF
--- a/apps/core/src/services/source-import-sync.service.test.ts
+++ b/apps/core/src/services/source-import-sync.service.test.ts
@@ -51,6 +51,7 @@ interface PendingBlobStub {
   sourceUrl: string;
   status: BlobStatus;
   createdAt: Date;
+  event: { jobId: string } | null;
 }
 
 interface ImportPendingResultBlobsOptions {
@@ -77,6 +78,7 @@ function createPendingBlob(index: number): PendingBlobStub {
     sourceUrl: `https://example.com/blob-${index}.txt`,
     status: BlobStatus.PENDING,
     createdAt: new Date(`2026-02-25T10:00:0${index}.000Z`),
+    event: { jobId: "job-1" },
   };
 }
 
@@ -181,6 +183,69 @@ describe("sourceImportSyncService.importPendingResultBlobs", () => {
 
     const processedCount = await runPromise;
     expect(processedCount).toBe(6);
+  });
+
+  it("stores imported blobs under jobs/{jobId}/ pathname", async () => {
+    const sourceImportSyncService = await getSourceImportSyncService();
+    const pendingBlob = createPendingBlob(1);
+
+    blobFindManyMock.mockResolvedValue([pendingBlob]);
+    blobFindUniqueMock.mockResolvedValue(pendingBlob);
+
+    global.fetch = vi.fn(async () => {
+      return new Response("hello", {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    await sourceImportSyncService.importPendingResultBlobs(
+      createImportOptions(),
+    );
+
+    expect(blobPutMock).toHaveBeenCalledOnce();
+    const [pathname] = blobPutMock.mock.calls[0] ?? [];
+    expect(pathname).toMatch(/^jobs\/job-1\//);
+    expect(pathname).not.toMatch(/^blobs\//);
+    expect(blobUpdateMock).toHaveBeenCalledWith({
+      where: { id: pendingBlob.id },
+      data: expect.objectContaining({
+        status: BlobStatus.READY,
+        fileUrl: expect.stringContaining("jobs/job-1/"),
+      }),
+    });
+  });
+
+  it("marks blob FAILED when jobId is missing and skips put", async () => {
+    const sourceImportSyncService = await getSourceImportSyncService();
+    const pendingBlob: PendingBlobStub = {
+      ...createPendingBlob(1),
+      event: null,
+    };
+
+    blobFindManyMock.mockResolvedValue([pendingBlob]);
+    blobFindUniqueMock.mockResolvedValue(pendingBlob);
+
+    global.fetch = vi.fn(async () => {
+      return new Response("hello", {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    await sourceImportSyncService.importPendingResultBlobs(
+      createImportOptions(),
+    );
+
+    expect(blobPutMock).not.toHaveBeenCalled();
+    expect(blobUpdateMock).toHaveBeenCalledWith({
+      where: { id: pendingBlob.id },
+      data: { status: BlobStatus.FAILED },
+    });
   });
 
   it("stops processing when cancellation is reached and keeps timed-out blobs pending", async () => {

--- a/apps/core/src/services/source-import-sync.service.ts
+++ b/apps/core/src/services/source-import-sync.service.ts
@@ -1,6 +1,6 @@
 import { BlobStatus } from "@sokosumi/database";
 import { ssrfSafeFetch } from "@sokosumi/net";
-import { getUrlBasename } from "@sokosumi/utils";
+import { buildJobBlobPathname, getUrlBasename } from "@sokosumi/utils";
 import { head, put } from "@vercel/blob";
 
 import { getEnv } from "@/config/env";
@@ -12,11 +12,6 @@ interface ImportPendingResultBlobsOptions {
   abortSignal: AbortSignal;
   deadlineMs: number;
   shouldContinue: () => boolean;
-}
-
-/** Sanitize filename for blob storage path (matches web's uploadFileForBlob behavior). */
-function sanitizePathSegment(name: string): string {
-  return name.replace(/ /g, "_");
 }
 
 function parseContentDispositionFilename(
@@ -93,9 +88,27 @@ async function importBlob(
     return;
   }
 
-  const blob = await prisma.blob.findUnique({ where: { id: blobId } });
+  const blob = await prisma.blob.findUnique({
+    where: { id: blobId },
+    include: {
+      event: {
+        select: { jobId: true },
+      },
+    },
+  });
 
   if (!blob || blob.status !== BlobStatus.PENDING) {
+    return;
+  }
+
+  const jobId = blob.event?.jobId;
+  if (!jobId) {
+    await prisma.blob.update({
+      where: { id: blob.id },
+      data: {
+        status: BlobStatus.FAILED,
+      },
+    });
     return;
   }
 
@@ -133,17 +146,13 @@ async function importBlob(
       throw new Error("BLOB_READ_WRITE_TOKEN is not configured");
     }
 
-    const pathSegment = sanitizePathSegment(suggestedName);
-    const uploadResult = await put(
-      `blobs/${blob.id}/${pathSegment}`,
-      sourceFile,
-      {
-        access: "public",
-        addRandomSuffix: true,
-        abortSignal,
-        token: blobToken,
-      },
-    );
+    const pathname = buildJobBlobPathname(jobId, suggestedName);
+    const uploadResult = await put(pathname, sourceFile, {
+      access: "public",
+      addRandomSuffix: true,
+      abortSignal,
+      token: blobToken,
+    });
     const blobMetadata = await head(uploadResult.url, {
       abortSignal,
       token: blobToken,

--- a/packages/utils/src/__tests__/job-blob-path.test.ts
+++ b/packages/utils/src/__tests__/job-blob-path.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { buildJobBlobPathname, buildJobBlobPrefix } from "../job-blob-path.js";
+
+describe("buildJobBlobPrefix", () => {
+  it("returns jobs/{jobId}/", () => {
+    expect(buildJobBlobPrefix("job_123")).toBe("jobs/job_123/");
+  });
+});
+
+describe("buildJobBlobPathname", () => {
+  it("builds a sanitized pathname under the job blob prefix", () => {
+    expect(buildJobBlobPathname("job_123", "hello world.txt")).toBe(
+      "jobs/job_123/hello_world.txt",
+    );
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -108,6 +108,10 @@ export {
   sanitizeOrganizationLogoForApi,
 } from "./ipfs-url.js";
 export {
+  buildJobBlobPathname,
+  buildJobBlobPrefix,
+} from "./job-blob-path.js";
+export {
   type AppLocale,
   DEFAULT_LOCALE,
   getEmailLocale,

--- a/packages/utils/src/job-blob-path.ts
+++ b/packages/utils/src/job-blob-path.ts
@@ -1,0 +1,19 @@
+import { sanitizeUserUploadFilename } from "./user-upload-path.js";
+
+const JOB_BLOBS_DIR = "jobs";
+
+/**
+ * Prefix for job-owned result blobs.
+ * Example: `jobs/{jobId}/`
+ */
+export function buildJobBlobPrefix(jobId: string): string {
+  return `${JOB_BLOBS_DIR}/${jobId}/`;
+}
+
+/**
+ * Base pathname before Vercel Blob applies a random suffix.
+ * Example: `jobs/{jobId}/hello_world.txt`
+ */
+export function buildJobBlobPathname(jobId: string, fileName: string): string {
+  return `${buildJobBlobPrefix(jobId)}${sanitizeUserUploadFilename(fileName)}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-667](https://linear.app/masumi/issue/SOK-667/store-imported-job-result-blobs-under-jobsjobid).

**Summary**
- New `@sokosumi/utils` helpers: `buildJobBlobPrefix` / `buildJobBlobPathname` → `jobs/{jobId}/…`
- Source-import sync loads `Blob` → `JobEvent.jobId` before put; keeps random suffix
- Missing `jobId` marks blob FAILED and skips put
- No legacy `blobs/…` rewrite; no JobFile/mint/webhook

**Verify**
- `pnpm --filter @sokosumi/utils check` / `test`
- `pnpm --filter core check` / `pnpm core:test`

Synced with `main` (merge commit). Awaiting human merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-667](https://linear.app/masumi/issue/SOK-667/store-imported-job-result-blobs-under-jobsjobid)

<div><a href="https://cursor.com/agents/bc-98313222-7f78-4205-9c48-2d2cdf74d9d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98313222-7f78-4205-9c48-2d2cdf74d9d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

