### PR TITLE
feat(web): add Accept and Dismiss on vendor-access notifications

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -765,6 +765,7 @@
       "markAllReadError": "Alle Benachrichtigungen konnten nicht als gelesen markiert werden",
       "fetchError": "Benachrichtigungen konnten nicht geladen werden",
       "retry": "Erneut versuchen",
+      "accept": "Akzeptieren",
       "dismiss": "Schließen",
       "view": "Ansehen",
       "dismissNotification": "Benachrichtigung schließen",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "Benachrichtigungen erhalten, wenn du in einem anderen Tab bist",
       "browserPermissionDescription": "Erlaube Browser-Benachrichtigungen für Jobs, Tasks, Abrechnung, System und Chat, während Sokosumi geöffnet, aber nicht fokussiert ist.",
       "browserPermissionEnable": "Browser-Benachrichtigungen aktivieren",
-      "browserPermissionRequesting": "Warte auf Berechtigung…"
+      "browserPermissionRequesting": "Warte auf Berechtigung…",
+      "vendorGrantAcceptSuccess": "Vendor-Zugriff genehmigt",
+      "vendorGrantAcceptError": "Vendor-Zugriff konnte nicht genehmigt werden"
     },
     "HashValue": {
       "copy": "Kopieren",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -781,6 +781,7 @@
       "markAllReadError": "Failed to mark all notifications as read",
       "fetchError": "Could not load notifications",
       "retry": "Try again",
+      "accept": "Accept",
       "dismiss": "Dismiss",
       "view": "View",
       "dismissNotification": "Dismiss notification",
@@ -788,7 +789,9 @@
       "browserPermissionTitle": "Get alerts when you're in another tab",
       "browserPermissionDescription": "Allow browser notifications for jobs, tasks, billing, system, and chat updates while Sokosumi is open but not focused.",
       "browserPermissionEnable": "Enable browser notifications",
-      "browserPermissionRequesting": "Waiting for permission…"
+      "browserPermissionRequesting": "Waiting for permission…",
+      "vendorGrantAcceptSuccess": "Vendor access approved",
+      "vendorGrantAcceptError": "Failed to approve vendor access"
     },
     "HashValue": {
       "copy": "Copy",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -765,6 +765,7 @@
       "markAllReadError": "No se pudieron marcar todas las notificaciones como leídas",
       "fetchError": "No se pudieron cargar las notificaciones",
       "retry": "Intentar de nuevo",
+      "accept": "Aceptar",
       "dismiss": "Descartar",
       "view": "Ver",
       "dismissNotification": "Descartar notificación",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "Recibe alertas cuando estés en otra pestaña",
       "browserPermissionDescription": "Permite notificaciones del navegador para trabajos, tareas, facturación, sistema y chat mientras Sokosumi esté abierto pero no enfocado.",
       "browserPermissionEnable": "Activar notificaciones del navegador",
-      "browserPermissionRequesting": "Esperando permiso…"
+      "browserPermissionRequesting": "Esperando permiso…",
+      "vendorGrantAcceptSuccess": "Acceso de proveedor aprobado",
+      "vendorGrantAcceptError": "No se pudo aprobar el acceso de proveedor"
     },
     "HashValue": {
       "copy": "Copiar",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -765,6 +765,7 @@
       "markAllReadError": "Impossible de marquer toutes les notifications comme lues",
       "fetchError": "Impossible de charger les notifications",
       "retry": "Réessayer",
+      "accept": "Accepter",
       "dismiss": "Ignorer",
       "view": "Voir",
       "dismissNotification": "Ignorer la notification",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "Recevez des alertes lorsque vous êtes dans un autre onglet",
       "browserPermissionDescription": "Autorisez les notifications du navigateur pour les jobs, tâches, facturation, système et chat pendant que Sokosumi est ouvert mais non focalisé.",
       "browserPermissionEnable": "Activer les notifications du navigateur",
-      "browserPermissionRequesting": "En attente de l’autorisation…"
+      "browserPermissionRequesting": "En attente de l’autorisation…",
+      "vendorGrantAcceptSuccess": "Accès fournisseur approuvé",
+      "vendorGrantAcceptError": "Échec de l'approbation de l'accès fournisseur"
     },
     "HashValue": {
       "copy": "Copier",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -765,6 +765,7 @@
       "markAllReadError": "Impossibile segnare tutte le notifiche come lette",
       "fetchError": "Impossibile caricare le notifiche",
       "retry": "Riprova",
+      "accept": "Accetta",
       "dismiss": "Ignora",
       "view": "Visualizza",
       "dismissNotification": "Ignora notifica",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "Ricevi avvisi quando sei in un’altra scheda",
       "browserPermissionDescription": "Consenti le notifiche del browser per job, task, fatturazione, sistema e chat mentre Sokosumi è aperto ma non in primo piano.",
       "browserPermissionEnable": "Attiva le notifiche del browser",
-      "browserPermissionRequesting": "In attesa del permesso…"
+      "browserPermissionRequesting": "In attesa del permesso…",
+      "vendorGrantAcceptSuccess": "Accesso vendor approvato",
+      "vendorGrantAcceptError": "Impossibile approvare l'accesso vendor"
     },
     "HashValue": {
       "copy": "Copia",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -765,6 +765,7 @@
       "markAllReadError": "すべての通知を既読にできませんでした",
       "fetchError": "通知を読み込めませんでした",
       "retry": "再試行",
+      "accept": "承認",
       "dismiss": "閉じる",
       "view": "表示",
       "dismissNotification": "通知を閉じる",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "別のタブにいるときもアラートを受け取る",
       "browserPermissionDescription": "Sokosumiが開いているがフォーカスされていない間も、ジョブ・タスク・請求・システム・チャットのブラウザ通知を許可します。",
       "browserPermissionEnable": "ブラウザ通知を有効にする",
-      "browserPermissionRequesting": "許可を待機中…"
+      "browserPermissionRequesting": "許可を待機中…",
+      "vendorGrantAcceptSuccess": "ベンダーアクセスを承認しました",
+      "vendorGrantAcceptError": "ベンダーアクセスの承認に失敗しました"
     },
     "HashValue": {
       "copy": "コピー",

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -765,6 +765,7 @@
       "markAllReadError": "Não foi possível marcar todas as notificações como lidas",
       "fetchError": "Não foi possível carregar as notificações",
       "retry": "Tentar novamente",
+      "accept": "Aceitar",
       "dismiss": "Dispensar",
       "view": "Ver",
       "dismissNotification": "Dispensar notificação",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "Receba alertas quando estiver em outra aba",
       "browserPermissionDescription": "Permita notificações do navegador para jobs, tarefas, cobrança, sistema e chat enquanto o Sokosumi estiver aberto, mas sem foco.",
       "browserPermissionEnable": "Ativar notificações do navegador",
-      "browserPermissionRequesting": "Aguardando permissão…"
+      "browserPermissionRequesting": "Aguardando permissão…",
+      "vendorGrantAcceptSuccess": "Acesso do fornecedor aprovado",
+      "vendorGrantAcceptError": "Falha ao aprovar o acesso do fornecedor"
     },
     "HashValue": {
       "copy": "Copiar",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -765,6 +765,7 @@
       "markAllReadError": "Não foi possível marcar todas as notificações como lidas",
       "fetchError": "Não foi possível carregar as notificações",
       "retry": "Tentar novamente",
+      "accept": "Aceitar",
       "dismiss": "Dispensar",
       "view": "Ver",
       "dismissNotification": "Dispensar notificação",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "Receba alertas quando estiver noutro separador",
       "browserPermissionDescription": "Permita notificações do browser para jobs, tarefas, faturação, sistema e chat enquanto o Sokosumi estiver aberto mas não em foco.",
       "browserPermissionEnable": "Ativar notificações do browser",
-      "browserPermissionRequesting": "A aguardar permissão…"
+      "browserPermissionRequesting": "A aguardar permissão…",
+      "vendorGrantAcceptSuccess": "Acesso do fornecedor aprovado",
+      "vendorGrantAcceptError": "Falha ao aprovar o acesso do fornecedor"
     },
     "HashValue": {
       "copy": "Copy",

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -765,6 +765,7 @@
       "markAllReadError": "无法将所有通知标为已读",
       "fetchError": "无法加载通知",
       "retry": "重试",
+      "accept": "接受",
       "dismiss": "关闭",
       "view": "查看",
       "dismissNotification": "关闭通知",
@@ -772,7 +773,9 @@
       "browserPermissionTitle": "在其他标签页时也能收到提醒",
       "browserPermissionDescription": "在 Sokosumi 已打开但未聚焦时，允许浏览器通知推送任务、作业、账单、系统和聊天更新。",
       "browserPermissionEnable": "启用浏览器通知",
-      "browserPermissionRequesting": "正在等待权限…"
+      "browserPermissionRequesting": "正在等待权限…",
+      "vendorGrantAcceptSuccess": "已批准供应商访问",
+      "vendorGrantAcceptError": "批准供应商访问失败"
     },
     "HashValue": {
       "copy": "复制",

--- a/apps/web/src/app/(app)/components/header/notification-item.tsx
+++ b/apps/web/src/app/(app)/components/header/notification-item.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Bell } from "lucide-react";
+import { VendorGrantNotificationActions } from "@/components/notifications/vendor-grant-notification-actions";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
-import type { NotificationItem } from "@/lib/clients/generated/core";
+import type { NotificationItem as NotificationItemType } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { useNotificationMessage } from "@/lib/utils/notification-message";
+import { isPendingVendorGrantNotification } from "@/lib/utils/vendor-grant-notification";
 
 interface NotificationItemProps {
-  notification: NotificationItem;
+  notification: NotificationItemType;
   onClick: () => void;
   formatTime: (timestamp: string | Date) => string;
 }
@@ -22,6 +24,7 @@ export function NotificationItem({
     notification.messageKey,
     notification.messageParams ?? {},
   );
+  const showVendorGrantActions = isPendingVendorGrantNotification(notification);
 
   return (
     <DropdownMenuItem
@@ -45,6 +48,12 @@ export function NotificationItem({
           <p className="text-muted-foreground text-xs">
             {formatTime(notification.createdAt)}
           </p>
+          {showVendorGrantActions ? (
+            <VendorGrantNotificationActions
+              notification={notification}
+              layout="inline"
+            />
+          ) : null}
         </div>
       </div>
     </DropdownMenuItem>

--- a/apps/web/src/app/(app)/components/notification-toast-listener.tsx
+++ b/apps/web/src/app/(app)/components/notification-toast-listener.tsx
@@ -6,7 +6,9 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
+import { VendorGrantNotificationActions } from "@/components/notifications/vendor-grant-notification-actions";
 import { useNotifications } from "@/contexts/notification-provider";
+import type { NotificationEventData } from "@/lib/ably/schema";
 import { useNotificationRealtime } from "@/lib/ably/use-notification-realtime";
 import { authClient } from "@/lib/auth/auth.client";
 import { NOTIFICATION_TOASTER_ID } from "@/lib/constants/notification-toaster";
@@ -18,6 +20,7 @@ import {
 } from "@/lib/utils/browser-notification";
 import { useNotificationMessage } from "@/lib/utils/notification-message";
 import { handleNotificationNavigation } from "@/lib/utils/notification-navigation";
+import { isPendingVendorGrantNotification } from "@/lib/utils/vendor-grant-notification";
 
 interface NotificationToastListenerProps {
   userId: string;
@@ -42,6 +45,41 @@ function NotificationToastBody({
         {message}
       </span>
     </button>
+  );
+}
+
+interface NotificationToastContentProps {
+  notification: NotificationEventData;
+  message: string;
+  onOpen: () => void;
+  showVendorGrantActions: boolean;
+}
+
+function NotificationToastContent({
+  notification,
+  message,
+  onOpen,
+  showVendorGrantActions,
+}: NotificationToastContentProps) {
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-1">
+      <NotificationToastBody
+        message={message}
+        onOpen={() => {
+          toast.dismiss(notification.id);
+          onOpen();
+        }}
+      />
+      {showVendorGrantActions ? (
+        <VendorGrantNotificationActions
+          notification={notification}
+          layout="toast"
+          onDismissed={() => {
+            toast.dismiss(notification.id);
+          }}
+        />
+      ) : null}
+    </div>
   );
 }
 
@@ -79,6 +117,8 @@ export function NotificationToastListener({
         notification.messageKey,
         notification.messageParams ?? {},
       );
+      const showVendorGrantActions =
+        isPendingVendorGrantNotification(notification);
 
       const openNotification = () => {
         void (async () => {
@@ -124,12 +164,11 @@ export function NotificationToastListener({
 
       toast(
         () => (
-          <NotificationToastBody
+          <NotificationToastContent
+            notification={notification}
             message={message}
-            onOpen={() => {
-              toast.dismiss(notification.id);
-              openNotification();
-            }}
+            onOpen={openNotification}
+            showVendorGrantActions={showVendorGrantActions}
           />
         ),
         {
@@ -138,12 +177,16 @@ export function NotificationToastListener({
           duration: 10_000,
           dismissible: true,
           icon: <Bell className="text-primary size-5 shrink-0" />,
-          action: {
-            label: t("dismiss"),
-            onClick: () => {
-              toast.dismiss(notification.id);
-            },
-          },
+          ...(showVendorGrantActions
+            ? {}
+            : {
+                action: {
+                  label: t("dismiss"),
+                  onClick: () => {
+                    toast.dismiss(notification.id);
+                  },
+                },
+              }),
         },
       );
     },

--- a/apps/web/src/app/(app)/notifications/page-content.tsx
+++ b/apps/web/src/app/(app)/notifications/page-content.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { AccountNoticeRow } from "@/app/components/account-notice-row";
 import { NotificationBrowserPermissionPrimer } from "@/app/components/notification-browser-permission-primer";
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
+import { VendorGrantNotificationActions } from "@/components/notifications/vendor-grant-notification-actions";
 import { Button } from "@/components/ui/button";
 import { useAccountNotice } from "@/contexts/account-notice-provider";
 import { useNotifications } from "@/contexts/notification-provider";
@@ -18,6 +19,7 @@ import { cn } from "@/lib/utils";
 import { useNotificationMessage } from "@/lib/utils/notification-message";
 import { handleNotificationNavigation } from "@/lib/utils/notification-navigation";
 import { useNotificationTimeFormatter } from "@/lib/utils/notification-time";
+import { isPendingVendorGrantNotification } from "@/lib/utils/vendor-grant-notification";
 
 interface NotificationsPageContentProps {
   userId: string;
@@ -325,30 +327,63 @@ function NotificationRow({
   timeLabel,
   onClick,
 }: NotificationRowProps) {
+  const showVendorGrantActions = isPendingVendorGrantNotification(notification);
+  const rowClassName = cn(
+    "hover:bg-accent flex w-full p-4 text-left transition-colors [content-visibility:auto] [contain-intrinsic-size:auto_72px]",
+    !notification.isRead && "bg-accent/50",
+    isPending && "bg-accent opacity-80",
+    showVendorGrantActions ? "cursor-default" : "cursor-pointer",
+  );
+
+  const body = (
+    <div className="flex w-full items-start gap-3">
+      <Bell
+        className={cn(
+          "mt-0.5 size-4 shrink-0",
+          notification.isRead ? "text-muted-foreground" : "text-primary",
+        )}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {showVendorGrantActions ? (
+          <button
+            type="button"
+            className="hover:bg-accent/50 -mx-1 cursor-pointer rounded-md px-1 text-left"
+            onClick={() => onClick(notification)}
+          >
+            <p className={cn("text-sm", !notification.isRead && "font-medium")}>
+              {message}
+            </p>
+            <p className="text-muted-foreground text-xs">{timeLabel}</p>
+          </button>
+        ) : (
+          <>
+            <p className={cn("text-sm", !notification.isRead && "font-medium")}>
+              {message}
+            </p>
+            <p className="text-muted-foreground text-xs">{timeLabel}</p>
+          </>
+        )}
+        {showVendorGrantActions ? (
+          <VendorGrantNotificationActions
+            notification={notification}
+            layout="inline"
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+
+  if (showVendorGrantActions) {
+    return <div className={rowClassName}>{body}</div>;
+  }
+
   return (
     <button
       type="button"
-      className={cn(
-        "hover:bg-accent flex w-full cursor-pointer p-4 text-left transition-colors [content-visibility:auto] [contain-intrinsic-size:auto_72px]",
-        !notification.isRead && "bg-accent/50",
-        isPending && "bg-accent opacity-80",
-      )}
+      className={rowClassName}
       onClick={() => onClick(notification)}
     >
-      <div className="flex w-full items-start gap-3">
-        <Bell
-          className={cn(
-            "mt-0.5 size-4 shrink-0",
-            notification.isRead ? "text-muted-foreground" : "text-primary",
-          )}
-        />
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className={cn("text-sm", !notification.isRead && "font-medium")}>
-            {message}
-          </p>
-          <p className="text-muted-foreground text-xs">{timeLabel}</p>
-        </div>
-      </div>
+      {body}
     </button>
   );
 }

--- a/apps/web/src/components/notifications/vendor-grant-notification-actions.tsx
+++ b/apps/web/src/components/notifications/vendor-grant-notification-actions.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type MouseEvent, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useNotifications } from "@/contexts/notification-provider";
+import { approveMyVendorGrant } from "@/lib/actions/account/vendor-grant-action";
+import { approveOrganizationVendorGrant } from "@/lib/actions/organization/vendor-grant-action";
+import type { NotificationItem } from "@/lib/clients/generated/core";
+import { cn } from "@/lib/utils";
+import {
+  isPendingVendorGrantNotification,
+  resolveVendorGrantNotificationTarget,
+} from "@/lib/utils/vendor-grant-notification";
+
+interface VendorGrantNotificationActionsProps {
+  notification: Pick<
+    NotificationItem,
+    "id" | "messageKey" | "referenceId" | "metadata" | "isRead"
+  >;
+  layout: "toast" | "inline";
+  onDismissed?: () => void;
+}
+
+export function VendorGrantNotificationActions({
+  notification,
+  layout,
+  onDismissed,
+}: VendorGrantNotificationActionsProps) {
+  const t = useTranslations("Components.NotificationCenter");
+  const { markRead } = useNotifications();
+  const [loadingAction, setLoadingAction] = useState<
+    "accept" | "dismiss" | null
+  >(null);
+
+  const target = resolveVendorGrantNotificationTarget(notification);
+  if (!isPendingVendorGrantNotification(notification) || !target) {
+    return null;
+  }
+
+  const { grantId, organizationId } = target;
+
+  function finishSurface() {
+    toast.dismiss(notification.id);
+    onDismissed?.();
+  }
+
+  async function handleAccept(
+    event: MouseEvent<HTMLButtonElement>,
+  ): Promise<void> {
+    event.stopPropagation();
+    if (loadingAction !== null) {
+      return;
+    }
+
+    setLoadingAction("accept");
+    try {
+      const result =
+        typeof organizationId === "string"
+          ? await approveOrganizationVendorGrant({
+              organizationId,
+              grantId,
+            })
+          : await approveMyVendorGrant({ grantId });
+
+      if (!result.ok) {
+        toast.error(result.error?.message ?? t("vendorGrantAcceptError"));
+        return;
+      }
+
+      void markRead(notification.id).catch(() => {
+        // Grant is approved; surface cleanup still proceeds.
+      });
+      finishSurface();
+      toast.success(t("vendorGrantAcceptSuccess"));
+    } catch {
+      toast.error(t("vendorGrantAcceptError"));
+    } finally {
+      setLoadingAction(null);
+    }
+  }
+
+  async function handleDismiss(
+    event: MouseEvent<HTMLButtonElement>,
+  ): Promise<void> {
+    event.stopPropagation();
+    if (loadingAction !== null) {
+      return;
+    }
+
+    setLoadingAction("dismiss");
+    try {
+      if (!notification.isRead) {
+        await markRead(notification.id).catch(() => {
+          // Still dismiss the toast when mark-read fails.
+        });
+      }
+      finishSurface();
+    } finally {
+      setLoadingAction(null);
+    }
+  }
+
+  return (
+    <div
+      className={cn("flex flex-wrap gap-2", layout === "toast" && "pt-1")}
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <Button
+        type="button"
+        size="sm"
+        disabled={loadingAction !== null}
+        onPointerDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onClick={(event) => void handleAccept(event)}
+      >
+        {loadingAction === "accept" ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : null}
+        {t("accept")}
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={loadingAction !== null}
+        onPointerDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onClick={(event) => void handleDismiss(event)}
+      >
+        {loadingAction === "dismiss" ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : null}
+        {t("dismiss")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/notifications/vendor-grant-notification-actions.tsx
+++ b/apps/web/src/components/notifications/vendor-grant-notification-actions.tsx
@@ -35,9 +35,10 @@ export function VendorGrantNotificationActions({
   const [loadingAction, setLoadingAction] = useState<
     "accept" | "dismiss" | null
   >(null);
+  const [accepted, setAccepted] = useState(false);
 
   const target = resolveVendorGrantNotificationTarget(notification);
-  if (!isPendingVendorGrantNotification(notification) || !target) {
+  if (accepted || !isPendingVendorGrantNotification(notification) || !target) {
     return null;
   }
 
@@ -71,6 +72,7 @@ export function VendorGrantNotificationActions({
         return;
       }
 
+      setAccepted(true);
       void markRead(notification.id).catch(() => {
         // Grant is approved; surface cleanup still proceeds.
       });

--- a/apps/web/src/lib/utils/__tests__/vendor-grant-notification.test.ts
+++ b/apps/web/src/lib/utils/__tests__/vendor-grant-notification.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPendingVendorGrantNotification,
+  resolveVendorGrantNotificationTarget,
+  VENDOR_GRANT_PENDING_MESSAGE_KEY,
+} from "@/lib/utils/vendor-grant-notification";
+
+describe("isPendingVendorGrantNotification", () => {
+  it("detects pending vendor grant message key", () => {
+    expect(
+      isPendingVendorGrantNotification({
+        messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects other message keys", () => {
+    expect(
+      isPendingVendorGrantNotification({
+        messageKey: "notifications.job.completed",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveVendorGrantNotificationTarget", () => {
+  it("returns grantId from referenceId and organizationId from metadata", () => {
+    expect(
+      resolveVendorGrantNotificationTarget({
+        messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+        referenceId: "grant-1",
+        metadata: { organizationId: "org-1", vendorId: "v-1" },
+      }),
+    ).toEqual({ grantId: "grant-1", organizationId: "org-1" });
+  });
+
+  it("returns null organizationId for personal workspace grants", () => {
+    expect(
+      resolveVendorGrantNotificationTarget({
+        messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+        referenceId: "grant-2",
+        metadata: { organizationId: null, workspaceId: "ws-1" },
+      }),
+    ).toEqual({ grantId: "grant-2", organizationId: null });
+  });
+
+  it("returns null organizationId when metadata lacks organizationId", () => {
+    expect(
+      resolveVendorGrantNotificationTarget({
+        messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+        referenceId: "grant-3",
+        metadata: null,
+      }),
+    ).toEqual({ grantId: "grant-3", organizationId: null });
+  });
+
+  it("returns null organizationId when organizationId is not a string", () => {
+    expect(
+      resolveVendorGrantNotificationTarget({
+        messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+        referenceId: "grant-4",
+        metadata: { organizationId: 42 },
+      }),
+    ).toEqual({ grantId: "grant-4", organizationId: null });
+  });
+
+  it("returns null for non-vendor-grant notifications", () => {
+    expect(
+      resolveVendorGrantNotificationTarget({
+        messageKey: "notifications.job.completed",
+        referenceId: "grant-5",
+        metadata: { organizationId: "org-1" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when referenceId is empty", () => {
+    expect(
+      resolveVendorGrantNotificationTarget({
+        messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+        referenceId: "",
+        metadata: { organizationId: "org-1" },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/utils/vendor-grant-notification.ts
+++ b/apps/web/src/lib/utils/vendor-grant-notification.ts
@@ -1,0 +1,37 @@
+import type { NotificationItem } from "@/lib/clients/generated/core";
+
+export const VENDOR_GRANT_PENDING_MESSAGE_KEY =
+  "notifications.vendorGrant.pending";
+
+interface VendorGrantNotificationTarget {
+  grantId: string;
+  organizationId: string | null;
+}
+
+export function isPendingVendorGrantNotification(
+  notification: Pick<NotificationItem, "messageKey">,
+): boolean {
+  return notification.messageKey === VENDOR_GRANT_PENDING_MESSAGE_KEY;
+}
+
+export function resolveVendorGrantNotificationTarget(
+  notification: Pick<
+    NotificationItem,
+    "messageKey" | "referenceId" | "metadata"
+  >,
+): VendorGrantNotificationTarget | null {
+  if (!isPendingVendorGrantNotification(notification)) {
+    return null;
+  }
+
+  const grantId = notification.referenceId;
+  if (!grantId) {
+    return null;
+  }
+
+  const rawOrganizationId = notification.metadata?.organizationId;
+  const organizationId =
+    typeof rawOrganizationId === "string" ? rawOrganizationId : null;
+
+  return { grantId, organizationId };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [SOK-700](https://linear.app/masumi/issue/SOK-700/accept-and-dismiss-actions-on-vendor-access-notifications).

Vendor-access notifications (`notifications.vendorGrant.pending`) now show **Accept** and **Dismiss** on the in-app toast (vendor-grant only; aligns with #3585 removing generic toasts), header notification dropdown, and `/notifications` page.

- **Accept** approves the pending grant via existing personal/org approve actions (`referenceId` = grantId; org vs personal from `metadata.organizationId`), then marks the notification read and dismisses the toast.
- **Dismiss** marks the notification read and closes the toast only — grant stays `PENDING` (not Deny).
- Tasks list banner and task-detail approve/deny are unchanged. No app-wide layout banner.

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0)
- UI `/notifications`: Accept → grant `GRANTED` + success toast; Dismiss → mark read, grant stays `PENDING`

![Notifications page with Accept and Dismiss](https://cursor.com/artifacts/c/art-266cf3a1-ced0-4e45-81cb-48c019e6b557)
![After Accept success toast](https://cursor.com/artifacts/c/art-27cadaef-fa72-4acf-a6e5-8f8acc30964b)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| R7 / UX | `vendor-grant-notification-actions.tsx` | After Accept, CTAs hide via local state; a full remount can show Accept again on an already-`GRANTED` notification until Accept fails with error toast. No grant-status field on the notification DTO. |
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-700](https://linear.app/masumi/issue/SOK-700/accept-and-dismiss-actions-on-vendor-access-notifications)

<div><a href="https://cursor.com/agents/bc-348b2fc0-0631-4446-8ecb-aa4670f6b2e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-348b2fc0-0631-4446-8ecb-aa4670f6b2e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

