### PR TITLE
fix(web): keep subscription onboarding Skip reachable on short desktops

### DIFF
--- a/apps/web/src/app/(app)/components/onboarding-dialog.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog.tsx
@@ -655,7 +655,7 @@ export function OnboardingDialog({
           {tMetadata("description")}
         </DialogDescription>
 
-        <div className="bg-background flex max-h-svh flex-col overflow-hidden rounded-xl shadow-lg md:max-h-[85vh] md:min-h-[768px]">
+        <div className="bg-background flex max-h-svh flex-col overflow-hidden rounded-xl shadow-lg md:max-h-[85vh]">
           {/* Content area */}
           <div className="flex min-h-0 flex-1 flex-col overflow-y-auto md:overflow-hidden md:flex-row">
             {/* Visual panel — stacked on mobile, side panel on desktop */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Subscription onboarding Skip was clipped off-screen on short desktop viewports (e.g. 1024×640).

**Cause.** The dialog shell used `md:min-h-[768px]` with `md:max-h-[85vh]`. When viewport height was under ~768px, the fixed centered shell grew taller than the screen. Radix locks body scroll and the shell uses `overflow-hidden`, so the bottom Skip control sat below the fold with no way to reach it.

**Fix.** Drop `md:min-h-[768px]`. Keep `md:max-h-[85vh]` and the existing flex column so the nav stays visible while plan content scrolls.

**Verification.** Playwright harness mirroring the dialog classes:
- Before at 1024×640: `skipClippedBelow=true`, shell height 768
- After at 1024×640 / 1280×720 / 1366×768 / 1280×900: `skipFullyInViewport=true`
- Tall plan content still keeps Skip in view under `max-h-[85vh]`

Also: `pnpm check`, `pnpm typecheck`, onboarding-dialog unit tests.

![Before: Skip clipped at 1024x640](https://cursor.com/artifacts/c/art-30f029aa-1874-40ce-b026-590a44160068)
![After: Skip visible at 1024x640](https://cursor.com/artifacts/c/art-28ffe685-6084-4cc1-b931-2af52a5b702e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c4859cc-2510-49b8-a174-0cacc65abcb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c4859cc-2510-49b8-a174-0cacc65abcb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding dialog layout on smaller desktop screens by removing an unnecessary minimum height requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->