### PR TITLE
feat(web): enable Instant Navigations with Cache Components

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -27,6 +27,8 @@ const browserCoreApiBaseUrl = normalizeCoreApiBaseUrl(
 );
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
   async headers() {
     return [
       {

--- a/apps/web/src/app/(app)/admin/layout.tsx
+++ b/apps/web/src/app/(app)/admin/layout.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 
 import { requireAdminSession } from "@/lib/auth/admin-access";
 
+export const instant = false;
+
 interface AdminLayoutProps {
   children: ReactNode;
 }

--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
@@ -11,8 +12,7 @@ import { AgentsNotAvailable, AgentsSkeleton } from "@/components/agents";
 import { CoworkerGallerySection } from "@/components/agents/coworker-gallery-section";
 import { Skeleton } from "@/components/ui/skeleton";
 import { mapCoreCategoriesToCategories } from "@/lib/agents/core-dto-mappers";
-import { getAllCoreAgents } from "@/lib/agents/core-loaders";
-import { coreClient } from "@/lib/clients/core.client";
+import { getAllCoreAgents, getCoreCategories } from "@/lib/agents/core-loaders";
 import { coworkerService } from "@/lib/services/coworker.service";
 import { getAgentRatingStatsMap } from "@/lib/types/core-dto";
 
@@ -62,6 +62,10 @@ function AgentsCatalogFallback() {
 }
 
 async function CoworkersTier() {
+  // Defer before any cookies()/headers()-bound work so PPR shell probing does
+  // not soft-reject dynamic APIs while filling this Suspense hole.
+  await connection();
+
   const coworkers = await coworkerService
     .listCoworkers("tasks")
     .catch(() => []);
@@ -80,14 +84,16 @@ async function CoworkersTier() {
  * gallery, not a blocked wait on every catalog page.
  */
 async function AllAgentsTier() {
-  const [coreAgents, categoriesResponse, t] = await Promise.all([
+  await connection();
+
+  const [coreAgents, categories, t] = await Promise.all([
     getAllCoreAgents().catch((error) => {
       logAgentsCatalogFetchFailure("agent catalog", error);
       return [];
     }),
-    coreClient.getCategories().catch((error) => {
+    getCoreCategories().catch((error) => {
       logAgentsCatalogFetchFailure("categories", error);
-      return { data: [] };
+      return [];
     }),
     getTranslations("App.Agents"),
   ]);
@@ -96,7 +102,7 @@ async function AllAgentsTier() {
     return <AgentsNotAvailable />;
   }
 
-  const categories = mapCoreCategoriesToCategories(categoriesResponse.data);
+  const mappedCategories = mapCoreCategoriesToCategories(categories);
   const ratingStatsMap = getAgentRatingStatsMap(coreAgents);
 
   return (
@@ -112,7 +118,7 @@ async function AllAgentsTier() {
       <FilteredAgents
         agents={coreAgents}
         ratingStatsMap={ratingStatsMap}
-        categories={categories}
+        categories={mappedCategories}
       />
     </section>
   );

--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -33,6 +33,22 @@ function logAgentsCatalogFetchFailure(scope: string, error: unknown): void {
   });
 }
 
+function CoworkersTierFallback() {
+  return (
+    <section className="space-y-8">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-56 md:h-8" />
+        <Skeleton className="h-4 w-80 md:h-5" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }, (_, index) => (
+          <Skeleton key={index} className="h-40 w-full rounded-xl" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function AgentsCatalogFallback() {
   return (
     <section className="space-y-8">
@@ -42,6 +58,20 @@ function AgentsCatalogFallback() {
       </div>
       <AgentsSkeleton />
     </section>
+  );
+}
+
+async function CoworkersTier() {
+  const coworkers = await coworkerService
+    .listCoworkers("tasks")
+    .catch(() => []);
+  const coworkerOptions = getCoworkerOptions(coworkers);
+
+  return (
+    <CreateTaskModalProvider>
+      <CoworkerGallerySection coworkers={coworkers} />
+      <CreateTaskModal coworkerOptions={coworkerOptions} />
+    </CreateTaskModalProvider>
   );
 }
 
@@ -88,21 +118,13 @@ async function AllAgentsTier() {
   );
 }
 
-export default async function GalleryPage() {
-  // Tier 1 is the LCP surface: coworkers only. CreateTaskModal lazy-loads agent
-  // names + design.md when opened (same pattern as the tasks board).
-  const coworkers = await coworkerService
-    .listCoworkers("tasks")
-    .catch(() => []);
-  const coworkerOptions = getCoworkerOptions(coworkers);
-
+export default function GalleryPage() {
   return (
     <div className="w-full">
       <div className="space-y-16 px-2 pb-8 md:space-y-24">
-        <CreateTaskModalProvider>
-          <CoworkerGallerySection coworkers={coworkers} />
-          <CreateTaskModal coworkerOptions={coworkerOptions} />
-        </CreateTaskModalProvider>
+        <Suspense fallback={<CoworkersTierFallback />}>
+          <CoworkersTier />
+        </Suspense>
 
         <Suspense fallback={<AgentsCatalogFallback />}>
           <AllAgentsTier />

--- a/apps/web/src/app/(app)/components/app-header-fallback.tsx
+++ b/apps/web/src/app/(app)/components/app-header-fallback.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+import CustomTrigger from "./sidebar/components/custom-trigger";
+
+interface AppHeaderFallbackProps {
+  className?: string;
+}
+
+export function AppHeaderFallback({ className }: AppHeaderFallbackProps) {
+  return (
+    <header
+      className={cn(
+        "border-grid bg-sidebar fixed top-0 z-50 flex w-full items-center justify-between gap-2 border-b md:sticky md:items-center md:pl-6",
+        className,
+      )}
+    >
+      <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
+        <CustomTrigger when="invisible" />
+      </div>
+
+      <div className="hidden min-w-0 flex-1 flex-row gap-2 sm:flex">
+        <div className="bg-muted h-4 w-40 animate-pulse rounded-md" />
+      </div>
+
+      <div className="ml-auto flex min-w-0 shrink-0 items-center gap-2">
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col items-end gap-1">
+            <div className="bg-muted h-4 w-28 animate-pulse rounded-md" />
+            <div className="bg-muted h-3 w-36 animate-pulse rounded-md" />
+          </div>
+          <div className="bg-muted size-8 animate-pulse rounded-full" />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/app/(app)/components/app-shell-loading-frame.tsx
+++ b/apps/web/src/app/(app)/components/app-shell-loading-frame.tsx
@@ -1,0 +1,35 @@
+import { BreadcrumbOverrideProvider } from "@/contexts/breadcrumb-override-context";
+
+import { AppHeaderFallback } from "./app-header-fallback";
+import { AppSidebarFallback } from "./app-sidebar-fallback";
+
+interface AppShellLoadingFrameProps {
+  children: React.ReactNode;
+}
+
+export function AppShellLoadingFrame({ children }: AppShellLoadingFrameProps) {
+  return (
+    <BreadcrumbOverrideProvider>
+      <AppSidebarFallback />
+      <div className="flex min-w-0 flex-1 overflow-clip" data-app-content>
+        <div
+          className="flex min-w-0 flex-1 flex-col overflow-clip"
+          data-app-content-inner
+        >
+          <AppHeaderFallback className="h-16 p-4" />
+          <main
+            className="relative flex max-h-svh min-h-svh flex-1 flex-col overflow-x-hidden overflow-y-auto p-4 pt-20 md:max-h-[calc(100svh-64px)] md:min-h-[calc(100svh-64px)] md:pt-4"
+            data-app-main
+          >
+            <div
+              className="flex h-full flex-1 flex-col overflow-visible"
+              data-app-main-inner
+            >
+              {children}
+            </div>
+          </main>
+        </div>
+      </div>
+    </BreadcrumbOverrideProvider>
+  );
+}

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -1,0 +1,82 @@
+import { Suspense } from "react";
+import type { Coworker } from "@/app/chat/utils/types";
+import { HistorySearchDialogProvider } from "@/app/components/history-search-dialog-provider";
+import { EmergencyDialog } from "@/components/emergency-dialog";
+import { AccountNoticeProvider } from "@/contexts/account-notice-provider";
+import { BreadcrumbOverrideProvider } from "@/contexts/breadcrumb-override-context";
+import { CoworkersProvider } from "@/contexts/coworkers-context";
+import { NotificationProvider } from "@/contexts/notification-provider";
+import { getSessionOrRedirect } from "@/lib/auth/auth.server";
+import type { Notice } from "@/lib/clients/generated/core";
+
+import AppShellChrome from "./app-shell-chrome";
+import { AppSidebarFallback } from "./app-sidebar-fallback";
+import Header from "./header";
+import { LoginAccountNoticeToast } from "./login-account-notice-toast.client";
+import { NoticeDialogProvider } from "./notice-dialog-context";
+import { NotificationToastListener } from "./notification-toast-listener";
+import { NotificationToaster } from "./notification-toaster.client";
+
+const EMPTY_COWORKERS: Coworker[] = [];
+const EMPTY_NOTICES: Notice[] = [];
+
+interface AuthenticatedAppFrameProps {
+  children: React.ReactNode;
+}
+
+export default async function AuthenticatedAppFrame({
+  children,
+}: AuthenticatedAppFrameProps) {
+  const session = await getSessionOrRedirect();
+
+  return (
+    <NotificationProvider userId={session.user.id}>
+      <AccountNoticeProvider notice={null} sessionId={session.session.id}>
+        <CoworkersProvider initialCoworkers={EMPTY_COWORKERS}>
+          <NoticeDialogProvider
+            legalNotices={EMPTY_NOTICES}
+            announcementNotices={EMPTY_NOTICES}
+          >
+            <NotificationToaster />
+            <NotificationToastListener userId={session.user.id} />
+            <LoginAccountNoticeToast />
+            <HistorySearchDialogProvider
+              activeOrganizationId={
+                session.session.activeOrganizationId ?? null
+              }
+            >
+              <BreadcrumbOverrideProvider>
+                <Suspense fallback={<AppSidebarFallback />}>
+                  <AppShellChrome session={session} />
+                </Suspense>
+                <div
+                  className="flex min-w-0 flex-1 overflow-clip"
+                  data-app-content
+                >
+                  <div
+                    className="flex min-w-0 flex-1 flex-col overflow-clip"
+                    data-app-content-inner
+                  >
+                    <Header className="h-16 p-4" session={session} />
+                    <main
+                      className="relative flex max-h-svh min-h-svh flex-1 flex-col overflow-x-hidden overflow-y-auto p-4 pt-20 md:max-h-[calc(100svh-64px)] md:min-h-[calc(100svh-64px)] md:pt-4"
+                      data-app-main
+                    >
+                      <EmergencyDialog />
+                      <div
+                        className="flex h-full flex-1 flex-col overflow-visible"
+                        data-app-main-inner
+                      >
+                        {children}
+                      </div>
+                    </main>
+                  </div>
+                </div>
+              </BreadcrumbOverrideProvider>
+            </HistorySearchDialogProvider>
+          </NoticeDialogProvider>
+        </CoworkersProvider>
+      </AccountNoticeProvider>
+    </NotificationProvider>
+  );
+}

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -31,6 +31,8 @@ export default function AppLayout({ children }: AppLayoutProps) {
       <AuthSessionGuard />
       <DynamicAblyProvider>
         <SidebarProvider
+          // Cookie preference restored client-side in SidebarProvider
+          // (useLayoutEffect) so this layout stays sync for Instant Nav.
           defaultOpen
           data-app-shell
           className="flex max-w-svw overflow-clip"

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,34 +1,13 @@
 import type { Metadata } from "next";
-import { cookies, headers } from "next/headers";
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
-import type { Coworker } from "@/app/chat/utils/types";
-import { HistorySearchDialogProvider } from "@/app/components/history-search-dialog-provider";
-import { EmergencyDialog } from "@/components/emergency-dialog";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { AccountNoticeProvider } from "@/contexts/account-notice-provider";
 import DynamicAblyProvider from "@/contexts/alby-provider.dynamic";
-import { BreadcrumbOverrideProvider } from "@/contexts/breadcrumb-override-context";
-import { CoworkersProvider } from "@/contexts/coworkers-context";
-import { NotificationProvider } from "@/contexts/notification-provider";
 import QueryProvider from "@/contexts/query-provider";
-import { getSessionOrRedirect } from "@/lib/auth/auth.server";
-import type { Notice } from "@/lib/clients/generated/core";
-import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
-import AppShellChrome from "./components/app-shell-chrome";
-import { AppSidebarFallback } from "./components/app-sidebar-fallback";
+import { AppShellLoadingFrame } from "./components/app-shell-loading-frame";
 import { AuthSessionGuard } from "./components/auth-session-guard";
-import Header from "./components/header";
-import { LoginAccountNoticeToast } from "./components/login-account-notice-toast.client";
-import { NoticeDialogProvider } from "./components/notice-dialog-context";
-import { NotificationToastListener } from "./components/notification-toast-listener";
-import { NotificationToaster } from "./components/notification-toaster.client";
-
-/** Stable empties so client providers do not see a new [] reference each RSC pass. */
-const EMPTY_COWORKERS: Coworker[] = [];
-const EMPTY_NOTICES: Notice[] = [];
+import AuthenticatedAppFrame from "./components/authenticated-app-frame";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -46,85 +25,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function AppLayout({ children }: AppLayoutProps) {
-  const headersList = await headers();
-  const pathname = headersList.get("x-pathname");
-
-  if (pathname === "/") {
-    redirect(DEFAULT_AUTHENTICATED_LANDING_PATH);
-  }
-
-  const cookieStorePromise = cookies();
-  const session = await getSessionOrRedirect();
-
-  const cookieStore = await cookieStorePromise;
-  const defaultOpen = cookieStore.get("sidebar_state")?.value !== "false";
-
+export default function AppLayout({ children }: AppLayoutProps) {
   return (
     <QueryProvider>
       <AuthSessionGuard />
       <DynamicAblyProvider>
-        <NotificationProvider userId={session.user.id}>
-          <AccountNoticeProvider notice={null} sessionId={session.session.id}>
-            <CoworkersProvider initialCoworkers={EMPTY_COWORKERS}>
-              <NoticeDialogProvider
-                legalNotices={EMPTY_NOTICES}
-                announcementNotices={EMPTY_NOTICES}
-              >
-                <NotificationToaster />
-                <NotificationToastListener userId={session.user.id} />
-                <LoginAccountNoticeToast />
-                <SidebarProvider
-                  defaultOpen={defaultOpen}
-                  data-app-shell
-                  className="flex max-w-svw overflow-clip"
-                >
-                  <HistorySearchDialogProvider
-                    activeOrganizationId={
-                      session.session.activeOrganizationId ?? null
-                    }
-                  >
-                    <BreadcrumbOverrideProvider>
-                      <Suspense fallback={<AppSidebarFallback />}>
-                        <AppShellChrome session={session} />
-                      </Suspense>
-                      <div
-                        className="flex min-w-0 flex-1 overflow-clip"
-                        data-app-content
-                      >
-                        <div
-                          className="flex min-w-0 flex-1 flex-col overflow-clip"
-                          data-app-content-inner
-                        >
-                          <Header className="h-16 p-4" session={session} />
-                          {/* Below md the header is `fixed` (out of flow), so
-                              main starts at y=0 and must be a full viewport
-                              tall — subtracting the header height there left
-                              a dead 64px strip along the bottom of every
-                              page, which a bottom-anchored composer sits on
-                              top of. From md the header is `sticky` and does
-                              occupy flow, so the subtraction is correct. */}
-                          <main
-                            className="relative flex max-h-svh min-h-svh flex-1 flex-col overflow-x-hidden overflow-y-auto p-4 pt-20 md:max-h-[calc(100svh-64px)] md:min-h-[calc(100svh-64px)] md:pt-4"
-                            data-app-main
-                          >
-                            <EmergencyDialog />
-                            <div
-                              className="flex h-full flex-1 flex-col overflow-visible"
-                              data-app-main-inner
-                            >
-                              {children}
-                            </div>
-                          </main>
-                        </div>
-                      </div>
-                    </BreadcrumbOverrideProvider>
-                  </HistorySearchDialogProvider>
-                </SidebarProvider>
-              </NoticeDialogProvider>
-            </CoworkersProvider>
-          </AccountNoticeProvider>
-        </NotificationProvider>
+        <SidebarProvider
+          defaultOpen
+          data-app-shell
+          className="flex max-w-svw overflow-clip"
+        >
+          <Suspense
+            fallback={<AppShellLoadingFrame>{children}</AppShellLoadingFrame>}
+          >
+            <AuthenticatedAppFrame>{children}</AuthenticatedAppFrame>
+          </Suspense>
+        </SidebarProvider>
       </DynamicAblyProvider>
     </QueryProvider>
   );

--- a/apps/web/src/app/(app)/personal-assistant/layout.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/layout.tsx
@@ -6,6 +6,8 @@ import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 
 import FullscreenEffect from "./components/fullscreen-effect";
 
+export const instant = false;
+
 interface HermesLayoutProps {
   children: ReactNode;
 }

--- a/apps/web/src/app/(auth)/components/auth-background.tsx
+++ b/apps/web/src/app/(auth)/components/auth-background.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 
 import { KanjiLogo } from "@/components/masumi-logos";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 
 const AUTH_BACKGROUND_IMAGES = [
   "/images/backgrounds/auth-bg-1.png",
@@ -10,14 +14,17 @@ const AUTH_BACKGROUND_IMAGES = [
   "/images/backgrounds/auth-bg-5.png",
 ] as const;
 
-function getRandomAuthBackground() {
-  const randomIndex = Math.floor(Math.random() * AUTH_BACKGROUND_IMAGES.length);
-
-  return AUTH_BACKGROUND_IMAGES[randomIndex];
-}
-
 export default function AuthBackground() {
-  const backgroundImage = getRandomAuthBackground();
+  const [backgroundImage, setBackgroundImage] = useState<
+    (typeof AUTH_BACKGROUND_IMAGES)[number]
+  >(AUTH_BACKGROUND_IMAGES[0]);
+
+  useMountEffect(() => {
+    const randomIndex = Math.floor(
+      Math.random() * AUTH_BACKGROUND_IMAGES.length,
+    );
+    setBackgroundImage(AUTH_BACKGROUND_IMAGES[randomIndex]);
+  });
 
   return (
     <div className="hidden h-full w-1/2 lg:block">

--- a/apps/web/src/app/api/billing/portal/route.ts
+++ b/apps/web/src/app/api/billing/portal/route.ts
@@ -16,8 +16,6 @@ import {
 } from "@/lib/billing/billing-portal-redirect";
 import { isAllowedStripeBillingPortalUrl } from "@/lib/billing/stripe-billing-portal-url";
 
-export const dynamic = "force-dynamic";
-
 const SAFE_RETURN_FALLBACK = "/billing?tab=subscription";
 
 function redirectToSignIn(

--- a/apps/web/src/app/api/export/docx/route.ts
+++ b/apps/web/src/app/api/export/docx/route.ts
@@ -33,9 +33,6 @@ import { setupDomContext } from "@/lib/utils/dom-context";
 import { hasHtmlContent } from "@/lib/utils/html-detection";
 import { readRequestJsonWithByteLimit } from "@/lib/utils/read-request-json-limited";
 
-export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
-
 interface GenerateDocxRequest {
   markdown?: string;
   fileName?: string;

--- a/apps/web/src/app/api/export/pdf/route.ts
+++ b/apps/web/src/app/api/export/pdf/route.ts
@@ -8,9 +8,6 @@ import { getSession } from "@/lib/auth/auth.server";
 import { installPdfExportRequestGuard } from "@/lib/utils/pdf-export-ssrf";
 import { readRequestJsonWithByteLimit } from "@/lib/utils/read-request-json-limited";
 
-export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
-
 /** Hard cap on HTML payload size to limit Chromium memory/CPU abuse. */
 const MAX_HTML_BYTES = 1_500_000;
 

--- a/apps/web/src/app/components/document-locale.tsx
+++ b/apps/web/src/app/components/document-locale.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { useLayoutEffect } from "react";
+
+/**
+ * Root `<html lang>` stays on `DEFAULT_LOCALE` so the document shell can stay
+ * sync under Cache Components. Sync the live locale onto `documentElement`
+ * after intl resolves (cookie / Accept-Language).
+ */
+export function DocumentLocale() {
+  const locale = useLocale();
+
+  useLayoutEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  return null;
+}

--- a/apps/web/src/app/components/root-intl-tree.tsx
+++ b/apps/web/src/app/components/root-intl-tree.tsx
@@ -7,6 +7,8 @@ import { GlobalModalsContextProvider } from "@/components/modals/global-modals-c
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/contexts/theme-context";
 
+import { DocumentLocale } from "./document-locale";
+
 interface RootProvidersProps {
   children: React.ReactNode;
   locale: string;
@@ -18,6 +20,7 @@ function RootProviders({ children, locale, messages }: RootProvidersProps) {
     <NuqsAdapter>
       <ThemeProvider>
         <NextIntlClientProvider locale={locale} messages={messages}>
+          <DocumentLocale />
           <GlobalModalsContextProvider>
             <div className="bg-background">{children}</div>
           </GlobalModalsContextProvider>

--- a/apps/web/src/app/components/root-intl-tree.tsx
+++ b/apps/web/src/app/components/root-intl-tree.tsx
@@ -1,0 +1,43 @@
+import type { AbstractIntlMessages } from "next-intl";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+
+import { GlobalModalsContextProvider } from "@/components/modals/global-modals-context";
+import { Toaster } from "@/components/ui/sonner";
+import { ThemeProvider } from "@/contexts/theme-context";
+
+interface RootProvidersProps {
+  children: React.ReactNode;
+  locale: string;
+  messages: AbstractIntlMessages;
+}
+
+function RootProviders({ children, locale, messages }: RootProvidersProps) {
+  return (
+    <NuqsAdapter>
+      <ThemeProvider>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <GlobalModalsContextProvider>
+            <div className="bg-background">{children}</div>
+          </GlobalModalsContextProvider>
+          <Toaster />
+        </NextIntlClientProvider>
+      </ThemeProvider>
+    </NuqsAdapter>
+  );
+}
+
+interface RootIntlTreeProps {
+  children: React.ReactNode;
+}
+
+export async function RootIntlTree({ children }: RootIntlTreeProps) {
+  const [locale, messages] = await Promise.all([getLocale(), getMessages()]);
+
+  return (
+    <RootProviders locale={locale} messages={messages}>
+      {children}
+    </RootProviders>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,19 +2,17 @@ import "./globals.css";
 
 import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import * as Sentry from "@sentry/nextjs";
+import { DEFAULT_LOCALE } from "@sokosumi/utils";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { NextIntlClientProvider } from "next-intl";
-import { getLocale, getMessages } from "next-intl/server";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Suspense } from "react";
 
 import { ClientAnalytics } from "@/components/analytics/client-analytics";
 import { DeploymentRefreshHandler } from "@/components/deployment-refresh-handler";
-import { GlobalModalsContextProvider } from "@/components/modals/global-modals-context";
 import { ApplePwaHead } from "@/components/pwa/apple-pwa-head";
-import { Toaster } from "@/components/ui/sonner";
 import { getEnvPublicConfig } from "@/config/env.public";
-import { ThemeProvider } from "@/contexts/theme-context";
+
+import { RootIntlTree } from "./components/root-intl-tree";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -38,34 +36,29 @@ export function generateMetadata(): Metadata {
   };
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [locale, messages] = await Promise.all([getLocale(), getMessages()]);
   const gtmId = getEnvPublicConfig().NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID;
   const gaId = getEnvPublicConfig().NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
   return (
-    <html lang={locale} suppressHydrationWarning className={inter.className}>
+    <html
+      lang={DEFAULT_LOCALE}
+      suppressHydrationWarning
+      className={inter.className}
+    >
       <head>
         <ApplePwaHead />
       </head>
       {gtmId && <GoogleTagManager gtmId={gtmId} />}
       {gaId && <GoogleAnalytics gaId={gaId} />}
       <body className="bg-background min-h-svh max-w-dvw antialiased">
-        <NuqsAdapter>
-          <ThemeProvider>
-            <NextIntlClientProvider messages={messages}>
-              <GlobalModalsContextProvider>
-                <div className="bg-background">{children}</div>
-              </GlobalModalsContextProvider>
-              {/* Toaster */}
-              <Toaster />
-            </NextIntlClientProvider>
-          </ThemeProvider>
-        </NuqsAdapter>
+        <Suspense fallback={<div className="bg-background min-h-svh" />}>
+          <RootIntlTree>{children}</RootIntlTree>
+        </Suspense>
         <ClientAnalytics />
         <DeploymentRefreshHandler />
       </body>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE } from "@sokosumi/utils";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -14,7 +15,10 @@ import {
 } from "@/components/ui/card";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("NotFound");
+  const t = await getTranslations({
+    locale: DEFAULT_LOCALE,
+    namespace: "NotFound",
+  });
   return {
     title: t("title"),
     description: t("description"),

--- a/apps/web/src/components/ui/__tests__/sidebar-cookie.test.tsx
+++ b/apps/web/src/components/ui/__tests__/sidebar-cookie.test.tsx
@@ -1,0 +1,56 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+import { SidebarProvider, useSidebar } from "@/components/ui/sidebar";
+
+function SidebarStateProbe() {
+  const { open, state } = useSidebar();
+  return (
+    <div data-testid="sidebar-state" data-open={String(open)} data-state={state} />
+  );
+}
+
+describe("SidebarProvider cookie preference", () => {
+  beforeEach(() => {
+    document.cookie =
+      "sidebar_state=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  });
+
+  it("restores collapsed preference from cookie before paint", async () => {
+    document.cookie = "sidebar_state=false; path=/";
+
+    const { getByTestId } = render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("sidebar-state")).toHaveAttribute("data-open", "false");
+      expect(getByTestId("sidebar-state")).toHaveAttribute(
+        "data-state",
+        "collapsed",
+      );
+    });
+  });
+
+  it("keeps defaultOpen when cookie is absent", async () => {
+    const { getByTestId } = render(
+      <SidebarProvider defaultOpen>
+        <SidebarStateProbe />
+      </SidebarProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("sidebar-state")).toHaveAttribute("data-open", "true");
+      expect(getByTestId("sidebar-state")).toHaveAttribute(
+        "data-state",
+        "expanded",
+      );
+    });
+  });
+});

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -72,6 +72,9 @@ function SidebarProvider({
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
+  // SSR / hydration always start from `defaultOpen` so the sync Instant Nav
+  // shell does not need `cookies()`. Restore the persisted preference in
+  // `useLayoutEffect` before paint to avoid an open/closed flash.
   const [_open, _setOpen] = React.useState(defaultOpen);
   const open = openProp ?? _open;
   const setOpen = React.useCallback(
@@ -88,6 +91,26 @@ function SidebarProvider({
     },
     [setOpenProp, open],
   );
+
+  React.useLayoutEffect(() => {
+    if (openProp !== undefined) {
+      return;
+    }
+
+    const raw = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith(`${SIDEBAR_COOKIE_NAME}=`))
+      ?.slice(SIDEBAR_COOKIE_NAME.length + 1);
+
+    if (raw === "true") {
+      _setOpen(true);
+      return;
+    }
+
+    if (raw === "false") {
+      _setOpen(false);
+    }
+  }, [openProp]);
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {

--- a/apps/web/src/lib/agents/core-loaders.ts
+++ b/apps/web/src/lib/agents/core-loaders.ts
@@ -6,18 +6,25 @@ import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import type {
   Agent as CoreAgent,
   AgentDetail as CoreAgentDetail,
+  Category as CoreCategory,
 } from "@/lib/clients/generated/core";
 
 const AGENTS_PAGE_SIZE = 100;
 
-// The agent catalog is global and changes infrequently. Without cross-request
-// caching, every page that needs agents re-paginates the whole catalog over
-// HTTP (React `cache()` only dedupes within a single request). Cache the
-// underlying fetches with a short TTL + tag so the catalog is fetched at most
-// once per window across all requests; call `updateTag(AGENTS_CACHE_TAG)` from
-// a Server Action to invalidate on demand (e.g. after admin overwrite edits).
-const AGENTS_CACHE_REVALIDATE_SECONDS = 60;
+// The agent + category catalogs are global and change infrequently. Without
+// cross-request caching, every page that needs them re-fetches over HTTP
+// (React `cache()` only dedupes within a single request). Opt into fetch-level
+// revalidation + tags so payloads are shared across users (URL-keyed; no
+// per-user fields). Invalidate with `updateTag(...)` from Server Actions.
+//
+// Full cookie-free `'use cache'` fill is blocked until Core offers a public or
+// service-token catalog read — `coreClient` forwards session cookies via
+// `headers()`, which is illegal inside `'use cache'`. Callers that run under
+// Cache Components Suspense should `await connection()` first so prerender
+// does not soft-reject `headers()` while probing the boundary.
+const CATALOG_CACHE_REVALIDATE_SECONDS = 60;
 export const AGENTS_CACHE_TAG = "core-agents-catalog";
+export const CATEGORIES_CACHE_TAG = "core-categories-catalog";
 
 export const getCoreAgentById = cache(
   async (agentId: string): Promise<CoreAgentDetail | null> => {
@@ -47,7 +54,7 @@ export const getAllCoreAgents = cache(async (): Promise<CoreAgent[]> => {
         limit: AGENTS_PAGE_SIZE,
       },
       {
-        revalidate: AGENTS_CACHE_REVALIDATE_SECONDS,
+        revalidate: CATALOG_CACHE_REVALIDATE_SECONDS,
         tags: [AGENTS_CACHE_TAG],
       },
     );
@@ -57,4 +64,13 @@ export const getAllCoreAgents = cache(async (): Promise<CoreAgent[]> => {
   } while (cursor);
 
   return agents;
+});
+
+export const getCoreCategories = cache(async (): Promise<CoreCategory[]> => {
+  const response = await coreClient.getCategories(undefined, {
+    revalidate: CATALOG_CACHE_REVALIDATE_SECONDS,
+    tags: [CATEGORIES_CACHE_TAG],
+  });
+
+  return response.data;
 });

--- a/apps/web/src/lib/clients/core.shared.ts
+++ b/apps/web/src/lib/clients/core.shared.ts
@@ -2244,14 +2244,21 @@ export function createCoreClient(getClient: GetClient) {
     );
   }
 
-  async function getCategories(query?: GetCategoriesData["query"]) {
+  async function getCategories(
+    query?: GetCategoriesData["query"],
+    cacheOptions?: { revalidate: number; tags?: string[] },
+  ) {
     return executeOperation(
       getClient,
       (client) =>
         coreGetCategories({
           client,
           query,
-          cache: "no-store",
+          // Categories are global (same as GET /v1/agents) — callers may opt
+          // into cross-request revalidation. Default stays `no-store`.
+          ...(cacheOptions
+            ? { next: cacheOptions }
+            : { cache: "no-store" as const }),
         }),
       "Failed to fetch categories",
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables Next.js 16.3 Instant Navigations for the web app ([SOK-704](https://linear.app/masumi/issue/SOK-704/instant-navigations-with-cache-components-and-partial-prefetching)).

- `cacheComponents` + `partialPrefetching` on in `next.config.ts`
- `(app)` layout paints a sync shell; session chrome streams under Suspense (mobile sidebar trigger kept in fallback)
- Sidebar `sidebar_state` cookie restored in `SidebarProvider` via `useLayoutEffect` (pre-paint) so the layout stays sync
- `/agents` streams coworker + catalog tiers separately (Partial Prerender); tiers `await connection()` so PPR probing does not soft-reject `headers()`
- Categories join the same tagged fetch Data Cache as the agent catalog (`getCoreCategories`)
- `DocumentLocale` syncs `document.documentElement.lang` after intl resolves (root `<html lang>` stays `DEFAULT_LOCALE` for a sync shell)
- `instant = false` on Hermes personal-assistant and admin (must-block auth gates)
- Root intl streams so locale cookies do not block the document shell
- Auth background `Math.random` moved to client mount (Cache Components sync-IO)

## Out of scope

`useOffline`, PWA offline, Core API contract changes. Broader route conversion beyond the agents pilot and must-block opt-outs.

Cookie-free `'use cache'` for the global catalog still needs a public or service-token Core catalog read (session cookies via `headers()` are illegal inside `'use cache'`).

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0; includes sidebar cookie restore tests)
- `pnpm web:build` (exit 0; `/agents` → Partial Prerender; no soft-caught `headers()` noise)
- UI: signed in as `alice@sokosumi.test`, `/agents` shows shell + coworkers + catalog

**headSha:** `932925f1393588cc19ff252b3dbb0aad1d469d4f`

Linear Issue: [SOK-704](https://linear.app/masumi/issue/SOK-704/instant-navigations-with-cache-components-and-partial-prefetching)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-704](https://linear.app/masumi/issue/SOK-704/instant-navigations-with-cache-components-and-partial-prefetching)

<div><a href="https://cursor.com/agents/bc-207ad073-6f9f-4dae-a64c-e32711666fa1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-207ad073-6f9f-4dae-a64c-e32711666fa1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

