### PR TITLE
fix(web): show who reacted in mobile chat action sheet

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { und # weitere}}",
-        "andMore": "und {count} weitere"
+        "andMore": "und {count} weitere",
+        "whoReactedList": "Wer reagiert hat"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4826,7 +4826,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other {, and # more}}",
-        "andMore": "and {count} more"
+        "andMore": "and {count} more",
+        "whoReactedList": "Who reacted"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { y # más}}",
-        "andMore": "y {count} más"
+        "andMore": "y {count} más",
+        "whoReactedList": "Quién reaccionó"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { et # de plus}}",
-        "andMore": "et {count} de plus"
+        "andMore": "et {count} de plus",
+        "whoReactedList": "Qui a réagi"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { e altri #}}",
-        "andMore": "e altri {count}"
+        "andMore": "e altri {count}",
+        "whoReactedList": "Chi ha reagito"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other {、他#人}}",
-        "andMore": "他{count}人"
+        "andMore": "他{count}人",
+        "whoReactedList": "リアクションした人"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { e mais #}}",
-        "andMore": "e mais {count}"
+        "andMore": "e mais {count}",
+        "whoReactedList": "Quem reagiu"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { e mais #}}",
-        "andMore": "e mais {count}"
+        "andMore": "e mais {count}",
+        "whoReactedList": "Quem reagiu"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -4707,7 +4707,8 @@
         "add": "Add reaction",
         "toggle": "React with {emoji}",
         "whoReacted": "{names}{more, plural, =0 {} other { 以及其他 # 人}}",
-        "andMore": "以及其他 {count} 人"
+        "andMore": "以及其他 {count} 人",
+        "whoReactedList": "谁回应了"
       },
       "Presence": {
         "online": "Online",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -359,6 +359,63 @@ describe("ChatMessageRow", () => {
     }
   });
 
+  it("shows who reacted in the message actions sheet when hover is unavailable", async () => {
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+    try {
+      vi.useFakeTimers();
+      renderRow({
+        onQuote: vi.fn(),
+        message: userMessage({
+          reactions: [
+            {
+              emoji: "👍",
+              count: 2,
+              reactedByCurrentUser: true,
+              reactors: [
+                { id: "user-1", name: "Ada" },
+                { id: "user-2", name: "Bob" },
+              ],
+            },
+          ],
+        }),
+      });
+      const article = screen.getByRole("article");
+
+      await act(async () => {
+        article.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            clientX: 10,
+            clientY: 10,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      const dialog = screen.getByRole("dialog");
+      expect(
+        within(dialog).getByRole("list", { name: "Reactions.whoReactedList" }),
+      ).toBeInTheDocument();
+      expect(within(dialog).getByText("Ada, Bob")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+      matchMediaSpy.mockRestore();
+    }
+  });
+
   it("reserves hover-only right gutter on article", () => {
     renderRow();
 

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -797,6 +797,13 @@ function TouchMessageActionsSheet({
   const { contentRef, swipeHandlers } = useBottomSheetSwipeDismiss(open, () => {
     onOpenChange(false);
   });
+  const whoReactedRows = message.reactions.flatMap((reaction) => {
+    const whoReactedLabel = formatWhoReactedLabel(reaction, t);
+    if (!whoReactedLabel) {
+      return [];
+    }
+    return [{ emoji: reaction.emoji, whoReactedLabel }];
+  });
 
   function runAndClose(action: () => void) {
     action();
@@ -857,6 +864,23 @@ function TouchMessageActionsSheet({
             }}
           />
         </div>
+        {whoReactedRows.length > 0 ? (
+          <ul
+            aria-label={t("Reactions.whoReactedList")}
+            className="border-border space-y-2 border-t px-4 py-3"
+          >
+            {whoReactedRows.map((row) => (
+              <li key={row.emoji} className="flex items-start gap-2 text-sm">
+                <span className="text-base leading-none" aria-hidden>
+                  {row.emoji}
+                </span>
+                <span className="text-muted-foreground min-w-0 flex-1">
+                  {row.whoReactedLabel}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
         <div className="border-border flex flex-col gap-1 border-t px-2 py-2">
           {showEditButton && onEdit ? (
             <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Mobile chat users could not see who reacted. Reactor names only lived in the hover tooltip from SOK-679, and long-press opens the message actions sheet instead.

This change lists each existing reaction and its reactor names in that sheet. Desktop tooltip and tap-to-toggle stay the same.

**How it looks (long-press → sheet)**

![Mobile message actions sheet with who reacted list](https://cursor.com/artifacts/c/art-1a016089-a9d4-4295-a58a-36a4936010e7)

Between the emoji reaction row and Edit/Quote/Thread/Delete, the sheet now shows each emoji with reactor names (e.g. `👍 Patrick Tobler`).

**Verification**
- Fail then pass: `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx -t "shows who reacted in the message actions sheet"`
- Full file: 35/35 pass after merging main
- Related: https://linear.app/masumi/issue/SOK-679/show-who-reacted-on-chat-room-messages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc883-1c06-7e63-ad76-3b3368f5e23d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc883-1c06-7e63-ad76-3b3368f5e23d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

