### PR TITLE
fix(chat): stick thread panel viewport to bottom like room timeline

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-stick-to-bottom.test.tsx
@@ -1,0 +1,256 @@
+import { act, render, screen } from "@testing-library/react";
+import { type ReactNode, type Ref, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import type { RoomComposerHandle } from "../room-composer";
+import { ThreadPanel } from "../thread-panel";
+
+type ResizeObserverCallback = (
+  entries: ResizeObserverEntry[],
+  observer: ResizeObserver,
+) => void;
+
+const observerCallbacks = new Set<ResizeObserverCallback>();
+
+class ResizeObserverMock {
+  private readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    observerCallbacks.add(callback);
+  }
+
+  observe(_target: Element) {}
+
+  disconnect() {
+    observerCallbacks.delete(this.callback);
+  }
+
+  unobserve() {}
+}
+
+function fireResize() {
+  for (const callback of observerCallbacks) {
+    callback([], {} as ResizeObserver);
+  }
+}
+
+function setScrollerMetrics(
+  el: HTMLElement,
+  {
+    scrollHeight,
+    clientHeight,
+    scrollTop,
+  }: {
+    scrollHeight: number;
+    clientHeight: number;
+    scrollTop: number;
+  },
+) {
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight,
+  });
+  el.scrollTop = scrollTop;
+}
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "Thread.replyCount" && values) {
+      return `replies:${values.count}`;
+    }
+    return key;
+  },
+}));
+
+vi.mock("../room-file-drop-zone", () => ({
+  RoomFileDropZone: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../room-session-composer", () => ({
+  RoomSessionComposer: ({
+    ref,
+    onChromeResize,
+  }: {
+    ref?: Ref<RoomComposerHandle>;
+    onChromeResize?: () => void;
+  }) => {
+    useImperativeHandle(ref, () => ({
+      attachFiles: () => undefined,
+      focus: () => undefined,
+    }));
+    return (
+      <button
+        type="button"
+        data-testid="chrome-resize"
+        onClick={onChromeResize}
+      >
+        chrome-resize
+      </button>
+    );
+  },
+}));
+
+vi.mock("../room-message-row", () => ({
+  ChatMessageRow: ({ message }: { message: ChatRoomMessage }) => (
+    <div>{message.content}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({
+    children,
+    ref,
+    className,
+  }: {
+    children: ReactNode;
+    ref?: Ref<HTMLDivElement>;
+    className?: string;
+  }) => (
+    <div ref={ref} data-testid="thread-scroller" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+function parentMessage(
+  overrides: Partial<ChatRoomMessage> = {},
+): ChatRoomMessage {
+  return {
+    id: "parent-1",
+    roomId: "room-1",
+    parentMessageId: null,
+    content: "Parent",
+    createdAt: new Date("2026-07-01T14:35:00.000Z"),
+    editedAt: null,
+    deletedAt: null,
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 2,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function replyMessage(id: string): ChatRoomMessage {
+  return parentMessage({
+    id,
+    parentMessageId: "parent-1",
+    content: `Reply ${id}`,
+    threadReplyCount: 0,
+  });
+}
+
+function renderThreadPanel(replies: ChatRoomMessage[] = [replyMessage("r1")]) {
+  return render(
+    <ThreadPanel
+      parentMessage={parentMessage()}
+      replies={replies}
+      isLoading={false}
+      olderNextCursor={null}
+      isLoadingOlder={false}
+      onLoadOlder={() => undefined}
+      coworkersById={new Map()}
+      coworkersBySlug={new Map()}
+      mentionRecords={{}}
+      draftKey="thread:parent-1"
+      onSendReply={async () => ({ ok: true })}
+      isSendingReply={false}
+      onClose={() => undefined}
+      onToggleReaction={() => undefined}
+      roomId="room-1"
+    />,
+  );
+}
+
+describe("ThreadPanel stick-to-bottom", () => {
+  beforeEach(() => {
+    observerCallbacks.clear();
+    global.ResizeObserver =
+      ResizeObserverMock as unknown as typeof global.ResizeObserver;
+  });
+
+  afterEach(() => {
+    observerCallbacks.clear();
+  });
+
+  it("pins the thread viewport when content grows while sticky", () => {
+    renderThreadPanel();
+    const scroller = screen.getByTestId("thread-scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    });
+
+    act(() => {
+      fireResize();
+    });
+
+    expect(scroller.scrollTop).toBe(1000);
+  });
+
+  it("does not pin after the user scrolls away from the bottom", () => {
+    renderThreadPanel();
+    const scroller = screen.getByTestId("thread-scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 200,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    const scrollTopBefore = scroller.scrollTop;
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1400,
+      clientHeight: 400,
+      scrollTop: scrollTopBefore,
+    });
+    act(() => {
+      fireResize();
+    });
+
+    expect(scroller.scrollTop).toBe(scrollTopBefore);
+  });
+
+  it("scrollToBottomIfPinned no-ops on chrome resize when unpinned", () => {
+    renderThreadPanel();
+    const scroller = screen.getByTestId("thread-scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 50,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    act(() => {
+      screen.getByTestId("chrome-resize").click();
+    });
+
+    expect(scroller.scrollTop).toBe(50);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -3,6 +3,7 @@
 import { Loader2, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRef } from "react";
+import { useStickToBottom } from "@/app/chat/hooks/use-stick-to-bottom";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -104,7 +105,10 @@ export function ThreadPanel({
 }) {
   const t = useTranslations("App.Channels");
   const threadComposerRef = useRef<RoomComposerHandle | null>(null);
-  const threadBottomRef = useRef<HTMLDivElement | null>(null);
+  const { scrollerRef, contentRef, contentMinHeight, scrollToBottomIfPinned } =
+    useStickToBottom({
+      resetKey: parentMessage.id,
+    });
 
   useMountEffect(() => {
     requestAnimationFrame(() => {
@@ -171,8 +175,16 @@ export function ThreadPanel({
             <X className="size-4" aria-hidden />
           </Button>
         </header>
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="px-4 py-4">
+        <ScrollArea ref={scrollerRef} className="min-h-0 flex-1">
+          <div
+            ref={contentRef}
+            className="flex w-full flex-col justify-end px-4 py-4"
+            style={
+              contentMinHeight != null
+                ? { minHeight: contentMinHeight }
+                : undefined
+            }
+          >
             <ChatMessageRow
               message={parentMessage}
               coworkersById={coworkersById}
@@ -246,7 +258,6 @@ export function ThreadPanel({
                     {t("Thread.empty")}
                   </p>
                 )}
-                <div ref={threadBottomRef} />
               </>
             )}
           </div>
@@ -264,9 +275,7 @@ export function ThreadPanel({
           pendingQuote={pendingQuote}
           onClearPendingQuote={onClearPendingQuote}
           onRestorePendingQuote={onRestorePendingQuote}
-          onChromeResize={() => {
-            threadBottomRef.current?.scrollIntoView({ block: "end" });
-          }}
+          onChromeResize={scrollToBottomIfPinned}
           onBeforeSend={onBeforeSendReply}
           onSend={onSendReply}
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Thread panel never got stick-to-bottom after the main room timeline (#3518 / #3557). New replies and content growth left the viewport behind; only composer chrome resize forced a `scrollIntoView`.

Wires the same `useStickToBottom` hook into `ThreadPanel` (pin on content resize, unpin when scrolled away, re-pin on parent change, short-thread `justify-end`). Removes the sentinel/`scrollIntoView` path.

**Verification**
- Failing repro: `thread-panel-stick-to-bottom.test.tsx` expected pin on growth (`600` stayed `600`)
- After fix: that suite + focus + hook tests pass (12/12)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de7c4af8-aa0a-4b17-bd3d-a8c499d78f1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de7c4af8-aa0a-4b17-bd3d-a8c499d78f1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

