### PR TITLE
fix(web): keep chat rooms read across mobile sidebar remount

### DIFF
--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -35,6 +35,7 @@ import {
 import { peekPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
 import { PresenceDot } from "@/components/chat/presence-dot";
+import { rememberRoomRead } from "@/components/chat/room-read-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
@@ -632,7 +633,14 @@ export function RoomsClient({
 
     let cancelled = false;
     markOrganizationChatRoomReadAction(selectedRoomReadId).then((result) => {
-      if (cancelled || !result.ok) {
+      if (!result.ok) {
+        return;
+      }
+      // Persist before the cancelled check: mobile Sheet unmounts the sidebar
+      // list so the event below often has no listener, and remount would
+      // otherwise rehydrate unread from stale RSC props.
+      rememberRoomRead(result.data);
+      if (cancelled) {
         return;
       }
       window.dispatchEvent(

--- a/apps/web/src/components/chat/__tests__/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/__tests__/room-read-overlay.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyRoomReadOverlays,
+  clearRoomReadOverlays,
+  forgetRoomRead,
+  rememberRoomRead,
+} from "../room-read-overlay";
+
+function room(overrides: {
+  id?: string;
+  updatedAt?: string;
+  unreadCount?: number;
+  unreadMentionCount?: number;
+  markedUnread?: boolean;
+}) {
+  return {
+    id: overrides.id ?? "room-1",
+    updatedAt: overrides.updatedAt ?? "2026-08-01T12:00:00.000Z",
+    unreadCount: overrides.unreadCount ?? 0,
+    unreadMentionCount: overrides.unreadMentionCount ?? 0,
+    markedUnread: overrides.markedUnread ?? false,
+  };
+}
+
+afterEach(() => {
+  clearRoomReadOverlays();
+});
+
+describe("room-read-overlay", () => {
+  it("keeps a room cleared after remount with stale unread props (mobile sheet)", () => {
+    // Mark-read succeeded while the sheet (and list) was unmounted.
+    rememberRoomRead(
+      room({
+        updatedAt: "2026-08-01T12:00:00.000Z",
+        unreadCount: 0,
+      }),
+    );
+
+    // Remount hydrates from RSC props that still carry pre-read unread.
+    const remounted = applyRoomReadOverlays([
+      room({
+        updatedAt: "2026-08-01T12:00:00.000Z",
+        unreadCount: 4,
+        unreadMentionCount: 1,
+        markedUnread: true,
+      }),
+    ]);
+
+    expect(remounted[0]).toMatchObject({
+      unreadCount: 0,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
+  });
+
+  it("drops the overlay when the server reports newer room activity", () => {
+    rememberRoomRead(
+      room({
+        updatedAt: "2026-08-01T12:00:00.000Z",
+        unreadCount: 0,
+      }),
+    );
+
+    const withNewMessages = applyRoomReadOverlays([
+      room({
+        updatedAt: "2026-08-01T12:05:00.000Z",
+        unreadCount: 2,
+        unreadMentionCount: 1,
+      }),
+    ]);
+
+    expect(withNewMessages[0]).toMatchObject({
+      unreadCount: 2,
+      unreadMentionCount: 1,
+    });
+  });
+
+  it("forgets the overlay when the user marks the room unread again", () => {
+    rememberRoomRead(room({ unreadCount: 0 }));
+    forgetRoomRead("room-1");
+
+    const rows = applyRoomReadOverlays([
+      room({ unreadCount: 0, markedUnread: true }),
+    ]);
+
+    expect(rows[0]?.markedUnread).toBe(true);
+  });
+});

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -44,6 +44,11 @@ import {
   listOrganizationArchivedChatRoomsAction,
   listOrganizationChatRoomsAction,
 } from "./organization-chat-list.actions";
+import {
+  applyRoomReadOverlays,
+  forgetRoomRead,
+  rememberRoomRead,
+} from "./room-read-overlay";
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
 
@@ -241,7 +246,7 @@ export function OrganizationChatList({
   const tActions = useTranslations("App.Channels.Actions");
   const pathname = usePathname();
   const router = useRouter();
-  const [roomRows, setRoomRows] = useState(rooms);
+  const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
   const [archivedRows, setArchivedRows] = useState(archivedRooms);
   const [channelSectionOpen, setChannelSectionOpen] = useState(true);
   const [archivedSectionOpen, setArchivedSectionOpen] = useState(false);
@@ -251,7 +256,7 @@ export function OrganizationChatList({
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
 
   useEffect(() => {
-    setRoomRows(rooms);
+    setRoomRows(applyRoomReadOverlays(rooms));
   }, [rooms]);
 
   useEffect(() => {
@@ -272,12 +277,16 @@ export function OrganizationChatList({
         return;
       }
       if (activeResult.ok) {
-        setRoomRows(activeResult.data);
+        setRoomRows(applyRoomReadOverlays(activeResult.data));
       }
       if (archivedResult.ok) {
         setArchivedRows(archivedResult.data);
       }
     };
+
+    // Mobile sheet remounts the list with stale RSC props; refresh immediately
+    // so overlays can drop once Core confirms the mark-read.
+    void refreshRooms();
 
     const intervalId = window.setInterval(
       refreshRooms,
@@ -301,16 +310,22 @@ export function OrganizationChatList({
         return;
       }
 
+      if (detail.room) {
+        rememberRoomRead(detail.room);
+      }
+
       setRoomRows((current) =>
-        current.map((room) =>
-          room.id === detail.roomId
-            ? (detail.room ?? {
-                ...room,
-                unreadCount: 0,
-                unreadMentionCount: 0,
-                markedUnread: false,
-              })
-            : room,
+        applyRoomReadOverlays(
+          current.map((room) =>
+            room.id === detail.roomId
+              ? (detail.room ?? {
+                  ...room,
+                  unreadCount: 0,
+                  unreadMentionCount: 0,
+                  markedUnread: false,
+                })
+              : room,
+          ),
         ),
       );
     };
@@ -330,7 +345,7 @@ export function OrganizationChatList({
       if (room) {
         setRoomRows((current) => {
           const without = current.filter((row) => row.id !== room.id);
-          return [room, ...without];
+          return applyRoomReadOverlays([room, ...without]);
         });
         setArchivedRows((current) =>
           current.filter((row) => row.id !== room.id),
@@ -348,7 +363,7 @@ export function OrganizationChatList({
           return;
         }
         if (activeResult.ok) {
-          setRoomRows(activeResult.data);
+          setRoomRows(applyRoomReadOverlays(activeResult.data));
         }
         if (archivedResult.ok) {
           setArchivedRows(archivedResult.data);
@@ -385,7 +400,7 @@ export function OrganizationChatList({
       setArchivedRows((current) => current.filter((row) => row.id !== room.id));
       setRoomRows((current) => {
         const without = current.filter((row) => row.id !== result.data.id);
-        return [result.data, ...without];
+        return applyRoomReadOverlays([result.data, ...without]);
       });
       router.push(`/chat/rooms/${result.data.id}`);
       router.refresh();
@@ -393,8 +408,15 @@ export function OrganizationChatList({
   }
 
   function handleRoomUpdated(updated: ChatRoom) {
+    if (updated.markedUnread) {
+      forgetRoomRead(updated.id);
+    } else if (updated.unreadCount === 0 && updated.unreadMentionCount === 0) {
+      rememberRoomRead(updated);
+    }
     setRoomRows((current) =>
-      current.map((room) => (room.id === updated.id ? updated : room)),
+      applyRoomReadOverlays(
+        current.map((room) => (room.id === updated.id ? updated : room)),
+      ),
     );
   }
 

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -1,0 +1,87 @@
+/**
+ * Session memory for rooms the client has successfully marked read.
+ *
+ * Mobile sidebar mounts OrganizationChatList inside a Sheet that unmounts when
+ * closed. Mark-read then dispatches `organization-chat-room-read` with no
+ * listener, and remount rehydrates from stale RSC props so unread flash back.
+ * This overlay survives unmount and is reapplied on every list hydrate/poll.
+ */
+
+interface RoomReadOverlay {
+  /** Room `updatedAt` at mark-read time. Newer activity invalidates the overlay. */
+  updatedAtMs: number;
+}
+
+const overlaysByRoomId = new Map<string, RoomReadOverlay>();
+
+function toUpdatedAtMs(updatedAt: string | Date): number {
+  const ms = new Date(updatedAt).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+export function rememberRoomRead(room: {
+  id: string;
+  updatedAt: string | Date;
+}): void {
+  overlaysByRoomId.set(room.id, {
+    updatedAtMs: toUpdatedAtMs(room.updatedAt),
+  });
+}
+
+export function forgetRoomRead(roomId: string): void {
+  overlaysByRoomId.delete(roomId);
+}
+
+export function clearRoomReadOverlays(): void {
+  overlaysByRoomId.clear();
+}
+
+interface RoomAttentionFields {
+  id: string;
+  updatedAt: string | Date;
+  unreadCount: number;
+  unreadMentionCount: number;
+  markedUnread: boolean;
+}
+
+/**
+ * Reapply cleared attention for rooms marked read this session when the
+ * incoming list is stale (same or older `updatedAt`). Real new activity
+ * (newer `updatedAt`) drops the overlay and trusts the server row.
+ */
+export function applyRoomReadOverlays<T extends RoomAttentionFields>(
+  rooms: readonly T[],
+): T[] {
+  if (overlaysByRoomId.size === 0) {
+    return rooms as T[];
+  }
+
+  return rooms.map((room) => {
+    const overlay = overlaysByRoomId.get(room.id);
+    if (!overlay) {
+      return room;
+    }
+
+    const incomingUpdatedAtMs = toUpdatedAtMs(room.updatedAt);
+    if (incomingUpdatedAtMs > overlay.updatedAtMs) {
+      overlaysByRoomId.delete(room.id);
+      return room;
+    }
+
+    if (
+      room.unreadCount === 0 &&
+      room.unreadMentionCount === 0 &&
+      room.markedUnread === false
+    ) {
+      overlaysByRoomId.delete(room.id);
+      return room;
+    }
+
+    return {
+      ...room,
+      unreadCount: 0,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    };
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, opening a chat room clears unread styling, then the room goes bold/unread again when the sidebar Sheet remounts.

Root cause: the mobile Sheet unmounts `OrganizationChatList`. Mark-read succeeds and dispatches `organization-chat-room-read`, but no listener is mounted. Remount rehydrates from stale RSC `rooms` props, so unread returns.

## Fix

- Session overlay remembers successful mark-reads across unmount
- Reapplied on list hydrate, poll, and room updates
- Newer `updatedAt` (real new messages) drops the overlay and trusts the server
- Mark-read persists the overlay even when the event is cancelled
- List refreshes immediately on mount

## Verification

Unit tests:

```text
pnpm --filter web test src/components/chat/__tests__/room-read-overlay.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Mobile UI (390px) against local web+core with agent Neon DB:

1. Unread DM "Bob Agent" showed bold in mobile sidebar
2. Opened room (mark-read wrote `lastReadAt`)
3. Navigated away to `/tasks`, reopened sidebar
4. "Bob Agent" stayed non-bold (`font-semibold` absent, `isActive` null)

![Mobile sidebar before read](https://cursor.com/artifacts/c/art-d330488e-1bef-48c1-851b-0576439b3bfa)
![Mobile sidebar after leave stays read](https://cursor.com/artifacts/c/art-73cb4932-4d19-4d40-8deb-a8aed9bb0545)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90d22d42-cb97-4401-a14b-3aec9fca0971?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90d22d42-cb97-4401-a14b-3aec9fca0971&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

