### PR TITLE
fix(chat): clear selection when opening mobile message actions

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -359,6 +359,59 @@ describe("ChatMessageRow", () => {
     }
   });
 
+  it("clears native text selection when long-press opens message actions", async () => {
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+    try {
+      vi.useFakeTimers();
+      renderRow({
+        message: userMessage({ content: "Selectable chat body" }),
+        onQuote: vi.fn(),
+      });
+      const article = screen.getByRole("article");
+
+      const range = document.createRange();
+      range.selectNodeContents(article);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      expect(selection?.rangeCount).toBeGreaterThan(0);
+
+      await act(async () => {
+        article.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 10,
+            clientY: 10,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+      expect(article.className).toContain("[@media(hover:none)]:select-none");
+      expect(article.className).toContain(
+        "[@media(hover:none)]:[-webkit-touch-callout:none]",
+      );
+    } finally {
+      vi.useRealTimers();
+      matchMediaSpy.mockRestore();
+    }
+  });
+
   it("reserves hover-only right gutter on article", () => {
     renderRow();
 

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -415,12 +415,18 @@ function ChannelMessageBody({
 const QUICK_MESSAGE_REACTIONS = ["👍", "❤️", "😂", "🎉", "👀"] as const;
 const LONG_PRESS_DELAY_MS = 450;
 const LONG_PRESS_MOVE_TOLERANCE_PX = 12;
+const TOUCH_MESSAGE_SELECT_NONE_CLASS =
+  "[@media(hover:none)]:select-none [@media(hover:none)]:[-webkit-touch-callout:none]";
 
 function devicePrefersHover(): boolean {
   if (typeof window === "undefined") {
     return true;
   }
   return window.matchMedia("(hover: hover)").matches;
+}
+
+function clearDomTextSelection() {
+  window.getSelection()?.removeAllRanges();
 }
 
 function useLongPress(onLongPress: () => void): {
@@ -454,6 +460,7 @@ function useLongPress(onLongPress: () => void): {
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
         startRef.current = null;
+        clearDomTextSelection();
         onLongPress();
       }, LONG_PRESS_DELAY_MS);
     },
@@ -1187,6 +1194,7 @@ export function ChatMessageRow({
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
         "group relative -mx-2 flex gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
+        showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation ? "min-h-0 py-0.5" : "mt-3 min-h-0 pt-1 pb-0.5",
       )}
       {...(showActions ? longPress : {})}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On touch devices, long-pressing a chat message opened the actions sheet while iOS Safari kept a native text selection highlight over the chat.

Root cause: `useLongPress` only blocked `contextmenu`; it did not clear DOM selection or disable touch text selection on message rows.

Fix: clear `window.getSelection()` when the long-press fires, and apply `select-none` / `-webkit-touch-callout: none` on actionable rows under `(hover: none)`.

Verification: failing-then-passing regression in `room-message-row.test.tsx` (34 passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc883-9d2a-7f2c-8d35-2afc6e648d44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc883-9d2a-7f2c-8d35-2afc6e648d44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

