### PR TITLE
feat(chat): focus composer on thread open and quote

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-composer-focus.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-composer-focus.test.tsx
@@ -1,0 +1,153 @@
+import { render, waitFor } from "@testing-library/react";
+import {
+  type ReactNode,
+  type Ref,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RoomComposer,
+  type RoomComposerHandle,
+} from "@/app/chat/components/room-composer";
+
+const editorFocus = vi.hoisted(() => vi.fn());
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/components/chat/composer-wysiwyg-editor", () => ({
+  ComposerWysiwygEditor: ({
+    ref,
+  }: {
+    ref?: Ref<{
+      focus: () => void;
+      insertText: (text: string) => void;
+      openMentions: () => void;
+      applyFormat: () => void;
+      insertLink: () => void;
+      getSelectedPlainText: () => string;
+    }>;
+  }) => {
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        editorFocus();
+      },
+      insertText: () => undefined,
+      openMentions: () => undefined,
+      applyFormat: () => undefined,
+      insertLink: () => undefined,
+      getSelectedPlainText: () => "",
+    }));
+    return <div role="textbox" />;
+  },
+}));
+
+vi.mock("@/components/chat/room-message-composer", () => ({
+  ROOM_COMPOSER_TEXTAREA_CLASSNAME: "",
+  ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME: "",
+  RoomComposerEmojiPicker: () => null,
+  RoomMessageComposer: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/chat/composer-format-toolbar", () => ({
+  ComposerFormatToolbar: () => null,
+}));
+
+vi.mock("@/components/chat/composer-add-link-dialog", () => ({
+  ComposerAddLinkDialog: () => null,
+}));
+
+describe("RoomComposerHandle.focus", () => {
+  it("exposes focus and calling it focuses the editor", async () => {
+    editorFocus.mockClear();
+
+    function Harness() {
+      const composerRef = useRef<RoomComposerHandle | null>(null);
+      const [value, setValue] = useState("");
+      return (
+        <>
+          <button type="button" onClick={() => composerRef.current?.focus()}>
+            focus-composer
+          </button>
+          <RoomComposer
+            ref={composerRef}
+            value={value}
+            onValueChange={setValue}
+            mentions={{}}
+            onSelectedKeysChange={() => undefined}
+            placeholder="Message"
+            attachments={[]}
+            onAttachmentsChange={() => undefined}
+            onSubmit={(event) => event.preventDefault()}
+            isSending={false}
+            sendDisabled={false}
+            showMentionShortcut={false}
+            allowAttachments={false}
+          />
+        </>
+      );
+    }
+
+    const { getByRole } = render(<Harness />);
+    await waitFor(() => {
+      expect(getByRole("textbox")).toBeInTheDocument();
+    });
+
+    getByRole("button", { name: "focus-composer" }).click();
+    expect(editorFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("still exposes attachFiles on the handle", async () => {
+    function Probe() {
+      const composerRef = useRef<RoomComposerHandle | null>(null);
+      const [value, setValue] = useState("");
+      const [ready, setReady] = useState(false);
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setReady(
+                typeof composerRef.current?.attachFiles === "function" &&
+                  typeof composerRef.current?.focus === "function",
+              );
+            }}
+          >
+            probe
+          </button>
+          <span data-testid="ready">{ready ? "yes" : "no"}</span>
+          <RoomComposer
+            ref={composerRef}
+            value={value}
+            onValueChange={setValue}
+            mentions={{}}
+            onSelectedKeysChange={() => undefined}
+            placeholder="Message"
+            attachments={[]}
+            onAttachmentsChange={() => undefined}
+            onSubmit={(event) => event.preventDefault()}
+            isSending={false}
+            sendDisabled={false}
+            showMentionShortcut={false}
+            allowAttachments={false}
+          />
+        </>
+      );
+    }
+
+    const { getByRole, getByTestId } = render(<Probe />);
+    await waitFor(() => {
+      expect(getByRole("textbox")).toBeInTheDocument();
+    });
+    getByRole("button", { name: "probe" }).click();
+    await waitFor(() => {
+      expect(getByTestId("ready").textContent).toBe("yes");
+    });
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-focus.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-focus.test.tsx
@@ -1,0 +1,183 @@
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { type ReactNode, type Ref, useImperativeHandle } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import type { RoomComposerHandle } from "../room-composer";
+import type { PendingRoomQuote } from "../room-helpers";
+import { ThreadPanel } from "../thread-panel";
+
+const composerFocus = vi.hoisted(() => vi.fn());
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "Thread.replyCount" && values) {
+      return `replies:${values.count}`;
+    }
+    return key;
+  },
+}));
+
+vi.mock("../room-file-drop-zone", () => ({
+  RoomFileDropZone: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../room-session-composer", () => ({
+  RoomSessionComposer: ({ ref }: { ref?: Ref<RoomComposerHandle> }) => {
+    useImperativeHandle(ref, () => ({
+      attachFiles: () => undefined,
+      focus: () => {
+        composerFocus();
+      },
+    }));
+    return <div data-testid="thread-composer" />;
+  },
+}));
+
+vi.mock("../room-message-row", () => ({
+  ChatMessageRow: ({
+    message,
+    onQuote,
+  }: {
+    message: ChatRoomMessage;
+    onQuote?: (message: ChatRoomMessage) => void;
+  }) => (
+    <button type="button" onClick={() => onQuote?.(message)}>
+      {`quote-${message.id}`}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+function parentMessage(
+  overrides: Partial<ChatRoomMessage> = {},
+): ChatRoomMessage {
+  return {
+    id: "parent-1",
+    roomId: "room-1",
+    parentMessageId: null,
+    content: "Parent",
+    createdAt: new Date("2026-07-01T14:35:00.000Z"),
+    editedAt: null,
+    deletedAt: null,
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 1,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function renderThreadPanel(
+  overrides: {
+    onQuote?: (message: ChatRoomMessage) => void;
+    onRestorePendingQuote?: (quote: PendingRoomQuote) => void;
+  } = {},
+) {
+  return render(
+    <ThreadPanel
+      parentMessage={parentMessage()}
+      replies={[]}
+      isLoading={false}
+      olderNextCursor={null}
+      isLoadingOlder={false}
+      onLoadOlder={() => undefined}
+      coworkersById={new Map()}
+      coworkersBySlug={new Map()}
+      mentionRecords={{}}
+      draftKey="thread:parent-1"
+      onSendReply={async () => ({ ok: true })}
+      isSendingReply={false}
+      onClose={() => undefined}
+      onToggleReaction={() => undefined}
+      onQuote={overrides.onQuote}
+      onRestorePendingQuote={overrides.onRestorePendingQuote}
+      roomId="room-1"
+    />,
+  );
+}
+
+async function flushAnimationFrame() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+describe("ThreadPanel composer focus", () => {
+  it("focuses the thread composer once after mount via rAF", async () => {
+    composerFocus.mockClear();
+    renderThreadPanel();
+
+    expect(composerFocus).not.toHaveBeenCalled();
+    await flushAnimationFrame();
+    await waitFor(() => {
+      expect(composerFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("calls onQuote and focuses the thread composer after rAF", async () => {
+    composerFocus.mockClear();
+    const onQuote = vi.fn();
+    const { getByRole } = renderThreadPanel({ onQuote });
+
+    await flushAnimationFrame();
+    await waitFor(() => {
+      expect(composerFocus).toHaveBeenCalledTimes(1);
+    });
+    composerFocus.mockClear();
+
+    const message = parentMessage();
+    fireEvent.click(getByRole("button", { name: `quote-${message.id}` }));
+
+    expect(onQuote).toHaveBeenCalledTimes(1);
+    expect(onQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ id: message.id }),
+    );
+    expect(composerFocus).not.toHaveBeenCalled();
+
+    await flushAnimationFrame();
+    expect(composerFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not focus when onRestorePendingQuote runs", async () => {
+    composerFocus.mockClear();
+    const onRestorePendingQuote = vi.fn();
+    renderThreadPanel({ onRestorePendingQuote });
+
+    await flushAnimationFrame();
+    await waitFor(() => {
+      expect(composerFocus).toHaveBeenCalledTimes(1);
+    });
+    composerFocus.mockClear();
+
+    onRestorePendingQuote({
+      messageId: "quoted-1",
+      authorName: "Ada",
+      snippet: "quoted",
+      attachment: null,
+    });
+
+    await flushAnimationFrame();
+    expect(composerFocus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -69,9 +69,10 @@ export interface RoomComposerAttachment extends RoomMessageComposerAttachment {
   mediaType: string | null;
 }
 
-/** Shell drop zones call this to reuse the paperclip upload path. */
+/** Shell drop zones + Quote/Thread callers reuse this surface. */
 export interface RoomComposerHandle {
   attachFiles: (files: FileList | File[] | null) => void;
+  focus: () => void;
 }
 
 function RoomMentionSuggestion({
@@ -394,6 +395,9 @@ export function RoomComposer({
     () => ({
       attachFiles: (files) => {
         void handleFilesSelected(files);
+      },
+      focus: () => {
+        editorRef.current?.focus();
       },
     }),
     [handleFilesSelected],

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1054,6 +1054,9 @@ export function RoomsClient({
 
   function handleQuoteMessage(message: ChatRoomMessage) {
     setPendingQuote(pendingQuoteFromMessage(message));
+    requestAnimationFrame(() => {
+      roomComposerRef.current?.focus();
+    });
   }
 
   function handleQuoteThreadMessage(message: ChatRoomMessage) {

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -6,6 +6,7 @@ import { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import type {
   ChatRoomCoworkerParticipant,
   ChatRoomMessage,
@@ -105,6 +106,19 @@ export function ThreadPanel({
   const threadComposerRef = useRef<RoomComposerHandle | null>(null);
   const threadBottomRef = useRef<HTMLDivElement | null>(null);
 
+  useMountEffect(() => {
+    requestAnimationFrame(() => {
+      threadComposerRef.current?.focus();
+    });
+  });
+
+  function handleQuote(message: ChatRoomMessage) {
+    onQuote?.(message);
+    requestAnimationFrame(() => {
+      threadComposerRef.current?.focus();
+    });
+  }
+
   function editPropsFor(messageId: string) {
     const isEditing = editSession?.messageId === messageId;
     return {
@@ -169,7 +183,7 @@ export function ThreadPanel({
               onOpenDirectMessage={onOpenDirectMessage}
               openingDirectParticipantKey={openingDirectParticipantKey}
               onToggleReaction={onToggleReaction}
-              onQuote={onQuote}
+              onQuote={onQuote ? handleQuote : undefined}
               showThreadButton={false}
               {...editPropsFor(parentMessage.id)}
             />
@@ -217,7 +231,7 @@ export function ThreadPanel({
                           openingDirectParticipantKey
                         }
                         onToggleReaction={onToggleReaction}
-                        onQuote={onQuote}
+                        onQuote={onQuote ? handleQuote : undefined}
                         showThreadButton={false}
                         isContinuation={isMessageContinuation(
                           replies[index - 1],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Quote a message or open a thread, and the matching composer takes keyboard focus so you can type immediately.

## How

- `RoomComposerHandle.focus()` forwards to the wysiwyg editor (same imperative surface as `attachFiles`)
- Main-room Quote: `requestAnimationFrame` → `roomComposerRef.focus()`
- Open Thread: `ThreadPanel` `useMountEffect` focuses the thread composer once
- Quote in an open thread: panel wraps `onQuote` and focuses after the parent setter

## Verify

```bash
pnpm --filter web test 'src/app/(app)/chat/components/__tests__/room-composer-focus.test.tsx' 'src/app/(app)/chat/components/__tests__/thread-panel-focus.test.tsx'
```

5/5 passed locally. CI green (Biome, Typecheck, Test Web/Core/Packages, Build).

## Design note

Chose imperative handle over a `focusRequestId` token so Quote stays an event-handler side effect (web effects rule), not state-as-flag for an effect.

No Linear issue with `## Requirement` matched this ask; shipped as a small Feature UX fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b687620f-954d-487f-9aff-d6d161df0af2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b687620f-954d-487f-9aff-d6d161df0af2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

