### PR TITLE
feat(web): chat participant hover cards with open DM

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Mensch",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Mensch",
+      "openDirectMessage": "Nachricht",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Mensch",
       "openDirectMessage": "Nachricht",
+      "viewCoworkerProfile": "Profil ansehen",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Mensch",
       "openDirectMessage": "Nachricht",
-      "viewCoworkerProfile": "Profil ansehen",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4705,7 +4705,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Human",
       "openDirectMessage": "Message",
-      "viewCoworkerProfile": "View profile",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4705,6 +4705,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Human",
       "openDirectMessage": "Message",
+      "viewCoworkerProfile": "View profile",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4703,6 +4703,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Human",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4704,6 +4704,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Human",
+      "openDirectMessage": "Message",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
       "openDirectMessage": "Mensaje",
+      "viewCoworkerProfile": "Ver perfil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
       "openDirectMessage": "Mensaje",
-      "viewCoworkerProfile": "Ver perfil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
+      "openDirectMessage": "Mensaje",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Humano",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humain",
       "openDirectMessage": "Message",
-      "viewCoworkerProfile": "Voir le profil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humain",
       "openDirectMessage": "Message",
+      "viewCoworkerProfile": "Voir le profil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Humain",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humain",
+      "openDirectMessage": "Message",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Umano",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Umano",
+      "openDirectMessage": "Messaggio",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Umano",
       "openDirectMessage": "Messaggio",
+      "viewCoworkerProfile": "Vedi profilo",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Umano",
       "openDirectMessage": "Messaggio",
-      "viewCoworkerProfile": "Vedi profilo",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "人間",
       "openDirectMessage": "メッセージ",
+      "viewCoworkerProfile": "プロフィールを見る",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "人間",
+      "openDirectMessage": "メッセージ",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "人間",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "人間",
       "openDirectMessage": "メッセージ",
-      "viewCoworkerProfile": "プロフィールを見る",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
+      "openDirectMessage": "Mensagem",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
       "openDirectMessage": "Mensagem",
+      "viewCoworkerProfile": "Ver perfil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Humano",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
       "openDirectMessage": "Mensagem",
-      "viewCoworkerProfile": "Ver perfil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
+      "openDirectMessage": "Mensagem",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
       "openDirectMessage": "Mensagem",
+      "viewCoworkerProfile": "Ver perfil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "Humano",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "Humano",
       "openDirectMessage": "Mensagem",
-      "viewCoworkerProfile": "Ver perfil",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4585,6 +4585,7 @@
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
       "humanBadge": "人类",
+      "openDirectMessage": "发消息",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4586,6 +4586,7 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "人类",
       "openDirectMessage": "发消息",
+      "viewCoworkerProfile": "查看资料",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4584,6 +4584,7 @@
       "send": "Send message",
       "noTopic": "No topic set.",
       "coworkerBadge": "AI coworker",
+      "humanBadge": "人类",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4586,7 +4586,6 @@
       "coworkerBadge": "AI coworker",
       "humanBadge": "人类",
       "openDirectMessage": "发消息",
-      "viewCoworkerProfile": "查看资料",
       "humanCount": "{count, plural, one {# human} other {# humans}}",
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -66,7 +66,7 @@ describe("ChatParticipantHoverCard", () => {
     expect(card).toHaveTextContent("Ada Lovelace");
     expect(card).toHaveTextContent("Human");
     expect(card).toHaveTextContent("ada@example.com");
-    expect(card).toHaveTextContent("Online");
+    expect(card).not.toHaveTextContent("Online");
     expect(card).not.toHaveTextContent("AI coworker");
   });
 
@@ -84,7 +84,7 @@ describe("ChatParticipantHoverCard", () => {
     expect(card).toHaveTextContent("Hannah");
     expect(card).toHaveTextContent("AI coworker");
     expect(card).toHaveTextContent("Research assistant");
-    expect(card).toHaveTextContent("Away");
+    expect(card).not.toHaveTextContent("Away");
     expect(card).not.toHaveTextContent("@hannah");
   });
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -166,6 +166,32 @@ describe("ChatParticipantHoverCard", () => {
     expect(onOpenDirect).toHaveBeenCalledWith(coworkerProfile);
   });
 
+  it("disables Message while another direct open is busy", () => {
+    render(
+      <ChatParticipantHoverCard
+        profile={coworkerProfile}
+        onOpenDirect={vi.fn()}
+        isDirectActionBusy
+      >
+        <span>Hannah</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(screen.getByRole("button", { name: "Message" })).toBeDisabled();
+  });
+
+  it("names the avatar trigger with the participant name", () => {
+    render(
+      <ChatParticipantHoverCard profile={humanProfile}>
+        <span aria-hidden="true">avatar</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Ada Lovelace" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders children only when profile is missing", () => {
     render(
       <ChatParticipantHoverCard profile={null}>

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -12,12 +12,29 @@ vi.mock("next-intl", () => ({
       coworkerBadge: "AI coworker",
       humanBadge: "Human",
       openDirectMessage: "Message",
+      viewCoworkerProfile: "View profile",
       "Presence.online": "Online",
       "Presence.afk": "Away",
       "Presence.offline": "Offline",
     };
     return labels[key] ?? key;
   },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock("@/components/ui/hover-card", () => ({
@@ -164,6 +181,38 @@ describe("ChatParticipantHoverCard", () => {
     await user.click(screen.getByRole("button", { name: "Message" }));
 
     expect(onOpenDirect).toHaveBeenCalledWith(coworkerProfile);
+  });
+
+  it("links coworkers to the agents gallery detail", () => {
+    render(
+      <ChatParticipantHoverCard profile={coworkerProfile}>
+        <span>Hannah</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    const profileLinks = screen.getAllByRole("link", {
+      name: /Hannah|View profile/,
+    });
+    expect(profileLinks.length).toBeGreaterThanOrEqual(1);
+    for (const link of profileLinks) {
+      expect(link).toHaveAttribute("href", "/agents?query=hannah");
+    }
+    expect(
+      screen.getByRole("link", { name: "View profile" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not link humans to a coworker profile", () => {
+    render(
+      <ChatParticipantHoverCard profile={humanProfile}>
+        <span>Ada Lovelace</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View profile" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders children only when profile is missing", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatParticipantHoverCard } from "../chat-participant-hover-card";
+import type { ChatParticipantHoverProfile } from "../room-helpers";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const labels: Record<string, string> = {
+      coworkerBadge: "AI coworker",
+      humanBadge: "Human",
+      "Presence.online": "Online",
+      "Presence.afk": "Away",
+      "Presence.offline": "Offline",
+    };
+    return labels[key] ?? key;
+  },
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    "data-testid"?: string;
+  }) => <div {...props}>{children}</div>,
+}));
+
+const humanProfile: ChatParticipantHoverProfile = {
+  kind: "human",
+  id: "user-1",
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  image: null,
+  presence: "online",
+};
+
+const coworkerProfile: ChatParticipantHoverProfile = {
+  kind: "coworker",
+  id: "coworker-1",
+  name: "Hannah",
+  slug: "hannah",
+  caption: "Research assistant",
+  image: null,
+  presence: "afk",
+};
+
+describe("ChatParticipantHoverCard", () => {
+  it("shows human email and human badge", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatParticipantHoverCard profile={humanProfile}>
+        <span>Ada Lovelace</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Ada Lovelace" }));
+
+    const card = screen.getByTestId("chat-participant-hover-card");
+    expect(card).toHaveTextContent("Ada Lovelace");
+    expect(card).toHaveTextContent("Human");
+    expect(card).toHaveTextContent("ada@example.com");
+    expect(card).toHaveTextContent("Online");
+    expect(card).not.toHaveTextContent("AI coworker");
+  });
+
+  it("shows coworker caption, slug fallback, and AI badge", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatParticipantHoverCard profile={coworkerProfile}>
+        <span>Hannah</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Hannah" }));
+
+    const card = screen.getByTestId("chat-participant-hover-card");
+    expect(card).toHaveTextContent("Hannah");
+    expect(card).toHaveTextContent("AI coworker");
+    expect(card).toHaveTextContent("Research assistant");
+    expect(card).toHaveTextContent("Away");
+    expect(card).not.toHaveTextContent("@hannah");
+  });
+
+  it("falls back to @slug when coworker caption is empty", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatParticipantHoverCard profile={{ ...coworkerProfile, caption: null }}>
+        <span>Hannah</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Hannah" }));
+
+    expect(screen.getByTestId("chat-participant-hover-card")).toHaveTextContent(
+      "@hannah",
+    );
+  });
+
+  it("renders children only when profile is missing", () => {
+    render(
+      <ChatParticipantHoverCard profile={null}>
+        <span>No card</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(screen.getByText("No card")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("chat-participant-hover-card"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -12,29 +12,12 @@ vi.mock("next-intl", () => ({
       coworkerBadge: "AI coworker",
       humanBadge: "Human",
       openDirectMessage: "Message",
-      viewCoworkerProfile: "View profile",
       "Presence.online": "Online",
       "Presence.afk": "Away",
       "Presence.offline": "Offline",
     };
     return labels[key] ?? key;
   },
-}));
-
-vi.mock("next/link", () => ({
-  default: ({
-    href,
-    children,
-    ...props
-  }: {
-    href: string;
-    children: ReactNode;
-    className?: string;
-  }) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
 }));
 
 vi.mock("@/components/ui/hover-card", () => ({
@@ -181,38 +164,6 @@ describe("ChatParticipantHoverCard", () => {
     await user.click(screen.getByRole("button", { name: "Message" }));
 
     expect(onOpenDirect).toHaveBeenCalledWith(coworkerProfile);
-  });
-
-  it("links coworkers to the agents gallery detail", () => {
-    render(
-      <ChatParticipantHoverCard profile={coworkerProfile}>
-        <span>Hannah</span>
-      </ChatParticipantHoverCard>,
-    );
-
-    const profileLinks = screen.getAllByRole("link", {
-      name: /Hannah|View profile/,
-    });
-    expect(profileLinks.length).toBeGreaterThanOrEqual(1);
-    for (const link of profileLinks) {
-      expect(link).toHaveAttribute("href", "/agents?query=hannah");
-    }
-    expect(
-      screen.getByRole("link", { name: "View profile" }),
-    ).toBeInTheDocument();
-  });
-
-  it("does not link humans to a coworker profile", () => {
-    render(
-      <ChatParticipantHoverCard profile={humanProfile}>
-        <span>Ada Lovelace</span>
-      </ChatParticipantHoverCard>,
-    );
-
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "View profile" }),
-    ).not.toBeInTheDocument();
   });
 
   it("renders children only when profile is missing", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -11,6 +11,7 @@ vi.mock("next-intl", () => ({
     const labels: Record<string, string> = {
       coworkerBadge: "AI coworker",
       humanBadge: "Human",
+      openDirectMessage: "Message",
       "Presence.online": "Online",
       "Presence.afk": "Away",
       "Presence.offline": "Offline",
@@ -100,6 +101,69 @@ describe("ChatParticipantHoverCard", () => {
     expect(screen.getByTestId("chat-participant-hover-card")).toHaveTextContent(
       "@hannah",
     );
+  });
+
+  it("shows Message for another human when human directs are available", () => {
+    render(
+      <ChatParticipantHoverCard
+        profile={humanProfile}
+        currentUserId="user-2"
+        canOpenHumanDirect
+        onOpenDirect={vi.fn()}
+      >
+        <span>Ada Lovelace</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(screen.getByRole("button", { name: "Message" })).toBeInTheDocument();
+  });
+
+  it("hides Message for the current human user", () => {
+    render(
+      <ChatParticipantHoverCard
+        profile={humanProfile}
+        currentUserId={humanProfile.id}
+        canOpenHumanDirect
+        onOpenDirect={vi.fn()}
+      >
+        <span>Ada Lovelace</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Message" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Message for a coworker without human direct access", () => {
+    render(
+      <ChatParticipantHoverCard
+        profile={coworkerProfile}
+        currentUserId="user-1"
+        onOpenDirect={vi.fn()}
+      >
+        <span>Hannah</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(screen.getByRole("button", { name: "Message" })).toBeInTheDocument();
+  });
+
+  it("calls onOpenDirect with the participant", async () => {
+    const user = userEvent.setup();
+    const onOpenDirect = vi.fn();
+    render(
+      <ChatParticipantHoverCard
+        profile={coworkerProfile}
+        onOpenDirect={onOpenDirect}
+      >
+        <span>Hannah</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Message" }));
+
+    expect(onOpenDirect).toHaveBeenCalledWith(coworkerProfile);
   });
 
   it("renders children only when profile is missing", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/open-direct-with-participant.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/open-direct-with-participant.test.tsx
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatRoom } from "@/lib/clients/generated/core";
+
+import {
+  canShowOpenDirect,
+  openDirectWithParticipant,
+} from "../open-direct-with-participant";
+import type { ChatParticipantHoverProfile } from "../room-helpers";
+
+const {
+  createDirectRoomActionMock,
+  ensureCoworkerDirectRoomActionMock,
+  notifyOrganizationChatRoomsChangedMock,
+} = vi.hoisted(() => ({
+  createDirectRoomActionMock: vi.fn(),
+  ensureCoworkerDirectRoomActionMock: vi.fn(),
+  notifyOrganizationChatRoomsChangedMock: vi.fn(),
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  createDirectRoomAction: createDirectRoomActionMock,
+  ensureCoworkerDirectRoomAction: ensureCoworkerDirectRoomActionMock,
+}));
+
+vi.mock("@/components/chat/organization-chat-events", () => ({
+  notifyOrganizationChatRoomsChanged: notifyOrganizationChatRoomsChangedMock,
+}));
+
+const humanProfile: ChatParticipantHoverProfile = {
+  kind: "human",
+  id: "user-1",
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  image: null,
+  presence: "online",
+};
+
+const coworkerProfile: ChatParticipantHoverProfile = {
+  kind: "coworker",
+  id: "coworker-1",
+  name: "Hannah",
+  slug: "hannah",
+  caption: "Research assistant",
+  image: null,
+  presence: "afk",
+};
+
+function room(id: string): ChatRoom {
+  return { id } as ChatRoom;
+}
+
+describe("canShowOpenDirect", () => {
+  const onOpenDirect = vi.fn();
+
+  it("hides for the current human user", () => {
+    expect(
+      canShowOpenDirect({
+        profile: humanProfile,
+        currentUserId: humanProfile.id,
+        canOpenHumanDirect: true,
+        onOpenDirect,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides a human when human directs are unavailable", () => {
+    expect(
+      canShowOpenDirect({
+        profile: humanProfile,
+        currentUserId: "user-2",
+        canOpenHumanDirect: false,
+        onOpenDirect,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows a coworker when human directs are unavailable", () => {
+    expect(
+      canShowOpenDirect({
+        profile: coworkerProfile,
+        currentUserId: "user-1",
+        canOpenHumanDirect: false,
+        onOpenDirect,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides without an open callback", () => {
+    expect(
+      canShowOpenDirect({
+        profile: coworkerProfile,
+        currentUserId: "user-1",
+        canOpenHumanDirect: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("openDirectWithParticipant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a human direct, notifies, and navigates", async () => {
+    const directRoom = room("room-human");
+    const push = vi.fn();
+    const onError = vi.fn();
+    createDirectRoomActionMock.mockResolvedValue({
+      ok: true,
+      data: directRoom,
+    });
+
+    const result = await openDirectWithParticipant({
+      profile: humanProfile,
+      selectedRoomId: "room-other",
+      router: { push },
+      onError,
+    });
+
+    expect(createDirectRoomActionMock).toHaveBeenCalledWith({
+      memberUserId: humanProfile.id,
+    });
+    expect(ensureCoworkerDirectRoomActionMock).not.toHaveBeenCalled();
+    expect(notifyOrganizationChatRoomsChangedMock).toHaveBeenCalledWith(
+      directRoom,
+    );
+    expect(push).toHaveBeenCalledWith("/chat/rooms/room-human");
+    expect(onError).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, roomId: "room-human" });
+  });
+
+  it("ensures a coworker direct, notifies, and navigates", async () => {
+    const directRoom = room("room-coworker");
+    const push = vi.fn();
+    ensureCoworkerDirectRoomActionMock.mockResolvedValue({
+      ok: true,
+      data: directRoom,
+    });
+
+    await openDirectWithParticipant({
+      profile: coworkerProfile,
+      selectedRoomId: null,
+      router: { push },
+      onError: vi.fn(),
+    });
+
+    expect(ensureCoworkerDirectRoomActionMock).toHaveBeenCalledWith(
+      coworkerProfile.id,
+    );
+    expect(createDirectRoomActionMock).not.toHaveBeenCalled();
+    expect(notifyOrganizationChatRoomsChangedMock).toHaveBeenCalledWith(
+      directRoom,
+    );
+    expect(push).toHaveBeenCalledWith("/chat/rooms/room-coworker");
+  });
+
+  it("skips navigation when the direct is already selected", async () => {
+    const directRoom = room("room-selected");
+    const push = vi.fn();
+    createDirectRoomActionMock.mockResolvedValue({
+      ok: true,
+      data: directRoom,
+    });
+
+    await openDirectWithParticipant({
+      profile: humanProfile,
+      selectedRoomId: directRoom.id,
+      router: { push },
+      onError: vi.fn(),
+    });
+
+    expect(notifyOrganizationChatRoomsChangedMock).toHaveBeenCalledWith(
+      directRoom,
+    );
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("reports action errors without notifying or navigating", async () => {
+    const push = vi.fn();
+    const onError = vi.fn();
+    createDirectRoomActionMock.mockResolvedValue({
+      ok: false,
+      message: "Could not create direct.",
+    });
+
+    const result = await openDirectWithParticipant({
+      profile: humanProfile,
+      selectedRoomId: null,
+      router: { push },
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith("Could not create direct.");
+    expect(notifyOrganizationChatRoomsChangedMock).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("reports a missing room without notifying or navigating", async () => {
+    const push = vi.fn();
+    const onError = vi.fn();
+    ensureCoworkerDirectRoomActionMock.mockResolvedValue({
+      ok: true,
+      data: null,
+    });
+
+    const result = await openDirectWithParticipant({
+      profile: coworkerProfile,
+      selectedRoomId: null,
+      router: { push },
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith("Could not start direct message.");
+    expect(notifyOrganizationChatRoomsChangedMock).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false });
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-message-grouping.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-message-grouping.test.ts
@@ -5,6 +5,7 @@ import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 import {
   isMessageContinuation,
   MESSAGE_GROUP_GAP_MS,
+  messageSender,
   messageSenderKey,
 } from "../room-helpers";
 
@@ -96,6 +97,35 @@ describe("messageSenderKey", () => {
     expect(
       messageSenderKey(unknownMessage("m3", "2026-07-01T12:00:00.000Z")),
     ).toBeNull();
+  });
+});
+
+describe("messageSender", () => {
+  it("returns human profile with email and presence", () => {
+    expect(
+      messageSender(userMessage("m1", "2026-07-01T12:00:00.000Z")),
+    ).toEqual({
+      kind: "human",
+      id: "user-1",
+      name: "Ada",
+      email: "ada@example.com",
+      image: null,
+      presence: "offline",
+    });
+  });
+
+  it("returns coworker profile with slug, caption, and presence", () => {
+    expect(
+      messageSender(coworkerMessage("m2", "2026-07-01T12:00:00.000Z")),
+    ).toEqual({
+      kind: "coworker",
+      id: "cow-1",
+      name: "Jamal",
+      slug: "jamal",
+      caption: null,
+      image: null,
+      presence: "online",
+    });
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { ExternalLink, Loader2, MessageCircle } from "lucide-react";
-import Link from "next/link";
+import { Loader2, MessageCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { CSSProperties, ReactNode } from "react";
 
@@ -22,10 +21,6 @@ import {
   type ChatParticipantHoverProfile,
   presenceLabel,
 } from "./room-helpers";
-
-export function coworkerDetailHref(slug: string): string {
-  return `/agents?query=${encodeURIComponent(slug)}`;
-}
 
 interface ChatParticipantHoverCardProps {
   profile: ChatParticipantHoverProfile | null | undefined;
@@ -71,10 +66,6 @@ export function ChatParticipantHoverCard({
     canOpenHumanDirect,
     onOpenDirect,
   });
-  const coworkerProfileHref =
-    profile.kind === "coworker" && profile.slug
-      ? coworkerDetailHref(profile.slug)
-      : null;
 
   return (
     <HoverCard openDelay={200} closeDelay={100}>
@@ -122,16 +113,7 @@ export function ChatParticipantHoverCard({
           </div>
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1">
-              {coworkerProfileHref ? (
-                <Link
-                  href={coworkerProfileHref}
-                  className="truncate text-sm font-semibold hover:underline"
-                >
-                  {profile.name}
-                </Link>
-              ) : (
-                <p className="truncate text-sm font-semibold">{profile.name}</p>
-              )}
+              <p className="truncate text-sm font-semibold">{profile.name}</p>
               {profile.kind === "coworker" ? (
                 <AiCoworkerIcon className="size-3.5 shrink-0" />
               ) : null}
@@ -154,43 +136,25 @@ export function ChatParticipantHoverCard({
             </p>
           </div>
         </div>
-        {showOpenDirect || coworkerProfileHref ? (
-          <div className="mt-3 flex flex-col gap-2">
-            {showOpenDirect ? (
-              <Button
-                type="button"
-                size="sm"
-                className="w-full"
-                disabled={isOpeningDirect}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  onOpenDirect?.(profile);
-                }}
-              >
-                {isOpeningDirect ? (
-                  <Loader2 className="size-4 animate-spin" aria-hidden />
-                ) : (
-                  <MessageCircle className="size-4" aria-hidden />
-                )}
-                {t("openDirectMessage")}
-              </Button>
-            ) : null}
-            {coworkerProfileHref ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="w-full"
-                asChild
-              >
-                <Link href={coworkerProfileHref}>
-                  <ExternalLink className="size-4" aria-hidden />
-                  {t("viewCoworkerProfile")}
-                </Link>
-              </Button>
-            ) : null}
-          </div>
+        {showOpenDirect ? (
+          <Button
+            type="button"
+            size="sm"
+            className="mt-3 w-full"
+            disabled={isOpeningDirect}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onOpenDirect?.(profile);
+            }}
+          >
+            {isOpeningDirect ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : (
+              <MessageCircle className="size-4" aria-hidden />
+            )}
+            {t("openDirectMessage")}
+          </Button>
         ) : null}
       </HoverCardContent>
     </HoverCard>

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Loader2, MessageCircle } from "lucide-react";
+import { ExternalLink, Loader2, MessageCircle } from "lucide-react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { CSSProperties, ReactNode } from "react";
 
@@ -21,6 +22,10 @@ import {
   type ChatParticipantHoverProfile,
   presenceLabel,
 } from "./room-helpers";
+
+export function coworkerDetailHref(slug: string): string {
+  return `/agents?query=${encodeURIComponent(slug)}`;
+}
 
 interface ChatParticipantHoverCardProps {
   profile: ChatParticipantHoverProfile | null | undefined;
@@ -66,6 +71,10 @@ export function ChatParticipantHoverCard({
     canOpenHumanDirect,
     onOpenDirect,
   });
+  const coworkerProfileHref =
+    profile.kind === "coworker" && profile.slug
+      ? coworkerDetailHref(profile.slug)
+      : null;
 
   return (
     <HoverCard openDelay={200} closeDelay={100}>
@@ -113,7 +122,16 @@ export function ChatParticipantHoverCard({
           </div>
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1">
-              <p className="truncate text-sm font-semibold">{profile.name}</p>
+              {coworkerProfileHref ? (
+                <Link
+                  href={coworkerProfileHref}
+                  className="truncate text-sm font-semibold hover:underline"
+                >
+                  {profile.name}
+                </Link>
+              ) : (
+                <p className="truncate text-sm font-semibold">{profile.name}</p>
+              )}
               {profile.kind === "coworker" ? (
                 <AiCoworkerIcon className="size-3.5 shrink-0" />
               ) : null}
@@ -136,25 +154,43 @@ export function ChatParticipantHoverCard({
             </p>
           </div>
         </div>
-        {showOpenDirect ? (
-          <Button
-            type="button"
-            size="sm"
-            className="mt-3 w-full"
-            disabled={isOpeningDirect}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onOpenDirect?.(profile);
-            }}
-          >
-            {isOpeningDirect ? (
-              <Loader2 className="size-4 animate-spin" aria-hidden />
-            ) : (
-              <MessageCircle className="size-4" aria-hidden />
-            )}
-            {t("openDirectMessage")}
-          </Button>
+        {showOpenDirect || coworkerProfileHref ? (
+          <div className="mt-3 flex flex-col gap-2">
+            {showOpenDirect ? (
+              <Button
+                type="button"
+                size="sm"
+                className="w-full"
+                disabled={isOpeningDirect}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onOpenDirect?.(profile);
+                }}
+              >
+                {isOpeningDirect ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                ) : (
+                  <MessageCircle className="size-4" aria-hidden />
+                )}
+                {t("openDirectMessage")}
+              </Button>
+            ) : null}
+            {coworkerProfileHref ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-full"
+                asChild
+              >
+                <Link href={coworkerProfileHref}>
+                  <ExternalLink className="size-4" aria-hidden />
+                  {t("viewCoworkerProfile")}
+                </Link>
+              </Button>
+            ) : null}
+          </div>
         ) : null}
       </HoverCardContent>
     </HoverCard>

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { Loader2, MessageCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { CSSProperties, ReactNode } from "react";
 
@@ -150,7 +150,9 @@ export function ChatParticipantHoverCard({
           >
             {isOpeningDirect ? (
               <Loader2 className="size-4 animate-spin" aria-hidden />
-            ) : null}
+            ) : (
+              <MessageCircle className="size-4" aria-hidden />
+            )}
             {t("openDirectMessage")}
           </Button>
         ) : null}

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { CSSProperties, ReactNode } from "react";
+
+import { PresenceDot } from "@/components/chat/presence-dot";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
+import { getInitials } from "@/lib/utils/text";
+
+import { AiCoworkerIcon } from "./room-draft-shared";
+import {
+  type ChatParticipantHoverProfile,
+  presenceLabel,
+} from "./room-helpers";
+
+interface ChatParticipantHoverCardProps {
+  profile: ChatParticipantHoverProfile | null | undefined;
+  children: ReactNode;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function ChatParticipantHoverCard({
+  profile,
+  children,
+  side = "top",
+  align = "start",
+  className,
+  style,
+}: ChatParticipantHoverCardProps) {
+  const t = useTranslations("App.Channels");
+
+  if (!profile) {
+    return children;
+  }
+
+  const statusLabel = presenceLabel(t, profile.presence);
+  const kindLabel =
+    profile.kind === "coworker" ? t("coworkerBadge") : t("humanBadge");
+  const detail =
+    profile.kind === "human"
+      ? profile.email
+      : profile.caption?.trim() || (profile.slug ? `@${profile.slug}` : null);
+
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          style={style}
+          className={cn(
+            "relative inline-flex max-w-full cursor-pointer rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+        >
+          {children}
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side={side}
+        align={align}
+        sideOffset={8}
+        className="w-72 p-3"
+        data-testid="chat-participant-hover-card"
+      >
+        <div className="flex gap-3">
+          <div className="relative shrink-0">
+            <Avatar className="size-12">
+              <AvatarImage src={profile.image ?? undefined} alt="" />
+              <AvatarFallback
+                className={cn(
+                  "text-sm",
+                  profile.kind === "coworker"
+                    ? "bg-primary/10 text-primary"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                {getInitials(profile.name)}
+              </AvatarFallback>
+            </Avatar>
+            <span aria-hidden="true">
+              <PresenceDot
+                presence={profile.presence}
+                label={statusLabel}
+                className="absolute -right-0.5 -bottom-0.5 size-3"
+              />
+            </span>
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1">
+              <p className="truncate text-sm font-semibold">{profile.name}</p>
+              {profile.kind === "coworker" ? (
+                <AiCoworkerIcon className="size-3.5 shrink-0" />
+              ) : null}
+            </div>
+            <p className="text-muted-foreground text-xs font-medium">
+              {kindLabel}
+            </p>
+            {detail ? (
+              <p className="text-muted-foreground truncate text-xs">{detail}</p>
+            ) : null}
+            <p className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <span aria-hidden="true">
+                <PresenceDot
+                  presence={profile.presence}
+                  label={statusLabel}
+                  className="size-2 border-0"
+                />
+              </span>
+              {statusLabel}
+            </p>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -124,7 +124,6 @@ export function ChatParticipantHoverCard({
             {detail ? (
               <p className="text-muted-foreground truncate text-xs">{detail}</p>
             ) : null}
-            <p className="text-muted-foreground text-xs">{statusLabel}</p>
           </div>
         </div>
         {showOpenDirect ? (

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -124,16 +124,7 @@ export function ChatParticipantHoverCard({
             {detail ? (
               <p className="text-muted-foreground truncate text-xs">{detail}</p>
             ) : null}
-            <p className="text-muted-foreground flex items-center gap-1.5 text-xs">
-              <span aria-hidden="true">
-                <PresenceDot
-                  presence={profile.presence}
-                  label={statusLabel}
-                  className="size-2 border-0"
-                />
-              </span>
-              {statusLabel}
-            </p>
+            <p className="text-muted-foreground text-xs">{statusLabel}</p>
           </div>
         </div>
         {showOpenDirect ? (

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -32,7 +32,10 @@ interface ChatParticipantHoverCardProps {
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirect?: (profile: ChatParticipantHoverProfile) => void;
+  /** True while this participant's DM is being created/opened. */
   isOpeningDirect?: boolean;
+  /** True while any hover-card DM open is in flight (disables Message). */
+  isDirectActionBusy?: boolean;
 }
 
 export function ChatParticipantHoverCard({
@@ -46,6 +49,7 @@ export function ChatParticipantHoverCard({
   canOpenHumanDirect = false,
   onOpenDirect,
   isOpeningDirect = false,
+  isDirectActionBusy = false,
 }: ChatParticipantHoverCardProps) {
   const t = useTranslations("App.Channels");
 
@@ -73,6 +77,7 @@ export function ChatParticipantHoverCard({
         <button
           type="button"
           style={style}
+          aria-label={profile.name}
           className={cn(
             "relative inline-flex max-w-full cursor-pointer rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
             className,
@@ -131,7 +136,7 @@ export function ChatParticipantHoverCard({
             type="button"
             size="sm"
             className="mt-3 w-full"
-            disabled={isOpeningDirect}
+            disabled={isOpeningDirect || isDirectActionBusy}
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -89,7 +89,7 @@ export function ChatParticipantHoverCard({
         data-testid="chat-participant-hover-card"
       >
         <div className="flex gap-3">
-          <div className="relative shrink-0">
+          <div className="relative size-12 shrink-0 self-start">
             <Avatar className="size-12">
               <AvatarImage src={profile.image ?? undefined} alt="" />
               <AvatarFallback

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { CSSProperties, ReactNode } from "react";
 
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import {
   HoverCard,
   HoverCardContent,
@@ -13,6 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
 
+import { canShowOpenDirect } from "./open-direct-with-participant";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import {
   type ChatParticipantHoverProfile,
@@ -26,6 +29,10 @@ interface ChatParticipantHoverCardProps {
   align?: "start" | "center" | "end";
   className?: string;
   style?: CSSProperties;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirect?: (profile: ChatParticipantHoverProfile) => void;
+  isOpeningDirect?: boolean;
 }
 
 export function ChatParticipantHoverCard({
@@ -35,6 +42,10 @@ export function ChatParticipantHoverCard({
   align = "start",
   className,
   style,
+  currentUserId,
+  canOpenHumanDirect = false,
+  onOpenDirect,
+  isOpeningDirect = false,
 }: ChatParticipantHoverCardProps) {
   const t = useTranslations("App.Channels");
 
@@ -49,6 +60,12 @@ export function ChatParticipantHoverCard({
     profile.kind === "human"
       ? profile.email
       : profile.caption?.trim() || (profile.slug ? `@${profile.slug}` : null);
+  const showOpenDirect = canShowOpenDirect({
+    profile,
+    currentUserId,
+    canOpenHumanDirect,
+    onOpenDirect,
+  });
 
   return (
     <HoverCard openDelay={200} closeDelay={100}>
@@ -119,6 +136,24 @@ export function ChatParticipantHoverCard({
             </p>
           </div>
         </div>
+        {showOpenDirect ? (
+          <Button
+            type="button"
+            size="sm"
+            className="mt-3 w-full"
+            disabled={isOpeningDirect}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onOpenDirect?.(profile);
+            }}
+          >
+            {isOpeningDirect ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : null}
+            {t("openDirectMessage")}
+          </Button>
+        ) : null}
       </HoverCardContent>
     </HoverCard>
   );

--- a/apps/web/src/app/(app)/chat/components/open-direct-with-participant.ts
+++ b/apps/web/src/app/(app)/chat/components/open-direct-with-participant.ts
@@ -1,0 +1,56 @@
+import {
+  createDirectRoomAction,
+  ensureCoworkerDirectRoomAction,
+} from "@/app/chat/actions";
+import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
+
+import type { ChatParticipantHoverProfile } from "./room-helpers";
+
+export function participantDirectKey(
+  profile: ChatParticipantHoverProfile,
+): `${"human" | "coworker"}:${string}` {
+  return `${profile.kind}:${profile.id}`;
+}
+
+export function canShowOpenDirect(options: {
+  profile: ChatParticipantHoverProfile;
+  currentUserId: string | undefined;
+  canOpenHumanDirect: boolean;
+  onOpenDirect?: (profile: ChatParticipantHoverProfile) => void;
+}): boolean {
+  const { profile, currentUserId, canOpenHumanDirect, onOpenDirect } = options;
+  if (!onOpenDirect) return false;
+  if (profile.kind === "human") {
+    if (!canOpenHumanDirect) return false;
+    if (currentUserId && profile.id === currentUserId) return false;
+  }
+  return true;
+}
+
+export async function openDirectWithParticipant(options: {
+  profile: ChatParticipantHoverProfile;
+  selectedRoomId: string | null | undefined;
+  router: { push: (href: string) => void };
+  onError: (message: string) => void;
+}): Promise<{ ok: true; roomId: string } | { ok: false }> {
+  const { profile, selectedRoomId, router, onError } = options;
+  const result =
+    profile.kind === "coworker"
+      ? await ensureCoworkerDirectRoomAction(profile.id)
+      : await createDirectRoomAction({ memberUserId: profile.id });
+
+  if (!result.ok) {
+    onError(result.message);
+    return { ok: false };
+  }
+  if (!result.data) {
+    onError("Could not start direct message.");
+    return { ok: false };
+  }
+
+  notifyOrganizationChatRoomsChanged(result.data);
+  if (result.data.id !== selectedRoomId) {
+    router.push(`/chat/rooms/${result.data.id}`);
+  }
+  return { ok: true, roomId: result.data.id };
+}

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -24,13 +24,35 @@ export interface DirectParticipantPreview {
   kind: "human" | "coworker";
 }
 
-export interface RoomParticipantPreview {
-  id: string;
-  name: string;
-  image: string | null;
-  presence: ChatRoomPresence;
-  kind: "human" | "coworker";
-}
+/** Shared hover / roster shape for humans vs AI coworkers in a room. */
+export type ChatParticipantHoverProfile =
+  | {
+      kind: "human";
+      id: string;
+      name: string;
+      email: string;
+      image: string | null;
+      presence: ChatRoomPresence;
+    }
+  | {
+      kind: "coworker";
+      id: string;
+      name: string;
+      slug: string;
+      caption: string | null;
+      image: string | null;
+      presence: ChatRoomPresence;
+    };
+
+export type RoomParticipantPreview = ChatParticipantHoverProfile;
+
+export type MessageSenderProfile =
+  | ChatParticipantHoverProfile
+  | {
+      kind: "unknown";
+      name: string;
+      image: null;
+    };
 
 /** Catalog / chip key for room-wide @all. Not a user UUID. */
 export const ROOM_MENTION_ALL_ID = "all" as const;
@@ -226,25 +248,34 @@ export function scrollToRoomMessageElement(messageId: string): boolean {
   return true;
 }
 
-export function messageSender(message: ChatRoomMessage) {
+export function messageSender(message: ChatRoomMessage): MessageSenderProfile {
   if (message.sender.type === "user") {
+    const user = message.sender.user;
     return {
-      name: message.sender.user.name,
-      image: message.sender.user.image,
-      kind: "human" as const,
+      kind: "human",
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      image: user.image,
+      presence: user.presence,
     };
   }
   if (message.sender.type === "coworker") {
+    const coworker = message.sender.coworker;
     return {
-      name: message.sender.coworker.name,
-      image: message.sender.coworker.image,
-      kind: "coworker" as const,
+      kind: "coworker",
+      id: coworker.id,
+      name: coworker.name,
+      slug: coworker.slug,
+      caption: coworker.caption,
+      image: coworker.image,
+      presence: coworker.presence,
     };
   }
   return {
+    kind: "unknown",
     name: "Unknown",
     image: null,
-    kind: "unknown" as const,
   };
 }
 
@@ -456,20 +487,27 @@ export function getRoomParticipantPreviews(
   room: ChatRoom,
 ): RoomParticipantPreview[] {
   return [
-    ...room.userMembers.map((member) => ({
-      id: member.id,
-      name: member.name || member.email,
-      image: member.image,
-      presence: member.presence,
-      kind: "human" as const,
-    })),
-    ...room.coworkerMembers.map((coworker) => ({
-      id: coworker.id,
-      name: coworker.name,
-      image: coworker.image,
-      presence: coworker.presence,
-      kind: "coworker" as const,
-    })),
+    ...room.userMembers.map(
+      (member): ChatParticipantHoverProfile => ({
+        kind: "human",
+        id: member.id,
+        name: member.name || member.email,
+        email: member.email,
+        image: member.image,
+        presence: member.presence,
+      }),
+    ),
+    ...room.coworkerMembers.map(
+      (coworker): ChatParticipantHoverProfile => ({
+        kind: "coworker",
+        id: coworker.id,
+        name: coworker.name,
+        slug: coworker.slug,
+        caption: coworker.caption,
+        image: coworker.image,
+        presence: coworker.presence,
+      }),
+    ),
   ];
 }
 

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -66,6 +66,7 @@ import type {
 } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
+import { ChatParticipantHoverCard } from "./chat-participant-hover-card";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import {
   formatMessageTime,
@@ -1038,6 +1039,7 @@ export function ChatMessageRow({
   const tChat = useTranslations("App.Chat.Chat");
   const tChannels = useTranslations("App.Channels");
   const sender = messageSender(message);
+  const hoverProfile = sender.kind === "unknown" ? null : sender;
   const isStreamOverlay = message.id.startsWith("stream:");
   const isDeleted = message.deletedAt != null;
   const isThinking =
@@ -1104,12 +1106,19 @@ export function ChatMessageRow({
           </time>
         </div>
       ) : (
-        <Avatar className="mt-0.5 size-8 shrink-0">
-          <AvatarImage src={sender.image ?? undefined} alt="" />
-          <AvatarFallback className="text-xs">
-            {getInitials(sender.name)}
-          </AvatarFallback>
-        </Avatar>
+        <ChatParticipantHoverCard
+          profile={hoverProfile}
+          side="right"
+          align="start"
+          className="mt-0.5 shrink-0"
+        >
+          <Avatar className="size-8">
+            <AvatarImage src={sender.image ?? undefined} alt="" />
+            <AvatarFallback className="text-xs">
+              {getInitials(sender.name)}
+            </AvatarFallback>
+          </Avatar>
+        </ChatParticipantHoverCard>
       )}
       <div
         className={cn(
@@ -1119,9 +1128,16 @@ export function ChatMessageRow({
       >
         {isContinuation ? null : (
           <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
-            <span className="truncate text-sm font-semibold">
-              {sender.name}
-            </span>
+            <ChatParticipantHoverCard
+              profile={hoverProfile}
+              side="bottom"
+              align="start"
+              className="min-w-0 max-w-full"
+            >
+              <span className="truncate text-sm font-semibold">
+                {sender.name}
+              </span>
+            </ChatParticipantHoverCard>
             {sender.kind === "coworker" ? <AiCoworkerIcon /> : null}
             <time
               dateTime={createdAtIso}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -67,8 +67,10 @@ import type {
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
 import { ChatParticipantHoverCard } from "./chat-participant-hover-card";
+import { participantDirectKey } from "./open-direct-with-participant";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import {
+  type ChatParticipantHoverProfile,
   formatMessageTime,
   formatRoomMarkdownMentions,
   messageSender,
@@ -999,6 +1001,9 @@ export function ChatMessageRow({
   usersById,
   usersBySlug,
   currentUserId,
+  canOpenHumanDirect = false,
+  onOpenDirectMessage,
+  openingDirectParticipantKey = null,
   onToggleReaction,
   onOpenThread,
   onQuote,
@@ -1020,6 +1025,9 @@ export function ChatMessageRow({
   usersById?: Map<string, UserMentionLookup>;
   usersBySlug?: Map<string, UserMentionLookup>;
   currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
   onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
   onOpenThread?: (message: ChatRoomMessage) => void;
   onQuote?: (message: ChatRoomMessage) => void;
@@ -1040,6 +1048,9 @@ export function ChatMessageRow({
   const tChannels = useTranslations("App.Channels");
   const sender = messageSender(message);
   const hoverProfile = sender.kind === "unknown" ? null : sender;
+  const isOpeningDirect = hoverProfile
+    ? openingDirectParticipantKey === participantDirectKey(hoverProfile)
+    : false;
   const isStreamOverlay = message.id.startsWith("stream:");
   const isDeleted = message.deletedAt != null;
   const isThinking =
@@ -1111,6 +1122,10 @@ export function ChatMessageRow({
           side="right"
           align="start"
           className="mt-0.5 shrink-0"
+          currentUserId={currentUserId}
+          canOpenHumanDirect={canOpenHumanDirect}
+          onOpenDirect={onOpenDirectMessage}
+          isOpeningDirect={isOpeningDirect}
         >
           <Avatar className="size-8">
             <AvatarImage src={sender.image ?? undefined} alt="" />
@@ -1133,6 +1148,10 @@ export function ChatMessageRow({
               side="bottom"
               align="start"
               className="min-w-0 max-w-full"
+              currentUserId={currentUserId}
+              canOpenHumanDirect={canOpenHumanDirect}
+              onOpenDirect={onOpenDirectMessage}
+              isOpeningDirect={isOpeningDirect}
             >
               <span className="truncate text-sm font-semibold">
                 {sender.name}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1119,7 +1119,7 @@ export function ChatMessageRow({
       ) : (
         <ChatParticipantHoverCard
           profile={hoverProfile}
-          side="right"
+          side="top"
           align="start"
           className="mt-0.5 shrink-0"
           currentUserId={currentUserId}
@@ -1145,7 +1145,7 @@ export function ChatMessageRow({
           <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
             <ChatParticipantHoverCard
               profile={hoverProfile}
-              side="bottom"
+              side="top"
               align="start"
               className="min-w-0 max-w-full"
               currentUserId={currentUserId}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1051,6 +1051,7 @@ export function ChatMessageRow({
   const isOpeningDirect = hoverProfile
     ? openingDirectParticipantKey === participantDirectKey(hoverProfile)
     : false;
+  const isDirectActionBusy = openingDirectParticipantKey != null;
   const isStreamOverlay = message.id.startsWith("stream:");
   const isDeleted = message.deletedAt != null;
   const isThinking =
@@ -1126,6 +1127,7 @@ export function ChatMessageRow({
           canOpenHumanDirect={canOpenHumanDirect}
           onOpenDirect={onOpenDirectMessage}
           isOpeningDirect={isOpeningDirect}
+          isDirectActionBusy={isDirectActionBusy}
         >
           <Avatar className="size-8">
             <AvatarImage src={sender.image ?? undefined} alt="" />
@@ -1152,6 +1154,7 @@ export function ChatMessageRow({
               canOpenHumanDirect={canOpenHumanDirect}
               onOpenDirect={onOpenDirectMessage}
               isOpeningDirect={isOpeningDirect}
+              isDirectActionBusy={isDirectActionBusy}
             >
               <span className="truncate text-sm font-semibold">
                 {sender.name}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -155,6 +155,7 @@ function RoomParticipantStack({
             isOpeningDirect={
               openingDirectKey === participantDirectKey(participant)
             }
+            isDirectActionBusy={openingDirectKey != null}
           >
             <Avatar className="border-background ring-border/60 size-6 border-2 shadow-xs ring-1 md:size-7">
               <AvatarImage src={participant.image ?? undefined} alt="" />

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -50,6 +50,7 @@ import type {
 import { cn } from "@/lib/utils";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 import { getInitials } from "@/lib/utils/text";
+import { ChatParticipantHoverCard } from "./chat-participant-hover-card";
 import { DraftChannel } from "./draft-channel";
 import { DraftDirectMessage } from "./draft-direct-message";
 import { EditChannelDialog } from "./edit-channel-dialog";
@@ -124,11 +125,13 @@ function RoomParticipantStack({ room }: { room: ChatRoom }) {
           .join(", ")}
       >
         {visibleParticipants.map((participant, index) => (
-          <span
+          <ChatParticipantHoverCard
             key={`${participant.kind}-${participant.id}`}
-            className="relative block size-6 shrink-0 md:size-7"
+            profile={participant}
+            side="bottom"
+            align="center"
+            className="size-6 shrink-0 md:size-7"
             style={{ zIndex: visibleParticipants.length - index }}
-            title={participant.name}
           >
             <Avatar className="border-background ring-border/60 size-6 border-2 shadow-xs ring-1 md:size-7">
               <AvatarImage src={participant.image ?? undefined} alt="" />
@@ -148,7 +151,7 @@ function RoomParticipantStack({ room }: { room: ChatRoom }) {
               label={presenceLabel(t, participant.presence)}
               className="absolute -right-0.5 -bottom-0.5"
             />
-          </span>
+          </ChatParticipantHoverCard>
         ))}
       </div>
       {remainingCount > 0 ? (

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -54,11 +54,16 @@ import { ChatParticipantHoverCard } from "./chat-participant-hover-card";
 import { DraftChannel } from "./draft-channel";
 import { DraftDirectMessage } from "./draft-direct-message";
 import { EditChannelDialog } from "./edit-channel-dialog";
+import {
+  openDirectWithParticipant,
+  participantDirectKey,
+} from "./open-direct-with-participant";
 import { type RoomComposerHandle } from "./room-composer";
 import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
   appendMessage,
   buildRoomAllMentionRecord,
+  type ChatParticipantHoverProfile,
   getRoomDisplayName,
   getRoomParticipantPreviews,
   hasPendingCoworkerMention,
@@ -106,7 +111,19 @@ const COWORKER_RESPONSE_POLL_MAX_ATTEMPTS = 60;
 /** Match sidebar channel-list cadence for peer traffic while a room is open. */
 const ROOM_LIVE_POLL_MS = 15_000;
 
-function RoomParticipantStack({ room }: { room: ChatRoom }) {
+function RoomParticipantStack({
+  room,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirect,
+  openingDirectKey,
+}: {
+  room: ChatRoom;
+  currentUserId: string;
+  canOpenHumanDirect: boolean;
+  onOpenDirect: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectKey: string | null;
+}) {
   const t = useTranslations("App.Channels");
   const participants = getRoomParticipantPreviews(room);
   const visibleParticipants = participants.slice(0, 4);
@@ -132,6 +149,12 @@ function RoomParticipantStack({ room }: { room: ChatRoom }) {
             align="center"
             className="size-6 shrink-0 md:size-7"
             style={{ zIndex: visibleParticipants.length - index }}
+            currentUserId={currentUserId}
+            canOpenHumanDirect={canOpenHumanDirect}
+            onOpenDirect={onOpenDirect}
+            isOpeningDirect={
+              openingDirectKey === participantDirectKey(participant)
+            }
           >
             <Avatar className="border-background ring-border/60 size-6 border-2 shadow-xs ring-1 md:size-7">
               <AvatarImage src={participant.image ?? undefined} alt="" />
@@ -180,6 +203,8 @@ export function RoomsClient({
   const t = useTranslations("App.Channels");
   const tBreadcrumb = useTranslations("Components.Breadcrumb");
   const router = useRouter();
+  const canOpenHumanDirect = Boolean(activeOrganization);
+  const [openingDirectKey, setOpeningDirectKey] = useState<string | null>(null);
   const [pendingQuote, setPendingQuote] = useState<PendingRoomQuote | null>(
     null,
   );
@@ -242,6 +267,23 @@ export function RoomsClient({
   const selectedRoom = isNewDirectMessage
     ? null
     : (rooms.find((room) => room.id === selectedRoomId) ?? null);
+
+  async function handleOpenDirectMessage(
+    profile: ChatParticipantHoverProfile,
+  ): Promise<void> {
+    if (openingDirectKey) return;
+    setOpeningDirectKey(participantDirectKey(profile));
+    try {
+      await openDirectWithParticipant({
+        profile,
+        selectedRoomId,
+        router,
+        onError: toast.error,
+      });
+    } finally {
+      setOpeningDirectKey(null);
+    }
+  }
 
   function isStillSelectedRoom(roomId: string): boolean {
     return selectedRoomIdRef.current === roomId;
@@ -1186,7 +1228,13 @@ export function RoomsClient({
                   </p>
                 </div>
                 <div className="flex shrink-0 items-center gap-1.5 md:gap-2">
-                  <RoomParticipantStack room={selectedRoom} />
+                  <RoomParticipantStack
+                    room={selectedRoom}
+                    currentUserId={currentUserId}
+                    canOpenHumanDirect={canOpenHumanDirect}
+                    onOpenDirect={handleOpenDirectMessage}
+                    openingDirectKey={openingDirectKey}
+                  />
                   {isDirectRoom ? null : (
                     <EditChannelDialog
                       channel={selectedRoom}
@@ -1266,6 +1314,9 @@ export function RoomsClient({
                           usersById={usersById}
                           usersBySlug={usersBySlug}
                           currentUserId={currentUserId}
+                          canOpenHumanDirect={canOpenHumanDirect}
+                          onOpenDirectMessage={handleOpenDirectMessage}
+                          openingDirectParticipantKey={openingDirectKey}
                           onToggleReaction={handleToggleReaction}
                           onOpenThread={
                             shouldShowChatRoomThreadButton({
@@ -1390,6 +1441,9 @@ export function RoomsClient({
             onToggleReaction={handleToggleReaction}
             onQuote={handleQuoteThreadMessage}
             currentUserId={currentUserId}
+            canOpenHumanDirect={canOpenHumanDirect}
+            onOpenDirectMessage={handleOpenDirectMessage}
+            openingDirectParticipantKey={openingDirectKey}
             onStartEdit={handleStartEdit}
             onDelete={handleDeleteMessage}
             editSession={editSession}

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -14,6 +14,7 @@ import type {
 import { type RoomComposerHandle } from "./room-composer";
 import { RoomFileDropZone } from "./room-file-drop-zone";
 import {
+  type ChatParticipantHoverProfile,
   isMessageContinuation,
   type PendingRoomQuote,
   type RoomMentionParticipant,
@@ -45,6 +46,9 @@ export function ThreadPanel({
   onToggleReaction,
   onQuote,
   currentUserId,
+  canOpenHumanDirect = false,
+  onOpenDirectMessage,
+  openingDirectParticipantKey = null,
   onStartEdit,
   onDelete,
   editSession = null,
@@ -80,6 +84,9 @@ export function ThreadPanel({
   onToggleReaction: (message: ChatRoomMessage, emoji: string) => void;
   onQuote?: (message: ChatRoomMessage) => void;
   currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
   onStartEdit?: (message: ChatRoomMessage) => void;
   onDelete?: (message: ChatRoomMessage) => void;
   editSession?: { messageId: string; draft: string } | null;
@@ -158,6 +165,9 @@ export function ThreadPanel({
               coworkersBySlug={coworkersBySlug}
               usersById={usersById}
               usersBySlug={usersBySlug}
+              canOpenHumanDirect={canOpenHumanDirect}
+              onOpenDirectMessage={onOpenDirectMessage}
+              openingDirectParticipantKey={openingDirectParticipantKey}
               onToggleReaction={onToggleReaction}
               onQuote={onQuote}
               showThreadButton={false}
@@ -201,6 +211,11 @@ export function ThreadPanel({
                         coworkersBySlug={coworkersBySlug}
                         usersById={usersById}
                         usersBySlug={usersBySlug}
+                        canOpenHumanDirect={canOpenHumanDirect}
+                        onOpenDirectMessage={onOpenDirectMessage}
+                        openingDirectParticipantKey={
+                          openingDirectParticipantKey
+                        }
                         onToggleReaction={onToggleReaction}
                         onQuote={onQuote}
                         showThreadButton={false}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Hover a chat username or avatar to see participant details, then open a DM in one click.

## Humans vs coworkers
| | Hover details | Message action |
| --- | --- | --- |
| Human | badge, email, presence | `createDirectRoomAction` (org required; hidden for self / no org) |
| Coworker | AI badge, caption/`@slug`, presence | `ensureCoworkerDirectRoomAction` (works without org) |

Both paths create-or-get the existing `kind:direct` room and navigate to `/chat/rooms/{id}`.

## Design
Presentational `ChatParticipantHoverCard` plus shared `openDirectWithParticipant` helper. `RoomsClient` owns busy state, toast, and routing. No new Core API.

## Verify
- Unit tests for hover content, Message visibility, and open helper branching
- Manual: hover another human → Message → land in that DM; coworker same; self has no Message button

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0801ddb-d75c-415b-803b-176c4151ee30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0801ddb-d75c-415b-803b-176c4151ee30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

