### PR TITLE
feat(web): private-cache personalized sidebar chrome for Instant Nav

### DIFF
--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -3,6 +3,8 @@
 import { revalidatePath } from "next/cache";
 import { actionErrorMessage } from "@/app/chat/action-error-message";
 import { directCreateShapeError } from "@/app/chat/utils/direct-create-shape";
+import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
+import { getSession } from "@/lib/auth/auth.server";
 import type {
   ChatRoom,
   ChatRoomMessage,
@@ -74,6 +76,17 @@ function cleanDiscoverability(
   return undefined;
 }
 
+async function invalidateSidebarChatList(): Promise<void> {
+  const session = await getSession();
+  if (!session) {
+    return;
+  }
+  invalidatePrivateSidebarChrome({
+    userId: session.user.id,
+    organizationId: session.session.activeOrganizationId ?? null,
+  });
+}
+
 export async function createChannelAction(
   input: CreateChannelInput,
 ): Promise<RoomActionResult<ChatRoom>> {
@@ -96,6 +109,7 @@ export async function createChannelAction(
       memberUserIds: cleanIds(input.memberUserIds),
       coworkerIds: cleanIds(input.coworkerIds),
     });
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: room };
   } catch (error) {
@@ -140,6 +154,7 @@ export async function createDirectRoomAction(
       memberUserIds,
       coworkerIds,
     });
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: room };
   } catch (error) {
@@ -168,6 +183,7 @@ export async function ensureCoworkerDirectRoomAction(
       memberUserIds: [],
       coworkerIds: [cleanCoworkerId],
     });
+    await invalidateSidebarChatList();
     return { ok: true, data: room };
   } catch (error) {
     return {
@@ -211,6 +227,7 @@ export async function sendNewDirectMessageAction(
       mentionedCoworkerIds: cleanIds(input.mentionedCoworkerIds),
       mentionedUserIds: cleanIds(input.mentionedUserIds),
     });
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: { room, message } };
   } catch (error) {
@@ -241,6 +258,7 @@ export async function updateRoomAction(
 
   try {
     const room = await chatRoomService.updateRoom(roomId, body);
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: room };
   } catch (error) {
@@ -258,6 +276,7 @@ export async function archiveRoomAction(
     const archived = await chatRoomService.archiveRoom(roomId);
     // The room disappears from every member's list, so the server-rendered
     // room list has to be rebuilt rather than patched client side.
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: { id: archived.id } };
   } catch (error) {
@@ -273,6 +292,7 @@ export async function restoreRoomAction(
 ): Promise<RoomActionResult<ChatRoom>> {
   try {
     const restored = await chatRoomService.restoreRoom(roomId);
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: restored };
   } catch (error) {
@@ -288,6 +308,7 @@ export async function deleteRoomAction(
 ): Promise<RoomActionResult<{ id: string }>> {
   try {
     await chatRoomService.deleteRoom(roomId);
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: { id: roomId } };
   } catch (error) {
@@ -303,6 +324,7 @@ export async function leaveRoomAction(
 ): Promise<RoomActionResult<{ id: string }>> {
   try {
     const left = await chatRoomService.leaveRoom(roomId);
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: { id: left.id } };
   } catch (error) {
@@ -323,6 +345,7 @@ export async function joinRoomAction(
 
   try {
     const room = await chatRoomService.joinRoom(cleanRoomId);
+    await invalidateSidebarChatList();
     revalidatePath("/chat");
     return { ok: true, data: room };
   } catch (error) {

--- a/apps/web/src/app/(app)/components/__tests__/private-sidebar-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/private-sidebar-cache.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateTagMock = vi.fn();
+const getMyCreditsMock = vi.fn();
+
+vi.mock("next/cache", () => ({
+  updateTag: (...args: unknown[]) => updateTagMock(...args),
+}));
+
+vi.mock("@/lib/clients/core.client", () => ({
+  coreClient: {
+    getMyCredits: (...args: unknown[]) => getMyCreditsMock(...args),
+  },
+}));
+
+describe("private-sidebar-cache", () => {
+  beforeEach(() => {
+    updateTagMock.mockReset();
+    getMyCreditsMock.mockReset();
+  });
+
+  it("builds stable user and org tags", async () => {
+    const { privateSidebarOrgTag, privateSidebarUserTag } = await import(
+      "../private-sidebar-cache"
+    );
+
+    expect(privateSidebarUserTag("user-1")).toBe("app-sidebar-user-user-1");
+    expect(privateSidebarOrgTag("org-1")).toBe("app-sidebar-org-org-1");
+  });
+
+  it("invalidates user tag and current + previous org tags", async () => {
+    const { invalidatePrivateSidebarChrome } = await import(
+      "../private-sidebar-cache"
+    );
+
+    invalidatePrivateSidebarChrome({
+      userId: "user-1",
+      organizationId: "org-new",
+      previousOrganizationId: "org-old",
+    });
+
+    expect(updateTagMock).toHaveBeenCalledWith("app-sidebar-user-user-1");
+    expect(updateTagMock).toHaveBeenCalledWith("app-sidebar-org-org-new");
+    expect(updateTagMock).toHaveBeenCalledWith("app-sidebar-org-org-old");
+  });
+
+  it("skips duplicate previous org when unchanged", async () => {
+    const { invalidatePrivateSidebarChrome } = await import(
+      "../private-sidebar-cache"
+    );
+
+    invalidatePrivateSidebarChrome({
+      userId: "user-1",
+      organizationId: "org-1",
+      previousOrganizationId: "org-1",
+    });
+
+    expect(updateTagMock).toHaveBeenCalledTimes(2);
+    expect(updateTagMock).toHaveBeenCalledWith("app-sidebar-user-user-1");
+    expect(updateTagMock).toHaveBeenCalledWith("app-sidebar-org-org-1");
+  });
+
+  it("returns null when credits fetch fails", async () => {
+    getMyCreditsMock.mockRejectedValueOnce(new Error("boom"));
+    const { getCachedMyCredits } = await import("../private-sidebar-cache");
+
+    await expect(getCachedMyCredits()).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/app/(app)/components/__tests__/shell-hydrators.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/shell-hydrators.test.tsx
@@ -1,0 +1,62 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Coworker } from "@/app/chat/utils/types";
+import type { AccountNotice } from "@/app/components/account-notice-state";
+
+const hydrateAccountNoticeMock = vi.fn();
+const hydrateCoworkersMock = vi.fn();
+
+vi.mock("@/contexts/account-notice-provider", () => ({
+  useAccountNoticeHydration: () => hydrateAccountNoticeMock,
+}));
+
+vi.mock("@/contexts/coworkers-context", () => ({
+  useCoworkersHydration: () => hydrateCoworkersMock,
+}));
+
+vi.mock("@/app/components/notice-dialog-context", () => ({
+  useNoticeDialogHydration: () => vi.fn(),
+}));
+
+import {
+  AccountNoticeHydrator,
+  CoworkersHydrator,
+} from "@/app/components/shell-hydrators.client";
+
+const ACCOUNT_NOTICE: AccountNotice = {
+  email: "alice@example.com",
+  tone: "warning",
+  type: "emailVerification",
+};
+
+const COWORKERS: Coworker[] = [
+  {
+    id: "cw-1",
+    name: "Helper",
+    description: "Helps with tasks",
+    useCase: "general",
+    slug: "helper",
+  },
+];
+
+describe("shell hydrator split", () => {
+  beforeEach(() => {
+    hydrateAccountNoticeMock.mockReset();
+    hydrateCoworkersMock.mockReset();
+  });
+
+  it("hydrates account notice without touching coworkers", () => {
+    render(<AccountNoticeHydrator accountNotice={ACCOUNT_NOTICE} />);
+
+    expect(hydrateAccountNoticeMock).toHaveBeenCalledWith(ACCOUNT_NOTICE);
+    expect(hydrateCoworkersMock).not.toHaveBeenCalled();
+  });
+
+  it("hydrates coworkers without touching account notice", () => {
+    render(<CoworkersHydrator coworkers={COWORKERS} />);
+
+    expect(hydrateCoworkersMock).toHaveBeenCalledWith(COWORKERS);
+    expect(hydrateAccountNoticeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/components/app-shell-overlays.tsx
+++ b/apps/web/src/app/(app)/components/app-shell-overlays.tsx
@@ -3,11 +3,7 @@ import { cookies } from "next/headers";
 import { Suspense } from "react";
 import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
 import { getPendingNoticesAction } from "@/lib/actions/notice";
-import { coreClient } from "@/lib/clients/core.client";
-import type {
-  GetUsersByIdCreditsResponse,
-  Notice,
-} from "@/lib/clients/generated/core";
+import type { Notice, Organization } from "@/lib/clients/generated/core";
 import { NoticeKind } from "@/lib/clients/generated/core";
 import { userService } from "@/lib/services";
 import { coworkerService } from "@/lib/services/coworker.service";
@@ -17,6 +13,7 @@ import {
 } from "@/lib/subscription-onboarding-gate-cookie";
 
 import { OnboardingDialogLoader } from "./onboarding-dialog-loader";
+import { getCachedMyCredits } from "./private-sidebar-cache";
 import {
   CoworkersHydrator,
   NoticeDialogHydrator,
@@ -30,25 +27,25 @@ interface AppShellOverlaysProps {
  * Onboarding, pending notices, and coworkers hydration — streamed separately
  * from the private-cached sidebar chrome (`Suspense fallback={null}`).
  * Must not private-cache: cookies() for onboarding gate + non-chrome data.
+ *
+ * Credits/org are fetched only on the branches that need them so we do not
+ * always duplicate the private sidebar Core reads.
  */
 export default async function AppShellOverlays({
   session,
 }: AppShellOverlaysProps) {
-  const cookieStore = await cookies();
+  const cookieStorePromise = cookies();
   const [
     shouldShowOnboarding,
     pendingNoticesResult,
-    activeOrganization,
-    creditsResultRaw,
     coworkersResult,
+    cookieStore,
   ] = await Promise.all([
     userService.showOnboarding(session),
     getPendingNoticesAction(),
-    userService.getActiveOrganization(),
-    coreClient.getMyCredits().catch(() => null),
     coworkerService.listCoworkers().catch(() => []),
+    cookieStorePromise,
   ]);
-  const creditsResult = creditsResultRaw as GetUsersByIdCreditsResponse | null;
   const coworkers = coworkersResult.map(mapDbCoworkerToChatCoworker);
   const pendingNotices = pendingNoticesResult.ok
     ? pendingNoticesResult.data
@@ -59,12 +56,7 @@ export default async function AppShellOverlays({
   const announcementNotices = pendingNotices.filter(
     (notice: Notice) => notice.kind === NoticeKind.ANNOUNCEMENT,
   );
-  const currentPlan =
-    creditsResult != null
-      ? (creditsResult.data.subscription?.plan ?? "free")
-      : null;
-  const shouldShowFreeSubscriptionGate =
-    !shouldShowOnboarding && currentPlan === "free";
+
   const subscriptionOnboardingGateCookie = cookieStore.get(
     SUBSCRIPTION_ONBOARDING_GATE_SESSION_COOKIE_NAME,
   )?.value;
@@ -73,8 +65,25 @@ export default async function AppShellOverlays({
       subscriptionOnboardingGateCookie,
       session.session.id,
     );
-  const shouldLoadSubscriptionOnboarding =
-    shouldShowFreeSubscriptionGate && !subscriptionOnboardingGateAlreadyServed;
+
+  let activeOrganization: Organization | null = null;
+  let shouldLoadSubscriptionOnboarding = false;
+
+  if (shouldShowOnboarding) {
+    activeOrganization = await userService.getActiveOrganization();
+  } else if (!subscriptionOnboardingGateAlreadyServed) {
+    // Shared React.cache with PrivateCachedAppSidebar — one Core hit per request
+    // when both cold-fill; skipped entirely when gate already served.
+    const creditsResult = await getCachedMyCredits();
+    const currentPlan =
+      creditsResult != null
+        ? (creditsResult.data.subscription?.plan ?? "free")
+        : null;
+    if (currentPlan === "free") {
+      activeOrganization = await userService.getActiveOrganization();
+      shouldLoadSubscriptionOnboarding = true;
+    }
+  }
 
   return (
     <>

--- a/apps/web/src/app/(app)/components/app-shell-overlays.tsx
+++ b/apps/web/src/app/(app)/components/app-shell-overlays.tsx
@@ -2,9 +2,7 @@ import type { Session } from "@sokosumi/utils";
 import { cookies } from "next/headers";
 import { Suspense } from "react";
 import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
-import { getEnvPublicConfig } from "@/config/env.public";
 import { getPendingNoticesAction } from "@/lib/actions/notice";
-import { hasAdminRole } from "@/lib/auth/admin-access";
 import { coreClient } from "@/lib/clients/core.client";
 import type {
   GetUsersByIdCreditsResponse,
@@ -18,16 +16,24 @@ import {
   SUBSCRIPTION_ONBOARDING_GATE_SESSION_COOKIE_NAME,
 } from "@/lib/subscription-onboarding-gate-cookie";
 
-import { resolveAccountNotice } from "./account-notice-state";
 import { OnboardingDialogLoader } from "./onboarding-dialog-loader";
-import { NoticeDialogHydrator, ShellHydrators } from "./shell-hydrators.client";
-import Sidebar from "./sidebar";
+import {
+  CoworkersHydrator,
+  NoticeDialogHydrator,
+} from "./shell-hydrators.client";
 
-interface AppShellChromeProps {
+interface AppShellOverlaysProps {
   session: Session;
 }
 
-export default async function AppShellChrome({ session }: AppShellChromeProps) {
+/**
+ * Onboarding, pending notices, and coworkers hydration — streamed separately
+ * from the private-cached sidebar chrome (`Suspense fallback={null}`).
+ * Must not private-cache: cookies() for onboarding gate + non-chrome data.
+ */
+export default async function AppShellOverlays({
+  session,
+}: AppShellOverlaysProps) {
   const cookieStore = await cookies();
   const [
     shouldShowOnboarding,
@@ -53,10 +59,6 @@ export default async function AppShellChrome({ session }: AppShellChromeProps) {
   const announcementNotices = pendingNotices.filter(
     (notice: Notice) => notice.kind === NoticeKind.ANNOUNCEMENT,
   );
-  const adminMenuEnabled = hasAdminRole(
-    (session.user as typeof session.user & { role?: string | null }).role,
-  );
-  const creditsData = creditsResult?.data.credits ?? null;
   const currentPlan =
     creditsResult != null
       ? (creditsResult.data.subscription?.plan ?? "free")
@@ -73,30 +75,10 @@ export default async function AppShellChrome({ session }: AppShellChromeProps) {
     );
   const shouldLoadSubscriptionOnboarding =
     shouldShowFreeSubscriptionGate && !subscriptionOnboardingGateAlreadyServed;
-  const currentTimestampMs = creditsResult?.meta?.timestamp
-    ? new Date(creditsResult.meta.timestamp).getTime()
-    : 0;
-  const lowCreditsThreshold =
-    getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
-  const accountNotice = resolveAccountNotice({
-    credits: creditsData?.total ?? null,
-    currentPlan,
-    email: session.user.email,
-    emailVerified: session.user.emailVerified,
-    threshold: lowCreditsThreshold,
-  });
 
   return (
     <>
-      <ShellHydrators accountNotice={accountNotice} coworkers={coworkers} />
-      <Sidebar
-        adminMenuEnabled={adminMenuEnabled}
-        creditsData={creditsData}
-        currentTimestampMs={currentTimestampMs}
-        organizationName={activeOrganization?.name ?? null}
-        session={session}
-        lowCreditsThreshold={lowCreditsThreshold}
-      />
+      <CoworkersHydrator coworkers={coworkers} />
       {shouldShowOnboarding ? (
         <Suspense fallback={null}>
           <OnboardingDialogLoader

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -7,15 +7,17 @@ import { BreadcrumbOverrideProvider } from "@/contexts/breadcrumb-override-conte
 import { CoworkersProvider } from "@/contexts/coworkers-context";
 import { NotificationProvider } from "@/contexts/notification-provider";
 import { getSessionOrRedirect } from "@/lib/auth/auth.server";
+import { hasAdminRole } from "@/lib/auth/has-admin-role";
 import type { Notice } from "@/lib/clients/generated/core";
 
-import AppShellChrome from "./app-shell-chrome";
+import AppShellOverlays from "./app-shell-overlays";
 import { AppSidebarFallback } from "./app-sidebar-fallback";
 import Header from "./header";
 import { LoginAccountNoticeToast } from "./login-account-notice-toast.client";
 import { NoticeDialogProvider } from "./notice-dialog-context";
 import { NotificationToastListener } from "./notification-toast-listener";
 import { NotificationToaster } from "./notification-toaster.client";
+import PrivateCachedAppSidebar from "./private-cached-app-sidebar";
 
 const EMPTY_COWORKERS: Coworker[] = [];
 const EMPTY_NOTICES: Notice[] = [];
@@ -28,6 +30,9 @@ export default async function AuthenticatedAppFrame({
   children,
 }: AuthenticatedAppFrameProps) {
   const session = await getSessionOrRedirect();
+  const adminMenuEnabled = hasAdminRole(
+    (session.user as typeof session.user & { role?: string | null }).role,
+  );
 
   return (
     <NotificationProvider userId={session.user.id}>
@@ -47,7 +52,16 @@ export default async function AuthenticatedAppFrame({
             >
               <BreadcrumbOverrideProvider>
                 <Suspense fallback={<AppSidebarFallback />}>
-                  <AppShellChrome session={session} />
+                  <PrivateCachedAppSidebar
+                    userId={session.user.id}
+                    activeOrganizationId={
+                      session.session.activeOrganizationId ?? null
+                    }
+                    adminMenuEnabled={adminMenuEnabled}
+                  />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <AppShellOverlays session={session} />
                 </Suspense>
                 <div
                   className="flex min-w-0 flex-1 overflow-clip"

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -1,0 +1,159 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { getTranslations } from "next-intl/server";
+import {
+  resolveAccountNotice,
+  resolveLowCreditsBillingPath,
+} from "@/app/components/account-notice-state";
+import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
+import { getEnvPublicConfig } from "@/config/env.public";
+import { getSession } from "@/lib/auth/auth.server";
+import { coreClient } from "@/lib/clients/core.client";
+import type { GetUsersByIdCreditsResponse } from "@/lib/clients/generated/core";
+import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
+import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
+import { chatRoomService, userService } from "@/lib/services";
+import {
+  resolvePlanName,
+  resolvePlanSecondaryLabel,
+} from "@/lib/utils/plan-label";
+
+import { AccountNoticeHydrator } from "./shell-hydrators.client";
+import Sidebar, { resolveCreditUsage } from "./sidebar";
+
+interface PrivateCachedAppSidebarProps {
+  userId: string;
+  activeOrganizationId: string | null;
+  adminMenuEnabled: boolean;
+}
+
+/**
+ * Session-aware sidebar chrome for Instant Navigations.
+ * Private-cache slice loads all sidebar data inside this boundary so soft
+ * navigations can fill the Suspense hole from browser memory without uncached
+ * async SC children under the cached tree.
+ */
+export default async function PrivateCachedAppSidebar({
+  userId,
+  activeOrganizationId,
+  adminMenuEnabled,
+}: PrivateCachedAppSidebarProps) {
+  "use cache: private";
+  cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
+  cacheTag(`app-sidebar-user-${userId}`);
+  if (activeOrganizationId) {
+    cacheTag(`app-sidebar-org-${activeOrganizationId}`);
+  }
+
+  const session = await getSession();
+  if (!session || session.user.id !== userId) {
+    return null;
+  }
+
+  const tCreditPromise = getTranslations("App.Header.Credit");
+  const tPlanPromise = getTranslations("App.Header.Plan");
+  const hermesMenuEnabled = isHermesBetaAccessEmail(session.user.email);
+  const lowCreditsThreshold =
+    getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
+
+  const membersPromise = userService
+    .getMyMembersWithOrganizations()
+    .catch(() => []);
+  // Personal coworker directs exist with no active org; Core returns those when
+  // organization context is null. Named channels still need an org (empty list then).
+  const chatRoomsPromise = chatRoomService.listRooms().catch(() => []);
+  const archivedChatRoomsPromise = activeOrganizationId
+    ? chatRoomService.listArchivedRooms().catch(() => [])
+    : Promise.resolve(
+        [] as Awaited<ReturnType<typeof chatRoomService.listArchivedRooms>>,
+      );
+  const activeOrganizationPromise = userService.getActiveOrganization();
+  const creditsPromise = coreClient.getMyCredits().catch(() => null);
+
+  const [
+    tCredit,
+    tPlan,
+    members,
+    chatRooms,
+    archivedChatRooms,
+    { showVendors: showDeveloperVendors },
+    activeOrganization,
+    creditsResultRaw,
+  ] = await Promise.all([
+    tCreditPromise,
+    tPlanPromise,
+    membersPromise,
+    chatRoomsPromise,
+    archivedChatRoomsPromise,
+    getDeveloperVendorAdminAccess(),
+    activeOrganizationPromise,
+    creditsPromise,
+  ]);
+  const creditsResult = creditsResultRaw as GetUsersByIdCreditsResponse | null;
+
+  const creditsData = creditsResult?.data.credits ?? null;
+  const currentPlan = creditsData?.subscription?.plan ?? "free";
+  const planForLabel = creditsData === null ? null : currentPlan;
+  const organizationName = activeOrganization?.name ?? null;
+  const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
+  const currentTimestampMs = creditsResult?.meta?.timestamp
+    ? new Date(creditsResult.meta.timestamp).getTime()
+    : 0;
+  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
+  const subscriptionPeriodEndMs = subscriptionPeriodEnd
+    ? new Date(subscriptionPeriodEnd).getTime()
+    : null;
+
+  const [planLabel, planName] = await Promise.all([
+    resolvePlanSecondaryLabel({
+      plan: planForLabel,
+      organizationName: activeOrganizationId
+        ? (organizationName ?? tCredit("unavailable"))
+        : null,
+    }),
+    resolvePlanName(planForLabel),
+  ]);
+
+  const canDeleteArchivedRooms = Boolean(
+    activeOrganizationId &&
+      members.some(
+        (membership) =>
+          membership.organizationId === activeOrganizationId &&
+          isOrganizationOwnerOrAdmin(membership.role),
+      ),
+  );
+
+  const accountNotice = resolveAccountNotice({
+    credits: creditsData?.total ?? null,
+    currentPlan: creditsData === null ? null : currentPlan,
+    email: session.user.email,
+    emailVerified: session.user.emailVerified,
+    threshold: lowCreditsThreshold,
+  });
+
+  return (
+    <>
+      <AccountNoticeHydrator accountNotice={accountNotice} />
+      <Sidebar
+        activeOrganizationId={activeOrganizationId}
+        adminMenuEnabled={adminMenuEnabled}
+        archivedChatRooms={archivedChatRooms}
+        buyCreditsLabel={tPlan("getMoreCredits")}
+        buyCreditsPath={buyCreditsPath}
+        canDeleteArchivedRooms={canDeleteArchivedRooms}
+        chatRooms={chatRooms}
+        creditsData={creditsData}
+        creditUsage={resolveCreditUsage(creditsData)}
+        currentTimestampMs={currentTimestampMs}
+        currentUserId={session.user.id}
+        hermesMenuEnabled={hermesMenuEnabled}
+        lowCreditsThreshold={lowCreditsThreshold}
+        members={members}
+        planLabel={planLabel}
+        planName={planName}
+        sessionUser={session.user}
+        showDeveloperVendors={showDeveloperVendors}
+        subscriptionPeriodEndMs={subscriptionPeriodEndMs}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -7,8 +7,6 @@ import {
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
 import { getEnvPublicConfig } from "@/config/env.public";
 import { getSession } from "@/lib/auth/auth.server";
-import { coreClient } from "@/lib/clients/core.client";
-import type { GetUsersByIdCreditsResponse } from "@/lib/clients/generated/core";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 import { chatRoomService, userService } from "@/lib/services";
@@ -17,6 +15,11 @@ import {
   resolvePlanSecondaryLabel,
 } from "@/lib/utils/plan-label";
 
+import {
+  getCachedMyCredits,
+  privateSidebarOrgTag,
+  privateSidebarUserTag,
+} from "./private-sidebar-cache";
 import { AccountNoticeHydrator } from "./shell-hydrators.client";
 import Sidebar, { resolveCreditUsage } from "./sidebar";
 
@@ -39,9 +42,9 @@ export default async function PrivateCachedAppSidebar({
 }: PrivateCachedAppSidebarProps) {
   "use cache: private";
   cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
-  cacheTag(`app-sidebar-user-${userId}`);
+  cacheTag(privateSidebarUserTag(userId));
   if (activeOrganizationId) {
-    cacheTag(`app-sidebar-org-${activeOrganizationId}`);
+    cacheTag(privateSidebarOrgTag(activeOrganizationId));
   }
 
   const session = await getSession();
@@ -67,7 +70,7 @@ export default async function PrivateCachedAppSidebar({
         [] as Awaited<ReturnType<typeof chatRoomService.listArchivedRooms>>,
       );
   const activeOrganizationPromise = userService.getActiveOrganization();
-  const creditsPromise = coreClient.getMyCredits().catch(() => null);
+  const creditsPromise = getCachedMyCredits();
 
   const [
     tCredit,
@@ -77,7 +80,7 @@ export default async function PrivateCachedAppSidebar({
     archivedChatRooms,
     { showVendors: showDeveloperVendors },
     activeOrganization,
-    creditsResultRaw,
+    creditsResult,
   ] = await Promise.all([
     tCreditPromise,
     tPlanPromise,
@@ -88,7 +91,6 @@ export default async function PrivateCachedAppSidebar({
     activeOrganizationPromise,
     creditsPromise,
   ]);
-  const creditsResult = creditsResultRaw as GetUsersByIdCreditsResponse | null;
 
   const creditsData = creditsResult?.data.credits ?? null;
   const currentPlan = creditsData?.subscription?.plan ?? "free";

--- a/apps/web/src/app/(app)/components/private-sidebar-cache.ts
+++ b/apps/web/src/app/(app)/components/private-sidebar-cache.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+import { updateTag } from "next/cache";
+import { cache } from "react";
+import { coreClient } from "@/lib/clients/core.client";
+import type { GetUsersByIdCreditsResponse } from "@/lib/clients/generated/core";
+
+export function privateSidebarUserTag(userId: string): string {
+  return `app-sidebar-user-${userId}`;
+}
+
+export function privateSidebarOrgTag(organizationId: string): string {
+  return `app-sidebar-org-${organizationId}`;
+}
+
+/**
+ * Request-scoped credits read shared by private sidebar + overlays so a cold
+ * layout fill does not double-hit Core for the same session.
+ */
+export const getCachedMyCredits = cache(
+  async (): Promise<GetUsersByIdCreditsResponse | null> => {
+    try {
+      return (await coreClient.getMyCredits()) as GetUsersByIdCreditsResponse;
+    } catch {
+      return null;
+    }
+  },
+);
+
+interface InvalidatePrivateSidebarChromeArgs {
+  userId: string;
+  organizationId?: string | null;
+  previousOrganizationId?: string | null;
+}
+
+/**
+ * Clears browser private-cache entries for personalized sidebar chrome.
+ * Call from Server Actions after org switch, room list mutations, or credits.
+ */
+export function invalidatePrivateSidebarChrome({
+  userId,
+  organizationId,
+  previousOrganizationId,
+}: InvalidatePrivateSidebarChromeArgs): void {
+  updateTag(privateSidebarUserTag(userId));
+  if (organizationId) {
+    updateTag(privateSidebarOrgTag(organizationId));
+  }
+  if (previousOrganizationId && previousOrganizationId !== organizationId) {
+    updateTag(privateSidebarOrgTag(previousOrganizationId));
+  }
+}

--- a/apps/web/src/app/(app)/components/shell-hydrators.client.tsx
+++ b/apps/web/src/app/(app)/components/shell-hydrators.client.tsx
@@ -9,21 +9,35 @@ import { useAccountNoticeHydration } from "@/contexts/account-notice-provider";
 import { useCoworkersHydration } from "@/contexts/coworkers-context";
 import type { Notice } from "@/lib/clients/generated/core";
 
-interface ShellHydratorsProps {
+interface AccountNoticeHydratorProps {
   accountNotice: AccountNotice | null;
-  coworkers: Coworker[];
 }
 
-export function ShellHydrators({
+/**
+ * Hydrates account notice independently so coworkers streaming must not wipe it.
+ */
+export function AccountNoticeHydrator({
   accountNotice,
-  coworkers,
-}: ShellHydratorsProps) {
+}: AccountNoticeHydratorProps) {
   const hydrateAccountNotice = useAccountNoticeHydration();
-  const hydrateCoworkers = useCoworkersHydration();
 
   useEffect(() => {
     hydrateAccountNotice(accountNotice);
   }, [accountNotice, hydrateAccountNotice]);
+
+  return null;
+}
+
+interface CoworkersHydratorProps {
+  coworkers: Coworker[];
+}
+
+/**
+ * Hydrates coworkers independently so account-notice private-cache stream
+ * is unaffected when overlays resolve.
+ */
+export function CoworkersHydrator({ coworkers }: CoworkersHydratorProps) {
+  const hydrateCoworkers = useCoworkersHydration();
 
   useEffect(() => {
     hydrateCoworkers(coworkers);

--- a/apps/web/src/app/(app)/components/sidebar/__tests__/resolve-credit-usage.test.ts
+++ b/apps/web/src/app/(app)/components/sidebar/__tests__/resolve-credit-usage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { StripeSubscriptionStatus } from "@/lib/clients/generated/core";
+
+import type { SidebarCreditsData } from "../index";
+import { resolveCreditUsage } from "../index";
+
+function buildCreditsData(
+  subscriptionCredits: NonNullable<
+    NonNullable<SidebarCreditsData["subscription"]>["credits"]
+  > | null = {
+    total: 100,
+    used: 25,
+    remaining: 75,
+  },
+): SidebarCreditsData {
+  return {
+    total: 100,
+    buffer: 0,
+    subscription: {
+      plan: "pro",
+      status: StripeSubscriptionStatus.ACTIVE,
+      periodEnd: null,
+      credits: subscriptionCredits,
+    },
+  };
+}
+
+describe("resolveCreditUsage", () => {
+  it("returns null when credits data is missing", () => {
+    expect(resolveCreditUsage(null)).toBeNull();
+  });
+
+  it("returns null when subscription credits total is zero", () => {
+    expect(
+      resolveCreditUsage(buildCreditsData({ total: 0, used: 0, remaining: 0 })),
+    ).toBeNull();
+  });
+
+  it("returns null when subscription credits are null", () => {
+    expect(resolveCreditUsage(buildCreditsData(null))).toBeNull();
+  });
+
+  it("maps subscription credits into chip usage", () => {
+    expect(resolveCreditUsage(buildCreditsData())).toEqual({
+      percentageUsed: 25,
+      remaining: 75,
+      total: 100,
+      used: 25,
+    });
+  });
+});

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -1,7 +1,4 @@
-import type { Session } from "@sokosumi/utils";
-import { getTranslations } from "next-intl/server";
-import { resolveLowCreditsBillingPath } from "@/app/components/account-notice-state";
-import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
+import type { SessionUser } from "@sokosumi/utils";
 import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
 import {
   Sidebar as ShadcnSidebar,
@@ -10,15 +7,12 @@ import {
   SidebarHeader,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
-import type { GetUsersByIdCreditsResponse } from "@/lib/clients/generated/core";
-import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
-import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
-import { chatRoomService, userService } from "@/lib/services";
+import type {
+  ChatRoom,
+  GetUsersByIdCreditsResponse,
+  MemberWithOrganization,
+} from "@/lib/clients/generated/core";
 import type { CreditUsage } from "@/lib/types/credit";
-import {
-  resolvePlanName,
-  resolvePlanSecondaryLabel,
-} from "@/lib/utils/plan-label";
 
 import AdminSettingsMenuGroup from "./components/admin-settings-menu-group.client";
 import AnnouncementCards from "./components/announcement-cards";
@@ -35,7 +29,7 @@ export type SidebarCreditsData = GetUsersByIdCreditsResponse["data"]["credits"];
  * Subscription-period usage only exists once a paid period grants credits; the
  * free plan has no allowance to draw down, so the chip hides the bar entirely.
  */
-function resolveCreditUsage(
+export function resolveCreditUsage(
   creditsData: SidebarCreditsData | null,
 ): CreditUsage | null {
   const subscriptionCredits = creditsData?.subscription?.credits ?? null;
@@ -55,80 +49,48 @@ function resolveCreditUsage(
 }
 
 interface SidebarProps {
+  activeOrganizationId: string | null;
   adminMenuEnabled: boolean;
+  archivedChatRooms: ChatRoom[];
+  buyCreditsLabel: string;
+  buyCreditsPath: string;
+  canDeleteArchivedRooms: boolean;
+  chatRooms: ChatRoom[];
   creditsData: SidebarCreditsData | null;
+  creditUsage: CreditUsage | null;
   currentTimestampMs: number;
-  organizationName: string | null;
-  session: Session;
+  currentUserId: string;
+  hermesMenuEnabled: boolean;
   lowCreditsThreshold: number;
+  members: MemberWithOrganization[];
+  planLabel: string;
+  planName: string | null;
+  sessionUser: SessionUser;
+  showDeveloperVendors: boolean;
+  subscriptionPeriodEndMs: number | null;
 }
 
-export default async function Sidebar({
+export default function Sidebar({
+  activeOrganizationId,
   adminMenuEnabled,
+  archivedChatRooms,
+  buyCreditsLabel,
+  buyCreditsPath,
+  canDeleteArchivedRooms,
+  chatRooms,
   creditsData,
+  creditUsage,
   currentTimestampMs,
-  organizationName,
-  session,
+  currentUserId,
+  hermesMenuEnabled,
   lowCreditsThreshold,
+  members,
+  planLabel,
+  planName,
+  sessionUser,
+  showDeveloperVendors,
+  subscriptionPeriodEndMs,
 }: SidebarProps) {
-  const tCreditPromise = getTranslations("App.Header.Credit");
-  const tPlanPromise = getTranslations("App.Header.Plan");
-  // Hermes beta gate: the Personal Assistant entry only renders for
-  // whitelisted email domains; /personal-assistant itself 404s in its layout.
-  const hermesMenuEnabled = isHermesBetaAccessEmail(session.user.email);
-  const currentPlan = creditsData?.subscription?.plan ?? "free";
-  const planForLabel = creditsData === null ? null : currentPlan;
-  const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
-  const activeOrganizationId = session.session.activeOrganizationId ?? null;
-
-  const membersPromise = userService
-    .getMyMembersWithOrganizations()
-    .catch(() => []);
-  // Personal coworker directs exist with no active org; Core returns those when
-  // organization context is null. Named channels still need an org (empty list then).
-  const chatRoomsPromise = chatRoomService.listRooms().catch(() => []);
-  const archivedChatRoomsPromise = activeOrganizationId
-    ? chatRoomService.listArchivedRooms().catch(() => [])
-    : Promise.resolve(
-        [] as Awaited<ReturnType<typeof chatRoomService.listArchivedRooms>>,
-      );
-  const planLabelPromise = tCreditPromise.then((tCredit) =>
-    resolvePlanSecondaryLabel({
-      plan: planForLabel,
-      organizationName: activeOrganizationId
-        ? (organizationName ?? tCredit("unavailable"))
-        : null,
-    }),
-  );
-
-  const [
-    tPlan,
-    members,
-    chatRooms,
-    archivedChatRooms,
-    { showVendors: showDeveloperVendors },
-    planLabel,
-    planName,
-  ] = await Promise.all([
-    tPlanPromise,
-    membersPromise,
-    chatRoomsPromise,
-    archivedChatRoomsPromise,
-    getDeveloperVendorAdminAccess(),
-    planLabelPromise,
-    resolvePlanName(planForLabel),
-  ]);
-  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
-
-  const canDeleteArchivedRooms = Boolean(
-    activeOrganizationId &&
-      members.some(
-        (membership) =>
-          membership.organizationId === activeOrganizationId &&
-          isOrganizationOwnerOrAdmin(membership.role),
-      ),
-  );
-
   return (
     <ShadcnSidebar collapsible="icon">
       <SidebarHeader className="h-16 border-b p-0">
@@ -155,7 +117,7 @@ export default async function Sidebar({
             <OrganizationChatList
               rooms={chatRooms}
               archivedRooms={archivedChatRooms}
-              currentUserId={session.user.id}
+              currentUserId={currentUserId}
               organizationId={activeOrganizationId}
               canDeleteArchivedRooms={canDeleteArchivedRooms}
             />
@@ -169,19 +131,15 @@ export default async function Sidebar({
             grows on phones, where the home indicator sits in that 8px. */}
         <div className="p-2 pt-0 pb-[env(safe-area-inset-bottom)] group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
           <SidebarAccountChip
-            sessionUser={session.user}
+            sessionUser={sessionUser}
             planName={planName}
             totalCredits={creditsData?.total ?? null}
             extraCredits={creditsData?.buffer ?? null}
-            creditUsage={resolveCreditUsage(creditsData)}
-            subscriptionPeriodEndMs={
-              subscriptionPeriodEnd
-                ? new Date(subscriptionPeriodEnd).getTime()
-                : null
-            }
+            creditUsage={creditUsage}
+            subscriptionPeriodEndMs={subscriptionPeriodEndMs}
             currentTimestampMs={currentTimestampMs}
             lowCreditsThreshold={lowCreditsThreshold}
-            buyCreditsLabel={tPlan("getMoreCredits")}
+            buyCreditsLabel={buyCreditsLabel}
             buyCreditsPath={buyCreditsPath}
           />
         </div>

--- a/apps/web/src/lib/actions/credits/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/credits/__tests__/action.test.ts
@@ -32,6 +32,13 @@ vi.mock("@/lib/clients/core.client", () => ({
   },
 }));
 
+const invalidatePrivateSidebarChromeMock = vi.fn();
+
+vi.mock("@/app/components/private-sidebar-cache", () => ({
+  invalidatePrivateSidebarChrome: (...args: unknown[]) =>
+    invalidatePrivateSidebarChromeMock(...args),
+}));
+
 describe("credits actions", () => {
   const session = {
     user: {

--- a/apps/web/src/lib/actions/credits/action.ts
+++ b/apps/web/src/lib/actions/credits/action.ts
@@ -2,6 +2,7 @@
 
 import { isPositiveIntegerCredits } from "@sokosumi/utils";
 
+import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
 import {
   type ActionError,
   CommonErrorCode,
@@ -25,7 +26,7 @@ interface PurchaseCreditsParameters extends AuthenticatedRequest {
 export const purchaseCredits = withSession<
   PurchaseCreditsParameters,
   Result<{ url: string }, ActionError>
->(async ({ organizationId, credits, returnPath }) => {
+>(async ({ organizationId, credits, returnPath, session }) => {
   if (!isPositiveIntegerCredits(credits)) {
     return Err({
       message: "Invalid credits",
@@ -50,6 +51,13 @@ export const purchaseCredits = withSession<
       returnPath,
     });
 
+    // Clear private sidebar so soft nav after checkout return refetches credits.
+    invalidatePrivateSidebarChrome({
+      userId: session.user.id,
+      organizationId:
+        organizationId ?? session.session.activeOrganizationId ?? null,
+    });
+
     return Ok({ url: data.url });
   } catch (error) {
     console.error("Failed to purchase credits", error);
@@ -68,7 +76,7 @@ interface ClaimFreeCreditsWithCouponParameters extends AuthenticatedRequest {
 export const claimFreeCreditsWithCoupon = withSession<
   ClaimFreeCreditsWithCouponParameters,
   Result<{ url: string }, ActionError>
->(async ({ organizationId, couponId, returnPath }) => {
+>(async ({ organizationId, couponId, returnPath, session }) => {
   if (organizationId) {
     const member = await userService.getMyMemberInOrganization(organizationId);
     if (!member) {
@@ -94,6 +102,12 @@ export const claimFreeCreditsWithCoupon = withSession<
       credits: coupon.credits,
       promotionCodeId: promo.data.promotionCodeId,
       returnPath: returnPath ?? "/coupon",
+    });
+
+    invalidatePrivateSidebarChrome({
+      userId: session.user.id,
+      organizationId:
+        organizationId ?? session.session.activeOrganizationId ?? null,
     });
 
     return Ok({ url: data.url });

--- a/apps/web/src/lib/actions/organization/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/organization/__tests__/action.test.ts
@@ -58,9 +58,19 @@ vi.mock("next/headers", () => ({
   headers: () => headersMock(),
 }));
 
+const invalidatePrivateSidebarChromeMock = vi.fn();
+
+vi.mock("@/app/components/private-sidebar-cache", () => ({
+  invalidatePrivateSidebarChrome: (...args: unknown[]) =>
+    invalidatePrivateSidebarChromeMock(...args),
+}));
+
 const session = {
   user: {
     id: "user-1",
+  },
+  session: {
+    activeOrganizationId: "org-prev",
   },
 } as never;
 
@@ -274,6 +284,11 @@ describe("updatePreferredOrganization", () => {
       data: { organizationId: "org-1" },
     });
     expect(setMyPreferredOrganizationMock).toHaveBeenCalledWith("org-1");
+    expect(invalidatePrivateSidebarChromeMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+      previousOrganizationId: "org-prev",
+    });
   });
 
   it("clears the preferred organization when null is provided", async () => {

--- a/apps/web/src/lib/actions/organization/action.ts
+++ b/apps/web/src/lib/actions/organization/action.ts
@@ -2,6 +2,7 @@
 
 import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
 import * as z from "zod";
+import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
 import { getEnvSecrets } from "@/config/env.secrets";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
@@ -153,7 +154,7 @@ interface UpdatePreferredOrganizationParameters extends AuthenticatedRequest {
 export const updatePreferredOrganization = withSession<
   UpdatePreferredOrganizationParameters,
   Result<{ organizationId: string | null }, ActionError>
->(async ({ organizationId }) => {
+>(async ({ organizationId, session }) => {
   const parsedResult = updatePreferredOrganizationSchema.safeParse({
     organizationId,
   });
@@ -165,10 +166,18 @@ export const updatePreferredOrganization = withSession<
     });
   }
 
+  const previousOrganizationId = session.session.activeOrganizationId ?? null;
+
   try {
     const { data } = await coreClient.setMyPreferredOrganization(
       parsedResult.data.organizationId,
     );
+
+    invalidatePrivateSidebarChrome({
+      userId: session.user.id,
+      organizationId: data.organizationId,
+      previousOrganizationId,
+    });
 
     return Ok({
       organizationId: data.organizationId,

--- a/apps/web/src/lib/actions/subscription/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/subscription/__tests__/action.test.ts
@@ -33,6 +33,13 @@ vi.mock("@/middleware/auth-middleware", () => ({
       await handler(params),
 }));
 
+const invalidatePrivateSidebarChromeMock = vi.fn();
+
+vi.mock("@/app/components/private-sidebar-cache", () => ({
+  invalidatePrivateSidebarChrome: (...args: unknown[]) =>
+    invalidatePrivateSidebarChromeMock(...args),
+}));
+
 const organizationSession = {
   user: {
     id: "user-1",
@@ -87,6 +94,10 @@ describe("subscription actions", () => {
       "org-1",
       9,
     );
+    expect(invalidatePrivateSidebarChromeMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
   });
 
   it("maps enterprise exclusivity errors from core seat updates", async () => {

--- a/apps/web/src/lib/actions/subscription/action.ts
+++ b/apps/web/src/lib/actions/subscription/action.ts
@@ -2,6 +2,7 @@
 
 import type { PaidSubscriptionPlanName } from "@sokosumi/utils";
 import * as z from "zod";
+import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toSubscriptionSeatsActionError } from "@/lib/actions/subscription/map-core-subscription-seats-error";
 import type { SubscriptionChangeResult } from "@/lib/auth/subscription.server";
@@ -61,7 +62,7 @@ interface UpdateOrganizationSubscriptionSeatsParameters
 export const updateOrganizationSubscriptionSeats = withSession<
   UpdateOrganizationSubscriptionSeatsParameters,
   Result<{ seats: number }, ActionError>
->(async ({ organizationId, seats }) => {
+>(async ({ organizationId, seats, session }) => {
   const parsed = updateOrganizationSubscriptionSeatsSchema.safeParse({
     organizationId,
     seats,
@@ -77,6 +78,11 @@ export const updateOrganizationSubscriptionSeats = withSession<
       parsed.data.organizationId,
       parsed.data.seats,
     );
+
+    invalidatePrivateSidebarChrome({
+      userId: session.user.id,
+      organizationId: parsed.data.organizationId,
+    });
 
     return Ok({ seats: data.seats });
   } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Personalized **sidebar chrome** now participates in Instant Navigations via `'use cache: private'` ([SOK-710](https://linear.app/masumi/issue/SOK-710/prefetch-personalized-app-chrome-with-private-cache-components)).

- `PrivateCachedAppSidebar` loads org/credits/members/chat rooms under `cacheLife({ stale: 300 })` so the slice can join the App Shell
- Existing `AppSidebarFallback` Suspense stays; soft navs can fill chrome from browser private cache
- Onboarding, notices, and coworkers stream separately (`AppShellOverlays`) — not private-cached
- Overlays fetch credits/org **only when needed**; shared `getCachedMyCredits` React.cache with sidebar
- `invalidatePrivateSidebarChrome` / `updateTag` on org switch, chat room list mutations, credits checkout, and seat updates
- Account-notice vs coworkers hydrators split so overlay stream cannot wipe notice
- Sync `(app)` layout cookie behavior unchanged; Ably/notifications outside private cache; `instant = false` on admin/Hermes unchanged

## Out of scope

Header profile private-cache, route Instant Nav expansion (SOK-708), shared catalog `'use cache'` (SOK-709).

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0; 2426 passed)
- `pnpm --filter web typecheck` (exit 0)

Linear Issue: [SOK-710](https://linear.app/masumi/issue/SOK-710/prefetch-personalized-app-chrome-with-private-cache-components)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-710](https://linear.app/masumi/issue/SOK-710/prefetch-personalized-app-chrome-with-private-cache-components)

<div><a href="https://cursor.com/agents/bc-a07c8c64-09b5-4fa0-92d7-035fba59dd41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07c8c64-09b5-4fa0-92d7-035fba59dd41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented sidebar caching for improved performance and faster load times.

* **Bug Fixes**
  * Sidebar now properly refreshes when organization, subscription, or billing changes occur.

* **Refactor**
  * Restructured overlay and sidebar components for better separation of responsibilities and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->