### PR TITLE
fix(chat): tighten room message and day-separator spacing

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/day-separator.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/day-separator.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DaySeparator from "../day-separator";
+
+describe("DaySeparator", () => {
+  it("uses tight vertical padding on the outer wrapper", () => {
+    const { container } = render(
+      <DaySeparator
+        date={new Date("2026-07-01T12:00:00.000Z")}
+        formatDaySeparator={(date) => date.toISOString()}
+      />,
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper).toHaveClass("pt-2");
+    expect(wrapper).toHaveClass("pb-1");
+    expect(wrapper).not.toHaveClass("py-4");
+    expect(screen.getByText("2026-07-01T12:00:00.000Z")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -107,6 +107,7 @@ function coworkerMessage(
 function renderRow({
   message = userMessage(),
   isContinuation = false,
+  isFirstOfDay = false,
   onQuote,
   currentUserId,
   onStartEdit,
@@ -120,6 +121,7 @@ function renderRow({
 }: {
   message?: ChatRoomMessage;
   isContinuation?: boolean;
+  isFirstOfDay?: boolean;
   onQuote?: (message: ChatRoomMessage) => void;
   currentUserId?: string;
   onStartEdit?: (message: ChatRoomMessage) => void;
@@ -148,6 +150,7 @@ function renderRow({
       onSaveEdit={onSaveEdit}
       isSavingEdit={isSavingEdit}
       isContinuation={isContinuation}
+      isFirstOfDay={isFirstOfDay}
     />,
   );
 }
@@ -228,9 +231,18 @@ describe("ChatMessageRow", () => {
     renderRow({ isContinuation: false });
 
     const article = screen.getByRole("article");
-    expect(article).toHaveClass("mt-3");
+    expect(article).toHaveClass("mt-2");
     expect(article).toHaveClass("pb-0.5");
     expect(article).not.toHaveClass("py-2.5");
+  });
+
+  it("omits top margin for first message of the day after a day separator", () => {
+    renderRow({ isContinuation: false, isFirstOfDay: true });
+
+    const article = screen.getByRole("article");
+    expect(article).toHaveClass("mt-0");
+    expect(article).not.toHaveClass("mt-2");
+    expect(article).not.toHaveClass("mt-3");
   });
 
   it("exposes message id for quote jump targets", () => {

--- a/apps/web/src/app/(app)/chat/components/day-separator.tsx
+++ b/apps/web/src/app/(app)/chat/components/day-separator.tsx
@@ -10,7 +10,7 @@ export default function DaySeparator({
   formatDaySeparator,
 }: DaySeparatorProps) {
   return (
-    <div className="flex items-center justify-center py-4">
+    <div className="flex items-center justify-center pt-2 pb-1">
       <span className="text-muted-foreground bg-muted-foreground/10 rounded-full px-3 py-1 text-xs font-medium">
         {formatDaySeparator(date)}
       </span>

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1134,6 +1134,7 @@ export function ChatMessageRow({
   showThreadButton = true,
   showQuoteButton = true,
   isContinuation = false,
+  isFirstOfDay = false,
 }: {
   message: ChatRoomMessage;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -1159,6 +1160,8 @@ export function ChatMessageRow({
   showQuoteButton?: boolean;
   /** Slack-style continuation: omit avatar / name / primary timestamp. */
   isContinuation?: boolean;
+  /** First message of a calendar day after a day separator; omit top margin because separator already provides rhythm. */
+  isFirstOfDay?: boolean;
 }) {
   const tChat = useTranslations("App.Chat.Chat");
   const tChannels = useTranslations("App.Channels");
@@ -1219,7 +1222,11 @@ export function ChatMessageRow({
       className={cn(
         "group relative -mx-2 flex gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
-        isContinuation ? "min-h-0 py-0.5" : "mt-3 min-h-0 pt-1 pb-0.5",
+        isContinuation
+          ? "min-h-0 py-0.5"
+          : isFirstOfDay
+            ? "mt-0 min-h-0 pt-1 pb-0.5"
+            : "mt-2 min-h-0 pt-1 pb-0.5",
       )}
       {...(showActions ? longPress : {})}
     >

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1484,6 +1484,7 @@ export function RoomsClient({
                             room: selectedRoom,
                             isStreamOverlay,
                           })}
+                          isFirstOfDay={showDaySeparator}
                           isContinuation={
                             !showDaySeparator &&
                             isMessageContinuation(previousMessage, message)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Room chat timeline had oversized vertical gaps: day pills used `py-4`, and the first message of each day still applied author-group top margin (`mt-3`), so separator padding and row margin stacked. Same-day author changes also felt loose.

## Change

- Day separator: `py-4` → `pt-2 pb-1` (centered pill unchanged).
- Author-group rows: `mt-3` → `mt-2`.
- First-of-day rows: `isFirstOfDay` omits top margin so the separator alone sets the rhythm.

Date indicator stays centered. Moving it did not clearly improve density over fixing stacked margins.

## Verification

```bash
pnpm --filter web test 'src/app/(app)/chat/components/__tests__/room-message-row.test.tsx' 'src/app/(app)/chat/components/__tests__/day-separator.test.tsx'
```

37 tests passed. CI green on `ea88931d`.

Runtime (seeded `#spacing-verify` as alice): same-day author gap **8px**; day-boundary gap including separator **36px** (was stacked `py-4` + `mt-3`).

![Chat spacing after fix](https://cursor.com/artifacts/c/art-f3d45a9a-829f-40d4-a326-1d4c6d376501)
![Day separators after fix](https://cursor.com/artifacts/c/art-7b682f07-6257-47b1-a7fb-9b451b5eae15)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-841276bc-2f93-4c32-a13e-0f5b1498a0c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-841276bc-2f93-4c32-a13e-0f5b1498a0c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

