### PR TITLE
feat(web): extend Instant Navigations to tasks, chat, and account

### DIFF
--- a/apps/web/src/app/(app)/account/page.tsx
+++ b/apps/web/src/app/(app)/account/page.tsx
@@ -1,8 +1,10 @@
 import { getUserMetadata } from "@sokosumi/utils";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
-import type { ReactNode } from "react";
+import { type ReactNode, Suspense } from "react";
 import { CoreAuthReadRetry } from "@/components/auth/core-auth-read-retry";
 import { BillingPortalErrorToast } from "@/components/billing/billing-portal-error-toast";
+import DefaultLoading from "@/components/default-loading";
 import { getSession, listUserAccounts } from "@/lib/auth/auth.server";
 import { coreClient } from "@/lib/clients/core.client";
 import type { StripeCustomerBillingDetails } from "@/lib/clients/generated/core";
@@ -11,7 +13,19 @@ import { designMdService } from "@/lib/services/design-md.service";
 
 import { AccountSettings } from "./components/account-settings";
 
-export default async function Page() {
+function AccountPageFallback() {
+  return (
+    <div className="flex items-center justify-center gap-16 md:p-8">
+      <DefaultLoading />
+    </div>
+  );
+}
+
+async function AccountPageContent() {
+  // Defer before any cookies()/headers()-bound work so PPR shell probing does
+  // not soft-reject dynamic APIs while filling this Suspense hole.
+  await connection();
+
   const t = await getTranslations("App.Account.LinkedAccounts");
   const tBilling = await getTranslations("App.Account.BillingDetails");
   const [accountsResult, session] = await Promise.all([
@@ -68,5 +82,13 @@ export default async function Page() {
         />
       </div>
     </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<AccountPageFallback />}>
+      <AccountPageContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(app)/chat/loading.tsx
+++ b/apps/web/src/app/(app)/chat/loading.tsx
@@ -1,0 +1,5 @@
+import DefaultLoading from "@/components/default-loading";
+
+export default function ChatLoading() {
+  return <DefaultLoading className="h-full min-h-[300px] w-full flex-1 p-8" />;
+}

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 import { ChatLandingNotice } from "@/app/chat/components/chat-landing-notice";
 import { ChatWelcomeClient } from "@/app/chat/components/chat-welcome-client";
 import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
+import DefaultLoading from "@/components/default-loading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/auth.server";
 import { chatRoomService, userService } from "@/lib/services";
@@ -37,11 +40,19 @@ export async function generateMetadata({
   };
 }
 
+function ChatPageFallback() {
+  return <DefaultLoading className="h-full min-h-[300px] w-full flex-1 p-8" />;
+}
+
 /**
  * `/chat` landing = classic coworker welcome. Draft modes via query:
  * `?create=channel`, `?dm=new`. Open rooms: `/chat/rooms/[roomId]`.
  */
-export default async function ChatPage({ searchParams }: ChatPageProps) {
+async function ChatPageContent({ searchParams }: ChatPageProps) {
+  // Defer before any cookies()/headers()-bound work so PPR shell probing does
+  // not soft-reject dynamic APIs while filling this Suspense hole.
+  await connection();
+
   const [query, tChannels, activeOrganization, session] = await Promise.all([
     searchParams,
     getTranslations("App.Channels"),
@@ -145,5 +156,13 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
         userName={session?.user.name ?? undefined}
       />
     </>
+  );
+}
+
+export default function ChatPage({ searchParams }: ChatPageProps) {
+  return (
+    <Suspense fallback={<ChatPageFallback />}>
+      <ChatPageContent searchParams={searchParams} />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -17,6 +17,10 @@ vi.mock("next/navigation", () => ({
   redirect: (url: string) => redirectMock(url),
 }));
 
+vi.mock("next/server", () => ({
+  connection: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("next-intl/server", () => ({
   getTranslations:
     async () => (key: string, values?: Record<string, unknown>) =>
@@ -56,7 +60,7 @@ vi.mock("@/app/chat/components/rooms-client", () => ({
   RoomsClient: () => <div data-testid="rooms-client" />,
 }));
 
-import ChatRoomPage from "../page";
+import { ChatRoomPageContent } from "../page";
 
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const ORG_A = "org_a";
@@ -124,7 +128,7 @@ describe("ChatRoomPage org deep-link guard", () => {
     getRoomMock.mockResolvedValue(room({ organizationId: ORG_A }));
 
     await expect(
-      ChatRoomPage({ params: Promise.resolve({ roomId: ROOM_ID }) }),
+      ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
     ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
 
     expect(redirectMock).toHaveBeenCalledWith("/chat?notice=room-unavailable");
@@ -141,7 +145,7 @@ describe("ChatRoomPage org deep-link guard", () => {
     );
 
     await expect(
-      ChatRoomPage({ params: Promise.resolve({ roomId: ROOM_ID }) }),
+      ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
     ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
 
     expect(redirectMock).toHaveBeenCalledWith("/chat?notice=room-unavailable");
@@ -156,7 +160,7 @@ describe("ChatRoomPage org deep-link guard", () => {
     getRoomMock.mockResolvedValue(null);
 
     await expect(
-      ChatRoomPage({ params: Promise.resolve({ roomId: ROOM_ID }) }),
+      ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
     ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
   });
 
@@ -168,7 +172,7 @@ describe("ChatRoomPage org deep-link guard", () => {
     });
     getRoomMock.mockResolvedValue(room({ organizationId: ORG_A }));
 
-    const element = (await ChatRoomPage({
+    const element = (await ChatRoomPageContent({
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 
@@ -189,7 +193,7 @@ describe("ChatRoomPage org deep-link guard", () => {
       failed: true,
     });
 
-    const element = (await ChatRoomPage({
+    const element = (await ChatRoomPageContent({
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 
@@ -206,7 +210,7 @@ describe("ChatRoomPage org deep-link guard", () => {
       room({ organizationId: null, kind: "direct" }),
     );
 
-    const element = (await ChatRoomPage({
+    const element = (await ChatRoomPageContent({
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata(): Promise<Metadata> {
  *
  * Non-member / missing room → soft land on `/chat` (cutover design), not 404.
  */
-async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
+export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
   // Defer before any cookies()/headers()-bound work so PPR shell probing does
   // not soft-reject dynamic APIs while filling this Suspense hole.
   await connection();

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 import { RoomsClient } from "@/app/chat/components/rooms-client";
 import { loadOrganizationMembers } from "@/app/chat/load-organization-members";
 import { loadRoomMessages } from "@/app/chat/load-room-messages";
+import DefaultLoading from "@/components/default-loading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/auth.server";
 import { chatRoomService, userService } from "@/lib/services";
@@ -36,6 +39,10 @@ function NoOrganizationCard({
   );
 }
 
+function ChatRoomPageFallback() {
+  return <DefaultLoading className="h-full min-h-[300px] w-full flex-1 p-8" />;
+}
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("App.Channels.Metadata");
 
@@ -51,7 +58,11 @@ export async function generateMetadata(): Promise<Metadata> {
  *
  * Non-member / missing room → soft land on `/chat` (cutover design), not 404.
  */
-export default async function ChatRoomPage({ params }: ChatRoomPageProps) {
+async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
+  // Defer before any cookies()/headers()-bound work so PPR shell probing does
+  // not soft-reject dynamic APIs while filling this Suspense hole.
+  await connection();
+
   const [{ roomId }, t, activeOrganization, session] = await Promise.all([
     params,
     getTranslations("App.Channels"),
@@ -137,5 +148,13 @@ export default async function ChatRoomPage({ params }: ChatRoomPageProps) {
       messages={messagePage.messages}
       messagesNextCursor={messagePage.nextCursor}
     />
+  );
+}
+
+export default function ChatRoomPage({ params }: ChatRoomPageProps) {
+  return (
+    <Suspense fallback={<ChatRoomPageFallback />}>
+      <ChatRoomPageContent params={params} />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(app)/tasks/(root)/loading.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/loading.tsx
@@ -1,48 +1,5 @@
-import { cookies } from "next/headers";
-import { getTranslations } from "next-intl/server";
+import { TasksPageSkeleton } from "@/app/tasks/components/tasks-loading-view";
 
-import { TasksLoadingView } from "@/app/tasks/components/tasks-loading-view";
-import type { KanbanColumnId } from "@/app/tasks/types/task-board";
-import {
-  parseTasksViewMode,
-  TASKS_VIEW_MODE_COOKIE_NAME,
-} from "@/lib/ui-preferences/tasks-view-mode";
-
-export default async function TasksRootLoading() {
-  const [t, tColumns, cookieStore] = await Promise.all([
-    getTranslations("App.Tasks"),
-    getTranslations("App.Tasks.Columns"),
-    cookies(),
-  ]);
-  const viewMode =
-    parseTasksViewMode(cookieStore.get(TASKS_VIEW_MODE_COOKIE_NAME)?.value) ??
-    "board";
-
-  const columnLabels: Record<KanbanColumnId, string> = {
-    backlog: tColumns("backlog"),
-    todo: tColumns("todo"),
-    "in-progress": tColumns("inProgress"),
-    "input-required": tColumns("inputRequired"),
-    done: tColumns("done"),
-  };
-
-  return (
-    <div className="w-full px-2">
-      <TasksLoadingView
-        viewMode={viewMode}
-        labels={{
-          tabs: {
-            tasks: t("Tabs.tasks"),
-            jobs: t("Tabs.jobs"),
-          },
-          columns: columnLabels,
-          add: t("Actions.add"),
-          addTask: t("Actions.addTask"),
-          display: {
-            button: t("Display.button"),
-          },
-        }}
-      />
-    </div>
-  );
+export default function TasksRootLoading() {
+  return <TasksPageSkeleton />;
 }

--- a/apps/web/src/app/(app)/tasks/(root)/page.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/page.tsx
@@ -1,6 +1,8 @@
 import { cookies } from "next/headers";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
+import { TasksPageSkeleton } from "@/app/tasks/components/tasks-loading-view";
 import { TasksPendingVendorGrantBannerSlot } from "@/app/tasks/components/tasks-pending-vendor-grant-banner-slot";
 import { TasksView } from "@/app/tasks/components/tasks-view";
 import {
@@ -69,7 +71,11 @@ async function loadTasksPageData() {
   ]);
 }
 
-export default async function TasksPage({ searchParams }: TasksPageProps) {
+async function TasksPageContent({ searchParams }: TasksPageProps) {
+  // Defer before any cookies()/headers()-bound work so PPR shell probing does
+  // not soft-reject dynamic APIs while filling this Suspense hole.
+  await connection();
+
   const {
     create,
     assignee: assigneeSlugParam,
@@ -355,5 +361,13 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
         }}
       />
     </div>
+  );
+}
+
+export default function TasksPage({ searchParams }: TasksPageProps) {
+  return (
+    <Suspense fallback={<TasksPageSkeleton />}>
+      <TasksPageContent searchParams={searchParams} />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(app)/tasks/components/tasks-loading-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-loading-view.tsx
@@ -28,6 +28,37 @@ interface TasksLoadingViewProps {
   labels: TasksLoadingLabels;
 }
 
+/** Sync shell labels for Instant Navigations / `loading.tsx` (no cookies/i18n). */
+export const TASKS_LOADING_DEFAULT_LABELS: TasksLoadingLabels = {
+  tabs: {
+    tasks: "Tasks",
+    jobs: "Jobs",
+  },
+  columns: {
+    backlog: "Backlog",
+    todo: "Todo",
+    "in-progress": "In Progress",
+    "input-required": "Input Required",
+    done: "Done",
+  },
+  add: "New Task",
+  addTask: "New Task",
+  display: {
+    button: "Display",
+  },
+};
+
+export function TasksPageSkeleton() {
+  return (
+    <div className="w-full px-2">
+      <TasksLoadingView
+        viewMode="board"
+        labels={TASKS_LOADING_DEFAULT_LABELS}
+      />
+    </div>
+  );
+}
+
 export function TasksLoadingView({ viewMode, labels }: TasksLoadingViewProps) {
   const resolvedViewMode = viewMode ?? "board";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends Instant Navigations beyond the `/agents` pilot ([SOK-708](https://linear.app/masumi/issue/SOK-708/extend-instant-navigations-beyond-the-agents-pilot)).

- Sync page shells + Suspense for `/tasks`, `/chat`, `/chat/rooms/[roomId]`, `/account`
- Async tiers call `await connection()` before session/cookies/Core reads
- Tasks loading/skeleton sync (no cookie read); cookie prefs stay inside streamed content
- Admin + personal-assistant keep `instant = false`
- Merged latest `main` (includes unread-threads live refresh #3611)

## Out of scope

Task detail/new/edit, projects/history/notifications, `'use cache: private'` (SOK-710), cookie-free catalog (SOK-709), Core API changes, offline.

## Verification

- `pnpm web:check` / `pnpm web:test` / `pnpm web:build` (exit 0; Partial Prerender on `/tasks`, `/chat`, `/chat/rooms/[roomId]`, `/account`)
- UI: signed in as `alice@sokosumi.test` — `/tasks`, `/chat`, `/account` render shell + streamed content
- Re-verified after merge from `main`

**headSha:** `3c63668545f7c4040a19ed718dd75eb09ea377c0`

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| R6 | `tasks-loading-view.tsx` `TASKS_LOADING_DEFAULT_LABELS` | Sync skeleton uses English default labels (not locale); streamed `TasksView` keeps translated labels |

Linear Issue: [SOK-708](https://linear.app/masumi/issue/SOK-708/extend-instant-navigations-beyond-the-agents-pilot)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c43d73-c7be-48b6-88d6-eea721b4656e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c43d73-c7be-48b6-88d6-eea721b4656e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

