### PR TITLE
fix(web): keep page on vendor-grant Accept in header bell

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/notification-item.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/notification-item.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationItem } from "@/app/components/header/notification-item";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { NotificationItem as NotificationItemType } from "@/lib/clients/generated/core";
+import { VENDOR_GRANT_PENDING_MESSAGE_KEY } from "@/lib/utils/vendor-grant-notification";
+
+const approveMyVendorGrantMock = vi.fn();
+const approveOrganizationVendorGrantMock = vi.fn();
+const markReadMock = vi.fn();
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/contexts/notification-provider", () => ({
+  useNotifications: () => ({
+    markRead: markReadMock,
+  }),
+}));
+
+vi.mock("@/lib/actions/account/vendor-grant-action", () => ({
+  approveMyVendorGrant: (...args: unknown[]) =>
+    approveMyVendorGrantMock(...args),
+}));
+
+vi.mock("@/lib/actions/organization/vendor-grant-action", () => ({
+  approveOrganizationVendorGrant: (...args: unknown[]) =>
+    approveOrganizationVendorGrantMock(...args),
+}));
+
+function createPendingVendorGrantNotification(
+  overrides: Partial<NotificationItemType> = {},
+): NotificationItemType {
+  return {
+    id: "notification-grant-1",
+    userId: "user-1",
+    kind: "SYSTEM",
+    referenceId: "grant-1",
+    eventId: "event-1",
+    messageKey: VENDOR_GRANT_PENDING_MESSAGE_KEY,
+    messageParams: {},
+    metadata: { vendorId: "vendor-1" },
+    isRead: false,
+    readAt: null,
+    createdAt: new Date("2026-06-18T09:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function renderInOpenDropdown(
+  notification: NotificationItemType,
+  onClick: () => void,
+) {
+  return render(
+    <DropdownMenu open>
+      <DropdownMenuTrigger asChild>
+        <button type="button">Open</button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <NotificationItem
+          notification={notification}
+          onClick={onClick}
+          formatTime={() => "just now"}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>,
+  );
+}
+
+describe("NotificationItem vendor-grant Accept", () => {
+  beforeEach(() => {
+    approveMyVendorGrantMock.mockReset();
+    approveOrganizationVendorGrantMock.mockReset();
+    markReadMock.mockReset();
+    approveMyVendorGrantMock.mockResolvedValue({ ok: true, data: {} });
+    markReadMock.mockResolvedValue(undefined);
+  });
+
+  it("does not fire row navigation onClick when Accept is clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const notification = createPendingVendorGrantNotification();
+
+    renderInOpenDropdown(notification, onClick);
+
+    const acceptButton = await screen.findByRole("button", { name: "accept" });
+    await user.click(acceptButton);
+
+    await waitFor(() => {
+      expect(approveMyVendorGrantMock).toHaveBeenCalledWith({
+        grantId: "grant-1",
+      });
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("fires row navigation onClick when the message is clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const notification = createPendingVendorGrantNotification();
+
+    renderInOpenDropdown(notification, onClick);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(VENDOR_GRANT_PENDING_MESSAGE_KEY),
+      }),
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/(app)/components/header/notification-item.tsx
+++ b/apps/web/src/app/(app)/components/header/notification-item.tsx
@@ -26,36 +26,68 @@ export function NotificationItem({
   );
   const showVendorGrantActions = isPendingVendorGrantNotification(notification);
 
-  return (
-    <DropdownMenuItem
-      className={cn(
-        "flex cursor-pointer flex-col items-start gap-1 px-4 py-3",
-        !notification.isRead && "bg-accent/50",
-      )}
-      onClick={onClick}
-    >
-      <div className="flex w-full items-start gap-3">
-        <Bell
-          className={cn(
-            "mt-0.5 size-4 shrink-0",
-            notification.isRead ? "text-muted-foreground" : "text-primary",
-          )}
-        />
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className={cn("text-sm", !notification.isRead && "font-medium")}>
-            {message}
-          </p>
-          <p className="text-muted-foreground text-xs">
-            {formatTime(notification.createdAt)}
-          </p>
-          {showVendorGrantActions ? (
-            <VendorGrantNotificationActions
-              notification={notification}
-              layout="inline"
-            />
-          ) : null}
-        </div>
+  const itemClassName = cn(
+    "flex cursor-pointer flex-col items-start gap-1 px-4 py-3",
+    !notification.isRead && "bg-accent/50",
+    showVendorGrantActions && "cursor-default",
+  );
+
+  const body = (
+    <div className="flex w-full items-start gap-3">
+      <Bell
+        className={cn(
+          "mt-0.5 size-4 shrink-0",
+          notification.isRead ? "text-muted-foreground" : "text-primary",
+        )}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {showVendorGrantActions ? (
+          <button
+            type="button"
+            className="hover:bg-accent/50 -mx-1 cursor-pointer rounded-md px-1 text-left"
+            onClick={onClick}
+          >
+            <p className={cn("text-sm", !notification.isRead && "font-medium")}>
+              {message}
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {formatTime(notification.createdAt)}
+            </p>
+          </button>
+        ) : (
+          <>
+            <p className={cn("text-sm", !notification.isRead && "font-medium")}>
+              {message}
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {formatTime(notification.createdAt)}
+            </p>
+          </>
+        )}
+        {showVendorGrantActions ? (
+          <VendorGrantNotificationActions
+            notification={notification}
+            layout="inline"
+          />
+        ) : null}
       </div>
+    </div>
+  );
+
+  if (showVendorGrantActions) {
+    return (
+      <DropdownMenuItem
+        className={itemClassName}
+        onSelect={(event) => event.preventDefault()}
+      >
+        {body}
+      </DropdownMenuItem>
+    );
+  }
+
+  return (
+    <DropdownMenuItem className={itemClassName} onClick={onClick}>
+      {body}
     </DropdownMenuItem>
   );
 }

--- a/apps/web/src/components/notifications/vendor-grant-notification-actions.tsx
+++ b/apps/web/src/components/notifications/vendor-grant-notification-actions.tsx
@@ -120,6 +120,9 @@ export function VendorGrantNotificationActions({
           event.preventDefault();
           event.stopPropagation();
         }}
+        onPointerUp={(event) => {
+          event.stopPropagation();
+        }}
         onClick={(event) => void handleAccept(event)}
       >
         {loadingAction === "accept" ? (
@@ -134,6 +137,9 @@ export function VendorGrantNotificationActions({
         disabled={loadingAction !== null}
         onPointerDown={(event) => {
           event.preventDefault();
+          event.stopPropagation();
+        }}
+        onPointerUp={(event) => {
           event.stopPropagation();
         }}
         onClick={(event) => void handleDismiss(event)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Accept on a vendor-access notification in the **header bell** left the current page (often `/`). Toast and `/notifications` already stayed put. You should stay on the page after Accept.

## Root cause

Header `NotificationItem` put Accept inside a `DropdownMenuItem` whose `onClick` runs `handleNotificationNavigation` → `router.push(href)`.

Accept stops `pointerdown` propagation, so Radix never sets `isPointerDownRef`. On `pointerup`, Radix synthesizes `menuItem.click()`, which fires row navigation despite Accept's click `stopPropagation`. Pre-SOK-701 (and non-matching SYSTEM rows) that `href` is `/`.

## Fix

Mirror the `/notifications` row split for pending vendor-grant items:

- Message is its own button (navigate)
- Accept/Dismiss are siblings outside that control
- Item uses `onSelect={(e) => e.preventDefault()}` so nested controls are not treated as row select
- Also stop `pointerUp` on Accept/Dismiss as defense in depth

## Verification

```text
# Failing repro (on pre-fix tree): Accept called row onClick once
# After fix:
pnpm --filter web test 'src/app/(app)/components/header/__tests__/notification-item.test.tsx'
# exit 0 — Accept does not call onClick; message click still does
```

Related: SOK-700 (Accept/Dismiss), SOK-701 (deep-link).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-142f62b3-8d44-4a0b-a5f2-21d05215f9e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-142f62b3-8d44-4a0b-a5f2-21d05215f9e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

