### PR TITLE
feat(chat): persist format-toolbar open preference in localStorage

### DIFF
--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -21,6 +21,11 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
+import {
+  getFormatToolbarOpenPreference,
+  resolveFormatToolbarOpenOnMount,
+  setFormatToolbarOpenPreference,
+} from "@/app/chat/utils/format-toolbar-preference-storage";
 import { getTaskAttachmentUploadLabelTemplate } from "@/app/tasks/components/task-attachment-upload-labels";
 import { ComposerAddLinkDialog } from "@/components/chat/composer-add-link-dialog";
 import { ComposerFormatToolbar } from "@/components/chat/composer-format-toolbar";
@@ -275,7 +280,7 @@ export function RoomComposer({
   const [linkInitialUrl, setLinkInitialUrl] = useState("");
   /**
    * Slack Aa toggle: formatting strip above the editor.
-   * SSR + first paint start closed (hydration-safe). Desktop opens once on mount.
+   * SSR + first paint start closed (hydration-safe). Preference persisted via localStorage on Aa.
    */
   const [formatToolbarOpen, setFormatToolbarOpen] = useState(false);
   const [activeFormats, setActiveFormats] = useState<ComposerActiveFormats>(
@@ -288,11 +293,15 @@ export function RoomComposer({
     ? onSelectedKeysChange
     : undefined;
 
-  // Desktop default open (SOK-681); mobile stays closed. No resize re-apply.
+  // Stored pref wins; else desktop open / mobile closed (SOK-681). No resize re-apply.
   useMountEffect(() => {
-    if (window.innerWidth >= MOBILE_BREAKPOINT) {
-      setFormatToolbarOpen(true);
-    }
+    setFormatToolbarOpen(
+      resolveFormatToolbarOpenOnMount({
+        stored: getFormatToolbarOpenPreference(),
+        viewportWidth: window.innerWidth,
+        mobileBreakpoint: MOBILE_BREAKPOINT,
+      }),
+    );
   });
 
   // After paint so the format strip / quote chip have height before scroll.
@@ -518,7 +527,13 @@ export function RoomComposer({
                   : t("Toolbar.showFormatting")
               }
               aria-pressed={formatToolbarOpen}
-              onClick={() => setFormatToolbarOpen((open) => !open)}
+              onClick={() => {
+                setFormatToolbarOpen((open) => {
+                  const next = !open;
+                  setFormatToolbarOpenPreference(next);
+                  return next;
+                });
+              }}
             >
               <ALargeSmall className="size-4" aria-hidden />
             </Button>

--- a/apps/web/src/app/(app)/chat/utils/__tests__/format-toolbar-preference-storage.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/format-toolbar-preference-storage.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FORMAT_TOOLBAR_OPEN_STORAGE_KEY,
+  getFormatToolbarOpenPreference,
+  resolveFormatToolbarOpenOnMount,
+  setFormatToolbarOpenPreference,
+} from "../format-toolbar-preference-storage";
+
+describe("format-toolbar-preference-storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the storage key constant", () => {
+    expect(FORMAT_TOOLBAR_OPEN_STORAGE_KEY).toBe(
+      "sokosumi:format-toolbar-open:v1",
+    );
+  });
+
+  it("roundtrips true and false", () => {
+    setFormatToolbarOpenPreference(true);
+    expect(getFormatToolbarOpenPreference()).toBe(true);
+    expect(window.localStorage.getItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY)).toBe(
+      "true",
+    );
+
+    setFormatToolbarOpenPreference(false);
+    expect(getFormatToolbarOpenPreference()).toBe(false);
+    expect(window.localStorage.getItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY)).toBe(
+      "false",
+    );
+  });
+
+  it("returns null when the key is missing", () => {
+    expect(getFormatToolbarOpenPreference()).toBeNull();
+  });
+
+  it("returns null for invalid stored strings", () => {
+    window.localStorage.setItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY, "TRUE");
+    expect(getFormatToolbarOpenPreference()).toBeNull();
+
+    window.localStorage.setItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY, "1");
+    expect(getFormatToolbarOpenPreference()).toBeNull();
+
+    window.localStorage.setItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY, "");
+    expect(getFormatToolbarOpenPreference()).toBeNull();
+  });
+
+  it("soft-fails when localStorage throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(getFormatToolbarOpenPreference()).toBeNull();
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => setFormatToolbarOpenPreference(true)).not.toThrow();
+  });
+
+  it("resolve prefers stored preference over viewport", () => {
+    expect(
+      resolveFormatToolbarOpenOnMount({
+        stored: true,
+        viewportWidth: 320,
+        mobileBreakpoint: 768,
+      }),
+    ).toBe(true);
+    expect(
+      resolveFormatToolbarOpenOnMount({
+        stored: false,
+        viewportWidth: 1280,
+        mobileBreakpoint: 768,
+      }),
+    ).toBe(false);
+  });
+
+  it("resolve defaults to desktop open and mobile closed when unset", () => {
+    expect(
+      resolveFormatToolbarOpenOnMount({
+        stored: null,
+        viewportWidth: 768,
+        mobileBreakpoint: 768,
+      }),
+    ).toBe(true);
+    expect(
+      resolveFormatToolbarOpenOnMount({
+        stored: null,
+        viewportWidth: 767,
+        mobileBreakpoint: 768,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/format-toolbar-preference-storage.ts
+++ b/apps/web/src/app/(app)/chat/utils/format-toolbar-preference-storage.ts
@@ -1,0 +1,52 @@
+export const FORMAT_TOOLBAR_OPEN_STORAGE_KEY =
+  "sokosumi:format-toolbar-open:v1" as const;
+
+export interface ResolveFormatToolbarOpenOnMountInput {
+  stored: boolean | null;
+  viewportWidth: number;
+  mobileBreakpoint: number;
+}
+
+export function getFormatToolbarOpenPreference(): boolean | null {
+  try {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    const raw = window.localStorage.getItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY);
+    if (raw === "true") {
+      return true;
+    }
+    if (raw === "false") {
+      return false;
+    }
+    if (raw != null) {
+      window.localStorage.removeItem(FORMAT_TOOLBAR_OPEN_STORAGE_KEY);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function setFormatToolbarOpenPreference(open: boolean): void {
+  try {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem(
+      FORMAT_TOOLBAR_OPEN_STORAGE_KEY,
+      open ? "true" : "false",
+    );
+  } catch {
+    // Best-effort: quota / private mode must not break compose.
+  }
+}
+
+export function resolveFormatToolbarOpenOnMount(
+  input: ResolveFormatToolbarOpenOnMountInput,
+): boolean {
+  if (input.stored !== null) {
+    return input.stored;
+  }
+  return input.viewportWidth >= input.mobileBreakpoint;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Chat room composer Aa (show/hide formatting) preference now survives reloads and sessions via `localStorage`.

## Behavior

- Explicit Aa toggle writes `sokosumi:format-toolbar-open:v1` (`"true"` / `"false"`).
- On mount, stored preference wins; if unset, desktop still opens by default and mobile stays closed (SOK-681 / SOK-688).
- Format-command / link-dialog force-open does not overwrite the stored preference.
- Soft-fail if `localStorage` is unavailable.

## Verification

```bash
pnpm --filter web test src/app/(app)/chat/utils/__tests__/format-toolbar-preference-storage.test.ts
```

7 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14ec56d9-7e2d-478a-ab8e-e8b2a6f8eaf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14ec56d9-7e2d-478a-ab8e-e8b2a6f8eaf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

