### PR TITLE
fix(web): rank @mention suggestions prefix before substring

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import {
   createMentionSpan,
   deslugifyMentionSlug,
+  filterNormalizedMentions,
   findPositionForOffset,
   getActiveTrigger,
   getCaretRect,
@@ -158,11 +159,8 @@ export const MarkdownEditor = forwardRef<
   );
 
   const filteredMentions = useMemo(() => {
-    if (query === null || query === "") return normalizedMentions;
-    const normalizedQuery = query.toLowerCase();
-    return normalizedMentions.filter((mention) =>
-      mention.value.toLowerCase().includes(normalizedQuery),
-    );
+    if (query === null) return normalizedMentions;
+    return filterNormalizedMentions(normalizedMentions, query);
   }, [normalizedMentions, query]);
 
   const openSuggestions = useCallback(

--- a/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
+++ b/apps/web/src/components/__tests__/mention-textarea-utils.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildMentionToken,
+  filterNormalizedMentions,
   getActiveEmojiTrigger,
   getActiveTrigger,
   getPopupPositionFromRect,
+  type NormalizedMention,
   POPUP_HEIGHT_PX,
   serializeEditorText,
   setEditorFromRaw,
@@ -143,6 +145,91 @@ describe("mention-textarea utils", () => {
       );
 
       expect(position.side).toBe("bottom");
+    });
+  });
+
+  describe("filterNormalizedMentions", () => {
+    const sandro: NormalizedMention = {
+      key: "sandro",
+      value: "Sandro",
+      slug: "sandro",
+    };
+    const andreas: NormalizedMention = {
+      key: "andreas",
+      value: "Andreas Osberghaus",
+      slug: "andreas-osberghaus",
+    };
+    const allMention: NormalizedMention = {
+      key: "all",
+      value: "all",
+      slug: "all",
+    };
+    const alice: NormalizedMention = {
+      key: "alice",
+      value: "Alice",
+      slug: "alice",
+    };
+    const bob: NormalizedMention = {
+      key: "bob",
+      value: "Bob",
+      slug: "bob",
+    };
+
+    it("preserves input order for empty query including @all pin", () => {
+      const items = [allMention, sandro, andreas];
+      expect(filterNormalizedMentions(items, "").map((m) => m.key)).toEqual([
+        "all",
+        "sandro",
+        "andreas",
+      ]);
+    });
+
+    it("ranks prefix matches before substring includes for andr", () => {
+      const items = [sandro, andreas];
+      const result = filterNormalizedMentions(items, "andr");
+      expect(result.map((m) => m.key)).toEqual(["andreas", "sandro"]);
+    });
+
+    it("still returns includes-only matches when no prefix peer", () => {
+      expect(
+        filterNormalizedMentions([sandro, andreas], "ndr").map((m) => m.key),
+      ).toEqual(["sandro", "andreas"]);
+    });
+
+    it("keeps within-tier input order for multiple prefix matches", () => {
+      const items = [alice, bob];
+      expect(filterNormalizedMentions(items, "a").map((m) => m.key)).toEqual([
+        "alice",
+      ]);
+      const prefixPeers: NormalizedMention[] = [
+        { key: "anna", value: "Anna", slug: "anna" },
+        { key: "andrew", value: "Andrew", slug: "andrew" },
+      ];
+      expect(
+        filterNormalizedMentions(prefixPeers, "an").map((m) => m.key),
+      ).toEqual(["anna", "andrew"]);
+    });
+
+    it("matches slug when value does not contain query", () => {
+      const bySlug: NormalizedMention = {
+        key: "u1",
+        value: "Display Name",
+        slug: "andreas-osberghaus",
+      };
+      expect(
+        filterNormalizedMentions([sandro, bySlug], "andr").map((m) => m.key),
+      ).toEqual(["u1", "sandro"]);
+    });
+
+    it("returns empty when nothing matches", () => {
+      expect(filterNormalizedMentions([sandro, andreas], "zzz")).toEqual([]);
+    });
+
+    it("does not mutate the input array", () => {
+      const items = [sandro, andreas];
+      const before = [...items];
+      filterNormalizedMentions(items, "andr");
+      expect(items).toEqual(before);
     });
   });
 });

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -18,6 +18,7 @@ import {
 import {
   createMentionSpan,
   deslugifyMentionSlug,
+  filterNormalizedMentions,
   findPositionForOffset,
   getActiveEmojiTrigger,
   getActiveTrigger,
@@ -233,13 +234,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
   const filteredMentions = useMemo(() => {
     if (mentionQuery === null) return [];
-    if (mentionQuery === "") return normalizedMentions;
-    const normalizedQuery = mentionQuery.toLowerCase();
-    return normalizedMentions.filter(
-      (mention) =>
-        mention.value.toLowerCase().includes(normalizedQuery) ||
-        mention.slug.toLowerCase().includes(normalizedQuery),
-    );
+    return filterNormalizedMentions(normalizedMentions, mentionQuery);
   }, [mentionQuery, normalizedMentions]);
 
   const mentionGroups = useMemo(() => {
@@ -739,15 +734,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
     const listLength =
       live.kind === "emoji"
         ? live.matches.length
-        : live.query === ""
-          ? normalizedMentions.length
-          : normalizedMentions.filter((mention) => {
-              const q = live.query.toLowerCase();
-              return (
-                mention.value.toLowerCase().includes(q) ||
-                mention.slug.toLowerCase().includes(q)
-              );
-            }).length;
+        : filterNormalizedMentions(normalizedMentions, live.query).length;
 
     if (listLength === 0) {
       closeSuggestions();

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -24,11 +24,23 @@ export function filterNormalizedMentions<TData = unknown>(
     return [...items];
   }
 
-  return items.filter((mention) => {
+  const prefixMatches: NormalizedMention<TData>[] = [];
+  const includesMatches: NormalizedMention<TData>[] = [];
+
+  for (const mention of items) {
     const value = mention.value.toLowerCase();
     const slug = mention.slug.toLowerCase();
-    return value.includes(q) || slug.includes(q);
-  });
+
+    if (value.startsWith(q) || slug.startsWith(q)) {
+      prefixMatches.push(mention);
+      continue;
+    }
+    if (value.includes(q) || slug.includes(q)) {
+      includesMatches.push(mention);
+    }
+  }
+
+  return [...prefixMatches, ...includesMatches];
 }
 
 /** Optional sectioned mention picker groups (e.g. People / Coworkers). */

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -15,34 +15,6 @@ export interface NormalizedMention<TData = unknown> {
   data?: TData;
 }
 
-export function filterNormalizedMentions<TData = unknown>(
-  items: readonly NormalizedMention<TData>[],
-  query: string,
-): NormalizedMention<TData>[] {
-  const q = query.toLowerCase();
-  if (q.length === 0) {
-    return [...items];
-  }
-
-  const prefixMatches: NormalizedMention<TData>[] = [];
-  const includesMatches: NormalizedMention<TData>[] = [];
-
-  for (const mention of items) {
-    const value = mention.value.toLowerCase();
-    const slug = mention.slug.toLowerCase();
-
-    if (value.startsWith(q) || slug.startsWith(q)) {
-      prefixMatches.push(mention);
-      continue;
-    }
-    if (value.includes(q) || slug.includes(q)) {
-      includesMatches.push(mention);
-    }
-  }
-
-  return [...prefixMatches, ...includesMatches];
-}
-
 /** Optional sectioned mention picker groups (e.g. People / Coworkers). */
 export interface MentionSuggestionGroup<TData = unknown> {
   id: string;
@@ -78,6 +50,34 @@ export const VIEWPORT_PADDING_PX = 8;
 export const MENTION_CLASSNAME =
   "text-primary cursor-pointer font-semibold hover:underline";
 export const UNKNOWN_MENTION_CLASSNAME = "opacity-80";
+
+export function filterNormalizedMentions<TData = unknown>(
+  items: readonly NormalizedMention<TData>[],
+  query: string,
+): NormalizedMention<TData>[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) {
+    return [...items];
+  }
+
+  const prefixMatches: NormalizedMention<TData>[] = [];
+  const includesMatches: NormalizedMention<TData>[] = [];
+
+  for (const mention of items) {
+    const value = mention.value.toLowerCase();
+    const slug = mention.slug.toLowerCase();
+
+    if (value.startsWith(q) || slug.startsWith(q)) {
+      prefixMatches.push(mention);
+      continue;
+    }
+    if (value.includes(q) || slug.includes(q)) {
+      includesMatches.push(mention);
+    }
+  }
+
+  return [...prefixMatches, ...includesMatches];
+}
 
 export function isWhitespaceChar(char: string): boolean {
   return char.trim() === "";

--- a/apps/web/src/components/ui/mention-textarea-utils.ts
+++ b/apps/web/src/components/ui/mention-textarea-utils.ts
@@ -15,6 +15,22 @@ export interface NormalizedMention<TData = unknown> {
   data?: TData;
 }
 
+export function filterNormalizedMentions<TData = unknown>(
+  items: readonly NormalizedMention<TData>[],
+  query: string,
+): NormalizedMention<TData>[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) {
+    return [...items];
+  }
+
+  return items.filter((mention) => {
+    const value = mention.value.toLowerCase();
+    const slug = mention.slug.toLowerCase();
+    return value.includes(q) || slug.includes(q);
+  });
+}
+
 /** Optional sectioned mention picker groups (e.g. People / Coworkers). */
 export interface MentionSuggestionGroup<TData = unknown> {
   id: string;

--- a/apps/web/src/components/ui/mention-textarea.tsx
+++ b/apps/web/src/components/ui/mention-textarea.tsx
@@ -18,6 +18,7 @@ import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
 import {
   createMentionSpan,
   deslugifyMentionSlug,
+  filterNormalizedMentions,
   findPositionForOffset,
   getActiveTrigger,
   getCaretOffset,
@@ -383,11 +384,8 @@ function MentionTextareaInner<TData = unknown>(
   );
 
   const filteredMentions = useMemo(() => {
-    if (query === null || query === "") return normalizedMentions;
-    const normalizedQuery = query.toLowerCase();
-    return normalizedMentions.filter((mention) =>
-      mention.value.toLowerCase().includes(normalizedQuery),
-    );
+    if (query === null) return normalizedMentions;
+    return filterNormalizedMentions(normalizedMentions, query);
   }, [normalizedMentions, query]);
 
   const selectedKeys = useMemo(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Typing `@andr` put Sandro above Andreas Osberghaus. Filter used substring `.includes()` and kept roster order, so mid-name hits beat real prefixes.

**Fix.** Shared `filterNormalizedMentions` ranks like emoji shortcodes: prefix on name/slug first, then includes. Empty query still preserves order (`@all` pin stays). Wired into the chat WYSIWYG composer, `MentionTextarea`, and the tasks markdown editor.

**Verify.**
```
pnpm --filter web test src/components/__tests__/mention-textarea-utils.test.ts
```
Failing-then-passing history: commit `9167bb2f` (includes-only stub) then `86c20dd6` (prefix ranking).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3e96d9e-9fff-44b5-b17e-19aca0469703?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3e96d9e-9fff-44b5-b17e-19aca0469703&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

