### PR TITLE
feat(chat): show unread count in document title

### DIFF
--- a/apps/web/src/components/chat/__tests__/chat-unread-document-title.test.ts
+++ b/apps/web/src/components/chat/__tests__/chat-unread-document-title.test.ts
@@ -1,53 +1,53 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  countChatRoomsWithUnreadAttention,
   formatChatUnreadDocumentTitle,
   stripChatUnreadTitlePrefix,
-  sumChatRoomsUnreadAttention,
 } from "../chat-unread-document-title";
 
-describe("sumChatRoomsUnreadAttention", () => {
-  it("sums unreadCount across rooms", () => {
+describe("countChatRoomsWithUnreadAttention", () => {
+  it("counts rooms with unread, not message totals", () => {
     expect(
-      sumChatRoomsUnreadAttention([
+      countChatRoomsWithUnreadAttention([
         { id: "a", unreadCount: 2 },
         { id: "b", unreadCount: 3 },
       ]),
-    ).toBe(5);
+    ).toBe(2);
   });
 
   it("skips the active room", () => {
     expect(
-      sumChatRoomsUnreadAttention(
+      countChatRoomsWithUnreadAttention(
         [
           { id: "a", unreadCount: 2 },
           { id: "b", unreadCount: 3 },
         ],
         { activeRoomId: "a" },
       ),
-    ).toBe(3);
+    ).toBe(1);
   });
 
-  it("counts forced-unread rooms with unreadCount 0 as 1", () => {
+  it("counts forced-unread rooms with unreadCount 0 as one room", () => {
     expect(
-      sumChatRoomsUnreadAttention([
+      countChatRoomsWithUnreadAttention([
         { id: "a", unreadCount: 0, markedUnread: true },
         { id: "b", unreadCount: 2 },
       ]),
-    ).toBe(3);
+    ).toBe(2);
   });
 
   it("does not double-count markedUnread when unreadCount is already > 0", () => {
     expect(
-      sumChatRoomsUnreadAttention([
+      countChatRoomsWithUnreadAttention([
         { id: "a", unreadCount: 4, markedUnread: true },
       ]),
-    ).toBe(4);
+    ).toBe(1);
   });
 
   it("skips an active forced-unread room", () => {
     expect(
-      sumChatRoomsUnreadAttention(
+      countChatRoomsWithUnreadAttention(
         [
           { id: "a", unreadCount: 0, markedUnread: true },
           { id: "b", unreadCount: 1 },
@@ -55,6 +55,25 @@ describe("sumChatRoomsUnreadAttention", () => {
         { activeRoomId: "a" },
       ),
     ).toBe(1);
+  });
+
+  it("skips muted rooms even when they have unread", () => {
+    expect(
+      countChatRoomsWithUnreadAttention([
+        { id: "a", unreadCount: 5, mutedAt: "2026-08-03T12:00:00.000Z" },
+        { id: "b", unreadCount: 1 },
+        { id: "c", unreadCount: 0, markedUnread: true, mutedAt: new Date() },
+      ]),
+    ).toBe(1);
+  });
+
+  it("ignores rooms with no unread and not marked unread", () => {
+    expect(
+      countChatRoomsWithUnreadAttention([
+        { id: "a", unreadCount: 0 },
+        { id: "b", unreadCount: 0, mutedAt: null },
+      ]),
+    ).toBe(0);
   });
 });
 

--- a/apps/web/src/components/chat/__tests__/chat-unread-document-title.test.ts
+++ b/apps/web/src/components/chat/__tests__/chat-unread-document-title.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatChatUnreadDocumentTitle,
+  stripChatUnreadTitlePrefix,
+  sumChatRoomsUnreadAttention,
+} from "../chat-unread-document-title";
+
+describe("sumChatRoomsUnreadAttention", () => {
+  it("sums unreadCount across rooms", () => {
+    expect(
+      sumChatRoomsUnreadAttention([
+        { id: "a", unreadCount: 2 },
+        { id: "b", unreadCount: 3 },
+      ]),
+    ).toBe(5);
+  });
+
+  it("skips the active room", () => {
+    expect(
+      sumChatRoomsUnreadAttention(
+        [
+          { id: "a", unreadCount: 2 },
+          { id: "b", unreadCount: 3 },
+        ],
+        { activeRoomId: "a" },
+      ),
+    ).toBe(3);
+  });
+
+  it("counts forced-unread rooms with unreadCount 0 as 1", () => {
+    expect(
+      sumChatRoomsUnreadAttention([
+        { id: "a", unreadCount: 0, markedUnread: true },
+        { id: "b", unreadCount: 2 },
+      ]),
+    ).toBe(3);
+  });
+
+  it("does not double-count markedUnread when unreadCount is already > 0", () => {
+    expect(
+      sumChatRoomsUnreadAttention([
+        { id: "a", unreadCount: 4, markedUnread: true },
+      ]),
+    ).toBe(4);
+  });
+
+  it("skips an active forced-unread room", () => {
+    expect(
+      sumChatRoomsUnreadAttention(
+        [
+          { id: "a", unreadCount: 0, markedUnread: true },
+          { id: "b", unreadCount: 1 },
+        ],
+        { activeRoomId: "a" },
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("stripChatUnreadTitlePrefix", () => {
+  it("strips a leading (N) prefix", () => {
+    expect(stripChatUnreadTitlePrefix("(3) Sokosumi")).toBe("Sokosumi");
+  });
+
+  it("leaves titles without a prefix unchanged", () => {
+    expect(stripChatUnreadTitlePrefix("Sokosumi")).toBe("Sokosumi");
+  });
+
+  it("only strips a leading digit group prefix", () => {
+    expect(stripChatUnreadTitlePrefix("(3) Chat (2) room")).toBe(
+      "Chat (2) room",
+    );
+  });
+});
+
+describe("formatChatUnreadDocumentTitle", () => {
+  it("prefixes when unreadTotal is greater than 0", () => {
+    expect(formatChatUnreadDocumentTitle("Sokosumi", 2)).toBe("(2) Sokosumi");
+  });
+
+  it("replaces an existing unread prefix", () => {
+    expect(formatChatUnreadDocumentTitle("(1) Sokosumi", 4)).toBe(
+      "(4) Sokosumi",
+    );
+  });
+
+  it("strips the prefix when unreadTotal is 0", () => {
+    expect(formatChatUnreadDocumentTitle("(2) Sokosumi", 0)).toBe("Sokosumi");
+  });
+
+  it("leaves a clean title unchanged when unreadTotal is 0", () => {
+    expect(formatChatUnreadDocumentTitle("Sokosumi", 0)).toBe("Sokosumi");
+  });
+});

--- a/apps/web/src/components/chat/chat-unread-document-title.ts
+++ b/apps/web/src/components/chat/chat-unread-document-title.ts
@@ -2,15 +2,20 @@ interface ChatRoomUnreadAttention {
   id: string;
   unreadCount: number;
   markedUnread?: boolean;
+  mutedAt?: string | Date | null;
 }
 
-interface SumChatRoomsUnreadAttentionOptions {
+interface CountChatRoomsWithUnreadAttentionOptions {
   activeRoomId?: string | null;
 }
 
-export function sumChatRoomsUnreadAttention(
+/**
+ * Count rooms that would show sidebar attention (bold), for the tab title.
+ * One per room — not a sum of unread messages. Skips active and muted rooms.
+ */
+export function countChatRoomsWithUnreadAttention(
   rooms: ChatRoomUnreadAttention[],
-  options: SumChatRoomsUnreadAttentionOptions = {},
+  options: CountChatRoomsWithUnreadAttentionOptions = {},
 ): number {
   let total = 0;
 
@@ -19,12 +24,13 @@ export function sumChatRoomsUnreadAttention(
       continue;
     }
 
-    if (room.markedUnread === true && room.unreadCount === 0) {
-      total += 1;
+    if (room.mutedAt != null) {
       continue;
     }
 
-    total += room.unreadCount;
+    if (room.unreadCount > 0 || room.markedUnread === true) {
+      total += 1;
+    }
   }
 
   return total;

--- a/apps/web/src/components/chat/chat-unread-document-title.ts
+++ b/apps/web/src/components/chat/chat-unread-document-title.ts
@@ -1,0 +1,48 @@
+interface ChatRoomUnreadAttention {
+  id: string;
+  unreadCount: number;
+  markedUnread?: boolean;
+}
+
+interface SumChatRoomsUnreadAttentionOptions {
+  activeRoomId?: string | null;
+}
+
+export function sumChatRoomsUnreadAttention(
+  rooms: ChatRoomUnreadAttention[],
+  options: SumChatRoomsUnreadAttentionOptions = {},
+): number {
+  let total = 0;
+
+  for (const room of rooms) {
+    if (options.activeRoomId != null && room.id === options.activeRoomId) {
+      continue;
+    }
+
+    if (room.markedUnread === true && room.unreadCount === 0) {
+      total += 1;
+      continue;
+    }
+
+    total += room.unreadCount;
+  }
+
+  return total;
+}
+
+const CHAT_UNREAD_TITLE_PREFIX_RE = /^\(\d+\) /;
+
+export function stripChatUnreadTitlePrefix(title: string): string {
+  return title.replace(CHAT_UNREAD_TITLE_PREFIX_RE, "");
+}
+
+export function formatChatUnreadDocumentTitle(
+  currentTitle: string,
+  unreadTotal: number,
+): string {
+  const base = stripChatUnreadTitlePrefix(currentTitle);
+  if (unreadTotal > 0) {
+    return `(${unreadTotal}) ${base}`;
+  }
+  return base;
+}

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -34,11 +34,13 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { useChatUnreadDocumentTitle } from "@/hooks/use-chat-unread-document-title";
 import type { ChatRoom, ChatRoomPresence } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
 import { compareChatRoomsByRecentActivity } from "./chat-room-activity-sort";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
+import { sumChatRoomsUnreadAttention } from "./chat-unread-document-title";
 import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "./organization-chat-events";
 import {
   listOrganizationArchivedChatRoomsAction,
@@ -254,6 +256,8 @@ export function OrganizationChatList({
   const [restoringRoomId, setRestoringRoomId] = useState<string | null>(null);
   const [_isRestoring, startRestoreTransition] = useTransition();
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
+  const unreadTotal = sumChatRoomsUnreadAttention(roomRows, { activeRoomId });
+  useChatUnreadDocumentTitle(unreadTotal);
 
   useEffect(() => {
     setRoomRows(applyRoomReadOverlays(rooms));

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -40,7 +40,7 @@ import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
 import { compareChatRoomsByRecentActivity } from "./chat-room-activity-sort";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
-import { sumChatRoomsUnreadAttention } from "./chat-unread-document-title";
+import { countChatRoomsWithUnreadAttention } from "./chat-unread-document-title";
 import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "./organization-chat-events";
 import {
   listOrganizationArchivedChatRoomsAction,
@@ -256,8 +256,10 @@ export function OrganizationChatList({
   const [restoringRoomId, setRestoringRoomId] = useState<string | null>(null);
   const [_isRestoring, startRestoreTransition] = useTransition();
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
-  const unreadTotal = sumChatRoomsUnreadAttention(roomRows, { activeRoomId });
-  useChatUnreadDocumentTitle(unreadTotal);
+  const unreadRoomCount = countChatRoomsWithUnreadAttention(roomRows, {
+    activeRoomId,
+  });
+  useChatUnreadDocumentTitle(unreadRoomCount);
 
   useEffect(() => {
     setRoomRows(applyRoomReadOverlays(rooms));

--- a/apps/web/src/hooks/__tests__/use-chat-unread-document-title.test.ts
+++ b/apps/web/src/hooks/__tests__/use-chat-unread-document-title.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useChatUnreadDocumentTitle } from "@/hooks/use-chat-unread-document-title";
+
+describe("useChatUnreadDocumentTitle", () => {
+  beforeEach(() => {
+    document.title = "Sokosumi";
+  });
+
+  afterEach(() => {
+    document.title = "";
+  });
+
+  it("applies an unread prefix to document.title", () => {
+    renderHook(() => useChatUnreadDocumentTitle(3));
+
+    expect(document.title).toBe("(3) Sokosumi");
+  });
+
+  it("strips the prefix when unreadTotal becomes 0", () => {
+    const { rerender } = renderHook(
+      ({ unreadTotal }) => useChatUnreadDocumentTitle(unreadTotal),
+      { initialProps: { unreadTotal: 2 } },
+    );
+
+    expect(document.title).toBe("(2) Sokosumi");
+
+    rerender({ unreadTotal: 0 });
+
+    expect(document.title).toBe("Sokosumi");
+  });
+
+  it("strips the prefix on unmount", () => {
+    const { unmount } = renderHook(() => useChatUnreadDocumentTitle(5));
+
+    expect(document.title).toBe("(5) Sokosumi");
+
+    unmount();
+
+    expect(document.title).toBe("Sokosumi");
+  });
+
+  it("re-applies the unread prefix after an external title mutation", async () => {
+    renderHook(() => useChatUnreadDocumentTitle(2));
+
+    expect(document.title).toBe("(2) Sokosumi");
+
+    await act(async () => {
+      document.title = "Room · Sokosumi";
+      await Promise.resolve();
+    });
+
+    expect(document.title).toBe("(2) Room · Sokosumi");
+  });
+});

--- a/apps/web/src/hooks/use-chat-unread-document-title.ts
+++ b/apps/web/src/hooks/use-chat-unread-document-title.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import {
+  formatChatUnreadDocumentTitle,
+  stripChatUnreadTitlePrefix,
+} from "@/components/chat/chat-unread-document-title";
+
+export function useChatUnreadDocumentTitle(unreadTotal: number): void {
+  const unreadTotalRef = useRef(unreadTotal);
+  unreadTotalRef.current = unreadTotal;
+
+  useEffect(() => {
+    let isSelfWrite = false;
+
+    function applyTitle() {
+      const nextTitle = formatChatUnreadDocumentTitle(
+        document.title,
+        unreadTotalRef.current,
+      );
+      if (nextTitle === document.title) {
+        return;
+      }
+      isSelfWrite = true;
+      document.title = nextTitle;
+      queueMicrotask(() => {
+        isSelfWrite = false;
+      });
+    }
+
+    applyTitle();
+
+    const titleElement = document.querySelector("title");
+    const observer = new MutationObserver(() => {
+      if (isSelfWrite) {
+        return;
+      }
+      applyTitle();
+    });
+
+    if (titleElement) {
+      observer.observe(titleElement, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    }
+
+    return () => {
+      observer.disconnect();
+      isSelfWrite = true;
+      document.title = stripChatUnreadTitlePrefix(document.title);
+    };
+  }, [unreadTotal]);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Browser tab title prefixes with the number of rooms that have unread attention, e.g. `(3) Sokosumi - Chat`.

**What changed for users.** When you have unread chat activity outside the room you are viewing, the tab shows `(N)` where **N is the number of rooms** (not total messages). Opening the room or clearing unread removes that room from the count. Soft navigation keeps the prefix on the new page title.

**Muted rooms.** Muted rooms are excluded from the tab count, same as sidebar attention (no bold / badge).

**How it works.** Sidebar `OrganizationChatList` already polls room unreads. We count rooms with unread or mark-unread (active + muted skipped) and sync `document.title` via a small hook + `MutationObserver` so metadata updates do not wipe the prefix.

**Not in this PR.** Notification-center unread. No Core aggregate endpoint. No Ably for room-list unread.

**Verification.**
- `pnpm --filter web test src/components/chat/__tests__/chat-unread-document-title.test.ts src/hooks/__tests__/use-chat-unread-document-title.test.ts`
- Rebased onto main (includes mute chat rooms)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ab7053-eaae-4749-a707-9b97097610bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ab7053-eaae-4749-a707-9b97097610bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

