### PR TITLE
feat(web): show recovery when browser notifications denied

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "Benachrichtigungen erhalten, wenn du in einem anderen Tab bist",
       "browserPermissionDescription": "Erlaube Browser-Benachrichtigungen für Jobs, Tasks, Abrechnung, System und Chat, während Sokosumi geöffnet, aber nicht fokussiert ist.",
       "browserPermissionEnable": "Browser-Benachrichtigungen aktivieren",
-      "browserPermissionRequesting": "Warte auf Berechtigung…"
+      "browserPermissionRequesting": "Warte auf Berechtigung…",
+      "browserPermissionDeniedTitle": "Browser-Benachrichtigungen sind blockiert",
+      "browserPermissionDeniedDescription": "Benachrichtigungen für diese Website sind in deinem Browser blockiert. Öffne die Browser-Benachrichtigungseinstellungen für Sokosumi, um sie zuzulassen."
     },
     "HashValue": {
       "copy": "Kopieren",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -788,7 +788,9 @@
       "browserPermissionTitle": "Get alerts when you're in another tab",
       "browserPermissionDescription": "Allow browser notifications for jobs, tasks, billing, system, and chat updates while Sokosumi is open but not focused.",
       "browserPermissionEnable": "Enable browser notifications",
-      "browserPermissionRequesting": "Waiting for permission…"
+      "browserPermissionRequesting": "Waiting for permission…",
+      "browserPermissionDeniedTitle": "Browser notifications are blocked",
+      "browserPermissionDeniedDescription": "Notifications for this site are blocked in your browser. Open your browser’s notification settings for Sokosumi to allow them."
     },
     "HashValue": {
       "copy": "Copy",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "Recibe alertas cuando estés en otra pestaña",
       "browserPermissionDescription": "Permite notificaciones del navegador para trabajos, tareas, facturación, sistema y chat mientras Sokosumi esté abierto pero no enfocado.",
       "browserPermissionEnable": "Activar notificaciones del navegador",
-      "browserPermissionRequesting": "Esperando permiso…"
+      "browserPermissionRequesting": "Esperando permiso…",
+      "browserPermissionDeniedTitle": "Las notificaciones del navegador están bloqueadas",
+      "browserPermissionDeniedDescription": "Las notificaciones de este sitio están bloqueadas en tu navegador. Abre la configuración de notificaciones del navegador para Sokosumi y permítelas."
     },
     "HashValue": {
       "copy": "Copiar",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "Recevez des alertes lorsque vous êtes dans un autre onglet",
       "browserPermissionDescription": "Autorisez les notifications du navigateur pour les jobs, tâches, facturation, système et chat pendant que Sokosumi est ouvert mais non focalisé.",
       "browserPermissionEnable": "Activer les notifications du navigateur",
-      "browserPermissionRequesting": "En attente de l’autorisation…"
+      "browserPermissionRequesting": "En attente de l’autorisation…",
+      "browserPermissionDeniedTitle": "Les notifications du navigateur sont bloquées",
+      "browserPermissionDeniedDescription": "Les notifications pour ce site sont bloquées dans votre navigateur. Ouvrez les paramètres de notification du navigateur pour Sokosumi afin de les autoriser."
     },
     "HashValue": {
       "copy": "Copier",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "Ricevi avvisi quando sei in un’altra scheda",
       "browserPermissionDescription": "Consenti le notifiche del browser per job, task, fatturazione, sistema e chat mentre Sokosumi è aperto ma non in primo piano.",
       "browserPermissionEnable": "Attiva le notifiche del browser",
-      "browserPermissionRequesting": "In attesa del permesso…"
+      "browserPermissionRequesting": "In attesa del permesso…",
+      "browserPermissionDeniedTitle": "Le notifiche del browser sono bloccate",
+      "browserPermissionDeniedDescription": "Le notifiche per questo sito sono bloccate nel browser. Apri le impostazioni delle notifiche del browser per Sokosumi per consentirle."
     },
     "HashValue": {
       "copy": "Copia",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "別のタブにいるときもアラートを受け取る",
       "browserPermissionDescription": "Sokosumiが開いているがフォーカスされていない間も、ジョブ・タスク・請求・システム・チャットのブラウザ通知を許可します。",
       "browserPermissionEnable": "ブラウザ通知を有効にする",
-      "browserPermissionRequesting": "許可を待機中…"
+      "browserPermissionRequesting": "許可を待機中…",
+      "browserPermissionDeniedTitle": "ブラウザ通知がブロックされています",
+      "browserPermissionDeniedDescription": "このサイトの通知はブラウザでブロックされています。Sokosumi のブラウザ通知設定を開いて許可してください。"
     },
     "HashValue": {
       "copy": "コピー",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "Receba alertas quando estiver em outra aba",
       "browserPermissionDescription": "Permita notificações do navegador para jobs, tarefas, cobrança, sistema e chat enquanto o Sokosumi estiver aberto, mas sem foco.",
       "browserPermissionEnable": "Ativar notificações do navegador",
-      "browserPermissionRequesting": "Aguardando permissão…"
+      "browserPermissionRequesting": "Aguardando permissão…",
+      "browserPermissionDeniedTitle": "As notificações do navegador estão bloqueadas",
+      "browserPermissionDeniedDescription": "As notificações deste site estão bloqueadas no navegador. Abra as configurações de notificações do navegador para o Sokosumi e permita-as."
     },
     "HashValue": {
       "copy": "Copiar",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "Receba alertas quando estiver noutro separador",
       "browserPermissionDescription": "Permita notificações do browser para jobs, tarefas, faturação, sistema e chat enquanto o Sokosumi estiver aberto mas não em foco.",
       "browserPermissionEnable": "Ativar notificações do browser",
-      "browserPermissionRequesting": "A aguardar permissão…"
+      "browserPermissionRequesting": "A aguardar permissão…",
+      "browserPermissionDeniedTitle": "As notificações do browser estão bloqueadas",
+      "browserPermissionDeniedDescription": "As notificações deste site estão bloqueadas no browser. Abra as definições de notificações do browser para o Sokosumi para as permitir."
     },
     "HashValue": {
       "copy": "Copy",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -772,7 +772,9 @@
       "browserPermissionTitle": "在其他标签页时也能收到提醒",
       "browserPermissionDescription": "在 Sokosumi 已打开但未聚焦时，允许浏览器通知推送任务、作业、账单、系统和聊天更新。",
       "browserPermissionEnable": "启用浏览器通知",
-      "browserPermissionRequesting": "正在等待权限…"
+      "browserPermissionRequesting": "正在等待权限…",
+      "browserPermissionDeniedTitle": "浏览器通知已被屏蔽",
+      "browserPermissionDeniedDescription": "此网站的通知已在浏览器中被屏蔽。请打开浏览器中 Sokosumi 的通知设置以允许通知。"
     },
     "HashValue": {
       "copy": "复制",

--- a/apps/web/src/app/(app)/components/notification-browser-permission-primer.tsx
+++ b/apps/web/src/app/(app)/components/notification-browser-permission-primer.tsx
@@ -11,6 +11,7 @@ import {
   type BrowserNotificationPermission,
   getBrowserNotificationPermission,
   requestBrowserNotificationPermission,
+  subscribeBrowserNotificationPermission,
 } from "@/lib/utils/browser-notification";
 
 interface NotificationBrowserPermissionPrimerProps {
@@ -29,10 +30,40 @@ export function NotificationBrowserPermissionPrimer({
 
   useMountEffect(() => {
     setPermission(getBrowserNotificationPermission());
+    return subscribeBrowserNotificationPermission(setPermission);
   });
 
-  if (permission !== "default") {
+  if (
+    permission === null ||
+    permission === "granted" ||
+    permission === "unsupported"
+  ) {
     return null;
+  }
+
+  if (permission === "denied") {
+    return (
+      <div
+        className={cn(
+          "border-border/60 bg-muted/30 flex flex-col gap-2 rounded-md border p-3",
+          variant === "page" &&
+            "sm:flex-row sm:items-center sm:justify-between",
+          className,
+        )}
+      >
+        <div className="flex min-w-0 items-start gap-2">
+          <BellRing className="text-primary mt-0.5 size-4 shrink-0" />
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm leading-snug font-medium">
+              {t("browserPermissionDeniedTitle")}
+            </p>
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              {t("browserPermissionDeniedDescription")}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const handleEnable = () => {

--- a/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
+++ b/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
@@ -6,6 +6,7 @@ import {
   shouldShowBrowserNotification,
   shouldShowInAppNotificationToast,
   showBrowserNotification,
+  subscribeBrowserNotificationPermission,
 } from "@/lib/utils/browser-notification";
 
 describe("shouldShowBrowserNotification", () => {
@@ -198,5 +199,177 @@ describe("browser notification API helpers", () => {
         body: "Job completed",
       }),
     ).toBeNull();
+  });
+});
+
+describe("subscribeBrowserNotificationPermission", () => {
+  const originalNotification = globalThis.Notification;
+  const originalPermissions = navigator.permissions;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: originalNotification,
+    });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      writable: true,
+      value: originalPermissions,
+    });
+  });
+
+  it("re-reads permission on window focus", () => {
+    const requestPermission = vi.fn();
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: {
+        permission: "denied",
+        requestPermission,
+      },
+    });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const onChange = vi.fn();
+    const unsubscribe = subscribeBrowserNotificationPermission(onChange);
+
+    window.dispatchEvent(new Event("focus"));
+
+    expect(onChange).toHaveBeenCalledWith("denied");
+    expect(requestPermission).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it("subscribes to Permissions API change when available", async () => {
+    const requestPermission = vi.fn();
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: {
+        permission: "denied",
+        requestPermission,
+      },
+    });
+
+    const listeners = new Set<() => void>();
+    const status = {
+      state: "denied",
+      addEventListener: vi.fn((_type: string, listener: () => void) => {
+        listeners.add(listener);
+      }),
+      removeEventListener: vi.fn((_type: string, listener: () => void) => {
+        listeners.delete(listener);
+      }),
+    };
+    const query = vi.fn().mockResolvedValue(status);
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      writable: true,
+      value: { query },
+    });
+
+    const onChange = vi.fn();
+    const unsubscribe = subscribeBrowserNotificationPermission(onChange);
+
+    await vi.waitFor(() => {
+      expect(status.addEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+    });
+
+    Object.defineProperty(globalThis.Notification, "permission", {
+      configurable: true,
+      value: "granted",
+    });
+    for (const listener of listeners) {
+      listener();
+    }
+
+    expect(onChange).toHaveBeenCalledWith("granted");
+    expect(requestPermission).not.toHaveBeenCalled();
+
+    unsubscribe();
+    expect(status.removeEventListener).toHaveBeenCalled();
+  });
+
+  it("cleanup removes the focus listener", () => {
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: {
+        permission: "default",
+        requestPermission: vi.fn(),
+      },
+    });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const onChange = vi.fn();
+    const unsubscribe = subscribeBrowserNotificationPermission(onChange);
+    unsubscribe();
+
+    window.dispatchEvent(new Event("focus"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when Notification and Permissions API are missing", () => {
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const onChange = vi.fn();
+    expect(() => {
+      const unsubscribe = subscribeBrowserNotificationPermission(onChange);
+      window.dispatchEvent(new Event("focus"));
+      unsubscribe();
+    }).not.toThrow();
+    expect(onChange).toHaveBeenCalledWith("unsupported");
+  });
+
+  it("ignores Permissions API query failures", async () => {
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: {
+        permission: "denied",
+        requestPermission: vi.fn(),
+      },
+    });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      writable: true,
+      value: {
+        query: vi.fn().mockRejectedValue(new Error("not supported")),
+      },
+    });
+
+    const onChange = vi.fn();
+    const unsubscribe = subscribeBrowserNotificationPermission(onChange);
+
+    await Promise.resolve();
+    window.dispatchEvent(new Event("focus"));
+    expect(onChange).toHaveBeenCalledWith("denied");
+    unsubscribe();
   });
 });

--- a/apps/web/src/lib/utils/browser-notification.ts
+++ b/apps/web/src/lib/utils/browser-notification.ts
@@ -75,6 +75,60 @@ export async function requestBrowserNotificationPermission(): Promise<BrowserNot
 }
 
 /**
+ * Re-reads `Notification.permission` when the Permissions API reports a
+ * change (if available) and whenever the window gains focus. Never calls
+ * `requestPermission`.
+ */
+export function subscribeBrowserNotificationPermission(
+  onChange: (permission: BrowserNotificationPermission) => void,
+): () => void {
+  const notify = () => {
+    onChange(getBrowserNotificationPermission());
+  };
+
+  const handleFocus = () => {
+    notify();
+  };
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("focus", handleFocus);
+  }
+
+  let permissionStatus: PermissionStatus | null = null;
+  let cancelled = false;
+
+  const handlePermissionChange = () => {
+    notify();
+  };
+
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator.permissions?.query === "function"
+  ) {
+    void navigator.permissions
+      .query({ name: "notifications" as PermissionName })
+      .then((status) => {
+        if (cancelled) {
+          return;
+        }
+        permissionStatus = status;
+        status.addEventListener("change", handlePermissionChange);
+      })
+      .catch(() => {
+        // Permissions API missing/throws → focus re-read only.
+      });
+  }
+
+  return () => {
+    cancelled = true;
+    if (typeof window !== "undefined") {
+      window.removeEventListener("focus", handleFocus);
+    }
+    permissionStatus?.removeEventListener("change", handlePermissionChange);
+  };
+}
+
+/**
  * Creates an OS notification. Callers must gate with
  * `shouldShowBrowserNotification` first.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [SOK-702](https://linear.app/masumi/issue/SOK-702/recover-browser-notifications-after-permission-denial).

When browser notification permission is `denied`, the notification dropdown and `/notifications` show a short recovery state explaining how to re-enable alerts in browser settings. Does not call `requestPermission` after deny.

### Spec summary
- Extend primer with distinct `denied` informational UI (no re-prompt CTA)
- Sync permission via Permissions API `change` + window `focus` re-read
- Always visible while denied; hide when granted/unsupported
- Mount sites unchanged; classic Notification API only (not Web Push)

### Verification
- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0; 2285 passed)
- UI route `/notifications`: denied recovery copy shown; no Enable CTA
- CI green at `cf0a5eb7668b873c85b1f85c0711197dad6c7c50`

![Denied recovery on /notifications](https://cursor.com/artifacts/c/art-b490632f-85be-4961-9bd8-8ea49c545faa)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-702](https://linear.app/masumi/issue/SOK-702/recover-browser-notifications-after-permission-denial)

<div><a href="https://cursor.com/agents/bc-38bd5ffe-9b48-4798-9e55-9bf1faac4ddb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38bd5ffe-9b48-4798-9e55-9bf1faac4ddb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

