### PR TITLE
fix(chat): show inert image thumb in message quotes

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -373,7 +373,7 @@ describe("ChatMessageRow", () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
-  it("shows quote image attachment as filename chip, not re-embedded image", () => {
+  it("shows quote image attachment as inert thumbnail, not a link", () => {
     renderRow({
       message: userMessage({
         content: "Reply body",
@@ -390,15 +390,21 @@ describe("ChatMessageRow", () => {
       }),
     });
 
-    const chip = screen.getByRole("link", { name: /launch\.png/i });
-    expect(chip).toHaveAttribute("href", "https://blob.example/launch.png");
-    expect(screen.getByText("check this shot")).toBeInTheDocument();
+    const jumpButton = screen.getByRole("button", {
+      name: "Jump to message from Bob",
+    });
+    const thumb = jumpButton.querySelector(
+      'img[src="https://blob.example/launch.png"]',
+    );
+    expect(thumb).toBeInTheDocument();
+    expect(thumb).toHaveAttribute("alt", "");
     expect(
-      screen.queryByRole("img", { name: "launch.png" }),
+      screen.queryByRole("link", { name: /launch\.png/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByText("check this shot")).toBeInTheDocument();
   });
 
-  it("shows quote file attachment as filename chip", () => {
+  it("shows quote file attachment as inert icon thumb, not a link", () => {
     renderRow({
       message: userMessage({
         content: "Reply body",
@@ -415,10 +421,54 @@ describe("ChatMessageRow", () => {
       }),
     });
 
-    expect(screen.getByRole("link", { name: /brief\.pdf/i })).toHaveAttribute(
-      "href",
-      "https://blob.example/brief.pdf",
-    );
+    const jumpButton = screen.getByRole("button", {
+      name: "Jump to message from Bob",
+    });
+    expect(
+      screen.queryByRole("link", { name: /brief\.pdf/i }),
+    ).not.toBeInTheDocument();
+    expect(jumpButton.querySelector("svg")).not.toBeNull();
+    expect(screen.queryByText("brief.pdf")).not.toBeInTheDocument();
+  });
+
+  it("jumps to original message when quote attachment thumb is clicked", async () => {
+    const user = userEvent.setup();
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    const original = document.createElement("article");
+    original.setAttribute("data-message-id", "original-with-thumb");
+    document.body.appendChild(original);
+
+    try {
+      renderRow({
+        message: userMessage({
+          content: "Reply body",
+          quote: {
+            messageId: "original-with-thumb",
+            authorName: "Bob",
+            snippet: "check this shot",
+            attachment: {
+              fileName: "launch.png",
+              url: "https://blob.example/launch.png",
+              mediaKind: "image",
+            },
+          },
+        }),
+      });
+
+      const jumpButton = screen.getByRole("button", {
+        name: "Jump to message from Bob",
+      });
+      const thumb = jumpButton.querySelector(
+        'img[src="https://blob.example/launch.png"]',
+      );
+      expect(thumb).toBeTruthy();
+      await user.click(thumb!);
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      original.remove();
+    }
   });
 
   it("keeps legacy quotes without attachment text-only", () => {

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -111,34 +111,46 @@ function useClampedOverflow(resetKey: string) {
   return { expanded, setExpanded, overflows, contentRef };
 }
 
-function MessageQuoteAttachmentChip({
+function MessageQuoteAttachmentThumb({
   attachment,
 }: {
   attachment: RoomQuoteAttachment;
 }) {
-  const extension =
-    getExtensionFromUrl(attachment.fileName) ||
-    getExtensionFromUrl(attachment.url) ||
-    "file";
+  const thumbClassName =
+    "bg-accent/30 mt-1 size-10 shrink-0 overflow-hidden rounded-xl border";
 
-  return (
-    <a
-      href={attachment.url}
-      target="_blank"
-      rel="noreferrer noopener"
-      className="bg-accent/30 hover:bg-accent/50 text-muted-foreground focus-visible:ring-ring mt-1 inline-flex max-w-full items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs outline-none transition focus-visible:ring-2"
-      onClick={(event) => {
-        event.stopPropagation();
-      }}
-    >
-      <span className="size-3.5 shrink-0" aria-hidden>
-        <FileTypeIcon extension={extension} />
-      </span>
-      <span className="text-foreground truncate font-medium">
-        {attachment.fileName}
-      </span>
-    </a>
-  );
+  switch (attachment.mediaKind) {
+    case "image":
+      return (
+        <div className={thumbClassName} aria-hidden>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={attachment.url}
+            alt=""
+            className="size-full object-cover object-center"
+          />
+        </div>
+      );
+    case "file": {
+      const extension =
+        getExtensionFromUrl(attachment.fileName) ||
+        getExtensionFromUrl(attachment.url) ||
+        "file";
+      return (
+        <div className={thumbClassName} aria-hidden>
+          <div className="text-muted-foreground flex size-full items-center justify-center">
+            <div className="flex size-6 items-center justify-center">
+              <FileTypeIcon extension={extension} />
+            </div>
+          </div>
+        </div>
+      );
+    }
+    default: {
+      const _exhaustive: never = attachment.mediaKind;
+      return _exhaustive;
+    }
+  }
 }
 
 function formatWhoReactedLabel(
@@ -210,10 +222,10 @@ function MessageQuoteBlock({
             </Markdown>
           </div>
         ) : null}
+        {attachment ? (
+          <MessageQuoteAttachmentThumb attachment={attachment} />
+        ) : null}
       </button>
-      {attachment ? (
-        <MessageQuoteAttachmentChip attachment={attachment} />
-      ) : null}
       {expanded || overflows ? (
         <button
           type="button"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Quote attachments used to render as a separate download link (filename chip) outside the jump control. That stole clicks from “go to original message.”

**For chat readers:** image quotes now show a small thumbnail. File quotes show a small icon tile. Neither has its own action. Clicking the quote (including the thumb) always jumps to the original message.

**Change:** replace `MessageQuoteAttachmentChip` with inert `MessageQuoteAttachmentThumb` inside the jump button, branched on `mediaKind`.

**Verify:** `pnpm --filter web test 'src/app/(app)/chat/components/__tests__/room-message-row.test.tsx'` (31 passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0190bd33-f332-4c91-9707-eeed0181e056?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0190bd33-f332-4c91-9707-eeed0181e056&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

