### PR TITLE
feat(chat): let any channel member add members; drop creator elevation

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.test.ts
@@ -113,55 +113,52 @@ beforeEach(() => {
 });
 
 describe("POST /chats/rooms/{id}/archive", () => {
-  it("archives a room for its creator and returns the timestamp", async () => {
+  it("rejects a creator who is only a plain member", async () => {
     roomFindFirstMock.mockResolvedValue(room());
+    memberFindUniqueMock.mockResolvedValue({ role: "member" });
 
     const response = await archive();
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.id).toBe(ROOM_ID);
-    expect(typeof body.data.archivedAt).toBe("string");
-
-    const sqlParts = queryRawMock.mock.calls[0]?.[0] as TemplateStringsArray;
-    expect(sqlParts.join(" ")).toContain("FOR UPDATE");
-    expect(roomUpdateManyMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: ROOM_ID, archivedAt: null },
-        data: { archivedAt: expect.any(Date) },
-      }),
-    );
+    expect(response.status).toBe(403);
+    const text = await response.text();
+    expect(text).toMatch(/organization owner or admin/i);
+    expect(text).not.toMatch(/creator/i);
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it.each([
     ["admin", MemberRole.ADMIN],
     ["owner", MemberRole.OWNER],
   ])(
-    "lets an organization %s archive a room they did not create",
+    "lets an organization %s archive a room and returns the timestamp",
     async (_label, role) => {
       roomFindFirstMock.mockResolvedValue(room({ createdByUserId: OTHER_ID }));
       memberFindUniqueMock.mockResolvedValue({ role });
 
-      expect((await archive()).status).toBe(200);
+      const response = await archive();
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data.id).toBe(ROOM_ID);
+      expect(typeof body.data.archivedAt).toBe("string");
+
+      const sqlParts = queryRawMock.mock.calls[0]?.[0] as TemplateStringsArray;
+      expect(sqlParts.join(" ")).toContain("FOR UPDATE");
+      expect(roomUpdateManyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: ROOM_ID, archivedAt: null },
+          data: { archivedAt: expect.any(Date) },
+        }),
+      );
     },
   );
 
-  it("rejects a plain member who is not the creator", async () => {
+  it("rejects a plain member who is not elevated", async () => {
     roomFindFirstMock.mockResolvedValue(
       room({
         createdByUserId: OTHER_ID,
         memberIds: [CREATOR_ID, OTHER_ID, "user_third"],
       }),
-    );
-    memberFindUniqueMock.mockResolvedValue({ role: "member" });
-
-    expect((await archive()).status).toBe(403);
-    expect(roomUpdateManyMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects the last human member when they are not creator or elevated", async () => {
-    roomFindFirstMock.mockResolvedValue(
-      room({ createdByUserId: OTHER_ID, memberIds: [CREATOR_ID] }),
     );
     memberFindUniqueMock.mockResolvedValue({ role: "member" });
 
@@ -194,6 +191,7 @@ describe("POST /chats/rooms/{id}/archive", () => {
 
   it("404s when a concurrent archive already set archivedAt under the lock", async () => {
     roomFindFirstMock.mockResolvedValue(room());
+    memberFindUniqueMock.mockResolvedValue({ role: MemberRole.OWNER });
     roomUpdateManyMock.mockResolvedValue({ count: 0 });
 
     expect((await archive()).status).toBe(404);

--- a/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/archive/post.ts
@@ -32,7 +32,7 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/{id}/archive",
     description:
-      "Archive an organization chat room. Every read filters on archivedAt, so it disappears for all members while its messages stay in the database. Only the room creator or an organization owner/admin may archive. Direct rooms cannot be archived.",
+      "Archive an organization chat room. Every read filters on archivedAt, so it disappears for all members while its messages stay in the database. Only an organization owner/admin may archive. Direct rooms cannot be archived.",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
@@ -89,15 +89,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         userId: userContext.userId,
         tx,
       });
-      if (
-        !canManageChatRoomLifecycle({
-          createdByUserId: existing.createdByUserId,
-          userId: userContext.userId,
-          role,
-        })
-      ) {
+      if (!canManageChatRoomLifecycle({ role })) {
         throw forbidden(
-          "Only the room creator or an organization owner or admin can archive this room.",
+          "Only an organization owner or admin can archive this room.",
         );
       }
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
@@ -28,7 +28,7 @@ const route = withGlobalHeaderParameters(
     method: "delete",
     path: "/{id}/members/me",
     description:
-      "Leave an organization chat room. Removes only the caller's membership and read marker; the room and its messages are untouched for everyone else. Any member can leave. The last remaining member cannot leave (ask the channel creator or an organization owner/admin to archive instead), and direct rooms cannot be left.",
+      "Leave an organization chat room. Removes only the caller's membership and read marker; the room and its messages are untouched for everyone else. Any member can leave. The last remaining member cannot leave (ask an organization owner/admin to archive instead), and direct rooms cannot be left.",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
@@ -94,11 +94,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       });
       // Nobody left to archive it afterwards: the room would linger with an
       // empty roster, invisible to every user yet still holding its slug.
-      // Last member cannot leave — creator or org owner/admin (who must also
+      // Last member cannot leave — an organization owner/admin (who must also
       // be members under current access rules) must archive instead.
       if (remainingUserMemberCount === 0) {
         throw badRequest(
-          "You are the last member of this room. Ask the channel creator or an organization owner or admin to archive it.",
+          "You are the last member of this room. Ask an organization owner or admin to archive it.",
         );
       }
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
@@ -179,15 +179,60 @@ beforeEach(() => {
 });
 
 describe("PATCH /chats/rooms/{id}", () => {
-  it("updates a channel room when the caller is the creator", async () => {
-    const existing = channelRoom();
-    const updated = channelRoom({
-      name: "Ship Room",
-      slug: "ship-room",
-      topic: "Go live checklist",
-    });
+  it("allows a non-creator member to PATCH roster-only", async () => {
+    const existing = channelRoom({ createdByUserId: OTHER_USER_ID });
+    const updated = channelRoom({ createdByUserId: OTHER_USER_ID });
     roomFindFirstMock.mockResolvedValueOnce(existing);
+    memberFindUniqueMock.mockResolvedValue({ role: "member" });
     roomUpdateMock.mockResolvedValueOnce(updated);
+    userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
+    userMemberCreateManyMock.mockResolvedValue({ count: 2 });
+    readStateDeleteManyMock.mockResolvedValue({ count: 0 });
+    readStateCreateManyMock.mockResolvedValue({ count: 0 });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        memberUserIds: [USER_ID, OTHER_USER_ID],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(userMemberCreateManyMock).toHaveBeenCalled();
+    expect(roomUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: ROOM_ID },
+        data: {},
+      }),
+    );
+  });
+
+  it("rejects a non-creator member PATCH that touches settings", async () => {
+    roomFindFirstMock.mockResolvedValueOnce(
+      channelRoom({ createdByUserId: OTHER_USER_ID }),
+    );
+    memberFindUniqueMock.mockResolvedValue({ role: "member" });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Nope" }),
+    });
+
+    expect(response.status).toBe(403);
+    const text = await response.text();
+    expect(text).toMatch(/organization owner or admin/i);
+    expect(text).not.toMatch(/creator/i);
+    expect(roomUpdateMock).not.toHaveBeenCalled();
+    expect(userMemberDeleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a creator who is only a plain member from PATCH settings", async () => {
+    roomFindFirstMock.mockResolvedValueOnce(channelRoom());
+    memberFindUniqueMock.mockResolvedValue({ role: "member" });
 
     const app = createApp(userAuthContext);
     const response = await app.request(`/${ROOM_ID}`, {
@@ -199,55 +244,21 @@ describe("PATCH /chats/rooms/{id}", () => {
       }),
     });
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.name).toBe("Ship Room");
-    expect(body.data.slug).toBe("ship-room");
-    expect(body.data.topic).toBe("Go live checklist");
-    expect(roomUpdateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: ROOM_ID },
-        data: {
-          name: "Ship Room",
-          slug: "ship-room",
-          topic: "Go live checklist",
-        },
-      }),
-    );
+    expect(response.status).toBe(403);
+    expect(roomUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("updates channel discoverability when the caller can manage the room", async () => {
-    const existing = channelRoom({ discoverability: "private" });
-    const updated = channelRoom({ discoverability: "public" });
-    roomFindFirstMock.mockResolvedValueOnce(existing);
-    roomUpdateMock.mockResolvedValueOnce(updated);
-
-    const app = createApp(userAuthContext);
-    const response = await app.request(`/${ROOM_ID}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        discoverability: "public",
-      }),
+  it("updates channel settings when the caller is an organization admin", async () => {
+    const existing = channelRoom({
+      createdByUserId: OTHER_USER_ID,
+      discoverability: "private",
     });
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.discoverability).toBe("public");
-    expect(roomUpdateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: ROOM_ID },
-        data: { discoverability: "public" },
-      }),
-    );
-  });
-
-  it("allows an organization admin who is not the creator to update", async () => {
-    const existing = channelRoom({ createdByUserId: OTHER_USER_ID });
     const updated = channelRoom({
       createdByUserId: OTHER_USER_ID,
-      name: "Ops",
-      slug: "ops",
+      name: "Ship Room",
+      slug: "ship-room",
+      topic: "Go live checklist",
+      discoverability: "public",
     });
     roomFindFirstMock.mockResolvedValueOnce(existing);
     memberFindUniqueMock.mockResolvedValue({ role: "admin" });
@@ -257,11 +268,28 @@ describe("PATCH /chats/rooms/{id}", () => {
     const response = await app.request(`/${ROOM_ID}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name: "Ops" }),
+      body: JSON.stringify({
+        name: "Ship Room",
+        topic: "Go live checklist",
+        discoverability: "public",
+      }),
     });
 
     expect(response.status).toBe(200);
-    expect(roomUpdateMock).toHaveBeenCalled();
+    const body = await response.json();
+    expect(body.data.name).toBe("Ship Room");
+    expect(body.data.discoverability).toBe("public");
+    expect(roomUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: ROOM_ID },
+        data: {
+          name: "Ship Room",
+          slug: "ship-room",
+          topic: "Go live checklist",
+          discoverability: "public",
+        },
+      }),
+    );
   });
 
   it("rejects direct room edits with 400", async () => {
@@ -276,26 +304,6 @@ describe("PATCH /chats/rooms/{id}", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("Direct rooms cannot be edited.");
-    expect(roomUpdateMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-creator members with 403", async () => {
-    roomFindFirstMock.mockResolvedValueOnce(
-      channelRoom({ createdByUserId: OTHER_USER_ID }),
-    );
-    memberFindUniqueMock.mockResolvedValue({ role: "member" });
-
-    const app = createApp(userAuthContext);
-    const response = await app.request(`/${ROOM_ID}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name: "Nope" }),
-    });
-
-    expect(response.status).toBe(403);
-    expect(await response.text()).toContain(
-      "Only the room creator or an organization owner or admin can update this room.",
-    );
     expect(roomUpdateMock).not.toHaveBeenCalled();
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
@@ -1,7 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { MemberRole } from "@sokosumi/database";
 
-import { badRequest, conflict, forbidden } from "@/helpers/error";
+import { badRequest, conflict } from "@/helpers/error";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
 import { resolveMemberOrganizationById } from "@/helpers/organization";
 import { isSlugUniqueConstraintError } from "@/helpers/prisma";
@@ -18,6 +17,7 @@ import {
 } from "@/schemas/chat-room.schema";
 
 import {
+  assertChatRoomPatchAuth,
   buildUniqueRoomSlug,
   chatRoomInclude,
   mapChatRoomWithSidebarFlags,
@@ -94,24 +94,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         }
         const organizationId = existing.organizationId;
 
-        // Membership alone only proves the caller can read the room. Editing
-        // rewrites the whole roster, so a plain member could otherwise evict
-        // everyone else from a room they merely belong to.
+        // Membership proves the caller can read the room. Settings (name/topic/
+        // discoverability) need OWNER/ADMIN; roster rewrite is open to any
+        // active channel member. Assert before any writes.
         const { role } = await resolveMemberOrganizationById({
           id: organizationId,
           userId: userContext.userId,
           tx,
         });
-        const canManageRoom =
-          existing.createdByUserId === userContext.userId ||
-          role === MemberRole.OWNER ||
-          role === MemberRole.ADMIN;
-
-        if (!canManageRoom) {
-          throw forbidden(
-            "Only the room creator or an organization owner or admin can update this room.",
-          );
-        }
+        assertChatRoomPatchAuth({ role, body });
 
         const updateData: {
           name?: string;

--- a/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.test.ts
@@ -119,34 +119,24 @@ beforeEach(() => {
 });
 
 describe("POST /chats/rooms/{id}/restore", () => {
-  it("clears archivedAt and returns the live room for the creator", async () => {
-    const archived = archivedRoom();
-    const live = { ...archived, archivedAt: null };
-    roomFindFirstMock
-      .mockResolvedValueOnce(archived)
-      .mockResolvedValueOnce(live);
+  it("rejects a creator who is only a plain member", async () => {
+    roomFindFirstMock.mockResolvedValue(archivedRoom());
+    memberFindUniqueMock.mockResolvedValue({ role: "member" });
 
     const response = await restore();
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.id).toBe(ROOM_ID);
-    expect(body.data.name).toBe("general");
-    expect(body.data.slug).toBe("general");
-
-    const sqlParts = queryRawMock.mock.calls[0]?.[0] as TemplateStringsArray;
-    expect(sqlParts.join(" ")).toContain("FOR UPDATE");
-    expect(roomUpdateManyMock).toHaveBeenCalledWith({
-      where: { id: ROOM_ID, archivedAt: { not: null } },
-      data: { archivedAt: null },
-    });
+    expect(response.status).toBe(403);
+    const text = await response.text();
+    expect(text).toMatch(/organization owner or admin/i);
+    expect(text).not.toMatch(/creator/i);
+    expect(roomUpdateManyMock).not.toHaveBeenCalled();
   });
 
   it.each([
     ["admin", MemberRole.ADMIN],
     ["owner", MemberRole.OWNER],
   ])(
-    "lets an organization %s restore a room they did not create",
+    "lets an organization %s restore a room and returns the live room",
     async (_label, role) => {
       const archived = archivedRoom({ createdByUserId: OTHER_ID });
       roomFindFirstMock
@@ -154,11 +144,24 @@ describe("POST /chats/rooms/{id}/restore", () => {
         .mockResolvedValueOnce({ ...archived, archivedAt: null });
       memberFindUniqueMock.mockResolvedValue({ role });
 
-      expect((await restore()).status).toBe(200);
+      const response = await restore();
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data.id).toBe(ROOM_ID);
+      expect(body.data.name).toBe("general");
+      expect(body.data.slug).toBe("general");
+
+      const sqlParts = queryRawMock.mock.calls[0]?.[0] as TemplateStringsArray;
+      expect(sqlParts.join(" ")).toContain("FOR UPDATE");
+      expect(roomUpdateManyMock).toHaveBeenCalledWith({
+        where: { id: ROOM_ID, archivedAt: { not: null } },
+        data: { archivedAt: null },
+      });
     },
   );
 
-  it("rejects a plain member who is not the creator", async () => {
+  it("rejects a plain member who is not elevated", async () => {
     roomFindFirstMock.mockResolvedValue(
       archivedRoom({ createdByUserId: OTHER_ID, memberIds: [SELF_ID] }),
     );
@@ -191,6 +194,7 @@ describe("POST /chats/rooms/{id}/restore", () => {
 
   it("400s when a concurrent restore already cleared archivedAt", async () => {
     roomFindFirstMock.mockResolvedValue(archivedRoom());
+    memberFindUniqueMock.mockResolvedValue({ role: MemberRole.OWNER });
     roomUpdateManyMock.mockResolvedValue({ count: 0 });
 
     expect((await restore()).status).toBe(400);

--- a/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/restore/post.ts
@@ -34,7 +34,7 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/{id}/restore",
     description:
-      "Restore a soft-archived organization chat room. Clears archivedAt so the room reappears for remaining members while keeping its existing slug. Only the room creator or an organization owner/admin may restore. Direct rooms cannot be restored because they cannot be archived.",
+      "Restore a soft-archived organization chat room. Clears archivedAt so the room reappears for remaining members while keeping its existing slug. Only an organization owner/admin may restore. Direct rooms cannot be restored because they cannot be archived.",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
@@ -87,15 +87,9 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         userId: userContext.userId,
         tx,
       });
-      if (
-        !canManageChatRoomLifecycle({
-          createdByUserId: existing.createdByUserId,
-          userId: userContext.userId,
-          role,
-        })
-      ) {
+      if (!canManageChatRoomLifecycle({ role })) {
         throw forbidden(
-          "Only the room creator or an organization owner or admin can restore this room.",
+          "Only an organization owner or admin can restore this room.",
         );
       }
 

--- a/apps/core/src/routes/v1/chats/rooms/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.test.ts
@@ -105,28 +105,15 @@ describe("GET /chats/rooms", () => {
     expect(roomCountMock).toHaveBeenCalledOnce();
   });
 
-  it("lists archived rooms the plain member created", async () => {
+  it("returns an empty archived list for a plain member (no creator filter)", async () => {
     const response = await createApp(ORG_ID).request("/?status=archived");
 
     expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual([]);
     expect(prismaTransactionMock).not.toHaveBeenCalled();
-    expect(roomFindManyMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          archivedAt: { not: null },
-          organizationId: ORG_ID,
-          createdByUserId: USER_ID,
-          userMembers: { some: { userId: USER_ID } },
-        }),
-      }),
-    );
-    expect(roomCountMock).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        archivedAt: { not: null },
-        createdByUserId: USER_ID,
-        organizationId: ORG_ID,
-      }),
-    });
+    expect(roomFindManyMock).not.toHaveBeenCalled();
+    expect(roomCountMock).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/core/src/routes/v1/chats/rooms/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/get.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { MemberRole } from "@sokosumi/database";
 
 import { LIMITS } from "@/config/constants";
 import {
@@ -31,6 +30,7 @@ import {
   getChatRoomSidebarFlags,
   getChatRoomUnreadCounts,
   getChatRoomUnreadMentionCounts,
+  isOrganizationOwnerOrAdmin,
   mapChatRoom,
 } from "./helpers";
 
@@ -50,7 +50,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
   status: chatRoomListStatusSchema.default("active").openapi({
     param: { name: "status", in: "query" },
     description:
-      "Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (creator, or org owner/admin, and still a member).",
+      "Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (organization owner/admin, and still a member).",
     example: "active",
   }),
   limit: z.coerce
@@ -71,7 +71,7 @@ const route = withGlobalHeaderParameters(
     method: "get",
     path: "/",
     description:
-      "List chat rooms visible to the current user for the active organization only. With no active organization, lists personal coworker directs (`organizationId` null). Pass `status=archived` to list soft-archived membership rooms the caller may restore (creator or organization owner/admin).",
+      "List chat rooms visible to the current user for the active organization only. With no active organization, lists personal coworker directs (`organizationId` null). Pass `status=archived` to list soft-archived membership rooms the caller may restore (organization owner/admin).",
     tags: ["Chat Rooms"],
     request: {
       query: querySchema,
@@ -118,9 +118,13 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     // with no org cannot match anything — return an empty page instead of
     // silently overriding the filter to directs. Archived rooms are always
     // org channels, so personal workspace returns empty for status=archived.
+    // Archived list is OWNER/ADMIN only (same gate as restore).
+    const canManageAnyArchived =
+      organizationRole != null && isOrganizationOwnerOrAdmin(organizationRole);
     if (
       (!organizationId && kind === "channel") ||
-      (!organizationId && status === "archived")
+      (!organizationId && status === "archived") ||
+      (status === "archived" && !canManageAnyArchived)
     ) {
       return ok(
         c,
@@ -129,25 +133,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       );
     }
 
-    // Archived list is for restore: same gate as archive/restore endpoints.
-    // Owners/admins see every archived room they still belong to; everyone
-    // else only rooms they created. Keep the filter in SQL so cursor pages
-    // and counts stay honest.
-    const canManageAnyArchived =
-      organizationRole === MemberRole.OWNER ||
-      organizationRole === MemberRole.ADMIN;
-    const archivedLifecycleWhere =
-      status === "archived" && !canManageAnyArchived
-        ? { createdByUserId: userContext.userId }
-        : {};
-
     const where = {
       archivedAt: status === "archived" ? { not: null } : null,
       ...(kind ? { kind } : {}),
       userMembers: {
         some: { userId: userContext.userId },
       },
-      ...archivedLifecycleWhere,
       ...(organizationId
         ? { organizationId }
         : {

--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -2,6 +2,7 @@ import { MemberRole, NotificationKind } from "@sokosumi/database";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  assertChatRoomPatchAuth,
   buildDirectCoworkerRoomKey,
   buildDirectParticipantRoomKey,
   buildDirectRoomKey,
@@ -215,43 +216,15 @@ describe("buildDirectRoomName", () => {
 });
 
 describe("canManageChatRoomLifecycle", () => {
-  const creatorId = "user_creator";
-  const otherId = "user_other";
-
-  it("allows the channel creator regardless of org role", () => {
-    expect(
-      canManageChatRoomLifecycle({
-        createdByUserId: creatorId,
-        userId: creatorId,
-        role: MemberRole.MEMBER,
-      }),
-    ).toBe(true);
-  });
-
   it.each([
     ["owner", MemberRole.OWNER],
     ["admin", MemberRole.ADMIN],
-  ] as const)(
-    "allows an organization %s who is not the creator",
-    (_label, role) => {
-      expect(
-        canManageChatRoomLifecycle({
-          createdByUserId: creatorId,
-          userId: otherId,
-          role,
-        }),
-      ).toBe(true);
-    },
-  );
+  ] as const)("allows an organization %s", (_label, role) => {
+    expect(canManageChatRoomLifecycle({ role })).toBe(true);
+  });
 
-  it("denies a plain member who did not create the room", () => {
-    expect(
-      canManageChatRoomLifecycle({
-        createdByUserId: creatorId,
-        userId: otherId,
-        role: MemberRole.MEMBER,
-      }),
-    ).toBe(false);
+  it("denies a creator who is only a plain member", () => {
+    expect(canManageChatRoomLifecycle({ role: MemberRole.MEMBER })).toBe(false);
   });
 });
 
@@ -267,6 +240,39 @@ describe("canPermanentlyDeleteChatRoom", () => {
     expect(canPermanentlyDeleteChatRoom({ role: MemberRole.MEMBER })).toBe(
       false,
     );
+  });
+});
+
+describe("assertChatRoomPatchAuth", () => {
+  it("allows a plain member to PATCH roster-only", () => {
+    expect(() =>
+      assertChatRoomPatchAuth({
+        role: MemberRole.MEMBER,
+        body: { memberUserIds: ["user_a"], coworkerIds: [] },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a plain member PATCH that touches settings", () => {
+    expect(() =>
+      assertChatRoomPatchAuth({
+        role: MemberRole.MEMBER,
+        body: { name: "Nope" },
+      }),
+    ).toThrow(/organization owner or admin/i);
+  });
+
+  it("allows an organization admin to PATCH settings and roster", () => {
+    expect(() =>
+      assertChatRoomPatchAuth({
+        role: MemberRole.ADMIN,
+        body: {
+          name: "Ops",
+          memberUserIds: ["user_a"],
+          coworkerIds: [],
+        },
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -5,7 +5,7 @@ import {
   CHAT_PRESENCE_ONLINE_WINDOW_MS,
 } from "@sokosumi/utils";
 
-import { badRequest, notFound } from "@/helpers/error";
+import { badRequest, forbidden, notFound } from "@/helpers/error";
 import { resolveMemberOrganizationById } from "@/helpers/organization";
 import {
   type ChatRoomMessageQuote,
@@ -721,31 +721,77 @@ export async function buildUniqueRoomSlug(
 }
 
 /**
- * Archive and restore hide or resurface a room for everyone, so only the
- * creator or an organization owner/admin may do either. Plain members leave
- * instead (or ask someone elevated to archive).
+ * Organization owner/admin elevation for channel lifecycle and settings.
+ * Room creator is provenance only — never authorizes.
+ */
+export function isOrganizationOwnerOrAdmin(role: string): boolean {
+  return role === MemberRole.OWNER || role === MemberRole.ADMIN;
+}
+
+/**
+ * Archive and restore hide or resurface a room for everyone, so only an
+ * organization owner/admin may do either. Plain members leave instead (or ask
+ * someone elevated to archive).
  */
 export function canManageChatRoomLifecycle(options: {
-  createdByUserId: string;
-  userId: string;
   /** Organization membership role from Prisma (`string`); compare to `MemberRole`. */
   role: string;
 }): boolean {
-  return (
-    options.createdByUserId === options.userId ||
-    options.role === MemberRole.OWNER ||
-    options.role === MemberRole.ADMIN
-  );
+  return isOrganizationOwnerOrAdmin(options.role);
 }
 
 /**
  * Permanent delete removes the room and cascaded children for everyone.
- * Organization owner/admin only — room creator membership is not enough.
+ * Same elevation as archive/restore — organization owner/admin only.
  */
 export function canPermanentlyDeleteChatRoom(options: {
   role: string;
 }): boolean {
-  return options.role === MemberRole.OWNER || options.role === MemberRole.ADMIN;
+  return canManageChatRoomLifecycle(options);
+}
+
+export function chatRoomPatchTouchesSettings(body: {
+  name?: unknown;
+  topic?: unknown;
+  discoverability?: unknown;
+}): boolean {
+  return (
+    body.name !== undefined ||
+    body.topic !== undefined ||
+    body.discoverability !== undefined
+  );
+}
+
+export function chatRoomPatchTouchesRoster(body: {
+  memberUserIds?: unknown;
+  coworkerIds?: unknown;
+}): boolean {
+  return body.memberUserIds !== undefined || body.coworkerIds !== undefined;
+}
+
+/**
+ * Split PATCH gates: settings (name/topic/discoverability) need OWNER/ADMIN;
+ * roster rewrite is allowed for any active channel member (membership already
+ * proven by the access helper). Fail settings before any writes.
+ */
+export function assertChatRoomPatchAuth(options: {
+  role: string;
+  body: {
+    name?: unknown;
+    topic?: unknown;
+    discoverability?: unknown;
+    memberUserIds?: unknown;
+    coworkerIds?: unknown;
+  };
+}): void {
+  if (
+    chatRoomPatchTouchesSettings(options.body) &&
+    !isOrganizationOwnerOrAdmin(options.role)
+  ) {
+    throw forbidden(
+      "Only an organization owner or admin can update channel settings.",
+    );
+  }
 }
 
 export async function requireChatRoomUserAccess(

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -384,7 +384,7 @@ export const leftChatRoomSchema = z
     }),
     remainingUserMemberCount: z.number().int().min(1).openapi({
       description:
-        "Human members left in the room after the caller leaves. Always at least one: the final member cannot leave; the channel creator or an organization owner/admin must archive instead.",
+        "Human members left in the room after the caller leaves. Always at least one: the final member cannot leave; an organization owner/admin must archive instead.",
       example: 3,
     }),
   })

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -47,15 +47,21 @@ export function EditChannelDialog({
   channel,
   members,
   coworkers,
-  canManage,
+  canEditMembers,
+  canManageSettings,
+  canArchive,
   canLeave,
   membersLoadFailed = false,
 }: {
   channel: ChatRoom;
   members: Member[];
   coworkers: Coworker[];
-  /** Creator or organization owner/admin — manage name/topic/members/archive. */
-  canManage: boolean;
+  /** Any active channel member may rewrite the roster. */
+  canEditMembers: boolean;
+  /** Organization owner/admin — name/topic/discoverability. */
+  canManageSettings: boolean;
+  /** Organization owner/admin — archive the channel. */
+  canArchive: boolean;
   /** Any member can leave, except the last one: an empty roster could not be
    * archived by a remaining elevated member. */
   canLeave: boolean;
@@ -82,6 +88,8 @@ export function EditChannelDialog({
   );
   const [isPending, startTransition] = useTransition();
 
+  const canSubmit = canEditMembers || canManageSettings;
+
   useEffect(() => {
     if (!open) return;
     setName(channel.name);
@@ -95,15 +103,24 @@ export function EditChannelDialog({
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!canManage) return;
+    if (!canSubmit) return;
     startTransition(async () => {
-      const result = await updateRoomAction(channel.id, {
-        name,
-        topic,
-        discoverability,
-        memberUserIds: memberIds,
-        coworkerIds,
-      });
+      // Roster-only body when the caller cannot change settings (R3).
+      const result = await updateRoomAction(
+        channel.id,
+        canManageSettings
+          ? {
+              name,
+              topic,
+              discoverability,
+              memberUserIds: memberIds,
+              coworkerIds,
+            }
+          : {
+              memberUserIds: memberIds,
+              coworkerIds,
+            },
+      );
       if (!result.ok) {
         toast.error(result.message);
         return;
@@ -178,79 +195,90 @@ export function EditChannelDialog({
                 {t("Dialog.editDescription")}
               </DialogDescription>
             </DialogHeader>
-            {canManage ? (
+            {canManageSettings || canEditMembers ? (
               <div className="grid gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="edit-channel-name">{t("Dialog.name")}</Label>
-                  <Input
-                    id="edit-channel-name"
-                    value={name}
-                    onChange={(event) => setName(event.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="edit-channel-topic">
-                    {t("Dialog.topic")}
-                  </Label>
-                  <Textarea
-                    id="edit-channel-topic"
-                    value={topic}
-                    onChange={(event) => setTopic(event.target.value)}
-                    rows={3}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>{t("Visibility.label")}</Label>
-                  <RadioGroup
-                    value={discoverability}
-                    onValueChange={(value) => {
-                      if (value === "public" || value === "private") {
-                        setDiscoverability(value);
-                      }
-                    }}
-                    className="flex flex-wrap gap-4"
-                  >
-                    <div className="flex items-center gap-2">
-                      <RadioGroupItem value="public" id="edit-channel-public" />
-                      <Label
-                        htmlFor="edit-channel-public"
-                        className="cursor-pointer font-normal"
-                      >
-                        {t("Visibility.public")}
+                {canManageSettings ? (
+                  <>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-channel-name">
+                        {t("Dialog.name")}
                       </Label>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <RadioGroupItem
-                        value="private"
-                        id="edit-channel-private"
+                      <Input
+                        id="edit-channel-name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        required
                       />
-                      <Label
-                        htmlFor="edit-channel-private"
-                        className="cursor-pointer font-normal"
-                      >
-                        {t("Visibility.private")}
-                      </Label>
                     </div>
-                  </RadioGroup>
-                  <p className="text-muted-foreground text-xs">
-                    {discoverability === "public"
-                      ? t("Visibility.publicHelp")
-                      : t("Visibility.privateHelp")}
-                  </p>
-                </div>
-                <ParticipantCheckboxes
-                  members={members}
-                  coworkers={coworkers}
-                  memberIds={memberIds}
-                  coworkerIds={coworkerIds}
-                  onMemberIdsChange={setMemberIds}
-                  onCoworkerIdsChange={setCoworkerIds}
-                  membersLoadFailed={membersLoadFailed}
-                />
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-channel-topic">
+                        {t("Dialog.topic")}
+                      </Label>
+                      <Textarea
+                        id="edit-channel-topic"
+                        value={topic}
+                        onChange={(event) => setTopic(event.target.value)}
+                        rows={3}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>{t("Visibility.label")}</Label>
+                      <RadioGroup
+                        value={discoverability}
+                        onValueChange={(value) => {
+                          if (value === "public" || value === "private") {
+                            setDiscoverability(value);
+                          }
+                        }}
+                        className="flex flex-wrap gap-4"
+                      >
+                        <div className="flex items-center gap-2">
+                          <RadioGroupItem
+                            value="public"
+                            id="edit-channel-public"
+                          />
+                          <Label
+                            htmlFor="edit-channel-public"
+                            className="cursor-pointer font-normal"
+                          >
+                            {t("Visibility.public")}
+                          </Label>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <RadioGroupItem
+                            value="private"
+                            id="edit-channel-private"
+                          />
+                          <Label
+                            htmlFor="edit-channel-private"
+                            className="cursor-pointer font-normal"
+                          >
+                            {t("Visibility.private")}
+                          </Label>
+                        </div>
+                      </RadioGroup>
+                      <p className="text-muted-foreground text-xs">
+                        {discoverability === "public"
+                          ? t("Visibility.publicHelp")
+                          : t("Visibility.privateHelp")}
+                      </p>
+                    </div>
+                  </>
+                ) : null}
+                {canEditMembers ? (
+                  <ParticipantCheckboxes
+                    members={members}
+                    coworkers={coworkers}
+                    memberIds={memberIds}
+                    coworkerIds={coworkerIds}
+                    onMemberIdsChange={setMemberIds}
+                    onCoworkerIdsChange={setCoworkerIds}
+                    membersLoadFailed={membersLoadFailed}
+                  />
+                ) : null}
               </div>
             ) : null}
-            {canManage || canLeave ? (
+            {canArchive || canLeave ? (
               <div className="space-y-3 border-t pt-4">
                 <p className="text-sm font-medium">
                   {tActions("sectionTitle")}
@@ -267,7 +295,7 @@ export function EditChannelDialog({
                       {tActions("leave")}
                     </Button>
                   ) : null}
-                  {canManage ? (
+                  {canArchive ? (
                     <Button
                       type="button"
                       variant="outline"
@@ -289,7 +317,7 @@ export function EditChannelDialog({
               >
                 {t("Dialog.cancel")}
               </Button>
-              {canManage ? (
+              {canSubmit ? (
                 <Button type="submit" variant="primary" disabled={isPending}>
                   {isPending ? (
                     <Loader2 className="size-4 animate-spin" />

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -325,16 +325,17 @@ export function RoomsClient({
   const currentMemberRole = organizationMembers.find(
     (member) => member.user.id === currentUserId,
   )?.role;
-  // Archiving hides the room for everyone: creator or org owner/admin only.
-  const canArchiveSelectedRoom = Boolean(
-    selectedRoom &&
-      !isDirectRoom &&
-      (selectedRoom.createdByUserId === currentUserId ||
-        currentMemberRole === "owner" ||
-        currentMemberRole === "admin"),
+  const isOrgOwnerOrAdmin =
+    currentMemberRole === "owner" || currentMemberRole === "admin";
+  // Any active channel member may rewrite the roster.
+  const canEditSelectedRoomMembers = Boolean(selectedRoom && !isDirectRoom);
+  // Name/topic/discoverability and archive: organization owner/admin only.
+  const canManageSelectedRoomSettings = Boolean(
+    selectedRoom && !isDirectRoom && isOrgOwnerOrAdmin,
   );
+  const canArchiveSelectedRoom = canManageSelectedRoomSettings;
   // Any member can leave, but not the last one — an empty roster could not be
-  // archived (archive requires membership of creator/owner/admin).
+  // archived (archive requires membership of an org owner/admin).
   const canLeaveSelectedRoom = Boolean(
     selectedRoom && !isDirectRoom && selectedRoom.userMembers.length > 1,
   );
@@ -1369,7 +1370,9 @@ export function RoomsClient({
                       channel={selectedRoom}
                       members={organizationMembers}
                       coworkers={coworkers}
-                      canManage={canArchiveSelectedRoom}
+                      canEditMembers={canEditSelectedRoomMembers}
+                      canManageSettings={canManageSelectedRoomSettings}
+                      canArchive={canArchiveSelectedRoom}
                       canLeave={canLeaveSelectedRoom}
                       membersLoadFailed={membersLoadFailed}
                     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-707](https://linear.app/masumi/issue/SOK-707/any-channel-member-can-add-org-members-drop-creator)

## Summary
- Any active channel member may rewrite `memberUserIds` / `coworkerIds` on channel PATCH.
- Name, topic, and discoverability require organization owner/admin only (no creator elevation).
- Archive and restore require owner/admin only; same elevation family as permanent delete.
- Archived room list is owner/admin-only; `createdByUserId` remains audit/provenance.
- Web Edit Channel dialog splits `canEditMembers` vs `canManageSettings` / archive.

## Verification
- `pnpm --filter core check` / `pnpm core:test` / `pnpm web:check` / `pnpm web:test` (exit 0)
- CI green at `847b6aaee36633024057dd85f9bfcad9ab48d9dd`
- UI: bob (org member, not creator) edit dialog shows roster + Save, no name/topic/archive; alice (owner) shows settings + Archive; bob added Elena coworker

### Review notes - medium (human review)
- `chatRoomPatchTouchesRoster` exported but unused (settings gate only needs the settings touch helper).
- Some OpenAPI/DTO prose may still mention creator for archived list semantics; runtime auth no longer uses creator.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-707](https://linear.app/masumi/issue/SOK-707/any-channel-member-can-add-org-members-drop-creator-elevation)

<div><a href="https://cursor.com/agents/bc-3ffc4497-d7ef-4711-b7cc-ded27efd65bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ffc4497-d7ef-4711-b7cc-ded27efd65bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

