### PR TITLE
fix(web): soft-dismiss subscription onboarding gate on Skip

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
@@ -284,4 +284,94 @@ describe("OnboardingDialog organization subscription", () => {
     expect(upgradePersonalSubscriptionMock).not.toHaveBeenCalled();
     expect(upgradeOrganizationSubscriptionMock).not.toHaveBeenCalled();
   });
+
+  it("soft-dismisses subscription-only Skip without completing onboarding", async () => {
+    render(
+      <OnboardingDialog
+        loginId="session-1"
+        paidPlans={createPaidPlans()}
+        subscriptionCheckoutMode="personal"
+        subscriptionOnly
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "navigation.skip" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "navigation.skip" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "navigation.subscribe" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(trackMock).toHaveBeenCalledWith("Onboarding skipped");
+    expect(markSubscriptionOnboardingGateSessionSeenMock).toHaveBeenCalledWith(
+      "session-1",
+    );
+    expect(
+      window.localStorage.getItem(SUBSCRIPTION_ONBOARDING_LOGIN_STORAGE_KEY),
+    ).toBe("session-1");
+    expect(completeOnboardingMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("OnboardingDialog full intro Skip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    markSubscriptionOnboardingGateSessionSeenMock.mockResolvedValue(undefined);
+    window.localStorage.clear();
+    completeOnboardingMock.mockResolvedValue({
+      data: { redirectUrl: "/tasks" },
+      ok: true,
+    });
+  });
+
+  it("still completes onboarding when Skip is used on full intro", async () => {
+    render(
+      <OnboardingDialog
+        paidPlans={createPaidPlans()}
+        subscriptionCheckoutMode="personal"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "navigation.skip" }));
+
+    await waitFor(() => {
+      expect(completeOnboardingMock).toHaveBeenCalled();
+    });
+    expect(trackMock).toHaveBeenCalledWith("Onboarding skipped");
+    expect(pushMock).toHaveBeenCalledWith("/tasks");
+    expect(
+      markSubscriptionOnboardingGateSessionSeenMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open and toasts when completeOnboarding fails", async () => {
+    completeOnboardingMock.mockResolvedValue({
+      error: { message: "boom" },
+      ok: false,
+    });
+
+    render(
+      <OnboardingDialog
+        paidPlans={createPaidPlans()}
+        subscriptionCheckoutMode="personal"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "navigation.skip" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("boom");
+    });
+    expect(
+      screen.getByRole("button", { name: "navigation.skip" }),
+    ).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/app/(app)/components/onboarding-dialog.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog.tsx
@@ -501,6 +501,15 @@ export function OnboardingDialog({
     }
   };
 
+  function handleSubscriptionOnlySkip() {
+    track("Onboarding skipped");
+    if (loginId) {
+      writeLastSubscriptionOnboardingLoginId(loginId);
+      markSubscriptionOnboardingGateSeenSafely(loginId);
+    }
+    setOpen(false);
+  }
+
   function handleSubscriptionActionError(
     error: { code: string; message?: string | null },
     options: {
@@ -810,7 +819,13 @@ export function OnboardingDialog({
                 if (subscriptionOnly) return;
                 setStep((currentStep) => currentStep + 1);
               }}
-              onSkip={() => void handleComplete("Onboarding skipped")}
+              onSkip={() => {
+                if (subscriptionOnly) {
+                  handleSubscriptionOnlySkip();
+                  return;
+                }
+                void handleComplete("Onboarding skipped");
+              }}
               onFinish={() => void handleStartSubscription()}
             />
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SOK-715](https://linear.app/masumi/issue/SOK-715/subscription-onboarding-skip-leaves-gate-stuck-when-complete-fails)

## Summary
- Subscription-only Skip soft-dismisses the gate (localStorage + gate-seen cookie) without calling `completeOnboarding`
- Core onboarding-complete failures no longer leave the subscription banner stuck open
- Full intro Skip still uses `completeOnboarding` and surfaces errors
- Restricted org no-cookie rule unchanged

## Verification
- `pnpm web:check`
- `pnpm web:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-715](https://linear.app/masumi/issue/SOK-715/subscription-onboarding-skip-leaves-gate-stuck-when-complete-fails)

<div><a href="https://cursor.com/agents/bc-2607617b-ae70-45d9-a1ee-6fd979b9d04e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2607617b-ae70-45d9-a1ee-6fd979b9d04e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

