### PR TITLE
fix(chat): stop document title flicker when switching channels

### DIFF
--- a/apps/web/src/app/(app)/chat/layout.tsx
+++ b/apps/web/src/app/(app)/chat/layout.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import DefaultErrorBoundary from "@/components/default-error-boundary";
 
 import { ChatErrorFallback } from "./components/chat-error-fallback";
@@ -6,6 +8,15 @@ import { ChatErrorFallback } from "./components/chat-error-fallback";
  * When the virtual keyboard opens on mobile, the layout viewport resizes so
  * the room composer stays above the keyboard.
  */
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("App.Channels.Metadata");
+
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
+
 export const viewport = {
   interactiveWidget: "resizes-content" as const,
 };

--- a/apps/web/src/app/(app)/chat/layout.tsx
+++ b/apps/web/src/app/(app)/chat/layout.tsx
@@ -4,10 +4,6 @@ import DefaultErrorBoundary from "@/components/default-error-boundary";
 
 import { ChatErrorFallback } from "./components/chat-error-fallback";
 
-/**
- * When the virtual keyboard opens on mobile, the layout viewport resizes so
- * the room composer stays above the keyboard.
- */
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("App.Channels.Metadata");
 
@@ -17,6 +13,10 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+/**
+ * When the virtual keyboard opens on mobile, the layout viewport resizes so
+ * the room composer stays above the keyboard.
+ */
 export const viewport = {
   interactiveWidget: "resizes-content" as const,
 };

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
@@ -21,23 +20,6 @@ interface ChatPageProps {
     dm?: string | string[];
     notice?: string | string[];
   }>;
-}
-
-export async function generateMetadata({
-  searchParams,
-}: ChatPageProps): Promise<Metadata> {
-  const query = await searchParams;
-  const isDraftMode =
-    firstSearchValue(query.create) === "channel" ||
-    firstSearchValue(query.dm) === "new";
-  const t = await getTranslations(
-    isDraftMode ? "App.Channels.Metadata" : "App.Chat.Metadata",
-  );
-
-  return {
-    title: t("title"),
-    description: t("description"),
-  };
 }
 
 function ChatPageFallback() {

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
@@ -41,15 +40,6 @@ function NoOrganizationCard({
 
 function ChatRoomPageFallback() {
   return <DefaultLoading className="h-full min-h-[300px] w-full flex-1 p-8" />;
-}
-
-export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("App.Channels.Metadata");
-
-  return {
-    title: t("title"),
-    description: t("description"),
-  };
 }
 
 /**

--- a/apps/web/src/hooks/__tests__/use-chat-unread-document-title.test.ts
+++ b/apps/web/src/hooks/__tests__/use-chat-unread-document-title.test.ts
@@ -3,12 +3,62 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { useChatUnreadDocumentTitle } from "@/hooks/use-chat-unread-document-title";
 
+function getDocumentTitleDescriptor(): {
+  descriptor: PropertyDescriptor & {
+    get: (this: Document) => string;
+    set: (this: Document, value: string) => void;
+  };
+} {
+  let owner: object | null = document;
+  while (owner) {
+    const descriptor = Object.getOwnPropertyDescriptor(owner, "title");
+    if (descriptor?.get && descriptor.set) {
+      return {
+        descriptor: descriptor as PropertyDescriptor & {
+          get: (this: Document) => string;
+          set: (this: Document, value: string) => void;
+        },
+      };
+    }
+    owner = Object.getPrototypeOf(owner);
+  }
+  throw new Error("document.title descriptor unavailable");
+}
+
+function trackVisibleDocumentTitles(): {
+  titles: string[];
+  restore: () => void;
+} {
+  const titles: string[] = [];
+  const { descriptor } = getDocumentTitleDescriptor();
+
+  Object.defineProperty(document, "title", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return descriptor.get.call(document);
+    },
+    set(value: string) {
+      descriptor.set.call(document, value);
+      titles.push(descriptor.get.call(document));
+    },
+  });
+
+  return {
+    titles,
+    restore() {
+      Reflect.deleteProperty(document, "title");
+    },
+  };
+}
+
 describe("useChatUnreadDocumentTitle", () => {
   beforeEach(() => {
     document.title = "Sokosumi";
   });
 
   afterEach(() => {
+    Reflect.deleteProperty(document, "title");
     document.title = "";
   });
 
@@ -52,5 +102,47 @@ describe("useChatUnreadDocumentTitle", () => {
     });
 
     expect(document.title).toBe("(2) Room · Sokosumi");
+  });
+
+  it("does not strip the unread prefix between channel navigations when unreadTotal changes", () => {
+    const { titles, restore } = trackVisibleDocumentTitles();
+
+    try {
+      const { rerender } = renderHook(
+        ({ unreadTotal }) => useChatUnreadDocumentTitle(unreadTotal),
+        { initialProps: { unreadTotal: 2 } },
+      );
+
+      expect(document.title).toBe("(2) Sokosumi");
+      titles.length = 0;
+
+      // Channel soft-nav changes activeRoomId → unread room count often shifts.
+      rerender({ unreadTotal: 1 });
+
+      expect(titles.some((title) => !/^\(\d+\) /.test(title))).toBe(false);
+      expect(document.title).toBe("(1) Sokosumi");
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not expose an unprefixed title when soft navigation rewrites metadata", async () => {
+    renderHook(() => useChatUnreadDocumentTitle(3));
+    expect(document.title).toBe("(3) Sokosumi");
+
+    const { titles, restore } = trackVisibleDocumentTitles();
+
+    try {
+      await act(async () => {
+        document.title = "Sokosumi - Chat";
+        await Promise.resolve();
+      });
+
+      expect(titles.length).toBeGreaterThan(0);
+      expect(titles.some((title) => !/^\(\d+\) /.test(title))).toBe(false);
+      expect(document.title).toBe("(3) Sokosumi - Chat");
+    } finally {
+      restore();
+    }
   });
 });

--- a/apps/web/src/hooks/__tests__/use-chat-unread-document-title.test.ts
+++ b/apps/web/src/hooks/__tests__/use-chat-unread-document-title.test.ts
@@ -145,4 +145,27 @@ describe("useChatUnreadDocumentTitle", () => {
       restore();
     }
   });
+
+  it("restores the previous title when soft navigation clears document.title", async () => {
+    renderHook(() => useChatUnreadDocumentTitle(0));
+
+    await act(async () => {
+      document.title = "Sokosumi - Chat";
+      await Promise.resolve();
+    });
+    expect(document.title).toBe("Sokosumi - Chat");
+
+    await act(async () => {
+      // Next App Router clears <title> during soft navigations before writing
+      // the next metadata title. Browsers show the page host while empty.
+      const titleElement = document.querySelector("title");
+      if (!titleElement) {
+        throw new Error("document title element missing");
+      }
+      titleElement.textContent = "";
+      await Promise.resolve();
+    });
+
+    expect(document.title).toBe("Sokosumi - Chat");
+  });
 });

--- a/apps/web/src/hooks/use-chat-unread-document-title.ts
+++ b/apps/web/src/hooks/use-chat-unread-document-title.ts
@@ -25,6 +25,10 @@ function getDocumentTitleDescriptor(target: Document): PropertyDescriptor & {
   throw new Error("document.title descriptor unavailable");
 }
 
+// Survives hook remounts during soft navigations so an empty <title> mid-swap
+// cannot fall back to the browser host / a generic default.
+let sharedLastGoodBase = "Sokosumi";
+
 export function useChatUnreadDocumentTitle(unreadTotal: number): void {
   const unreadTotalRef = useRef(unreadTotal);
   unreadTotalRef.current = unreadTotal;
@@ -32,6 +36,12 @@ export function useChatUnreadDocumentTitle(unreadTotal: number): void {
   useEffect(() => {
     let isSelfWrite = false;
     const descriptor = getDocumentTitleDescriptor(document);
+    const initialBase = stripChatUnreadTitlePrefix(
+      descriptor.get.call(document),
+    ).trim();
+    if (initialBase) {
+      sharedLastGoodBase = initialBase;
+    }
 
     function writeTitle(nextTitle: string) {
       if (nextTitle === descriptor.get.call(document)) {
@@ -44,9 +54,20 @@ export function useChatUnreadDocumentTitle(unreadTotal: number): void {
       });
     }
 
-    function applyTitle(baseTitle = descriptor.get.call(document)) {
+    function rememberBase(rawTitle: string) {
+      const base = stripChatUnreadTitlePrefix(rawTitle).trim();
+      if (base) {
+        sharedLastGoodBase = base;
+      }
+    }
+
+    function applyTitle(rawTitle = descriptor.get.call(document)) {
+      rememberBase(rawTitle);
       writeTitle(
-        formatChatUnreadDocumentTitle(baseTitle, unreadTotalRef.current),
+        formatChatUnreadDocumentTitle(
+          sharedLastGoodBase,
+          unreadTotalRef.current,
+        ),
       );
     }
 
@@ -57,15 +78,18 @@ export function useChatUnreadDocumentTitle(unreadTotal: number): void {
         return descriptor.get.call(document);
       },
       set(value: string) {
+        rememberBase(value);
         writeTitle(
-          formatChatUnreadDocumentTitle(value, unreadTotalRef.current),
+          formatChatUnreadDocumentTitle(
+            sharedLastGoodBase,
+            unreadTotalRef.current,
+          ),
         );
       },
     });
 
     applyTitle();
 
-    const titleElement = document.querySelector("title");
     const observer = new MutationObserver(() => {
       if (isSelfWrite) {
         return;
@@ -73,13 +97,11 @@ export function useChatUnreadDocumentTitle(unreadTotal: number): void {
       applyTitle();
     });
 
-    if (titleElement) {
-      observer.observe(titleElement, {
-        childList: true,
-        characterData: true,
-        subtree: true,
-      });
-    }
+    observer.observe(document.head, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
 
     return () => {
       observer.disconnect();

--- a/apps/web/src/hooks/use-chat-unread-document-title.ts
+++ b/apps/web/src/hooks/use-chat-unread-document-title.ts
@@ -7,27 +7,61 @@ import {
   stripChatUnreadTitlePrefix,
 } from "@/components/chat/chat-unread-document-title";
 
+function getDocumentTitleDescriptor(target: Document): PropertyDescriptor & {
+  get: (this: Document) => string;
+  set: (this: Document, value: string) => void;
+} {
+  let owner: object | null = target;
+  while (owner) {
+    const descriptor = Object.getOwnPropertyDescriptor(owner, "title");
+    if (descriptor?.get && descriptor.set) {
+      return descriptor as PropertyDescriptor & {
+        get: (this: Document) => string;
+        set: (this: Document, value: string) => void;
+      };
+    }
+    owner = Object.getPrototypeOf(owner);
+  }
+  throw new Error("document.title descriptor unavailable");
+}
+
 export function useChatUnreadDocumentTitle(unreadTotal: number): void {
   const unreadTotalRef = useRef(unreadTotal);
   unreadTotalRef.current = unreadTotal;
 
   useEffect(() => {
     let isSelfWrite = false;
+    const descriptor = getDocumentTitleDescriptor(document);
 
-    function applyTitle() {
-      const nextTitle = formatChatUnreadDocumentTitle(
-        document.title,
-        unreadTotalRef.current,
-      );
-      if (nextTitle === document.title) {
+    function writeTitle(nextTitle: string) {
+      if (nextTitle === descriptor.get.call(document)) {
         return;
       }
       isSelfWrite = true;
-      document.title = nextTitle;
+      descriptor.set.call(document, nextTitle);
       queueMicrotask(() => {
         isSelfWrite = false;
       });
     }
+
+    function applyTitle(baseTitle = descriptor.get.call(document)) {
+      writeTitle(
+        formatChatUnreadDocumentTitle(baseTitle, unreadTotalRef.current),
+      );
+    }
+
+    Object.defineProperty(document, "title", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return descriptor.get.call(document);
+      },
+      set(value: string) {
+        writeTitle(
+          formatChatUnreadDocumentTitle(value, unreadTotalRef.current),
+        );
+      },
+    });
 
     applyTitle();
 
@@ -49,8 +83,18 @@ export function useChatUnreadDocumentTitle(unreadTotal: number): void {
 
     return () => {
       observer.disconnect();
-      isSelfWrite = true;
-      document.title = stripChatUnreadTitlePrefix(document.title);
+      Reflect.deleteProperty(document, "title");
+      writeTitle(stripChatUnreadTitlePrefix(descriptor.get.call(document)));
     };
+  }, []);
+
+  useEffect(() => {
+    const nextTitle = formatChatUnreadDocumentTitle(
+      document.title,
+      unreadTotal,
+    );
+    if (nextTitle !== document.title) {
+      document.title = nextTitle;
+    }
   }, [unreadTotal]);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Browser tab title flickered on every channel soft-navigation. After the first unread-prefix fix, the tab still briefly showed the **page host** (domain), because Next clears `<title>` to empty during soft navigations.

## Root cause

1. Soft navigation clears the `<title>` DOM node (not always via `document.title` setter).
2. While empty, Chromium shows the page host.
3. New metadata then writes `Sokosumi - Chat` again.

Confirmed with a Playwright harness: every channel click logged `title=""` then `"Sokosumi - Chat"`.

## Fix

- Remember the last non-empty title base and restore it from a `document.head` MutationObserver before paint when Next clears the title.
- Keep unread-prefix interception for count updates without teardown flicker.
- Hoist chat metadata to `chat/layout.tsx` and drop per-room / per-page `generateMetadata` that only returned the same title.

## Verification

```text
# Unit
pnpm --filter web test src/hooks/__tests__/use-chat-unread-document-title.test.ts
# 7 passed (includes empty-title restore)

# Browser (local harness)
# Before: empty_count > 0 on soft nav; rAF would see ""
# After: 264 requestAnimationFrame samples across 8 channel navigations
#        raf_empty_count 0
#        raf_unique [ 'Sokosumi - Chat' ]
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af4db1b8-873c-41c4-b70e-fc1c04ad6e36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af4db1b8-873c-41c4-b70e-fc1c04ad6e36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

