### PR TITLE
fix(chat): wrap consecutive message attachments horizontally

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -35,7 +35,13 @@ vi.mock("@/components/markdown", () => ({
 }));
 
 vi.mock("@/components/jobs/job-details/file-chip-with-metadata", () => ({
-  FileChipMiniPreviewWithMetadata: () => null,
+  FileChipMiniPreviewWithMetadata: ({
+    fileName,
+  }: {
+    fileName: string;
+    url: string;
+    sizeClass?: string;
+  }) => <span data-testid="chip">{fileName}</span>,
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -427,6 +433,19 @@ describe("ChatMessageRow", () => {
 
     expect(screen.getByText("old text-only quote")).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("wraps consecutive file attachments in one horizontal row", () => {
+    renderRow({
+      message: userMessage({
+        content:
+          "[a.png](https://cdn.example/a.png)\n[b.png](https://cdn.example/b.png)\n",
+      }),
+    });
+
+    const rows = screen.getAllByTestId("room-message-attachment-row");
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getAllByTestId("chip")).toHaveLength(2);
   });
 
   it("styles @all mention tokens in quote snippets", () => {

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  findMarkdownLinks,
-  getExtensionFromUrl,
-  isFileLikeUrl,
-  unescapeMarkdownLinkUrl,
-} from "@sokosumi/utils";
+import { getExtensionFromUrl } from "@sokosumi/utils";
 import {
   CheckCircle2,
   Loader2,
@@ -17,7 +12,6 @@ import {
 import { useTranslations } from "next-intl";
 import {
   type MouseEvent as ReactMouseEvent,
-  type ReactNode,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
   useCallback,
@@ -26,6 +20,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { segmentRoomMessageContent } from "@/app/chat/utils/room-message-segments";
 import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import Markdown from "@/components/markdown";
@@ -266,17 +261,12 @@ function ChannelMessageText({
   usersById?: Map<string, UserMentionLookup>;
   usersBySlug?: Map<string, UserMentionLookup>;
 }) {
-  const fileLinks = findMarkdownLinks(content)
-    .map((link) => ({
-      ...link,
-      url: unescapeMarkdownLinkUrl(link.rawUrl),
-    }))
-    .filter((link) => isFileLikeUrl(link.url));
+  const segments = segmentRoomMessageContent(content);
 
-  if (fileLinks.length === 0) {
+  if (segments.length === 1 && segments[0].kind === "text") {
     return (
       <ChannelMarkdownSegment
-        content={content}
+        content={segments[0].content}
         coworkersById={coworkersById}
         coworkersBySlug={coworkersBySlug}
         usersById={usersById}
@@ -285,46 +275,46 @@ function ChannelMessageText({
     );
   }
 
-  const nodes: ReactNode[] = [];
-  let lastIndex = 0;
-  fileLinks.forEach((link, index) => {
-    if (link.index > lastIndex) {
-      nodes.push(
-        <ChannelMarkdownSegment
-          key={`message-${index}-before`}
-          content={content.slice(lastIndex, link.index)}
-          coworkersById={coworkersById}
-          coworkersBySlug={coworkersBySlug}
-          usersById={usersById}
-          usersBySlug={usersBySlug}
-        />,
-      );
-    }
-    nodes.push(
-      <div key={`${link.index}-${link.url}`} className="my-2 flex">
-        <FileChipMiniPreviewWithMetadata
-          url={link.url}
-          fileName={link.text}
-          sizeClass="size-16"
-        />
-      </div>,
-    );
-    lastIndex = link.index + link.match.length;
-  });
-  if (lastIndex < content.length) {
-    nodes.push(
-      <ChannelMarkdownSegment
-        key="message-after"
-        content={content.slice(lastIndex)}
-        coworkersById={coworkersById}
-        coworkersBySlug={coworkersBySlug}
-        usersById={usersById}
-        usersBySlug={usersBySlug}
-      />,
-    );
-  }
-
-  return <>{nodes}</>;
+  return (
+    <>
+      {segments.map((segment, i) => {
+        switch (segment.kind) {
+          case "text":
+            return (
+              <ChannelMarkdownSegment
+                key={`text-${i}-${segment.start}`}
+                content={segment.content}
+                coworkersById={coworkersById}
+                coworkersBySlug={coworkersBySlug}
+                usersById={usersById}
+                usersBySlug={usersBySlug}
+              />
+            );
+          case "files":
+            return (
+              <div
+                key={`files-${i}-${segment.links[0].index}`}
+                className="my-2 flex flex-wrap gap-2"
+                data-testid="room-message-attachment-row"
+              >
+                {segment.links.map((link) => (
+                  <FileChipMiniPreviewWithMetadata
+                    key={`${link.index}-${link.url}`}
+                    url={link.url}
+                    fileName={link.fileName}
+                    sizeClass="size-16"
+                  />
+                ))}
+              </div>
+            );
+          default: {
+            const _exhaustive: never = segment;
+            return _exhaustive;
+          }
+        }
+      })}
+    </>
+  );
 }
 
 const QUICK_MESSAGE_REACTIONS = ["👍", "❤️", "😂", "🎉", "👀"] as const;

--- a/apps/web/src/app/(app)/chat/utils/__tests__/room-message-segments.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/room-message-segments.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { segmentRoomMessageContent } from "../room-message-segments";
+
+describe("segmentRoomMessageContent", () => {
+  it("groups consecutive file links separated only by newlines", () => {
+    const content =
+      "[a.png](https://cdn.example/a.png)\n[b.png](https://cdn.example/b.png)\n";
+    expect(segmentRoomMessageContent(content)).toEqual([
+      {
+        kind: "files",
+        links: [
+          expect.objectContaining({ fileName: "a.png" }),
+          expect.objectContaining({ fileName: "b.png" }),
+        ],
+      },
+    ]);
+  });
+
+  it("splits file groups when prose sits between attachments", () => {
+    const content =
+      "[a.png](https://cdn.example/a.png)\nsee also\n[b.png](https://cdn.example/b.png)";
+    const kinds = segmentRoomMessageContent(content).map((s) => s.kind);
+    expect(kinds).toEqual(["files", "text", "files"]);
+  });
+
+  it("returns a single text segment for text-only content", () => {
+    expect(segmentRoomMessageContent("hello world")).toEqual([
+      { kind: "text", content: "hello world", start: 0 },
+    ]);
+  });
+
+  it("returns a single text segment for empty content", () => {
+    expect(segmentRoomMessageContent("")).toEqual([
+      { kind: "text", content: "", start: 0 },
+    ]);
+  });
+
+  it("keeps trailing text after files", () => {
+    const content = "[a.png](https://cdn.example/a.png)\nand then more prose";
+    const segments = segmentRoomMessageContent(content);
+    expect(segments.map((s) => s.kind)).toEqual(["files", "text"]);
+    expect(segments[1]).toEqual(
+      expect.objectContaining({
+        kind: "text",
+        content: "\nand then more prose",
+      }),
+    );
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/room-message-segments.ts
+++ b/apps/web/src/app/(app)/chat/utils/room-message-segments.ts
@@ -1,0 +1,98 @@
+import {
+  findMarkdownLinks,
+  isFileLikeUrl,
+  unescapeMarkdownLinkUrl,
+} from "@sokosumi/utils";
+
+export interface RoomMessageFileLink {
+  url: string;
+  fileName: string;
+  index: number;
+  matchLength: number;
+}
+
+export interface RoomMessageTextSegment {
+  kind: "text";
+  content: string;
+  start: number;
+}
+
+export interface RoomMessageFilesSegment {
+  kind: "files";
+  links: [RoomMessageFileLink, ...RoomMessageFileLink[]];
+}
+
+export type RoomMessageSegment =
+  | RoomMessageTextSegment
+  | RoomMessageFilesSegment;
+
+function isAttachmentRunGap(gap: string): boolean {
+  return /^\s*$/.test(gap);
+}
+
+export function segmentRoomMessageContent(
+  content: string,
+): RoomMessageSegment[] {
+  const fileLinks: RoomMessageFileLink[] = [];
+  for (const match of findMarkdownLinks(content)) {
+    const url = unescapeMarkdownLinkUrl(match.rawUrl);
+    if (!isFileLikeUrl(url)) {
+      continue;
+    }
+    fileLinks.push({
+      url,
+      fileName: match.text,
+      index: match.index,
+      matchLength: match.match.length,
+    });
+  }
+
+  if (fileLinks.length === 0) {
+    return [{ kind: "text", content, start: 0 }];
+  }
+
+  const segments: RoomMessageSegment[] = [];
+  let cursor = 0;
+  let openFiles: RoomMessageFileLink[] | null = null;
+
+  function flushFiles(): void {
+    if (openFiles === null || openFiles.length === 0) {
+      return;
+    }
+    const [head, ...rest] = openFiles;
+    segments.push({ kind: "files", links: [head, ...rest] });
+    openFiles = null;
+  }
+
+  for (const link of fileLinks) {
+    const gap = content.slice(cursor, link.index);
+
+    if (openFiles === null) {
+      if (gap.length > 0 && !isAttachmentRunGap(gap)) {
+        segments.push({ kind: "text", content: gap, start: cursor });
+      }
+      openFiles = [link];
+    } else if (isAttachmentRunGap(gap)) {
+      openFiles.push(link);
+    } else {
+      flushFiles();
+      if (gap.length > 0) {
+        segments.push({ kind: "text", content: gap, start: cursor });
+      }
+      openFiles = [link];
+    }
+
+    cursor = link.index + link.matchLength;
+  }
+
+  flushFiles();
+
+  if (cursor < content.length) {
+    const trailing = content.slice(cursor);
+    if (trailing.length > 0 && !isAttachmentRunGap(trailing)) {
+      segments.push({ kind: "text", content: trailing, start: cursor });
+    }
+  }
+
+  return segments;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Room chat message attachments stacked vertically even when the column had free width. Each file link lived in its own block wrapper.

**For readers in channels/DMs.** Consecutive image and file chips now share one `flex flex-wrap` row and wrap only when the row runs out of space. Text between attachments still splits groups.

**For maintainers.** Grouping policy lives in `segmentRoomMessageContent` (`chat/utils/room-message-segments.ts`) as a typed text/files segment list. `ChannelMessageText` maps segments to markdown or a chip row.

### Design choices
| Option | Outcome |
| --- | --- |
| Typed segment list + flex-wrap row | Chosen. Testable coalesce/split; matches composer whitespace (`\n` between attachments). |
| Loop-local flush buffer only | Same UX, weaker pure tests. |
| CSS per-chip wrappers without grouping | Rejected. Does not form a row across whitespace gaps. |

### Verify
- Unit: `pnpm --filter web test` on `room-message-segments.test.ts` and `room-message-row.test.tsx` (33 passed)
- Layout probe of the shipped `flex flex-wrap gap-2` row classes: wide column stays one row; narrow column wraps

![Wide row horizontal; narrow row wraps](https://cursor.com/artifacts/c/art-5b455f8b-deb6-47cc-be2f-f806f960e2a7)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59c047e8-86f5-472e-8952-79bfb061208f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59c047e8-86f5-472e-8952-79bfb061208f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

