### PR TITLE
fix(chat): restore room live poll and isolate Ably fan-out failures

### DIFF
--- a/apps/core/src/helpers/chat-room-message-realtime.test.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.test.ts
@@ -116,6 +116,34 @@ describe("publishChatRoomMessageRealtime", () => {
       publishChatRoomMessageRealtime(baseMessage as never),
     ).resolves.toBeUndefined();
   });
+
+  it("keeps publishing to other members when one fan-out fails", async () => {
+    findManyMembersMock.mockResolvedValue([
+      { userId: "user_a" },
+      { userId: "user_b" },
+    ]);
+    publishChatRoomMessageEventMock.mockImplementation(
+      async ({ userId }: { userId: string }) => {
+        if (userId === "user_a") {
+          throw new Error("ably down for user_a");
+        }
+      },
+    );
+
+    await expect(
+      publishChatRoomMessageRealtime(baseMessage as never),
+    ).resolves.toBeUndefined();
+
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledTimes(2);
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_b",
+      message: {
+        id: baseMessage.id,
+        roomId: baseMessage.roomId,
+        forUser: "user_b",
+      },
+    });
+  });
 });
 
 describe("publishChatRoomMessageRealtimeById", () => {

--- a/apps/core/src/helpers/chat-room-message-realtime.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.ts
@@ -22,7 +22,9 @@ export async function publishChatRoomMessageRealtime(
       select: { userId: true },
     });
 
-    await Promise.all(
+    // Per-member isolation: one map/parse/publish failure must not cancel
+    // fan-out to the rest of the room (Promise.all would fail-fast).
+    const results = await Promise.allSettled(
       members.map(async ({ userId }) => {
         const dto = chatRoomMessageSchema.parse(
           mapChatRoomMessage(message, userId),
@@ -33,6 +35,26 @@ export async function publishChatRoomMessageRealtime(
         });
       }),
     );
+
+    for (const [index, result] of results.entries()) {
+      if (result.status === "fulfilled") {
+        continue;
+      }
+      const userId = members[index]?.userId;
+      console.error(
+        "Failed to publish chat room message over Ably for member:",
+        userId,
+        result.reason,
+      );
+      Sentry.captureException(result.reason, {
+        extra: {
+          messageId: message.id,
+          roomId: message.roomId,
+          userId,
+          errorType: "ably-publish-chat-room-message",
+        },
+      });
+    }
   } catch (error) {
     console.error("Failed to publish chat room message over Ably:", error);
     Sentry.captureException(error, {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-live-poll.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-live-poll.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Human peer traffic must not depend on Ably alone while a room stays focused.
+ * #3582 removed the interval; focus/visibility is not enough when Ably drops
+ * or lags — peer rows then land late via createdAt merge between own sends.
+ */
+describe("room live poll backstop", () => {
+  it("wires a focused-room setInterval into RoomsClient", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../rooms-client.tsx"),
+      "utf8",
+    );
+    expect(source).toMatch(/ROOM_LIVE_POLL_MS\s*=\s*\d+/);
+    expect(source).toContain("setInterval(refreshLatest, ROOM_LIVE_POLL_MS)");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -122,6 +122,12 @@ interface RoomsClientProps {
 const COWORKER_RESPONSE_POLL_MS = 2500;
 /** ~2.5 minutes of polling before we stop waiting for a coworker reply. */
 const COWORKER_RESPONSE_POLL_MAX_ATTEMPTS = 60;
+/**
+ * Focused-room backstop for human peer traffic. Ably is still primary;
+ * without a timer, dropped/lagged events only recover on focus/visibility and
+ * then jump into the timeline by createdAt between already-shown own sends.
+ */
+const ROOM_LIVE_POLL_MS = 3000;
 
 function RoomMessageRealtimeBridge({
   userId,
@@ -808,8 +814,9 @@ export function RoomsClient({
     };
   }, [selectedRoom?.id, hasPendingRoomCoworkerMention]);
 
-  // Safety net when Ably is unavailable or a message was missed while hidden.
-  // Live peer traffic arrives via Ably Pub/Sub (RoomMessageRealtimeBridge).
+  // Ably Pub/Sub is primary (RoomMessageRealtimeBridge). Keep a short poll +
+  // focus/visibility refresh so human peer rows still land when Ably drops or
+  // lags while the room stays open.
   useEffect(() => {
     if (!selectedRoom) {
       return;
@@ -854,6 +861,7 @@ export function RoomsClient({
       setAttentionRefreshToken((token) => token + 1);
     };
 
+    const intervalId = window.setInterval(refreshLatest, ROOM_LIVE_POLL_MS);
     window.addEventListener("focus", refreshLatest);
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -864,6 +872,7 @@ export function RoomsClient({
 
     return () => {
       cancelled = true;
+      window.clearInterval(intervalId);
       window.removeEventListener("focus", refreshLatest);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };

--- a/apps/web/src/app/(app)/chat/utils/__tests__/live-peer-message-ordering.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/live-peer-message-ordering.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { appendMessage } from "@/app/chat/components/room-helpers";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import { mergeRoomMessages } from "../merge-room-messages";
+
+function message(
+  id: string,
+  createdAt: string,
+  content: string,
+  userId: string,
+): ChatRoomMessage {
+  return {
+    id,
+    roomId: "room-1",
+    parentMessageId: null,
+    content,
+    createdAt: new Date(createdAt),
+    editedAt: null,
+    sender: {
+      type: "user",
+      user: {
+        id: userId,
+        name: userId,
+        email: `${userId}@example.com`,
+        image: null,
+        presence: "online",
+      },
+    },
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    membership: null,
+    deletedAt: null,
+  };
+}
+
+/**
+ * Repro for human peer latency: own sends append immediately; a peer message
+ * that arrives later (missed Ably / focus-only backstop) is merged by
+ * createdAt and jumps between messages already on screen.
+ */
+describe("live peer message ordering", () => {
+  it("inserts a late peer message between already-appended own messages", () => {
+    const ownFirst = message(
+      "alice-1",
+      "2026-08-04T12:00:01.000Z",
+      "alice first",
+      "alice",
+    );
+    const ownSecond = message(
+      "alice-2",
+      "2026-08-04T12:00:03.000Z",
+      "alice second",
+      "alice",
+    );
+    const peerBetween = message(
+      "bob-1",
+      "2026-08-04T12:00:02.000Z",
+      "bob in between",
+      "bob",
+    );
+
+    let state = appendMessage([], ownFirst);
+    state = appendMessage(state, ownSecond);
+    expect(state.map((row) => row.id)).toEqual(["alice-1", "alice-2"]);
+
+    state = mergeRoomMessages(state, [peerBetween]);
+
+    expect(state.map((row) => row.content)).toEqual([
+      "alice first",
+      "bob in between",
+      "alice second",
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Human peer messages in an open room could arrive seconds late. Own sends append immediately. A late peer row then merges by `createdAt` and jumps between messages already on screen.

## Root cause

PR #3582 made Ably the only live path and removed the focused-room poll. Focus/visibility refetch stayed as the backstop. When Ably drops or lags while the tab stays open, peers only show up later. `mergeRoomMessages` then inserts them chronologically between own appends.

A secondary Core hazard. `Promise.all` fan-out failed fast on one member map/parse/publish error and swallowed the whole batch.

## Fix

- Restore a 3s focused-room `setInterval` refresh (Ably stays primary).
- Publish per member with `Promise.allSettled` and report each failure to Sentry.

## Verification

```
BEFORE_POLL [ 'alice-before', 'alice-after' ]
AFTER_POLL [ 'alice-before', 'bob-middle', 'alice-after' ]
PASS true
```

- `pnpm --filter web test` on `room-live-poll.test.ts` + `live-peer-message-ordering.test.ts`
- `pnpm --filter core test src/helpers/chat-room-message-realtime.test.ts`
- Core API DM alice/bob. Server list order. `alice-before`, `bob-middle`, `alice-after`.
- Browser UI verify blocked here. Placeholder Ably keys (auth 500). Room chrome fell through to Channels coming soon under the agent web session.

![Room UI verify blocked](https://cursor.com/artifacts/c/art-a0576739-3162-44c3-8143-ec1c6705396b)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fbd6727-1333-4fd9-b73c-a4c1766e9e4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fbd6727-1333-4fd9-b73c-a4c1766e9e4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat room message delivery reliability; failures for individual members no longer prevent delivery to others.
  * Fixed live chat message ordering when peer messages arrive out of sequence.

* **New Features**
  * Added live polling backstop for chat room updates as a recovery mechanism for dropped or delayed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->