### PR TITLE
fix(web): open chat hover card only on avatar or name

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -183,7 +183,7 @@ describe("ChatParticipantHoverCard", () => {
   it("names the avatar trigger with the participant name", () => {
     render(
       <ChatParticipantHoverCard profile={humanProfile}>
-        <span aria-hidden="true">avatar</span>
+        <span>avatar</span>
       </ChatParticipantHoverCard>,
     );
 
@@ -192,19 +192,26 @@ describe("ChatParticipantHoverCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the trigger from stretching to tall flex-row message height", () => {
+  it("uses the child control itself as the hover trigger hit target", () => {
     render(
-      <ChatParticipantHoverCard
-        profile={humanProfile}
-        className="mt-0.5 shrink-0"
-      >
-        <span aria-hidden="true">avatar</span>
-      </ChatParticipantHoverCard>,
+      <div className="flex" style={{ display: "flex", height: 400 }}>
+        <ChatParticipantHoverCard
+          profile={humanProfile}
+          className="mt-0.5 shrink-0"
+        >
+          <span
+            data-testid="avatar-hit-target"
+            className="size-8"
+            style={{ width: 32, height: 32, display: "block" }}
+          />
+        </ChatParticipantHoverCard>
+        <div style={{ flex: 1 }}>tall message body</div>
+      </div>,
     );
 
-    expect(screen.getByRole("button", { name: "Ada Lovelace" })).toHaveClass(
-      "self-start",
-    );
+    const trigger = screen.getByRole("button", { name: "Ada Lovelace" });
+    expect(trigger).toHaveAttribute("data-testid", "avatar-hit-target");
+    expect(trigger).toHaveClass("size-8");
   });
 
   it("renders children only when profile is missing", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -192,6 +192,21 @@ describe("ChatParticipantHoverCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the trigger from stretching to tall flex-row message height", () => {
+    render(
+      <ChatParticipantHoverCard
+        profile={humanProfile}
+        className="mt-0.5 shrink-0"
+      >
+        <span aria-hidden="true">avatar</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    expect(screen.getByRole("button", { name: "Ada Lovelace" })).toHaveClass(
+      "self-start",
+    );
+  });
+
   it("renders children only when profile is missing", () => {
     render(
       <ChatParticipantHoverCard profile={null}>

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -68,7 +68,7 @@ function renderHoverTrigger({
     if (typeof child === "string" || typeof child === "number") {
       return String(child).trim().length > 0;
     }
-    return child != null && child !== false;
+    return true;
   });
   const singleChild =
     childItems.length === 1 && isValidElement<TriggerChildProps>(childItems[0])

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -2,7 +2,13 @@
 
 import { Loader2, MessageCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { CSSProperties, ReactNode } from "react";
+import {
+  Children,
+  type CSSProperties,
+  cloneElement,
+  isValidElement,
+  type ReactNode,
+} from "react";
 
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -36,6 +42,68 @@ interface ChatParticipantHoverCardProps {
   isOpeningDirect?: boolean;
   /** True while any hover-card DM open is in flight (disables Message). */
   isDirectActionBusy?: boolean;
+}
+
+interface TriggerChildProps {
+  className?: string;
+  style?: CSSProperties;
+  role?: string;
+  tabIndex?: number;
+  "aria-label"?: string;
+  "aria-hidden"?: boolean | "true" | "false";
+}
+
+function renderHoverTrigger({
+  profileName,
+  children,
+  className,
+  style,
+}: {
+  profileName: string;
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const childItems = Children.toArray(children).filter((child) => {
+    if (typeof child === "string" || typeof child === "number") {
+      return String(child).trim().length > 0;
+    }
+    return child != null && child !== false;
+  });
+  const singleChild =
+    childItems.length === 1 && isValidElement<TriggerChildProps>(childItems[0])
+      ? childItems[0]
+      : null;
+
+  if (singleChild) {
+    return cloneElement(singleChild, {
+      role: singleChild.props.role ?? "button",
+      tabIndex: singleChild.props.tabIndex ?? 0,
+      "aria-label": singleChild.props["aria-label"] ?? profileName,
+      "aria-hidden": undefined,
+      style: { ...singleChild.props.style, ...style },
+      className: cn(
+        "cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        singleChild.props.className,
+        className,
+      ),
+    });
+  }
+
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label={profileName}
+      style={style}
+      className={cn(
+        "relative inline-flex w-fit max-w-full cursor-pointer self-start p-0 leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
 }
 
 export function ChatParticipantHoverCard({
@@ -74,17 +142,12 @@ export function ChatParticipantHoverCard({
   return (
     <HoverCard openDelay={200} closeDelay={100}>
       <HoverCardTrigger asChild>
-        <button
-          type="button"
-          style={style}
-          aria-label={profile.name}
-          className={cn(
-            "relative inline-flex max-w-full cursor-pointer self-start rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            className,
-          )}
-        >
-          {children}
-        </button>
+        {renderHoverTrigger({
+          profileName: profile.name,
+          children,
+          className,
+          style,
+        })}
       </HoverCardTrigger>
       <HoverCardContent
         side={side}

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -79,7 +79,7 @@ export function ChatParticipantHoverCard({
           style={style}
           aria-label={profile.name}
           className={cn(
-            "relative inline-flex max-w-full cursor-pointer rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "relative inline-flex max-w-full cursor-pointer self-start rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
             className,
           )}
         >

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1149,7 +1149,7 @@ export function ChatMessageRow({
               profile={hoverProfile}
               side="top"
               align="start"
-              className="min-w-0 max-w-full"
+              className="w-fit min-w-0 max-w-full"
               currentUserId={currentUserId}
               canOpenHumanDirect={canOpenHumanDirect}
               onOpenDirect={onOpenDirectMessage}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -147,7 +147,7 @@ function RoomParticipantStack({
             profile={participant}
             side="bottom"
             align="center"
-            className="size-6 shrink-0 md:size-7"
+            className="relative size-6 shrink-0 md:size-7"
             style={{ zIndex: visibleParticipants.length - index }}
             currentUserId={currentUserId}
             canOpenHumanDirect={canOpenHumanDirect}
@@ -157,24 +157,26 @@ function RoomParticipantStack({
             }
             isDirectActionBusy={openingDirectKey != null}
           >
-            <Avatar className="border-background ring-border/60 size-6 border-2 shadow-xs ring-1 md:size-7">
-              <AvatarImage src={participant.image ?? undefined} alt="" />
-              <AvatarFallback
-                className={cn(
-                  "text-[10px]",
-                  participant.kind === "coworker"
-                    ? "bg-primary/10 text-primary"
-                    : "bg-muted text-muted-foreground",
-                )}
-              >
-                {getInitials(participant.name)}
-              </AvatarFallback>
-            </Avatar>
-            <PresenceDot
-              presence={participant.presence}
-              label={presenceLabel(t, participant.presence)}
-              className="absolute -right-0.5 -bottom-0.5"
-            />
+            <span className="relative inline-flex size-full">
+              <Avatar className="border-background ring-border/60 size-full border-2 shadow-xs ring-1">
+                <AvatarImage src={participant.image ?? undefined} alt="" />
+                <AvatarFallback
+                  className={cn(
+                    "text-[10px]",
+                    participant.kind === "coworker"
+                      ? "bg-primary/10 text-primary"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {getInitials(participant.name)}
+                </AvatarFallback>
+              </Avatar>
+              <PresenceDot
+                presence={participant.presence}
+                label={presenceLabel(t, participant.presence)}
+                className="absolute -right-0.5 -bottom-0.5"
+              />
+            </span>
           </ChatParticipantHoverCard>
         ))}
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chat participant hover cards opened when hovering tall-message left-gutter whitespace because the hover trigger stretched as a flex child. This PR makes the trigger the avatar/name itself (`asChild` when there is a single element child) so only those hit targets open the card.

## Follow-up CI fix

`Children.toArray` already drops booleans; comparing `child !== false` caused `TS2367` on typecheck and both Vercel web deploys. Removed that impossible comparison in `chat-participant-hover-card.tsx`.

## Verification

- `pnpm --filter web test src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx`
- `pnpm typecheck` / pre-commit check green locally
- Manual hover probe on tall message: whitespace closed; avatar/name open

Closes hover-hitbox bug on chat message rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94916aa7-5f01-4f8a-804f-8e232124b708?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94916aa7-5f01-4f8a-804f-8e232124b708&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

