### PR TITLE
fix(core): treat group directs as mention-only for chat notifications

### DIFF
--- a/apps/core/src/helpers/chat-direct-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.test.ts
@@ -32,19 +32,76 @@ vi.mock("@sentry/node", () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }));
 
-import { emitChatDirectMessageNotifications } from "./chat-direct-message-notifications";
+import {
+  emitChatDirectMessageNotifications,
+  shouldEmitChatDirectMessageNotifications,
+} from "./chat-direct-message-notifications";
 
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440002";
 const AUTHOR_ID = "user_author";
 const PEER_ID = "user_alice";
 const OTHER_ID = "user_bob";
+const THIRD_ID = "user_carol";
 
 beforeEach(() => {
   vi.clearAllMocks();
   createNotificationMock.mockResolvedValue({ created: true });
   workspaceFindUniqueMock.mockResolvedValue({ id: "workspace_1" });
   membershipFindManyMock.mockResolvedValue([]);
+});
+
+describe("shouldEmitChatDirectMessageNotifications", () => {
+  it("returns false for channel rooms regardless of member count", () => {
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "channel",
+        memberUserIds: [AUTHOR_ID],
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "channel",
+        memberUserIds: [AUTHOR_ID, PEER_ID],
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "channel",
+        memberUserIds: [AUTHOR_ID, PEER_ID, OTHER_ID],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for direct rooms with fewer than 3 human members", () => {
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "direct",
+        memberUserIds: [AUTHOR_ID],
+      }),
+    ).toBe(true);
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "direct",
+        memberUserIds: [AUTHOR_ID, PEER_ID],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for direct rooms with 3 or more human members", () => {
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "direct",
+        memberUserIds: [AUTHOR_ID, PEER_ID, OTHER_ID],
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitChatDirectMessageNotifications({
+        kind: "direct",
+        memberUserIds: [AUTHOR_ID, PEER_ID, OTHER_ID, THIRD_ID],
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("emitChatDirectMessageNotifications", () => {

--- a/apps/core/src/helpers/chat-direct-message-notifications.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.ts
@@ -4,6 +4,23 @@ import { NotificationKind } from "@sokosumi/database";
 import { createNotification } from "@/helpers/notifications";
 import prisma from "@/lib/db/prisma";
 
+export const MAX_HUMAN_MEMBERS_FOR_DIRECT_MESSAGE_NOTIFICATIONS = 2;
+
+export interface ShouldEmitChatDirectMessageNotificationsParams {
+  kind: string;
+  memberUserIds: readonly string[];
+}
+
+export function shouldEmitChatDirectMessageNotifications(
+  params: ShouldEmitChatDirectMessageNotificationsParams,
+): boolean {
+  return (
+    params.kind === "direct" &&
+    params.memberUserIds.length <=
+      MAX_HUMAN_MEMBERS_FOR_DIRECT_MESSAGE_NOTIFICATIONS
+  );
+}
+
 export interface EmitChatDirectMessageNotificationsParams {
   roomId: string;
   roomName: string;

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -64,10 +64,20 @@ vi.mock("@/helpers/chat-mention-notifications", () => ({
     emitChatMentionNotificationsMock(...args),
 }));
 
-vi.mock("@/helpers/chat-direct-message-notifications", () => ({
-  emitChatDirectMessageNotifications: (...args: unknown[]) =>
-    emitChatDirectMessageNotificationsMock(...args),
-}));
+vi.mock(
+  "@/helpers/chat-direct-message-notifications",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/helpers/chat-direct-message-notifications")
+      >();
+    return {
+      ...actual,
+      emitChatDirectMessageNotifications: (...args: unknown[]) =>
+        emitChatDirectMessageNotificationsMock(...args),
+    };
+  },
+);
 
 vi.mock("@/helpers/chat-room-message-realtime", () => ({
   publishChatRoomMessageRealtime: vi.fn().mockResolvedValue(undefined),
@@ -81,6 +91,7 @@ const QUOTE_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440004";
 const COWORKER_ID = "coworker_1";
 const USER_ID = "user_123";
 const ALICE_ID = "user_alice";
+const BOB_ID = "user_bob";
 
 const quoteSnapshot = {
   messageId: QUOTE_MESSAGE_ID,
@@ -645,8 +656,90 @@ describe("POST /chats/rooms/{id}/messages", () => {
       expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
     });
 
+    it("does not emit direct-message notifications for group directs", async () => {
+      roomFindFirstMock.mockResolvedValue(
+        roomWithMembers({
+          kind: "direct",
+          name: "Group",
+          userMembers: [
+            {
+              userId: USER_ID,
+              user: { name: "Patrick" },
+            },
+            {
+              userId: ALICE_ID,
+              user: { name: "Alice" },
+            },
+            {
+              userId: BOB_ID,
+              user: { name: "Bob" },
+            },
+          ],
+          coworkerMembers: [],
+        }),
+      );
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderUserId: USER_ID }),
+      );
+
+      const app = createApp(userAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "hey everyone" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatMentionNotificationsMock).not.toHaveBeenCalled();
+      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
+    });
+
+    it("emits mention notifications but not direct-message notifications in group directs", async () => {
+      roomFindFirstMock.mockResolvedValue(
+        roomWithMembers({
+          kind: "direct",
+          name: "Group",
+          userMembers: [
+            {
+              userId: USER_ID,
+              user: { name: "Patrick" },
+            },
+            {
+              userId: ALICE_ID,
+              user: { name: "Alice" },
+            },
+            {
+              userId: BOB_ID,
+              user: { name: "Bob" },
+            },
+          ],
+          coworkerMembers: [],
+        }),
+      );
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderUserId: USER_ID }),
+      );
+
+      const app = createApp(userAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "ping alice",
+          mentionedUserIds: [ALICE_ID],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatMentionNotificationsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mentionedUserIds: [ALICE_ID],
+        }),
+      );
+      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
+    });
+
     it("expands @all:all from content to notify other humans without ChatRoomMention rows", async () => {
-      const BOB_ID = "user_bob";
       roomFindFirstMock.mockResolvedValue(
         roomWithMembers({
           userMembers: [

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -1,7 +1,10 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { waitUntil } from "@vercel/functions";
 
-import { emitChatDirectMessageNotifications } from "@/helpers/chat-direct-message-notifications";
+import {
+  emitChatDirectMessageNotifications,
+  shouldEmitChatDirectMessageNotifications,
+} from "@/helpers/chat-direct-message-notifications";
 import { emitChatMentionNotifications } from "@/helpers/chat-mention-notifications";
 import { publishChatRoomMessageRealtime } from "@/helpers/chat-room-message-realtime";
 import { conflict } from "@/helpers/error";
@@ -355,7 +358,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         );
       }
 
-      if (room.kind === "direct") {
+      if (
+        shouldEmitChatDirectMessageNotifications({
+          kind: room.kind,
+          memberUserIds: room.memberUserIds,
+        })
+      ) {
         const mentionedUserIdSet = new Set(mentionedUserIds);
         const recipientUserIds = room.memberUserIds.filter(
           (userId) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Group direct rooms (≥3 human participants) no longer create a CHAT notification for every message. Only `@` mentions notify, matching channel behavior. Human 1:1 directs still notify on each message.

**Change.** `shouldEmitChatDirectMessageNotifications` gates the existing DM emit path when human roster length is under 3. Mention emit is unchanged.

**Verify.** `pnpm --filter core test` on `chat-direct-message-notifications.test.ts` and `rooms/[id]/messages/post.test.ts` (27 passed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-349d290e-82c9-4947-a5ee-5b2ca85ef2d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-349d290e-82c9-4947-a5ee-5b2ca85ef2d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

