### PR TITLE
fix(web): restore caret on ComposerWysiwygEditor.insertText

### DIFF
--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -235,4 +235,61 @@ describe("ComposerWysiwygEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: "restore" }));
     expect(editor.textContent).toContain("typing indicators please");
   });
+
+  it("inserts text at the saved caret after selection leaves the editor", () => {
+    function Harness() {
+      const editorRef = useRef<ComposerWysiwygEditorHandle>(null);
+      const [value, setValue] = useState("hello world");
+      return (
+        <>
+          <button type="button" onClick={() => editorRef.current?.focus()}>
+            focus-editor
+          </button>
+          <button
+            type="button"
+            onClick={() => editorRef.current?.insertText("😀")}
+          >
+            insert-emoji
+          </button>
+          <button type="button" aria-label="picker-search">
+            picker-search
+          </button>
+          <ComposerWysiwygEditor
+            ref={editorRef}
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+          />
+          <output data-testid="composer-value">{value}</output>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    fireEvent.click(screen.getByRole("button", { name: "focus-editor" }));
+
+    const textNode = editor.firstChild;
+    expect(textNode?.nodeType).toBe(Node.TEXT_NODE);
+    const selection = window.getSelection();
+    expect(selection).not.toBeNull();
+    const range = document.createRange();
+    // Caret after "hello " (offset 6).
+    range.setStart(textNode as Text, 6);
+    range.collapse(true);
+    selection!.removeAllRanges();
+    selection!.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+
+    // Picker search steals focus and clears the live document selection.
+    fireEvent.click(screen.getByRole("button", { name: "picker-search" }));
+    selection!.removeAllRanges();
+    document.dispatchEvent(new Event("selectionchange"));
+
+    fireEvent.click(screen.getByRole("button", { name: "insert-emoji" }));
+
+    expect(screen.getByTestId("composer-value")).toHaveTextContent(
+      "hello 😀world",
+    );
+  });
 });

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -22,6 +22,7 @@ import {
   findPositionForOffset,
   getActiveEmojiTrigger,
   getActiveTrigger,
+  getCaretOffset,
   getCaretRect,
   getPopupPositionFromRect,
   MENTION_CLASSNAME,
@@ -110,6 +111,17 @@ const EDITOR_PROSE_CLASSNAME = cn(
   "[&_span[data-mention-key]]:text-primary [&_span[data-mention-key]]:cursor-pointer [&_span[data-mention-key]]:font-semibold [&_span[data-mention-key]]:hover:underline",
 );
 
+function restoreCaretAtOffset(root: HTMLElement, offset: number): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const position = findPositionForOffset(root, offset);
+  const range = document.createRange();
+  range.setStart(position.node, position.offset);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
 function insertLineBreak(editor: HTMLElement): void {
   editor.focus();
   let didInsert = false;
@@ -161,6 +173,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
   const isInternalChange = useRef(false);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const manualMentionOpenRef = useRef(false);
+  const savedCaretOffsetRef = useRef<number | null>(null);
   const onActiveFormatsChangeRef = useRef(onActiveFormatsChange);
   onActiveFormatsChangeRef.current = onActiveFormatsChange;
   const [suggestionUi, setSuggestionUi] = useState<SuggestionUiState>({
@@ -569,7 +582,24 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
   const insertText = useCallback(
     (text: string) => {
-      editorRef.current?.focus();
+      const editor = editorRef.current;
+      if (!editor) return;
+
+      const offset = savedCaretOffsetRef.current;
+      editor.focus();
+      if (offset != null) {
+        restoreCaretAtOffset(editor, offset);
+      } else {
+        const selection = window.getSelection();
+        if (selection) {
+          const range = document.createRange();
+          range.selectNodeContents(editor);
+          range.collapse(false);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      }
+
       let didInsert = false;
       try {
         didInsert = document.execCommand("insertText", false, text);
@@ -586,10 +616,14 @@ export function ComposerWysiwygEditor<TData = unknown>({
           range.collapse(false);
           selection.removeAllRanges();
           selection.addRange(range);
-        } else if (editorRef.current) {
-          editorRef.current.appendChild(document.createTextNode(text));
+        } else {
+          editor.appendChild(document.createTextNode(text));
         }
       }
+
+      const nextOffset = getCaretOffset(editor);
+      savedCaretOffsetRef.current =
+        nextOffset ?? (offset != null ? offset + text.length : null);
 
       handleInput();
     },
@@ -896,6 +930,12 @@ export function ComposerWysiwygEditor<TData = unknown>({
   useEffect(() => {
     const onSelectionChange = () => {
       publishActiveFormats();
+      const editor = editorRef.current;
+      if (!editor) return;
+      const caretOffset = getCaretOffset(editor);
+      if (caretOffset != null) {
+        savedCaretOffsetRef.current = caretOffset;
+      }
     };
     document.addEventListener("selectionchange", onSelectionChange);
     return () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Emoji picker in the room WYSIWYG composer inserted at the start of the line (or end in some environments) instead of the caret. Picker search steals focus and clears the live selection. `insertText` then focused the editor with no restored caret.

## Fix

`ComposerWysiwygEditor` now saves the serialized caret offset on `selectionchange` (when the selection is inside the editor) and restores it in `insertText` before `execCommand`. Public `insertText` API and room-composer wiring are unchanged.

## Verification

```text
# Before (failing repro commit)
FAIL  inserts text at the saved caret after selection leaves the editor
Expected: hello 😀world
Received: hello world😀

# After
pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
Test Files  1 passed (1)
     Tests  8 passed (8)
```

Full in-app chat UI verify was inconclusive here (Core/DB not provisioned in this cloud run). Mechanism covered by the Vitest focus-steal repro.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba883eaf-314f-4e3e-a1be-4a5e4ea69daa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba883eaf-314f-4e3e-a1be-4a5e4ea69daa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

