### PR TITLE
fix(chat): hide file description tooltips in room messages

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -34,8 +34,8 @@ vi.mock("@/components/markdown", () => ({
   default: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock("@/components/jobs/job-details/file-chip-with-metadata", () => ({
-  FileChipMiniPreviewWithMetadata: ({
+vi.mock("@/components/ui/file-chip-mini-preview", () => ({
+  FileChipMiniPreviewFrame: ({
     fileName,
   }: {
     fileName: string;

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -22,7 +22,6 @@ import {
 } from "react";
 import { segmentRoomMessageContent } from "@/app/chat/utils/room-message-segments";
 import { EmojiPicker } from "@/components/chat/emoji-picker";
-import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import Markdown from "@/components/markdown";
 import {
   AlertDialog,
@@ -37,6 +36,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { FileChipMiniPreviewFrame } from "@/components/ui/file-chip-mini-preview";
 import { FileTypeIcon } from "@/components/ui/file-icon";
 import {
   Sheet,
@@ -298,7 +298,7 @@ function ChannelMessageText({
                 data-testid="room-message-attachment-row"
               >
                 {segment.links.map((link) => (
-                  <FileChipMiniPreviewWithMetadata
+                  <FileChipMiniPreviewFrame
                     key={`${link.index}-${link.url}`}
                     url={link.url}
                     fileName={link.fileName}

--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { FileChipMiniPreview } from "../file-chip-mini-preview";
+import {
+  FileChipMiniPreview,
+  FileChipMiniPreviewFrame,
+} from "../file-chip-mini-preview";
 
 vi.mock("next/image", () => ({
   default: ({
@@ -38,12 +41,97 @@ vi.mock("next-intl", () => ({
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+    <div data-testid="tooltip-content">{children}</div>
   ),
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+describe("FileChipMiniPreviewFrame", () => {
+  it("does not render filename or size description text", () => {
+    render(
+      <FileChipMiniPreviewFrame
+        url="https://blob.example.com/uploads/notes.pdf"
+        fileName="notes.pdf"
+        mediaType="application/pdf"
+        size={2048}
+      />,
+    );
+
+    expect(screen.queryByText("notes.pdf")).not.toBeInTheDocument();
+    expect(screen.queryByText(/2(\.0)?\s*KB/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
+  });
+
+  it("opens an image viewer instead of navigating away for image files", () => {
+    render(
+      <FileChipMiniPreviewFrame
+        url="https://blob.example.com/uploads/photo.png"
+        fileName="photo.png"
+        mediaType="image/png"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /photo\.png/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "View image photo.png" }));
+
+    expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Download image" }),
+    ).toHaveAttribute("href", "https://blob.example.com/uploads/photo.png");
+  });
+
+  it("keeps a download/open link for non-image files", () => {
+    render(
+      <FileChipMiniPreviewFrame
+        url="https://blob.example.com/uploads/notes.pdf"
+        fileName="notes.pdf"
+        mediaType="application/pdf"
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://blob.example.com/uploads/notes.pdf",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.queryByTestId("image-viewer")).not.toBeInTheDocument();
+  });
+});
+
 describe("FileChipMiniPreview", () => {
+  it("shows filename and size in tooltip content", () => {
+    render(
+      <FileChipMiniPreview
+        url="https://blob.example.com/uploads/notes.pdf"
+        fileName="notes.pdf"
+        mediaType="application/pdf"
+        size={2048}
+      />,
+    );
+
+    const tooltip = screen.getByTestId("tooltip-content");
+    expect(tooltip).toHaveTextContent("notes.pdf");
+    expect(tooltip).toHaveTextContent(/2(\.0)?\s*KB/i);
+  });
+
+  it("shows filename in tooltip content when size is omitted", () => {
+    render(
+      <FileChipMiniPreview
+        url="https://blob.example.com/uploads/notes.pdf"
+        fileName="notes.pdf"
+        mediaType="application/pdf"
+      />,
+    );
+
+    expect(screen.getByTestId("tooltip-content")).toHaveTextContent(
+      "notes.pdf",
+    );
+  });
+
   it("opens an image viewer instead of navigating away for image files", () => {
     render(
       <FileChipMiniPreview

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -4,7 +4,7 @@ import { getExtensionFromUrl, isImageUrl } from "@sokosumi/utils";
 import { X } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { FileTypeIcon } from "@/components/ui/file-icon";
 import { ImageViewer } from "@/components/ui/image-viewer";
@@ -30,73 +30,98 @@ export interface FileChipMiniPreviewProps {
 const previewTriggerClassName =
   "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 overflow-hidden rounded-xl border outline-none transition";
 
-export function FileChipMiniPreview({
+function FileChipMiniPreviewTrigger({
   url,
   fileName,
   mediaType,
-  size,
-  className,
-  sizeClass = "size-20",
-  onRemove,
-  removeLabel = "Remove file",
-}: FileChipMiniPreviewProps) {
+  sizeClass,
+  onOpenImage,
+}: {
+  url: string;
+  fileName?: string | null;
+  mediaType?: string | null;
+  sizeClass: string;
+  onOpenImage: () => void;
+}) {
   const t = useTranslations("Components.ImageViewer");
-  const [isViewerOpen, setIsViewerOpen] = useState(false);
   const resolvedFileName = fileName ?? url.split("/").pop() ?? url;
   const isImage =
     mediaType?.toLowerCase().startsWith("image/") ||
     isImageUrl(url) ||
     (fileName ? isImageUrl(fileName) : false);
   const extension = getExtensionFromUrl(fileName ?? url);
-  const prettySize = formatBytes(size);
+
+  if (isImage) {
+    return (
+      <button
+        type="button"
+        aria-label={t("viewImage", { fileName: resolvedFileName })}
+        className={cn(previewTriggerClassName, sizeClass)}
+        onClick={onOpenImage}
+      >
+        <div className="relative size-full overflow-hidden">
+          <Image
+            src={url}
+            alt={resolvedFileName}
+            fill
+            sizes="96px"
+            className="object-cover object-center"
+          />
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={cn(previewTriggerClassName, sizeClass)}
+    >
+      <div className="text-muted-foreground flex size-full items-center justify-center">
+        <div className="flex size-8 items-center justify-center rounded-md">
+          <FileTypeIcon extension={extension || "file"} />
+        </div>
+      </div>
+    </a>
+  );
+}
+
+function FileChipMiniPreviewShell({
+  url,
+  fileName,
+  mediaType,
+  className,
+  sizeClass = "size-20",
+  onRemove,
+  removeLabel = "Remove file",
+  wrapTrigger,
+}: FileChipMiniPreviewProps & {
+  wrapTrigger?: (trigger: ReactNode) => ReactNode;
+}) {
+  const [isViewerOpen, setIsViewerOpen] = useState(false);
+  const resolvedFileName = fileName ?? url.split("/").pop() ?? url;
+  const isImage =
+    mediaType?.toLowerCase().startsWith("image/") ||
+    isImageUrl(url) ||
+    (fileName ? isImageUrl(fileName) : false);
+
+  const trigger = (
+    <FileChipMiniPreviewTrigger
+      url={url}
+      fileName={fileName}
+      mediaType={mediaType}
+      sizeClass={sizeClass}
+      onOpenImage={() => {
+        setIsViewerOpen(true);
+      }}
+    />
+  );
 
   return (
     <div className={cn("not-prose relative inline-flex", className)}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          {isImage ? (
-            <button
-              type="button"
-              aria-label={t("viewImage", { fileName: resolvedFileName })}
-              className={cn(previewTriggerClassName, sizeClass)}
-              onClick={() => {
-                setIsViewerOpen(true);
-              }}
-            >
-              <div className="relative size-full overflow-hidden">
-                <Image
-                  src={url}
-                  alt={resolvedFileName}
-                  fill
-                  sizes="96px"
-                  className="object-cover object-center"
-                />
-              </div>
-            </button>
-          ) : (
-            <a
-              href={url}
-              target="_blank"
-              rel="noreferrer noopener"
-              className={cn(previewTriggerClassName, sizeClass)}
-            >
-              <div className="text-muted-foreground flex size-full items-center justify-center">
-                <div className="flex size-8 items-center justify-center rounded-md">
-                  <FileTypeIcon extension={extension || "file"} />
-                </div>
-              </div>
-            </a>
-          )}
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-64">
-          <div className="flex flex-col">
-            <span className="truncate">{resolvedFileName}</span>
-            {prettySize ? (
-              <span className="text-primary-foreground/80">{prettySize}</span>
-            ) : null}
-          </div>
-        </TooltipContent>
-      </Tooltip>
+      {wrapTrigger ? wrapTrigger(trigger) : trigger}
       {onRemove ? (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -122,5 +147,34 @@ export function FileChipMiniPreview({
         />
       ) : null}
     </div>
+  );
+}
+
+export function FileChipMiniPreviewFrame(props: FileChipMiniPreviewProps) {
+  return <FileChipMiniPreviewShell {...props} />;
+}
+
+export function FileChipMiniPreview(props: FileChipMiniPreviewProps) {
+  const resolvedFileName =
+    props.fileName ?? props.url.split("/").pop() ?? props.url;
+  const prettySize = formatBytes(props.size);
+
+  return (
+    <FileChipMiniPreviewShell
+      {...props}
+      wrapTrigger={(trigger) => (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent side="top" className="max-w-64">
+            <div className="flex flex-col">
+              <span className="truncate">{resolvedFileName}</span>
+              {prettySize ? (
+                <span className="text-primary-foreground/80">{prettySize}</span>
+              ) : null}
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Room message file chips no longer show the filename/size hover description.

**What changed**
- Extracted `FileChipMiniPreviewFrame` (preview only, no description tooltip).
- Room timeline attachments use the frame.
- Composer and task/job chips still use `FileChipMiniPreview` with filename(+size) tooltip.

**Why**
Room image grids read cleaner without metadata chrome. Filename stays in aria-label/alt for accessibility.

**Verification**
```bash
pnpm --filter web test src/components/ui/__tests__/file-chip-mini-preview.test.tsx src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
```
35 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e80032d-2b6e-40cd-bdf5-f31253a2c30d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e80032d-2b6e-40cd-bdf5-f31253a2c30d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

