### PR TITLE
fix(core): use idle stream timeouts for room coworker mentions

### DIFF
--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -10,7 +10,7 @@ const {
   createMock,
   deleteMock,
   messageFindUniqueMock,
-  generateTextMock,
+  streamTextMock,
   createCoworkerConversationMock,
   getSokosumiProviderMock,
   transactionUpdateManyMock,
@@ -25,7 +25,7 @@ const {
   createMock: vi.fn(),
   deleteMock: vi.fn(),
   messageFindUniqueMock: vi.fn(),
-  generateTextMock: vi.fn(),
+  streamTextMock: vi.fn(),
   createCoworkerConversationMock: vi.fn(),
   getSokosumiProviderMock: vi.fn(),
   transactionUpdateManyMock: vi.fn(),
@@ -77,13 +77,17 @@ vi.mock("@/routes/v1/chats/stream/coworker-conversation", () => ({
 }));
 
 vi.mock("ai", () => ({
-  generateText: generateTextMock,
+  streamText: streamTextMock,
 }));
 
 import {
   buildRoomMentionPrompt,
   dispatchChatRoomMention,
   listStaleSentChatRoomMentionIds,
+  ROOM_COWORKER_CHUNK_MS,
+  ROOM_COWORKER_FIRST_CHUNK_MS,
+  ROOM_COWORKER_STREAM_TIMEOUT,
+  ROOM_COWORKER_TOTAL_MS,
   ROOM_SENT_STALE_MS,
 } from "./chat-room-coworker-dispatch.service";
 
@@ -127,7 +131,9 @@ beforeEach(() => {
   getSokosumiProviderMock.mockReturnValue(() => "mock-model");
   createCoworkerConversationMock.mockResolvedValue({ id: "provider_conv_1" });
   findManyMock.mockResolvedValue([]);
-  generateTextMock.mockResolvedValue({ text: "Hello back" });
+  streamTextMock.mockReturnValue({
+    text: Promise.resolve("Hello back"),
+  });
   createMock.mockResolvedValue({ id: "reply_1" });
   deleteMock.mockResolvedValue({ id: "reply_1" });
   messageFindUniqueMock.mockResolvedValue({ deletedAt: null });
@@ -135,6 +141,20 @@ beforeEach(() => {
   updateManyMock.mockResolvedValue({ count: 1 });
   transactionUpdateManyMock.mockResolvedValue({ count: 1 });
   coworkerMemberFindUniqueMock.mockResolvedValue({ id: "membership_1" });
+});
+
+describe("room coworker stream timeout budgets", () => {
+  it("uses idle chunk timeouts under a hard total, with stale above total", () => {
+    expect(ROOM_COWORKER_STREAM_TIMEOUT).toEqual({
+      totalMs: ROOM_COWORKER_TOTAL_MS,
+      firstChunkMs: ROOM_COWORKER_FIRST_CHUNK_MS,
+      chunkMs: ROOM_COWORKER_CHUNK_MS,
+    });
+    expect(ROOM_COWORKER_CHUNK_MS).toBe(90_000);
+    expect(ROOM_COWORKER_FIRST_CHUNK_MS).toBe(90_000);
+    expect(ROOM_COWORKER_TOTAL_MS).toBeGreaterThan(ROOM_COWORKER_CHUNK_MS);
+    expect(ROOM_SENT_STALE_MS).toBeGreaterThan(ROOM_COWORKER_TOTAL_MS);
+  });
 });
 
 describe("buildRoomMentionPrompt", () => {
@@ -227,7 +247,7 @@ describe("dispatchChatRoomMention claim", () => {
         }),
       }),
     );
-    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
     expect(createCoworkerConversationMock).not.toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
   });
@@ -238,7 +258,14 @@ describe("dispatchChatRoomMention claim", () => {
 
     await dispatchChatRoomMention(MENTION_ID);
 
-    expect(generateTextMock).toHaveBeenCalled();
+    expect(streamTextMock).toHaveBeenCalled();
+    expect(streamTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: ROOM_COWORKER_STREAM_TIMEOUT,
+        maxRetries: 0,
+      }),
+    );
+    expect(streamTextMock.mock.calls[0]?.[0]).not.toHaveProperty("abortSignal");
     expect(createCoworkerConversationMock).toHaveBeenCalled();
     expect(createMock).toHaveBeenCalled();
     expect(transactionUpdateManyMock).toHaveBeenCalledWith({
@@ -292,7 +319,7 @@ describe("dispatchChatRoomMention claim", () => {
         data: { status: "sent", error: null },
       }),
     );
-    expect(generateTextMock).toHaveBeenCalled();
+    expect(streamTextMock).toHaveBeenCalled();
   });
 
   it("does not reclaim a fresh sent mention still in flight", async () => {
@@ -305,7 +332,7 @@ describe("dispatchChatRoomMention claim", () => {
 
     await dispatchChatRoomMention(MENTION_ID);
 
-    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
     expect(createCoworkerConversationMock).not.toHaveBeenCalled();
   });
 
@@ -322,11 +349,11 @@ describe("dispatchChatRoomMention claim", () => {
         error: "Coworker is no longer a member of this room",
       },
     });
-    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
   });
 
-  it("fails closed when membership disappears during generateText", async () => {
+  it("fails closed when membership disappears during streamText", async () => {
     findUniqueMock.mockResolvedValue(pendingMention());
     updateManyMock.mockResolvedValue({ count: 1 });
     coworkerMemberFindUniqueMock
@@ -335,7 +362,7 @@ describe("dispatchChatRoomMention claim", () => {
 
     await dispatchChatRoomMention(MENTION_ID);
 
-    expect(generateTextMock).toHaveBeenCalled();
+    expect(streamTextMock).toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
     expect(transactionUpdateManyMock).toHaveBeenCalledWith({
       where: {
@@ -368,11 +395,11 @@ describe("dispatchChatRoomMention claim", () => {
         error: "Source message was deleted",
       },
     });
-    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
   });
 
-  it("discards the reply when the source message is soft-deleted during generateText", async () => {
+  it("discards the reply when the source message is soft-deleted during streamText", async () => {
     findUniqueMock.mockResolvedValue(pendingMention());
     updateManyMock.mockResolvedValue({ count: 1 });
     messageFindUniqueMock.mockResolvedValue({
@@ -381,7 +408,7 @@ describe("dispatchChatRoomMention claim", () => {
 
     await dispatchChatRoomMention(MENTION_ID);
 
-    expect(generateTextMock).toHaveBeenCalled();
+    expect(streamTextMock).toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
     expect(transactionUpdateManyMock).toHaveBeenCalledWith({
       where: {

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -1,18 +1,25 @@
 import type { SokosumiProviderCallOptions } from "@sokosumi/ai-provider";
 import { coworkerTextLooksLikeAgentError } from "@sokosumi/ai-provider";
-import { generateText } from "ai";
+import { streamText } from "ai";
 
 import prisma from "@/lib/db/prisma";
 import { getSokosumiProvider } from "@/lib/sokosumi-ai-provider";
 import { createCoworkerConversation } from "@/routes/v1/chats/stream/coworker-conversation";
 
-const ROOM_COWORKER_TIMEOUT_MS = 90_000;
-/**
- * `sent` older than this is treated as abandoned (process killed after claim).
- * Must exceed `ROOM_COWORKER_TIMEOUT_MS` so an in-flight generateText is not
- * stolen by a reclaim.
- */
-export const ROOM_SENT_STALE_MS = ROOM_COWORKER_TIMEOUT_MS + 30_000;
+/** Hard ceiling for streamText only (not conversation create ≤25s). */
+export const ROOM_COWORKER_TOTAL_MS = 240_000;
+/** AI SDK stall budgets; content chunks reset these. */
+export const ROOM_COWORKER_FIRST_CHUNK_MS = 90_000;
+export const ROOM_COWORKER_CHUNK_MS = 90_000;
+
+export const ROOM_COWORKER_STREAM_TIMEOUT = {
+  totalMs: ROOM_COWORKER_TOTAL_MS,
+  firstChunkMs: ROOM_COWORKER_FIRST_CHUNK_MS,
+  chunkMs: ROOM_COWORKER_CHUNK_MS,
+} as const;
+
+/** Must exceed `ROOM_COWORKER_TOTAL_MS` so reclaim cannot steal an in-flight run. */
+export const ROOM_SENT_STALE_MS = ROOM_COWORKER_TOTAL_MS + 30_000;
 const STALE_SENT_RECLAIM_LIMIT = 10;
 
 /** How many prior messages the coworker sees as conversation context. */
@@ -243,7 +250,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
   }
 
   // Claim before any provider work so concurrent dispatches cannot both run
-  // generateText. Fresh `sent` (in flight) loses quietly; stale `sent` is
+  // streamText. Fresh `sent` (in flight) loses quietly; stale `sent` is
   // reclaimed after ROOM_SENT_STALE_MS.
   const claimed = await claimMentionForDispatch(mentionId);
   if (!claimed) {
@@ -344,18 +351,17 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
     contextMessages,
   });
 
-  // Bounds the coworker call: without it a stalled upstream keeps the mention
-  // non-terminal forever. Aborting throws, which the caller turns into failed.
-  const { text } = await generateText({
+  // Idle chunk timeouts abort stalls; totalMs is the hard ceiling.
+  const result = streamText({
     model: getSokosumiProvider()(null),
     messages: [{ role: "user", content: prompt }],
-    abortSignal: AbortSignal.timeout(ROOM_COWORKER_TIMEOUT_MS),
+    maxRetries: 0,
+    timeout: ROOM_COWORKER_STREAM_TIMEOUT,
     providerOptions: {
       sokosumi: providerOptions,
-    } as unknown as Parameters<typeof generateText>[0]["providerOptions"],
+    } as unknown as Parameters<typeof streamText>[0]["providerOptions"],
   });
-
-  const responseText = text.trim();
+  const responseText = (await result.text).trim();
   if (!responseText || coworkerTextLooksLikeAgentError(responseText)) {
     await markMentionFailed(
       mentionId,
@@ -365,7 +371,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
   }
 
   await prisma.$transaction(async (tx) => {
-    // Re-check membership after the provider call: eviction during generateText
+    // Re-check membership after the provider call: eviction during streamText
     // must not land a reply in a room the coworker left.
     const stillMember = await tx.chatRoomCoworkerMember.findUnique({
       where: {
@@ -390,7 +396,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
       return;
     }
 
-    // Soft-delete during generateText cancels the mention to `failed` and
+    // Soft-delete during streamText cancels the mention to `failed` and
     // wipes content; do not post a reply under a tombstone.
     const sourceMessage = await tx.chatRoomMessage.findUnique({
       where: { id: mention.message.id },

--- a/apps/core/vercel.json
+++ b/apps/core/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "pnpm vercel-build",
   "functions": {
     "dist/index.js": {
-      "maxDuration": 120
+      "maxDuration": 300
     }
   },
   "relatedProjects": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Channel `@mention` coworker replies were dying on a hard 90s wall-clock `AbortSignal.timeout` around `generateText`. Long active tool/reasoning runs failed even when the upstream stream was still alive.

### Change
- Switch mention dispatch to `streamText` with AI SDK `timeout: { totalMs: 240s, firstChunkMs: 90s, chunkMs: 90s }` so content chunks reset the stall timer.
- Raise Core `maxDuration` to 300s and `ROOM_SENT_STALE_MS` to 270s so create (≤25s) + stream total fit, and reclaim cannot steal an in-flight run.
- Leave 1:1 DM `streamText` without a new abort (it never had the 90s timer). Shared `maxDuration` bump still helps long DM Core invocations.

### Verification
```text
# before fix (tests expecting streamText timeout budgets): 6 failed
# after fix:
pnpm --filter core test src/services/chat-room-coworker-dispatch.service.test.ts
# → 15 passed
```

### Principles
- Fix root causes (wall-clock abort, not commit-gate / first-token myths)
- Prefer known libraries (AI SDK stream timeouts over custom SSE idle controller)
- Boundary discipline (abort stays in Core dispatch; no ai-provider API change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50aabb52-c0a0-4146-844a-9548148a693f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50aabb52-c0a0-4146-844a-9548148a693f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

