### PR TITLE
fix(web): address purchase-success CodeRabbit findings

### DIFF
--- a/apps/core/src/services/__tests__/stripe-billing.service.test.ts
+++ b/apps/core/src/services/__tests__/stripe-billing.service.test.ts
@@ -472,6 +472,7 @@ describe("getCheckoutSessionAnalytics ownership", () => {
   beforeEach(() => {
     getCheckoutSessionMock.mockResolvedValue({
       id: "cs_123",
+      status: "complete",
       amount_total: 12000,
       currency: "eur",
       customer: "cus_user",
@@ -502,6 +503,7 @@ describe("getCheckoutSessionAnalytics ownership", () => {
     ]);
     getCheckoutSessionMock.mockResolvedValue({
       id: "cs_123",
+      status: "complete",
       amount_total: 12000,
       currency: "eur",
       customer: "cus_org",
@@ -516,6 +518,23 @@ describe("getCheckoutSessionAnalytics ownership", () => {
 
   it("rejects checkout session analytics when the customer is not owned by the caller", async () => {
     findUniqueMock.mockResolvedValue({ stripeCustomerId: "cus_other" });
+
+    await expect(
+      stripeBillingService.getCheckoutSessionAnalytics("cs_123", "user_1"),
+    ).rejects.toThrow("Checkout session not found");
+  });
+
+  it("rejects checkout session analytics when the session is not complete", async () => {
+    findUniqueMock.mockResolvedValue({ stripeCustomerId: "cus_user" });
+    getCheckoutSessionMock.mockResolvedValue({
+      id: "cs_123",
+      status: "open",
+      amount_total: 12000,
+      currency: "eur",
+      customer: "cus_user",
+      line_items: { data: [] },
+      metadata: {},
+    });
 
     await expect(
       stripeBillingService.getCheckoutSessionAnalytics("cs_123", "user_1"),

--- a/apps/core/src/services/stripe-billing.service.ts
+++ b/apps/core/src/services/stripe-billing.service.ts
@@ -521,6 +521,12 @@ export const stripeBillingService = {
       throw notFound("Checkout session not found");
     }
 
+    // Incomplete/open/expired sessions must not unlock success UI or purchase
+    // analytics. Coupons can complete with payment_status=no_payment_required.
+    if (session.status !== "complete") {
+      throw notFound("Checkout session not found");
+    }
+
     return mapCheckoutSessionAnalytics(session);
   },
 };

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3612,7 +3612,7 @@
       "assignedSeatsLabel": "Zugewiesen",
       "unusedSeatsLabel": "Ungenutzte Seats",
       "PurchaseSuccess": {
-        "creditsTitle": "Zahlung erfolgreich!",
+        "creditsTitle": "Alles erledigt!",
         "creditsDescription": "Deine Credits wurden deinem Konto gutgeschrieben.",
         "subscriptionTitle": "Du bist jetzt im {plan}-Plan!",
         "subscriptionDescription": "Dein Abo ist jetzt aktiv.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3643,7 +3643,7 @@
         "retryButton": "Try Again"
       },
       "PurchaseSuccess": {
-        "creditsTitle": "Payment successful!",
+        "creditsTitle": "You're all set!",
         "creditsDescription": "Your credits have been added to your account.",
         "subscriptionTitle": "You're on the {plan} plan!",
         "subscriptionDescription": "Your subscription is now active.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3612,7 +3612,7 @@
       "assignedSeatsLabel": "Asignados",
       "unusedSeatsLabel": "Seats sin usar",
       "PurchaseSuccess": {
-        "creditsTitle": "¡Pago exitoso!",
+        "creditsTitle": "¡Todo listo!",
         "creditsDescription": "Tus Credits se han añadido a tu cuenta.",
         "subscriptionTitle": "¡Ahora tienes el plan {plan}!",
         "subscriptionDescription": "Tu suscripción ya está activa.",

--- a/apps/web/src/components/billing/__tests__/credits-checkout-return.test.tsx
+++ b/apps/web/src/components/billing/__tests__/credits-checkout-return.test.tsx
@@ -53,7 +53,7 @@ describe("CreditsCheckoutReturn", () => {
     expect(getCheckoutSessionAnalyticsMock).not.toHaveBeenCalled();
   });
 
-  it("mounts success UI and tracker when session id is present", async () => {
+  it("mounts success UI and tracker when session validates", async () => {
     const checkoutSession = {
       sessionId: "cs_1",
       currency: "eur",
@@ -78,6 +78,20 @@ describe("CreditsCheckoutReturn", () => {
       expect.objectContaining({ checkoutSession }),
     );
     expect(creditsCancelModalMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mount success UI when session validation fails", async () => {
+    getCheckoutSessionAnalyticsMock.mockRejectedValue(new Error("not found"));
+
+    render(
+      await CreditsCheckoutReturn({
+        coworkersPromise,
+        sessionId: "cs_invalid",
+      }),
+    );
+
+    expect(creditsPurchaseSuccessMock).not.toHaveBeenCalled();
+    expect(purchaseTrackerMock).not.toHaveBeenCalled();
   });
 
   it("mounts the cancel modal when cancel is present", async () => {

--- a/apps/web/src/components/billing/__tests__/purchase-success-coworker-row.test.tsx
+++ b/apps/web/src/components/billing/__tests__/purchase-success-coworker-row.test.tsx
@@ -7,13 +7,18 @@ vi.mock("next/link", () => ({
   default: ({
     children,
     href,
-    onClick,
+    onNavigate,
   }: {
     children: ReactNode;
     href: string;
-    onClick?: () => void;
+    onNavigate?: (event: { preventDefault: () => void }) => void;
   }) => (
-    <a href={href} onClick={onClick}>
+    <a
+      href={href}
+      onClick={() => {
+        onNavigate?.({ preventDefault() {} });
+      }}
+    >
       {children}
     </a>
   ),

--- a/apps/web/src/components/billing/__tests__/purchase-success-modal.test.tsx
+++ b/apps/web/src/components/billing/__tests__/purchase-success-modal.test.tsx
@@ -17,13 +17,18 @@ vi.mock("next/link", () => ({
   default: ({
     children,
     href,
-    onClick,
+    onNavigate,
   }: {
     children: ReactNode;
     href: string;
-    onClick?: () => void;
+    onNavigate?: (event: { preventDefault: () => void }) => void;
   }) => (
-    <a href={href} onClick={onClick}>
+    <a
+      href={href}
+      onClick={() => {
+        onNavigate?.({ preventDefault() {} });
+      }}
+    >
       {children}
     </a>
   ),

--- a/apps/web/src/components/billing/credits-checkout-return.tsx
+++ b/apps/web/src/components/billing/credits-checkout-return.tsx
@@ -33,14 +33,14 @@ export async function CreditsCheckoutReturn({
 
   return (
     <>
-      {sessionId ? (
-        <CreditsPurchaseSuccess
-          coworkersPromise={coworkersPromise}
-          initialOpen
-        />
-      ) : null}
       {checkoutSession ? (
-        <PurchaseTracker checkoutSession={checkoutSession} />
+        <>
+          <CreditsPurchaseSuccess
+            coworkersPromise={coworkersPromise}
+            initialOpen
+          />
+          <PurchaseTracker checkoutSession={checkoutSession} />
+        </>
       ) : null}
       {cancel ? <CreditsCancelModal /> : null}
     </>

--- a/apps/web/src/components/billing/purchase-success-coworker-row.tsx
+++ b/apps/web/src/components/billing/purchase-success-coworker-row.tsx
@@ -59,7 +59,7 @@ function CoworkerRowInner({
           key={coworker.id}
           href={`/tasks?create=true&assignee=${encodeURIComponent(coworker.slug)}`}
           aria-label={t("startTaskWith", { name: coworker.name })}
-          onClick={onNavigate}
+          onNavigate={onNavigate}
           className="group focus-visible:ring-ring flex flex-col items-center gap-2 rounded-lg p-1 outline-none focus-visible:ring-2"
         >
           <Avatar className="ring-border group-hover:ring-primary size-14 ring-1 transition-all group-hover:scale-105 group-hover:ring-2">
@@ -91,7 +91,7 @@ function GoToTasksFallback({
 
   return (
     <Button asChild variant="outline" className={className}>
-      <Link href="/tasks" onClick={onNavigate}>
+      <Link href="/tasks" onNavigate={onNavigate}>
         {t("goToTasks")}
         <ArrowRight className="size-4" aria-hidden />
       </Link>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the three actionable CodeRabbit comments on #3610 (verified still valid against `4660f6ad`).

1. **Neutral success copy** — shared credits/coupon modal no longer says “Payment successful!” (`en`/`de`/`es`).
2. **Gate on validated complete checkout** — `CreditsCheckoutReturn` mounts success UI + tracker only when Core analytics succeeds; Core `getCheckoutSessionAnalytics` now requires Stripe `session.status === "complete"` (covers paid and `no_payment_required` coupon completions).
3. **`Link` `onNavigate`** — coworker/tasks links clear the purchase marker only on same-tab client navigations, not Ctrl/Cmd-click.

### Intentionally not changed

- **Confetti hex palette** — pushback: particles are a fixed brand celebration gesture rendered via inline `backgroundColor`, not themed UI chrome. Wiring them through CSS variables would need runtime `getComputedStyle` for little gain; leaving the deterministic palette as-is.

## Test plan

- [x] `pnpm --filter core test src/services/__tests__/stripe-billing.service.test.ts`
- [x] `pnpm --filter web test` billing purchase-success / checkout-return tests
- [x] `pnpm check && pnpm typecheck` (pre-commit)

Stacked on `feat/purchase-success-task-cta` for #3610.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2638ab-2cff-48d9-9a1b-db0c5e4ea51b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2638ab-2cff-48d9-9a1b-db0c5e4ea51b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

