### PR TITLE
fix(web): await connection before session in Instant Nav shell

### DIFF
--- a/apps/web/src/app/(app)/components/app-shell-chrome.tsx
+++ b/apps/web/src/app/(app)/components/app-shell-chrome.tsx
@@ -1,5 +1,6 @@
 import type { Session } from "@sokosumi/utils";
 import { cookies } from "next/headers";
+import { connection } from "next/server";
 import { Suspense } from "react";
 import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
 import { getEnvPublicConfig } from "@/config/env.public";
@@ -28,6 +29,7 @@ interface AppShellChromeProps {
 }
 
 export default async function AppShellChrome({ session }: AppShellChromeProps) {
+  await connection();
   const cookieStore = await cookies();
   const [
     shouldShowOnboarding,

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { Suspense } from "react";
 import type { Coworker } from "@/app/chat/utils/types";
 import { HistorySearchDialogProvider } from "@/app/components/history-search-dialog-provider";
@@ -27,6 +28,9 @@ interface AuthenticatedAppFrameProps {
 export default async function AuthenticatedAppFrame({
   children,
 }: AuthenticatedAppFrameProps) {
+  // Defer before session cookies()/fetch so Cache Components PPR probing does
+  // not abort Core get-session (HANGING_PROMISE_REJECTION → null → /signin).
+  await connection();
   const session = await getSessionOrRedirect();
 
   return (

--- a/apps/web/src/app/(app)/history/page.tsx
+++ b/apps/web/src/app/(app)/history/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { HistoryList } from "@/app/history/components/history-list";
 import { HistoryToolbar } from "@/app/history/components/history-toolbar";
@@ -36,6 +37,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HistoryPage({ searchParams }: HistoryPageProps) {
+  await connection();
   const [rawSearchParams, t, jobStatusT, session] = await Promise.all([
     searchParams,
     getTranslations("App.History"),

--- a/apps/web/src/app/(app)/personal-assistant/layout.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/layout.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { connection } from "next/server";
 import type { ReactNode } from "react";
 
 import { ClientMessageBoundary } from "@/i18n/client-message-boundary";
@@ -17,6 +18,7 @@ interface HermesLayoutProps {
 export default async function HermesLayout({ children }: HermesLayoutProps) {
   // Hermes beta gate: outside the whitelisted email domains the whole route
   // does not exist — same 404 a made-up path would get, so nothing leaks.
+  await connection();
   const session = await getSession();
   if (!isHermesBetaAccessEmail(session?.user.email)) {
     notFound();

--- a/apps/web/src/app/(app)/personal-assistant/page.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/page.tsx
@@ -1,6 +1,7 @@
 import type { SelfServeSubscriptionPlanName } from "@sokosumi/utils";
 import gravatarUrl from "gravatar-url";
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
@@ -29,6 +30,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HermesPage() {
+  await connection();
   const session = await getSession();
   const userName = session?.user.name ?? null;
   const userEmail = session?.user.email ?? null;

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { connection } from "next/server";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 
@@ -33,6 +34,7 @@ export default async function AuthLayout({
 }>) {
   // Pathname from proxy (`x-pathname`). Callback/OAuth pages never redirect
   // away on an existing session, so skip the Core session read entirely.
+  await connection();
   const headersList = await headers();
   const pathname = headersList.get("x-pathname") || "";
   const shouldSkipSessionCheck =

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -133,6 +133,17 @@ describe("auth.server", () => {
     await expect(getSession({ refresh: true })).resolves.toBeNull();
   });
 
+  it("rethrows Cache Components hanging-promise aborts instead of null", async () => {
+    const hanging = Object.assign(new Error("Hanging promise rejection"), {
+      digest: "HANGING_PROMISE_REJECTION",
+    });
+    fetchMock.mockRejectedValue(hanging);
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).rejects.toBe(hanging);
+  });
+
   it("returns null when the response body is not valid JSON", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -212,6 +212,18 @@ async function fetchSession(
 
     return body;
   } catch (error) {
+    // PPR soft-abort during shell probe — not an auth failure. Rethrow so React
+    // / Cache Components can finish the boundary instead of treating this as
+    // "no session" and bouncing the user to /signin.
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "digest" in error &&
+      error.digest === "HANGING_PROMISE_REJECTION"
+    ) {
+      throw error;
+    }
+
     // Core unreachable, timed out, or returned a non-JSON body. Preserve the
     // null-returning contract callers rely on instead of throwing.
     console.error("Failed to fetch session from Core", error);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Authenticated app shell stopped opening after Instant Navigations landed: Cache Components PPR aborted Core `get-session` as `HANGING_PROMISE_REJECTION`, which `getSession` treated as “no session” and redirected to `/signin`.

## Fix

- `await connection()` before session / cookies / headers in Instant Nav shell paths (`AuthenticatedAppFrame`, `AppShellChrome`, auth layout, history, personal-assistant).
- Rethrow `HANGING_PROMISE_REJECTION` from `fetchSession` instead of mapping it to `null`.
- Unit coverage for the hanging-abort rethrow.

## Verification

- `pnpm check` + `pnpm typecheck` (pre-commit)
- `pnpm --filter web test src/lib/auth/__tests__/auth.server.test.ts`

## Notes

- Separate from SOK-709 (#3614).
- Subscription banner Skip failure is a secondary UX issue (`completeOnboarding` toast-fail can leave the dialog open); not the primary “can’t open app” cause.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-709](https://linear.app/masumi/issue/SOK-709/shared-cache-components-catalog-without-session-cookies)

<div><a href="https://cursor.com/agents/bc-95ca9288-27e8-461c-b51a-f9e978f44c6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95ca9288-27e8-461c-b51a-f9e978f44c6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

