### PR TITLE
fix(chat): show pointer cursor on file chips

### DIFF
--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -75,7 +75,11 @@ describe("FileChipMiniPreviewFrame", () => {
       screen.queryByRole("link", { name: /photo\.png/i }),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "View image photo.png" }));
+    const imageButton = screen.getByRole("button", {
+      name: "View image photo.png",
+    });
+    expect(imageButton).toHaveClass("cursor-pointer");
+    fireEvent.click(imageButton);
 
     expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
     expect(
@@ -93,6 +97,7 @@ describe("FileChipMiniPreviewFrame", () => {
     );
 
     const link = screen.getByRole("link");
+    expect(link).toHaveClass("cursor-pointer");
     expect(link).toHaveAttribute(
       "href",
       "https://blob.example.com/uploads/notes.pdf",
@@ -145,7 +150,11 @@ describe("FileChipMiniPreview", () => {
       screen.queryByRole("link", { name: /photo\.png/i }),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "View image photo.png" }));
+    const imageButton = screen.getByRole("button", {
+      name: "View image photo.png",
+    });
+    expect(imageButton).toHaveClass("cursor-pointer");
+    fireEvent.click(imageButton);
 
     expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
     expect(
@@ -163,6 +172,7 @@ describe("FileChipMiniPreview", () => {
     );
 
     const link = screen.getByRole("link");
+    expect(link).toHaveClass("cursor-pointer");
     expect(link).toHaveAttribute(
       "href",
       "https://blob.example.com/uploads/notes.pdf",

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -28,7 +28,7 @@ export interface FileChipMiniPreviewProps {
 }
 
 const previewTriggerClassName =
-  "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 overflow-hidden rounded-xl border outline-none transition";
+  "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 cursor-pointer overflow-hidden rounded-xl border outline-none transition";
 
 function FileChipMiniPreviewTrigger({
   url,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat file chips (message attachments and composer previews) now show the hand/pointer cursor on hover.

Image chips are a raw `<button>` under Tailwind preflight, so they kept the default arrow. `cursor-pointer` is on the shared mini-preview trigger, so message rows and composer chips both get it.

**Verify**
```bash
pnpm --filter web test src/components/ui/__tests__/file-chip-mini-preview.test.tsx
```
7 passed.

If you meant the 👋 quick reaction emoji instead of the mouse hand cursor, say so and we can swap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a336861c-101c-4835-b993-177d4f54bcf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a336861c-101c-4835-b993-177d4f54bcf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

