### PR TITLE
fix(chat): align composer gap with message spacing

### DIFF
--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1380,7 +1380,7 @@ export function RoomsClient({
               <ScrollArea ref={scrollerRef} className="min-h-0 flex-1">
                 <div
                   ref={contentRef}
-                  className="flex w-full flex-col justify-end px-5 pt-6 pb-3"
+                  className="flex w-full flex-col justify-end px-5 pt-6 pb-0"
                   style={
                     contentMinHeight != null
                       ? { minHeight: contentMinHeight }

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -172,7 +172,7 @@ export function ThreadPanel({
           </Button>
         </header>
         <ScrollArea className="min-h-0 flex-1">
-          <div className="px-4 py-4">
+          <div className="px-4 pt-4 pb-0">
             <ChatMessageRow
               message={parentMessage}
               coworkersById={coworkersById}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Last message sat farther from the composer than messages sit from each other.

**Cause.** Message list `pb-3` stacked with composer `pt-2 md:pt-3`, so last message → composer card was 24px on desktop while inter-message `mt-3` is 12px.

**Fix.** Drop list bottom padding in the room transcript and thread panel. Composer outer top padding stays the single gap source (matches its existing contract).

**Merge.** Rebased onto latest `main`. Thread panel conflict was simple: kept main's stick-to-bottom refs/`contentMinHeight` and this PR's `pt-4 pb-0`.

**Verify.** Browser measure on `#Everyone`: before `interArticleGap=12`, `lastArticleToCard=24`; after both `12` (`match: true`).

![Before](https://cursor.com/artifacts/c/art-7c69cdcb-e811-4e60-a85e-14fcea3ee619)
![After](https://cursor.com/artifacts/c/art-0504cde8-70e3-49c4-87d8-baaa86cd134f)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b249a51e-7a55-43d8-9fc2-80a894772526?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b249a51e-7a55-43d8-9fc2-80a894772526&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

