### PR TITLE
fix(web): opt auth out of Instant Nav prerender

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -15,6 +15,11 @@ import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
 import AuthBackground from "./components/auth-background";
 
+// Instant Nav prerenders a Cache Components shell that Vercel serves for
+// POST/RSC to /signin|/signup as 405 (Method Not Allowed). Auth entry must
+// stay fully dynamic — same opt-out as admin / Hermes must-block gates.
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("Auth.Metadata");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production `/signin` (and `/signup`) return **405 Method Not Allowed** on POST/RSC. Credential login itself hits Core Better Auth, but Next soft-nav/RSC POSTs to the prerendered auth shell are served from the Vercel CDN as static → 405. React hydration #412 is a follow-on of that mismatch.

**Not caused by** [`80f6526`](https://github.com/masumi-network/sokosumi/commit/80f6526470159b5547c30d8407283123da349fda) (SOK-709 catalog `'use cache'`). That commit does not touch auth. Timing correlates because it is the current production deploy; the mechanism comes from Instant Nav / Cache Components ([#3601](https://github.com/masumi-network/sokosumi/pull/3601)), which opted out admin/Hermes with `instant = false` but left `(auth)`.

## Fix

- `export const instant = false` on `apps/web/src/app/(auth)/layout.tsx` (same must-block opt-out as admin / Hermes)

## Evidence (prod)

```bash
curl -sI -X POST 'https://app.sokosumi.com/signin' \
  -H 'RSC: 1' -H 'Next-Url: /signin'
# → HTTP/2 405, x-matched-path: /signin.rsc, x-vercel-cache: HIT|PRERENDER
```

## Verification

- `pnpm check` + `pnpm typecheck` (pre-commit)
- After deploy: POST/RSC to `/signin` must not return 405 from prerender cache

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b12733c-2688-4100-ad3c-c3c14b6100f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b12733c-2688-4100-ad3c-c3c14b6100f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication entry routes by ensuring they load dynamically and display the correct access state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->