### PR TITLE
feat(web): add lucide icons to chat room sidebar menu

### DIFF
--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { BellOff, Ellipsis, Pin } from "lucide-react";
+import {
+  Bell,
+  BellOff,
+  Ellipsis,
+  MessageSquare,
+  Pin,
+  PinOff,
+} from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { type ReactNode, useTransition } from "react";
@@ -164,6 +171,7 @@ export function ChatRoomSidebarRow({
               });
             }}
           >
+            <MessageSquare className="size-4" aria-hidden />
             {tActions("markUnread")}
           </DropdownMenuItem>
           <DropdownMenuItem
@@ -182,6 +190,11 @@ export function ChatRoomSidebarRow({
               });
             }}
           >
+            {isPinned ? (
+              <PinOff className="size-4" aria-hidden />
+            ) : (
+              <Pin className="size-4" aria-hidden />
+            )}
             {isPinned ? tActions("unpin") : tActions("pin")}
           </DropdownMenuItem>
           <DropdownMenuItem
@@ -200,6 +213,11 @@ export function ChatRoomSidebarRow({
               });
             }}
           >
+            {isMuted ? (
+              <Bell className="size-4" aria-hidden />
+            ) : (
+              <BellOff className="size-4" aria-hidden />
+            )}
             {isMuted ? tActions("unmute") : tActions("mute")}
           </DropdownMenuItem>
         </DropdownMenuContent>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds lucide icons beside Mark unread, Pin/Unpin, and Mute/Unmute in the chat room sidebar overflow menu.

Follows the existing `DropdownMenuItem` + icon pattern used elsewhere in the web app. Pin/mute icons match the row trailing indicators (`Pin` / `BellOff`).

**Verification**
- `pnpm --filter web exec biome check src/components/chat/chat-room-sidebar-row.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9bee42-2beb-43ce-9963-d0d5260ea43c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9bee42-2beb-43ce-9963-d0d5260ea43c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

