### PR TITLE
fix(web): plumb mediaType into FileChip for MIME-based previews

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-activity.test.tsx
@@ -130,6 +130,13 @@ vi.mock("@/components/expandable-markdown", () => ({
 }));
 
 vi.mock("@/components/jobs/job-details/file-chip-with-metadata", () => ({
+  FileChipWithMetadata: ({
+    url,
+    fileName,
+  }: {
+    url: string;
+    fileName?: string | null;
+  }) => <div>{fileName ?? url}</div>,
   FileChipMiniPreviewWithMetadata: ({ url }: { url: string }) => (
     <div>{url}</div>
   ),
@@ -577,12 +584,11 @@ describe("TaskActivitySection", () => {
 
     render(<TaskActivitySection {...baseProps} events={events} />);
 
-    // report.pdf is now previewable, so it renders as a button that opens
-    // the DocumentViewer rather than a plain link — see file-chip.test.tsx
-    // for the click-to-preview behavior itself.
-    expect(
-      screen.getByRole("button", { name: /report\.pdf/i }),
-    ).toBeInTheDocument();
+    // Markdown keeps the inline link; SourcesGrid also lists the extracted
+    // file via FileChipWithMetadata (mocked above as the URL/name text).
+    expect(screen.getAllByText(/report\.pdf/i).length).toBeGreaterThanOrEqual(
+      1,
+    );
     expect(
       screen.getByRole("link", { name: /docs\.example\.com/i }),
     ).toHaveAttribute("href", "https://docs.example.com/article");

--- a/apps/web/src/app/(app)/tasks/components/task-files.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-files.tsx
@@ -6,7 +6,7 @@ import type {
 
 export type TaskFileListItem = Pick<
   TaskFile | PublicSharedTaskFile,
-  "id" | "name" | "fileUrl" | "size"
+  "id" | "name" | "fileUrl" | "size" | "mimeType"
 >;
 
 interface TaskFilesProps {
@@ -34,6 +34,7 @@ export function TaskFiles({ title, files, className }: TaskFilesProps) {
             key={file.id}
             url={file.fileUrl}
             fileName={file.name}
+            mediaType={file.mimeType}
             size={file.size}
           />
         ))}

--- a/apps/web/src/components/__tests__/expandable-markdown.test.tsx
+++ b/apps/web/src/components/__tests__/expandable-markdown.test.tsx
@@ -94,6 +94,29 @@ describe("ExpandableMarkdown", () => {
     expect(container.querySelector(".line-clamp-5")).not.toBeInTheDocument();
   });
 
+  it("shows collapse for overflow content that starts expanded via defaultOpen", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpandableMarkdown
+        content={"Some markdown content that overflows"}
+        expandLabel="Expand"
+        collapseLabel="Collapse"
+        defaultOpen
+      />,
+    );
+
+    const collapseButton = screen.getByRole("button", { name: "Collapse" });
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(collapseButton);
+
+    expect(screen.getByRole("button", { name: "Expand" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
   it("toggles the expanded state when the controls are clicked", async () => {
     const user = userEvent.setup();
 

--- a/apps/web/src/components/expandable-markdown.tsx
+++ b/apps/web/src/components/expandable-markdown.tsx
@@ -51,13 +51,25 @@ export function ExpandableMarkdown({
 
   useEffect(() => {
     const element = contentRef.current;
-    if (!element || open) {
+    if (!element) {
       return;
     }
 
     const measureOverflow = () => {
-      const hasOverflow = element.scrollHeight > element.clientHeight + 1;
-      setIsExpandable(hasOverflow);
+      const fullHeight = element.scrollHeight;
+      // When expanded, clientHeight equals full content, so overflow would
+      // always read false. Compare against the clamped height we'd use when
+      // collapsed so Collapse can still appear for defaultOpen long content.
+      let collapsedHeight = element.clientHeight;
+      if (open) {
+        const lineHeight = Number.parseFloat(
+          getComputedStyle(element).lineHeight,
+        );
+        if (Number.isFinite(lineHeight) && lineHeight > 0) {
+          collapsedHeight = lineHeight * effectiveLineClamp;
+        }
+      }
+      setIsExpandable(fullHeight > collapsedHeight + 1);
     };
 
     measureOverflow();
@@ -68,7 +80,7 @@ export function ExpandableMarkdown({
     return () => {
       observer.disconnect();
     };
-  }, [content, lineClampClass, open]);
+  }, [content, effectiveLineClamp, lineClampClass, open]);
 
   const shouldFade = !open && isExpandable;
 

--- a/apps/web/src/components/jobs/job-details/__tests__/file-chip-with-metadata.test.tsx
+++ b/apps/web/src/components/jobs/job-details/__tests__/file-chip-with-metadata.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FileChipWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
@@ -14,6 +14,26 @@ vi.mock("next/image", () => ({
   }) => {
     return <img src={props.src} alt={props.alt} className={props.className} />;
   },
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations:
+    (namespace?: string) => (key: string, values?: Record<string, unknown>) => {
+      if (namespace === "Components.DocumentViewer") {
+        const documentLabels: Record<string, string> = {
+          title: "Document",
+          download: "Download document",
+          openInNewTab: "Open in new tab",
+          loading: "Loading document…",
+          fetchError: "This document couldn't be loaded.",
+        };
+        return documentLabels[key] ?? key;
+      }
+      if (key === "download") {
+        return "Download image";
+      }
+      return key;
+    },
 }));
 
 const fetchMock = vi.fn();
@@ -163,5 +183,41 @@ describe("FileChipWithMetadata", () => {
       expect(screen.getByText("empty.txt")).toBeInTheDocument();
       expect(screen.getByText("0 B")).toBeInTheDocument();
     });
+  });
+
+  it("opens a document viewer for an extensionless URL after HEAD returns application/pdf", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: createHeaders({
+        "content-disposition": null,
+        "content-length": "4096",
+        "content-type": "application/pdf",
+      }),
+    });
+
+    render(
+      <FileChipWithMetadata
+        url="https://files.example/abcdef012345"
+        fileName="report"
+      />,
+    );
+
+    expect(screen.getByText("report")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /report/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /report/i }));
+
+    expect(screen.getByTestId("document-viewer")).toBeInTheDocument();
+    expect(screen.getByTitle("report")).toHaveAttribute(
+      "src",
+      "https://files.example/abcdef012345#toolbar=0&navpanes=0&scrollbar=0&view=FitH",
+    );
   });
 });

--- a/apps/web/src/components/jobs/job-details/file-chip-with-metadata.tsx
+++ b/apps/web/src/components/jobs/job-details/file-chip-with-metadata.tsx
@@ -80,15 +80,22 @@ function useFileHeadMetadata(url: string) {
 export function FileChipWithMetadata({
   url,
   title,
+  mediaType,
+  fileName,
+  size,
   ...props
-}: Omit<FileChipProps, "fileName" | "size">) {
+}: Omit<FileChipProps, "fileName" | "size"> & {
+  fileName?: string | null;
+  size?: number | bigint | null;
+}) {
   const metadata = useFileHeadMetadata(url);
 
   return (
     <FileChip
       url={url}
-      fileName={metadata?.fileName}
-      size={metadata?.size ?? undefined}
+      fileName={fileName ?? metadata?.fileName}
+      mediaType={mediaType ?? metadata?.contentType}
+      size={size ?? metadata?.size ?? undefined}
       title={title ?? metadata?.contentType}
       {...props}
     />

--- a/apps/web/src/components/sources/sources-grid.tsx
+++ b/apps/web/src/components/sources/sources-grid.tsx
@@ -15,6 +15,7 @@ export interface BlobLike {
   status: BlobStatus;
   name?: string | null;
   fileUrl?: string | null;
+  mimeType?: string | null;
 }
 
 export interface LinkLike {
@@ -87,6 +88,7 @@ function FileItemChip({ blob }: { blob: BlobLike }) {
     <FileChipWithMetadata
       url={getBlobUrl(blob)}
       fileName={blob.name}
+      mediaType={blob.mimeType}
       sizeClass="size-4"
     />
   );

--- a/apps/web/src/components/sources/sources-grid.tsx
+++ b/apps/web/src/components/sources/sources-grid.tsx
@@ -1,6 +1,7 @@
 import { FileIcon } from "lucide-react";
+
+import { FileChipWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Favicon } from "@/components/ui/favicon";
-import { FileChip } from "@/components/ui/file-chip";
 import { BlobStatus } from "@/lib/clients/generated/core";
 import { getBlobUrl } from "@/lib/helpers/blob";
 import { cn } from "@/lib/utils";
@@ -83,6 +84,10 @@ function FileItemChip({ blob }: { blob: BlobLike }) {
   }
 
   return (
-    <FileChip url={getBlobUrl(blob)} fileName={blob.name} sizeClass="size-4" />
+    <FileChipWithMetadata
+      url={getBlobUrl(blob)}
+      fileName={blob.name}
+      sizeClass="size-4"
+    />
   );
 }

--- a/apps/web/src/components/ui/__tests__/document-viewer.test.tsx
+++ b/apps/web/src/components/ui/__tests__/document-viewer.test.tsx
@@ -78,6 +78,9 @@ describe("DocumentViewer", () => {
       "https://blob.example.com/report.pdf",
     );
     expect(download).toHaveAttribute("download", "report.pdf");
+    expect(download).toHaveAttribute("title", "Download document");
+    expect(download.className).toMatch(/size-8/);
+    expect(download.className).toMatch(/sm:w-auto/);
 
     const openInNewTab = screen.getByRole("link", { name: "Open in new tab" });
     expect(openInNewTab).toHaveAttribute(
@@ -85,6 +88,9 @@ describe("DocumentViewer", () => {
       "https://blob.example.com/report.pdf",
     );
     expect(openInNewTab).toHaveAttribute("target", "_blank");
+    expect(openInNewTab).toHaveAttribute("title", "Open in new tab");
+    expect(openInNewTab.className).toMatch(/size-8/);
+    expect(openInNewTab.className).toMatch(/sm:w-auto/);
   });
 
   it("embeds a PDF natively with the toolbar hidden", () => {

--- a/apps/web/src/components/ui/__tests__/file-chip.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip.test.tsx
@@ -94,6 +94,40 @@ describe("FileChip", () => {
     );
   });
 
+  it("opens a document viewer for an extensionless URL when mediaType is a previewable MIME", () => {
+    render(
+      <FileChip
+        url="https://blob.example.com/uploads/abcdef012345"
+        mediaType="application/pdf"
+      />,
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    const trigger = screen.getByRole("button");
+    fireEvent.click(trigger);
+
+    expect(screen.getByTestId("document-viewer")).toBeInTheDocument();
+    expect(screen.getByTitle("abcdef012345")).toHaveAttribute(
+      "src",
+      "https://blob.example.com/uploads/abcdef012345#toolbar=0&navpanes=0&scrollbar=0&view=FitH",
+    );
+  });
+
+  it("opens an image viewer for an extensionless URL when mediaType is image/*", () => {
+    render(
+      <FileChip
+        url="https://blob.example.com/uploads/abcdef012345"
+        mediaType="image/png"
+      />,
+    );
+
+    const trigger = screen.getByRole("button");
+    fireEvent.click(trigger);
+
+    expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+  });
+
   it("keeps a plain download/open link for unsupported file types", () => {
     render(
       <FileChip

--- a/apps/web/src/components/ui/document-viewer.tsx
+++ b/apps/web/src/components/ui/document-viewer.tsx
@@ -152,7 +152,7 @@ function DocumentViewerContent({
 
   return (
     <>
-      <div className="border-border/60 flex items-center justify-between gap-3 border-b py-4 pr-14 pl-6">
+      <div className="border-border/60 flex items-center justify-between gap-2 border-b py-3 pr-14 pl-4 sm:gap-3 sm:py-4 sm:pl-6">
         <div className="flex min-w-0 items-center gap-2">
           <FileText
             className="text-muted-foreground size-4 shrink-0"
@@ -162,17 +162,38 @@ function DocumentViewerContent({
             {fileName}
           </DialogTitle>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Button asChild variant="outline" size="sm">
-            <a href={url} target="_blank" rel="noreferrer noopener">
-              {t("openInNewTab")}
+        <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+          <Button
+            asChild
+            variant="outline"
+            size="icon"
+            className="size-8 sm:h-8 sm:w-auto sm:gap-1.5 sm:px-3"
+          >
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer noopener"
+              aria-label={t("openInNewTab")}
+              title={t("openInNewTab")}
+            >
               <ExternalLink className="size-3.5" aria-hidden />
+              <span className="hidden sm:inline">{t("openInNewTab")}</span>
             </a>
           </Button>
-          <Button asChild variant="outline" size="sm">
-            <a download={fileName} href={url}>
-              {t("download")}
+          <Button
+            asChild
+            variant="outline"
+            size="icon"
+            className="size-8 sm:h-8 sm:w-auto sm:gap-1.5 sm:px-3"
+          >
+            <a
+              download={fileName}
+              href={url}
+              aria-label={t("download")}
+              title={t("download")}
+            >
               <Download className="size-3.5" aria-hidden />
+              <span className="hidden sm:inline">{t("download")}</span>
             </a>
           </Button>
         </div>

--- a/apps/web/src/components/ui/file-chip.tsx
+++ b/apps/web/src/components/ui/file-chip.tsx
@@ -15,6 +15,7 @@ import { formatBytes } from "@/lib/utils/format-bytes";
 export interface FileChipProps extends React.ComponentPropsWithoutRef<"a"> {
   url: string;
   fileName?: string | null;
+  mediaType?: string | null;
   size?: number | bigint | null;
   /**
    * Tailwind size class (e.g., `size-8`, `size-10`). Defaults to `size-10`.
@@ -31,6 +32,7 @@ export function FileChip(props: FileChipProps) {
   const {
     url,
     fileName: fileNameProp,
+    mediaType,
     size,
     className,
     sizeClass = "size-10",
@@ -39,7 +41,11 @@ export function FileChip(props: FileChipProps) {
     ...anchorProps
   } = props;
   const fileName = fileNameProp ?? url.split("/").pop() ?? url;
-  const { isImage, documentKind } = classifyFilePreview(url, fileNameProp);
+  const { isImage, documentKind } = classifyFilePreview(
+    url,
+    fileNameProp,
+    mediaType,
+  );
   const canUseNextImage = canUseNextImageSrc(url);
   const prettySize = formatBytes(size);
   const containerSizeClass = sizeClass;
@@ -87,7 +93,8 @@ export function FileChip(props: FileChipProps) {
         ) : (
           <div className={cn("flex size-full items-center justify-center", shouldApplyIconPadding && "p-1")}>
             {(() => {
-              const ext = getExtensionFromUrl(url) || "file";
+              const ext =
+                getExtensionFromUrl(fileNameProp ?? url) || "file";
               return <FileTypeIcon extension={ext} />;
             })()}
           </div>
@@ -143,6 +150,7 @@ export function FileChip(props: FileChipProps) {
           url={url}
           fileName={fileName}
           kind={documentKind}
+          mediaType={mediaType}
         />
       </>
     );

--- a/apps/web/src/lib/utils/__tests__/file-preview.test.ts
+++ b/apps/web/src/lib/utils/__tests__/file-preview.test.ts
@@ -69,6 +69,7 @@ describe("isPdfUrl / isPdfMediaType", () => {
   it("recognizes the application/pdf MIME type", () => {
     expect(isPdfMediaType("application/pdf")).toBe(true);
     expect(isPdfMediaType("APPLICATION/PDF")).toBe(true);
+    expect(isPdfMediaType("application/pdf; charset=binary")).toBe(true);
     expect(isPdfMediaType("application/zip")).toBe(false);
   });
 });
@@ -80,10 +81,12 @@ describe("isTextPreviewUrl / isTextPreviewMediaType", () => {
     expect(isTextPreviewUrl("https://blob.example/data.csv")).toBe(false);
   });
 
-  it("recognizes text/plain and text/markdown MIME types", () => {
+  it("recognizes text MIME types including Content-Type parameters", () => {
     expect(isTextPreviewMediaType("text/plain")).toBe(true);
+    expect(isTextPreviewMediaType("text/plain; charset=utf-8")).toBe(true);
     expect(isTextPreviewMediaType("text/markdown")).toBe(true);
     expect(isTextPreviewMediaType("text/csv")).toBe(false);
+    expect(isTextPreviewMediaType("application/json")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/utils/file-preview.ts
+++ b/apps/web/src/lib/utils/file-preview.ts
@@ -26,23 +26,28 @@ const TEXT_PREVIEW_MEDIA_TYPES = new Set([
   "text/x-markdown",
 ]);
 
+/** Strip parameters (`text/plain; charset=utf-8` → `text/plain`) for allowlist checks. */
+export function normalizeMediaType(mediaType?: string | null): string | null {
+  if (!mediaType) return null;
+  const base = mediaType.split(";", 1)[0]?.trim().toLowerCase();
+  return base || null;
+}
+
 export function isOfficeFile(url: string): boolean {
   return OFFICE_EXTENSIONS.has(getExtensionFromUrl(url));
 }
 
 export function isOfficeMediaType(mediaType?: string | null): boolean {
-  return mediaType
-    ? mediaType.toLowerCase() in OFFICE_MEDIA_TYPE_EXTENSION
-    : false;
+  const normalized = normalizeMediaType(mediaType);
+  return normalized ? normalized in OFFICE_MEDIA_TYPE_EXTENSION : false;
 }
 
 /** The Office file extension implied by a MIME type, when known. */
 export function officeExtensionFromMediaType(
   mediaType?: string | null,
 ): string | undefined {
-  return mediaType
-    ? OFFICE_MEDIA_TYPE_EXTENSION[mediaType.toLowerCase()]
-    : undefined;
+  const normalized = normalizeMediaType(mediaType);
+  return normalized ? OFFICE_MEDIA_TYPE_EXTENSION[normalized] : undefined;
 }
 
 export function isPdfUrl(url: string): boolean {
@@ -50,7 +55,7 @@ export function isPdfUrl(url: string): boolean {
 }
 
 export function isPdfMediaType(mediaType?: string | null): boolean {
-  return mediaType?.toLowerCase() === "application/pdf";
+  return normalizeMediaType(mediaType) === "application/pdf";
 }
 
 export function isTextPreviewUrl(url: string): boolean {
@@ -58,9 +63,8 @@ export function isTextPreviewUrl(url: string): boolean {
 }
 
 export function isTextPreviewMediaType(mediaType?: string | null): boolean {
-  return mediaType
-    ? TEXT_PREVIEW_MEDIA_TYPES.has(mediaType.toLowerCase())
-    : false;
+  const normalized = normalizeMediaType(mediaType);
+  return normalized ? TEXT_PREVIEW_MEDIA_TYPES.has(normalized) : false;
 }
 
 export type DocumentPreviewKind = "office" | "pdf" | "text";
@@ -98,7 +102,7 @@ export function classifyFilePreview(
   mediaType?: string | null,
 ): FilePreviewClassification {
   const isImage =
-    (mediaType?.toLowerCase().startsWith("image/") ?? false) ||
+    (normalizeMediaType(mediaType)?.startsWith("image/") ?? false) ||
     isImageUrl(url) ||
     (fileName ? isImageUrl(fileName) : false);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #3588 after a full poteto review (not the first Critique-lite pass).

## Why

#3588 preview path is right (FileChip → DocumentViewer, not remark). Full review found real Highs and MIME gaps on the stack tip.

## Changes

**#3591 (this PR), stacked on #3588**

1. `FileChip` takes `mediaType` → `classifyFilePreview` / `DocumentViewer`
2. `FileChipWithMetadata` forwards HEAD `Content-Type` (+ optional `fileName`/`size`)
3. `SourcesGrid` uses `FileChipWithMetadata` and passes Core `mimeType` when present
4. `TaskFiles` plumbs Core `mimeType`
5. `normalizeMediaType` strips `Content-Type` parameters (`charset=…`)
6. `ExpandableMarkdown` measures clamp height while `defaultOpen`, so Collapse appears for long completed summaries
7. `task-activity` mock exports `FileChipWithMetadata` after SourcesGrid switch
8. `DocumentViewer` header: icon-only actions under `sm`, labels from `sm` up (R9)

## Still out of scope

- Remark plugin as primary path (wrong layer)
- Dual prose-link + chip UI (pre-existing product choice)
- HEAD link→button flash when server MIME absent (acceptable)
- Private Office Online embeds (product/proxy; same limit as offer-card)

## Verify

```bash
pnpm --filter web test \
  src/lib/utils/__tests__/file-preview.test.ts \
  src/components/ui/__tests__/document-viewer.test.tsx \
  src/components/ui/__tests__/file-chip.test.tsx \
  src/components/ui/__tests__/file-chip-mini-preview.test.tsx \
  src/components/jobs/job-details/__tests__/file-chip-with-metadata.test.tsx \
  src/components/__tests__/expandable-markdown.test.tsx \
  src/components/jobs/job-details/__tests__/outputs.test.tsx \
  'src/app/(app)/tasks/components/__tests__/task-activity.test.tsx'
```

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| UX | `FileChipWithMetadata` | Link→button flash after HEAD when server MIME absent |
| Product | Office Online iframe | Needs publicly fetchable `src`; private blobs fail silently |

Stack onto #3588 (`feat/document-attachment-previews`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-add1b520-6ab7-44de-92af-dff78b2e791a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-add1b520-6ab7-44de-92af-dff78b2e791a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

