### PR TITLE
test(web): polish DESIGN.md picker minors from review

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1815,6 +1815,7 @@
           "customLabel": "{hostname} Markendesign",
           "tooltip": "DESIGN.md ist ein Markenleitfaden, der vom Inhaber bereits für {organization} erstellt wurde. Mit dieser Anlage wendet der Agent deine Marke automatisch an.",
           "tooltipPersonal": "DESIGN.md ist ein Markenleitfaden, den du bereits erstellt hast. Mit dieser Anlage wendet der Agent deine Marke automatisch an.",
+          "tooltipCustom": "DESIGN.md, erzeugt von {hostname}, nur für diese Aufgabe. Mit dieser Anlage wendet der Agent dieses Branding an. Es wird nichts in deinem Profil gespeichert.",
           "learnMore": "Mehr über DESIGN.md erfahren",
           "infoAria": "Über diese Anlage",
           "useDifferentBranding": "Anderes Branding verwenden",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1826,6 +1826,7 @@
           "customLabel": "{hostname} Brand Design",
           "tooltip": "DESIGN.md is a brand guide already created for {organization} by its owner. Attaching it here helps this agent apply your branding automatically.",
           "tooltipPersonal": "DESIGN.md is a brand guide you already created. Attaching it here helps this agent apply your branding automatically.",
+          "tooltipCustom": "DESIGN.md generated from {hostname} for this task only. Attaching it here helps this agent apply that branding. Nothing is saved to your profile.",
           "learnMore": "Learn more about DESIGN.md",
           "infoAria": "About this attachment",
           "useDifferentBranding": "Use different branding",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1815,6 +1815,7 @@
           "customLabel": "Diseño de marca de {hostname}",
           "tooltip": "DESIGN.md es una guía de marca ya creada para {organization} por su propietario. Adjuntarla aquí ayuda a que este agente aplique tu marca automáticamente.",
           "tooltipPersonal": "DESIGN.md es una guía de marca que ya creaste. Adjuntarla aquí ayuda a que este agente aplique tu marca automáticamente.",
+          "tooltipCustom": "DESIGN.md generado desde {hostname} solo para esta tarea. Adjuntarlo aquí ayuda a que este agente aplique esa marca. No se guarda nada en tu perfil.",
           "learnMore": "Más información sobre DESIGN.md",
           "infoAria": "Sobre este adjunto",
           "useDifferentBranding": "Usar otra marca",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1815,6 +1815,7 @@
           "customLabel": "Charte de marque de {hostname}",
           "tooltip": "DESIGN.md est une charte de marque déjà créée pour {organization} par son propriétaire. La joindre ici aide cet agent à appliquer automatiquement votre marque.",
           "tooltipPersonal": "DESIGN.md est une charte de marque que vous avez déjà créée. La joindre ici aide cet agent à appliquer automatiquement votre marque.",
+          "tooltipCustom": "DESIGN.md généré à partir de {hostname} pour cette tâche uniquement. La joindre ici aide cet agent à appliquer cette marque. Rien n'est enregistré dans votre profil.",
           "learnMore": "En savoir plus sur DESIGN.md",
           "infoAria": "À propos de cette pièce jointe",
           "useDifferentBranding": "Utiliser une autre marque",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1815,6 +1815,7 @@
           "customLabel": "Brand design di {hostname}",
           "tooltip": "DESIGN.md è una guida al brand già creata per {organization} dal proprietario. Allegarla qui aiuta questo agente ad applicare automaticamente il tuo brand.",
           "tooltipPersonal": "DESIGN.md è una guida al brand che hai già creato. Allegarla qui aiuta questo agente ad applicare automaticamente il tuo brand.",
+          "tooltipCustom": "DESIGN.md generato da {hostname} solo per questa attività. Allegarlo qui aiuta questo agente ad applicare quel brand. Non viene salvato nulla nel tuo profilo.",
           "learnMore": "Scopri di più su DESIGN.md",
           "infoAria": "Informazioni su questo allegato",
           "useDifferentBranding": "Usa un brand diverso",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1815,6 +1815,7 @@
           "customLabel": "{hostname} のブランドデザイン",
           "tooltip": "DESIGN.md は、オーナーが {organization} 用にすでに作成したブランドガイドです。ここに添付すると、このエージェントが自動的にあなたのブランドを適用します。",
           "tooltipPersonal": "DESIGN.md は、あなたがすでに作成したブランドガイドです。ここに添付すると、このエージェントが自動的にあなたのブランドを適用します。",
+          "tooltipCustom": "{hostname} からこのタスク専用に生成された DESIGN.md です。ここに添付すると、このエージェントがそのブランドを適用します。プロフィールには保存されません。",
           "learnMore": "DESIGN.md について詳しく",
           "infoAria": "この添付について",
           "useDifferentBranding": "別のブランドを使用",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -1815,6 +1815,7 @@
           "customLabel": "Design de marca de {hostname}",
           "tooltip": "O DESIGN.md é um guia de marca já criado para a {organization} pelo seu proprietário. Anexá-lo aqui ajuda este agente a aplicar sua marca automaticamente.",
           "tooltipPersonal": "O DESIGN.md é um guia de marca que você já criou. Anexá-lo aqui ajuda este agente a aplicar sua marca automaticamente.",
+          "tooltipCustom": "DESIGN.md gerado a partir de {hostname} apenas para esta tarefa. Anexá-lo aqui ajuda este agente a aplicar essa marca. Nada é salvo no seu perfil.",
           "learnMore": "Saiba mais sobre o DESIGN.md",
           "infoAria": "Sobre este anexo",
           "useDifferentBranding": "Usar outra marca",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1815,6 +1815,7 @@
           "customLabel": "Design de marca de {hostname}",
           "tooltip": "O DESIGN.md é um guia de marca já criado para a {organization} pelo seu proprietário. Anexá-lo aqui ajuda este agente a aplicar a tua marca automaticamente.",
           "tooltipPersonal": "O DESIGN.md é um guia de marca que já criaste. Anexá-lo aqui ajuda este agente a aplicar a tua marca automaticamente.",
+          "tooltipCustom": "DESIGN.md gerado a partir de {hostname} apenas para esta tarefa. Anexá-lo aqui ajuda este agente a aplicar essa marca. Nada é guardado no teu perfil.",
           "learnMore": "Saber mais sobre o DESIGN.md",
           "infoAria": "Sobre este anexo",
           "useDifferentBranding": "Usar outra marca",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -1815,6 +1815,7 @@
           "customLabel": "{hostname} 品牌设计",
           "tooltip": "DESIGN.md 是所有者已为 {organization} 创建的品牌指南。在此附加它可帮助该智能体自动应用你的品牌。",
           "tooltipPersonal": "DESIGN.md 是你已创建的品牌指南。在此附加它可帮助该智能体自动应用你的品牌。",
+          "tooltipCustom": "这是从 {hostname} 为此任务单独生成的 DESIGN.md。在此附加它可帮助该智能体应用该品牌。不会保存到你的个人资料。",
           "learnMore": "了解更多关于 DESIGN.md 的信息",
           "infoAria": "关于此附件",
           "useDifferentBranding": "使用其他品牌",

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-design-md-attachment.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-design-md-attachment.test.tsx
@@ -212,6 +212,34 @@ describe("TaskDesignMdAttachmentField", () => {
     expect(screen.getByText("resetToDefault")).toBeInTheDocument();
   });
 
+  it("explains the custom branding in the hover card, not the org default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskDesignMdAttachmentField
+        defaultAttachment={organizationAttachment}
+        selection={{
+          enabled: true,
+          custom: {
+            label: "DESIGN.md",
+            url: "https://blob.example/adhoc.md",
+            sourceUrl: "https://www.competitor.com",
+          },
+        }}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "infoAria" }));
+
+    expect(
+      await screen.findByText('tooltipCustom:{"hostname":"competitor.com"}'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('tooltip:{"organization":"Acme Inc"}'),
+    ).not.toBeInTheDocument();
+  });
+
   it("clears the custom attachment when reset is clicked, without reopening the dialog", async () => {
     const user = userEvent.setup();
     const onSelectionChange = vi.fn();

--- a/apps/web/src/app/(app)/tasks/components/task-design-md-attachment.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-design-md-attachment.tsx
@@ -66,10 +66,11 @@ export function TaskDesignMdAttachmentField({
     ? t("customLabel", { hostname: getHostname(selection.custom.sourceUrl) })
     : defaultLabel;
 
-  // The wording only makes sense pointed at a real, named owner — a custom
-  // ad hoc attachment describes itself well enough via its label already.
-  const tooltipText =
-    defaultAttachment.owner.type === "organization"
+  const tooltipText = selection.custom
+    ? t("tooltipCustom", {
+        hostname: getHostname(selection.custom.sourceUrl),
+      })
+    : defaultAttachment.owner.type === "organization"
       ? t("tooltip", { organization: defaultAttachment.owner.name })
       : t("tooltipPersonal");
 

--- a/apps/web/src/lib/services/__tests__/design-md.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/design-md.service.test.ts
@@ -393,6 +393,7 @@ describe("designMdService", () => {
         designMd: {
           label: "DESIGN.md",
           url: "https://blob.example/org-design.md",
+          owner: { type: "organization", name: "Acme Inc", logo: null },
         },
       },
     });
@@ -404,6 +405,7 @@ describe("designMdService", () => {
     expect(designMd).toEqual({
       label: "DESIGN.md",
       url: "https://blob.example/org-design.md",
+      owner: { type: "organization", name: "Acme Inc", logo: null },
     });
   });
 
@@ -424,6 +426,7 @@ describe("designMdService", () => {
         designMd: {
           label: "DESIGN.md",
           url: "https://blob.example/user-design.md",
+          owner: { type: "user" },
         },
       },
     });
@@ -443,7 +446,13 @@ describe("designMdService", () => {
   it("does not duplicate design.md links when the url needs markdown escaping", async () => {
     const designMdUrl = "https://blob.example/user-design).md";
     getWorkspaceDesignMdMock.mockResolvedValue({
-      data: { designMd: { label: "DESIGN.md", url: designMdUrl } },
+      data: {
+        designMd: {
+          label: "DESIGN.md",
+          url: designMdUrl,
+          owner: { type: "user" },
+        },
+      },
     });
 
     const { designMdService } = await import("../design-md.service");

--- a/packages/utils/src/__tests__/design-md-path.test.ts
+++ b/packages/utils/src/__tests__/design-md-path.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAdHocDesignMdPathname,
+  buildAdHocDesignMdPrefix,
   buildOrganizationDesignMdPathname,
   buildOrganizationDesignMdPrefix,
   buildUserDesignMdPathname,
@@ -51,6 +53,28 @@ describe("buildOrganizationDesignMdPathname", () => {
   it("keeps an extractionId-prefixed hash filename", () => {
     expect(buildOrganizationDesignMdPathname(ORG_ID, `55-${HASH}.md`)).toBe(
       `design-md/organizations/${ORG_ID}/55-${HASH}.md`,
+    );
+  });
+});
+
+describe("buildAdHocDesignMdPrefix", () => {
+  it("returns design-md/adhoc/{userId}/", () => {
+    expect(buildAdHocDesignMdPrefix(USER_ID)).toBe(
+      `design-md/adhoc/${USER_ID}/`,
+    );
+  });
+});
+
+describe("buildAdHocDesignMdPathname", () => {
+  it("appends the hash filename under the ad hoc design-md prefix", () => {
+    expect(buildAdHocDesignMdPathname(USER_ID, `${HASH}.md`)).toBe(
+      `design-md/adhoc/${USER_ID}/${HASH}.md`,
+    );
+  });
+
+  it("keeps an extractionId-prefixed hash filename", () => {
+    expect(buildAdHocDesignMdPathname(USER_ID, `99-${HASH}.md`)).toBe(
+      `design-md/adhoc/${USER_ID}/99-${HASH}.md`,
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Worth-it leftovers from the #3574 review.

**Fixed**
- Ad hoc path helpers covered in `packages/utils`
- Effective DESIGN.md service fixtures assert `owner`
- Custom branding uses `tooltipCustom` (all locales) instead of the org/personal hover copy

**Skipped on purpose**
- Ad hoc blob GC: needs lifecycle/TTL infra, not a picker polish
- Picker when no effective DESIGN.md: intentional product gate from the feature design

Stacked on #3574.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4d3971-3fe1-4d0c-b4d8-0af088ce7453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4d3971-3fe1-4d0c-b4d8-0af088ce7453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

