### PR TITLE
fix(chat): gate emoji shortcode autocomplete at two characters

### DIFF
--- a/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
+++ b/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
@@ -95,10 +95,16 @@ describe("mention-textarea utils", () => {
       query: "gri",
       triggerStart: 6,
     });
-    expect(getActiveEmojiTrigger(":", 1)).toEqual({
-      query: "",
+    expect(getActiveEmojiTrigger(":da", 3)).toEqual({
+      query: "da",
       triggerStart: 0,
     });
+  });
+
+  it("does not activate emoji trigger for bare colon or single-char query", () => {
+    expect(getActiveEmojiTrigger(":", 1)).toBeNull();
+    expect(getActiveEmojiTrigger(":d", 2)).toBeNull();
+    expect(getActiveEmojiTrigger(":D", 2)).toBeNull();
   });
 
   it("does not activate emoji trigger on space, @, or mid-token colon", () => {

--- a/apps/web/src/components/chat/__tests__/composer-suggestions.test.ts
+++ b/apps/web/src/components/chat/__tests__/composer-suggestions.test.ts
@@ -46,13 +46,23 @@ describe("resolveComposerSuggestion", () => {
     }
   });
 
-  it("resolves bare colon to capped emoji list", () => {
-    const result = resolveComposerSuggestion(":", 1, {
+  it("does not resolve bare colon or single-char emoji query", () => {
+    expect(
+      resolveComposerSuggestion(":", 1, { mentionsAvailable: false }),
+    ).toBeNull();
+    expect(
+      resolveComposerSuggestion(":d", 2, { mentionsAvailable: false }),
+    ).toBeNull();
+  });
+
+  it("resolves two-char emoji query", () => {
+    const result = resolveComposerSuggestion(":da", 3, {
       mentionsAvailable: false,
     });
     expect(result?.kind).toBe("emoji");
     if (result?.kind === "emoji") {
-      expect(result.query).toBe("");
+      expect(result.query).toBe("da");
+      expect(result.triggerStart).toBe(0);
       expect(result.matches.length).toBeGreaterThan(0);
       expect(result.matches.length).toBeLessThanOrEqual(20);
     }

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -386,6 +386,8 @@ export function getActiveTrigger(
 
 const EMOJI_SHORTCODE_QUERY_PATTERN = /^[a-z0-9_+-]*$/i;
 
+export const EMOJI_SHORTCODE_MIN_QUERY_LENGTH = 2;
+
 /**
  * Detect in-progress emoji shortcode at caret.
  * Token is start/whitespace-delimited, leading `:`, query = [a-z0-9_+-]*.
@@ -409,6 +411,7 @@ export function getActiveEmojiTrigger(
   const query = text.slice(tokenStart + 1, clampedCaret);
   if (query.includes("@") || query.includes(":")) return null;
   if (!EMOJI_SHORTCODE_QUERY_PATTERN.test(query)) return null;
+  if (query.length < EMOJI_SHORTCODE_MIN_QUERY_LENGTH) return null;
 
   return { query: query.toLowerCase(), triggerStart: tokenStart };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Room composer emoji shortcode suggestions no longer open on bare `:` or a single letter. Popup appears after two characters following `:` (Slack behavior). Closing `:name:` still inserts unicode without the popup.

Follow-up polish on SOK-682.

**Verify:** `pnpm --filter web test src/components/__tests__/mention-textarea-utils.test.ts src/components/chat/__tests__/composer-suggestions.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7abfea7-01ae-440e-b1c0-eaefe0ce656b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7abfea7-01ae-440e-b1c0-eaefe0ce656b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

