### PR TITLE
fix(web): stop NEXT_REDIRECT toast on channel member save 403

### DIFF
--- a/apps/web/src/app/(app)/chat/__tests__/action-error-message.test.ts
+++ b/apps/web/src/app/(app)/chat/__tests__/action-error-message.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { unstableRethrowMock } = vi.hoisted(() => ({
+  unstableRethrowMock: vi.fn((error: unknown) => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "digest" in error &&
+      typeof (error as { digest: unknown }).digest === "string" &&
+      (error as { digest: string }).digest.startsWith("NEXT_REDIRECT")
+    ) {
+      throw error;
+    }
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  unstable_rethrow: unstableRethrowMock,
+}));
+
+import { CoreApiRequestError } from "@/lib/clients/core.client";
+import { actionErrorMessage } from "../action-error-message";
+
+describe("actionErrorMessage", () => {
+  beforeEach(() => {
+    unstableRethrowMock.mockClear();
+  });
+
+  it("rethrows redirect-like errors via unstable_rethrow", () => {
+    const redirectError = Object.assign(new Error("NEXT_REDIRECT"), {
+      digest: "NEXT_REDIRECT;replace;/signin;307;",
+    });
+
+    expect(() => actionErrorMessage(redirectError, "fallback")).toThrow(
+      redirectError,
+    );
+    expect(unstableRethrowMock).toHaveBeenCalledWith(redirectError);
+  });
+
+  it("returns CoreApiRequestError permission message for 403", () => {
+    const message =
+      "Only the channel creator or an organization owner/admin can update members";
+
+    expect(
+      actionErrorMessage(
+        new CoreApiRequestError(message, { status: 403 }),
+        "Could not update channel.",
+      ),
+    ).toBe(message);
+    expect(unstableRethrowMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/chat/action-error-message.ts
+++ b/apps/web/src/app/(app)/chat/action-error-message.ts
@@ -1,0 +1,11 @@
+import { CoreApiRequestError } from "@/lib/clients/core.client";
+
+export function actionErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof CoreApiRequestError) {
+    return error.message;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/apps/web/src/app/(app)/chat/action-error-message.ts
+++ b/apps/web/src/app/(app)/chat/action-error-message.ts
@@ -1,6 +1,9 @@
+import { unstable_rethrow } from "next/navigation";
 import { CoreApiRequestError } from "@/lib/clients/core.client";
 
 export function actionErrorMessage(error: unknown, fallback: string): string {
+  unstable_rethrow(error);
+
   if (error instanceof CoreApiRequestError) {
     return error.message;
   }

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { actionErrorMessage } from "@/app/chat/action-error-message";
 import { directCreateShapeError } from "@/app/chat/utils/direct-create-shape";
-import { CoreApiRequestError } from "@/lib/clients/core.client";
 import type {
   ChatRoom,
   ChatRoomMessage,
@@ -69,16 +69,6 @@ function cleanDiscoverability(
     return value;
   }
   return undefined;
-}
-
-function actionErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof CoreApiRequestError) {
-    return error.message;
-  }
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  return fallback;
 }
 
 export async function createChannelAction(

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -47,16 +47,15 @@ export function EditChannelDialog({
   channel,
   members,
   coworkers,
-  canArchive,
+  canManage,
   canLeave,
   membersLoadFailed = false,
 }: {
   channel: ChatRoom;
   members: Member[];
   coworkers: Coworker[];
-  /** Creator or organization owner/admin — archiving hides the room for
-   * everyone. */
-  canArchive: boolean;
+  /** Creator or organization owner/admin — manage name/topic/members/archive. */
+  canManage: boolean;
   /** Any member can leave, except the last one: an empty roster could not be
    * archived by a remaining elevated member. */
   canLeave: boolean;
@@ -96,11 +95,12 @@ export function EditChannelDialog({
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (!canManage) return;
     startTransition(async () => {
       const result = await updateRoomAction(channel.id, {
         name,
         topic,
-        ...(canArchive ? { discoverability } : {}),
+        discoverability,
         memberUserIds: memberIds,
         coworkerIds,
       });
@@ -178,26 +178,28 @@ export function EditChannelDialog({
                 {t("Dialog.editDescription")}
               </DialogDescription>
             </DialogHeader>
-            <div className="grid gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="edit-channel-name">{t("Dialog.name")}</Label>
-                <Input
-                  id="edit-channel-name"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-channel-topic">{t("Dialog.topic")}</Label>
-                <Textarea
-                  id="edit-channel-topic"
-                  value={topic}
-                  onChange={(event) => setTopic(event.target.value)}
-                  rows={3}
-                />
-              </div>
-              {canArchive ? (
+            {canManage ? (
+              <div className="grid gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="edit-channel-name">{t("Dialog.name")}</Label>
+                  <Input
+                    id="edit-channel-name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-channel-topic">
+                    {t("Dialog.topic")}
+                  </Label>
+                  <Textarea
+                    id="edit-channel-topic"
+                    value={topic}
+                    onChange={(event) => setTopic(event.target.value)}
+                    rows={3}
+                  />
+                </div>
                 <div className="space-y-2">
                   <Label>{t("Visibility.label")}</Label>
                   <RadioGroup
@@ -237,18 +239,18 @@ export function EditChannelDialog({
                       : t("Visibility.privateHelp")}
                   </p>
                 </div>
-              ) : null}
-              <ParticipantCheckboxes
-                members={members}
-                coworkers={coworkers}
-                memberIds={memberIds}
-                coworkerIds={coworkerIds}
-                onMemberIdsChange={setMemberIds}
-                onCoworkerIdsChange={setCoworkerIds}
-                membersLoadFailed={membersLoadFailed}
-              />
-            </div>
-            {canArchive || canLeave ? (
+                <ParticipantCheckboxes
+                  members={members}
+                  coworkers={coworkers}
+                  memberIds={memberIds}
+                  coworkerIds={coworkerIds}
+                  onMemberIdsChange={setMemberIds}
+                  onCoworkerIdsChange={setCoworkerIds}
+                  membersLoadFailed={membersLoadFailed}
+                />
+              </div>
+            ) : null}
+            {canManage || canLeave ? (
               <div className="space-y-3 border-t pt-4">
                 <p className="text-sm font-medium">
                   {tActions("sectionTitle")}
@@ -265,7 +267,7 @@ export function EditChannelDialog({
                       {tActions("leave")}
                     </Button>
                   ) : null}
-                  {canArchive ? (
+                  {canManage ? (
                     <Button
                       type="button"
                       variant="outline"
@@ -287,10 +289,14 @@ export function EditChannelDialog({
               >
                 {t("Dialog.cancel")}
               </Button>
-              <Button type="submit" variant="primary" disabled={isPending}>
-                {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
-                {t("Dialog.save")}
-              </Button>
+              {canManage ? (
+                <Button type="submit" variant="primary" disabled={isPending}>
+                  {isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : null}
+                  {t("Dialog.save")}
+                </Button>
+              ) : null}
             </DialogFooter>
           </form>
         </DialogContent>

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1369,7 +1369,7 @@ export function RoomsClient({
                       channel={selectedRoom}
                       members={organizationMembers}
                       coworkers={coworkers}
-                      canArchive={canArchiveSelectedRoom}
+                      canManage={canArchiveSelectedRoom}
                       canLeave={canLeaveSelectedRoom}
                       membersLoadFailed={membersLoadFailed}
                     />

--- a/apps/web/src/lib/auth/__tests__/handle-unauthorized-core-error.test.ts
+++ b/apps/web/src/lib/auth/__tests__/handle-unauthorized-core-error.test.ts
@@ -51,6 +51,17 @@ describe("isUnauthorizedCoreApiError", () => {
       ),
     ).toBe(false);
   });
+
+  it("does not treat business 403 permission errors as unauthorized", () => {
+    expect(
+      isUnauthorizedCoreApiError(
+        new CoreApiRequestError(
+          "Only the channel creator or an organization owner/admin can update members",
+          { status: 403 },
+        ),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("redirectIfUnauthorizedCoreError", () => {
@@ -127,6 +138,19 @@ describe("withUnauthorizedCoreRedirect", () => {
     });
 
     await expect(client.getTask("task-id")).rejects.toBe(boom);
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows business 403 errors without redirecting", async () => {
+    const forbidden = new CoreApiRequestError(
+      "Only the channel creator or an organization owner/admin can update members",
+      { status: 403 },
+    );
+    const client = withUnauthorizedCoreRedirect({
+      updateRoom: (_roomId: string) => Promise.reject(forbidden),
+    });
+
+    await expect(client.updateRoom("room-id")).rejects.toBe(forbidden);
     expect(redirectMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auth/handle-unauthorized-core-error.ts
+++ b/apps/web/src/lib/auth/handle-unauthorized-core-error.ts
@@ -10,7 +10,7 @@ export function isUnauthorizedCoreApiError(error: unknown): boolean {
     return false;
   }
 
-  if (error.status === 401 || error.status === 403) {
+  if (error.status === 401) {
     return true;
   }
 

--- a/apps/web/src/lib/clients/core.client.ts
+++ b/apps/web/src/lib/clients/core.client.ts
@@ -38,14 +38,15 @@ const rawCoreClient = createCoreClient(createCoreGeneratedClient);
 export const coreClient = withUnauthorizedCoreRedirect(rawCoreClient);
 
 /**
- * Unwrapped Core client — bypasses the 401/403 → signin redirect proxy.
+ * Unwrapped Core client — bypasses the session-401 → signin redirect proxy.
  *
- * Use this only for endpoints where a 403/404/409 is a *business verdict about
- * the resource*, not a session-auth failure. The Hermes skills endpoints return
- * 403 ("skill blocked by audit policy"), 409 ("slug conflict") and 404
- * ("instance not found") as expected install outcomes; routed through the
- * redirecting client they would bounce the user to /signin (surfacing as a
- * cryptic `NEXT_REDIRECT`) instead of showing a toast. The page these actions
- * run on is an RSC that already guards genuine auth via the redirecting client.
+ * The redirect proxy is session-401 only; business 403s no longer redirect.
+ * This escape hatch is still useful where you want to avoid even a 401 redirect.
+ *
+ * Use this for endpoints where a 403/404/409 is a *business verdict about the
+ * resource*, not a session-auth failure. The Hermes skills endpoints return 403
+ * ("skill blocked by audit policy"), 409 ("slug conflict") and 404 ("instance
+ * not found") as expected install outcomes. The page these actions run on is an
+ * RSC that already guards genuine auth via the redirecting client.
  */
 export const coreClientNoRedirect = rawCoreClient;

--- a/apps/web/src/lib/clients/core.client.ts
+++ b/apps/web/src/lib/clients/core.client.ts
@@ -40,13 +40,9 @@ export const coreClient = withUnauthorizedCoreRedirect(rawCoreClient);
 /**
  * Unwrapped Core client — bypasses the session-401 → signin redirect proxy.
  *
- * The redirect proxy is session-401 only; business 403s no longer redirect.
- * This escape hatch is still useful where you want to avoid even a 401 redirect.
- *
- * Use this for endpoints where a 403/404/409 is a *business verdict about the
- * resource*, not a session-auth failure. The Hermes skills endpoints return 403
- * ("skill blocked by audit policy"), 409 ("slug conflict") and 404 ("instance
- * not found") as expected install outcomes. The page these actions run on is an
- * RSC that already guards genuine auth via the redirecting client.
+ * Prefer the redirecting `coreClient` for normal server reads. Use this when a
+ * caller must handle 401 itself (for example an action that maps auth failure
+ * to a toast) or when the surrounding RSC already proved the session via
+ * `coreClient`. Business 403s no longer redirect through the proxy.
  */
 export const coreClientNoRedirect = rawCoreClient;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What broke

Saving Edit Channel (add a member) could toast the literal string `NEXT_REDIRECT` instead of updating the roster or showing a real error.

## Root cause

1. Core `PATCH /chats/rooms/{id}` returns **403** when the caller is not the room creator or an org owner/admin.
2. Web’s `withUnauthorizedCoreRedirect` treated **every 403** like a stale session and called `redirect(/signin)`.
3. Chat server actions caught that Next.js redirect control-flow error and mapped `error.message` (`NEXT_REDIRECT`) into the toast.

Session auth failures from Core are **401**, not permission 403s.

## Fix

- Treat only **401** (plus the expired-session message regex) as unauthorized → sign-in.
- Call `unstable_rethrow` in chat `actionErrorMessage` so real redirects are not toasted.
- Gate Edit Channel name/topic/members/Save behind `canManage` (same predicate Core uses), so non-managers only see Leave.

## Verification

```text
pnpm --filter web test src/lib/auth/__tests__/handle-unauthorized-core-error.test.ts 'src/app/(app)/chat/__tests__/action-error-message.test.ts'
# 12 passed
```

Failing-test commit lands first (`c7767ade`), then the fix (`d5f2a384`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20441718-9ee9-46ab-81fa-5376192b7137?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20441718-9ee9-46ab-81fa-5376192b7137&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

