### PR TITLE
fix(web): address DESIGN.md branding picker review findings

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-detail-actions.test.tsx
@@ -367,19 +367,32 @@ vi.mock("@/app/tasks/components/task-share-button", () => ({
 vi.mock("@/app/tasks/components/task-form", () => ({
   TaskForm: ({
     initialValues,
+    initialDesignMdAttachment,
     onCreateTask,
     onSuccess,
   }: {
     initialValues?: { assigneeId?: string | null };
+    initialDesignMdAttachment?: {
+      label: string;
+      url: string;
+      owner: { type: "organization"; name: string; logo: string | null };
+    } | null;
     onCreateTask?: (input: {
       description: string;
       assigneeId: string | null;
       status: TaskStatus;
+      skipDesignMdAttachment?: boolean;
+      designMdAttachmentOverride?: { label: string; url: string };
     }) => Promise<{ taskId: string }>;
     onSuccess?: (taskId: string) => void;
   }) => (
     <div>
       <span>{initialValues?.assigneeId ?? "no-coworker"}</span>
+      {initialDesignMdAttachment ? (
+        <span data-testid="design-md-picker">
+          {initialDesignMdAttachment.label}
+        </span>
+      ) : null}
       <button
         type="button"
         onClick={async () => {
@@ -388,6 +401,10 @@ vi.mock("@/app/tasks/components/task-form", () => ({
             description: "Created related task",
             assigneeId: initialValues?.assigneeId ?? null,
             status: TaskStatus.READY,
+            skipDesignMdAttachment: initialDesignMdAttachment
+              ? false
+              : undefined,
+            designMdAttachmentOverride: undefined,
           });
           onSuccess?.(result.taskId);
         }}
@@ -1312,10 +1329,57 @@ describe("TaskDetailActions", () => {
         assigneeId: "coworker-1",
         status: TaskStatus.READY,
         relation: TaskLinkRelation.PARENT,
+        skipDesignMdAttachment: undefined,
+        designMdAttachmentOverride: undefined,
       });
     });
 
     expect(pushMock).toHaveBeenCalledWith("/tasks/task-created");
+  });
+
+  it("passes the DESIGN.md picker into create-related and forwards skip false", async () => {
+    const user = userEvent.setup();
+    const createTaskAndLinkMock = vi.mocked(createTaskAndLink);
+    createTaskAndLinkMock.mockResolvedValue({
+      taskId: "task-1",
+      createdTaskId: "task-created",
+      linkId: "link-created",
+      name: "Created related task",
+    });
+
+    renderActions({
+      initialDesignMdAttachment: {
+        label: "DESIGN.md",
+        url: "https://blob.example/design.md",
+        owner: { type: "organization", name: "Acme Inc", logo: null },
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: actionsMenuLabel }));
+    await user.click(screen.getByRole("menuitem", { name: "Create related" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Add sub-task" }),
+    );
+
+    expect(screen.getByTestId("design-md-picker")).toHaveTextContent(
+      "DESIGN.md",
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Submit related task" }),
+    );
+
+    await waitFor(() => {
+      expect(createTaskAndLinkMock).toHaveBeenCalledWith({
+        taskId: "task-1",
+        description: "Created related task",
+        assigneeId: "coworker-1",
+        status: TaskStatus.READY,
+        relation: TaskLinkRelation.PARENT,
+        skipDesignMdAttachment: false,
+        designMdAttachmentOverride: undefined,
+      });
+    });
   });
 
   it("shows remove parent when the task has a parent link", async () => {
@@ -1604,6 +1668,8 @@ describe("TaskDetailActions", () => {
         assigneeId: "coworker-1",
         status: TaskStatus.READY,
         relation: TaskLinkRelation.PARENT,
+        skipDesignMdAttachment: undefined,
+        designMdAttachmentOverride: undefined,
       });
     });
 

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-form.test.tsx
@@ -130,6 +130,63 @@ vi.mock("../markdown-editor", () => ({
   }),
 }));
 
+vi.mock("../task-design-md-attachment", () => ({
+  TaskDesignMdAttachmentField: ({
+    defaultAttachment,
+    selection,
+    onSelectionChange,
+  }: {
+    defaultAttachment: {
+      owner:
+        | { type: "organization"; name: string; logo: string | null }
+        | { type: "user" };
+    };
+    selection: {
+      enabled: boolean;
+      custom: null | { label: string; url: string; sourceUrl: string };
+    };
+    onSelectionChange: (next: {
+      enabled: boolean;
+      custom: null | { label: string; url: string; sourceUrl: string };
+    }) => void;
+  }) => (
+    <div>
+      <label>
+        <input
+          type="checkbox"
+          aria-label={
+            defaultAttachment.owner.type === "organization"
+              ? "organizationLabel"
+              : "personalLabel"
+          }
+          checked={selection.enabled}
+          onChange={(event) =>
+            onSelectionChange({
+              enabled: event.target.checked,
+              custom: selection.custom,
+            })
+          }
+        />
+      </label>
+      <button
+        type="button"
+        onClick={() =>
+          onSelectionChange({
+            enabled: true,
+            custom: {
+              label: "DESIGN.md",
+              url: "https://blob.example/design-md/adhoc/user-1/hash.md",
+              sourceUrl: "https://competitor.com",
+            },
+          })
+        }
+      >
+        set-custom-branding
+      </button>
+    </div>
+  ),
+}));
+
 const baseLabels = {
   details: "Details",
   detailsDescription: "Describe the task",
@@ -827,6 +884,53 @@ describe("TaskForm", () => {
       status: TaskStatus.READY,
       skipDesignMdAttachment: true,
       designMdAttachmentOverride: undefined,
+      schedule: {
+        mode: "none",
+        timezone: expect.any(String),
+      },
+    });
+  });
+
+  it("passes a custom DESIGN.md override when branding is swapped", async () => {
+    const user = userEvent.setup();
+    const createTaskMock = vi.mocked(createTask);
+    createTaskMock.mockResolvedValue({ taskId: "task-1", name: "Task one" });
+
+    render(
+      <TaskForm
+        variant="modal"
+        mode="create"
+        showCancel={false}
+        labels={baseLabels}
+        coworkerOptions={coworkerOptions}
+        initialValues={{ assigneeId: "coworker-2" }}
+        initialDesignMdAttachment={{
+          label: "DESIGN.md",
+          url: "https://blob.example/design.md",
+          owner: { type: "organization", name: "Acme Inc", logo: null },
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "set-custom-branding" }),
+    );
+    await user.type(
+      screen.getByTestId("markdown-editor"),
+      "Build landing page",
+    );
+    await user.click(screen.getByRole("button", { name: "Create Task" }));
+
+    expect(createTaskMock).toHaveBeenCalledWith({
+      description: "Build landing page",
+      assigneeId: "coworker-2",
+      status: TaskStatus.READY,
+      skipDesignMdAttachment: false,
+      designMdAttachmentOverride: {
+        label: "DESIGN.md",
+        url: "https://blob.example/design-md/adhoc/user-1/hash.md",
+      },
       schedule: {
         mode: "none",
         timezone: expect.any(String),

--- a/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-actions.tsx
@@ -77,7 +77,11 @@ import type { CoworkerOption } from "@/lib/types/coworker";
 import { cn } from "@/lib/utils";
 import { MoveTaskToWorkspaceDialog } from "./move-task-to-workspace-dialog";
 import { getTaskAttachmentUploadLabelTemplate } from "./task-attachment-upload-labels";
-import { TaskForm, type TaskFormLabels } from "./task-form";
+import {
+  TaskForm,
+  type TaskFormInitialDesignMdAttachment,
+  type TaskFormLabels,
+} from "./task-form";
 import { TaskFormModal } from "./task-form-modal";
 import { getTaskLinkRelationIcon } from "./task-link-relation-icon";
 import {
@@ -122,6 +126,8 @@ interface TaskDetailActionsProps {
   coworkerOptions: CoworkerOption[];
   agentNameById: Map<string, string>;
   defaultAssigneeId?: string | null;
+  /** Resolved DESIGN.md for create-related flow (same picker as new task). */
+  initialDesignMdAttachment?: TaskFormInitialDesignMdAttachment | null;
   actionsMenuLabel: string;
   labels: TaskDetailActionsLabels;
   currentOrganizationId?: string | null;
@@ -144,6 +150,7 @@ export function TaskDetailActions({
   coworkerOptions,
   agentNameById,
   defaultAssigneeId,
+  initialDesignMdAttachment = null,
   actionsMenuLabel,
   labels,
   currentOrganizationId,
@@ -938,6 +945,7 @@ export function TaskDetailActions({
             labels={createTaskLabels}
             coworkerOptions={coworkerOptions}
             agentNameById={agentNameById}
+            initialDesignMdAttachment={initialDesignMdAttachment}
             initialValues={
               defaultAssigneeId ? { assigneeId: defaultAssigneeId } : undefined
             }
@@ -947,6 +955,8 @@ export function TaskDetailActions({
               projectId,
               status,
               schedule,
+              skipDesignMdAttachment,
+              designMdAttachmentOverride,
             }) => {
               const result = await createTaskAndLink({
                 taskId,
@@ -955,6 +965,8 @@ export function TaskDetailActions({
                 projectId,
                 status,
                 schedule,
+                skipDesignMdAttachment,
+                designMdAttachmentOverride,
                 relation: selectedCreateRelatedOption.relation,
               });
 

--- a/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-detail-view.tsx
@@ -34,6 +34,7 @@ import { getSession } from "@/lib/auth/auth.server";
 import type { Task } from "@/lib/clients/generated/core/types.gen";
 import { agentService } from "@/lib/services";
 import { coworkerService } from "@/lib/services/coworker.service";
+import { designMdService } from "@/lib/services/design-md.service";
 import { projectService } from "@/lib/services/project.service";
 import { userService } from "@/lib/services/user.service";
 import { resolveAccountName } from "@/lib/utils/account-name";
@@ -441,6 +442,9 @@ async function TaskDetailActionsSlot({
       getTranslations("App.Tasks.Detail"),
       getTranslations("Components.MembersTable.Header"),
     ]);
+  const initialDesignMdAttachment = session?.user.id
+    ? await designMdService.resolveEffectiveDesignMd()
+    : null;
   const {
     task: taskWithCoworker,
     agentNameById,
@@ -482,6 +486,7 @@ async function TaskDetailActionsSlot({
       coworkerOptions={coworkerOptions}
       agentNameById={agentNameById}
       defaultAssigneeId={task.assigneeId}
+      initialDesignMdAttachment={initialDesignMdAttachment}
       currentOrganizationId={task.workspace.organizationId ?? null}
       organizations={members}
       personalWorkspaceLabel={personalWorkspaceMoveLabel}

--- a/apps/web/src/lib/actions/task/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/task/__tests__/action.test.ts
@@ -260,13 +260,15 @@ describe("task link actions", () => {
     taskServiceMock.createTask.mockResolvedValue(buildTask());
 
     const { createTask } = await import("../action");
+    const overrideUrl =
+      "https://blob.example/design-md/adhoc/user-1/42-hash.md";
 
     await createTask({
       description: "Created related task",
       assigneeId: null,
       designMdAttachmentOverride: {
         label: "DESIGN.md",
-        url: "https://blob.example/adhoc/design.md",
+        url: overrideUrl,
       },
       status: TaskStatus.READY,
     });
@@ -274,14 +276,73 @@ describe("task link actions", () => {
     expect(appendDesignMdToDescriptionMock).not.toHaveBeenCalled();
     expect(withDesignMdAttachmentMock).toHaveBeenCalledWith(
       "Created related task",
-      { label: "DESIGN.md", url: "https://blob.example/adhoc/design.md" },
+      { label: "DESIGN.md", url: overrideUrl },
     );
     expect(taskServiceMock.createTask).toHaveBeenCalledWith(
       expect.objectContaining({
-        description:
-          "[DESIGN.md](https://blob.example/adhoc/design.md)\n\nCreated related task",
+        description: `[DESIGN.md](${overrideUrl})\n\nCreated related task`,
       }),
     );
+  });
+
+  it("sanitizes override labels and rejects non-adhoc or non-https URLs", async () => {
+    taskServiceMock.createTask.mockResolvedValue(buildTask());
+
+    const { createTask } = await import("../action");
+
+    await createTask({
+      description: "Created related task",
+      assigneeId: null,
+      designMdAttachmentOverride: {
+        label: "Acme [Brand]",
+        url: "https://blob.example/design-md/adhoc/user-1/42-hash.md",
+      },
+      status: TaskStatus.READY,
+    });
+
+    expect(withDesignMdAttachmentMock).toHaveBeenCalledWith(
+      "Created related task",
+      {
+        label: "Acme Brand",
+        url: "https://blob.example/design-md/adhoc/user-1/42-hash.md",
+      },
+    );
+
+    await expect(
+      createTask({
+        description: "Created related task",
+        assigneeId: null,
+        designMdAttachmentOverride: {
+          label: "DESIGN.md",
+          url: "http://blob.example/design-md/adhoc/user-1/42-hash.md",
+        },
+        status: TaskStatus.READY,
+      }),
+    ).rejects.toThrow("DESIGN.md attachment URL must use https");
+
+    await expect(
+      createTask({
+        description: "Created related task",
+        assigneeId: null,
+        designMdAttachmentOverride: {
+          label: "DESIGN.md",
+          url: "https://blob.example/design-md/adhoc/other-user/42-hash.md",
+        },
+        status: TaskStatus.READY,
+      }),
+    ).rejects.toThrow("DESIGN.md attachment URL is not valid for this user");
+
+    await expect(
+      createTask({
+        description: "Created related task",
+        assigneeId: null,
+        designMdAttachmentOverride: {
+          label: "DESIGN.md",
+          url: "https://evil.example/not-design.md",
+        },
+        status: TaskStatus.READY,
+      }),
+    ).rejects.toThrow("DESIGN.md attachment URL is not valid for this user");
   });
 
   it("skips the override when skipDesignMdAttachment also is set", async () => {
@@ -295,7 +356,7 @@ describe("task link actions", () => {
       skipDesignMdAttachment: true,
       designMdAttachmentOverride: {
         label: "DESIGN.md",
-        url: "https://blob.example/adhoc/design.md",
+        url: "https://blob.example/design-md/adhoc/user-1/42-hash.md",
       },
       status: TaskStatus.READY,
     });

--- a/apps/web/src/lib/actions/task/action.ts
+++ b/apps/web/src/lib/actions/task/action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import {
+  buildAdHocDesignMdPrefix,
   hasActiveTaskSchedule,
   userTaskStatusTransitionRequiresComment,
 } from "@sokosumi/utils";
@@ -22,6 +23,7 @@ import { taskService } from "@/lib/services/task.service";
 import { taskScheduleService } from "@/lib/services/task-schedule.service";
 import type { TaskScheduleSelection } from "@/lib/types/task-schedule";
 import { normalizeOptionalProjectId } from "@/lib/utils/project";
+import { sanitizeTaskAttachmentLabel } from "@/lib/utils/task-attachments";
 import {
   hasTaskScheduleChanged,
   selectionToApiBody,
@@ -207,10 +209,43 @@ function revalidateTaskMutationRoutes(taskId: string, relatedTaskId?: string) {
   }
 }
 
+/**
+ * Ad hoc overrides are the only client-supplied DESIGN.md attach path.
+ * Description text is already freeform, but this gate still keeps the
+ * privileged prepend limited to https blobs under this user's ad hoc prefix
+ * and strips markdown-breaking brackets from the label.
+ */
+function resolveDesignMdAttachmentOverride(
+  override: { label: string; url: string },
+  userId: string,
+): { label: string; url: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(override.url.trim());
+  } catch {
+    throw new Error("Invalid DESIGN.md attachment URL");
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error("DESIGN.md attachment URL must use https");
+  }
+
+  const expectedPathPrefix = `/${buildAdHocDesignMdPrefix(userId)}`;
+  if (!parsed.pathname.startsWith(expectedPathPrefix)) {
+    throw new Error("DESIGN.md attachment URL is not valid for this user");
+  }
+
+  return {
+    label: sanitizeTaskAttachmentLabel(override.label, "DESIGN.md"),
+    url: parsed.href,
+  };
+}
+
 async function createTaskFromDescription(input: {
   description: string;
   assigneeId: string | null;
   projectId?: string | null;
+  userId: string;
   skipDesignMdAttachment?: boolean;
   designMdAttachmentOverride?: { label: string; url: string };
   status: Extract<TaskStatus, "DRAFT" | "READY">;
@@ -227,7 +262,10 @@ async function createTaskFromDescription(input: {
     : input.designMdAttachmentOverride
       ? designMdService.withDesignMdAttachment(
           trimmedDescription,
-          input.designMdAttachmentOverride,
+          resolveDesignMdAttachmentOverride(
+            input.designMdAttachmentOverride,
+            input.userId,
+          ),
         )
       : await designMdService.appendDesignMdToDescription(trimmedDescription);
 
@@ -387,6 +425,7 @@ export const createTask = withSession<
         description,
         assigneeId,
         projectId,
+        userId: session.user.id,
         skipDesignMdAttachment,
         designMdAttachmentOverride,
         status,
@@ -735,6 +774,7 @@ export const createTaskAndLink = withSession<
         description,
         assigneeId,
         projectId,
+        userId: session.user.id,
         skipDesignMdAttachment,
         designMdAttachmentOverride,
         status,

--- a/apps/web/src/lib/services/__tests__/design-md.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/design-md.service.test.ts
@@ -45,6 +45,7 @@ const getWorkspaceDesignMdMock = vi.fn();
 const getMyMemberInOrganizationMock = vi.fn();
 const setMyDesignMdMock = vi.fn();
 const setOrganizationDesignMdMock = vi.fn();
+const storeAdHocDesignMdMock = vi.fn();
 
 vi.mock("@/lib/clients/core.client", () => ({
   coreClient: {
@@ -55,6 +56,7 @@ vi.mock("@/lib/clients/core.client", () => ({
     setMyDesignMd: (...args: unknown[]) => setMyDesignMdMock(...args),
     setOrganizationDesignMd: (...args: unknown[]) =>
       setOrganizationDesignMdMock(...args),
+    storeAdHocDesignMd: (...args: unknown[]) => storeAdHocDesignMdMock(...args),
   },
 }));
 
@@ -91,6 +93,14 @@ describe("designMdService", () => {
       data: {
         designMd: {
           url: "https://blob.example/design-md/42-hash.md",
+          extractionId: "42",
+        },
+      },
+    });
+    storeAdHocDesignMdMock.mockResolvedValue({
+      data: {
+        designMd: {
+          url: "https://blob.example/design-md/adhoc/user-1/42-hash.md",
           extractionId: "42",
         },
       },
@@ -214,6 +224,83 @@ describe("designMdService", () => {
       previewUrl: "https://www.masumi.example/tools/design-md?cached=42",
       url: "https://blob.example/design-md/42-hash.md",
     });
+  });
+
+  it("stores ad hoc generation on the adhoc blob path, never a profile write", async () => {
+    submitMock.mockResolvedValue(
+      ok({
+        designMd: "# Competitor brand",
+        extractionId: 99,
+        status: "done",
+      }),
+    );
+
+    const { designMdService } = await import("../design-md.service");
+    const started = await designMdService.startDesignMdGeneration(
+      session,
+      { type: "adhoc" },
+      "https://competitor.example",
+    );
+
+    expect(started).toEqual({
+      kind: "completed",
+      data: {
+        extractionId: "42",
+        previewUrl: "https://www.masumi.example/tools/design-md?cached=42",
+        url: "https://blob.example/design-md/adhoc/user-1/42-hash.md",
+      },
+    });
+    expect(storeAdHocDesignMdMock).toHaveBeenCalledWith({
+      content: "# Competitor brand",
+      extractionId: "99",
+    });
+    expect(setMyDesignMdMock).not.toHaveBeenCalled();
+    expect(setOrganizationDesignMdMock).not.toHaveBeenCalled();
+    expect(getMyMemberInOrganizationMock).not.toHaveBeenCalled();
+  });
+
+  it("finalizes queued ad hoc jobs via storeAdHocDesignMd", async () => {
+    submitMock.mockResolvedValue(
+      ok({
+        jobId: "job_adhoc",
+        status: "queued",
+      }),
+    );
+    pollJobMock.mockResolvedValue(
+      ok({
+        designMd: "# Ad hoc brand",
+        extractionId: 7,
+        status: "done",
+      }),
+    );
+
+    const { designMdService } = await import("../design-md.service");
+    const started = await designMdService.startDesignMdGeneration(
+      session,
+      { type: "adhoc" },
+      "https://competitor.example",
+    );
+
+    if (started.kind !== "queued") {
+      throw new Error("Expected queued job");
+    }
+
+    const persisted = await designMdService.finalizeAndPersistDesignMd(
+      session,
+      { type: "adhoc" },
+      started.jobId,
+      started.jobToken,
+    );
+
+    expect(storeAdHocDesignMdMock).toHaveBeenCalledWith({
+      content: "# Ad hoc brand",
+      extractionId: "7",
+    });
+    expect(setMyDesignMdMock).not.toHaveBeenCalled();
+    expect(setOrganizationDesignMdMock).not.toHaveBeenCalled();
+    expect(persisted.url).toBe(
+      "https://blob.example/design-md/adhoc/user-1/42-hash.md",
+    );
   });
 
   it("requires organization admin access for organization owners", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review follow-ups for #3574 (`feat/task-design-md-branding-picker`).

- **Create-related tasks** now get the same DESIGN.md picker (`initialDesignMdAttachment` from `TaskDetailActionsSlot`) and forward `skipDesignMdAttachment` / `designMdAttachmentOverride` into `createTaskAndLink`.
- **Ad hoc override validation** on create: https only, pathname under `design-md/adhoc/{sessionUserId}/`, label sanitized via `sanitizeTaskAttachmentLabel`.
- **Tests**: ad hoc persist never hits profile writes; TaskForm asserts custom → override; create-related forwards picker flags.

### Out of scope (Minor from review)

- Utils ad hoc path unit tests, `owner` on resolveEffectiveDesignMd fixtures, hover copy for custom branding, ad hoc blob GC, picker when no effective DESIGN.md.

## Test plan

- [x] `pnpm --filter web test` on action, design-md.service, task-form, task-detail-actions
- [x] Pre-commit `pnpm check` + `pnpm typecheck`

Stacked on #3574 — merge into `feat/task-design-md-branding-picker` first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4d3971-3fe1-4d0c-b4d8-0af088ce7453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4d3971-3fe1-4d0c-b4d8-0af088ce7453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

