### PR TITLE
feat(chat): add leave option to channel sidebar menu

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4564,7 +4564,7 @@
         "archive": "Kanal archivieren",
         "cancel": "Abbrechen",
         "leaveConfirmTitle": "{name} verlassen?",
-        "leaveConfirmDescription": "Du erhältst keine Nachrichten mehr aus diesem Kanal und er verschwindet aus deiner Liste. Andere Mitglieder behalten ihren Zugriff und du kannst später wieder hinzugefügt werden.",
+        "leaveConfirmDescription": "Du erhältst keine Nachrichten mehr aus diesem Kanal und er verschwindet aus deiner Liste.",
         "leaveConfirm": "Kanal verlassen",
         "leaveSuccess": "Du hast {name} verlassen.",
         "archiveConfirmTitle": "{name} archivieren?",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4683,7 +4683,7 @@
         "archive": "Archive channel",
         "cancel": "Cancel",
         "leaveConfirmTitle": "Leave {name}?",
-        "leaveConfirmDescription": "You will stop receiving messages from this channel and it will disappear from your list. Other members keep their access, and you can be added back later.",
+        "leaveConfirmDescription": "You will stop receiving messages from this channel and it will disappear from your list.",
         "leaveConfirm": "Leave channel",
         "leaveSuccess": "You left {name}.",
         "archiveConfirmTitle": "Archive {name}?",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4564,7 +4564,7 @@
         "archive": "Archivar canal",
         "cancel": "Cancelar",
         "leaveConfirmTitle": "¿Salir de {name}?",
-        "leaveConfirmDescription": "Dejarás de recibir mensajes de este canal y desaparecerá de tu lista. Los demás miembros conservan su acceso y podrán volver a añadirte más adelante.",
+        "leaveConfirmDescription": "Dejarás de recibir mensajes de este canal y desaparecerá de tu lista.",
         "leaveConfirm": "Salir del canal",
         "leaveSuccess": "Saliste de {name}.",
         "archiveConfirmTitle": "¿Archivar {name}?",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4564,7 +4564,7 @@
         "archive": "Archiver le canal",
         "cancel": "Annuler",
         "leaveConfirmTitle": "Quitter {name} ?",
-        "leaveConfirmDescription": "Vous ne recevrez plus les messages de ce canal et il disparaîtra de votre liste. Les autres membres conservent leur accès et vous pourrez y être rajouté plus tard.",
+        "leaveConfirmDescription": "Vous ne recevrez plus les messages de ce canal et il disparaîtra de votre liste.",
         "leaveConfirm": "Quitter le canal",
         "leaveSuccess": "Vous avez quitté {name}.",
         "archiveConfirmTitle": "Archiver {name} ?",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4564,7 +4564,7 @@
         "archive": "Archivia il canale",
         "cancel": "Annulla",
         "leaveConfirmTitle": "Abbandonare {name}?",
-        "leaveConfirmDescription": "Non riceverai più i messaggi di questo canale e scomparirà dal tuo elenco. Gli altri membri mantengono l'accesso e potrai essere aggiunto di nuovo in seguito.",
+        "leaveConfirmDescription": "Non riceverai più i messaggi di questo canale e scomparirà dal tuo elenco.",
         "leaveConfirm": "Abbandona il canale",
         "leaveSuccess": "Hai abbandonato {name}.",
         "archiveConfirmTitle": "Archiviare {name}?",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4564,7 +4564,7 @@
         "archive": "チャンネルをアーカイブ",
         "cancel": "キャンセル",
         "leaveConfirmTitle": "{name} から退出しますか？",
-        "leaveConfirmDescription": "このチャンネルのメッセージは届かなくなり、一覧から消えます。他のメンバーのアクセスはそのままで、後から再度追加してもらうこともできます。",
+        "leaveConfirmDescription": "このチャンネルのメッセージは届かなくなり、一覧から消えます。",
         "leaveConfirm": "退出する",
         "leaveSuccess": "{name} から退出しました。",
         "archiveConfirmTitle": "{name} をアーカイブしますか？",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4564,7 +4564,7 @@
         "archive": "Arquivar canal",
         "cancel": "Cancelar",
         "leaveConfirmTitle": "Sair de {name}?",
-        "leaveConfirmDescription": "Você deixará de receber mensagens deste canal e ele desaparecerá da sua lista. Os outros membros mantêm o acesso e você pode ser adicionado novamente mais tarde.",
+        "leaveConfirmDescription": "Você deixará de receber mensagens deste canal e ele desaparecerá da sua lista.",
         "leaveConfirm": "Sair do canal",
         "leaveSuccess": "Você saiu de {name}.",
         "archiveConfirmTitle": "Arquivar {name}?",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4564,7 +4564,7 @@
         "archive": "Arquivar canal",
         "cancel": "Cancelar",
         "leaveConfirmTitle": "Sair de {name}?",
-        "leaveConfirmDescription": "Você deixará de receber mensagens deste canal e ele desaparecerá da sua lista. Os outros membros mantêm o acesso e você pode ser adicionado novamente mais tarde.",
+        "leaveConfirmDescription": "Você deixará de receber mensagens deste canal e ele desaparecerá da sua lista.",
         "leaveConfirm": "Sair do canal",
         "leaveSuccess": "Você saiu de {name}.",
         "archiveConfirmTitle": "Arquivar {name}?",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4564,7 +4564,7 @@
         "archive": "归档频道",
         "cancel": "取消",
         "leaveConfirmTitle": "退出 {name}？",
-        "leaveConfirmDescription": "你将不再接收该频道的消息，它也会从你的列表中消失。其他成员的访问权限不变，之后仍可将你重新加入。",
+        "leaveConfirmDescription": "你将不再接收该频道的消息，它也会从你的列表中消失。",
         "leaveConfirm": "退出频道",
         "leaveSuccess": "你已退出 {name}。",
         "archiveConfirmTitle": "归档 {name}？",

--- a/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
@@ -1,0 +1,412 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useContext,
+  useState,
+} from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatRoom } from "@/lib/clients/generated/core";
+
+const { leaveRoomActionMock, replaceMock, refreshMock, notifyMock } =
+  vi.hoisted(() => ({
+    leaveRoomActionMock: vi.fn(),
+    replaceMock: vi.fn(),
+    refreshMock: vi.fn(),
+    notifyMock: vi.fn(),
+  }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations:
+    (_namespace?: string) => (key: string, values?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        leave: "Leave channel",
+        leaveConfirmTitle: `Leave ${values?.name ?? ""}?`,
+        leaveConfirmDescription: `Leave description for ${values?.name ?? ""}`,
+        leaveConfirm: "Leave channel",
+        leaveSuccess: `You left ${values?.name ?? ""}.`,
+        cancel: "Cancel",
+        markUnread: "Mark as unread",
+        pin: "Pin",
+        unpin: "Unpin",
+        mute: "Mute",
+        unmute: "Unmute",
+        roomMenu: `Chat actions for ${values?.name ?? ""}`,
+        actionFailed: "Could not update this chat. Try again.",
+      };
+      return translations[key] ?? key;
+    },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  leaveRoomAction: (...args: unknown[]) => leaveRoomActionMock(...args),
+}));
+
+vi.mock("@/components/chat/organization-chat-events", () => ({
+  notifyOrganizationChatRoomsChanged: (...args: unknown[]) =>
+    notifyMock(...args),
+}));
+
+vi.mock("@/components/chat/organization-chat-list.actions", () => ({
+  markOrganizationChatRoomUnreadAction: vi.fn(),
+  muteOrganizationChatRoomAction: vi.fn(),
+  pinOrganizationChatRoomAction: vi.fn(),
+  unmuteOrganizationChatRoomAction: vi.fn(),
+  unpinOrganizationChatRoomAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  SheetClose: ({
+    children,
+    asChild,
+  }: {
+    children: ReactNode;
+    asChild?: boolean;
+  }) => (asChild && isValidElement(children) ? children : <>{children}</>),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarMenuButton: ({
+    children,
+    asChild,
+  }: {
+    children: ReactNode;
+    asChild?: boolean;
+  }) =>
+    asChild && isValidElement(children) ? children : <div>{children}</div>,
+  SidebarMenuItem: ({ children }: { children: ReactNode }) => (
+    <li>{children}</li>
+  ),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => {
+  interface DropdownMenuContextValue {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+  }
+
+  const DropdownMenuContext = createContext<DropdownMenuContextValue | null>(
+    null,
+  );
+
+  function DropdownMenu({ children }: { children: ReactNode }) {
+    const [open, setOpen] = useState(false);
+    return (
+      <DropdownMenuContext.Provider value={{ open, setOpen }}>
+        <div>{children}</div>
+      </DropdownMenuContext.Provider>
+    );
+  }
+
+  function DropdownMenuTrigger({
+    children,
+    asChild,
+  }: {
+    children: ReactNode;
+    asChild?: boolean;
+  }) {
+    const context = useContext(DropdownMenuContext);
+    if (!context) return null;
+
+    const handleClick = () => {
+      context.setOpen(!context.open);
+    };
+
+    if (asChild && isValidElement(children)) {
+      return cloneElement(children as ReactElement<{ onClick?: () => void }>, {
+        onClick: handleClick,
+      });
+    }
+
+    return (
+      <button type="button" onClick={handleClick}>
+        {children}
+      </button>
+    );
+  }
+
+  function DropdownMenuContent({ children }: { children: ReactNode }) {
+    const context = useContext(DropdownMenuContext);
+    if (!context?.open) return null;
+    return <div>{children}</div>;
+  }
+
+  function DropdownMenuItem({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) {
+    return (
+      <button
+        type="button"
+        role="menuitem"
+        disabled={disabled}
+        onClick={() => {
+          if (disabled) return;
+          onSelect?.();
+        }}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  function DropdownMenuSeparator() {
+    return <div data-slot="dropdown-menu-separator" />;
+  }
+
+  return {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+  };
+});
+
+vi.mock("@/components/ui/alert-dialog", () => {
+  function AlertDialog({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: ReactNode;
+  }) {
+    return open ? <div role="alertdialog">{children}</div> : null;
+  }
+
+  function Passthrough({ children }: { children: ReactNode }) {
+    return <>{children}</>;
+  }
+
+  function AlertDialogAction({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: (event: { preventDefault: () => void }) => void;
+    disabled?: boolean;
+  }) {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() =>
+          onClick?.({
+            preventDefault: () => undefined,
+          })
+        }
+      >
+        {children}
+      </button>
+    );
+  }
+
+  function AlertDialogCancel({
+    children,
+    disabled,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+  }) {
+    return (
+      <button type="button" disabled={disabled}>
+        {children}
+      </button>
+    );
+  }
+
+  return {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent: Passthrough,
+    AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+      <p>{children}</p>
+    ),
+    AlertDialogFooter: Passthrough,
+    AlertDialogHeader: Passthrough,
+    AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+      <h2>{children}</h2>
+    ),
+  };
+});
+
+import { toast } from "sonner";
+import { ChatRoomSidebarRow } from "../chat-room-sidebar-row";
+
+function makeUser(id: string) {
+  return {
+    id,
+    name: `User ${id}`,
+    email: `${id}@example.com`,
+    image: null,
+    presence: "offline" as const,
+  };
+}
+
+function makeRoom(overrides: Partial<ChatRoom> = {}): ChatRoom {
+  return {
+    id: "room-1",
+    organizationId: "org-1",
+    name: "general",
+    slug: "general",
+    kind: "channel",
+    directKey: null,
+    topic: null,
+    discoverability: "public",
+    createdByUserId: "user-1",
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    pinnedAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    userMembers: [makeUser("user-1"), makeUser("user-2")],
+    coworkerMembers: [],
+    ...overrides,
+  };
+}
+
+async function openRoomMenu(label = "general") {
+  const user = userEvent.setup();
+  await user.click(
+    screen.getByRole("button", { name: `Chat actions for ${label}` }),
+  );
+  return user;
+}
+
+describe("ChatRoomSidebarRow leave menu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    leaveRoomActionMock.mockResolvedValue({ ok: true, data: { id: "room-1" } });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides Leave for direct rooms", async () => {
+    render(
+      <ChatRoomSidebarRow
+        room={makeRoom({
+          kind: "direct",
+          userMembers: [makeUser("user-1"), makeUser("user-2")],
+        })}
+        href="/chat/rooms/room-1"
+        label="Alice"
+        isActive={false}
+        leading={<span>#</span>}
+        onRoomUpdated={vi.fn()}
+      />,
+    );
+
+    await openRoomMenu("Alice");
+
+    expect(
+      screen.queryByRole("menuitem", { name: /Leave channel/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Leave when channel has only one userMember", async () => {
+    render(
+      <ChatRoomSidebarRow
+        room={makeRoom({ userMembers: [makeUser("user-1")] })}
+        href="/chat/rooms/room-1"
+        label="general"
+        isActive={false}
+        leading={<span>#</span>}
+        onRoomUpdated={vi.fn()}
+      />,
+    );
+
+    await openRoomMenu();
+
+    expect(
+      screen.queryByRole("menuitem", { name: /Leave channel/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Leave for channel with two or more userMembers", async () => {
+    render(
+      <ChatRoomSidebarRow
+        room={makeRoom()}
+        href="/chat/rooms/room-1"
+        label="general"
+        isActive={false}
+        leading={<span>#</span>}
+        onRoomUpdated={vi.fn()}
+      />,
+    );
+
+    await openRoomMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /Leave channel/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens leave confirm and leaves on confirm", async () => {
+    render(
+      <ChatRoomSidebarRow
+        room={makeRoom()}
+        href="/chat/rooms/room-1"
+        label="general"
+        isActive
+        leading={<span>#</span>}
+        onRoomUpdated={vi.fn()}
+      />,
+    );
+
+    const user = await openRoomMenu();
+    await user.click(screen.getByRole("menuitem", { name: /Leave channel/i }));
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Leave general?" }),
+    ).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", {
+      name: /Leave channel/i,
+    });
+    await user.click(confirmButtons[confirmButtons.length - 1]!);
+
+    await waitFor(() => {
+      expect(leaveRoomActionMock).toHaveBeenCalledWith("room-1");
+    });
+    expect(toast.success).toHaveBeenCalledWith("You left general.");
+    expect(notifyMock).toHaveBeenCalledWith();
+    expect(replaceMock).toHaveBeenCalledWith("/chat");
+    expect(refreshMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -4,14 +4,19 @@ import {
   Bell,
   BellOff,
   Ellipsis,
+  Loader2,
+  LogOut,
   MessageSquare,
   Pin,
   PinOff,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type ReactNode, useTransition } from "react";
+import { type ReactNode, useState, useTransition } from "react";
 import { toast } from "sonner";
+import { leaveRoomAction } from "@/app/chat/actions";
+import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 import {
   markOrganizationChatRoomUnreadAction,
   muteOrganizationChatRoomAction,
@@ -20,11 +25,22 @@ import {
   unpinOrganizationChatRoomAction,
 } from "@/components/chat/organization-chat-list.actions";
 import { resolveRoomAttention } from "@/components/chat/room-attention";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SheetClose } from "@/components/ui/sheet";
@@ -71,9 +87,13 @@ export function ChatRoomSidebarRow({
   onRoomUpdated,
 }: ChatRoomSidebarRowProps) {
   const tActions = useTranslations("App.Channels.Actions");
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [leaveConfirmOpen, setLeaveConfirmOpen] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
   const isPinned = room.pinnedAt != null;
   const isMuted = room.mutedAt != null;
+  const canLeave = room.kind === "channel" && room.userMembers.length > 1;
   const { bold, badgeCount } = resolveRoomAttention({
     unreadCount: room.unreadCount,
     unreadMentionCount: room.unreadMentionCount,
@@ -100,6 +120,27 @@ export function ChatRoomSidebarRow({
       }
       onRoomUpdated(result.data);
     });
+  }
+
+  async function handleConfirmLeave() {
+    if (isLeaving) return;
+    setIsLeaving(true);
+    const result = await leaveRoomAction(room.id);
+    setIsLeaving(false);
+
+    if (!result.ok) {
+      toast.error(result.message);
+      setLeaveConfirmOpen(false);
+      return;
+    }
+
+    toast.success(tActions("leaveSuccess", { name: label }));
+    setLeaveConfirmOpen(false);
+    notifyOrganizationChatRoomsChanged();
+    if (isActive) {
+      router.replace("/chat");
+      router.refresh();
+    }
   }
 
   return (
@@ -220,8 +261,57 @@ export function ChatRoomSidebarRow({
             )}
             {isMuted ? tActions("unmute") : tActions("mute")}
           </DropdownMenuItem>
+          {canLeave ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={isPending || isLeaving}
+                onSelect={() => {
+                  setLeaveConfirmOpen(true);
+                }}
+              >
+                <LogOut className="size-4" aria-hidden />
+                {tActions("leave")}
+              </DropdownMenuItem>
+            </>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <AlertDialog
+        open={leaveConfirmOpen}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !isLeaving) setLeaveConfirmOpen(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {tActions("leaveConfirmTitle", { name: label })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {tActions("leaveConfirmDescription", { name: label })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isLeaving}>
+              {tActions("cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isLeaving}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleConfirmLeave();
+              }}
+            >
+              {isLeaving ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden />
+              ) : null}
+              {tActions("leaveConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </SidebarMenuItem>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds **Leave** to the channel sidebar overflow menu in a separated section below pin/mute actions.

Users can leave a multi-member channel from the row menu without opening channel settings. DMs and last-member channels stay without Leave. Confirm dialog, `leaveRoomAction`, list refresh, and navigate-away match the existing settings leave path.

Leave confirm copy now omits “Other members keep their access, and you can be added back later.” (all locales).

**Verification**
- `pnpm --filter web test src/components/chat/__tests__/chat-room-sidebar-row.test.tsx` (4/4)
- Biome check on touched files
- Browser login against local app blocked by react-hook-form automation; component tests cover Leave visibility, confirm, and leave success path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37899be6-978f-4c7c-9375-8d8ad48505a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37899be6-978f-4c7c-9375-8d8ad48505a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

