### PR TITLE
feat(chat): add in-room message search from header

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.test.ts
@@ -159,4 +159,44 @@ describe("GET /chats/rooms/{id}/messages", () => {
     expect(messageFindManyMock).not.toHaveBeenCalled();
     expect(messageCountMock).not.toHaveBeenCalled();
   });
+
+  it("filters by content when q is set and searches all thread depths", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?q=Hello&parentMessageId=${MESSAGE_ID}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(messageFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          roomId: ROOM_ID,
+          deletedAt: null,
+          content: { contains: "Hello", mode: "insensitive" },
+        },
+      }),
+    );
+    expect(listStaleSentChatRoomMentionIdsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects blank q", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?q=%20%20`,
+    );
+
+    expect(response.status).toBe(422);
+    expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("reclaims stale mentions on the timeline path without q", async () => {
+    listStaleSentChatRoomMentionIdsMock.mockResolvedValue([
+      "550e8400-e29b-41d4-a716-446655440099",
+    ]);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(listStaleSentChatRoomMentionIdsMock).toHaveBeenCalledWith(ROOM_ID);
+  });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
@@ -47,8 +47,20 @@ const querySchema = cursorPaginationQuerySchema.extend({
     .openapi({
       param: { name: "parentMessageId", in: "query" },
       description:
-        "When provided, returns replies for this root message. Otherwise returns top-level room messages.",
+        "When provided, returns replies for this root message. Otherwise returns top-level room messages. Ignored when `q` is set.",
       example: "550e8400-e29b-41d4-a716-446655440000",
+    }),
+  q: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .optional()
+    .openapi({
+      param: { name: "q", in: "query" },
+      description:
+        "Case-insensitive substring match on message content. When set, searches top-level and thread replies and excludes soft-deleted messages. `parentMessageId` is ignored.",
+      example: "budget",
     }),
 });
 
@@ -89,10 +101,17 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     // the default client is fine; Promise.all inside interactive txs is not
     // (#2559).
     await requireChatRoomUserMembership(id, userContext.userId, prisma);
-    const where = {
-      roomId: id,
-      parentMessageId: queryParams.parentMessageId ?? null,
-    };
+    const searchQuery = queryParams.q;
+    const where = searchQuery
+      ? {
+          roomId: id,
+          deletedAt: null,
+          content: { contains: searchQuery, mode: "insensitive" as const },
+        }
+      : {
+          roomId: id,
+          parentMessageId: queryParams.parentMessageId ?? null,
+        };
 
     const [messages, count] = await Promise.all([
       prisma.chatRoomMessage.findMany({
@@ -125,10 +144,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const orderedMessages = [...pageMessages].reverse();
 
     // Polls hit this route; kick abandoned `sent` mentions so reclaim can run
-    // after a killed waitUntil left them non-terminal.
-    const staleMentionIds = await listStaleSentChatRoomMentionIds(id);
-    for (const mentionId of staleMentionIds) {
-      waitUntil(dispatchChatRoomMention(mentionId));
+    // after a killed waitUntil left them non-terminal. Skip on search — not a
+    // live timeline poll.
+    if (!searchQuery) {
+      const staleMentionIds = await listStaleSentChatRoomMentionIds(id);
+      for (const mentionId of staleMentionIds) {
+        waitUntil(dispatchChatRoomMention(mentionId));
+      }
     }
 
     return ok(

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "Gruppendirektnachrichten können keine Coworker enthalten.",
         "coworkerDirectOneToOneOnly": "Coworker-Direktnachrichten sind 1:1."
       },
+      "RoomSearch": {
+        "open": "In diesem Chat suchen",
+        "placeholder": "Nachrichten suchen…",
+        "idle": "Tippe, um Nachrichten in diesem Chat zu suchen.",
+        "empty": "Keine Nachrichten passen zu deiner Suche.",
+        "loading": "Suche…",
+        "error": "Nachrichten konnten nicht gesucht werden. Versuch es erneut.",
+        "replyBadge": "Thread-Antwort"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4781,6 +4781,15 @@
         "groupDirectNoCoworkersError": "Group direct messages cannot include coworkers.",
         "coworkerDirectOneToOneOnly": "Coworker direct messages are 1:1."
       },
+      "RoomSearch": {
+        "open": "Search in this chat",
+        "placeholder": "Search messages…",
+        "idle": "Type to search messages in this chat.",
+        "empty": "No messages match your search.",
+        "loading": "Searching…",
+        "error": "Could not search messages. Try again.",
+        "replyBadge": "Thread reply"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "Los mensajes directos de grupo no pueden incluir coworkers.",
         "coworkerDirectOneToOneOnly": "Los mensajes directos con coworkers son 1:1."
       },
+      "RoomSearch": {
+        "open": "Buscar en este chat",
+        "placeholder": "Buscar mensajes…",
+        "idle": "Escribe para buscar mensajes en este chat.",
+        "empty": "Ningún mensaje coincide con tu búsqueda.",
+        "loading": "Buscando…",
+        "error": "No se pudieron buscar los mensajes. Inténtalo de nuevo.",
+        "replyBadge": "Respuesta del hilo"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "Les messages directs de groupe ne peuvent pas inclure de coworkers.",
         "coworkerDirectOneToOneOnly": "Les messages directs avec un coworker sont en 1:1."
       },
+      "RoomSearch": {
+        "open": "Rechercher dans ce chat",
+        "placeholder": "Rechercher des messages…",
+        "idle": "Saisissez du texte pour rechercher des messages dans ce chat.",
+        "empty": "Aucun message ne correspond à votre recherche.",
+        "loading": "Recherche…",
+        "error": "Impossible de rechercher les messages. Réessayez.",
+        "replyBadge": "Réponse du fil"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "I messaggi diretti di gruppo non possono includere coworker.",
         "coworkerDirectOneToOneOnly": "I messaggi diretti con coworker sono 1:1."
       },
+      "RoomSearch": {
+        "open": "Cerca in questa chat",
+        "placeholder": "Cerca messaggi…",
+        "idle": "Digita per cercare messaggi in questa chat.",
+        "empty": "Nessun messaggio corrisponde alla ricerca.",
+        "loading": "Ricerca…",
+        "error": "Impossibile cercare i messaggi. Riprova.",
+        "replyBadge": "Risposta del thread"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "グループのダイレクトメッセージにコワーカーは含められません。",
         "coworkerDirectOneToOneOnly": "コワーカーとのダイレクトメッセージは1対1です。"
       },
+      "RoomSearch": {
+        "open": "このチャット内を検索",
+        "placeholder": "メッセージを検索…",
+        "idle": "入力してこのチャット内のメッセージを検索します。",
+        "empty": "一致するメッセージはありません。",
+        "loading": "検索中…",
+        "error": "メッセージを検索できませんでした。もう一度お試しください。",
+        "replyBadge": "スレッド返信"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "Mensagens diretas em grupo não podem incluir coworkers.",
         "coworkerDirectOneToOneOnly": "Mensagens diretas com coworkers são 1:1."
       },
+      "RoomSearch": {
+        "open": "Pesquisar neste chat",
+        "placeholder": "Pesquisar mensagens…",
+        "idle": "Digite para pesquisar mensagens neste chat.",
+        "empty": "Nenhuma mensagem corresponde à sua pesquisa.",
+        "loading": "Pesquisando…",
+        "error": "Não foi possível pesquisar as mensagens. Tente novamente.",
+        "replyBadge": "Resposta do tópico"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "As mensagens diretas de grupo não podem incluir coworkers.",
         "coworkerDirectOneToOneOnly": "As mensagens diretas com coworkers são 1:1."
       },
+      "RoomSearch": {
+        "open": "Pesquisar neste chat",
+        "placeholder": "Pesquisar mensagens…",
+        "idle": "Escreva para pesquisar mensagens neste chat.",
+        "empty": "Nenhuma mensagem corresponde à pesquisa.",
+        "loading": "A pesquisar…",
+        "error": "Não foi possível pesquisar as mensagens. Tente novamente.",
+        "replyBadge": "Resposta do tópico"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4662,6 +4662,15 @@
         "groupDirectNoCoworkersError": "群组私信不能包含同事。",
         "coworkerDirectOneToOneOnly": "与同事的私信仅支持一对一。"
       },
+      "RoomSearch": {
+        "open": "在此聊天中搜索",
+        "placeholder": "搜索消息…",
+        "idle": "输入以搜索此聊天中的消息。",
+        "empty": "没有匹配的消息。",
+        "loading": "正在搜索…",
+        "error": "无法搜索消息。请重试。",
+        "replyBadge": "帖子回复"
+      },
       "Toolbar": {
         "mention": "Mention coworker",
         "attach": "Attach file",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-search-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-search-panel.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RoomSearchPanel } from "@/app/chat/components/room-search-panel";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+const getChatRoomMessagesMock = vi.fn();
+const scrollToRoomMessageElementMock = vi.fn((_messageId: string) => true);
+
+vi.mock("@/lib/clients/core.browser.client", () => ({
+  coreClient: {
+    getChatRoomMessages: (...args: unknown[]) =>
+      getChatRoomMessagesMock(...args),
+  },
+}));
+
+vi.mock("@/app/chat/components/room-helpers", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/app/chat/components/room-helpers")
+  >("@/app/chat/components/room-helpers");
+  return {
+    ...actual,
+    scrollToRoomMessageElement: (messageId: string) =>
+      scrollToRoomMessageElementMock(messageId),
+  };
+});
+
+vi.mock("@/lib/utils/datetime.client", () => ({
+  useLocalizedDateTime: () => ({
+    formatTimeAgo: () => "1m ago",
+  }),
+}));
+
+const labels = {
+  open: "Search in this chat",
+  placeholder: "Search messages…",
+  idle: "Type to search",
+  empty: "No matches",
+  loading: "Searching…",
+  error: "Search failed",
+  replyBadge: "Thread reply",
+};
+
+function message(overrides: Partial<ChatRoomMessage> = {}): ChatRoomMessage {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    roomId: "550e8400-e29b-41d4-a716-446655440000",
+    parentMessageId: null,
+    content: "Hello budget review",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    editedAt: null,
+    deletedAt: null,
+    metadata: null,
+    replyCount: 0,
+    sender: {
+      type: "user",
+      user: {
+        id: "user_1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+      },
+    },
+    reactions: [],
+    ...overrides,
+  } as ChatRoomMessage;
+}
+
+describe("RoomSearchPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getChatRoomMessagesMock.mockResolvedValue({ data: [message()] });
+  });
+
+  it("opens search surface from the header control", async () => {
+    render(
+      <RoomSearchPanel
+        roomId="550e8400-e29b-41d4-a716-446655440000"
+        labels={labels}
+        loadedMessages={[]}
+        onOpenThread={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("room-search-trigger"));
+    expect(screen.getByTestId("room-search-panel")).toBeInTheDocument();
+    expect(screen.getByText(labels.idle)).toBeInTheDocument();
+  });
+
+  it("shows results after a debounced query", async () => {
+    render(
+      <RoomSearchPanel
+        roomId="550e8400-e29b-41d4-a716-446655440000"
+        labels={labels}
+        loadedMessages={[]}
+        onOpenThread={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("room-search-trigger"));
+    fireEvent.change(screen.getByTestId("room-search-input"), {
+      target: { value: "budget" },
+    });
+
+    await waitFor(() => {
+      expect(getChatRoomMessagesMock).toHaveBeenCalledWith(
+        "550e8400-e29b-41d4-a716-446655440000",
+        expect.objectContaining({ q: "budget", limit: 50 }),
+      );
+    });
+
+    expect(await screen.findByTestId("room-search-result")).toHaveTextContent(
+      "Hello budget review",
+    );
+  });
+
+  it("shows empty state when there are no matches", async () => {
+    getChatRoomMessagesMock.mockResolvedValue({ data: [] });
+
+    render(
+      <RoomSearchPanel
+        roomId="550e8400-e29b-41d4-a716-446655440000"
+        labels={labels}
+        loadedMessages={[]}
+        onOpenThread={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("room-search-trigger"));
+    fireEvent.change(screen.getByTestId("room-search-input"), {
+      target: { value: "zzzz" },
+    });
+
+    expect(await screen.findByTestId("room-search-empty")).toHaveTextContent(
+      labels.empty,
+    );
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { Loader2, Search } from "lucide-react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+import {
+  messageSender,
+  scrollToRoomMessageElement,
+} from "@/app/chat/components/room-helpers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { coreClient } from "@/lib/clients/core.browser.client";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+import { cn } from "@/lib/utils";
+import { useLocalizedDateTime } from "@/lib/utils/datetime.client";
+
+const SEARCH_PAGE_SIZE = 50;
+const SEARCH_DEBOUNCE_MS = 250;
+const HIGHLIGHT_MS = 1500;
+const HIGHLIGHT_CLASS = "bg-accent/50";
+
+export interface RoomSearchPanelLabels {
+  open: string;
+  placeholder: string;
+  idle: string;
+  empty: string;
+  loading: string;
+  error: string;
+  replyBadge: string;
+}
+
+interface RoomSearchPanelProps {
+  roomId: string;
+  labels: RoomSearchPanelLabels;
+  loadedMessages: ChatRoomMessage[];
+  onOpenThread: (parent: ChatRoomMessage) => void;
+}
+
+function highlightRoomMessageElement(messageId: string): boolean {
+  if (!scrollToRoomMessageElement(messageId)) {
+    return false;
+  }
+  const target = document.querySelector<HTMLElement>(
+    `[data-message-id="${CSS.escape(messageId)}"]`,
+  );
+  if (!target) {
+    return false;
+  }
+  target.classList.add(HIGHLIGHT_CLASS);
+  window.setTimeout(() => {
+    target.classList.remove(HIGHLIGHT_CLASS);
+  }, HIGHLIGHT_MS);
+  return true;
+}
+
+export function RoomSearchPanel({
+  roomId,
+  labels,
+  loadedMessages,
+  onOpenThread,
+}: RoomSearchPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [results, setResults] = useState<ChatRoomMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const requestIdRef = useRef(0);
+  const { formatTimeAgo } = useLocalizedDateTime();
+
+  const searchMessages = useEffectEvent(async (searchQuery: string) => {
+    const requestId = ++requestIdRef.current;
+    if (!searchQuery) {
+      setResults([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await coreClient.getChatRoomMessages(roomId, {
+        q: searchQuery,
+        limit: SEARCH_PAGE_SIZE,
+      });
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setResults(response.data);
+    } catch {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setResults([]);
+      setError(labels.error);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  });
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedQuery(query.trim());
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    void searchMessages(debouncedQuery);
+  }, [debouncedQuery, open, roomId]);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setQuery("");
+      setDebouncedQuery("");
+      setResults([]);
+      setError(null);
+      setIsLoading(false);
+      requestIdRef.current += 1;
+    }
+    setOpen(nextOpen);
+  }
+
+  function handleSelect(hit: ChatRoomMessage) {
+    if (hit.parentMessageId) {
+      const parent = loadedMessages.find(
+        (message) => message.id === hit.parentMessageId,
+      );
+      if (parent) {
+        onOpenThread(parent);
+        window.setTimeout(() => {
+          highlightRoomMessageElement(hit.id);
+        }, 0);
+        handleOpenChange(false);
+        return;
+      }
+    }
+
+    highlightRoomMessageElement(hit.id);
+    handleOpenChange(false);
+  }
+
+  const showIdle = !debouncedQuery && !isLoading && !error;
+  const showEmpty =
+    Boolean(debouncedQuery) && !isLoading && !error && results.length === 0;
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={labels.open}
+          data-testid="room-search-trigger"
+        >
+          <Search className="size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-[min(100vw-2rem,24rem)] p-0"
+        data-testid="room-search-panel"
+      >
+        <div className="border-b p-2">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={labels.placeholder}
+            aria-label={labels.placeholder}
+            data-testid="room-search-input"
+            autoFocus
+          />
+        </div>
+        <div className="max-h-80 overflow-y-auto p-1">
+          {isLoading && results.length === 0 ? (
+            <div className="text-muted-foreground flex items-center justify-center gap-2 px-2 py-6 text-sm">
+              <Loader2 className="size-4 animate-spin" />
+              {labels.loading}
+            </div>
+          ) : null}
+          {!isLoading && error ? (
+            <p className="text-muted-foreground px-2 py-6 text-center text-sm">
+              {error}
+            </p>
+          ) : null}
+          {showIdle ? (
+            <p className="text-muted-foreground px-2 py-6 text-center text-sm">
+              {labels.idle}
+            </p>
+          ) : null}
+          {showEmpty ? (
+            <p
+              className="text-muted-foreground px-2 py-6 text-center text-sm"
+              data-testid="room-search-empty"
+            >
+              {labels.empty}
+            </p>
+          ) : null}
+          {results.map((message) => {
+            const sender = messageSender(message);
+            const isReply = message.parentMessageId != null;
+            return (
+              <button
+                key={message.id}
+                type="button"
+                className={cn(
+                  "hover:bg-accent flex w-full flex-col gap-0.5 rounded-md px-2 py-2 text-left text-sm",
+                )}
+                onClick={() => handleSelect(message)}
+                data-testid="room-search-result"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="truncate font-medium">{sender.name}</span>
+                  {isReply ? (
+                    <span className="text-muted-foreground shrink-0 text-xs">
+                      {labels.replyBadge}
+                    </span>
+                  ) : null}
+                  <span className="text-muted-foreground ml-auto shrink-0 text-xs">
+                    {formatTimeAgo(new Date(message.createdAt))}
+                  </span>
+                </div>
+                <p className="text-muted-foreground line-clamp-2 text-xs">
+                  {message.content}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -21,6 +21,7 @@ import {
   toggleMessageReactionAction,
 } from "@/app/chat/actions";
 import DaySeparator from "@/app/chat/components/day-separator";
+import { RoomSearchPanel } from "@/app/chat/components/room-search-panel";
 import {
   readStoredStreamParentMessageId,
   useCoworkerDirectRoomStream,
@@ -1240,6 +1241,21 @@ export function RoomsClient({
                   </p>
                 </div>
                 <div className="flex shrink-0 items-center gap-1.5 md:gap-2">
+                  <RoomSearchPanel
+                    key={selectedRoom.id}
+                    roomId={selectedRoom.id}
+                    loadedMessages={messagesState}
+                    onOpenThread={loadThreadMessages}
+                    labels={{
+                      open: t("RoomSearch.open"),
+                      placeholder: t("RoomSearch.placeholder"),
+                      idle: t("RoomSearch.idle"),
+                      empty: t("RoomSearch.empty"),
+                      loading: t("RoomSearch.loading"),
+                      error: t("RoomSearch.error"),
+                      replyBadge: t("RoomSearch.replyBadge"),
+                    }}
+                  />
                   <RoomParticipantStack
                     room={selectedRoom}
                     currentUserId={currentUserId}

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -4279,7 +4279,7 @@ export const ChatRoomSchema = {
             ],
             format: 'date-time',
             example: '2026-08-03T12:00:00.000Z',
-            description: 'When the current user muted this room in their sidebar. Null when unmuted.'
+            description: 'When the current user muted this room. Null when unmuted. Muted rooms sort last, hide sidebar attention chrome, and skip CHAT mention notifications.'
         },
         markedUnread: {
             type: 'boolean',

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -501,7 +501,7 @@ export const deleteChatsRoomsByIdPin = <ThrowOnError extends boolean = false>(op
 });
 
 /**
- * Pin an organization chat room for the current user.
+ * Pin an organization chat room for the current user. Cannot pin a muted room.
  */
 export const postChatsRoomsByIdPin = <ThrowOnError extends boolean = false>(options: Options<PostChatsRoomsByIdPinData, ThrowOnError>): RequestResult<PostChatsRoomsByIdPinResponses, PostChatsRoomsByIdPinErrors, ThrowOnError> => (options.client ?? client).post<PostChatsRoomsByIdPinResponses, PostChatsRoomsByIdPinErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsByIdPinResponseTransformer,
@@ -519,7 +519,7 @@ export const deleteChatsRoomsByIdMute = <ThrowOnError extends boolean = false>(o
 });
 
 /**
- * Mute an organization chat room for the current user.
+ * Mute an organization chat room for the current user. Cannot mute a pinned room.
  */
 export const postChatsRoomsByIdMute = <ThrowOnError extends boolean = false>(options: Options<PostChatsRoomsByIdMuteData, ThrowOnError>): RequestResult<PostChatsRoomsByIdMuteResponses, PostChatsRoomsByIdMuteErrors, ThrowOnError> => (options.client ?? client).post<PostChatsRoomsByIdMuteResponses, PostChatsRoomsByIdMuteErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsByIdMuteResponseTransformer,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1177,7 +1177,7 @@ export type ChatRoom = {
      */
     pinnedAt: Date | null;
     /**
-     * When the current user muted this room in their sidebar. Null when unmuted.
+     * When the current user muted this room. Null when unmuted. Muted rooms sort last, hide sidebar attention chrome, and skip CHAT mention notifications.
      */
     mutedAt: Date | null;
     /**
@@ -10271,6 +10271,20 @@ export type PostChatsRoomsByIdPinErrors = {
         };
     };
     /**
+     * Unprocessable Entity
+     */
+    422: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
      * Internal Server Error
      */
     500: {
@@ -10455,6 +10469,20 @@ export type PostChatsRoomsByIdMuteErrors = {
         };
     };
     /**
+     * Unprocessable Entity
+     */
+    422: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
      * Internal Server Error
      */
     500: {
@@ -10509,9 +10537,13 @@ export type GetChatsRoomsByIdMessagesData = {
          */
         limit?: number;
         /**
-         * When provided, returns replies for this root message. Otherwise returns top-level room messages.
+         * When provided, returns replies for this root message. Otherwise returns top-level room messages. Ignored when `q` is set.
          */
         parentMessageId?: string;
+        /**
+         * Case-insensitive substring match on message content. When set, searches top-level and thread replies and excludes soft-deleted messages. `parentMessageId` is ignored.
+         */
+        q?: string;
     };
     url: '/chats/rooms/{id}/messages';
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds in-room message search from the chat room header (magnifying-glass control). Members can find messages in the open channel or DM without scrolling the whole timeline.

## What changed

- **Core:** optional `q` on `GET /v1/chats/rooms/{id}/messages` — case-insensitive `content` contains, all thread depths, excludes soft-deleted; skips stale-mention reclaim on search requests
- **Web:** Search icon in the selected-room header opens a popover; debounced browser Core client call; click scrolls/highlights loaded hits or opens a thread when the parent is loaded
- Regenerated Core API client; i18n keys in all locale catalogs

## Out of scope

- Global search (SOK-515)
- Jump into unloaded history (`aroundMessageId`)
- Full-text ranking

## Verification

- `pnpm --filter core test 'src/routes/v1/chats/rooms/[id]/messages/get.test.ts'`
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-search-panel.test.tsx`
- CI green on draft PR

## Design notes

Chose extending the existing messages list with `q` (header Popover) over a dedicated `/messages/search` + CommandDialog. Keeps one pagination DTO and a lighter in-room surface.

No matching Linear `## Requirement` issue was found (SOK-515 is global search only). Shipped under Feature playbook from the product ask.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-283f7549-6e01-4088-9b2c-7f3facfc8f10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-283f7549-6e01-4088-9b2c-7f3facfc8f10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

