### PR TITLE
feat(chat): publish room messages over Ably Pub/Sub

### DIFF
--- a/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
+++ b/apps/core/src/helpers/__tests__/persist-assistant-to-chat-room.test.ts
@@ -11,6 +11,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
+vi.mock("@/helpers/chat-room-message-realtime", () => ({
+  publishChatRoomMessageRealtimeById: vi.fn().mockResolvedValue(undefined),
+}));
+
 import prisma from "@/lib/db/prisma";
 import {
   persistAssistantToChatRoom,

--- a/apps/core/src/helpers/chat-room-message-realtime.test.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  findManyMembersMock,
+  findUniqueMessageMock,
+  publishChatRoomMessageEventMock,
+  mapChatRoomMessageMock,
+} = vi.hoisted(() => ({
+  findManyMembersMock: vi.fn(),
+  findUniqueMessageMock: vi.fn(),
+  publishChatRoomMessageEventMock: vi.fn(),
+  mapChatRoomMessageMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    chatRoomUserMember: {
+      findMany: (...args: unknown[]) => findManyMembersMock(...args),
+    },
+    chatRoomMessage: {
+      findUnique: (...args: unknown[]) => findUniqueMessageMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/ably/publish", () => ({
+  publishChatRoomMessageEvent: (...args: unknown[]) =>
+    publishChatRoomMessageEventMock(...args),
+}));
+
+vi.mock("@/routes/v1/chats/rooms/helpers", () => ({
+  chatRoomMessageInclude: {},
+  mapChatRoomMessage: (...args: unknown[]) => mapChatRoomMessageMock(...args),
+}));
+
+vi.mock("@/schemas/chat-room.schema", () => ({
+  chatRoomMessageSchema: {
+    parse: (value: unknown) => value,
+  },
+}));
+
+import {
+  publishChatRoomMessageRealtime,
+  publishChatRoomMessageRealtimeById,
+} from "./chat-room-message-realtime";
+
+const baseMessage = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  roomId: "660e8400-e29b-41d4-a716-446655440000",
+  parentMessageId: null,
+  content: "hello",
+  createdAt: new Date("2026-08-03T12:00:00.000Z"),
+  deletedAt: null,
+  editedAt: null,
+  senderUserId: "user_a",
+  senderCoworkerId: null,
+  senderUser: null,
+  senderCoworker: null,
+  mentionsAsSource: [],
+  reactions: [],
+  replies: [],
+  _count: { replies: 0 },
+  metadata: null,
+};
+
+describe("publishChatRoomMessageRealtime", () => {
+  beforeEach(() => {
+    findManyMembersMock.mockReset();
+    findUniqueMessageMock.mockReset();
+    publishChatRoomMessageEventMock.mockReset();
+    mapChatRoomMessageMock.mockReset();
+    publishChatRoomMessageEventMock.mockResolvedValue(undefined);
+    mapChatRoomMessageMock.mockImplementation((_message, userId: string) => ({
+      id: baseMessage.id,
+      roomId: baseMessage.roomId,
+      forUser: userId,
+    }));
+  });
+
+  it("fans out a personalized DTO to each room user member", async () => {
+    findManyMembersMock.mockResolvedValue([
+      { userId: "user_a" },
+      { userId: "user_b" },
+    ]);
+
+    await publishChatRoomMessageRealtime(baseMessage as never);
+
+    expect(findManyMembersMock).toHaveBeenCalledWith({
+      where: { roomId: baseMessage.roomId },
+      select: { userId: true },
+    });
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledTimes(2);
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_a",
+      message: {
+        id: baseMessage.id,
+        roomId: baseMessage.roomId,
+        forUser: "user_a",
+      },
+    });
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_b",
+      message: {
+        id: baseMessage.id,
+        roomId: baseMessage.roomId,
+        forUser: "user_b",
+      },
+    });
+  });
+
+  it("swallows publish errors", async () => {
+    findManyMembersMock.mockResolvedValue([{ userId: "user_a" }]);
+    publishChatRoomMessageEventMock.mockRejectedValue(new Error("ably down"));
+
+    await expect(
+      publishChatRoomMessageRealtime(baseMessage as never),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("publishChatRoomMessageRealtimeById", () => {
+  beforeEach(() => {
+    findManyMembersMock.mockReset();
+    findUniqueMessageMock.mockReset();
+    publishChatRoomMessageEventMock.mockReset();
+    mapChatRoomMessageMock.mockReset();
+    publishChatRoomMessageEventMock.mockResolvedValue(undefined);
+    mapChatRoomMessageMock.mockImplementation((_message, userId: string) => ({
+      id: baseMessage.id,
+      roomId: baseMessage.roomId,
+      forUser: userId,
+    }));
+  });
+
+  it("loads the message then fans out", async () => {
+    findUniqueMessageMock.mockResolvedValue(baseMessage);
+    findManyMembersMock.mockResolvedValue([{ userId: "user_a" }]);
+
+    await publishChatRoomMessageRealtimeById(baseMessage.id);
+
+    expect(findUniqueMessageMock).toHaveBeenCalledWith({
+      where: { id: baseMessage.id },
+      include: {},
+    });
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_a",
+      message: {
+        id: baseMessage.id,
+        roomId: baseMessage.roomId,
+        forUser: "user_a",
+      },
+    });
+  });
+
+  it("no-ops when the message is missing", async () => {
+    findUniqueMessageMock.mockResolvedValue(null);
+
+    await publishChatRoomMessageRealtimeById(baseMessage.id);
+
+    expect(publishChatRoomMessageEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/helpers/chat-room-message-realtime.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.ts
@@ -1,0 +1,69 @@
+import * as Sentry from "@sentry/node";
+import type { Prisma } from "@sokosumi/database";
+
+import { publishChatRoomMessageEvent } from "@/lib/ably/publish";
+import prisma from "@/lib/db/prisma";
+import {
+  chatRoomMessageInclude,
+  mapChatRoomMessage,
+} from "@/routes/v1/chats/rooms/helpers";
+import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
+
+type ChatRoomMessageWithInclude = Prisma.ChatRoomMessageGetPayload<{
+  include: typeof chatRoomMessageInclude;
+}>;
+
+export async function publishChatRoomMessageRealtime(
+  message: ChatRoomMessageWithInclude,
+): Promise<void> {
+  try {
+    const members = await prisma.chatRoomUserMember.findMany({
+      where: { roomId: message.roomId },
+      select: { userId: true },
+    });
+
+    await Promise.all(
+      members.map(async ({ userId }) => {
+        const dto = chatRoomMessageSchema.parse(
+          mapChatRoomMessage(message, userId),
+        );
+        await publishChatRoomMessageEvent({
+          userId,
+          message: dto,
+        });
+      }),
+    );
+  } catch (error) {
+    console.error("Failed to publish chat room message over Ably:", error);
+    Sentry.captureException(error, {
+      extra: {
+        messageId: message.id,
+        roomId: message.roomId,
+        errorType: "ably-publish-chat-room-message",
+      },
+    });
+  }
+}
+
+export async function publishChatRoomMessageRealtimeById(
+  messageId: string,
+): Promise<void> {
+  try {
+    const message = await prisma.chatRoomMessage.findUnique({
+      where: { id: messageId },
+      include: chatRoomMessageInclude,
+    });
+    if (!message) {
+      return;
+    }
+    await publishChatRoomMessageRealtime(message);
+  } catch (error) {
+    console.error("Failed to load chat room message for Ably publish:", error);
+    Sentry.captureException(error, {
+      extra: {
+        messageId,
+        errorType: "ably-publish-chat-room-message-by-id",
+      },
+    });
+  }
+}

--- a/apps/core/src/helpers/persist-assistant-to-chat-room.ts
+++ b/apps/core/src/helpers/persist-assistant-to-chat-room.ts
@@ -1,3 +1,4 @@
+import { publishChatRoomMessageRealtimeById } from "@/helpers/chat-room-message-realtime";
 import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
 import type { PersistedChatUiPart } from "./message-content";
@@ -132,6 +133,7 @@ export async function persistAssistantToChatRoom(params: {
       responseId,
     );
     if (existing) {
+      await publishChatRoomMessageRealtimeById(existing.id);
       return { id: existing.id };
     }
   }
@@ -164,6 +166,7 @@ export async function persistAssistantToChatRoom(params: {
       });
       return message;
     });
+    await publishChatRoomMessageRealtimeById(created.id);
     return { id: created.id };
   } catch (error) {
     if (!responseId || !isPrismaUniqueViolation(error)) {
@@ -175,6 +178,7 @@ export async function persistAssistantToChatRoom(params: {
       responseId,
     );
     if (raced) {
+      await publishChatRoomMessageRealtimeById(raced.id);
       return { id: raced.id };
     }
     throw error;
@@ -221,6 +225,7 @@ export async function persistUserMessageToChatRoom(params: {
   if (clientId) {
     const existing = await findUserByClientMessageId(roomId, clientId);
     if (existing) {
+      await publishChatRoomMessageRealtimeById(existing.id);
       return { id: existing.id };
     }
   }
@@ -253,6 +258,7 @@ export async function persistUserMessageToChatRoom(params: {
       return message;
     });
 
+    await publishChatRoomMessageRealtimeById(created.id);
     return { id: created.id };
   } catch (error) {
     if (!clientId || !isPrismaUniqueViolation(error)) {
@@ -261,6 +267,7 @@ export async function persistUserMessageToChatRoom(params: {
     // Interactive tx aborted after failed create — re-read on root client.
     const raced = await findUserByClientMessageId(roomId, clientId);
     if (raced) {
+      await publishChatRoomMessageRealtimeById(raced.id);
       return { id: raced.id };
     }
     throw error;

--- a/apps/core/src/lib/ably/publish.test.ts
+++ b/apps/core/src/lib/ably/publish.test.ts
@@ -3,6 +3,7 @@ import { SokosumiJobStatus } from "@sokosumi/utils";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  publishChatRoomMessageEvent,
   publishJobStatusData,
   publishNotificationEvent,
   publishTaskEventData,
@@ -87,5 +88,43 @@ describe("publishNotificationEvent", () => {
       "notification_created",
       notification,
     );
+  });
+});
+
+describe("publishChatRoomMessageEvent", () => {
+  it("publishes chat room message event to the user channel", async () => {
+    const message = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      roomId: "660e8400-e29b-41d4-a716-446655440000",
+      parentMessageId: null,
+      content: "hello",
+      createdAt: "2026-08-03T12:00:00.000Z",
+      deletedAt: null,
+      editedAt: null,
+      sender: {
+        type: "user" as const,
+        user: {
+          id: "user_123",
+          name: "Alice",
+          email: "alice@example.com",
+          image: null,
+          presence: "online" as const,
+        },
+      },
+      mentions: [],
+      reactions: [],
+      threadReplyCount: 0,
+      threadLastReplyAt: null,
+      metadata: null,
+      quote: null,
+    };
+
+    await publishChatRoomMessageEvent({
+      userId: "user_123",
+      message,
+    });
+
+    expect(getMock).toHaveBeenCalledWith("chat_rooms:all:user_user_123");
+    expect(publishMock).toHaveBeenCalledWith("chat_room_message", { message });
   });
 });

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -1,10 +1,13 @@
 import { NotificationKind } from "@sokosumi/database";
 import {
   makeAgentJobsChannelName,
+  makeUserChatRoomsChannelName,
   makeUserNotificationsChannelName,
   makeUserTasksChannelName,
   SokosumiJobStatus,
 } from "@sokosumi/utils";
+
+import type { ChatRoomMessage } from "@/schemas/chat-room.schema";
 
 import { getRestClient } from "./client";
 
@@ -84,4 +87,18 @@ export async function publishNotificationEvent({
   const client = getRestClient();
   const channel = client.channels.get(makeUserNotificationsChannelName(userId));
   await channel.publish("notification_created", notification);
+}
+
+interface PublishChatRoomMessageEventInput {
+  userId: string;
+  message: ChatRoomMessage;
+}
+
+export async function publishChatRoomMessageEvent({
+  userId,
+  message,
+}: PublishChatRoomMessageEventInput) {
+  const client = getRestClient();
+  const channel = client.channels.get(makeUserChatRoomsChannelName(userId));
+  await channel.publish("chat_room_message", { message });
 }

--- a/apps/core/src/lib/ably/utils.ts
+++ b/apps/core/src/lib/ably/utils.ts
@@ -4,6 +4,7 @@
  */
 export {
   makeAgentJobsChannelName,
+  makeUserChatRoomsChannelName,
   makeUserNotificationsChannelName,
   makeUserTasksChannelName,
 } from "@sokosumi/utils";

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.test.ts
@@ -33,6 +33,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
+vi.mock("@/helpers/chat-room-message-realtime", () => ({
+  publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
+}));
+
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
 const USER_ID = "user_123";

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
+import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { forbidden, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -118,6 +119,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       return updated;
     });
+
+    await publishChatRoomMessageRealtime(message);
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
+vi.mock("@/helpers/chat-room-message-realtime", () => ({
+  publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
+}));
+
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
 const USER_ID = "user_123";

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
+import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { forbidden, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -110,6 +111,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         include: chatRoomMessageInclude,
       });
     });
+
+    await publishChatRoomMessageRealtime(message);
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.test.ts
@@ -35,6 +35,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
+vi.mock("@/helpers/chat-room-message-realtime", () => ({
+  publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
+}));
+
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
 const USER_ID = "user_123";

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
+import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { badRequest, notFound } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { ok } from "@/helpers/response";
@@ -125,6 +126,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         include: chatRoomMessageInclude,
       });
     });
+
+    await publishChatRoomMessageRealtime(message);
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -62,6 +62,10 @@ vi.mock("@/helpers/chat-mention-notifications", () => ({
     emitChatMentionNotificationsMock(...args),
 }));
 
+vi.mock("@/helpers/chat-room-message-realtime", () => ({
+  publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
+}));
+
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const PARENT_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { waitUntil } from "@vercel/functions";
 
 import { emitChatMentionNotifications } from "@/helpers/chat-mention-notifications";
+import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { conflict } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { isPrismaUniqueViolation } from "@/helpers/prisma";
@@ -116,6 +117,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
         return message;
       });
+
+      await publishChatRoomMessageRealtime(message);
 
       return created(
         c,
@@ -315,6 +318,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           "clientMessageId already used by another sender in this room",
         );
       }
+      await publishChatRoomMessageRealtime(raced);
+
       return created(
         c,
         chatRoomMessageSchema.parse(
@@ -345,6 +350,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         );
       }
     }
+
+    await publishChatRoomMessageRealtime(message);
 
     return created(
       c,

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -80,6 +80,10 @@ vi.mock("ai", () => ({
   streamText: streamTextMock,
 }));
 
+vi.mock("@/helpers/chat-room-message-realtime", () => ({
+  publishChatRoomMessageRealtimeById: vi.fn().mockResolvedValue(undefined),
+}));
+
 import {
   buildRoomMentionPrompt,
   dispatchChatRoomMention,

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -2,6 +2,7 @@ import type { SokosumiProviderCallOptions } from "@sokosumi/ai-provider";
 import { coworkerTextLooksLikeAgentError } from "@sokosumi/ai-provider";
 import { streamText } from "ai";
 
+import { publishChatRoomMessageRealtimeById } from "@/helpers/chat-room-message-realtime";
 import prisma from "@/lib/db/prisma";
 import { getSokosumiProvider } from "@/lib/sokosumi-ai-provider";
 import { createCoworkerConversation } from "@/routes/v1/chats/stream/coworker-conversation";
@@ -370,7 +371,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
     return;
   }
 
-  await prisma.$transaction(async (tx) => {
+  const publishedMessageIds = await prisma.$transaction(async (tx) => {
     // Re-check membership after the provider call: eviction during streamText
     // must not land a reply in a room the coworker left.
     const stillMember = await tx.chatRoomCoworkerMember.findUnique({
@@ -393,7 +394,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
           error: "Coworker is no longer a member of this room",
         },
       });
-      return;
+      return null;
     }
 
     // Soft-delete during streamText cancels the mention to `failed` and
@@ -413,7 +414,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
           error: "Source message was deleted",
         },
       });
-      return;
+      return null;
     }
 
     // Persist the reply first, then claim the mention transition. If another
@@ -444,12 +445,26 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
 
     if (finalized.count !== 1) {
       await tx.chatRoomMessage.delete({ where: { id: responseMessage.id } });
-      return;
+      return null;
     }
 
     await tx.chatRoom.update({
       where: { id: mention.message.roomId },
       data: { updatedAt: new Date() },
     });
+
+    return {
+      responseMessageId: responseMessage.id,
+      sourceMessageId: mention.message.id,
+    };
   });
+
+  if (publishedMessageIds) {
+    await publishChatRoomMessageRealtimeById(
+      publishedMessageIds.responseMessageId,
+    );
+    await publishChatRoomMessageRealtimeById(
+      publishedMessageIds.sourceMessageId,
+    );
+  }
 }

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChannelProvider } from "ably/react";
 import { Hash, Loader2, MessageCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -43,6 +44,12 @@ import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRegisterBreadcrumbOverride } from "@/contexts/breadcrumb-override-context";
+import {
+  type ChatRoomMessageEventData,
+  makeUserChatRoomsChannelName,
+} from "@/lib/ably";
+import { hydrateChatRoomMessageFromRealtime } from "@/lib/ably/hydrate-chat-room-message";
+import { useChatRoomRealtime } from "@/lib/ably/use-chat-room-realtime";
 import type {
   ChatRoom,
   ChatRoomMessage,
@@ -111,8 +118,23 @@ interface RoomsClientProps {
 const COWORKER_RESPONSE_POLL_MS = 2500;
 /** ~2.5 minutes of polling before we stop waiting for a coworker reply. */
 const COWORKER_RESPONSE_POLL_MAX_ATTEMPTS = 60;
-/** Match sidebar channel-list cadence for peer traffic while a room is open. */
-const ROOM_LIVE_POLL_MS = 15_000;
+
+function RoomMessageRealtimeBridge({
+  userId,
+  onMessage,
+}: {
+  userId: string;
+  onMessage: (event: ChatRoomMessageEventData) => void;
+}) {
+  useChatRoomRealtime({
+    userId,
+    onMessage,
+    onError: (error) => {
+      console.error("Ably chat room message error:", error);
+    },
+  });
+  return null;
+}
 
 function RoomParticipantStack({
   room,
@@ -380,6 +402,45 @@ export function RoomsClient({
     organizationSlug: activeOrganization?.slug ?? null,
     onStreamSettled: refreshRoomMessagesAfterStream,
   });
+
+  const isCoworkerStreamingRef = useRef(isCoworkerStreaming);
+  isCoworkerStreamingRef.current = isCoworkerStreaming;
+  const skipRealtimeWhileStreamingRef = useRef(isCoworkerStreamRoom);
+  skipRealtimeWhileStreamingRef.current = isCoworkerStreamRoom;
+  const threadParentMessageIdRef = useRef<string | null>(null);
+  threadParentMessageIdRef.current = threadParentMessage?.id ?? null;
+
+  const handleChatRoomRealtimeMessage = useCallback(
+    (event: ChatRoomMessageEventData) => {
+      const message = hydrateChatRoomMessageFromRealtime(event.message);
+      if (message.roomId !== selectedRoomIdRef.current) {
+        return;
+      }
+      if (
+        skipRealtimeWhileStreamingRef.current &&
+        isCoworkerStreamingRef.current
+      ) {
+        return;
+      }
+
+      setMessagesState((current) => mergeRoomMessages(current, [message]));
+      setThreadParentMessage((current) =>
+        current?.id === message.id ? message : current,
+      );
+
+      const openThreadParentId = threadParentMessageIdRef.current;
+      if (!openThreadParentId) {
+        return;
+      }
+      if (
+        message.id === openThreadParentId ||
+        message.parentMessageId === openThreadParentId
+      ) {
+        setThreadMessages((current) => mergeRoomMessages(current, [message]));
+      }
+    },
+    [],
+  );
 
   const topLevelStreamOverlayMessages = useMemo(
     () =>
@@ -727,9 +788,8 @@ export function RoomsClient({
     };
   }, [selectedRoom?.id, hasPendingRoomCoworkerMention]);
 
-  // Peer traffic while the room stays open: light poll + focus/visibility
-  // refetch. Merges into local state so previously loaded older pages survive.
-  // Skip ticks while a coworker DM stream is in flight (avoids duplicate overlay).
+  // Safety net when Ably is unavailable or a message was missed while hidden.
+  // Live peer traffic arrives via Ably Pub/Sub (RoomMessageRealtimeBridge).
   useEffect(() => {
     if (!selectedRoom) {
       return;
@@ -773,7 +833,6 @@ export function RoomsClient({
       }
     };
 
-    const intervalId = window.setInterval(refreshLatest, ROOM_LIVE_POLL_MS);
     window.addEventListener("focus", refreshLatest);
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -784,7 +843,6 @@ export function RoomsClient({
 
     return () => {
       cancelled = true;
-      window.clearInterval(intervalId);
       window.removeEventListener("focus", refreshLatest);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
@@ -1217,6 +1275,16 @@ export function RoomsClient({
 
   return (
     <div className="-m-4 flex h-[calc(100svh-64px)] min-h-0 flex-col overflow-hidden bg-background">
+      {currentUserId ? (
+        <ChannelProvider
+          channelName={makeUserChatRoomsChannelName(currentUserId)}
+        >
+          <RoomMessageRealtimeBridge
+            userId={currentUserId}
+            onMessage={handleChatRoomRealtimeMessage}
+          />
+        </ChannelProvider>
+      ) : null}
       {/* `relative` anchors the thread panel's mobile full-screen takeover. */}
       <main className="relative flex min-h-0 flex-1">
         <section className="flex min-h-0 min-w-0 flex-1 flex-col">

--- a/apps/web/src/lib/ably/__tests__/hydrate-chat-room-message.test.ts
+++ b/apps/web/src/lib/ably/__tests__/hydrate-chat-room-message.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { hydrateChatRoomMessageFromRealtime } from "@/lib/ably/hydrate-chat-room-message";
+
+describe("hydrateChatRoomMessageFromRealtime", () => {
+  it("converts ISO date strings to Date instances", () => {
+    const hydrated = hydrateChatRoomMessageFromRealtime({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      roomId: "660e8400-e29b-41d4-a716-446655440000",
+      parentMessageId: null,
+      content: "hello",
+      createdAt: "2026-08-03T12:00:00.000Z",
+      deletedAt: null,
+      editedAt: "2026-08-03T12:05:00.000Z",
+      sender: {
+        type: "user",
+        user: {
+          id: "user_1",
+          name: "Alice",
+          email: "alice@example.com",
+          image: null,
+          presence: "online",
+        },
+      },
+      mentions: [],
+      reactions: [],
+      threadReplyCount: 0,
+      threadLastReplyAt: null,
+      metadata: null,
+      quote: null,
+    });
+
+    expect(hydrated.createdAt).toEqual(new Date("2026-08-03T12:00:00.000Z"));
+    expect(hydrated.editedAt).toEqual(new Date("2026-08-03T12:05:00.000Z"));
+    expect(hydrated.deletedAt).toBeNull();
+    expect(hydrated.threadLastReplyAt).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ably/auth.ts
+++ b/apps/web/src/lib/ably/auth.ts
@@ -12,6 +12,7 @@ export default async function createAuthTokenRequest(userId: string) {
       [`agent_jobs:*:user_${userId}`]: ["subscribe"],
       [`tasks:*:user_${userId}`]: ["subscribe"],
       [`notifications:*:user_${userId}`]: ["subscribe"],
+      [`chat_rooms:*:user_${userId}`]: ["subscribe"],
     },
   });
   return tokenRequest;

--- a/apps/web/src/lib/ably/hydrate-chat-room-message.ts
+++ b/apps/web/src/lib/ably/hydrate-chat-room-message.ts
@@ -1,0 +1,34 @@
+import type { ChatRoomMessageEventData } from "@/lib/ably/schema";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+function toDate(value: string): Date {
+  return new Date(value);
+}
+
+function toNullableDate(value: string | null): Date | null {
+  return value == null ? null : new Date(value);
+}
+
+/**
+ * Ably JSON carries ISO strings; Core client DTOs use Date for the same fields.
+ */
+export function hydrateChatRoomMessageFromRealtime(
+  message: ChatRoomMessageEventData["message"],
+): ChatRoomMessage {
+  return {
+    id: message.id,
+    roomId: message.roomId,
+    parentMessageId: message.parentMessageId,
+    content: message.content,
+    createdAt: toDate(message.createdAt),
+    deletedAt: toNullableDate(message.deletedAt),
+    editedAt: toNullableDate(message.editedAt),
+    sender: message.sender as ChatRoomMessage["sender"],
+    mentions: message.mentions as ChatRoomMessage["mentions"],
+    reactions: message.reactions as ChatRoomMessage["reactions"],
+    threadReplyCount: message.threadReplyCount,
+    threadLastReplyAt: toNullableDate(message.threadLastReplyAt),
+    metadata: message.metadata,
+    quote: message.quote as ChatRoomMessage["quote"],
+  };
+}

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -34,3 +34,28 @@ export const notificationEventDataSchema = z.object({
 });
 
 export type NotificationEventData = z.infer<typeof notificationEventDataSchema>;
+
+export const chatRoomMessageEventDataSchema = z.object({
+  message: z
+    .object({
+      id: z.string().min(1),
+      roomId: z.string().min(1),
+      parentMessageId: z.string().nullable(),
+      content: z.string(),
+      createdAt: z.string(),
+      deletedAt: z.string().nullable(),
+      editedAt: z.string().nullable(),
+      sender: z.unknown(),
+      mentions: z.array(z.unknown()),
+      reactions: z.array(z.unknown()),
+      threadReplyCount: z.number().int().min(0),
+      threadLastReplyAt: z.string().nullable(),
+      metadata: z.record(z.string(), z.unknown()).nullable(),
+      quote: z.unknown().nullable(),
+    })
+    .passthrough(),
+});
+
+export type ChatRoomMessageEventData = z.infer<
+  typeof chatRoomMessageEventDataSchema
+>;

--- a/apps/web/src/lib/ably/use-chat-room-realtime.tsx
+++ b/apps/web/src/lib/ably/use-chat-room-realtime.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type * as Ably from "ably";
+import { useChannel } from "ably/react";
+import { useCallback } from "react";
+
+import {
+  type ChatRoomMessageEventData,
+  chatRoomMessageEventDataSchema,
+  makeUserChatRoomsChannelName,
+} from "@/lib/ably";
+
+const CHAT_ROOM_MESSAGE_EVENT_NAME = "chat_room_message";
+
+interface UseChatRoomRealtimeOptions {
+  userId: string;
+  onMessage?: (event: ChatRoomMessageEventData) => void;
+  onError?: (error: Error) => void;
+}
+
+export function useChatRoomRealtime({
+  userId,
+  onMessage,
+  onError,
+}: UseChatRoomRealtimeOptions) {
+  const handleMessage = useCallback(
+    (message: Ably.Message) => {
+      const parsedResult = chatRoomMessageEventDataSchema.safeParse(
+        message.data,
+      );
+      if (!parsedResult.success) {
+        const error = new Error(
+          `Failed to parse ChatRoomMessageEventData from message: ${parsedResult.error.message}`,
+        );
+        console.error(error, message, parsedResult.error);
+        onError?.(error);
+        return;
+      }
+
+      onMessage?.(parsedResult.data);
+    },
+    [onMessage, onError],
+  );
+
+  useChannel(
+    makeUserChatRoomsChannelName(userId),
+    CHAT_ROOM_MESSAGE_EVENT_NAME,
+    handleMessage,
+  );
+}

--- a/apps/web/src/lib/ably/utils.ts
+++ b/apps/web/src/lib/ably/utils.ts
@@ -4,6 +4,7 @@
  */
 export {
   makeAgentJobsChannelName,
+  makeUserChatRoomsChannelName,
   makeUserNotificationsChannelName,
   makeUserTasksChannelName,
 } from "@sokosumi/utils";

--- a/packages/utils/src/__tests__/ably-channel.test.ts
+++ b/packages/utils/src/__tests__/ably-channel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   makeAgentJobsChannelName,
+  makeUserChatRoomsChannelName,
   makeUserTasksChannelName,
 } from "../ably-channel";
 
@@ -17,6 +18,14 @@ describe("makeAgentJobsChannelName", () => {
   it("builds an agent-user scoped jobs channel", () => {
     expect(makeAgentJobsChannelName("agent_123", "user_123")).toBe(
       "agent_jobs:agent_agent_123:user_user_123",
+    );
+  });
+});
+
+describe("makeUserChatRoomsChannelName", () => {
+  it("builds a user-scoped chat rooms channel", () => {
+    expect(makeUserChatRoomsChannelName("user_123")).toBe(
+      "chat_rooms:all:user_user_123",
     );
   });
 });

--- a/packages/utils/src/ably-channel.ts
+++ b/packages/utils/src/ably-channel.ts
@@ -18,3 +18,7 @@ export function makeUserTasksChannelName(userId: string): string {
 export function makeUserNotificationsChannelName(userId: string): string {
   return `notifications:all:user_${userId}`;
 }
+
+export function makeUserChatRoomsChannelName(userId: string): string {
+  return `chat_rooms:all:user_${userId}`;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export {
   makeAgentJobsChannelName,
+  makeUserChatRoomsChannelName,
   makeUserNotificationsChannelName,
   makeUserTasksChannelName,
 } from "./ably-channel.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live chat room updates now use the same Ably Pub/Sub pattern as notifications: Core persists to `chat_room*`, then fans out a message DTO to each room member’s channel. The open-room 15s peer poll is gone. Prisma stays the source of truth. Ably Chat SDK is not used.

## What changed

- Channel helper: `chat_rooms:all:user_{userId}`
- Core publish after message create/edit/delete/reaction, stream persist, and coworker mention replies
- Web subscribe + `mergeRoomMessages`; focus/visibility refetch kept as a safety net
- Coworker mention status polling (2.5s) unchanged

## Design choices

| Option | Decision |
| --- | --- |
| Ably Chat SDK | Rejected (second message store + no durable membership) |
| Room channels | Rejected (breaks existing `*:user_{id}` capability wildcards) |
| Per-user Pub/Sub fanout | Chosen (matches notifications; personalizes `reactedByCurrentUser`) |

## Verification

- `pnpm --filter @sokosumi/utils test src/__tests__/ably-channel.test.ts`
- `pnpm --filter core test` (publish, fanout helper, message routes, persist, coworker dispatch)
- `pnpm --filter web test src/lib/ably/__tests__/hydrate-chat-room-message.test.ts`
- Husky `pnpm check && pnpm typecheck` on commit

## Notes

Realtime still needs valid Ably keys in the environment (`ABLY_PUBLISH_ONLY_KEY` / `ABLY_SUBSCRIBE_ONLY_KEY`). Cloud placeholders will not deliver live events until configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f46b22a6-9b50-4fad-8a19-890ad5d82575?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f46b22a6-9b50-4fad-8a19-890ad5d82575&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

