### PR TITLE
chore: replace stale CODEOWNERS @mrgrauel with @mrosberghaus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Global Owners
-* @mrgrauel @francisluz
+* @mrosberghaus @francisluz
 
 # Frontend
 apps/web/ @francisluz
 
 # Backend
-apps/core/ @mrgrauel
+apps/core/ @mrosberghaus
 
 # Packages
-packages/ @mrgrauel @francisluz
+packages/ @mrosberghaus @francisluz
 


### PR DESCRIPTION
## Summary
- Replace invalid `@mrgrauel` CODEOWNERS entries with `@mrosberghaus` (global, `apps/core/`, `packages/`)
- Fixes GitHub “unknown owner” errors so both valid owners are requested for review

## Test plan
- [ ] Confirm GitHub CODEOWNERS has no unknown-owner errors on this PR
- [ ] Confirm both `@mrosberghaus` and `@francisluz` appear as reviewers for matching paths


Made with [Cursor](https://cursor.com)