### PR TITLE
fix(chat): append newest pin after existing pins

### DIFF
--- a/apps/web/src/components/chat/__tests__/chat-room-activity-sort.test.ts
+++ b/apps/web/src/components/chat/__tests__/chat-room-activity-sort.test.ts
@@ -62,7 +62,7 @@ describe("compareChatRoomsByRecentActivity", () => {
     ).toEqual(["older-pinned", "newer-unpinned"]);
   });
 
-  it("orders pinned rooms by pinnedAt descending", () => {
+  it("orders pinned rooms by pinnedAt ascending", () => {
     const pinnedEarlier = {
       id: "earlier",
       updatedAt: "2026-08-02T18:00:00.000Z",
@@ -78,6 +78,6 @@ describe("compareChatRoomsByRecentActivity", () => {
       [pinnedEarlier, pinnedLater]
         .sort(compareChatRoomsByRecentActivity)
         .map((r) => r.id),
-    ).toEqual(["later", "earlier"]);
+    ).toEqual(["earlier", "later"]);
   });
 });

--- a/apps/web/src/components/chat/chat-room-activity-sort.ts
+++ b/apps/web/src/components/chat/chat-room-activity-sort.ts
@@ -4,6 +4,10 @@ export interface ChatRoomActivitySortKey {
   pinnedAt?: string | Date | null;
 }
 
+function isPinned(value: string | Date | null | undefined): boolean {
+  return value != null;
+}
+
 function pinnedAtMs(value: string | Date | null | undefined): number {
   if (value == null) {
     return 0;
@@ -11,14 +15,25 @@ function pinnedAtMs(value: string | Date | null | undefined): number {
   return new Date(value).getTime();
 }
 
-/** Pinned first (pinnedAt desc), then newest activity; stable id tie-break. */
+/**
+ * Pinned before unpinned; among pins oldest pinnedAt first (first pin stays top);
+ * then newest activity; stable id tie-break.
+ */
 export function compareChatRoomsByRecentActivity(
   a: ChatRoomActivitySortKey,
   b: ChatRoomActivitySortKey,
 ): number {
-  const byPinned = pinnedAtMs(b.pinnedAt) - pinnedAtMs(a.pinnedAt);
-  if (byPinned !== 0) {
-    return byPinned;
+  const aPinned = isPinned(a.pinnedAt);
+  const bPinned = isPinned(b.pinnedAt);
+  if (aPinned !== bPinned) {
+    return aPinned ? -1 : 1;
+  }
+
+  if (aPinned) {
+    const byPinned = pinnedAtMs(a.pinnedAt) - pinnedAtMs(b.pinnedAt);
+    if (byPinned !== 0) {
+      return byPinned;
+    }
   }
 
   const byActivity =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pinned chat rooms in the org sidebar kept jumping newest-first, which bumped the first pin off the top.

`compareChatRoomsByRecentActivity` now keeps pinned rooms above unpinned ones, orders pins by `pinnedAt` ascending (first pin stays top; newest pin at the end of the pin block), and leaves unpinned activity order unchanged.

**Verify:** `pnpm --filter web test src/components/chat/__tests__/chat-room-activity-sort.test.ts`

No Linear issue linked; requirement came from the agent task text.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7f34fdd-1641-4f67-9041-562272abc6e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7f34fdd-1641-4f67-9041-562272abc6e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

