### PR TITLE
feat(chat): collapse long room message bodies with show more/less

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "Löschen",
         "deleteConfirm": "Diese Nachricht löschen? Andere sehen, dass sie gelöscht wurde.",
-        "deleted": "Diese Nachricht wurde gelöscht"
+        "deleted": "Diese Nachricht wurde gelöscht",
+        "showMore": "Mehr anzeigen",
+        "showLess": "Weniger anzeigen"
       },
       "MentionAll": {
         "label": "Alle"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4849,7 +4849,9 @@
       "Message": {
         "delete": "Delete",
         "deleteConfirm": "Delete this message? Others will see that it was deleted.",
-        "deleted": "This message was deleted"
+        "deleted": "This message was deleted",
+        "showMore": "Show more",
+        "showLess": "Show less"
       },
       "Edit": {
         "action": "Edit",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "Eliminar",
         "deleteConfirm": "¿Eliminar este mensaje? Los demás verán que fue eliminado.",
-        "deleted": "Este mensaje fue eliminado"
+        "deleted": "Este mensaje fue eliminado",
+        "showMore": "Mostrar más",
+        "showLess": "Mostrar menos"
       },
       "MentionAll": {
         "label": "Todos"

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "Supprimer",
         "deleteConfirm": "Supprimer ce message ? Les autres verront qu’il a été supprimé.",
-        "deleted": "Ce message a été supprimé"
+        "deleted": "Ce message a été supprimé",
+        "showMore": "Afficher plus",
+        "showLess": "Afficher moins"
       },
       "MentionAll": {
         "label": "Tout le monde"

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "Elimina",
         "deleteConfirm": "Eliminare questo messaggio? Gli altri vedranno che è stato eliminato.",
-        "deleted": "Questo messaggio è stato eliminato"
+        "deleted": "Questo messaggio è stato eliminato",
+        "showMore": "Mostra di più",
+        "showLess": "Mostra meno"
       },
       "MentionAll": {
         "label": "Tutti"

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "削除",
         "deleteConfirm": "このメッセージを削除しますか？他の人には削除されたことが表示されます。",
-        "deleted": "このメッセージは削除されました"
+        "deleted": "このメッセージは削除されました",
+        "showMore": "続きを表示",
+        "showLess": "折りたたむ"
       },
       "MentionAll": {
         "label": "全員"

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "Excluir",
         "deleteConfirm": "Excluir esta mensagem? Os outros verão que ela foi excluída.",
-        "deleted": "Esta mensagem foi excluída"
+        "deleted": "Esta mensagem foi excluída",
+        "showMore": "Mostrar mais",
+        "showLess": "Mostrar menos"
       },
       "MentionAll": {
         "label": "Todos"

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "Eliminar",
         "deleteConfirm": "Eliminar esta mensagem? Os outros verão que foi eliminada.",
-        "deleted": "Esta mensagem foi eliminada"
+        "deleted": "Esta mensagem foi eliminada",
+        "showMore": "Mostrar mais",
+        "showLess": "Mostrar menos"
       },
       "MentionAll": {
         "label": "Todos"

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4730,7 +4730,9 @@
       "Message": {
         "delete": "删除",
         "deleteConfirm": "删除这条消息？其他人会看到该消息已被删除。",
-        "deleted": "此消息已删除"
+        "deleted": "此消息已删除",
+        "showMore": "显示更多",
+        "showLess": "收起"
       },
       "MentionAll": {
         "label": "所有人"

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -8,25 +8,27 @@ import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 import { ChatMessageRow } from "../room-message-row";
 
 vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
-    if (key === "Reactions.whoReacted" && values) {
-      const names = String(values.names ?? "");
-      const more = Number(values.more ?? 0);
-      return more > 0 ? `${names}, and ${more} more` : names;
-    }
-    if (key === "Reactions.andMore" && values) {
-      return `and ${values.count} more`;
-    }
-    if (key === "jump" && values) {
-      return `Jump to message from ${values.author}`;
-    }
-    if (key === "showMore") {
-      return "More";
-    }
-    if (key === "showLess") {
-      return "Less";
-    }
-    return key;
+  useTranslations: (namespace?: string) => {
+    return (key: string, values?: Record<string, unknown>) => {
+      if (key === "Reactions.whoReacted" && values) {
+        const names = String(values.names ?? "");
+        const more = Number(values.more ?? 0);
+        return more > 0 ? `${names}, and ${more} more` : names;
+      }
+      if (key === "Reactions.andMore" && values) {
+        return `and ${values.count} more`;
+      }
+      if (key === "jump" && values) {
+        return `Jump to message from ${values.author}`;
+      }
+      if (key === "showMore") {
+        return namespace === "App.Channels.Message" ? "Show more" : "More";
+      }
+      if (key === "showLess") {
+        return namespace === "App.Channels.Message" ? "Show less" : "Less";
+      }
+      return key;
+    };
   },
 }));
 
@@ -596,6 +598,125 @@ describe("ChatMessageRow", () => {
       expect(
         screen.getByRole("button", { name: "Jump to message from Phil" }),
       ).toBeInTheDocument();
+    } finally {
+      if (scrollDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollDescriptor,
+        );
+      }
+      if (clientDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "clientHeight",
+          clientDescriptor,
+        );
+      }
+    }
+  });
+
+  it("clamps long message bodies and expands with Show more/Show less", async () => {
+    const user = userEvent.setup();
+    const scrollDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+    const clientDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return 400;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return 80;
+      },
+    });
+
+    try {
+      const longBody = Array.from(
+        { length: 20 },
+        (_, i) => `Line ${i + 1} of a very long chat message.`,
+      ).join("\n");
+
+      renderRow({
+        message: userMessage({ content: longBody }),
+      });
+
+      const body = screen.getByTestId("room-message-body");
+      expect(body.className).toContain("line-clamp-[16]");
+      expect(
+        screen.getByRole("button", { name: "Show more" }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Show more" }));
+      expect(body.className).not.toContain("line-clamp-[16]");
+      expect(
+        screen.getByRole("button", { name: "Show less" }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Show less" }));
+      expect(body.className).toContain("line-clamp-[16]");
+      expect(
+        screen.getByRole("button", { name: "Show more" }),
+      ).toBeInTheDocument();
+    } finally {
+      if (scrollDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollDescriptor,
+        );
+      }
+      if (clientDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "clientHeight",
+          clientDescriptor,
+        );
+      }
+    }
+  });
+
+  it("hides Show more when the message body does not overflow", () => {
+    const scrollDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+    const clientDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return 40;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return 40;
+      },
+    });
+
+    try {
+      renderRow({
+        message: userMessage({ content: "Short message" }),
+      });
+
+      expect(screen.getByTestId("room-message-body").className).toContain(
+        "line-clamp-[16]",
+      );
+      expect(
+        screen.queryByRole("button", { name: "Show more" }),
+      ).not.toBeInTheDocument();
     } finally {
       if (scrollDescriptor) {
         Object.defineProperty(

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -76,6 +76,41 @@ type UserMentionLookup = Pick<ChatRoomUserParticipant, "id" | "name">;
 type RoomMessageQuoteSnapshot = Exclude<ChatRoomMessageQuote, null>;
 type RoomQuoteAttachment = Exclude<ChatRoomMessageQuoteAttachment, null>;
 
+/** Collapsed preview height for primary message bodies (taller than quotes). */
+const MESSAGE_BODY_CLAMP_CLASS = "line-clamp-[16]";
+
+function useClampedOverflow(resetKey: string) {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    setExpanded(false);
+  }, [resetKey]);
+
+  useLayoutEffect(() => {
+    const node = contentRef.current;
+    if (!node || expanded) {
+      return;
+    }
+
+    function measureOverflow() {
+      const el = contentRef.current;
+      if (!el) {
+        return;
+      }
+      setOverflows(el.scrollHeight > el.clientHeight + 1);
+    }
+
+    measureOverflow();
+    const observer = new ResizeObserver(measureOverflow);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [expanded, resetKey]);
+
+  return { expanded, setExpanded, overflows, contentRef };
+}
+
 function MessageQuoteAttachmentChip({
   attachment,
 }: {
@@ -137,33 +172,9 @@ function MessageQuoteBlock({
   usersBySlug?: Map<string, UserMentionLookup>;
 }) {
   const t = useTranslations("App.Channels.Quote");
-  const [expanded, setExpanded] = useState(false);
-  const [overflows, setOverflows] = useState(false);
-  const snippetRef = useRef<HTMLDivElement | null>(null);
-
-  useLayoutEffect(() => {
-    setExpanded(false);
-  }, [quote.messageId, quote.snippet]);
-
-  useLayoutEffect(() => {
-    const node = snippetRef.current;
-    if (!node || expanded) {
-      return;
-    }
-
-    function measureOverflow() {
-      const el = snippetRef.current;
-      if (!el) {
-        return;
-      }
-      setOverflows(el.scrollHeight > el.clientHeight + 1);
-    }
-
-    measureOverflow();
-    const observer = new ResizeObserver(measureOverflow);
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [expanded, quote.snippet]);
+  const { expanded, setExpanded, overflows, contentRef } = useClampedOverflow(
+    `${quote.messageId}\0${quote.snippet}`,
+  );
 
   const attachment = quote.attachment ?? null;
 
@@ -182,7 +193,7 @@ function MessageQuoteBlock({
         </div>
         {quote.snippet.trim() ? (
           <div
-            ref={snippetRef}
+            ref={contentRef}
             className={cn(
               "text-muted-foreground text-xs leading-5",
               expanded ? null : "line-clamp-4",
@@ -314,6 +325,56 @@ function ChannelMessageText({
         }
       })}
     </>
+  );
+}
+
+function ChannelMessageBody({
+  messageId,
+  content,
+  coworkersById,
+  coworkersBySlug,
+  usersById,
+  usersBySlug,
+}: {
+  messageId: string;
+  content: string;
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, UserMentionLookup>;
+  usersBySlug?: Map<string, UserMentionLookup>;
+}) {
+  const t = useTranslations("App.Channels.Message");
+  const { expanded, setExpanded, overflows, contentRef } = useClampedOverflow(
+    `${messageId}\0${content}`,
+  );
+
+  return (
+    <div>
+      <div
+        ref={contentRef}
+        data-testid="room-message-body"
+        className={cn(expanded ? null : MESSAGE_BODY_CLAMP_CLASS)}
+      >
+        <ChannelMessageText
+          content={content}
+          coworkersById={coworkersById}
+          coworkersBySlug={coworkersBySlug}
+          usersById={usersById}
+          usersBySlug={usersBySlug}
+        />
+      </div>
+      {expanded || overflows ? (
+        <button
+          type="button"
+          className="text-primary hover:text-primary/80 mt-1 text-xs font-medium outline-none focus-visible:underline"
+          onClick={() => {
+            setExpanded((current) => !current);
+          }}
+        >
+          {expanded ? t("showLess") : t("showMore")}
+        </button>
+      ) : null}
+    </div>
   );
 }
 
@@ -1200,7 +1261,8 @@ export function ChatMessageRow({
                 </span>
               ) : (
                 <>
-                  <ChannelMessageText
+                  <ChannelMessageBody
+                    messageId={message.id}
                     content={message.content}
                     coworkersById={coworkersById}
                     coworkersBySlug={coworkersBySlug}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Long room messages used to paint full height and crowd out the rest of the conversation. Bodies that overflow a 16-line clamp now collapse with **Show more** / **Show less**, using the same measured-overflow approach as quote snippets.

**What changed**
- Shared `useClampedOverflow` for quote + body
- Primary message bodies clamp at 16 lines when content overflows
- i18n keys under `App.Channels.Message` in all locales
- Unit coverage for expand / collapse / no-overflow

**Verify**
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx`
- `pnpm web:check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5694887-c983-4c2c-a058-fd75657a3f6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5694887-c983-4c2c-a058-fd75657a3f6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

