### PR TITLE
chore(chat): clean up SOK-707 leftover dead code and docs

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -762,13 +762,6 @@ export function chatRoomPatchTouchesSettings(body: {
   );
 }
 
-export function chatRoomPatchTouchesRoster(body: {
-  memberUserIds?: unknown;
-  coworkerIds?: unknown;
-}): boolean {
-  return body.memberUserIds !== undefined || body.coworkerIds !== undefined;
-}
-
 /**
  * Split PATCH gates: settings (name/topic/discoverability) need OWNER/ADMIN;
  * roster rewrite is allowed for any active channel member (membership already

--- a/apps/web/src/app/(app)/chat/__tests__/action-error-message.test.ts
+++ b/apps/web/src/app/(app)/chat/__tests__/action-error-message.test.ts
@@ -39,7 +39,7 @@ describe("actionErrorMessage", () => {
 
   it("returns CoreApiRequestError permission message for 403", () => {
     const message =
-      "Only the channel creator or an organization owner/admin can update members";
+      "Only an organization owner or admin can update channel settings.";
 
     expect(
       actionErrorMessage(

--- a/apps/web/src/lib/auth/__tests__/handle-unauthorized-core-error.test.ts
+++ b/apps/web/src/lib/auth/__tests__/handle-unauthorized-core-error.test.ts
@@ -56,7 +56,7 @@ describe("isUnauthorizedCoreApiError", () => {
     expect(
       isUnauthorizedCoreApiError(
         new CoreApiRequestError(
-          "Only the channel creator or an organization owner/admin can update members",
+          "Only an organization owner or admin can update channel settings.",
           { status: 403 },
         ),
       ),
@@ -143,7 +143,7 @@ describe("withUnauthorizedCoreRedirect", () => {
 
   it("rethrows business 403 errors without redirecting", async () => {
     const forbidden = new CoreApiRequestError(
-      "Only the channel creator or an organization owner/admin can update members",
+      "Only an organization owner or admin can update channel settings.",
       { status: 403 },
     );
     const client = withUnauthorizedCoreRedirect({

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -4443,7 +4443,7 @@ export const ChatRoomListStatusSchema = {
         'archived'
     ],
     default: 'active',
-    description: 'Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (creator, or org owner/admin, and still a member).',
+    description: 'Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (organization owner/admin, and still a member).',
     example: 'active'
 } as const;
 
@@ -4891,7 +4891,7 @@ export const LeftChatRoomSchema = {
         remainingUserMemberCount: {
             type: 'integer',
             minimum: 1,
-            description: 'Human members left in the room after the caller leaves. Always at least one: the final member cannot leave; the channel creator or an organization owner/admin must archive instead.',
+            description: 'Human members left in the room after the caller leaves. Always at least one: the final member cannot leave; an organization owner/admin must archive instead.',
             example: 3
         }
     },

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -377,7 +377,7 @@ export const getCategories = <ThrowOnError extends boolean = false>(options?: Op
 });
 
 /**
- * List chat rooms visible to the current user for the active organization only. With no active organization, lists personal coworker directs (`organizationId` null). Pass `status=archived` to list soft-archived membership rooms the caller may restore (creator or organization owner/admin).
+ * List chat rooms visible to the current user for the active organization only. With no active organization, lists personal coworker directs (`organizationId` null). Pass `status=archived` to list soft-archived membership rooms the caller may restore (organization owner/admin).
  */
 export const getChatsRooms = <ThrowOnError extends boolean = false>(options?: Options<GetChatsRoomsData, ThrowOnError>): RequestResult<GetChatsRoomsResponses, GetChatsRoomsErrors, ThrowOnError> => (options?.client ?? client).get<GetChatsRoomsResponses, GetChatsRoomsErrors, ThrowOnError>({
     responseTransformer: getChatsRoomsResponseTransformer,
@@ -461,7 +461,7 @@ export const patchChatsRoomsById = <ThrowOnError extends boolean = false>(option
 });
 
 /**
- * Archive an organization chat room. Every read filters on archivedAt, so it disappears for all members while its messages stay in the database. Only the room creator or an organization owner/admin may archive. Direct rooms cannot be archived.
+ * Archive an organization chat room. Every read filters on archivedAt, so it disappears for all members while its messages stay in the database. Only an organization owner/admin may archive. Direct rooms cannot be archived.
  */
 export const postChatsRoomsByIdArchive = <ThrowOnError extends boolean = false>(options: Options<PostChatsRoomsByIdArchiveData, ThrowOnError>): RequestResult<PostChatsRoomsByIdArchiveResponses, PostChatsRoomsByIdArchiveErrors, ThrowOnError> => (options.client ?? client).post<PostChatsRoomsByIdArchiveResponses, PostChatsRoomsByIdArchiveErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsByIdArchiveResponseTransformer,
@@ -470,7 +470,7 @@ export const postChatsRoomsByIdArchive = <ThrowOnError extends boolean = false>(
 });
 
 /**
- * Restore a soft-archived organization chat room. Clears archivedAt so the room reappears for remaining members while keeping its existing slug. Only the room creator or an organization owner/admin may restore. Direct rooms cannot be restored because they cannot be archived.
+ * Restore a soft-archived organization chat room. Clears archivedAt so the room reappears for remaining members while keeping its existing slug. Only an organization owner/admin may restore. Direct rooms cannot be restored because they cannot be archived.
  */
 export const postChatsRoomsByIdRestore = <ThrowOnError extends boolean = false>(options: Options<PostChatsRoomsByIdRestoreData, ThrowOnError>): RequestResult<PostChatsRoomsByIdRestoreResponses, PostChatsRoomsByIdRestoreErrors, ThrowOnError> => (options.client ?? client).post<PostChatsRoomsByIdRestoreResponses, PostChatsRoomsByIdRestoreErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsByIdRestoreResponseTransformer,
@@ -479,7 +479,7 @@ export const postChatsRoomsByIdRestore = <ThrowOnError extends boolean = false>(
 });
 
 /**
- * Leave an organization chat room. Removes only the caller's membership and read marker; the room and its messages are untouched for everyone else. Any member can leave. The last remaining member cannot leave (ask the channel creator or an organization owner/admin to archive instead), and direct rooms cannot be left.
+ * Leave an organization chat room. Removes only the caller's membership and read marker; the room and its messages are untouched for everyone else. Any member can leave. The last remaining member cannot leave (ask an organization owner/admin to archive instead), and direct rooms cannot be left.
  */
 export const deleteChatsRoomsByIdMembersMe = <ThrowOnError extends boolean = false>(options: Options<DeleteChatsRoomsByIdMembersMeData, ThrowOnError>): RequestResult<DeleteChatsRoomsByIdMembersMeResponses, DeleteChatsRoomsByIdMembersMeErrors, ThrowOnError> => (options.client ?? client).delete<DeleteChatsRoomsByIdMembersMeResponses, DeleteChatsRoomsByIdMembersMeErrors, ThrowOnError>({
     responseTransformer: deleteChatsRoomsByIdMembersMeResponseTransformer,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1239,12 +1239,12 @@ export const ChatRoomKind = { CHANNEL: 'channel', DIRECT: 'direct' } as const;
 export type ChatRoomKind = typeof ChatRoomKind[keyof typeof ChatRoomKind];
 
 /**
- * Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (creator, or org owner/admin, and still a member).
+ * Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (organization owner/admin, and still a member).
  */
 export const ChatRoomListStatus = { ACTIVE: 'active', ARCHIVED: 'archived' } as const;
 
 /**
- * Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (creator, or org owner/admin, and still a member).
+ * Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (organization owner/admin, and still a member).
  */
 export type ChatRoomListStatus = typeof ChatRoomListStatus[keyof typeof ChatRoomListStatus];
 
@@ -1351,7 +1351,7 @@ export type ArchivedChatRoom = {
 export type LeftChatRoom = {
     id: string;
     /**
-     * Human members left in the room after the caller leaves. Always at least one: the final member cannot leave; the channel creator or an organization owner/admin must archive instead.
+     * Human members left in the room after the caller leaves. Always at least one: the final member cannot leave; an organization owner/admin must archive instead.
      */
     remainingUserMemberCount: number;
 };
@@ -8825,7 +8825,7 @@ export type GetChatsRoomsData = {
          */
         kind?: ChatRoomKind;
         /**
-         * Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (creator, or org owner/admin, and still a member).
+         * Room visibility. `active` (default) lists live rooms; `archived` lists soft-archived channels the caller can restore (organization owner/admin, and still a member).
          */
         status?: ChatRoomListStatus;
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleanup leftovers from SOK-707 (`feat(chat): let any channel member add members; drop creator elevation` / #3604).

- Remove unused `chatRoomPatchTouchesRoster` helper from Core chat room helpers
- Regenerate web Core OpenAPI client so archive/restore descriptions match owner/admin-only auth (stale “creator” wording)
- Align web test fixtures with current channel-settings 403 copy: `Only an organization owner or admin can update channel settings.`

## Verification

- `pnpm --filter core check`
- `pnpm --filter core test` (2633 passed)
- `pnpm --filter web check`
- `pnpm --filter web test` on updated auth/chat error fixtures
- Husky precommit: `pnpm check && pnpm typecheck`

Related: SOK-707 / #3604
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-707](https://linear.app/masumi/issue/SOK-707/any-channel-member-can-add-org-members-drop-creator-elevation)

<div><a href="https://cursor.com/agents/bc-3ffc4497-d7ef-4711-b7cc-ded27efd65bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ffc4497-d7ef-4711-b7cc-ded27efd65bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

