### PR TITLE
fix(chat): keep thread stick-to-bottom after send and content growth

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-stick-to-bottom.test.tsx
@@ -79,22 +79,35 @@ vi.mock("../room-session-composer", () => ({
   RoomSessionComposer: ({
     ref,
     onChromeResize,
+    onSend,
   }: {
     ref?: Ref<RoomComposerHandle>;
     onChromeResize?: () => void;
+    onSend?: () => Promise<{ ok: boolean }>;
   }) => {
     useImperativeHandle(ref, () => ({
       attachFiles: () => undefined,
       focus: () => undefined,
     }));
     return (
-      <button
-        type="button"
-        data-testid="chrome-resize"
-        onClick={onChromeResize}
-      >
-        chrome-resize
-      </button>
+      <>
+        <button
+          type="button"
+          data-testid="chrome-resize"
+          onClick={onChromeResize}
+        >
+          chrome-resize
+        </button>
+        <button
+          type="button"
+          data-testid="send-reply"
+          onClick={() => {
+            void onSend?.();
+          }}
+        >
+          send-reply
+        </button>
+      </>
     );
   },
 }));
@@ -216,6 +229,15 @@ describe("ThreadPanel stick-to-bottom", () => {
     setScrollerMetrics(scroller, {
       scrollHeight: 1000,
       clientHeight: 400,
+      scrollTop: 600,
+    });
+    act(() => {
+      fireResize();
+    });
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
       scrollTop: 200,
     });
     act(() => {
@@ -252,5 +274,31 @@ describe("ThreadPanel stick-to-bottom", () => {
     });
 
     expect(scroller.scrollTop).toBe(50);
+  });
+
+  it("re-pins to bottom after a successful send even when previously unpinned", async () => {
+    renderThreadPanel();
+    const scroller = screen.getByTestId("thread-scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 50,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1300,
+      clientHeight: 400,
+      scrollTop: 50,
+    });
+
+    await act(async () => {
+      screen.getByTestId("send-reply").click();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    expect(scroller.scrollTop).toBe(1300);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -105,10 +105,15 @@ export function ThreadPanel({
 }) {
   const t = useTranslations("App.Channels");
   const threadComposerRef = useRef<RoomComposerHandle | null>(null);
-  const { scrollerRef, contentRef, contentMinHeight, scrollToBottomIfPinned } =
-    useStickToBottom({
-      resetKey: parentMessage.id,
-    });
+  const {
+    scrollerRef,
+    contentRef,
+    contentMinHeight,
+    scrollToBottom,
+    scrollToBottomIfPinned,
+  } = useStickToBottom({
+    resetKey: parentMessage.id,
+  });
 
   useMountEffect(() => {
     requestAnimationFrame(() => {
@@ -121,6 +126,21 @@ export function ThreadPanel({
     requestAnimationFrame(() => {
       threadComposerRef.current?.focus();
     });
+  }
+
+  async function handleSendReply(
+    request: RoomSessionSendRequest,
+  ): Promise<RoomSessionSendResult> {
+    const result = await onSendReply(request);
+    if (result.ok) {
+      // Own send always reveals the new reply, even if typing/composer resize
+      // cleared the sticky flag. Re-pin so ResizeObserver follows late layout.
+      scrollToBottom();
+      requestAnimationFrame(() => {
+        scrollToBottom();
+      });
+    }
+    return result;
   }
 
   function editPropsFor(messageId: string) {
@@ -277,7 +297,7 @@ export function ThreadPanel({
           onRestorePendingQuote={onRestorePendingQuote}
           onChromeResize={scrollToBottomIfPinned}
           onBeforeSend={onBeforeSendReply}
-          onSend={onSendReply}
+          onSend={handleSendReply}
         />
       </RoomFileDropZone>
     </aside>

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -119,7 +119,15 @@ describe("useStickToBottom", () => {
     setScrollerMetrics(scroller, {
       scrollHeight: 1000,
       clientHeight: 400,
-      // distance = 400 >= NEAR
+      scrollTop: 600,
+    });
+    act(() => {
+      fireResize();
+    });
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
       scrollTop: 200,
     });
     act(() => {
@@ -238,7 +246,7 @@ describe("useStickToBottom", () => {
       scrollTop: 600,
     });
     act(() => {
-      scroller.dispatchEvent(new Event("scroll"));
+      fireResize();
     });
 
     const growth = STICK_TO_BOTTOM_NEAR_PX + 50;

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -224,4 +224,43 @@ describe("useStickToBottom", () => {
 
     expect(scroller.scrollTop).toBe(1200);
   });
+
+  it("still pins after growth when a scroll event unpins before ResizeObserver runs", () => {
+    // Real browsers clamp scrollTop to scrollHeight - clientHeight. Content
+    // growth leaves scrollTop put, distance jumps, and a scroll event can clear
+    // the sticky flag before ResizeObserver runs. Hook must recover.
+    render(<Harness resetKey="room-1" />);
+    const scroller = screen.getByTestId("scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      // clamped bottom (not jsdom's unclamped scrollHeight assignment)
+      scrollTop: 600,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    const growth = STICK_TO_BOTTOM_NEAR_PX + 50;
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000 + growth,
+      clientHeight: 400,
+      scrollTop: 600,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    // Sticky flag cleared: chrome pin-scroll no-ops.
+    act(() => {
+      screen.getByRole("button", { name: "pin-scroll" }).click();
+    });
+    expect(scroller.scrollTop).toBe(600);
+
+    act(() => {
+      fireResize();
+    });
+
+    expect(scroller.scrollTop).toBe(1000 + growth);
+  });
 });

--- a/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
@@ -14,6 +14,10 @@ interface UseStickToBottomOptions {
   nearBottomPx?: number;
 }
 
+function distanceFromBottom(el: HTMLElement): number {
+  return el.scrollHeight - el.scrollTop - el.clientHeight;
+}
+
 export function useStickToBottom({
   resetKey = null,
   nearBottomPx = STICK_TO_BOTTOM_NEAR_PX,
@@ -23,6 +27,9 @@ export function useStickToBottom({
   // Sticky flag measured on scroll *before* growth. Measuring after a
   // ResizeObserver jump can make a pinned user look scrolled-up for a frame.
   const stickToBottomRef = useRef(true);
+  // Last observed scroller scrollHeight so ResizeObserver can recover when a
+  // growth-driven scroll event clears the sticky flag mid-frame.
+  const lastScrollHeightRef = useRef(0);
   // Pixel min-height so short transcripts can justify-end inside Radix's
   // display:table viewport wrapper (percentage min-height does not resolve).
   const [contentMinHeight, setContentMinHeight] = useState<number>();
@@ -58,14 +65,33 @@ export function useStickToBottom({
       return;
     }
 
+    lastScrollHeightRef.current = scroller.scrollHeight;
+
     const observer = new ResizeObserver(() => {
+      const previousHeight = lastScrollHeightRef.current;
+      const nextHeight = scroller.scrollHeight;
+      const growth = nextHeight - previousHeight;
+      lastScrollHeightRef.current = nextHeight;
+
       if (stickToBottomRef.current) {
         scroller.scrollTop = scroller.scrollHeight;
+        return;
+      }
+
+      // Content growth can fire `scroll` before this callback. Distance then
+      // looks large and clears the sticky flag even though the user was at the
+      // pre-growth bottom. Recover from that false unpin.
+      if (growth > 0) {
+        const distanceBeforeGrowth = distanceFromBottom(scroller) - growth;
+        if (distanceBeforeGrowth < nearBottomPx) {
+          scroller.scrollTop = scroller.scrollHeight;
+          stickToBottomRef.current = true;
+        }
       }
     });
     observer.observe(content);
     return () => observer.disconnect();
-  }, [resetKey]);
+  }, [nearBottomPx, resetKey]);
 
   useEffect(() => {
     const scroller = scrollerRef.current;
@@ -98,8 +124,7 @@ export function useStickToBottom({
       if (!node) {
         return;
       }
-      const distance = node.scrollHeight - node.scrollTop - node.clientHeight;
-      stickToBottomRef.current = distance < nearBottomPx;
+      stickToBottomRef.current = distanceFromBottom(node) < nearBottomPx;
     }
 
     scroller.addEventListener("scroll", handleScroll, { passive: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Thread panel lost stick-to-bottom after sending a reply (and sometimes when content grew while pinned). User had to scroll manually to see their new message.

## Root cause

Content growth in the thread scroller could fire a `scroll` event that made distance-from-bottom look large, clearing the sticky flag before `ResizeObserver` ran. The observer then no-oped. Composer growth while typing could clear the pin before send as well.

## Fix

- `useStickToBottom`: recover pin when distance *before* growth was still near the bottom.
- `ThreadPanel`: on successful own send, re-pin and scroll to bottom so the new reply is always visible.

## Test plan

- [x] `pnpm --filter web test src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx src/app/(app)/chat/components/__tests__/thread-panel-stick-to-bottom.test.tsx` (11/11 pass)
- [ ] Manual: open a long thread, stay at bottom, send a reply — panel should stay at the new message without manual scroll
- [ ] Manual: scroll up in thread, send should still re-pin for own send (expected by this fix)

## Notes

Main room send does not yet mirror the ThreadPanel send re-pin; shared hook race recovery still covers growth there. Optional follow-up if main room shows the same UX gap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39fa597e-a821-4f0e-8264-71135d299516?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39fa597e-a821-4f0e-8264-71135d299516&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

