### PR TITLE
fix(web): harden purchase-success checkout return host

### DIFF
--- a/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/billing/__tests__/page.test.tsx
@@ -26,6 +26,7 @@ const getEnterpriseContractBillingSummaryMock = vi.fn();
 const enterpriseContractSummaryMock = vi.fn();
 const getFeaturedCoworkersMock = vi.fn();
 const subscriptionSuccessModalMock = vi.fn();
+const creditsCheckoutReturnMock = vi.fn();
 
 vi.mock("next/headers", () => ({
   headers: async () => new Headers(),
@@ -170,6 +171,13 @@ vi.mock("@/components/billing/personal-subscription-section", () => ({
 vi.mock("@/components/billing/subscription-success-modal", () => ({
   SubscriptionSuccessModal: (props: unknown) => {
     subscriptionSuccessModalMock(props);
+    return null;
+  },
+}));
+
+vi.mock("@/components/billing/credits-checkout-return", () => ({
+  CreditsCheckoutReturn: (props: unknown) => {
+    creditsCheckoutReturnMock(props);
     return null;
   },
 }));
@@ -459,6 +467,30 @@ describe("BillingPage", () => {
         headline: 'subscriptionTitle:{"plan":"Plans.pro.name"}',
         returnPath: "/billing?tab=subscription",
         status: "success",
+      }),
+    );
+  });
+
+  it("threads credits checkout markers and coworkers into CreditsCheckoutReturn outside tabs", async () => {
+    getActiveOrganizationMock.mockResolvedValue(null);
+
+    const { default: BillingPage } = await import("../page");
+
+    render(
+      await BillingPage({
+        searchParams: Promise.resolve({
+          cancel: "true",
+          session_id: "cs_test_123",
+          tab: "subscription",
+        }),
+      }),
+    );
+
+    expect(creditsCheckoutReturnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cancel: "true",
+        coworkersPromise,
+        sessionId: "cs_test_123",
       }),
     );
   });

--- a/apps/web/src/app/(app)/billing/page.tsx
+++ b/apps/web/src/app/(app)/billing/page.tsx
@@ -5,6 +5,7 @@ import { BalanceSection } from "@/components/billing/balance-section";
 import { BillingPortalErrorToast } from "@/components/billing/billing-portal-error-toast";
 import { BillingTabs } from "@/components/billing/billing-tabs";
 import CouponSection from "@/components/billing/coupon-section";
+import { CreditsCheckoutReturn } from "@/components/billing/credits-checkout-return";
 import CreditsSection from "@/components/billing/credits-section";
 import { EnterpriseContractSummary } from "@/components/billing/enterprise-contract-summary";
 import { getFeaturedCoworkers } from "@/components/billing/get-featured-coworkers";
@@ -130,14 +131,6 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
     const showOrganizationBillingPortal = !isEnterpriseConsumable;
     const canPurchaseCredits =
       isOwnerOrAdmin && (currentPlan !== "free" || canPurchaseOnFreePlan);
-    const creditsCheckoutParams =
-      canPurchaseCredits && activeTab === "credits"
-        ? { cancel: query.cancel, session_id: query.session_id }
-        : undefined;
-    const couponCheckoutParams =
-      activeTab === "coupon"
-        ? { cancel: query.cancel, session_id: query.session_id }
-        : undefined;
 
     const [
       enterpriseContractSummary,
@@ -258,25 +251,26 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
             }
             creditsContent={
               <CreditsSection
-                coworkersPromise={coworkersPromise}
                 isPurchaseEnabled={canPurchaseCredits}
                 organization={activeOrganization}
                 pricing={creditPricing}
                 returnPath="/billing?tab=credits"
-                searchParams={creditsCheckoutParams}
               />
             }
             couponContent={
               <CouponSection
-                coworkersPromise={coworkersPromise}
                 organization={activeOrganization}
                 returnPath="/billing?tab=coupon"
-                searchParams={couponCheckoutParams}
               />
             }
           />
         </div>
 
+        <CreditsCheckoutReturn
+          cancel={query.cancel}
+          coworkersPromise={coworkersPromise}
+          sessionId={query.session_id}
+        />
         <SubscriptionSuccessModal
           coworkersPromise={coworkersPromise}
           description={subscriptionSuccessDescription}
@@ -321,14 +315,6 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
   });
 
   const canPurchaseCredits = currentPlan !== "free" || canPurchaseOnFreePlan;
-  const creditsCheckoutParams =
-    canPurchaseCredits && activeTab === "credits"
-      ? { cancel: query.cancel, session_id: query.session_id }
-      : undefined;
-  const couponCheckoutParams =
-    activeTab === "coupon"
-      ? { cancel: query.cancel, session_id: query.session_id }
-      : undefined;
 
   return (
     <div className="min-h-full w-full">
@@ -376,25 +362,26 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
           }
           creditsContent={
             <CreditsSection
-              coworkersPromise={coworkersPromise}
               isPurchaseEnabled={canPurchaseCredits}
               organization={null}
               pricing={creditPricing}
               returnPath="/billing?tab=credits"
-              searchParams={creditsCheckoutParams}
             />
           }
           couponContent={
             <CouponSection
-              coworkersPromise={coworkersPromise}
               organization={null}
               returnPath="/billing?tab=coupon"
-              searchParams={couponCheckoutParams}
             />
           }
         />
       </div>
 
+      <CreditsCheckoutReturn
+        cancel={query.cancel}
+        coworkersPromise={coworkersPromise}
+        sessionId={query.session_id}
+      />
       <SubscriptionSuccessModal
         coworkersPromise={coworkersPromise}
         description={subscriptionSuccessDescription}

--- a/apps/web/src/app/(app)/coupon/page.tsx
+++ b/apps/web/src/app/(app)/coupon/page.tsx
@@ -1,4 +1,5 @@
 import CouponSection from "@/components/billing/coupon-section";
+import { CreditsCheckoutReturn } from "@/components/billing/credits-checkout-return";
 import { getFeaturedCoworkers } from "@/components/billing/get-featured-coworkers";
 import { userService } from "@/lib/services";
 
@@ -17,13 +18,13 @@ export default async function CouponPage({ searchParams }: CouponPageProps) {
   return (
     <div className="min-h-full w-full">
       <div className="mx-auto max-w-4xl space-y-12 px-4">
-        <CouponSection
-          coworkersPromise={coworkersPromise}
-          organization={activeOrganization}
-          returnPath="/coupon"
-          searchParams={{ cancel, session_id }}
-        />
+        <CouponSection organization={activeOrganization} returnPath="/coupon" />
       </div>
+      <CreditsCheckoutReturn
+        cancel={cancel}
+        coworkersPromise={coworkersPromise}
+        sessionId={session_id}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/billing/__tests__/credits-checkout-return.test.tsx
+++ b/apps/web/src/components/billing/__tests__/credits-checkout-return.test.tsx
@@ -1,0 +1,95 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoworkerOption } from "@/lib/types/coworker";
+
+const getCheckoutSessionAnalyticsMock = vi.fn();
+const creditsPurchaseSuccessMock = vi.fn();
+const purchaseTrackerMock = vi.fn();
+const creditsCancelModalMock = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/clients/core.client", () => ({
+  coreClient: {
+    getCheckoutSessionAnalytics: (...args: unknown[]) =>
+      getCheckoutSessionAnalyticsMock(...args),
+  },
+}));
+
+vi.mock("@/components/billing/credits-purchase-success", () => ({
+  CreditsPurchaseSuccess: (props: unknown) => {
+    creditsPurchaseSuccessMock(props);
+    return <div data-testid="credits-purchase-success" />;
+  },
+}));
+
+vi.mock("@/components/billing/purchase-tracker", () => ({
+  PurchaseTracker: (props: unknown) => {
+    purchaseTrackerMock(props);
+    return <div data-testid="purchase-tracker" />;
+  },
+}));
+
+vi.mock("@/components/billing/credits-cancel-modal", () => ({
+  CreditsCancelModal: () => {
+    creditsCancelModalMock();
+    return <div data-testid="credits-cancel-modal" />;
+  },
+}));
+
+import { CreditsCheckoutReturn } from "../credits-checkout-return";
+
+const coworkersPromise: Promise<CoworkerOption[]> = Promise.resolve([]);
+
+describe("CreditsCheckoutReturn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when there is no session id or cancel marker", async () => {
+    const view = render(await CreditsCheckoutReturn({ coworkersPromise }));
+
+    expect(view.container).toBeEmptyDOMElement();
+    expect(getCheckoutSessionAnalyticsMock).not.toHaveBeenCalled();
+  });
+
+  it("mounts success UI and tracker when session id is present", async () => {
+    const checkoutSession = {
+      sessionId: "cs_1",
+      currency: "eur",
+      value: 1,
+      items: [],
+    };
+    getCheckoutSessionAnalyticsMock.mockResolvedValue({
+      data: checkoutSession,
+    });
+
+    render(
+      await CreditsCheckoutReturn({
+        coworkersPromise,
+        sessionId: "cs_1",
+      }),
+    );
+
+    expect(creditsPurchaseSuccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({ coworkersPromise, initialOpen: true }),
+    );
+    expect(purchaseTrackerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ checkoutSession }),
+    );
+    expect(creditsCancelModalMock).not.toHaveBeenCalled();
+  });
+
+  it("mounts the cancel modal when cancel is present", async () => {
+    render(
+      await CreditsCheckoutReturn({
+        cancel: "true",
+        coworkersPromise,
+      }),
+    );
+
+    expect(creditsCancelModalMock).toHaveBeenCalled();
+    expect(creditsPurchaseSuccessMock).not.toHaveBeenCalled();
+    expect(getCheckoutSessionAnalyticsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/billing/__tests__/credits-purchase-success.test.tsx
+++ b/apps/web/src/components/billing/__tests__/credits-purchase-success.test.tsx
@@ -1,6 +1,6 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CoworkerOption } from "@/lib/types/coworker";
 
 const purchaseSuccessModalMock = vi.fn();
@@ -21,12 +21,22 @@ import { CreditsPurchaseSuccess } from "../credits-purchase-success";
 const coworkersPromise: Promise<CoworkerOption[]> = Promise.resolve([]);
 
 describe("CreditsPurchaseSuccess", () => {
-  it("opens the modal when session_id is present in the URL", () => {
-    render(<CreditsPurchaseSuccess coworkersPromise={coworkersPromise} />, {
-      wrapper: withNuqsTestingAdapter({
-        searchParams: "?session_id=cs_test_123",
-      }),
-    });
+  beforeEach(() => {
+    purchaseSuccessModalMock.mockClear();
+  });
+
+  it("opens the modal when initialOpen is true", () => {
+    render(
+      <CreditsPurchaseSuccess
+        coworkersPromise={coworkersPromise}
+        initialOpen
+      />,
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: "?session_id=cs_test_123",
+        }),
+      },
+    );
 
     expect(purchaseSuccessModalMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -38,7 +48,7 @@ describe("CreditsPurchaseSuccess", () => {
     );
   });
 
-  it("does not open the modal when session_id is absent", () => {
+  it("does not open the modal when initialOpen is false", () => {
     render(<CreditsPurchaseSuccess coworkersPromise={coworkersPromise} />, {
       wrapper: withNuqsTestingAdapter({}),
     });
@@ -51,12 +61,18 @@ describe("CreditsPurchaseSuccess", () => {
   it("clears session_id from the URL when the modal is dismissed", async () => {
     const onUrlUpdate = vi.fn();
 
-    render(<CreditsPurchaseSuccess coworkersPromise={coworkersPromise} />, {
-      wrapper: withNuqsTestingAdapter({
-        searchParams: "?session_id=cs_test_123",
-        onUrlUpdate,
-      }),
-    });
+    render(
+      <CreditsPurchaseSuccess
+        coworkersPromise={coworkersPromise}
+        initialOpen
+      />,
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: "?session_id=cs_test_123",
+          onUrlUpdate,
+        }),
+      },
+    );
 
     const { onOpenChange } = purchaseSuccessModalMock.mock.calls.at(-1)?.[0];
     onOpenChange(false);
@@ -71,16 +87,45 @@ describe("CreditsPurchaseSuccess", () => {
   it("does not clear the URL when the modal open-change fires with open=true", () => {
     const onUrlUpdate = vi.fn();
 
-    render(<CreditsPurchaseSuccess coworkersPromise={coworkersPromise} />, {
-      wrapper: withNuqsTestingAdapter({
-        searchParams: "?session_id=cs_test_123",
-        onUrlUpdate,
-      }),
-    });
+    render(
+      <CreditsPurchaseSuccess
+        coworkersPromise={coworkersPromise}
+        initialOpen
+      />,
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: "?session_id=cs_test_123",
+          onUrlUpdate,
+        }),
+      },
+    );
 
     const { onOpenChange } = purchaseSuccessModalMock.mock.calls.at(-1)?.[0];
     onOpenChange(true);
 
     expect(onUrlUpdate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the modal closed after dismiss via local open latch", async () => {
+    render(
+      <CreditsPurchaseSuccess
+        coworkersPromise={coworkersPromise}
+        initialOpen
+      />,
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: "?session_id=cs_test_123",
+        }),
+      },
+    );
+
+    const { onOpenChange } = purchaseSuccessModalMock.mock.calls.at(-1)?.[0];
+    await act(async () => {
+      onOpenChange(false);
+    });
+
+    expect(purchaseSuccessModalMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ open: false }),
+    );
   });
 });

--- a/apps/web/src/components/billing/__tests__/purchase-success-coworker-row.test.tsx
+++ b/apps/web/src/components/billing/__tests__/purchase-success-coworker-row.test.tsx
@@ -174,4 +174,26 @@ describe("PurchaseSuccessCoworkerRow", () => {
 
     consoleError.mockRestore();
   });
+
+  it("calls onNavigate from the error-boundary 'go to tasks' fallback", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onNavigate = vi.fn();
+
+    await act(async () => {
+      render(
+        <PurchaseSuccessCoworkerRow
+          coworkersPromise={Promise.reject(new Error("boom"))}
+          onNavigate={onNavigate}
+        />,
+      );
+    });
+
+    screen.getByText("goToTasks").closest("a")?.click();
+
+    expect(onNavigate).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
 });

--- a/apps/web/src/components/billing/__tests__/purchase-tracker.test.tsx
+++ b/apps/web/src/components/billing/__tests__/purchase-tracker.test.tsx
@@ -1,0 +1,67 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CheckoutSessionAnalytics } from "@/lib/clients/generated/core";
+
+const purchaseMock = vi.fn();
+
+vi.mock("@/lib/gtm-events", () => ({
+  fireGTMEvent: {
+    purchase: (...args: unknown[]) => purchaseMock(...args),
+  },
+}));
+
+import {
+  PurchaseTracker,
+  resetFiredPurchaseSessionIdsForTests,
+} from "../purchase-tracker";
+
+const checkoutSession: CheckoutSessionAnalytics = {
+  sessionId: "cs_once",
+  currency: "eur",
+  value: 12,
+  items: [
+    {
+      itemId: "credits",
+      itemName: "Credits",
+      quantity: 100,
+    },
+  ],
+};
+
+describe("PurchaseTracker", () => {
+  beforeEach(() => {
+    purchaseMock.mockClear();
+    resetFiredPurchaseSessionIdsForTests();
+  });
+
+  it("fires the GTM purchase event on mount", () => {
+    render(<PurchaseTracker checkoutSession={checkoutSession} />);
+
+    expect(purchaseMock).toHaveBeenCalledTimes(1);
+    expect(purchaseMock).toHaveBeenCalledWith("cs_once", "eur", 12, [
+      { item_id: "credits", item_name: "Credits", quantity: 100 },
+    ]);
+  });
+
+  it("does not re-fire for the same session id after remount", () => {
+    const { unmount } = render(
+      <PurchaseTracker checkoutSession={checkoutSession} />,
+    );
+    unmount();
+
+    render(<PurchaseTracker checkoutSession={checkoutSession} />);
+
+    expect(purchaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again for a different session id", () => {
+    render(<PurchaseTracker checkoutSession={checkoutSession} />);
+    render(
+      <PurchaseTracker
+        checkoutSession={{ ...checkoutSession, sessionId: "cs_other" }}
+      />,
+    );
+
+    expect(purchaseMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/billing/coupon-section.tsx
+++ b/apps/web/src/components/billing/coupon-section.tsx
@@ -1,49 +1,14 @@
-import CreditsCancelModal from "@/app/credits/components/cancel-modal";
-import { CreditsPurchaseSuccess } from "@/app/credits/components/credits-purchase-success";
-import PurchaseTracker from "@/app/credits/components/purchase-tracker";
 import CouponForm from "@/components/credits/coupon-form";
-import { coreClient } from "@/lib/clients/core.client";
 import type { Organization } from "@/lib/clients/generated/core";
-import type { CoworkerOption } from "@/lib/types/coworker";
 
 interface CouponSectionProps {
-  // Provided by the billing page, which creates it once and shares it across
-  // the credits/coupon/subscription tabs — avoids fetching coworkers 3x per render.
-  coworkersPromise: Promise<CoworkerOption[]>;
   organization: Organization | null;
   returnPath?: string;
-  searchParams?: {
-    cancel?: string;
-    session_id?: string;
-  };
 }
 
 export default async function CouponSection({
-  coworkersPromise,
   organization,
   returnPath,
-  searchParams,
 }: CouponSectionProps) {
-  const sessionId = searchParams?.session_id;
-  const cancel = searchParams?.cancel;
-
-  const checkoutSession = sessionId
-    ? await coreClient
-        .getCheckoutSessionAnalytics(sessionId)
-        .then((response) => response.data)
-        .catch(() => null)
-    : null;
-
-  return (
-    <>
-      <CouponForm organization={organization} returnPath={returnPath} />
-      {sessionId ? (
-        <CreditsPurchaseSuccess coworkersPromise={coworkersPromise} />
-      ) : null}
-      {checkoutSession ? (
-        <PurchaseTracker checkoutSession={checkoutSession} />
-      ) : null}
-      {cancel ? <CreditsCancelModal /> : null}
-    </>
-  );
+  return <CouponForm organization={organization} returnPath={returnPath} />;
 }

--- a/apps/web/src/components/billing/credits-cancel-modal.tsx
+++ b/apps/web/src/components/billing/credits-cancel-modal.tsx
@@ -3,6 +3,7 @@
 import { useQueryState } from "nuqs";
 import { Suspense } from "react";
 
+import CancelCard from "@/app/credits/components/cancel-card";
 import {
   Dialog,
   DialogContent,
@@ -11,9 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-import CancelCard from "./cancel-card";
-
-export default function CreditsCancelModal() {
+export function CreditsCancelModal() {
   return (
     <Suspense>
       <CreditsCancelModalInner />

--- a/apps/web/src/components/billing/credits-checkout-return.tsx
+++ b/apps/web/src/components/billing/credits-checkout-return.tsx
@@ -1,0 +1,48 @@
+import { CreditsCancelModal } from "@/components/billing/credits-cancel-modal";
+import { CreditsPurchaseSuccess } from "@/components/billing/credits-purchase-success";
+import { PurchaseTracker } from "@/components/billing/purchase-tracker";
+import { coreClient } from "@/lib/clients/core.client";
+import type { CoworkerOption } from "@/lib/types/coworker";
+
+interface CreditsCheckoutReturnProps {
+  coworkersPromise: Promise<CoworkerOption[]>;
+  cancel?: string;
+  sessionId?: string;
+}
+
+/**
+ * Stripe credits/coupon return UI. Rendered once as a sibling of BillingTabs
+ * (or on standalone /coupon) so tab unmount cannot remount the success modal
+ * or re-fire purchase analytics.
+ */
+export async function CreditsCheckoutReturn({
+  coworkersPromise,
+  cancel,
+  sessionId,
+}: CreditsCheckoutReturnProps) {
+  if (!sessionId && !cancel) {
+    return null;
+  }
+
+  const checkoutSession = sessionId
+    ? await coreClient
+        .getCheckoutSessionAnalytics(sessionId)
+        .then((response) => response.data)
+        .catch(() => null)
+    : null;
+
+  return (
+    <>
+      {sessionId ? (
+        <CreditsPurchaseSuccess
+          coworkersPromise={coworkersPromise}
+          initialOpen
+        />
+      ) : null}
+      {checkoutSession ? (
+        <PurchaseTracker checkoutSession={checkoutSession} />
+      ) : null}
+      {cancel ? <CreditsCancelModal /> : null}
+    </>
+  );
+}

--- a/apps/web/src/components/billing/credits-purchase-success.tsx
+++ b/apps/web/src/components/billing/credits-purchase-success.tsx
@@ -2,13 +2,16 @@
 
 import { useTranslations } from "next-intl";
 import { useQueryState } from "nuqs";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 
 import { PurchaseSuccessModal } from "@/components/billing/purchase-success-modal";
 import type { CoworkerOption } from "@/lib/types/coworker";
 
 interface CreditsPurchaseSuccessProps {
   coworkersPromise: Promise<CoworkerOption[]>;
+  /** Seeded from the server-seen `session_id` so open state matches
+   * SubscriptionSuccessModal (latch + clear marker on dismiss). */
+  initialOpen?: boolean;
 }
 
 export function CreditsPurchaseSuccess(props: CreditsPurchaseSuccessProps) {
@@ -21,16 +24,23 @@ export function CreditsPurchaseSuccess(props: CreditsPurchaseSuccessProps) {
 
 function CreditsPurchaseSuccessInner({
   coworkersPromise,
+  initialOpen = false,
 }: CreditsPurchaseSuccessProps) {
   const t = useTranslations("App.Billing.PurchaseSuccess");
-  const [sessionId, setSessionId] = useQueryState("session_id");
+  const [, setSessionId] = useQueryState("session_id");
+  const [open, setOpen] = useState(initialOpen);
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      void setSessionId(null);
+    }
+  }
 
   return (
     <PurchaseSuccessModal
-      open={!!sessionId}
-      onOpenChange={(open) => {
-        if (!open) setSessionId(null);
-      }}
+      open={open}
+      onOpenChange={handleOpenChange}
       headline={t("creditsTitle")}
       description={t("creditsDescription")}
       coworkersPromise={coworkersPromise}

--- a/apps/web/src/components/billing/credits-section.tsx
+++ b/apps/web/src/components/billing/credits-section.tsx
@@ -1,63 +1,30 @@
-import CreditsCancelModal from "@/app/credits/components/cancel-modal";
-import { CreditsPurchaseSuccess } from "@/app/credits/components/credits-purchase-success";
-import PurchaseTracker from "@/app/credits/components/purchase-tracker";
 import CreditsForm from "@/components/credits/credits-form";
-import { coreClient } from "@/lib/clients/core.client";
 import type {
   CreditTopUpPricing,
   Organization,
 } from "@/lib/clients/generated/core";
-import type { CoworkerOption } from "@/lib/types/coworker";
 
 interface CreditsSectionProps {
-  // Provided by the billing page, which creates it once and shares it across
-  // the credits/coupon/subscription tabs — avoids fetching coworkers 3x per render.
-  coworkersPromise: Promise<CoworkerOption[]>;
   isPurchaseEnabled?: boolean;
   organization: Organization | null;
   // Provided by the billing page, which already fetches the catalog to gate
   // free-plan purchases — avoids a second identical Core round-trip per render.
   pricing: CreditTopUpPricing;
   returnPath?: string;
-  searchParams?: {
-    cancel?: string;
-    session_id?: string;
-  };
 }
 
 export default async function CreditsSection({
-  coworkersPromise,
   isPurchaseEnabled = true,
   organization,
   pricing,
   returnPath,
-  searchParams,
 }: CreditsSectionProps) {
-  const sessionId = searchParams?.session_id;
-  const cancel = searchParams?.cancel;
-
-  const checkoutSession = sessionId
-    ? await coreClient
-        .getCheckoutSessionAnalytics(sessionId)
-        .then((response) => response.data)
-        .catch(() => null)
-    : null;
-
   return (
-    <>
-      <CreditsForm
-        isPurchaseEnabled={isPurchaseEnabled}
-        pricing={pricing}
-        organization={organization}
-        returnPath={returnPath}
-      />
-      {sessionId ? (
-        <CreditsPurchaseSuccess coworkersPromise={coworkersPromise} />
-      ) : null}
-      {checkoutSession ? (
-        <PurchaseTracker checkoutSession={checkoutSession} />
-      ) : null}
-      {cancel ? <CreditsCancelModal /> : null}
-    </>
+    <CreditsForm
+      isPurchaseEnabled={isPurchaseEnabled}
+      pricing={pricing}
+      organization={organization}
+      returnPath={returnPath}
+    />
   );
 }

--- a/apps/web/src/components/billing/purchase-success-coworker-row.tsx
+++ b/apps/web/src/components/billing/purchase-success-coworker-row.tsx
@@ -26,7 +26,12 @@ export function PurchaseSuccessCoworkerRow(
 ) {
   return (
     <DefaultErrorBoundary
-      fallback={<GoToTasksFallback className={props.className} />}
+      fallback={
+        <GoToTasksFallback
+          className={props.className}
+          onNavigate={props.onNavigate}
+        />
+      }
     >
       <Suspense fallback={<CoworkerRowLoading />}>
         <CoworkerRowInner {...props} />

--- a/apps/web/src/components/billing/purchase-tracker.tsx
+++ b/apps/web/src/components/billing/purchase-tracker.tsx
@@ -20,12 +20,21 @@ export interface CheckoutSessionData {
   }[];
 }
 
-export default function PurchaseTracker({
-  checkoutSession,
-}: PurchaseTrackerProps) {
+/** Fires at most once per checkout session id for the lifetime of this JS realm. */
+const firedPurchaseSessionIds = new Set<string>();
+
+export function resetFiredPurchaseSessionIdsForTests() {
+  firedPurchaseSessionIds.clear();
+}
+
+export function PurchaseTracker({ checkoutSession }: PurchaseTrackerProps) {
   useEffect(() => {
     const { session_id, currency, value, items } =
       mapCheckoutSession(checkoutSession);
+    if (firedPurchaseSessionIds.has(session_id)) {
+      return;
+    }
+    firedPurchaseSessionIds.add(session_id);
     fireGTMEvent.purchase(session_id, currency, value, items);
   }, [checkoutSession]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes review findings from https://github.com/masumi-network/sokosumi/pull/3610 that were tech debt (not product questions).

- Pass `onNavigate` into the ErrorBoundary `GoToTasksFallback` so Back cannot replay the modal/GTM after a coworker-row failure.
- Hoist credits/coupon success, cancel, and GTM tracker into `CreditsCheckoutReturn`, rendered as a sibling of `BillingTabs` (and on standalone `/coupon`). Same mount topology as `SubscriptionSuccessModal`.
- Latch credits success open state from server-seen `session_id` (`initialOpen`), clear marker on dismiss.
- Fire `PurchaseTracker` GTM purchase at most once per session id.
- Move return UI modules from `app/(app)/credits/components/` into `components/billing/`.
- Cover host, tracker remount, ErrorBoundary navigate, and billing page wiring in tests.

Stacked onto https://github.com/masumi-network/sokosumi/pull/3610.

## Not in this PR (product, not tech debt)
- Org `status=cancel` has no in-section banner (personal still does). Product call on whether org cancel needs UI.

## Test plan
- [x] `pnpm --filter web test` for coworker-row, credits-purchase-success, credits-checkout-return, purchase-tracker, billing/page
- [x] `pnpm check` / `pnpm typecheck` (pre-commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2638ab-2cff-48d9-9a1b-db0c5e4ea51b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2638ab-2cff-48d9-9a1b-db0c5e4ea51b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

