### PR TITLE
feat(web): live-refresh unread threads badge and panel

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/unread-threads-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/unread-threads-panel.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { UnreadThreadsPanel } from "@/app/chat/components/unread-threads-panel";
 import type {
   ChatRoomMessage,
@@ -35,12 +41,14 @@ const labels = {
     count === 1 ? "1 unread reply" : `${count} unread replies`,
 };
 
+const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
+
 function parentMessage(
   overrides: Partial<ChatRoomMessage> = {},
 ): ChatRoomMessage {
   return {
     id: "550e8400-e29b-41d4-a716-446655440001",
-    roomId: "550e8400-e29b-41d4-a716-446655440000",
+    roomId: ROOM_ID,
     parentMessageId: null,
     content: "Budget review parent",
     createdAt: new Date("2026-08-01T00:00:00.000Z"),
@@ -79,6 +87,22 @@ function unreadThreadItem(
   };
 }
 
+interface RenderPanelOptions {
+  attentionRefreshToken?: number;
+  onOpenThread?: (parent: ChatRoomMessage) => boolean | Promise<boolean>;
+}
+
+function renderPanel(options: RenderPanelOptions = {}) {
+  return render(
+    <UnreadThreadsPanel
+      roomId={ROOM_ID}
+      labels={labels}
+      attentionRefreshToken={options.attentionRefreshToken ?? 0}
+      onOpenThread={options.onOpenThread ?? vi.fn().mockResolvedValue(true)}
+    />,
+  );
+}
+
 describe("UnreadThreadsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -92,14 +116,12 @@ describe("UnreadThreadsPanel", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("opens unread threads surface from the header control", async () => {
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={vi.fn().mockResolvedValue(true)}
-      />,
-    );
+    renderPanel();
 
     expect(
       screen.queryByTestId("unread-threads-panel"),
@@ -112,9 +134,7 @@ describe("UnreadThreadsPanel", () => {
     expect(screen.getByText(labels.title)).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(listUnreadThreadsActionMock).toHaveBeenCalledWith(
-        "550e8400-e29b-41d4-a716-446655440000",
-      );
+      expect(listUnreadThreadsActionMock).toHaveBeenCalledWith(ROOM_ID);
     });
 
     expect(await screen.findByTestId("unread-threads-item")).toHaveTextContent(
@@ -130,13 +150,7 @@ describe("UnreadThreadsPanel", () => {
   it("shows no badge when there are no unread threads", async () => {
     listUnreadThreadsActionMock.mockResolvedValue({ ok: true, data: [] });
 
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={vi.fn().mockResolvedValue(true)}
-      />,
-    );
+    renderPanel();
 
     await waitFor(() => {
       expect(listUnreadThreadsActionMock).toHaveBeenCalled();
@@ -159,13 +173,7 @@ describe("UnreadThreadsPanel", () => {
       ],
     });
 
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={vi.fn().mockResolvedValue(true)}
-      />,
-    );
+    renderPanel();
 
     fireEvent.click(screen.getByTestId("unread-threads-trigger"));
     const item = await screen.findByTestId("unread-threads-item");
@@ -177,13 +185,7 @@ describe("UnreadThreadsPanel", () => {
   it("shows empty state when nothing needs attention", async () => {
     listUnreadThreadsActionMock.mockResolvedValue({ ok: true, data: [] });
 
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={vi.fn().mockResolvedValue(true)}
-      />,
-    );
+    renderPanel();
 
     fireEvent.click(screen.getByTestId("unread-threads-trigger"));
 
@@ -196,13 +198,7 @@ describe("UnreadThreadsPanel", () => {
   });
 
   it("marks all unread threads as read and clears badge", async () => {
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={vi.fn().mockResolvedValue(true)}
-      />,
-    );
+    renderPanel();
 
     expect(
       await screen.findByTestId("unread-threads-badge"),
@@ -211,9 +207,7 @@ describe("UnreadThreadsPanel", () => {
     fireEvent.click(await screen.findByTestId("unread-threads-mark-all-read"));
 
     await waitFor(() => {
-      expect(markAllUnreadThreadsReadActionMock).toHaveBeenCalledWith(
-        "550e8400-e29b-41d4-a716-446655440000",
-      );
+      expect(markAllUnreadThreadsReadActionMock).toHaveBeenCalledWith(ROOM_ID);
     });
     expect(await screen.findByTestId("unread-threads-empty")).toHaveTextContent(
       labels.empty,
@@ -235,13 +229,7 @@ describe("UnreadThreadsPanel", () => {
         }),
     );
 
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={vi.fn().mockResolvedValue(true)}
-      />,
-    );
+    renderPanel();
 
     expect(
       await screen.findByTestId("unread-threads-badge"),
@@ -273,13 +261,7 @@ describe("UnreadThreadsPanel", () => {
   it("opens thread and decrements badge only when look-state persists", async () => {
     const onOpenThread = vi.fn().mockResolvedValue(true);
 
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={onOpenThread}
-      />,
-    );
+    renderPanel({ onOpenThread });
 
     expect(
       await screen.findByTestId("unread-threads-badge"),
@@ -305,13 +287,7 @@ describe("UnreadThreadsPanel", () => {
   it("keeps badge when mark-read fails", async () => {
     const onOpenThread = vi.fn().mockResolvedValue(false);
 
-    render(
-      <UnreadThreadsPanel
-        roomId="550e8400-e29b-41d4-a716-446655440000"
-        labels={labels}
-        onOpenThread={onOpenThread}
-      />,
-    );
+    renderPanel({ onOpenThread });
 
     expect(
       await screen.findByTestId("unread-threads-badge"),
@@ -325,5 +301,180 @@ describe("UnreadThreadsPanel", () => {
     expect(await screen.findByTestId("unread-threads-badge")).toHaveTextContent(
       "1",
     );
+  });
+
+  it("coalesces rapid attentionRefreshToken bumps into one fetch after 300ms", async () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={0}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const mountCalls = listUnreadThreadsActionMock.mock.calls.length;
+
+    rerender(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={1}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+    rerender(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={2}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+    rerender(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={3}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    expect(listUnreadThreadsActionMock).toHaveBeenCalledTimes(mountCalls);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299);
+    });
+    expect(listUnreadThreadsActionMock).toHaveBeenCalledTimes(mountCalls);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(listUnreadThreadsActionMock).toHaveBeenCalledTimes(mountCalls + 1);
+  });
+
+  it("updates badge from live refresh while closed without showing the list", async () => {
+    listUnreadThreadsActionMock.mockResolvedValueOnce({
+      ok: true,
+      data: [],
+    });
+
+    const { rerender } = render(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={0}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listUnreadThreadsActionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.queryByTestId("unread-threads-badge"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("unread-threads-panel"),
+    ).not.toBeInTheDocument();
+
+    listUnreadThreadsActionMock.mockResolvedValueOnce({
+      ok: true,
+      data: [unreadThreadItem(), unreadThreadItem()],
+    });
+
+    vi.useFakeTimers();
+    rerender(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={1}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("unread-threads-badge")).toHaveTextContent("2");
+    });
+    expect(
+      screen.queryByTestId("unread-threads-panel"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unread-threads-item")).not.toBeInTheDocument();
+  });
+
+  it("refreshes the open panel list when attentionRefreshToken bumps", async () => {
+    listUnreadThreadsActionMock.mockResolvedValue({
+      ok: true,
+      data: [
+        unreadThreadItem({
+          parentMessage: parentMessage({ content: "First unread" }),
+        }),
+      ],
+    });
+
+    const { rerender } = render(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={0}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listUnreadThreadsActionMock).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByTestId("unread-threads-trigger"));
+    expect(await screen.findByTestId("unread-threads-item")).toHaveTextContent(
+      "First unread",
+    );
+    const callsBeforeLive = listUnreadThreadsActionMock.mock.calls.length;
+
+    listUnreadThreadsActionMock.mockResolvedValue({
+      ok: true,
+      data: [
+        unreadThreadItem({
+          parentMessage: parentMessage({
+            id: "550e8400-e29b-41d4-a716-446655440099",
+            content: "Live refreshed unread",
+          }),
+        }),
+      ],
+    });
+
+    vi.useFakeTimers();
+    rerender(
+      <UnreadThreadsPanel
+        roomId={ROOM_ID}
+        labels={labels}
+        attentionRefreshToken={1}
+        onOpenThread={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => {
+      expect(listUnreadThreadsActionMock.mock.calls.length).toBeGreaterThan(
+        callsBeforeLive,
+      );
+    });
+    expect(await screen.findByTestId("unread-threads-item")).toHaveTextContent(
+      "Live refreshed unread",
+    );
+    expect(screen.getByTestId("unread-threads-panel")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -37,6 +37,7 @@ import {
   mergeRoomMessages,
 } from "@/app/chat/utils/merge-room-messages";
 import { peekPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
+import { shouldSignalUnreadThreadsAttention } from "@/app/chat/utils/should-signal-unread-threads-attention";
 import { ChannelDiscoverabilityIcon } from "@/components/chat/channel-discoverability-icon";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
 import { PresenceDot } from "@/components/chat/presence-dot";
@@ -282,6 +283,15 @@ export function RoomsClient({
   // handlers must not merge into messagesState after the selection moved.
   const selectedRoomIdRef = useRef(selectedRoomId);
   selectedRoomIdRef.current = selectedRoomId;
+  const currentUserIdRef = useRef(currentUserId);
+  currentUserIdRef.current = currentUserId;
+  const [attentionRefreshToken, setAttentionRefreshToken] = useState(0);
+  const [syncedAttentionRoomId, setSyncedAttentionRoomId] =
+    useState(selectedRoomId);
+  if (selectedRoomId !== syncedAttentionRoomId) {
+    setSyncedAttentionRoomId(selectedRoomId);
+    setAttentionRefreshToken(0);
+  }
   const [isSending, startSendingTransition] = useTransition();
   const [isThreadLoading, startThreadLoadingTransition] = useTransition();
   const [isSendingThreadReply, startSendingThreadReplyTransition] =
@@ -431,6 +441,12 @@ export function RoomsClient({
       setThreadParentMessage((current) =>
         current?.id === message.id ? message : current,
       );
+
+      if (
+        shouldSignalUnreadThreadsAttention(message, currentUserIdRef.current)
+      ) {
+        setAttentionRefreshToken((token) => token + 1);
+      }
 
       const openThreadParentId = threadParentMessageIdRef.current;
       if (!openThreadParentId) {
@@ -835,6 +851,7 @@ export function RoomsClient({
           mergeRoomMessages(current, threadResult.data.messages),
         );
       }
+      setAttentionRefreshToken((token) => token + 1);
     };
 
     window.addEventListener("focus", refreshLatest);
@@ -1371,6 +1388,7 @@ export function RoomsClient({
                   <UnreadThreadsPanel
                     key={`unread-threads-${selectedRoom.id}`}
                     roomId={selectedRoom.id}
+                    attentionRefreshToken={attentionRefreshToken}
                     onOpenThread={loadThreadMessages}
                     labels={{
                       open: t("UnreadThreads.open"),

--- a/apps/web/src/app/(app)/chat/components/unread-threads-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/unread-threads-panel.tsx
@@ -36,9 +36,16 @@ export interface UnreadThreadsPanelLabels {
 interface UnreadThreadsPanelProps {
   roomId: string;
   labels: UnreadThreadsPanelLabels;
+  /**
+   * Monotonic epoch from the parent. Values > 0 trigger a debounced
+   * unread-threads refetch (badge always; list only while open).
+   */
+  attentionRefreshToken: number;
   /** Returns true when thread look-state was persisted successfully. */
   onOpenThread: (parent: ChatRoomMessage) => boolean | Promise<boolean>;
 }
+
+const ATTENTION_REFRESH_DEBOUNCE_MS = 300;
 
 function UnreadThreadsBadge({ count }: { count: number }) {
   if (count <= 0) {
@@ -61,6 +68,7 @@ function UnreadThreadsBadge({ count }: { count: number }) {
 export function UnreadThreadsPanel({
   roomId,
   labels,
+  attentionRefreshToken,
   onOpenThread,
 }: UnreadThreadsPanelProps) {
   const [open, setOpen] = useState(false);
@@ -70,6 +78,8 @@ export function UnreadThreadsPanel({
   const [isLoading, setIsLoading] = useState(false);
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
   const requestIdRef = useRef(0);
+  const openRef = useRef(open);
+  openRef.current = open;
   const { formatTimeAgo } = useLocalizedDateTime();
 
   const loadUnreadThreads = useEffectEvent(
@@ -113,6 +123,18 @@ export function UnreadThreadsPanel({
     }
     void loadUnreadThreads({ forPanel: true });
   }, [open, roomId]);
+
+  useEffect(() => {
+    if (attentionRefreshToken <= 0) {
+      return;
+    }
+    const timerId = window.setTimeout(() => {
+      void loadUnreadThreads({ forPanel: openRef.current });
+    }, ATTENTION_REFRESH_DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [attentionRefreshToken]);
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/should-signal-unread-threads-attention.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/should-signal-unread-threads-attention.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { shouldSignalUnreadThreadsAttention } from "@/app/chat/utils/should-signal-unread-threads-attention";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+const CURRENT_USER_ID = "user_self";
+
+function message(
+  overrides: Partial<Pick<ChatRoomMessage, "parentMessageId" | "sender">> = {},
+): Pick<ChatRoomMessage, "parentMessageId" | "sender"> {
+  return {
+    parentMessageId: "parent-1",
+    sender: {
+      type: "user",
+      user: {
+        id: "user_other",
+        name: "Other",
+        email: "other@example.com",
+        image: null,
+        presence: "offline",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("shouldSignalUnreadThreadsAttention", () => {
+  it("returns false for top-level messages", () => {
+    expect(
+      shouldSignalUnreadThreadsAttention(
+        message({ parentMessageId: null }),
+        CURRENT_USER_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for the current user's own replies", () => {
+    expect(
+      shouldSignalUnreadThreadsAttention(
+        message({
+          sender: {
+            type: "user",
+            user: {
+              id: CURRENT_USER_ID,
+              name: "Self",
+              email: "self@example.com",
+              image: null,
+              presence: "online",
+            },
+          },
+        }),
+        CURRENT_USER_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for another user's thread reply", () => {
+    expect(shouldSignalUnreadThreadsAttention(message(), CURRENT_USER_ID)).toBe(
+      true,
+    );
+  });
+
+  it("returns true for a coworker thread reply", () => {
+    expect(
+      shouldSignalUnreadThreadsAttention(
+        message({
+          sender: {
+            type: "coworker",
+            coworker: {
+              id: "coworker_1",
+              name: "Bot",
+              slug: "bot",
+              caption: null,
+              image: null,
+              presence: "online",
+            },
+          },
+        }),
+        CURRENT_USER_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for unknown senders", () => {
+    expect(
+      shouldSignalUnreadThreadsAttention(
+        message({ sender: { type: "unknown" } }),
+        CURRENT_USER_ID,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/should-signal-unread-threads-attention.ts
+++ b/apps/web/src/app/(app)/chat/utils/should-signal-unread-threads-attention.ts
@@ -1,0 +1,24 @@
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+/**
+ * Whether a realtime/hydrated room message should bump unread-threads attention.
+ * Top-level messages and the current user's own replies never signal.
+ */
+export function shouldSignalUnreadThreadsAttention(
+  message: Pick<ChatRoomMessage, "parentMessageId" | "sender">,
+  currentUserId: string,
+): boolean {
+  if (!message.parentMessageId) {
+    return false;
+  }
+
+  if (message.sender.type === "user") {
+    return message.sender.user.id !== currentUserId;
+  }
+
+  if (message.sender.type === "coworker") {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-712](https://linear.app/masumi/issue/SOK-712/live-refresh-for-room-unread-threads-badge-and-panel).

While a room stays open, Unread Threads badge (and open panel list) stay in sync with live non-self thread replies.

- Bump `attentionRefreshToken` from room Ably replies + focus/visibility refresh
- Debounce ~300ms; badge always; list only when popover open
- Skip top-level and current-user replies; coworkers still signal
- No Core/API or look-state rule changes

**Verify:** `pnpm web:check`, `pnpm web:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-712](https://linear.app/masumi/issue/SOK-712/live-refresh-for-room-unread-threads-badge-and-panel)

<div><a href="https://cursor.com/agents/bc-24bac5c6-f770-4410-8e70-5e1b85b8d139?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24bac5c6-f770-4410-8e70-5e1b85b8d139&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

