### PR TITLE
fix(web): keep PWA session across iOS resume

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
@@ -189,6 +189,46 @@ describe("AuthSessionGuard", () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
+  it("does not redirect when unmounted during an in-flight resume probe", async () => {
+    vi.useFakeTimers();
+
+    let resolveInFlightResume:
+      | ((value: typeof missingSession) => void)
+      | undefined;
+    const inFlightResume = new Promise<typeof missingSession>((resolve) => {
+      resolveInFlightResume = resolve;
+    });
+    let getSessionCalls = 0;
+
+    vi.mocked(authClient.getSession).mockImplementation(() => {
+      getSessionCalls += 1;
+      if (getSessionCalls === 1) {
+        return Promise.resolve(presentSession);
+      }
+      return inFlightResume;
+    });
+
+    const { unmount } = render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    expect(getSessionCalls).toBe(2);
+
+    unmount();
+    window.history.replaceState({}, "", "/agents/other");
+    resolveInFlightResume?.(missingSession);
+    await flushMicrotasks();
+    await advance(250);
+    await flushMicrotasks();
+    await advance(750);
+    await flushMicrotasks();
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
   it("does not redirect when an overlapping resume probe finds a session", async () => {
     vi.useFakeTimers();
 

--- a/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
@@ -188,4 +188,55 @@ describe("AuthSessionGuard", () => {
     expect(authClient.getSession).toHaveBeenCalledTimes(2);
     expect(replaceMock).not.toHaveBeenCalled();
   });
+
+  it("does not redirect when an overlapping resume probe finds a session", async () => {
+    vi.useFakeTimers();
+
+    let resolveStaleResumeAttempt:
+      | ((value: typeof missingSession) => void)
+      | undefined;
+    const staleResumeAttempt = new Promise<typeof missingSession>((resolve) => {
+      resolveStaleResumeAttempt = resolve;
+    });
+    let getSessionCalls = 0;
+
+    vi.mocked(authClient.getSession).mockImplementation(() => {
+      getSessionCalls += 1;
+      if (getSessionCalls === 1) {
+        return Promise.resolve(presentSession);
+      }
+      if (getSessionCalls === 2) {
+        return staleResumeAttempt;
+      }
+      if (getSessionCalls === 3) {
+        return Promise.resolve(presentSession);
+      }
+      return Promise.resolve(missingSession);
+    });
+
+    render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    expect(getSessionCalls).toBe(2);
+
+    window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    expect(getSessionCalls).toBe(3);
+    expect(replaceMock).not.toHaveBeenCalled();
+
+    resolveStaleResumeAttempt?.(missingSession);
+    await flushMicrotasks();
+    await advance(250);
+    await flushMicrotasks();
+    await advance(750);
+    await flushMicrotasks();
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
@@ -1,8 +1,9 @@
-import { render, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthSessionGuard } from "@/app/components/auth-session-guard";
 import { authClient } from "@/lib/auth/auth.client";
+import { SESSION_RESUME_DEBOUNCE_MS } from "@/lib/auth/auth.utils";
 
 const replaceMock = vi.fn();
 
@@ -18,23 +19,47 @@ vi.mock("@/lib/auth/auth.client", () => ({
   },
 }));
 
+const presentSession = {
+  data: {
+    session: {
+      activeOrganizationId: null,
+    },
+  },
+  error: null,
+};
+
+const missingSession = {
+  data: null,
+  error: null,
+};
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
 describe("AuthSessionGuard", () => {
   beforeEach(() => {
     replaceMock.mockReset();
     vi.mocked(authClient.getSession).mockReset();
+    vi.useRealTimers();
 
     window.history.replaceState({}, "", "/agents?view=grid");
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("revalidates the session without cookie cache on mount", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: {
-        session: {
-          activeOrganizationId: null,
-        },
-      },
-      error: null,
-    });
+    vi.mocked(authClient.getSession).mockResolvedValue(presentSession);
 
     render(<AuthSessionGuard />);
 
@@ -48,10 +73,7 @@ describe("AuthSessionGuard", () => {
   });
 
   it("redirects to sign-in when the session is missing", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: null,
-      error: null,
-    });
+    vi.mocked(authClient.getSession).mockResolvedValue(missingSession);
 
     render(<AuthSessionGuard />);
 
@@ -63,23 +85,107 @@ describe("AuthSessionGuard", () => {
   });
 
   it("revalidates again on focus without redirecting when the session is present", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: {
-        session: {
-          activeOrganizationId: null,
-        },
-      },
-      error: null,
-    });
+    vi.useFakeTimers();
+    vi.mocked(authClient.getSession).mockResolvedValue(presentSession);
 
     render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(1);
 
     window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
 
-    await waitFor(() => {
-      expect(authClient.getSession).toHaveBeenCalledTimes(2);
+    expect(authClient.getSession).toHaveBeenCalledTimes(2);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("stays signed in when resume briefly returns null then a session", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authClient.getSession)
+      .mockResolvedValueOnce(presentSession)
+      .mockResolvedValueOnce(missingSession)
+      .mockResolvedValueOnce(presentSession);
+
+    render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(2);
+
+    await advance(250);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(3);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects after resume retries when the session stays missing", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authClient.getSession)
+      .mockResolvedValueOnce(presentSession)
+      .mockResolvedValue(missingSession);
+
+    render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+    await advance(250);
+    await flushMicrotasks();
+    await advance(750);
+    await flushMicrotasks();
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/signin?returnUrl=%2Fagents%3Fview%3Dgrid",
+    );
+    expect(authClient.getSession).toHaveBeenCalledTimes(4);
+  });
+
+  it("coalesces focus and visibility into a single resume probe wave", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authClient.getSession).mockResolvedValue(presentSession);
+
+    render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event("focus"));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
     });
+    document.dispatchEvent(new Event("visibilitychange"));
 
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(2);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect when resume probing throws", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authClient.getSession)
+      .mockResolvedValueOnce(presentSession)
+      .mockRejectedValueOnce(new Error("network"));
+
+    render(<AuthSessionGuard />);
+    await flushMicrotasks();
+
+    window.dispatchEvent(new Event("focus"));
+    await advance(SESSION_RESUME_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(2);
     expect(replaceMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/components/auth-session-guard.tsx
+++ b/apps/web/src/app/(app)/components/auth-session-guard.tsx
@@ -16,6 +16,7 @@ import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
 export function AuthSessionGuard() {
   const router = useRouter();
   const isRedirectingRef = useRef(false);
+  const resumeGenerationRef = useRef(0);
   const getFreshSession = createAuthSessionGetter(() =>
     authClient.getSession({
       query: {
@@ -54,9 +55,12 @@ export function AuthSessionGuard() {
         return;
       }
 
+      const generation = ++resumeGenerationRef.current;
       const result = await probeSessionWithRetry({
         getSession: getFreshSession,
-        shouldCancel: () => isRedirectingRef.current,
+        shouldCancel: () =>
+          isRedirectingRef.current ||
+          generation !== resumeGenerationRef.current,
       });
 
       if (result === "missing") {

--- a/apps/web/src/app/(app)/components/auth-session-guard.tsx
+++ b/apps/web/src/app/(app)/components/auth-session-guard.tsx
@@ -16,6 +16,7 @@ import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
 export function AuthSessionGuard() {
   const router = useRouter();
   const isRedirectingRef = useRef(false);
+  const mountedRef = useRef(true);
   const resumeGenerationRef = useRef(0);
   const getFreshSession = createAuthSessionGetter(() =>
     authClient.getSession({
@@ -59,6 +60,7 @@ export function AuthSessionGuard() {
       const result = await probeSessionWithRetry({
         getSession: getFreshSession,
         shouldCancel: () =>
+          !mountedRef.current ||
           isRedirectingRef.current ||
           generation !== resumeGenerationRef.current,
       });
@@ -92,6 +94,7 @@ export function AuthSessionGuard() {
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
+      mountedRef.current = false;
       scheduler.cancel();
       window.removeEventListener("focus", handleWindowFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);

--- a/apps/web/src/app/(app)/components/auth-session-guard.tsx
+++ b/apps/web/src/app/(app)/components/auth-session-guard.tsx
@@ -4,7 +4,13 @@ import { useRouter } from "next/navigation";
 import { useEffect, useEffectEvent, useRef } from "react";
 
 import { authClient } from "@/lib/auth/auth.client";
-import { createAuthSessionGetter } from "@/lib/auth/auth.utils";
+import {
+  createAuthSessionGetter,
+  createDebouncedScheduler,
+  probeSessionWithRetry,
+  SESSION_RESUME_DEBOUNCE_MS,
+  type SessionValidateReason,
+} from "@/lib/auth/auth.utils";
 import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
 
 export function AuthSessionGuard() {
@@ -18,17 +24,8 @@ export function AuthSessionGuard() {
     }),
   );
 
-  const validateSession = useEffectEvent(async () => {
+  const redirectToSignIn = useEffectEvent(() => {
     if (isRedirectingRef.current) {
-      return;
-    }
-
-    try {
-      const session = await getFreshSession();
-      if (isRedirectingRef.current || session) {
-        return;
-      }
-    } catch {
       return;
     }
 
@@ -37,18 +34,53 @@ export function AuthSessionGuard() {
     router.replace(`/signin?returnUrl=${returnUrl}`);
   });
 
+  const validateSession = useEffectEvent(
+    async (reason: SessionValidateReason) => {
+      if (isRedirectingRef.current) {
+        return;
+      }
+
+      if (reason === "mount") {
+        try {
+          const session = await getFreshSession();
+          if (isRedirectingRef.current || session) {
+            return;
+          }
+        } catch {
+          return;
+        }
+
+        redirectToSignIn();
+        return;
+      }
+
+      const result = await probeSessionWithRetry({
+        getSession: getFreshSession,
+        shouldCancel: () => isRedirectingRef.current,
+      });
+
+      if (result === "missing") {
+        redirectToSignIn();
+      }
+    },
+  );
+
   useEffect(() => {
-    void validateSession();
+    void validateSession("mount");
   }, []);
 
   useEffect(() => {
+    const scheduler = createDebouncedScheduler(() => {
+      void validateSession("resume");
+    }, SESSION_RESUME_DEBOUNCE_MS);
+
     function handleWindowFocus() {
-      void validateSession();
+      scheduler.schedule();
     }
 
     function handleVisibilityChange() {
       if (document.visibilityState === "visible") {
-        void validateSession();
+        scheduler.schedule();
       }
     }
 
@@ -56,6 +88,7 @@ export function AuthSessionGuard() {
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
+      scheduler.cancel();
       window.removeEventListener("focus", handleWindowFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };

--- a/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
@@ -5,10 +5,12 @@ import {
   buildOAuthConsentReturnUrlFromSearchParams,
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
+  createDebouncedScheduler,
   getAbsoluteAuthRedirectUrl,
   getAbsoluteRedirectUrlForOrigin,
   getAuthOAuthRedirect,
   normalizeAuthReturnUrl,
+  probeSessionWithRetry,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";
 
@@ -419,5 +421,131 @@ describe("createAuthSessionGetter", () => {
     }));
 
     await expect(getSession()).resolves.toBeNull();
+  });
+});
+
+describe("probeSessionWithRetry", () => {
+  it("returns session on the first successful attempt", async () => {
+    const waitForMs = vi.fn(async () => undefined);
+    const getSession = vi.fn().mockResolvedValue({ id: "session_1" });
+
+    await expect(
+      probeSessionWithRetry({
+        getSession,
+        delaysMs: [0, 250, 750],
+        waitForMs,
+      }),
+    ).resolves.toBe("session");
+
+    expect(getSession).toHaveBeenCalledTimes(1);
+    expect(waitForMs).not.toHaveBeenCalled();
+  });
+
+  it("retries after null and returns session on a later attempt", async () => {
+    const waitForMs = vi.fn(async () => undefined);
+    const getSession = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "session_1" });
+
+    await expect(
+      probeSessionWithRetry({
+        getSession,
+        delaysMs: [0, 250, 750],
+        waitForMs,
+      }),
+    ).resolves.toBe("session");
+
+    expect(getSession).toHaveBeenCalledTimes(2);
+    expect(waitForMs).toHaveBeenCalledTimes(1);
+    expect(waitForMs).toHaveBeenCalledWith(250);
+  });
+
+  it("returns missing when every attempt is null", async () => {
+    const waitForMs = vi.fn(async () => undefined);
+    const getSession = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      probeSessionWithRetry({
+        getSession,
+        delaysMs: [0, 250, 750],
+        waitForMs,
+      }),
+    ).resolves.toBe("missing");
+
+    expect(getSession).toHaveBeenCalledTimes(3);
+    expect(waitForMs).toHaveBeenNthCalledWith(1, 250);
+    expect(waitForMs).toHaveBeenNthCalledWith(2, 750);
+  });
+
+  it("returns error and stops when getSession throws", async () => {
+    const waitForMs = vi.fn(async () => undefined);
+    const getSession = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue({ id: "session_1" });
+
+    await expect(
+      probeSessionWithRetry({
+        getSession,
+        delaysMs: [0, 250, 750],
+        waitForMs,
+      }),
+    ).resolves.toBe("error");
+
+    expect(getSession).toHaveBeenCalledTimes(1);
+    expect(waitForMs).not.toHaveBeenCalled();
+  });
+
+  it("returns cancelled when shouldCancel is true between attempts", async () => {
+    const waitForMs = vi.fn(async (_ms: number) => undefined);
+    const getSession = vi.fn().mockResolvedValue(null);
+    let cancelled = false;
+    const shouldCancel = () => cancelled;
+
+    const probePromise = probeSessionWithRetry({
+      getSession,
+      delaysMs: [0, 250, 750],
+      waitForMs: async (ms) => {
+        cancelled = true;
+        await waitForMs(ms);
+      },
+      shouldCancel,
+    });
+
+    await expect(probePromise).resolves.toBe("cancelled");
+    expect(getSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createDebouncedScheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces rapid schedule calls into one invocation", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const { schedule } = createDebouncedScheduler(fn, 300);
+
+    schedule();
+    schedule();
+    schedule();
+
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel prevents a pending invocation", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const { schedule, cancel } = createDebouncedScheduler(fn, 300);
+
+    schedule();
+    cancel();
+    vi.advanceTimersByTime(300);
+
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auth/auth.utils.ts
+++ b/apps/web/src/lib/auth/auth.utils.ts
@@ -36,6 +36,80 @@ function waitForMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export type SessionValidateReason = "mount" | "resume";
+
+export type ProbeSessionResult = "session" | "missing" | "error" | "cancelled";
+
+export const SESSION_RESUME_PROBE_DELAYS_MS = [0, 250, 750] as const;
+export const SESSION_RESUME_DEBOUNCE_MS = 300;
+
+interface ProbeSessionWithRetryOptions {
+  getSession: () => Promise<unknown>;
+  delaysMs?: readonly number[];
+  waitForMs?: (ms: number) => Promise<void>;
+  shouldCancel?: () => boolean;
+}
+
+export async function probeSessionWithRetry({
+  getSession,
+  delaysMs = SESSION_RESUME_PROBE_DELAYS_MS,
+  waitForMs: waitForMsFn = waitForMs,
+  shouldCancel,
+}: ProbeSessionWithRetryOptions): Promise<ProbeSessionResult> {
+  for (let index = 0; index < delaysMs.length; index += 1) {
+    if (shouldCancel?.()) {
+      return "cancelled";
+    }
+
+    const delayMs = delaysMs[index] ?? 0;
+    if (delayMs > 0) {
+      await waitForMsFn(delayMs);
+      if (shouldCancel?.()) {
+        return "cancelled";
+      }
+    }
+
+    try {
+      const session = await getSession();
+      if (shouldCancel?.()) {
+        return "cancelled";
+      }
+      if (session) {
+        return "session";
+      }
+    } catch {
+      return "error";
+    }
+  }
+
+  return "missing";
+}
+
+export function createDebouncedScheduler(
+  fn: () => void,
+  debounceMs: number = SESSION_RESUME_DEBOUNCE_MS,
+): { schedule: () => void; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    schedule() {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = null;
+        fn();
+      }, debounceMs);
+    },
+    cancel() {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
 export function createAuthSessionGetter<TSession>(
   getSessionResponse: () => Promise<AuthSessionResponse<TSession> | null>,
 ): () => Promise<TSession | null> {


### PR DESCRIPTION
## Summary

- https://linear.app/masumi/issue/SOK-713/pwa-logs-out-after-short-background-on-ios
- Resume (focus + visibility) debounces ~300ms into one probe wave.
- Resume probes `getSession` up to 3 times at `[0, 250, 750]` ms; transient null stays signed in; all null redirects to `/signin?returnUrl=`.
- Throw on any attempt fails open (no redirect). Mount stays a single probe.
- Web-only; no Core or session TTL changes.

## Spec

| Case | Expected |
| --- | --- |
| Brief iOS PWA background | Stay signed in (absorb transient null) |
| True missing session | Redirect after retries |
| Transient throw | No redirect |

## Test plan

- [x] `pnpm web:check`
- [x] `pnpm web:test`
- [ ] Confirm on iOS installed PWA: short background → still signed in


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session validation when returning to the app, including retries for temporary session availability issues.
  * Prevented outdated checks from overriding newer session state or redirecting after the app is closed.
  * Reduced redundant validation caused by rapid focus and visibility changes.
  * Improved handling of session retrieval errors and missing sessions.

* **Tests**
  * Added coverage for retry behavior, debouncing, cancellation, error handling, and overlapping validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->