### PR TITLE
fix(chat): show archived restore as icon-only hover CTA

### DIFF
--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -507,7 +507,10 @@ export function OrganizationChatList({
                 {sortedArchivedChannels.map((room) => {
                   const isRestoring = restoringRoomId === room.id;
                   return (
-                    <SidebarMenuItem key={room.id}>
+                    <SidebarMenuItem
+                      key={room.id}
+                      className="group/room-row relative"
+                    >
                       <div className="text-tertiary-foreground dark:text-muted-foreground flex min-h-auto w-full items-center gap-2 px-3 py-1.5">
                         <Hash
                           className="size-4 shrink-0 opacity-60"
@@ -516,25 +519,31 @@ export function OrganizationChatList({
                         <span className="min-w-0 flex-1 truncate">
                           {room.name}
                         </span>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="group-data-[collapsible=icon]:hidden h-7 shrink-0 gap-1 px-2 text-xs"
-                          disabled={isRestoring || restoringRoomId !== null}
-                          onClick={() => handleRestoreRoom(room)}
-                          aria-label={`${tActions("restore")} ${room.name}`}
-                        >
-                          <RotateCcw
-                            className={cn(
-                              "size-3",
-                              isRestoring && "animate-spin",
-                            )}
-                            aria-hidden
-                          />
-                          {tActions("restore")}
-                        </Button>
+                        <span className="size-7 shrink-0" aria-hidden />
                       </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={cn(
+                          "absolute top-1/2 right-1 z-10 flex size-7 -translate-y-1/2 items-center justify-center",
+                          "group-data-[collapsible=icon]:hidden text-muted-foreground",
+                          isRestoring
+                            ? "opacity-100"
+                            : "opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover/room-row:opacity-100 [@media(hover:hover)]:group-focus-within/room-row:opacity-100",
+                        )}
+                        disabled={isRestoring || restoringRoomId !== null}
+                        onClick={() => handleRestoreRoom(room)}
+                        aria-label={`${tActions("restore")} ${room.name}`}
+                      >
+                        <RotateCcw
+                          className={cn(
+                            "size-3.5",
+                            isRestoring && "animate-spin",
+                          )}
+                          aria-hidden
+                        />
+                      </Button>
                     </SidebarMenuItem>
                   );
                 })}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Archived channel rows in the sidebar no longer show a permanent "Restore" label. The restore control is icon-only, matching live room trailing actions. On hover-capable desktops it appears on row hover/focus; on touch it stays visible.

**Change.** `organization-chat-list.client.tsx` archived row markup only. Restore action/service path unchanged. `aria-label` still uses the restore translation.

**Verify.** Expand Archived in org sidebar → no "Restore" text → hover row on desktop shows rotate icon → click still restores.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2d5cbfc-30d9-40a0-9e79-0a9bafa5485b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d5cbfc-30d9-40a0-9e79-0a9bafa5485b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

