### PR TITLE
fix(core): emit CHAT notifications for direct room messages

### DIFF
--- a/apps/core/src/helpers/chat-direct-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.test.ts
@@ -1,0 +1,140 @@
+import { NotificationKind } from "@sokosumi/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createNotificationMock,
+  workspaceFindUniqueMock,
+  membershipFindManyMock,
+  captureExceptionMock,
+} = vi.hoisted(() => ({
+  createNotificationMock: vi.fn(),
+  workspaceFindUniqueMock: vi.fn(),
+  membershipFindManyMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@/helpers/notifications", () => ({
+  createNotification: (...args: unknown[]) => createNotificationMock(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    workspace: {
+      findUnique: workspaceFindUniqueMock,
+    },
+    chatRoomUserMember: {
+      findMany: membershipFindManyMock,
+    },
+  },
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+import { emitChatDirectMessageNotifications } from "./chat-direct-message-notifications";
+
+const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
+const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
+const AUTHOR_ID = "user_author";
+const PEER_ID = "user_alice";
+const OTHER_ID = "user_bob";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createNotificationMock.mockResolvedValue({ created: true });
+  workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
+  membershipFindManyMock.mockResolvedValue([]);
+});
+
+describe("emitChatDirectMessageNotifications", () => {
+  it("creates one CHAT notification per human recipient in a direct room", async () => {
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Alice",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: AUTHOR_ID,
+      authorName: "Patrick",
+      recipientUserIds: [PEER_ID, OTHER_ID],
+    });
+
+    expect(membershipFindManyMock).toHaveBeenCalledWith({
+      where: {
+        roomId: ROOM_ID,
+        userId: { in: [PEER_ID, OTHER_ID] },
+        mutedAt: { not: null },
+      },
+      select: { userId: true },
+    });
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+    expect(createNotificationMock).toHaveBeenCalledWith({
+      userId: PEER_ID,
+      kind: NotificationKind.CHAT,
+      referenceId: ROOM_ID,
+      eventId: MESSAGE_ID,
+      messageKey: "Notifications.Chat.directMessage",
+      messageParams: {
+        authorName: "Patrick",
+        roomName: "Alice",
+      },
+      metadata: {
+        messageId: MESSAGE_ID,
+        workspaceId: "workspace_1",
+      },
+    });
+  });
+
+  it("skips recipients who muted the room", async () => {
+    membershipFindManyMock.mockResolvedValue([{ userId: PEER_ID }]);
+
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Alice",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: AUTHOR_ID,
+      authorName: "Patrick",
+      recipientUserIds: [PEER_ID, OTHER_ID],
+    });
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: OTHER_ID }),
+    );
+  });
+
+  it("filters the author and no-ops when nobody remains", async () => {
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Alice",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: AUTHOR_ID,
+      authorName: "Patrick",
+      recipientUserIds: [AUTHOR_ID],
+    });
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+    expect(membershipFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("continues when createNotification fails for one recipient", async () => {
+    createNotificationMock.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(
+      emitChatDirectMessageNotifications({
+        roomId: ROOM_ID,
+        roomName: "Alice",
+        organizationId: "org_1",
+        messageId: MESSAGE_ID,
+        authorUserId: AUTHOR_ID,
+        authorName: "Patrick",
+        recipientUserIds: [PEER_ID, OTHER_ID],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captureExceptionMock).toHaveBeenCalled();
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/core/src/helpers/chat-direct-message-notifications.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.ts
@@ -1,0 +1,89 @@
+import * as Sentry from "@sentry/node";
+import { NotificationKind } from "@sokosumi/database";
+
+import { createNotification } from "@/helpers/notifications";
+import prisma from "@/lib/db/prisma";
+
+export interface EmitChatDirectMessageNotificationsParams {
+  roomId: string;
+  roomName: string;
+  organizationId: string | null;
+  messageId: string;
+  authorUserId: string;
+  authorName: string;
+  recipientUserIds: readonly string[];
+}
+
+/** Emit CHAT notifications for other humans in a direct room. Schedule via waitUntil. */
+export async function emitChatDirectMessageNotifications(
+  params: EmitChatDirectMessageNotificationsParams,
+): Promise<void> {
+  const recipientUserIds = [
+    ...new Set(
+      params.recipientUserIds.filter(
+        (userId) => userId !== params.authorUserId,
+      ),
+    ),
+  ];
+
+  if (recipientUserIds.length === 0) {
+    return;
+  }
+
+  const mutedMemberships = await prisma.chatRoomUserMember.findMany({
+    where: {
+      roomId: params.roomId,
+      userId: { in: recipientUserIds },
+      mutedAt: { not: null },
+    },
+    select: { userId: true },
+  });
+  const mutedUserIds = new Set(
+    mutedMemberships.map((membership) => membership.userId),
+  );
+  const notifyUserIds = recipientUserIds.filter(
+    (userId) => !mutedUserIds.has(userId),
+  );
+
+  if (notifyUserIds.length === 0) {
+    return;
+  }
+
+  let workspaceId: string | null = null;
+  if (params.organizationId) {
+    const workspace = await prisma.workspace.findUnique({
+      where: { organizationId: params.organizationId },
+      select: { id: true },
+    });
+    workspaceId = workspace?.id ?? null;
+  }
+
+  for (const userId of notifyUserIds) {
+    try {
+      await createNotification({
+        userId,
+        kind: NotificationKind.CHAT,
+        referenceId: params.roomId,
+        eventId: params.messageId,
+        messageKey: "Notifications.Chat.directMessage",
+        messageParams: {
+          authorName: params.authorName,
+          roomName: params.roomName,
+        },
+        metadata: {
+          messageId: params.messageId,
+          workspaceId,
+        },
+      });
+    } catch (error) {
+      Sentry.captureException(error, {
+        extra: {
+          roomId: params.roomId,
+          messageId: params.messageId,
+          userId,
+          notificationType: "chat-direct-message-notification",
+        },
+      });
+    }
+  }
+}

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -20,6 +20,7 @@ const {
   prismaTransactionMock,
   dispatchMock,
   emitChatMentionNotificationsMock,
+  emitChatDirectMessageNotificationsMock,
   waitUntilMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
@@ -34,6 +35,7 @@ const {
   prismaTransactionMock: vi.fn(),
   dispatchMock: vi.fn(),
   emitChatMentionNotificationsMock: vi.fn(),
+  emitChatDirectMessageNotificationsMock: vi.fn(),
   waitUntilMock: vi.fn(),
 }));
 
@@ -60,6 +62,11 @@ vi.mock("@/services/chat-room-coworker-dispatch.service", () => ({
 vi.mock("@/helpers/chat-mention-notifications", () => ({
   emitChatMentionNotifications: (...args: unknown[]) =>
     emitChatMentionNotificationsMock(...args),
+}));
+
+vi.mock("@/helpers/chat-direct-message-notifications", () => ({
+  emitChatDirectMessageNotifications: (...args: unknown[]) =>
+    emitChatDirectMessageNotificationsMock(...args),
 }));
 
 vi.mock("@/helpers/chat-room-message-realtime", () => ({
@@ -147,18 +154,29 @@ const coworkerAuthContext: AuthVariables["authContext"] = {
 
 function roomWithMembers(
   overrides: {
+    kind?: "channel" | "direct";
+    name?: string;
     userMembers?: Array<{
       userId: string;
       user: { name: string };
+    }>;
+    coworkerMembers?: Array<{
+      coworker: {
+        id: string;
+        name: string;
+        slug: string;
+        caption: string | null;
+        image: string | null;
+      };
     }>;
   } = {},
 ) {
   return {
     id: ROOM_ID,
     organizationId: "org_1",
-    name: "general",
+    name: overrides.name ?? "general",
     slug: "general",
-    kind: "channel",
+    kind: overrides.kind ?? "channel",
     directKey: null,
     topic: null,
     createdByUserId: USER_ID,
@@ -166,7 +184,7 @@ function roomWithMembers(
     updatedAt: new Date("2025-01-01T00:00:00.000Z"),
     archivedAt: null,
     userMembers: overrides.userMembers ?? [],
-    coworkerMembers: [
+    coworkerMembers: overrides.coworkerMembers ?? [
       {
         coworker: {
           id: COWORKER_ID,
@@ -541,6 +559,90 @@ describe("POST /chats/rooms/{id}/messages", () => {
 
       expect(response.status).toBe(201);
       expect(emitChatMentionNotificationsMock).not.toHaveBeenCalled();
+      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
+    });
+
+    it("emits direct-message notifications to other humans in a direct room", async () => {
+      roomFindFirstMock.mockResolvedValue(
+        roomWithMembers({
+          kind: "direct",
+          name: "Alice",
+          userMembers: [
+            {
+              userId: USER_ID,
+              user: { name: "Patrick" },
+            },
+            {
+              userId: ALICE_ID,
+              user: { name: "Alice" },
+            },
+          ],
+          coworkerMembers: [],
+        }),
+      );
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderUserId: USER_ID }),
+      );
+
+      const app = createApp(userAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "hey, are you free?" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatMentionNotificationsMock).not.toHaveBeenCalled();
+      expect(emitChatDirectMessageNotificationsMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        roomName: "Alice",
+        organizationId: "org_1",
+        messageId: MESSAGE_ID,
+        authorUserId: USER_ID,
+        authorName: "Patrick",
+        recipientUserIds: [ALICE_ID],
+      });
+    });
+
+    it("skips direct-message emit for humans already covered by mention notifications", async () => {
+      roomFindFirstMock.mockResolvedValue(
+        roomWithMembers({
+          kind: "direct",
+          name: "Alice",
+          userMembers: [
+            {
+              userId: USER_ID,
+              user: { name: "Patrick" },
+            },
+            {
+              userId: ALICE_ID,
+              user: { name: "Alice" },
+            },
+          ],
+          coworkerMembers: [],
+        }),
+      );
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderUserId: USER_ID }),
+      );
+
+      const app = createApp(userAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "ping",
+          mentionedUserIds: [ALICE_ID],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatMentionNotificationsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mentionedUserIds: [ALICE_ID],
+        }),
+      );
+      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
     });
 
     it("expands @all:all from content to notify other humans without ChatRoomMention rows", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { waitUntil } from "@vercel/functions";
 
+import { emitChatDirectMessageNotifications } from "@/helpers/chat-direct-message-notifications";
 import { emitChatMentionNotifications } from "@/helpers/chat-mention-notifications";
 import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { conflict } from "@/helpers/error";
@@ -166,6 +167,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
                 id: room.id,
                 name: room.name,
                 organizationId: room.organizationId,
+                kind: room.kind,
+                memberUserIds: room.userMembers.map((member) => member.userId),
               },
               didCreate: false,
             };
@@ -292,6 +295,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             id: room.id,
             name: room.name,
             organizationId: room.organizationId,
+            kind: room.kind,
+            memberUserIds: room.userMembers.map((member) => member.userId),
           },
           didCreate: true,
         };
@@ -348,6 +353,27 @@ export default function mount(app: OpenAPIHonoWithAuth) {
             mentionedUserIds,
           }),
         );
+      }
+
+      if (room.kind === "direct") {
+        const mentionedUserIdSet = new Set(mentionedUserIds);
+        const recipientUserIds = room.memberUserIds.filter(
+          (userId) =>
+            userId !== userContext.userId && !mentionedUserIdSet.has(userId),
+        );
+        if (recipientUserIds.length > 0) {
+          waitUntil(
+            emitChatDirectMessageNotifications({
+              roomId: room.id,
+              roomName: room.name,
+              organizationId: room.organizationId,
+              messageId: message.id,
+              authorUserId: userContext.userId,
+              authorName: message.senderUser?.name ?? "Someone",
+              recipientUserIds,
+            }),
+          );
+        }
       }
     }
 

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} wurde abgebrochen"
       },
       "Chat": {
-        "mentioned": "{authorName} hat dich in {roomName} erwähnt"
+        "mentioned": "{authorName} hat dich in {roomName} erwähnt",
+        "directMessage": "{authorName} hat dir eine Nachricht gesendet"
       }
     }
   },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5171,7 +5171,8 @@
         "canceled": "{taskName} was canceled"
       },
       "Chat": {
-        "mentioned": "{authorName} mentioned you in {roomName}"
+        "mentioned": "{authorName} mentioned you in {roomName}",
+        "directMessage": "{authorName} sent you a message"
       }
     }
   },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} fue cancelado"
       },
       "Chat": {
-        "mentioned": "{authorName} te mencionó en {roomName}"
+        "mentioned": "{authorName} te mencionó en {roomName}",
+        "directMessage": "{authorName} te envió un mensaje"
       }
     }
   },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} a été annulé"
       },
       "Chat": {
-        "mentioned": "{authorName} vous a mentionné dans {roomName}"
+        "mentioned": "{authorName} vous a mentionné dans {roomName}",
+        "directMessage": "{authorName} vous a envoyé un message"
       }
     }
   },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} è stato annullato"
       },
       "Chat": {
-        "mentioned": "{authorName} ti ha menzionato in {roomName}"
+        "mentioned": "{authorName} ti ha menzionato in {roomName}",
+        "directMessage": "{authorName} ti ha inviato un messaggio"
       }
     }
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName}はキャンセルされました"
       },
       "Chat": {
-        "mentioned": "{authorName}が{roomName}であなたにメンションしました"
+        "mentioned": "{authorName}が{roomName}であなたにメンションしました",
+        "directMessage": "{authorName} からメッセージが届きました"
       }
     }
   },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} foi cancelado"
       },
       "Chat": {
-        "mentioned": "{authorName} mencionou você em {roomName}"
+        "mentioned": "{authorName} mencionou você em {roomName}",
+        "directMessage": "{authorName} enviou uma mensagem para você"
       }
     }
   },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} foi cancelado"
       },
       "Chat": {
-        "mentioned": "{authorName} mencionou-te em {roomName}"
+        "mentioned": "{authorName} mencionou-te em {roomName}",
+        "directMessage": "{authorName} enviou-te uma mensagem"
       }
     }
   },

--- a/apps/web/messages/zh-Hans.json
+++ b/apps/web/messages/zh-Hans.json
@@ -5052,7 +5052,8 @@
         "canceled": "{taskName} 已取消"
       },
       "Chat": {
-        "mentioned": "{authorName}在{roomName}中提到了你"
+        "mentioned": "{authorName}在{roomName}中提到了你",
+        "directMessage": "{authorName} 给你发了一条消息"
       }
     }
   },

--- a/apps/web/src/app/(app)/components/notification-toast-listener.tsx
+++ b/apps/web/src/app/(app)/components/notification-toast-listener.tsx
@@ -1,19 +1,15 @@
 "use client";
 
-import { Bell } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
 import { useNotifications } from "@/contexts/notification-provider";
 import { useNotificationRealtime } from "@/lib/ably/use-notification-realtime";
 import { authClient } from "@/lib/auth/auth.client";
-import { NOTIFICATION_TOASTER_ID } from "@/lib/constants/notification-toaster";
 import {
   getBrowserNotificationPermission,
   shouldShowBrowserNotification,
-  shouldShowInAppNotificationToast,
   showBrowserNotification,
 } from "@/lib/utils/browser-notification";
 import { useNotificationMessage } from "@/lib/utils/notification-message";
@@ -21,28 +17,6 @@ import { handleNotificationNavigation } from "@/lib/utils/notification-navigatio
 
 interface NotificationToastListenerProps {
   userId: string;
-}
-
-interface NotificationToastBodyProps {
-  message: string;
-  onOpen: () => void;
-}
-
-function NotificationToastBody({
-  message,
-  onOpen,
-}: NotificationToastBodyProps) {
-  return (
-    <button
-      type="button"
-      onClick={onOpen}
-      className="hover:bg-accent/50 -my-1 flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md py-1 text-left transition-colors"
-    >
-      <span className="min-w-0 flex-1 text-sm font-medium leading-snug">
-        {message}
-      </span>
-    </button>
-  );
 }
 
 export function NotificationToastListener({
@@ -66,12 +40,8 @@ export function NotificationToastListener({
         isDocumentFocused,
         isRead: notification.isRead,
       });
-      const showToast = shouldShowInAppNotificationToast({
-        isDocumentFocused,
-        isRead: notification.isRead,
-      });
 
-      if (!showBrowser && !showToast) {
+      if (!showBrowser) {
         return;
       }
 
@@ -102,53 +72,25 @@ export function NotificationToastListener({
         })();
       };
 
-      if (showBrowser) {
-        const browserNotification = showBrowserNotification({
-          id: notification.id,
-          title: t("browserNotificationTitle"),
-          body: message,
-          icon: new URL(
-            "/images/app-icons/apple-icon-180.png",
-            window.location.origin,
-          ).href,
-          onClick: openNotification,
-        });
-        if (browserNotification == null) {
-          console.error(
-            "Browser notification gate passed but OS notification was not shown",
-            { id: notification.id },
-          );
-        }
-        return;
+      const browserNotification = showBrowserNotification({
+        id: notification.id,
+        title: t("browserNotificationTitle"),
+        body: message,
+        icon: new URL(
+          "/images/app-icons/apple-icon-180.png",
+          window.location.origin,
+        ).href,
+        onClick: openNotification,
+      });
+      if (browserNotification == null) {
+        console.error(
+          "Browser notification gate passed but OS notification was not shown",
+          { id: notification.id },
+        );
       }
-
-      toast(
-        () => (
-          <NotificationToastBody
-            message={message}
-            onOpen={() => {
-              toast.dismiss(notification.id);
-              openNotification();
-            }}
-          />
-        ),
-        {
-          id: notification.id,
-          toasterId: NOTIFICATION_TOASTER_ID,
-          duration: 10_000,
-          dismissible: true,
-          icon: <Bell className="text-primary size-5 shrink-0" />,
-          action: {
-            label: t("dismiss"),
-            onClick: () => {
-              toast.dismiss(notification.id);
-            },
-          },
-        },
-      );
     },
     onError: (error) => {
-      console.error("Notification toast error:", error);
+      console.error("Notification browser alert error:", error);
     },
   });
 

--- a/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
+++ b/apps/web/src/lib/utils/__tests__/browser-notification.test.ts
@@ -4,7 +4,6 @@ import {
   getBrowserNotificationPermission,
   requestBrowserNotificationPermission,
   shouldShowBrowserNotification,
-  shouldShowInAppNotificationToast,
   showBrowserNotification,
   subscribeBrowserNotificationPermission,
 } from "@/lib/utils/browser-notification";
@@ -60,29 +59,6 @@ describe("shouldShowBrowserNotification", () => {
         permission: "unsupported",
         isDocumentFocused: false,
         isRead: false,
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("shouldShowInAppNotificationToast", () => {
-  it("shows unread toasts only while the document is focused", () => {
-    expect(
-      shouldShowInAppNotificationToast({
-        isDocumentFocused: true,
-        isRead: false,
-      }),
-    ).toBe(true);
-    expect(
-      shouldShowInAppNotificationToast({
-        isDocumentFocused: false,
-        isRead: false,
-      }),
-    ).toBe(false);
-    expect(
-      shouldShowInAppNotificationToast({
-        isDocumentFocused: true,
-        isRead: true,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/lib/utils/browser-notification.ts
+++ b/apps/web/src/lib/utils/browser-notification.ts
@@ -48,20 +48,6 @@ export function shouldShowBrowserNotification({
   return !isDocumentFocused;
 }
 
-export function shouldShowInAppNotificationToast({
-  isDocumentFocused,
-  isRead,
-}: {
-  isDocumentFocused: boolean;
-  isRead: boolean;
-}): boolean {
-  if (isRead) {
-    return false;
-  }
-
-  return isDocumentFocused;
-}
-
 export async function requestBrowserNotificationPermission(): Promise<BrowserNotificationPermission> {
   if (!isNotificationApiAvailable()) {
     return "unsupported";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Plain DMs showed `(1)` on the Chat tab via unread read-state, but never created a notification-center row. Browser notifications only fire on Ably `notification_created`, so OS alerts never appeared for those messages even with permission granted.

## Root cause

Chat `NotificationKind.CHAT` was only emitted for human `@mentions` (`emitChatMentionNotifications`). Title badge unread uses a separate `lastReadAt` path.

## Fix

- Emit CHAT notifications for other human members when a message is posted in a `direct` room
- Respect room mute
- Skip peers already covered by mention notifications (no double notify)
- Copy: `Notifications.Chat.directMessage` in all locales
- Remove focused in-app Sonner toasts for realtime feed alerts. Unfocused + granted → OS browser notification only. Notification center unread state unchanged.

## Verification

```
# failing repro (first commit)
pnpm --filter core test src/helpers/chat-direct-message-notifications.test.ts 'src/routes/v1/chats/rooms/[id]/messages/post.test.ts'
# → Cannot find module …/chat-direct-message-notifications; post.test expects DM emit (0 calls)

# after fix
pnpm --filter core test src/helpers/chat-direct-message-notifications.test.ts 'src/routes/v1/chats/rooms/[id]/messages/post.test.ts'
# → 22 passed

pnpm --filter web test src/lib/utils/__tests__/browser-notification.test.ts
# → 13 passed (toast gate removed)
```

Manual check on a deployed preview: grant notification permission, leave Sokosumi unfocused, send a plain DM from another account → OS notification with “{name} sent you a message”. Focused tab → no toast, no OS alert.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75baa281-5eb4-49e2-b86e-8a1972452d1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75baa281-5eb4-49e2-b86e-8a1972452d1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

