### PR TITLE
fix(web): align markdown ** asterisks in composers

### DIFF
--- a/apps/web/src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/markdown-editor.test.tsx
@@ -34,6 +34,11 @@ function setCaretToStart(element: HTMLElement): void {
 }
 
 describe("MarkdownEditor", () => {
+  it("disables Inter contextual alternates so ** markers stay aligned", () => {
+    render(<MarkdownEditor value="" onChange={vi.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveClass("markdown-compose-surface");
+  });
+
   it("keeps mailto links with @ while rendering mentions", async () => {
     render(
       <MarkdownEditor

--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -701,6 +701,7 @@ export const MarkdownEditor = forwardRef<
         role="textbox"
         aria-multiline="true"
         className={cn(
+          "markdown-compose-surface",
           "max-h-48 min-h-32 overflow-x-hidden overflow-y-auto px-3 py-2 text-sm",
           "outline-none focus:outline-none",
           "wrap-anywhere [word-break:break-word] whitespace-pre-wrap",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -508,6 +508,15 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
   }
 }
 
+/*
+ * Inter's default `calt` raises/lowers * unevenly before capitals
+ * (e.g. `**Andreas` → first * high, second * low). Compose surfaces
+ * type markdown markers often; keep asterisks aligned.
+ */
+@utility markdown-compose-surface {
+  font-variant-ligatures: no-contextual;
+}
+
 @utility landing-hero-bg {
   background-image:
     linear-gradient(rgba(0, 164, 250, 0.39), rgba(255, 255, 255, 1)),

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -28,6 +28,22 @@ vi.mock("@/components/ui/mention-textarea-utils", async (importOriginal) => {
 });
 
 describe("ComposerWysiwygEditor", () => {
+  it("disables Inter contextual alternates so ** markers stay aligned", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByRole("textbox")).toHaveClass("markdown-compose-surface");
+  });
+
   it("applies top-side flip and dynamic maxHeight to the mention listbox", () => {
     function Harness() {
       const editorRef = useRef<ComposerWysiwygEditorHandle>(null);

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -99,6 +99,7 @@ interface ComposerWysiwygEditorProps<TData = unknown> {
 }
 
 const EDITOR_PROSE_CLASSNAME = cn(
+  "markdown-compose-surface",
   "[&_em]:italic [&_i]:italic [&_strong]:font-bold [&_b]:font-bold",
   "[&_u]:underline [&_s]:line-through [&_strike]:line-through [&_del]:line-through",
   "[&_code]:bg-muted [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Inter’s default OpenType `calt` (contextual alternates) unevenly positions consecutive `*` before capitals — e.g. typing `**Andreas` showed the first `*` high and the second lowered. Bold markers stay `**text**`; this only fixes the visual.

## Fix

- Add `markdown-compose-surface` utility (`font-variant-ligatures: no-contextual`)
- Apply on chat WYSIWYG composer and task/DESIGN.md markdown editors

## Verification

![Before/after asterisk alignment](https://cursor.com/artifacts/c/art-c1da9812-1d7e-4430-a041-eb3e57669f3e)

- `pnpm --filter web test` on composer + markdown-editor tests
- Pre-commit `pnpm check && pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f01bcf6-411f-411b-a8bf-7fd1cbfd4040?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f01bcf6-411f-411b-a8bf-7fd1cbfd4040&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

