### PR TITLE
fix(chat): compact auto-growing message inputs

### DIFF
--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -983,7 +983,7 @@ function MessageEditComposer({
           onChange(event.target.value);
         }}
         disabled={isSaving}
-        className="min-h-9 max-h-40 resize-none overflow-y-auto field-sizing-content"
+        className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
         autoFocus
         onKeyDown={(event) => {
           if (event.key === "Escape") {

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -983,7 +983,7 @@ function MessageEditComposer({
           onChange(event.target.value);
         }}
         disabled={isSaving}
-        className="min-h-20"
+        className="min-h-9 max-h-40 resize-none overflow-y-auto field-sizing-content"
         autoFocus
         onKeyDown={(event) => {
           if (event.key === "Escape") {

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -565,9 +565,6 @@ function PureMultimodalInput({
             ROOM_COMPOSER_TEXTAREA_CLASSNAME,
           )}
           data-testid="multimodal-input"
-          disableAutoResize={true}
-          maxHeight={160}
-          minHeight={80}
           onClick={(event) => event.stopPropagation()}
           onChange={handleInput}
           placeholder={placeholder}
@@ -595,9 +592,6 @@ function PureMultimodalInput({
         ROOM_COMPOSER_TEXTAREA_CLASSNAME,
       )}
       data-testid="multimodal-input"
-      disableAutoResize={true}
-      maxHeight={160}
-      minHeight={80}
       onChange={handleInput}
       placeholder={placeholder}
       ref={textareaRef}

--- a/apps/web/src/components/chat/room-message-composer.tsx
+++ b/apps/web/src/components/chat/room-message-composer.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export const ROOM_COMPOSER_TEXTAREA_CLASSNAME =
-  "max-h-40 min-h-9 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 py-2 text-base ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-sm";
+  "max-h-40 min-h-10 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 pt-3.5 pb-2.5 text-base leading-6 ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-sm";
 
 export const ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME =
   "size-9 rounded-full sm:size-8";
@@ -101,8 +101,8 @@ export function RoomMessageComposer({
           {aboveEditor}
           {children}
           {belowEditor}
-          <div className="flex items-center justify-between gap-2 px-3 pb-2 md:pb-3">
-            <div className="text-muted-foreground flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          <div className="flex items-center justify-between gap-2 px-4 pt-2 pb-3">
+            <div className="text-muted-foreground flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto">
               {toolbarStart}
             </div>
             {submitControl ?? (

--- a/apps/web/src/components/chat/room-message-composer.tsx
+++ b/apps/web/src/components/chat/room-message-composer.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export const ROOM_COMPOSER_TEXTAREA_CLASSNAME =
-  "max-h-40 min-h-12 md:min-h-20 resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 py-2 md:py-3 text-base ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-sm";
+  "max-h-40 min-h-9 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 py-2 text-base ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-sm";
 
 export const ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME =
   "size-9 rounded-full sm:size-8";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Channel composer and inline message edit used a tall fixed floor (`md:min-h-20` / `min-h-20`). Empty and short messages left a large dead zone. This change starts both at a single-line height and grows with content up to `max-h-40`, with padding tuned so the shell does not feel squeezed.

### Changes
- Shared `ROOM_COMPOSER_TEXTAREA_CLASSNAME`: `min-h-10` + `field-sizing-content`, drop desktop `md:min-h-20`
- Composer chrome: aligned `px-4`, more top/bottom inset around placeholder and toolbar (`pt-3.5` / `pb-2.5` / toolbar `pt-2 pb-3`)
- `MessageEditComposer`: same compact auto-grow with comfortable padding
- Coworker multimodal inputs that reuse the room classname: enable content sizing (remove `disableAutoResize`)

### Verification
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx` (36 passed)
- Browser fixture: empty ~one line, multi-line caps at `max-h-40`; spacing inset aligned left and vertically

![Composer spacing after polish](https://cursor.com/artifacts/c/art-5e80358b-87cc-4d85-a218-df4d166c79d3)
![Empty compact inputs](https://cursor.com/artifacts/c/art-5e8835a7-64ec-4060-b566-83e441df4bed)
![Grown inputs capped at max height](https://cursor.com/artifacts/c/art-a0d8c0a9-53cb-41d0-acaf-92ddcd09dd28)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-879e3f56-60cb-46b2-83ac-10f7e459a3ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-879e3f56-60cb-46b2-83ac-10f7e459a3ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

