### PR TITLE
fix(chat): clear wysiwyg composer when parent value empties

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-session-composer.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-session-composer.test.tsx
@@ -1,0 +1,202 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  composeDraftKey,
+  getComposeDraft,
+  setComposeDraft,
+} from "@/app/chat/utils/compose-draft-storage";
+
+import { RoomSessionComposer } from "../room-session-composer";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/components/markdown", () => ({
+  default: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/utils/compose-upload.client", () => ({
+  uploadComposeAttachments: vi.fn(),
+}));
+
+describe("RoomSessionComposer draft clear on send", () => {
+  const roomId = "room-draft-clear";
+  const draftKey = composeDraftKey.room(roomId);
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("clears composer value and localStorage draft after successful send", async () => {
+    setComposeDraft(draftKey, {
+      text: "typing indicators please",
+      attachments: [],
+    });
+
+    const onSend = vi.fn().mockResolvedValue({ ok: true });
+
+    render(
+      <RoomSessionComposer
+        roomId={roomId}
+        draftKey={draftKey}
+        mentions={{}}
+        placeholder="Message"
+        pendingQuote={null}
+        isSending={false}
+        onSend={onSend}
+      />,
+    );
+
+    const editor = await screen.findByRole("textbox");
+    await waitFor(() => {
+      expect(editor.textContent).toContain("typing indicators please");
+    });
+
+    const form = editor.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(editor.textContent ?? "").toBe("");
+    });
+    expect(getComposeDraft(draftKey)).toBeNull();
+    expect(window.localStorage.getItem(draftKey)).toBeNull();
+  });
+
+  it("does not leave draft in localStorage when send succeeds after typing", async () => {
+    const onSend = vi.fn().mockResolvedValue({ ok: true });
+
+    render(
+      <RoomSessionComposer
+        roomId={roomId}
+        draftKey={draftKey}
+        mentions={{}}
+        placeholder="Message"
+        pendingQuote={null}
+        isSending={false}
+        onSend={onSend}
+      />,
+    );
+
+    const editor = await screen.findByRole("textbox");
+    await act(async () => {
+      editor.focus();
+      editor.innerHTML = "typing indicators please";
+      fireEvent.input(editor);
+    });
+
+    await waitFor(() => {
+      expect(editor.textContent).toContain("typing indicators please");
+    });
+
+    const form = editor.closest("form");
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(editor.textContent ?? "").toBe("");
+      expect(getComposeDraft(draftKey)).toBeNull();
+    });
+  });
+
+  it("restores composer when send fails", async () => {
+    const onSend = vi.fn().mockResolvedValue({
+      ok: false,
+      message: "failed",
+    });
+
+    render(
+      <RoomSessionComposer
+        roomId={roomId}
+        draftKey={draftKey}
+        mentions={{}}
+        placeholder="Message"
+        pendingQuote={null}
+        isSending={false}
+        onSend={onSend}
+      />,
+    );
+
+    const editor = await screen.findByRole("textbox");
+    await act(async () => {
+      editor.focus();
+      editor.innerHTML = "typing indicators please";
+      fireEvent.input(editor);
+    });
+
+    fireEvent.submit(editor.closest("form")!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(editor.textContent).toContain("typing indicators please");
+    });
+  });
+
+  it("clears editor when submit lands in the same act as the last input", async () => {
+    setComposeDraft(draftKey, {
+      text: "typing indicators please",
+      attachments: [],
+    });
+    const onSend = vi.fn().mockResolvedValue({ ok: true });
+
+    render(
+      <RoomSessionComposer
+        roomId={roomId}
+        draftKey={draftKey}
+        mentions={{}}
+        placeholder="Message"
+        pendingQuote={null}
+        isSending={false}
+        onSend={onSend}
+      />,
+    );
+
+    const editor = await screen.findByRole("textbox");
+    await waitFor(() => {
+      expect(editor.textContent).toContain("typing indicators please");
+    });
+    const form = editor.closest("form");
+    expect(form).not.toBeNull();
+
+    await act(async () => {
+      editor.focus();
+      fireEvent.input(editor);
+      fireEvent.submit(form!);
+    });
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(editor.textContent ?? "").toBe("");
+    });
+    expect(getComposeDraft(draftKey)).toBeNull();
+  });
+});

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-compose-draft.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-compose-draft.test.tsx
@@ -1,0 +1,153 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  composeDraftKey,
+  getComposeDraft,
+  setComposeDraft,
+} from "@/app/chat/utils/compose-draft-storage";
+
+import { usePersistComposeDraft } from "../use-compose-draft";
+
+describe("usePersistComposeDraft", () => {
+  const key = composeDraftKey.room("room-clear-test");
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  it("clears persisted draft and does not rewrite it after clearDraft", () => {
+    setComposeDraft(key, { text: "about to send", attachments: [] });
+
+    let hydratedText = "";
+    const { result, rerender, unmount } = renderHook(
+      ({ draft }) =>
+        usePersistComposeDraft({
+          key,
+          draft,
+          onHydrate: (next) => {
+            hydratedText = next.text;
+          },
+          debounceMs: 300,
+        }),
+      {
+        initialProps: {
+          draft: { text: "about to send", attachments: [] as [] },
+        },
+      },
+    );
+
+    expect(hydratedText).toBe("about to send");
+
+    act(() => {
+      result.current.clearDraft();
+    });
+
+    rerender({ draft: { text: "", attachments: [] } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(getComposeDraft(key)).toBeNull();
+    expect(window.localStorage.getItem(key)).toBeNull();
+
+    unmount();
+    expect(getComposeDraft(key)).toBeNull();
+  });
+
+  it("does not flush a pending typed draft after clearDraft on unmount", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ draft }) =>
+        usePersistComposeDraft({
+          key,
+          draft,
+          onHydrate: () => {},
+          debounceMs: 300,
+        }),
+      {
+        initialProps: {
+          draft: { text: "", attachments: [] as [] },
+        },
+      },
+    );
+
+    rerender({ draft: { text: "typing indicators please", attachments: [] } });
+
+    act(() => {
+      result.current.clearDraft();
+    });
+
+    rerender({ draft: { text: "", attachments: [] } });
+    unmount();
+
+    expect(getComposeDraft(key)).toBeNull();
+    expect(window.localStorage.getItem(key)).toBeNull();
+  });
+
+  it("persists typed draft after debounce when not cleared", () => {
+    const { rerender } = renderHook(
+      ({ draft }) =>
+        usePersistComposeDraft({
+          key,
+          draft,
+          onHydrate: () => {},
+          debounceMs: 300,
+        }),
+      {
+        initialProps: {
+          draft: { text: "", attachments: [] as [] },
+        },
+      },
+    );
+
+    // Skip the mount hydrate persist-skip, then type.
+    rerender({ draft: { text: "", attachments: [] } });
+    rerender({ draft: { text: "keep me", attachments: [] } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(getComposeDraft(key)?.text).toBe("keep me");
+  });
+
+  it("flushPending after navigate must not resurrect a cleared draft", () => {
+    const keyA = composeDraftKey.room("room-a");
+    const keyB = composeDraftKey.room("room-b");
+
+    const { result, rerender, unmount } = renderHook(
+      ({ draft, draftKey }) =>
+        usePersistComposeDraft({
+          key: draftKey,
+          draft,
+          onHydrate: () => {},
+          debounceMs: 300,
+        }),
+      {
+        initialProps: {
+          draft: { text: "typing indicators please", attachments: [] as [] },
+          draftKey: keyA,
+        },
+      },
+    );
+
+    act(() => {
+      result.current.clearDraft();
+    });
+    rerender({
+      draft: { text: "", attachments: [] },
+      draftKey: keyB,
+    });
+    unmount();
+
+    expect(getComposeDraft(keyA)).toBeNull();
+    expect(window.localStorage.getItem(keyA)).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useRef, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -110,5 +110,129 @@ describe("ComposerWysiwygEditor", () => {
       metaKey: true,
     });
     expect(onLinkShortcut).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears editor DOM when parent value is cleared while focused after typing", () => {
+    function Harness() {
+      const [value, setValue] = useState("typing indicators please");
+      return (
+        <>
+          <button type="button" onClick={() => setValue("")}>
+            clear
+          </button>
+          <ComposerWysiwygEditor
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    expect(editor).toHaveFocus();
+    expect(editor.textContent).toContain("typing indicators please");
+
+    fireEvent.click(screen.getByRole("button", { name: "clear" }));
+
+    expect(editor.textContent ?? "").toBe("");
+  });
+
+  it("clears editor DOM after internal input then external clear in the same focused session", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <>
+          <button type="button" onClick={() => setValue("")}>
+            clear
+          </button>
+          <ComposerWysiwygEditor
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.innerHTML = "typing indicators please";
+    fireEvent.input(editor);
+    expect(editor.textContent).toContain("typing indicators please");
+
+    fireEvent.click(screen.getByRole("button", { name: "clear" }));
+
+    expect(editor.textContent ?? "").toBe("");
+  });
+
+  it("clears editor when parent clears in the same act as an internal input", () => {
+    function Harness() {
+      const [value, setValue] = useState("typing indicators please");
+      return (
+        <>
+          <button type="button" onClick={() => setValue("")}>
+            clear-only
+          </button>
+          <ComposerWysiwygEditor
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    expect(editor.textContent).toContain("typing indicators please");
+
+    // Internal input marks isInternalChange; clear in the same act before the
+    // value-sync effect can reset that flag. Value must change (text → "") so
+    // React commits and the sync effect runs.
+    act(() => {
+      fireEvent.input(editor);
+      fireEvent.click(screen.getByRole("button", { name: "clear-only" }));
+    });
+
+    expect(editor.textContent ?? "").toBe("");
+  });
+
+  it("restores editor text while focused after an external clear", () => {
+    function Harness() {
+      const [value, setValue] = useState("typing indicators please");
+      return (
+        <>
+          <button type="button" onClick={() => setValue("")}>
+            clear
+          </button>
+          <button
+            type="button"
+            onClick={() => setValue("typing indicators please")}
+          >
+            restore
+          </button>
+          <ComposerWysiwygEditor
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+
+    fireEvent.click(screen.getByRole("button", { name: "clear" }));
+    expect(editor.textContent ?? "").toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: "restore" }));
+    expect(editor.textContent).toContain("typing indicators please");
   });
 });

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -354,15 +354,36 @@ export function ComposerWysiwygEditor<TData = unknown>({
   }, []);
 
   useEffect(() => {
-    if (editorRef.current && !isInternalChange.current) {
-      const currentHtml = editorRef.current.innerHTML;
-      const newHtml = markdownToHtml(value, resolveMentionDisplay);
-      const isFocused = editorRef.current.contains(document.activeElement);
-      const isExternalClear = value.trim().length === 0;
+    const editor = editorRef.current;
+    if (!editor) {
+      isInternalChange.current = false;
+      return;
+    }
 
-      if (currentHtml !== newHtml && (!isFocused || isExternalClear)) {
-        editorRef.current.innerHTML = newHtml || "";
-      }
+    const isExternalClear = value.trim().length === 0;
+    // Clears must win over isInternalChange: a same-turn clear after input
+    // otherwise leaves stale DOM because this effect will not re-run for "".
+    if (isInternalChange.current && !isExternalClear) {
+      isInternalChange.current = false;
+      return;
+    }
+
+    const currentHtml = editor.innerHTML;
+    const newHtml = markdownToHtml(value, resolveMentionDisplay);
+    const isFocused = editor.contains(document.activeElement);
+    const editorLooksEmpty =
+      currentHtml === "" ||
+      currentHtml === "<br>" ||
+      currentHtml === "<div><br></div>" ||
+      currentHtml === "<p><br></p>";
+
+    // Focused non-clear updates skip to keep the caret; still apply into an
+    // empty editor (restore after failed send cleared DOM first).
+    if (
+      currentHtml !== newHtml &&
+      (!isFocused || isExternalClear || editorLooksEmpty)
+    ) {
+      editor.innerHTML = newHtml || "";
     }
     isInternalChange.current = false;
   }, [value, resolveMentionDisplay]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Composer draft text stayed visible after a successful send. Root cause was in `ComposerWysiwygEditor`: the value-sync effect skipped DOM updates while `isInternalChange` was true, so a same-turn clear after input left stale contentEditable text.

## Fix

- Always apply external clears (empty parent value), even when `isInternalChange` is set
- Also apply focused restores into an empty editor (failed-send restore path)

## Test plan

- [x] `pnpm --filter web exec vitest run src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx`
- [x] Related compose-draft / room-session-composer tests pass
- [ ] Manually: type a message, send, confirm input clears

## Commits

1. `test(chat): reproduce composer draft remaining after send`
2. `fix(chat): clear wysiwyg composer when parent value empties`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a4d65b7-00af-44a2-a41d-0f27e9d406ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a4d65b7-00af-44a2-a41d-0f27e9d406ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

