### PR TITLE
fix(chat): stabilize group DM participant name and icon order

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -42,13 +42,13 @@ export const chatRoomInclude = {
     include: {
       user: { select: chatRoomUserSelect },
     },
-    orderBy: { createdAt: "asc" },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
   },
   coworkerMembers: {
     include: {
       coworker: { select: chatRoomCoworkerSelect },
     },
-    orderBy: { createdAt: "asc" },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
   },
 } as const satisfies Prisma.ChatRoomInclude;
 
@@ -855,7 +855,7 @@ const chatRoomWriteSelect = {
         },
       },
     },
-    orderBy: { createdAt: "asc" },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
   },
   coworkerMembers: {
     select: {
@@ -867,7 +867,7 @@ const chatRoomWriteSelect = {
         },
       },
     },
-    orderBy: { createdAt: "asc" },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
   },
 } as const satisfies Prisma.ChatRoomSelect;
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-direct-display-order.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-direct-display-order.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ChatRoom,
+  ChatRoomCoworkerParticipant,
+  ChatRoomUserParticipant,
+} from "@/lib/clients/generated/core";
+import {
+  getDirectRoomParticipants,
+  getRoomDisplayName,
+  getRoomParticipantPreviews,
+} from "../room-helpers";
+
+const CURRENT_USER_ID = "self";
+
+function human(
+  partial: Pick<ChatRoomUserParticipant, "id" | "name"> &
+    Partial<ChatRoomUserParticipant>,
+): ChatRoomUserParticipant {
+  return {
+    email: `${partial.id}@example.com`,
+    image: null,
+    presence: "offline",
+    ...partial,
+  };
+}
+
+function coworker(
+  partial: Pick<ChatRoomCoworkerParticipant, "id" | "name"> &
+    Partial<ChatRoomCoworkerParticipant>,
+): ChatRoomCoworkerParticipant {
+  return {
+    slug: partial.id,
+    caption: null,
+    image: null,
+    presence: "offline",
+    ...partial,
+  };
+}
+
+function directRoom(overrides: {
+  userMembers: ChatRoomUserParticipant[];
+  coworkerMembers?: ChatRoomCoworkerParticipant[];
+}): ChatRoom {
+  return {
+    id: "room-1",
+    organizationId: "org-1",
+    name: "Direct",
+    slug: "direct",
+    kind: "direct",
+    directKey: "key",
+    topic: null,
+    discoverability: null,
+    createdByUserId: CURRENT_USER_ID,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    pinnedAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    coworkerMembers: [],
+    ...overrides,
+  } as ChatRoom;
+}
+
+describe("direct room display order", () => {
+  it("getRoomDisplayName ignores opposite userMembers array orders", () => {
+    const self = human({ id: CURRENT_USER_ID, name: "Me" });
+    const francis = human({ id: "francis", name: "Francis Luz" });
+    const patrick = human({ id: "patrick", name: "Patrick Tobler" });
+
+    const orderA = directRoom({
+      userMembers: [self, francis, patrick],
+    });
+    const orderB = directRoom({
+      userMembers: [self, patrick, francis],
+    });
+
+    expect(getRoomDisplayName(orderA, CURRENT_USER_ID)).toBe(
+      "Francis Luz, Patrick Tobler",
+    );
+    expect(getRoomDisplayName(orderB, CURRENT_USER_ID)).toBe(
+      "Francis Luz, Patrick Tobler",
+    );
+  });
+
+  it("getDirectRoomParticipants returns stable id sequence across opposite input orders", () => {
+    const self = human({ id: CURRENT_USER_ID, name: "Me" });
+    const francis = human({ id: "francis", name: "Francis Luz" });
+    const patrick = human({ id: "patrick", name: "Patrick Tobler" });
+
+    const orderA = directRoom({
+      userMembers: [self, francis, patrick],
+    });
+    const orderB = directRoom({
+      userMembers: [self, patrick, francis],
+    });
+
+    const idsA = getDirectRoomParticipants(orderA, CURRENT_USER_ID).map(
+      (p) => p.id,
+    );
+    const idsB = getDirectRoomParticipants(orderB, CURRENT_USER_ID).map(
+      (p) => p.id,
+    );
+
+    expect(idsA).toEqual(["francis", "patrick"]);
+    expect(idsB).toEqual(idsA);
+  });
+
+  it("sorts humans before coworkers after name sort within each band", () => {
+    const self = human({ id: CURRENT_USER_ID, name: "Me" });
+    const zara = human({ id: "zara", name: "Zara" });
+    const ada = human({ id: "ada", name: "Ada" });
+    const aaron = coworker({ id: "aaron", name: "Aaron" });
+
+    const room = directRoom({
+      userMembers: [self, zara, ada],
+      coworkerMembers: [aaron],
+    });
+
+    expect(getRoomDisplayName(room, CURRENT_USER_ID)).toBe("Ada, Zara, Aaron");
+  });
+
+  it("breaks name ties by id", () => {
+    const self = human({ id: CURRENT_USER_ID, name: "Me" });
+    const alex2 = human({ id: "a-2", name: "Alex" });
+    const alex1 = human({ id: "a-1", name: "Alex" });
+
+    const room = directRoom({
+      userMembers: [self, alex2, alex1],
+    });
+
+    expect(
+      getDirectRoomParticipants(room, CURRENT_USER_ID).map((p) => p.id),
+    ).toEqual(["a-1", "a-2"]);
+  });
+
+  it("getRoomParticipantPreviews ignores input order within humans and coworkers", () => {
+    const self = human({ id: CURRENT_USER_ID, name: "Me" });
+    const zara = human({ id: "zara", name: "Zara" });
+    const ada = human({ id: "ada", name: "Ada" });
+    const coworkerZ = coworker({ id: "cw-z", name: "Zed" });
+    const coworkerA = coworker({ id: "cw-a", name: "Abby" });
+
+    const orderA = directRoom({
+      userMembers: [self, zara, ada],
+      coworkerMembers: [coworkerZ, coworkerA],
+    });
+    const orderB = directRoom({
+      userMembers: [ada, self, zara],
+      coworkerMembers: [coworkerA, coworkerZ],
+    });
+
+    const idsA = getRoomParticipantPreviews(orderA).map((p) => p.id);
+    const idsB = getRoomParticipantPreviews(orderB).map((p) => p.id);
+
+    expect(idsA).toEqual(["ada", CURRENT_USER_ID, "zara", "cw-a", "cw-z"]);
+    expect(idsB).toEqual(idsA);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -354,30 +354,45 @@ export function getDirectRoomTarget(room: ChatRoom, currentUserId: string) {
   );
 }
 
+function compareByDisplayNameThenId(
+  a: { name: string; id: string },
+  b: { name: string; id: string },
+): number {
+  const byName = a.name.localeCompare(b.name);
+  if (byName !== 0) {
+    return byName;
+  }
+  return a.id.localeCompare(b.id);
+}
+
 export function getDirectRoomParticipants(
   room: ChatRoom,
   currentUserId: string,
 ): DirectParticipantPreview[] {
-  return [
-    ...room.userMembers
-      .filter((member) => member.id !== currentUserId)
-      .map((member) => ({
-        id: member.id,
-        name: member.name || member.email,
-        detail: member.email,
-        image: member.image,
-        presence: member.presence,
-        kind: "human" as const,
-      })),
-    ...room.coworkerMembers.map((coworker) => ({
+  const humans = room.userMembers
+    .filter((member) => member.id !== currentUserId)
+    .map((member) => ({
+      id: member.id,
+      name: member.name || member.email,
+      detail: member.email,
+      image: member.image,
+      presence: member.presence,
+      kind: "human" as const,
+    }))
+    .toSorted(compareByDisplayNameThenId);
+
+  const coworkers = room.coworkerMembers
+    .map((coworker) => ({
       id: coworker.id,
       name: coworker.name,
       detail: coworker.caption,
       image: coworker.image,
       presence: coworker.presence,
       kind: "coworker" as const,
-    })),
-  ];
+    }))
+    .toSorted(compareByDisplayNameThenId);
+
+  return [...humans, ...coworkers];
 }
 
 /**
@@ -486,8 +501,8 @@ export function getRoomDisplayName(
 export function getRoomParticipantPreviews(
   room: ChatRoom,
 ): RoomParticipantPreview[] {
-  return [
-    ...room.userMembers.map(
+  const humans = room.userMembers
+    .map(
       (member): ChatParticipantHoverProfile => ({
         kind: "human",
         id: member.id,
@@ -496,8 +511,11 @@ export function getRoomParticipantPreviews(
         image: member.image,
         presence: member.presence,
       }),
-    ),
-    ...room.coworkerMembers.map(
+    )
+    .toSorted(compareByDisplayNameThenId);
+
+  const coworkers = room.coworkerMembers
+    .map(
       (coworker): ChatParticipantHoverProfile => ({
         kind: "coworker",
         id: coworker.id,
@@ -507,8 +525,10 @@ export function getRoomParticipantPreviews(
         image: coworker.image,
         presence: coworker.presence,
       }),
-    ),
-  ];
+    )
+    .toSorted(compareByDisplayNameThenId);
+
+  return [...humans, ...coworkers];
 }
 
 export function presenceLabel(

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -21,6 +21,10 @@ import {
 import { toast } from "sonner";
 import { deleteRoomAction, restoreRoomAction } from "@/app/chat/actions";
 import { BrowseChannelsDialog } from "@/app/chat/components/browse-channels-dialog";
+import {
+  getDirectRoomParticipants,
+  getRoomDisplayName,
+} from "@/app/chat/components/room-helpers";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import {
   AlertDialog,
@@ -85,70 +89,6 @@ interface OrganizationChatListProps {
   canDeleteArchivedRooms?: boolean;
 }
 
-interface DirectParticipant {
-  id: string;
-  name: string;
-  image: string | null;
-  presence: ChatRoomPresence;
-}
-
-function getDirectParticipants(
-  room: ChatRoom,
-  currentUserId: string,
-): DirectParticipant[] {
-  const humans = room.userMembers
-    .filter((member) => member.id !== currentUserId)
-    .map((member) => ({
-      id: member.id,
-      name: member.name,
-      image: member.image,
-      presence: member.presence,
-    }));
-
-  const coworkers = room.coworkerMembers.map((coworker) => ({
-    id: coworker.id,
-    name: coworker.name,
-    image: coworker.image,
-    presence: coworker.presence,
-  }));
-
-  return [...humans, ...coworkers];
-}
-
-const DIRECT_NAME_PREVIEW_LIMIT = 3;
-
-/**
- * Single source of truth for direct-channel titles: the sidebar and the
- * channels pane must never label the same conversation differently.
- */
-export function getDirectRoomDisplayName(
-  room: ChatRoom,
-  currentUserId: string,
-): string {
-  if (room.kind !== "direct") {
-    return room.name;
-  }
-
-  const names = [
-    ...room.userMembers
-      .filter((member) => member.id !== currentUserId)
-      .map((member) => member.name || member.email),
-    ...room.coworkerMembers.map((coworker) => coworker.name),
-  ];
-
-  if (names.length === 0) {
-    const self = room.userMembers[0] ?? null;
-    return self?.name || room.name;
-  }
-
-  if (names.length <= DIRECT_NAME_PREVIEW_LIMIT) {
-    return names.join(", ");
-  }
-
-  const shown = names.slice(0, DIRECT_NAME_PREVIEW_LIMIT);
-  return `${shown.join(", ")} and ${names.length - shown.length} more`;
-}
-
 function presenceLabel(
   t: ReturnType<typeof useTranslations<"App.Channels">>,
   presence: ChatRoomPresence,
@@ -172,7 +112,10 @@ function DirectAvatarStack({
   currentUserId: string;
 }) {
   const t = useTranslations("App.Channels");
-  const participants = getDirectParticipants(room, currentUserId).slice(0, 3);
+  const participants = getDirectRoomParticipants(room, currentUserId).slice(
+    0,
+    3,
+  );
 
   if (participants.length === 0) {
     return (
@@ -737,7 +680,7 @@ export function OrganizationChatList({
                   key={room.id}
                   room={room}
                   href={`/chat/rooms/${room.id}`}
-                  label={getDirectRoomDisplayName(room, currentUserId)}
+                  label={getRoomDisplayName(room, currentUserId)}
                   isActive={activeRoomId === room.id}
                   leading={
                     <DirectAvatarStack


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Group DM sidebar titles and avatar stacks no longer reshuffle when the room list refreshes.

## Why

Core returned `userMembers` / `coworkerMembers` ordered only by `createdAt`. Group creates often share the same timestamp, so Postgres could return ties in different orders. Web rendered that array order with no client sort, and the 15s poll replaced state, so names and icons jumped.

## Fix

- Web: one ordered participant list via `getDirectRoomParticipants` / `getRoomParticipantPreviews` — sort within humans and within coworkers by display name, then id. Sidebar and room pane both use these helpers (deleted duplicate sidebar helpers).
- Core: membership `orderBy` adds an `id` tiebreak so raw arrays are a total order.

## Verification

```
pnpm --filter web test 'src/app/(app)/chat/components/__tests__/room-helpers-direct-display-order.test.ts'
```

Opposite member array orders now produce the same title (`Francis Luz, Patrick Tobler`) and the same avatar id sequence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0111f8c-b2e7-4c06-8c0f-6d5a1ab40494?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0111f8c-b2e7-4c06-8c0f-6d5a1ab40494&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

