### PR TITLE
feat(web): autofocus room composer when opening channel or DM

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-composer-focus.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-composer-focus.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import {
   type ReactNode,
   type Ref,
@@ -14,6 +14,35 @@ import {
 } from "@/app/chat/components/room-composer";
 
 const editorFocus = vi.hoisted(() => vi.fn());
+
+async function flushAnimationFrame() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+function FocusHarness({ focusOnMount = false }: { focusOnMount?: boolean }) {
+  const [value, setValue] = useState("");
+  return (
+    <RoomComposer
+      value={value}
+      onValueChange={setValue}
+      mentions={{}}
+      onSelectedKeysChange={() => undefined}
+      placeholder="Message"
+      attachments={[]}
+      onAttachmentsChange={() => undefined}
+      onSubmit={(event) => event.preventDefault()}
+      isSending={false}
+      sendDisabled={false}
+      showMentionShortcut={false}
+      allowAttachments={false}
+      focusOnMount={focusOnMount}
+    />
+  );
+}
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -149,5 +178,26 @@ describe("RoomComposerHandle.focus", () => {
     await waitFor(() => {
       expect(getByTestId("ready").textContent).toBe("yes");
     });
+  });
+});
+
+describe("RoomComposer focusOnMount", () => {
+  it("focuses the editor once after mount via rAF when focusOnMount", async () => {
+    editorFocus.mockClear();
+    render(<FocusHarness focusOnMount />);
+
+    expect(editorFocus).not.toHaveBeenCalled();
+    await flushAnimationFrame();
+    await waitFor(() => {
+      expect(editorFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not autofocus when focusOnMount is omitted", async () => {
+    editorFocus.mockClear();
+    render(<FocusHarness />);
+
+    await flushAnimationFrame();
+    expect(editorFocus).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-focus.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-focus.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { type ReactNode, type Ref, useImperativeHandle } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -125,27 +125,10 @@ async function flushAnimationFrame() {
 }
 
 describe("ThreadPanel composer focus", () => {
-  it("focuses the thread composer once after mount via rAF", async () => {
-    composerFocus.mockClear();
-    renderThreadPanel();
-
-    expect(composerFocus).not.toHaveBeenCalled();
-    await flushAnimationFrame();
-    await waitFor(() => {
-      expect(composerFocus).toHaveBeenCalledTimes(1);
-    });
-  });
-
   it("calls onQuote and focuses the thread composer after rAF", async () => {
     composerFocus.mockClear();
     const onQuote = vi.fn();
     const { getByRole } = renderThreadPanel({ onQuote });
-
-    await flushAnimationFrame();
-    await waitFor(() => {
-      expect(composerFocus).toHaveBeenCalledTimes(1);
-    });
-    composerFocus.mockClear();
 
     const message = parentMessage();
     fireEvent.click(getByRole("button", { name: `quote-${message.id}` }));
@@ -164,12 +147,6 @@ describe("ThreadPanel composer focus", () => {
     composerFocus.mockClear();
     const onRestorePendingQuote = vi.fn();
     renderThreadPanel({ onRestorePendingQuote });
-
-    await flushAnimationFrame();
-    await waitFor(() => {
-      expect(composerFocus).toHaveBeenCalledTimes(1);
-    });
-    composerFocus.mockClear();
 
     onRestorePendingQuote({
       messageId: "quoted-1",

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -241,6 +241,7 @@ export function RoomComposer({
   pendingQuote = null,
   onClearPendingQuote,
   onChromeResize,
+  focusOnMount = false,
 }: {
   ref?: Ref<RoomComposerHandle>;
   /** When set, attaches mint via room chat file endpoint. */
@@ -267,6 +268,8 @@ export function RoomComposer({
    * so the parent can keep the latest message visible above the composer.
    */
   onChromeResize?: () => void;
+  /** Focus the editor after mount (room/thread open). */
+  focusOnMount?: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const tToolbar = useTranslations("App.Channels.Toolbar");
@@ -302,6 +305,16 @@ export function RoomComposer({
         mobileBreakpoint: MOBILE_BREAKPOINT,
       }),
     );
+  });
+
+  useMountEffect(() => {
+    if (!focusOnMount) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      editorRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
   });
 
   // After paint so the format strip / quote chip have height before scroll.

--- a/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
@@ -190,6 +190,7 @@ export function RoomSessionComposer({
       pendingQuote={pendingQuote}
       onClearPendingQuote={onClearPendingQuote}
       onChromeResize={onChromeResize}
+      focusOnMount
     />
   );
 }

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -7,7 +7,6 @@ import { useStickToBottom } from "@/app/chat/hooks/use-stick-to-bottom";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useMountEffect } from "@/hooks/use-mount-effect";
 import type {
   ChatRoomCoworkerParticipant,
   ChatRoomMessage,
@@ -114,12 +113,6 @@ export function ThreadPanel({
     scrollToBottomIfPinned,
   } = useStickToBottom({
     resetKey: parentMessage.id,
-  });
-
-  useMountEffect(() => {
-    requestAnimationFrame(() => {
-      threadComposerRef.current?.focus();
-    });
   });
 
   function handleQuote(message: ChatRoomMessage) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opening a channel or direct message now focuses the room composer so typing can start immediately (no click required).

- `RoomComposer` gains optional `focusOnMount` (rAF focus after mount)
- `RoomSessionComposer` enables it for room/thread surfaces (keyed remount on room switch)
- Draft new-DM keeps recipient search focused (`RoomComposer` without `focusOnMount`)
- Thread panel drops redundant mount autofocus; quote-focus unchanged

## Verification

```bash
pnpm --filter web test src/app/(app)/chat/components/__tests__/room-composer-focus.test.tsx src/app/(app)/chat/components/__tests__/thread-panel-focus.test.tsx
pnpm check && pnpm typecheck  # via husky precommit
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43c4bd02-3f56-4eff-9690-ab6ffead9b9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43c4bd02-3f56-4eff-9690-ab6ffead9b9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

