### PR TITLE
fix(web): move Ably off authenticated app shell for Instant Nav

### DIFF
--- a/apps/web/docs/PERFORMANCE_PROFILE.md
+++ b/apps/web/docs/PERFORMANCE_PROFILE.md
@@ -130,7 +130,7 @@ Ensure `getSessionOrRedirect` and any flag that calls `getSession()` use this ca
 
 ### 3.2 Heavy / third-party components
 
-**Observation:** Ably loads via mount-gated `import()` in `contexts/lazy-ably-provider.tsx` (Instant-safe; no `next/dynamic` + `ssr: false`). Root `ClientAnalytics` uses the same pattern for Vercel Analytics / SpeedInsights.
+**Observation:** Ably loads via mount-gated `import()` in `contexts/lazy-ably-provider.tsx` as **local islands** (notifications sibling under `NotificationProvider`, chat rooms bridge, jobs/tasks listeners) — not on `(app)/layout` / app shell. Instant-safe; no `next/dynamic` + `ssr: false`. Root `ClientAnalytics` uses the same pattern for Vercel Analytics / SpeedInsights.
 
 **Skill ref:** §2.3 Defer Non-Critical Third-Party Libraries, §2.4 Dynamic Imports for Heavy Components.
 

--- a/apps/web/src/app/(app)/__tests__/layout-ably-ownership.test.ts
+++ b/apps/web/src/app/(app)/__tests__/layout-ably-ownership.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("(app)/layout Ably ownership", () => {
+  it("does not import or wrap the shell in LazyAblyProvider", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../layout.tsx"),
+      "utf8",
+    );
+
+    expect(source).not.toContain("LazyAblyProvider");
+    expect(source).not.toContain("lazy-ably-provider");
+    expect(source).toContain("SidebarProvider");
+    expect(source).toContain("AppShellLoadingFrame");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("RoomsClient Ably island", () => {
+  it("wraps rooms ChannelProvider + bridge in local LazyAblyProvider", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../rooms-client.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('from "@/contexts/lazy-ably-provider"');
+    expect(source).toMatch(
+      /LazyAblyProvider>\s*<ChannelProvider[\s\S]*RoomMessageRealtimeBridge[\s\S]*<\/ChannelProvider>\s*<\/LazyAblyProvider>/,
+    );
+    expect(source).toContain('<main className="relative flex min-h-0 flex-1">');
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -47,6 +47,7 @@ import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRegisterBreadcrumbOverride } from "@/contexts/breadcrumb-override-context";
+import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import {
   type ChatRoomMessageEventData,
   makeUserChatRoomsChannelName,
@@ -1313,14 +1314,16 @@ export function RoomsClient({
   return (
     <div className="-m-4 flex h-[calc(100svh-64px)] min-h-0 flex-col overflow-hidden bg-background">
       {currentUserId ? (
-        <ChannelProvider
-          channelName={makeUserChatRoomsChannelName(currentUserId)}
-        >
-          <RoomMessageRealtimeBridge
-            userId={currentUserId}
-            onMessage={handleChatRoomRealtimeMessage}
-          />
-        </ChannelProvider>
+        <LazyAblyProvider>
+          <ChannelProvider
+            channelName={makeUserChatRoomsChannelName(currentUserId)}
+          >
+            <RoomMessageRealtimeBridge
+              userId={currentUserId}
+              onMessage={handleChatRoomRealtimeMessage}
+            />
+          </ChannelProvider>
+        </LazyAblyProvider>
       ) : null}
       {/* `relative` anchors the thread panel's mobile full-screen takeover. */}
       <main className="relative flex min-h-0 flex-1">

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -16,7 +16,6 @@ import { AppSidebarFallback } from "./app-sidebar-fallback";
 import Header from "./header";
 import { LoginAccountNoticeToast } from "./login-account-notice-toast.client";
 import { NoticeDialogProvider } from "./notice-dialog-context";
-import { NotificationToastListener } from "./notification-toast-listener";
 import { NotificationToaster } from "./notification-toaster.client";
 import PrivateCachedAppSidebar from "./private-cached-app-sidebar";
 
@@ -47,7 +46,6 @@ export default async function AuthenticatedAppFrame({
             announcementNotices={EMPTY_NOTICES}
           >
             <NotificationToaster />
-            <NotificationToastListener userId={session.user.id} />
             <LoginAccountNoticeToast />
             <HistorySearchDialogProvider
               activeOrganizationId={

--- a/apps/web/src/app/(app)/components/notification-toast-listener.tsx
+++ b/apps/web/src/app/(app)/components/notification-toast-listener.tsx
@@ -7,7 +7,6 @@ import { toast } from "sonner";
 
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
 import { VendorGrantNotificationActions } from "@/components/notifications/vendor-grant-notification-actions";
-import { useNotifications } from "@/contexts/notification-provider";
 import type { NotificationEventData } from "@/lib/ably/schema";
 import { useNotificationRealtime } from "@/lib/ably/use-notification-realtime";
 import { authClient } from "@/lib/auth/auth.client";
@@ -23,6 +22,7 @@ import { isPendingVendorGrantNotification } from "@/lib/utils/vendor-grant-notif
 
 interface NotificationToastListenerProps {
   userId: string;
+  markRead: (id: string) => Promise<void>;
 }
 
 interface NotificationToastBodyProps {
@@ -80,11 +80,11 @@ function VendorGrantNotificationToast({
 
 export function NotificationToastListener({
   userId,
+  markRead,
 }: NotificationToastListenerProps) {
   const t = useTranslations("Components.NotificationCenter");
   const tDetail = useTranslations("App.Tasks.Detail");
   const formatMessage = useNotificationMessage();
-  const { markRead } = useNotifications();
   const router = useRouter();
   const { handleSelectWorkspace } = useWorkspaceSwitcher();
 

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import QueryProvider from "@/contexts/query-provider";
 import { ClientMessageBoundary } from "@/i18n/client-message-boundary";
 import { APP_MESSAGE_PATHS } from "@/i18n/message-namespaces";
@@ -32,21 +31,19 @@ export default function AppLayout({ children }: AppLayoutProps) {
     <ClientMessageBoundary paths={APP_MESSAGE_PATHS}>
       <QueryProvider>
         <AuthSessionGuard />
-        <LazyAblyProvider>
-          <SidebarProvider
-            // Cookie preference restored client-side in SidebarProvider
-            // (useLayoutEffect) so this layout stays sync for Instant Nav.
-            defaultOpen
-            data-app-shell
-            className="flex max-w-svw overflow-clip"
+        <SidebarProvider
+          // Cookie preference restored client-side in SidebarProvider
+          // (useLayoutEffect) so this layout stays sync for Instant Nav.
+          defaultOpen
+          data-app-shell
+          className="flex max-w-svw overflow-clip"
+        >
+          <Suspense
+            fallback={<AppShellLoadingFrame>{children}</AppShellLoadingFrame>}
           >
-            <Suspense
-              fallback={<AppShellLoadingFrame>{children}</AppShellLoadingFrame>}
-            >
-              <AuthenticatedAppFrame>{children}</AuthenticatedAppFrame>
-            </Suspense>
-          </SidebarProvider>
-        </LazyAblyProvider>
+            <AuthenticatedAppFrame>{children}</AuthenticatedAppFrame>
+          </Suspense>
+        </SidebarProvider>
       </QueryProvider>
     </ClientMessageBoundary>
   );

--- a/apps/web/src/contexts/__tests__/notification-provider.island.test.tsx
+++ b/apps/web/src/contexts/__tests__/notification-provider.island.test.tsx
@@ -1,0 +1,153 @@
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  NotificationProvider,
+  useNotifications,
+} from "@/contexts/notification-provider";
+
+const getNotificationsMock = vi.fn();
+const getNotificationsUnreadCountMock = vi.fn();
+const useNotificationRealtimeMock = vi.fn();
+
+const lazyAblyProviderMock = vi.fn(
+  ({ children }: { children: React.ReactNode }): React.ReactNode => (
+    <>{children}</>
+  ),
+);
+
+vi.mock("@/lib/clients/core.browser.client", () => ({
+  coreClient: {
+    getNotifications: (...args: unknown[]) => getNotificationsMock(...args),
+    getNotificationsUnreadCount: (...args: unknown[]) =>
+      getNotificationsUnreadCountMock(...args),
+    patchNotificationRead: vi.fn(),
+    patchNotificationsReadAll: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/ably/use-notification-realtime", () => ({
+  useNotificationRealtime: (...args: unknown[]) =>
+    useNotificationRealtimeMock(...args),
+}));
+
+vi.mock("ably/react", () => ({
+  ChannelProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="notifications-channel-provider">{children}</div>
+  ),
+}));
+
+vi.mock("@/contexts/lazy-ably-provider", () => ({
+  default: (props: { children: React.ReactNode }) =>
+    lazyAblyProviderMock(props),
+}));
+
+vi.mock("@/app/components/notification-toast-listener", () => ({
+  NotificationToastListener: ({ userId }: { userId: string }) => (
+    <div data-testid="notification-toast-listener">{userId}</div>
+  ),
+}));
+
+function NotificationConsumer() {
+  const { isLoading, hasFetchError, unreadCount } = useNotifications();
+
+  return (
+    <div data-testid="notification-consumer">
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="fetch-error">{String(hasFetchError)}</span>
+      <span data-testid="unread-count">{unreadCount}</span>
+    </div>
+  );
+}
+
+describe("NotificationProvider island", () => {
+  beforeEach(() => {
+    getNotificationsMock.mockReset();
+    getNotificationsUnreadCountMock.mockReset();
+    useNotificationRealtimeMock.mockReset();
+    lazyAblyProviderMock.mockReset();
+    lazyAblyProviderMock.mockImplementation(
+      ({ children }: { children: React.ReactNode }): React.ReactNode => (
+        <>{children}</>
+      ),
+    );
+
+    getNotificationsMock.mockResolvedValue({ data: [] });
+    getNotificationsUnreadCountMock.mockResolvedValue({ data: { count: 0 } });
+  });
+
+  it("renders children and REST context without waiting on Ably", async () => {
+    lazyAblyProviderMock.mockImplementation((): React.ReactNode => null);
+
+    render(
+      <NotificationProvider userId="user-1">
+        <NotificationConsumer />
+      </NotificationProvider>,
+    );
+
+    expect(screen.getByTestId("notification-consumer")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("notifications-channel-provider"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("notification-toast-listener"),
+    ).not.toBeInTheDocument();
+    expect(useNotificationRealtimeMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getNotificationsMock).toHaveBeenCalled();
+    expect(getNotificationsUnreadCountMock).toHaveBeenCalled();
+    expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    expect(screen.getByTestId("fetch-error")).toHaveTextContent("false");
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+  });
+
+  it("mounts realtime bridge and toast listener under the LazyAbly island", async () => {
+    render(
+      <NotificationProvider userId="user-1">
+        <NotificationConsumer />
+      </NotificationProvider>,
+    );
+
+    expect(
+      screen.getByTestId("notifications-channel-provider"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("notification-toast-listener")).toHaveTextContent(
+      "user-1",
+    );
+    expect(useNotificationRealtimeMock).toHaveBeenCalled();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("surfaces fetch errors on the immediate path without Ably", async () => {
+    lazyAblyProviderMock.mockImplementation((): React.ReactNode => null);
+    getNotificationsMock.mockRejectedValue(new Error("network down"));
+
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <NotificationProvider userId="user-1">
+        <NotificationConsumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("fetch-error")).toHaveTextContent("true");
+    expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    expect(useNotificationRealtimeMock).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/web/src/contexts/__tests__/notification-provider.island.test.tsx
+++ b/apps/web/src/contexts/__tests__/notification-provider.island.test.tsx
@@ -43,9 +43,12 @@ vi.mock("@/contexts/lazy-ably-provider", () => ({
 }));
 
 vi.mock("@/app/components/notification-toast-listener", () => ({
-  NotificationToastListener: ({ userId }: { userId: string }) => (
-    <div data-testid="notification-toast-listener">{userId}</div>
-  ),
+  NotificationToastListener: ({
+    userId,
+  }: {
+    userId: string;
+    markRead: (id: string) => Promise<void>;
+  }) => <div data-testid="notification-toast-listener">{userId}</div>,
 }));
 
 function NotificationConsumer() {

--- a/apps/web/src/contexts/__tests__/notification-provider.island.test.tsx
+++ b/apps/web/src/contexts/__tests__/notification-provider.island.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import { type ReactNode, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -11,9 +12,7 @@ const getNotificationsUnreadCountMock = vi.fn();
 const useNotificationRealtimeMock = vi.fn();
 
 const lazyAblyProviderMock = vi.fn(
-  ({ children }: { children: React.ReactNode }): React.ReactNode => (
-    <>{children}</>
-  ),
+  ({ children }: { children: ReactNode }): ReactNode => <>{children}</>,
 );
 
 vi.mock("@/lib/clients/core.browser.client", () => ({
@@ -32,14 +31,13 @@ vi.mock("@/lib/ably/use-notification-realtime", () => ({
 }));
 
 vi.mock("ably/react", () => ({
-  ChannelProvider: ({ children }: { children: React.ReactNode }) => (
+  ChannelProvider: ({ children }: { children: ReactNode }) => (
     <div data-testid="notifications-channel-provider">{children}</div>
   ),
 }));
 
 vi.mock("@/contexts/lazy-ably-provider", () => ({
-  default: (props: { children: React.ReactNode }) =>
-    lazyAblyProviderMock(props),
+  default: (props: { children: ReactNode }) => lazyAblyProviderMock(props),
 }));
 
 vi.mock("@/app/components/notification-toast-listener", () => ({
@@ -70,9 +68,7 @@ describe("NotificationProvider island", () => {
     useNotificationRealtimeMock.mockReset();
     lazyAblyProviderMock.mockReset();
     lazyAblyProviderMock.mockImplementation(
-      ({ children }: { children: React.ReactNode }): React.ReactNode => (
-        <>{children}</>
-      ),
+      ({ children }: { children: ReactNode }): ReactNode => <>{children}</>,
     );
 
     getNotificationsMock.mockResolvedValue({ data: [] });
@@ -80,7 +76,7 @@ describe("NotificationProvider island", () => {
   });
 
   it("renders children and REST context without waiting on Ably", async () => {
-    lazyAblyProviderMock.mockImplementation((): React.ReactNode => null);
+    lazyAblyProviderMock.mockImplementation((): ReactNode => null);
 
     render(
       <NotificationProvider userId="user-1">
@@ -129,7 +125,7 @@ describe("NotificationProvider island", () => {
   });
 
   it("surfaces fetch errors on the immediate path without Ably", async () => {
-    lazyAblyProviderMock.mockImplementation((): React.ReactNode => null);
+    lazyAblyProviderMock.mockImplementation((): ReactNode => null);
     getNotificationsMock.mockRejectedValue(new Error("network down"));
 
     const consoleError = vi
@@ -152,5 +148,77 @@ describe("NotificationProvider island", () => {
     expect(useNotificationRealtimeMock).not.toHaveBeenCalled();
 
     consoleError.mockRestore();
+  });
+
+  it("refetches after the Ably island mounts so REST-before-subscribe gaps close", async () => {
+    let islandOpen = false;
+    let bumpGate: (() => void) | null = null;
+
+    function GatedLazyAbly({ children }: { children: ReactNode }) {
+      const [, setTick] = useState(0);
+      bumpGate = () => {
+        setTick((tick) => tick + 1);
+      };
+      if (!islandOpen) {
+        return null;
+      }
+      return <>{children}</>;
+    }
+
+    lazyAblyProviderMock.mockImplementation(
+      ({ children }: { children: ReactNode }) => (
+        <GatedLazyAbly>{children}</GatedLazyAbly>
+      ),
+    );
+
+    getNotificationsMock
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "notification-gap",
+            userId: "user-1",
+            kind: "JOB",
+            referenceId: "job-1",
+            eventId: "event-1",
+            messageKey: "Notifications.Job.completed",
+            messageParams: {},
+            metadata: {},
+            isRead: false,
+            readAt: null,
+            createdAt: new Date("2026-06-18T09:00:00.000Z"),
+          },
+        ],
+      });
+    getNotificationsUnreadCountMock
+      .mockResolvedValueOnce({ data: { count: 0 } })
+      .mockResolvedValueOnce({ data: { count: 1 } });
+
+    render(
+      <NotificationProvider userId="user-1">
+        <NotificationConsumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getNotificationsMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+    expect(useNotificationRealtimeMock).not.toHaveBeenCalled();
+
+    islandOpen = true;
+    await act(async () => {
+      bumpGate?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useNotificationRealtimeMock).toHaveBeenCalled();
+    expect(getNotificationsMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("1");
   });
 });

--- a/apps/web/src/contexts/lazy-ably-provider.tsx
+++ b/apps/web/src/contexts/lazy-ably-provider.tsx
@@ -8,6 +8,12 @@ interface LazyAblyProviderProps {
   children: ReactNode;
 }
 
+/**
+ * Mount-gated Ably island gate. Returns null until `ably-provider` loads, then
+ * wraps children. Use as a sibling of paint-critical UI — not as an app-shell
+ * parent — so Instant chrome is never blocked on the Ably chunk.
+ * Multiple instances share one realtime client via `getAblyRealtimeClient()`.
+ */
 export default function LazyAblyProvider({ children }: LazyAblyProviderProps) {
   const [Provider, setProvider] = useState<ComponentType<{
     children: ReactNode;

--- a/apps/web/src/contexts/notification-provider.tsx
+++ b/apps/web/src/contexts/notification-provider.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 
 import { NotificationToastListener } from "@/app/components/notification-toast-listener";
 import LazyAblyProvider from "@/contexts/lazy-ably-provider";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import {
   makeUserNotificationsChannelName,
   type NotificationEventData,
@@ -233,9 +234,11 @@ interface NotificationProviderProps {
 function NotificationRealtimeBridge({
   userId,
   onNotification,
+  onSubscribed,
 }: {
   userId: string;
   onNotification: (notification: NotificationEventData) => void;
+  onSubscribed: () => void;
 }) {
   useNotificationRealtime({
     userId,
@@ -243,6 +246,10 @@ function NotificationRealtimeBridge({
     onError: (error) => {
       console.error("Ably notification error:", error);
     },
+  });
+
+  useMountEffect(() => {
+    onSubscribed();
   });
 
   return null;
@@ -350,6 +357,10 @@ export function NotificationProvider({
     [],
   );
 
+  const handleRealtimeSubscribed = useCallback(() => {
+    void fetchNotifications();
+  }, [fetchNotifications]);
+
   useEffect(() => {
     void fetchNotifications();
   }, [fetchNotifications]);
@@ -372,6 +383,7 @@ export function NotificationProvider({
           <NotificationRealtimeBridge
             userId={userId}
             onNotification={handleNotificationEvent}
+            onSubscribed={handleRealtimeSubscribed}
           />
           <NotificationToastListener userId={userId} markRead={markRead} />
         </ChannelProvider>

--- a/apps/web/src/contexts/notification-provider.tsx
+++ b/apps/web/src/contexts/notification-provider.tsx
@@ -373,7 +373,7 @@ export function NotificationProvider({
             userId={userId}
             onNotification={handleNotificationEvent}
           />
-          <NotificationToastListener userId={userId} />
+          <NotificationToastListener userId={userId} markRead={markRead} />
         </ChannelProvider>
       </LazyAblyProvider>
     </NotificationContext>

--- a/apps/web/src/contexts/notification-provider.tsx
+++ b/apps/web/src/contexts/notification-provider.tsx
@@ -12,6 +12,8 @@ import {
 } from "react";
 import { toast } from "sonner";
 
+import { NotificationToastListener } from "@/app/components/notification-toast-listener";
+import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import {
   makeUserNotificationsChannelName,
   type NotificationEventData,
@@ -228,7 +230,30 @@ interface NotificationProviderProps {
   children: React.ReactNode;
 }
 
-function NotificationProviderBody({
+function NotificationRealtimeBridge({
+  userId,
+  onNotification,
+}: {
+  userId: string;
+  onNotification: (notification: NotificationEventData) => void;
+}) {
+  useNotificationRealtime({
+    userId,
+    onNotification,
+    onError: (error) => {
+      console.error("Ably notification error:", error);
+    },
+  });
+
+  return null;
+}
+
+/**
+ * Immediate path: reducer + REST fetch/mark-read + context + children.
+ * Sibling island: LazyAbly → ChannelProvider → realtime bridge + toast listener
+ * that dispatch into the same reducer. Children never wait on Ably.
+ */
+export function NotificationProvider({
   userId,
   children,
 }: NotificationProviderProps) {
@@ -325,14 +350,6 @@ function NotificationProviderBody({
     [],
   );
 
-  useNotificationRealtime({
-    userId,
-    onNotification: handleNotificationEvent,
-    onError: (error) => {
-      console.error("Ably notification error:", error);
-    },
-  });
-
   useEffect(() => {
     void fetchNotifications();
   }, [fetchNotifications]);
@@ -347,18 +364,18 @@ function NotificationProviderBody({
     hasFetchError,
   };
 
-  return <NotificationContext value={value}>{children}</NotificationContext>;
-}
-
-export function NotificationProvider({
-  userId,
-  children,
-}: NotificationProviderProps) {
   return (
-    <ChannelProvider channelName={makeUserNotificationsChannelName(userId)}>
-      <NotificationProviderBody userId={userId}>
-        {children}
-      </NotificationProviderBody>
-    </ChannelProvider>
+    <NotificationContext value={value}>
+      {children}
+      <LazyAblyProvider>
+        <ChannelProvider channelName={makeUserNotificationsChannelName(userId)}>
+          <NotificationRealtimeBridge
+            userId={userId}
+            onNotification={handleNotificationEvent}
+          />
+          <NotificationToastListener userId={userId} />
+        </ChannelProvider>
+      </LazyAblyProvider>
+    </NotificationContext>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to SOK-716 / #3621: Ably no longer wraps the authenticated `(app)` shell, so Instant Nav soft navigations can paint sync chrome (`SidebarProvider` / Suspense) without waiting on the Ably client.

## Changes

- Remove `LazyAblyProvider` from `(app)/layout.tsx`
- Split `NotificationProvider` into sync context + sibling Ably island (`LazyAblyProvider` → `ChannelProvider` → realtime bridge + toast listener)
- Refetch notifications when the Ably island mounts (`onSubscribed`) so REST-before-subscribe cannot leave the UI stale
- Local `LazyAblyProvider` in chat `rooms-client.tsx` (tasks/jobs islands unchanged)
- Keep Instant on chat/tasks/account; keep mount-gated Ably import (no `next/dynamic` + `ssr: false` on Instant shells)

## Linear

Closes [SOK-717](https://linear.app/masumi/issue/SOK-717/move-ably-off-the-authenticated-app-shell-for-instant-nav)

## Verification

- `pnpm web:check` / `pnpm web:test` (prior tips)
- UI (alice fixture): `/chat`, `/tasks`, `/account` show sync sidebar
- Merged latest `main` (includes #3625 Instant Nav auth headers) at `0a7a3599` — CI re-running

## Notes

- Draft until human merge
- Pin voided by main merges; re-pin after CI green on tip if Review gates still apply
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8349f1a0-e5fb-4a9e-ac72-84937a3268a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8349f1a0-e5fb-4a9e-ac72-84937a3268a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved initial app loading by deferring realtime service initialization until it is needed.
  - Preserved chat and notification functionality while realtime features load separately.

- **Bug Fixes**
  - Notifications now appear promptly using initial data, with updates synchronized after realtime connectivity is established.
  - Improved notification read-status handling and resilience when realtime services are delayed or unavailable.

- **Documentation**
  - Clarified how deferred realtime loading works and where it is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->