### PR TITLE
feat(web): match google chat image viewer chrome

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -783,7 +783,15 @@
       "title": "Bild",
       "viewImage": "Bild ansehen {fileName}",
       "download": "Bild herunterladen",
-      "close": "Schließen"
+      "close": "Schließen",
+      "print": "Drucken",
+      "zoomIn": "Vergrößern",
+      "zoomOut": "Verkleinern",
+      "zoomReset": "Zoom zurücksetzen",
+      "more": "Weitere Optionen",
+      "openInNewTab": "In neuem Tab öffnen",
+      "copyImage": "Bild kopieren",
+      "copyImageSuccess": "Bild kopiert"
     }
   },
   "Join": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -790,8 +790,7 @@
       "zoomReset": "Zoom zurücksetzen",
       "more": "Weitere Optionen",
       "openInNewTab": "In neuem Tab öffnen",
-      "copyImage": "Bild kopieren",
-      "copyImageSuccess": "Bild kopiert"
+      "copyImage": "Bild kopieren"
     }
   },
   "Join": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -794,7 +794,15 @@
       "title": "Image",
       "viewImage": "View image {fileName}",
       "download": "Download image",
-      "close": "Close"
+      "close": "Close",
+      "print": "Print",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "zoomReset": "Reset zoom",
+      "more": "More options",
+      "openInNewTab": "Open in new tab",
+      "copyImage": "Copy image",
+      "copyImageSuccess": "Image copied"
     }
   },
   "Join": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -801,8 +801,7 @@
       "zoomReset": "Reset zoom",
       "more": "More options",
       "openInNewTab": "Open in new tab",
-      "copyImage": "Copy image",
-      "copyImageSuccess": "Image copied"
+      "copyImage": "Copy image"
     }
   },
   "Join": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -783,7 +783,15 @@
       "title": "Imagen",
       "viewImage": "Ver imagen {fileName}",
       "download": "Descargar imagen",
-      "close": "Cerrar"
+      "close": "Cerrar",
+      "print": "Imprimir",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "zoomReset": "Restablecer zoom",
+      "more": "Más opciones",
+      "openInNewTab": "Abrir en una pestaña nueva",
+      "copyImage": "Copiar imagen",
+      "copyImageSuccess": "Imagen copiada"
     }
   },
   "Join": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -790,8 +790,7 @@
       "zoomReset": "Restablecer zoom",
       "more": "Más opciones",
       "openInNewTab": "Abrir en una pestaña nueva",
-      "copyImage": "Copiar imagen",
-      "copyImageSuccess": "Imagen copiada"
+      "copyImage": "Copiar imagen"
     }
   },
   "Join": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -790,8 +790,7 @@
       "zoomReset": "Réinitialiser le zoom",
       "more": "Plus d'options",
       "openInNewTab": "Ouvrir dans un nouvel onglet",
-      "copyImage": "Copier l'image",
-      "copyImageSuccess": "Image copiée"
+      "copyImage": "Copier l'image"
     }
   },
   "Join": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -783,7 +783,15 @@
       "title": "Image",
       "viewImage": "Voir l'image {fileName}",
       "download": "Télécharger l'image",
-      "close": "Fermer"
+      "close": "Fermer",
+      "print": "Imprimer",
+      "zoomIn": "Zoom avant",
+      "zoomOut": "Zoom arrière",
+      "zoomReset": "Réinitialiser le zoom",
+      "more": "Plus d'options",
+      "openInNewTab": "Ouvrir dans un nouvel onglet",
+      "copyImage": "Copier l'image",
+      "copyImageSuccess": "Image copiée"
     }
   },
   "Join": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -790,8 +790,7 @@
       "zoomReset": "Reimposta zoom",
       "more": "Altre opzioni",
       "openInNewTab": "Apri in una nuova scheda",
-      "copyImage": "Copia immagine",
-      "copyImageSuccess": "Immagine copiata"
+      "copyImage": "Copia immagine"
     }
   },
   "Join": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -783,7 +783,15 @@
       "title": "Immagine",
       "viewImage": "Visualizza immagine {fileName}",
       "download": "Scarica immagine",
-      "close": "Chiudi"
+      "close": "Chiudi",
+      "print": "Stampa",
+      "zoomIn": "Ingrandisci",
+      "zoomOut": "Riduci",
+      "zoomReset": "Reimposta zoom",
+      "more": "Altre opzioni",
+      "openInNewTab": "Apri in una nuova scheda",
+      "copyImage": "Copia immagine",
+      "copyImageSuccess": "Immagine copiata"
     }
   },
   "Join": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -790,8 +790,7 @@
       "zoomReset": "ズームをリセット",
       "more": "その他のオプション",
       "openInNewTab": "新しいタブで開く",
-      "copyImage": "画像をコピー",
-      "copyImageSuccess": "画像をコピーしました"
+      "copyImage": "画像をコピー"
     }
   },
   "Join": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -783,7 +783,15 @@
       "title": "画像",
       "viewImage": "画像を表示 {fileName}",
       "download": "画像をダウンロード",
-      "close": "閉じる"
+      "close": "閉じる",
+      "print": "印刷",
+      "zoomIn": "拡大",
+      "zoomOut": "縮小",
+      "zoomReset": "ズームをリセット",
+      "more": "その他のオプション",
+      "openInNewTab": "新しいタブで開く",
+      "copyImage": "画像をコピー",
+      "copyImageSuccess": "画像をコピーしました"
     }
   },
   "Join": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -790,8 +790,7 @@
       "zoomReset": "Redefinir zoom",
       "more": "Mais opções",
       "openInNewTab": "Abrir em nova aba",
-      "copyImage": "Copiar imagem",
-      "copyImageSuccess": "Imagem copiada"
+      "copyImage": "Copiar imagem"
     }
   },
   "Join": {

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -783,7 +783,15 @@
       "title": "Imagem",
       "viewImage": "Ver imagem {fileName}",
       "download": "Baixar imagem",
-      "close": "Fechar"
+      "close": "Fechar",
+      "print": "Imprimir",
+      "zoomIn": "Aumentar zoom",
+      "zoomOut": "Diminuir zoom",
+      "zoomReset": "Redefinir zoom",
+      "more": "Mais opções",
+      "openInNewTab": "Abrir em nova aba",
+      "copyImage": "Copiar imagem",
+      "copyImageSuccess": "Imagem copiada"
     }
   },
   "Join": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -783,7 +783,15 @@
       "title": "Imagem",
       "viewImage": "Ver imagem {fileName}",
       "download": "Descarregar imagem",
-      "close": "Fechar"
+      "close": "Fechar",
+      "print": "Imprimir",
+      "zoomIn": "Ampliar",
+      "zoomOut": "Reduzir",
+      "zoomReset": "Repor zoom",
+      "more": "Mais opções",
+      "openInNewTab": "Abrir num novo separador",
+      "copyImage": "Copiar imagem",
+      "copyImageSuccess": "Imagem copiada"
     }
   },
   "Join": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -790,8 +790,7 @@
       "zoomReset": "Repor zoom",
       "more": "Mais opções",
       "openInNewTab": "Abrir num novo separador",
-      "copyImage": "Copiar imagem",
-      "copyImageSuccess": "Imagem copiada"
+      "copyImage": "Copiar imagem"
     }
   },
   "Join": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -790,8 +790,7 @@
       "zoomReset": "重置缩放",
       "more": "更多选项",
       "openInNewTab": "在新标签页中打开",
-      "copyImage": "复制图片",
-      "copyImageSuccess": "图片已复制"
+      "copyImage": "复制图片"
     }
   },
   "Join": {

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -783,7 +783,15 @@
       "title": "图片",
       "viewImage": "查看图片 {fileName}",
       "download": "下载图片",
-      "close": "关闭"
+      "close": "关闭",
+      "print": "打印",
+      "zoomIn": "放大",
+      "zoomOut": "缩小",
+      "zoomReset": "重置缩放",
+      "more": "更多选项",
+      "openInNewTab": "在新标签页中打开",
+      "copyImage": "复制图片",
+      "copyImageSuccess": "图片已复制"
     }
   },
   "Join": {

--- a/apps/web/src/components/chat/chat-generated-image-bubble.tsx
+++ b/apps/web/src/components/chat/chat-generated-image-bubble.tsx
@@ -129,9 +129,6 @@ export function ChatGeneratedImageBubble({
           onOpenChange={setIsViewerOpen}
           src={src}
           alt={alt}
-          title={t("title")}
-          downloadLabel={downloadLabel}
-          closeLabel={t("close")}
           downloadFilename={getGeneratedImageDownloadFilename(src)}
         />
       ) : null}

--- a/apps/web/src/components/ui/__tests__/image-viewer.test.tsx
+++ b/apps/web/src/components/ui/__tests__/image-viewer.test.tsx
@@ -1,19 +1,35 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { ImageViewer } from "../image-viewer";
 
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const labels: Record<string, string> = {
+      title: "Image",
+      download: "Download image",
+      close: "Close",
+      print: "Print",
+      zoomIn: "Zoom in",
+      zoomOut: "Zoom out",
+      zoomReset: "Reset zoom",
+      more: "More options",
+      openInNewTab: "Open in new tab",
+      copyImage: "Copy image",
+    };
+    return labels[key] ?? key;
+  },
+}));
+
 describe("ImageViewer", () => {
-  it("renders toolbar actions outside the image stage", () => {
+  it("renders toolbar, zoom controls, and download link", () => {
     render(
       <ImageViewer
         open
         onOpenChange={vi.fn()}
         src="https://example.com/photo.png"
         alt="Photo"
-        title="View image"
-        downloadLabel="Download image"
-        closeLabel="Close"
         downloadFilename="photo.png"
       />,
     );
@@ -22,20 +38,75 @@ describe("ImageViewer", () => {
 
     const toolbar = screen.getByTestId("image-viewer-toolbar");
     const stage = screen.getByTestId("image-viewer-stage");
+    const zoom = screen.getByTestId("image-viewer-zoom");
 
+    expect(toolbar).toContainElement(
+      screen.getByRole("button", { name: "Close" }),
+    );
+    expect(toolbar).toContainElement(
+      screen.getByRole("button", { name: "Print" }),
+    );
     expect(toolbar).toContainElement(
       screen.getByRole("link", { name: "Download image" }),
     );
     expect(toolbar).toContainElement(
-      screen.getByRole("button", { name: "Close" }),
+      screen.getByRole("button", { name: "More options" }),
     );
+
+    expect(zoom).toContainElement(
+      screen.getByRole("button", { name: "Zoom out" }),
+    );
+    expect(zoom).toContainElement(
+      screen.getByRole("button", { name: "Reset zoom" }),
+    );
+    expect(zoom).toContainElement(
+      screen.getByRole("button", { name: "Zoom in" }),
+    );
+
     expect(stage).toContainElement(screen.getByRole("img", { name: "Photo" }));
-    expect(stage.querySelector("a")).toBeNull();
-    expect(stage.querySelector("button")).toBeNull();
 
     const download = screen.getByRole("link", { name: "Download image" });
     expect(download).toHaveAttribute("href", "https://example.com/photo.png");
     expect(download).toHaveAttribute("download", "photo.png");
+  });
+
+  it("closes when the stage is clicked but not when the image is clicked", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ImageViewer
+        open
+        onOpenChange={onOpenChange}
+        src="https://example.com/photo.png"
+        alt="Photo"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("img", { name: "Photo" }));
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("image-viewer-stage"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("increases image scale when zooming in", async () => {
+    const user = userEvent.setup();
+    render(
+      <ImageViewer
+        open
+        onOpenChange={vi.fn()}
+        src="https://example.com/photo.png"
+        alt="Photo"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Photo" });
+    expect(image).toHaveAttribute("data-zoom", "1");
+    expect(image).toHaveStyle({ transform: "scale(1)" });
+
+    await user.click(screen.getByRole("button", { name: "Zoom in" }));
+
+    expect(image).toHaveAttribute("data-zoom", "1.25");
+    expect(image).toHaveStyle({ transform: "scale(1.25)" });
   });
 
   it("does not render dialog content when closed", () => {
@@ -45,9 +116,6 @@ describe("ImageViewer", () => {
         onOpenChange={vi.fn()}
         src="https://example.com/photo.png"
         alt="Photo"
-        title="View image"
-        downloadLabel="Download image"
-        closeLabel="Close"
       />,
     );
 

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -118,9 +118,6 @@ export function FileChipMiniPreview({
           onOpenChange={setIsViewerOpen}
           src={url}
           alt={resolvedFileName}
-          title={t("title")}
-          downloadLabel={t("download")}
-          closeLabel={t("close")}
           downloadFilename={resolvedFileName}
         />
       ) : null}

--- a/apps/web/src/components/ui/image-viewer.tsx
+++ b/apps/web/src/components/ui/image-viewer.tsx
@@ -3,12 +3,12 @@
 import {
   Download,
   ImageIcon,
+  Minus,
   MoreVertical,
+  Plus,
   Printer,
   Search,
   XIcon,
-  ZoomIn,
-  ZoomOut,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -262,7 +262,7 @@ function ImageViewerChrome({
             disabled={zoom <= MIN_ZOOM}
             onClick={handleZoomOut}
           >
-            <ZoomOut className="size-4" aria-hidden="true" />
+            <Minus className="size-4" aria-hidden="true" />
           </Button>
           <Button
             type="button"
@@ -283,7 +283,7 @@ function ImageViewerChrome({
             disabled={zoom >= MAX_ZOOM}
             onClick={handleZoomIn}
           >
-            <ZoomIn className="size-4" aria-hidden="true" />
+            <Plus className="size-4" aria-hidden="true" />
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/ui/image-viewer.tsx
+++ b/apps/web/src/components/ui/image-viewer.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { Download, XIcon } from "lucide-react";
+import {
+  Download,
+  ImageIcon,
+  MoreVertical,
+  Printer,
+  Search,
+  XIcon,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -10,6 +21,12 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
 interface ImageViewerProps {
@@ -17,24 +34,268 @@ interface ImageViewerProps {
   onOpenChange: (open: boolean) => void;
   src: string;
   alt: string;
-  title: string;
-  downloadLabel: string;
-  closeLabel: string;
   downloadFilename?: string;
   className?: string;
 }
 
-const toolbarActionClassName =
-  "size-9 rounded-full border border-border/80 bg-background text-foreground shadow-sm hover:bg-muted";
+interface ViewerUiState {
+  zoom: number;
+}
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 4;
+const ZOOM_STEP = 0.25;
+
+const toolbarButtonClassName =
+  "size-9 shrink-0 rounded-full text-white hover:bg-white/10 hover:text-white";
+
+function clampZoom(zoom: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));
+}
+
+function printImage(src: string, alt: string): void {
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("aria-hidden", "true");
+  iframe.style.position = "fixed";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  iframe.style.opacity = "0";
+  iframe.style.pointerEvents = "none";
+  document.body.appendChild(iframe);
+
+  const doc = iframe.contentDocument;
+  if (!doc) {
+    iframe.remove();
+    return;
+  }
+
+  const escapedSrc = src.replaceAll('"', "&quot;");
+  const escapedAlt = alt.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+
+  doc.open();
+  doc.write(`<!doctype html><html><head><title>${escapedAlt}</title>
+<style>
+  html, body { margin: 0; padding: 0; background: #fff; }
+  img { max-width: 100%; max-height: 100vh; display: block; margin: 0 auto; }
+  @media print { body { -webkit-print-color-adjust: exact; } }
+</style></head><body><img src="${escapedSrc}" alt="${escapedAlt}" /></body></html>`);
+  doc.close();
+
+  function cleanup(): void {
+    iframe.remove();
+  }
+
+  iframe.onload = () => {
+    try {
+      iframe.contentWindow?.focus();
+      iframe.contentWindow?.print();
+    } finally {
+      window.setTimeout(cleanup, 500);
+    }
+  };
+}
+
+async function copyImageToClipboard(src: string): Promise<void> {
+  try {
+    const response = await fetch(src);
+    const blob = await response.blob();
+    const mimeType = blob.type || "image/png";
+    await navigator.clipboard.write([
+      new ClipboardItem({ [mimeType]: blob }),
+    ]);
+  } catch {
+    try {
+      await navigator.clipboard.writeText(src);
+    } catch {
+      // Best-effort; CORS or clipboard permission may deny both paths.
+    }
+  }
+}
+
+function ImageViewerChrome({
+  src,
+  alt,
+  downloadFilename,
+  onOpenChange,
+}: {
+  src: string;
+  alt: string;
+  downloadFilename?: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useTranslations("Components.ImageViewer");
+  const [{ zoom }, setUiState] = useState<ViewerUiState>({ zoom: 1 });
+  const displayName = downloadFilename ?? alt;
+
+  function setZoom(nextZoom: number): void {
+    setUiState({ zoom: clampZoom(nextZoom) });
+  }
+
+  function handleZoomIn(): void {
+    setZoom(zoom + ZOOM_STEP);
+  }
+
+  function handleZoomOut(): void {
+    setZoom(zoom - ZOOM_STEP);
+  }
+
+  function handleZoomReset(): void {
+    setZoom(1);
+  }
+
+  function handleStageClick(): void {
+    onOpenChange(false);
+  }
+
+  function handlePrint(): void {
+    printImage(src, alt);
+  }
+
+  function handleOpenInNewTab(): void {
+    window.open(src, "_blank", "noopener,noreferrer");
+  }
+
+  function handleCopyImage(): void {
+    void copyImageToClipboard(src);
+  }
+
+  return (
+    <>
+      <DialogTitle className="sr-only">{t("title")}</DialogTitle>
+      <DialogDescription className="sr-only">{alt}</DialogDescription>
+      <div
+        className="flex items-center justify-between gap-3 bg-black/80 px-3 py-2 text-white"
+        data-testid="image-viewer-toolbar"
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <div className="flex min-w-0 items-center gap-1">
+          <DialogClose asChild>
+            <Button
+              type="button"
+              aria-label={t("close")}
+              className={toolbarButtonClassName}
+              size="icon"
+              variant="ghost"
+            >
+              <XIcon className="size-4" aria-hidden="true" />
+            </Button>
+          </DialogClose>
+          <ImageIcon className="size-4 shrink-0 opacity-80" aria-hidden="true" />
+          <span className="truncate text-sm">{displayName}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            aria-label={t("print")}
+            className={toolbarButtonClassName}
+            size="icon"
+            variant="ghost"
+            onClick={handlePrint}
+          >
+            <Printer className="size-4" aria-hidden="true" />
+          </Button>
+          <Button
+            asChild
+            className={toolbarButtonClassName}
+            size="icon"
+            variant="ghost"
+          >
+            <a aria-label={t("download")} download={downloadFilename} href={src}>
+              <Download className="size-4" aria-hidden="true" />
+            </a>
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                aria-label={t("more")}
+                className={toolbarButtonClassName}
+                size="icon"
+                variant="ghost"
+              >
+                <MoreVertical className="size-4" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={handleOpenInNewTab}>
+                {t("openInNewTab")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleCopyImage}>
+                {t("copyImage")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+      <div
+        className="relative flex min-h-0 flex-1 items-center justify-center bg-black"
+        data-testid="image-viewer-stage"
+        onClick={handleStageClick}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={alt}
+          data-zoom={zoom}
+          className="max-h-full max-w-full object-contain transition-transform"
+          style={{ transform: `scale(${zoom})` }}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        />
+        <div
+          className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full bg-black/80 px-2 py-1 text-white"
+          data-testid="image-viewer-zoom"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          <Button
+            type="button"
+            aria-label={t("zoomOut")}
+            className={toolbarButtonClassName}
+            size="icon"
+            variant="ghost"
+            disabled={zoom <= MIN_ZOOM}
+            onClick={handleZoomOut}
+          >
+            <ZoomOut className="size-4" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            aria-label={t("zoomReset")}
+            className={toolbarButtonClassName}
+            size="icon"
+            variant="ghost"
+            onClick={handleZoomReset}
+          >
+            <Search className="size-4" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            aria-label={t("zoomIn")}
+            className={toolbarButtonClassName}
+            size="icon"
+            variant="ghost"
+            disabled={zoom >= MAX_ZOOM}
+            onClick={handleZoomIn}
+          >
+            <ZoomIn className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
 
 export function ImageViewer({
   open,
   onOpenChange,
   src,
   alt,
-  title,
-  downloadLabel,
-  closeLabel,
   downloadFilename,
   className,
 }: ImageViewerProps) {
@@ -43,54 +304,18 @@ export function ImageViewer({
       <DialogContent
         showCloseButton={false}
         className={cn(
-          "flex w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] flex-col gap-0 overflow-hidden border-border/60 p-0",
+          "fixed inset-0 top-0 left-0 z-50 flex h-screen w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 bg-black p-0 shadow-none sm:max-w-none",
           className,
         )}
         data-testid="image-viewer"
       >
-        <DialogTitle className="sr-only">{title}</DialogTitle>
-        <DialogDescription className="sr-only">{alt}</DialogDescription>
-        <div
-          className="bg-background flex items-center justify-between gap-3 border-b border-border/60 px-3 py-2"
-          data-testid="image-viewer-toolbar"
-        >
-          <Button
-            asChild
-            className={toolbarActionClassName}
-            size="icon"
-            variant="ghost"
-          >
-            <a
-              aria-label={downloadLabel}
-              download={downloadFilename}
-              href={src}
-            >
-              <Download className="size-4" aria-hidden="true" />
-            </a>
-          </Button>
-          <DialogClose asChild>
-            <Button
-              type="button"
-              aria-label={closeLabel}
-              className={toolbarActionClassName}
-              size="icon"
-              variant="ghost"
-            >
-              <XIcon className="size-4" aria-hidden="true" />
-            </Button>
-          </DialogClose>
-        </div>
-        <div
-          className="flex min-h-0 flex-1 items-center justify-center bg-muted/40 p-4 sm:p-6"
-          data-testid="image-viewer-stage"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={src}
-            alt={alt}
-            className="max-h-[min(80dvh,44rem)] max-w-full object-contain"
-          />
-        </div>
+        <ImageViewerChrome
+          key={src}
+          src={src}
+          alt={alt}
+          downloadFilename={downloadFilename}
+          onOpenChange={onOpenChange}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat image attachments now open a Google Chat–style lightbox instead of a centered card dialog.

**For users.** Full-screen dark viewer with top bar (close, filename, print, download, more), bottom zoom pill (− / reset / +), and click-outside-image to dismiss.

**For maintainers.** `ImageViewer` owns its i18n and zoom state. Call sites pass `src` / `alt` / optional `downloadFilename` only.

**Controls**
- Close, Escape, and stage click (not the image) dismiss
- Print via hidden iframe
- Download via `download` link
- More: open in new tab, copy image (URL fallback on CORS)
- Zoom in/out/reset

**Verify**
- Unit: `pnpm --filter web test` on `image-viewer`, `file-chip-mini-preview`, `chat-generated-image-bubble` (12 passed)
- Browser (alice@sokosumi.test): open chrome, zoom to 1.25, more menu, stage dismiss, close button

![Google Chat-style image viewer open](https://cursor.com/artifacts/c/art-4e4b8f25-b4b1-467d-a500-ccf9497c37a6)
![More menu with open and copy actions](https://cursor.com/artifacts/c/art-f838878b-0b3b-40f6-a8f8-277c0d844959)
![Dismissed after stage click](https://cursor.com/artifacts/c/art-aeb562bf-7d3f-41b4-8dca-48d0079594f7)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d342e370-9f24-4ba9-b88a-f51c1e4ee87e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d342e370-9f24-4ba9-b88a-f51c1e4ee87e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

