### PR TITLE
fix(web): gate browser notifications on document focus

### DIFF
--- a/apps/web/src/app/(app)/components/notification-toast-listener.tsx
+++ b/apps/web/src/app/(app)/components/notification-toast-listener.tsx
@@ -58,16 +58,16 @@ export function NotificationToastListener({
   useNotificationRealtime({
     userId,
     onNotification: (notification) => {
-      const documentHidden =
-        typeof document !== "undefined" ? document.hidden : false;
+      const isDocumentFocused =
+        typeof document !== "undefined" ? document.hasFocus() : true;
       const permission = getBrowserNotificationPermission();
       const showBrowser = shouldShowBrowserNotification({
         permission,
-        documentHidden,
+        isDocumentFocused,
         isRead: notification.isRead,
       });
       const showToast = shouldShowInAppNotificationToast({
-        documentHidden,
+        isDocumentFocused,
         isRead: notification.isRead,
       });
 

--- a/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
+++ b/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
@@ -10,7 +10,6 @@ import {
 
 describe("shouldShowBrowserNotification", () => {
   it("shows when granted, unread, and document unfocused (including visible-but-unfocused)", () => {
-    // Spec / product copy: "open but not focused" — not Page Visibility alone.
     expect(
       shouldShowBrowserNotification({
         permission: "granted",

--- a/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
+++ b/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
@@ -9,17 +9,7 @@ import {
 } from "@/lib/utils/browser-notification";
 
 describe("shouldShowBrowserNotification", () => {
-  it("shows only when granted, document unfocused, and unread", () => {
-    expect(
-      shouldShowBrowserNotification({
-        permission: "granted",
-        isDocumentFocused: false,
-        isRead: false,
-      }),
-    ).toBe(true);
-  });
-
-  it("shows when the tab is visible but unfocused (other app has OS focus)", () => {
+  it("shows when granted, unread, and document unfocused (including visible-but-unfocused)", () => {
     // Spec / product copy: "open but not focused" — not Page Visibility alone.
     expect(
       shouldShowBrowserNotification({

--- a/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
+++ b/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
@@ -9,11 +9,22 @@ import {
 } from "@/lib/utils/browser-notification";
 
 describe("shouldShowBrowserNotification", () => {
-  it("shows only when granted, document hidden, and unread", () => {
+  it("shows only when granted, document unfocused, and unread", () => {
     expect(
       shouldShowBrowserNotification({
         permission: "granted",
-        documentHidden: true,
+        isDocumentFocused: false,
+        isRead: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows when the tab is visible but unfocused (other app has OS focus)", () => {
+    // Spec / product copy: "open but not focused" — not Page Visibility alone.
+    expect(
+      shouldShowBrowserNotification({
+        permission: "granted",
+        isDocumentFocused: false,
         isRead: false,
       }),
     ).toBe(true);
@@ -23,31 +34,31 @@ describe("shouldShowBrowserNotification", () => {
     expect(
       shouldShowBrowserNotification({
         permission: "default",
-        documentHidden: true,
+        isDocumentFocused: false,
         isRead: false,
       }),
     ).toBe(false);
     expect(
       shouldShowBrowserNotification({
         permission: "denied",
-        documentHidden: true,
+        isDocumentFocused: false,
         isRead: false,
       }),
     ).toBe(false);
   });
 
-  it("hides when the tab is visible or the notification is read", () => {
+  it("hides when the document is focused or the notification is read", () => {
     expect(
       shouldShowBrowserNotification({
         permission: "granted",
-        documentHidden: false,
+        isDocumentFocused: true,
         isRead: false,
       }),
     ).toBe(false);
     expect(
       shouldShowBrowserNotification({
         permission: "granted",
-        documentHidden: true,
+        isDocumentFocused: false,
         isRead: true,
       }),
     ).toBe(false);
@@ -57,7 +68,7 @@ describe("shouldShowBrowserNotification", () => {
     expect(
       shouldShowBrowserNotification({
         permission: "unsupported",
-        documentHidden: true,
+        isDocumentFocused: false,
         isRead: false,
       }),
     ).toBe(false);
@@ -65,22 +76,22 @@ describe("shouldShowBrowserNotification", () => {
 });
 
 describe("shouldShowInAppNotificationToast", () => {
-  it("shows unread toasts only while the tab is visible", () => {
+  it("shows unread toasts only while the document is focused", () => {
     expect(
       shouldShowInAppNotificationToast({
-        documentHidden: false,
+        isDocumentFocused: true,
         isRead: false,
       }),
     ).toBe(true);
     expect(
       shouldShowInAppNotificationToast({
-        documentHidden: true,
+        isDocumentFocused: false,
         isRead: false,
       }),
     ).toBe(false);
     expect(
       shouldShowInAppNotificationToast({
-        documentHidden: false,
+        isDocumentFocused: true,
         isRead: true,
       }),
     ).toBe(false);

--- a/apps/web/src/lib/utils/browser-notification.ts
+++ b/apps/web/src/lib/utils/browser-notification.ts
@@ -37,8 +37,14 @@ export function shouldShowBrowserNotification({
   isDocumentFocused,
   isRead,
 }: BrowserNotificationGateInput): boolean {
-  if (isRead) return false;
-  if (permission !== "granted") return false;
+  if (isRead) {
+    return false;
+  }
+
+  if (permission !== "granted") {
+    return false;
+  }
+
   return !isDocumentFocused;
 }
 
@@ -49,7 +55,10 @@ export function shouldShowInAppNotificationToast({
   isDocumentFocused: boolean;
   isRead: boolean;
 }): boolean {
-  if (isRead) return false;
+  if (isRead) {
+    return false;
+  }
+
   return isDocumentFocused;
 }
 

--- a/apps/web/src/lib/utils/browser-notification.ts
+++ b/apps/web/src/lib/utils/browser-notification.ts
@@ -4,7 +4,7 @@ export type BrowserNotificationPermission =
 
 export interface BrowserNotificationGateInput {
   permission: BrowserNotificationPermission;
-  documentHidden: boolean;
+  isDocumentFocused: boolean;
   isRead: boolean;
 }
 
@@ -34,32 +34,23 @@ export function getBrowserNotificationPermission(): BrowserNotificationPermissio
 
 export function shouldShowBrowserNotification({
   permission,
-  documentHidden,
+  isDocumentFocused,
   isRead,
 }: BrowserNotificationGateInput): boolean {
-  if (isRead) {
-    return false;
-  }
-
-  if (permission !== "granted") {
-    return false;
-  }
-
-  return documentHidden;
+  if (isRead) return false;
+  if (permission !== "granted") return false;
+  return !isDocumentFocused;
 }
 
 export function shouldShowInAppNotificationToast({
-  documentHidden,
+  isDocumentFocused,
   isRead,
 }: {
-  documentHidden: boolean;
+  isDocumentFocused: boolean;
   isRead: boolean;
 }): boolean {
-  if (isRead) {
-    return false;
-  }
-
-  return !documentHidden;
+  if (isRead) return false;
+  return isDocumentFocused;
 }
 
 export async function requestBrowserNotificationPermission(): Promise<BrowserNotificationPermission> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to [SOK-698](https://linear.app/masumi/issue/SOK-698/browser-notifications-for-all-notification-kinds-via-ably) / #3572.

## What was broken
OS browser notifications only fired when `document.hidden` was true. Spec and permission copy promise alerts when Sokosumi is **open but not focused**. A visible window with another app focused got an in-app toast (easy to miss) instead of an OS notification.

## Fix
Gate on `document.hasFocus()` via `isDocumentFocused`. Unfocused → OS notification (when permission granted). Focused → in-app toast.

## Other failure modes found (not in this PR)
- Permission never granted / denied → no OS alerts; denial recovery tracked in [SOK-702](https://linear.app/masumi/issue/SOK-702)
- Tab/browser closed → needs Web Push ([SOK-699](https://linear.app/masumi/issue/SOK-699))
- Broken Ably keys → no realtime events at all (cloud agents often use placeholders)

## Verification
```
# failing repro (first commit)
pnpm --filter web test src/lib/utils/__tests__/browser-notification.test.ts
# → 4 failed before fix

# after fix
pnpm --filter web test src/lib/utils/__tests__/browser-notification.test.ts
# → 9 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c883f089-ed13-471c-b016-91d95ede3185?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c883f089-ed13-471c-b016-91d95ede3185&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

