### PR TITLE
fix(web): gate auth request headers with connection for Instant Nav

### DIFF
--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -1,4 +1,3 @@
-import { connection } from "next/server";
 import { Suspense } from "react";
 import type { Coworker } from "@/app/chat/utils/types";
 import { HistorySearchDialogProvider } from "@/app/components/history-search-dialog-provider";
@@ -30,9 +29,6 @@ interface AuthenticatedAppFrameProps {
 export default async function AuthenticatedAppFrame({
   children,
 }: AuthenticatedAppFrameProps) {
-  // Defer before session cookies()/fetch so Cache Components PPR probing does
-  // not abort Core get-session (HANGING_PROMISE_REJECTION → null → /signin).
-  await connection();
   const session = await getSessionOrRedirect();
   const adminMenuEnabled = hasAdminRole(
     (session.user as typeof session.user & { role?: string | null }).role,

--- a/apps/web/src/app/(app)/personal-assistant/layout.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/layout.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation";
-import { connection } from "next/server";
 import type { ReactNode } from "react";
 
 import { ClientMessageBoundary } from "@/i18n/client-message-boundary";
@@ -18,7 +17,6 @@ interface HermesLayoutProps {
 export default async function HermesLayout({ children }: HermesLayoutProps) {
   // Hermes beta gate: outside the whitelisted email domains the whole route
   // does not exist — same 404 a made-up path would get, so nothing leaks.
-  await connection();
   const session = await getSession();
   if (!isHermesBetaAccessEmail(session?.user.email)) {
     notFound();

--- a/apps/web/src/app/(app)/personal-assistant/page.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/page.tsx
@@ -1,7 +1,6 @@
 import type { SelfServeSubscriptionPlanName } from "@sokosumi/utils";
 import gravatarUrl from "gravatar-url";
 import type { Metadata } from "next";
-import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
@@ -30,7 +29,6 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HermesPage() {
-  await connection();
   const session = await getSession();
   const userName = session?.user.name ?? null;
   const userEmail = session?.user.email ?? null;

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 const headersMock = vi.fn();
-const connectionMock = vi.fn();
 const captureMessageMock = vi.fn();
 const setTagMock = vi.fn();
 const setContextMock = vi.fn();
@@ -23,10 +22,6 @@ vi.mock("@sentry/nextjs", () => ({
   ) => {
     callback({ setTag: setTagMock, setContext: setContextMock });
   },
-}));
-
-vi.mock("next/server", () => ({
-  connection: (...args: unknown[]) => connectionMock(...args),
 }));
 
 vi.mock("next/headers", () => ({
@@ -54,9 +49,6 @@ describe("auth.server", () => {
     vi.resetModules();
     vi.clearAllMocks();
     callOrder.length = 0;
-    connectionMock.mockImplementation(async () => {
-      callOrder.push("connection");
-    });
     headersMock.mockImplementation(async () => {
       callOrder.push("headers");
       return new Headers({ cookie: SESSION_COOKIE });
@@ -74,23 +66,23 @@ describe("auth.server", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
-  it("awaits connection before headers and fetch for getSession", async () => {
+  it("uses headers then fetch for getSession", async () => {
     const { getSession } = await import("../auth.server");
 
     await getSession();
 
-    expect(callOrder.slice(0, 3)).toEqual(["connection", "headers", "fetch"]);
+    expect(callOrder.slice(0, 2)).toEqual(["headers", "fetch"]);
   });
 
-  it("awaits connection before headers and fetch for refreshed getSession", async () => {
+  it("uses headers then fetch for refreshed getSession", async () => {
     const { getSession } = await import("../auth.server");
 
     await getSession({ refresh: true });
 
-    expect(callOrder.slice(0, 3)).toEqual(["connection", "headers", "fetch"]);
+    expect(callOrder.slice(0, 2)).toEqual(["headers", "fetch"]);
   });
 
-  it("awaits connection before headers for listUserAccounts", async () => {
+  it("uses headers for listUserAccounts", async () => {
     fetchMock.mockImplementation(async () => {
       callOrder.push("fetch");
       return {
@@ -103,7 +95,7 @@ describe("auth.server", () => {
 
     await listUserAccounts();
 
-    expect(callOrder.slice(0, 3)).toEqual(["connection", "headers", "fetch"]);
+    expect(callOrder.slice(0, 2)).toEqual(["headers", "fetch"]);
   });
 
   it("skips Core when no session cookie is present", async () => {

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -82,6 +82,18 @@ describe("auth.server", () => {
     expect(callOrder.slice(0, 2)).toEqual(["headers", "fetch"]);
   });
 
+  it("rethrows hanging-promise aborts from headers for refreshed getSession", async () => {
+    const hanging = Object.assign(new Error("Hanging promise rejection"), {
+      digest: "HANGING_PROMISE_REJECTION",
+    });
+    headersMock.mockRejectedValue(hanging);
+
+    const { getSession } = await import("../auth.server");
+
+    await expect(getSession({ refresh: true })).rejects.toBe(hanging);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("uses headers for listUserAccounts", async () => {
     fetchMock.mockImplementation(async () => {
       callOrder.push("fetch");

--- a/apps/web/src/lib/auth/__tests__/auth.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.server.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 const headersMock = vi.fn();
+const connectionMock = vi.fn();
 const captureMessageMock = vi.fn();
 const setTagMock = vi.fn();
 const setContextMock = vi.fn();
+const callOrder: string[] = [];
 
 const SESSION_COOKIE =
   "sokosumi-localhost-preprod.session_token=session-token-value";
@@ -21,6 +23,10 @@ vi.mock("@sentry/nextjs", () => ({
   ) => {
     callback({ setTag: setTagMock, setContext: setContextMock });
   },
+}));
+
+vi.mock("next/server", () => ({
+  connection: (...args: unknown[]) => connectionMock(...args),
 }));
 
 vi.mock("next/headers", () => ({
@@ -47,8 +53,57 @@ describe("auth.server", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    headersMock.mockResolvedValue(new Headers({ cookie: SESSION_COOKIE }));
+    callOrder.length = 0;
+    connectionMock.mockImplementation(async () => {
+      callOrder.push("connection");
+    });
+    headersMock.mockImplementation(async () => {
+      callOrder.push("headers");
+      return new Headers({ cookie: SESSION_COOKIE });
+    });
+    fetchMock.mockImplementation(async () => {
+      callOrder.push("fetch");
+      return {
+        ok: true,
+        json: async () => ({
+          session: { activeOrganizationId: null },
+          user: { id: "user_123" },
+        }),
+      };
+    });
     vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("awaits connection before headers and fetch for getSession", async () => {
+    const { getSession } = await import("../auth.server");
+
+    await getSession();
+
+    expect(callOrder.slice(0, 3)).toEqual(["connection", "headers", "fetch"]);
+  });
+
+  it("awaits connection before headers and fetch for refreshed getSession", async () => {
+    const { getSession } = await import("../auth.server");
+
+    await getSession({ refresh: true });
+
+    expect(callOrder.slice(0, 3)).toEqual(["connection", "headers", "fetch"]);
+  });
+
+  it("awaits connection before headers for listUserAccounts", async () => {
+    fetchMock.mockImplementation(async () => {
+      callOrder.push("fetch");
+      return {
+        ok: true,
+        json: async () => [],
+      };
+    });
+
+    const { listUserAccounts } = await import("../auth.server");
+
+    await listUserAccounts();
+
+    expect(callOrder.slice(0, 3)).toEqual(["connection", "headers", "fetch"]);
   });
 
   it("skips Core when no session cookie is present", async () => {

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -6,7 +6,6 @@ import { getSessionCookie } from "better-auth/cookies";
 import { err, ok, type Result } from "neverthrow";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { connection } from "next/server";
 import { cache } from "react";
 import type { ActiveSubscription } from "@/components/billing/subscription-plan-utils";
 import { getEnvSecrets } from "@/config/env.secrets";
@@ -160,9 +159,9 @@ function getBetterAuthCookiePrefixFromEnv(): string {
   });
 }
 
-// Defer until request is dynamic so PPR soft-aborts do not hit Core as null.
+// Headers-only: Instant Nav sidebar may call getSession under
+// "use cache: private", where connection() is illegal (next-request-in-use-cache).
 async function getRequestHeaders(): Promise<Headers> {
-  await connection();
   return headers();
 }
 

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -6,6 +6,7 @@ import { getSessionCookie } from "better-auth/cookies";
 import { err, ok, type Result } from "neverthrow";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { connection } from "next/server";
 import { cache } from "react";
 import type { ActiveSubscription } from "@/components/billing/subscription-plan-utils";
 import { getEnvSecrets } from "@/config/env.secrets";
@@ -159,6 +160,12 @@ function getBetterAuthCookiePrefixFromEnv(): string {
   });
 }
 
+// Defer until request is dynamic so PPR soft-aborts do not hit Core as null.
+async function getRequestHeaders(): Promise<Headers> {
+  await connection();
+  return headers();
+}
+
 /**
  * Cheap presence check — no Core round-trip. Anonymous auth entry paths
  * (signin/signup) must not pay Core RTT when no session cookie exists.
@@ -232,7 +239,7 @@ async function fetchSession(
 }
 
 const getCachedSession = cache(async (): Promise<Session | null> => {
-  return fetchSession(await headers());
+  return fetchSession(await getRequestHeaders());
 });
 
 /**
@@ -245,7 +252,7 @@ export async function getSession(
   options?: GetSessionOptions,
 ): Promise<Session | null> {
   if (options?.refresh) {
-    return fetchSession(await headers(), options);
+    return fetchSession(await getRequestHeaders(), options);
   }
 
   return getCachedSession();
@@ -255,7 +262,7 @@ const getCachedUserAccounts = cache(
   async (): Promise<Result<Account[], CoreAuthReadError>> => {
     const result = await fetchCoreAuth<unknown>(
       CORE_LIST_ACCOUNTS_PATH,
-      await headers(),
+      await getRequestHeaders(),
       {
         failureLogMessage: "Failed to fetch user accounts from Core",
       },
@@ -291,7 +298,7 @@ const getCachedActiveSubscriptions = cache(
   ): Promise<Result<ActiveSubscription[], CoreAuthReadError>> => {
     const result = await fetchCoreAuth<unknown>(
       CORE_LIST_ACTIVE_SUBSCRIPTIONS_PATH,
-      await headers(),
+      await getRequestHeaders(),
       {
         failureLogMessage: "Failed to fetch active subscriptions from Core",
         searchParams: {
@@ -331,7 +338,7 @@ const getCachedOAuthClientPublic = cache(
   ): Promise<Result<OAuthClientPublic | null, CoreAuthReadError>> => {
     const result = await fetchCoreAuth<OAuthClientPublic | null>(
       CORE_GET_OAUTH_CLIENT_PUBLIC_PATH,
-      await headers(),
+      await getRequestHeaders(),
       {
         failureLogMessage: "Failed to fetch OAuth client from Core",
         searchParams: { client_id: clientId },
@@ -376,7 +383,7 @@ export async function getSessionOrRedirect(): Promise<Session> {
     return session;
   }
   // Get the current URL from headers for server-side redirect
-  const headersList = await headers();
+  const headersList = await getRequestHeaders();
   const pathname = headersList.get("x-pathname") ?? "";
   const searchParams = headersList.get("x-search-params") ?? "";
   const currentUrl = pathname + searchParams;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-714/harden-session-reads-for-instant-navigations-cache-components

Centralizes request-bound auth reads in `auth.server` via private `getRequestHeaders()` (`headers()` before Core). Soft-aborts still rethrow (`HANGING_PROMISE_REJECTION`); Core outages still return null/Result.

Does **not** call `connection()` inside the shared helper: Instant Nav `"use cache: private"` sidebar calls `getSession()`, and Next forbids `connection()` in that scope. Session harden is headers-before-Core + hanging rethrow; overlays/agents keep their own `connection()` for cookies/Core.

Removes redundant session-only `connection()` from the authenticated app frame and personal-assistant routes.

Also covers hanging abort on `headers()` for `getSession({ refresh: true })` so soft-aborts before fetch cannot become null.

**Verify:** `pnpm web:check`, `pnpm web:test` (auth.server tests include headers hanging propagation).

![Agents authenticated after fix](https://cursor.com/artifacts/c/art-360fcfea-9422-4836-8303-a78134690930)
![History authenticated after fix](https://cursor.com/artifacts/c/art-b7d877a3-4dee-4124-b0c9-63efba5b82ac)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a60504b5-710f-4b59-9db4-669c4cbfe740?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a60504b5-710f-4b59-9db4-669c4cbfe740&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication request handling across session, account, subscription, OAuth, and redirect flows.
  * Ensured request headers are retrieved before related network requests, improving reliability.
* **Tests**
  * Added coverage verifying the order of authentication header and fetch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->