### PR TITLE
perf(core): lean job list and task nested job queries

### DIFF
--- a/apps/core/src/helpers/job-create-agent.test.ts
+++ b/apps/core/src/helpers/job-create-agent.test.ts
@@ -1,4 +1,4 @@
-import { jobSummaryInclude } from "@sokosumi/database/types/job";
+import { jobListSummaryInclude } from "@sokosumi/database/types/job";
 import type { InputSchemaSchemaType } from "@sokosumi/masumi/schemas";
 import { InputType } from "@sokosumi/masumi/types";
 import { ok } from "neverthrow";
@@ -191,7 +191,7 @@ describe("createAgentJobForUser schedule/max-cents behavior", () => {
             },
           },
         }),
-        include: jobSummaryInclude,
+        include: jobListSummaryInclude,
       }),
     );
   });

--- a/apps/core/src/helpers/job.test.ts
+++ b/apps/core/src/helpers/job.test.ts
@@ -1,5 +1,5 @@
 import { AgentJobStatus, type Prisma } from "@sokosumi/database";
-import { jobSummaryInclude } from "@sokosumi/database/types/job";
+import { jobListSummaryInclude } from "@sokosumi/database/types/job";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UserAuthenticationContext } from "@/middleware/auth";
@@ -57,7 +57,7 @@ describe("getUserJobs", () => {
             },
           ],
         },
-        include: jobSummaryInclude,
+        include: jobListSummaryInclude,
       }),
     );
   });

--- a/apps/core/src/helpers/job.ts
+++ b/apps/core/src/helpers/job.ts
@@ -12,8 +12,8 @@ import {
   jobPurchaseRepository,
 } from "@sokosumi/database/repositories";
 import {
-  type JobWithSummaryRelations,
-  jobSummaryInclude,
+  type JobWithListSummaryRelations,
+  jobListSummaryInclude,
 } from "@sokosumi/database/types/job";
 import { createAgentClient } from "@sokosumi/masumi";
 import type {
@@ -89,7 +89,7 @@ async function createPaidJob(
   agentJobResponse: StartPaidJobResponseSchemaType,
   identifierFromPurchaser: string,
   tx: Prisma.TransactionClient,
-): Promise<JobWithSummaryRelations> {
+): Promise<JobWithListSummaryRelations> {
   const inputSchemaSnapshot = JSON.stringify(input.inputSchema);
   const consumptions = await creditBucketRepository.prepareConsumption(
     input.ownerId,
@@ -156,7 +156,7 @@ async function createPaidJob(
       identifierFromPurchaser,
     },
     include: {
-      ...jobSummaryInclude,
+      ...jobListSummaryInclude,
     },
   });
 }
@@ -179,7 +179,7 @@ async function createFreeJob(
   },
   agentJobResponse: StartFreeJobResponseSchemaType,
   tx: Prisma.TransactionClient,
-): Promise<JobWithSummaryRelations> {
+): Promise<JobWithListSummaryRelations> {
   const inputSchemaSnapshot = JSON.stringify(input.inputSchema);
   return await tx.job.create({
     data: {
@@ -220,7 +220,7 @@ async function createFreeJob(
       identifierFromPurchaser: null,
     },
     include: {
-      ...jobSummaryInclude,
+      ...jobListSummaryInclude,
     },
   });
 }
@@ -249,7 +249,7 @@ export interface JobOwnerContext {
 
 export async function createAgentJobForUser(
   input: CreateAgentJobInput,
-): Promise<JobWithSummaryRelations> {
+): Promise<JobWithListSummaryRelations> {
   const { owner, agentInput, taskContext } = input;
   const maxCents =
     agentInput.maxAcceptedCents ??
@@ -538,7 +538,7 @@ export async function getUserJobs(
     cursor: cursor ? { id: cursor } : undefined,
     orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     include: {
-      ...jobSummaryInclude,
+      ...jobListSummaryInclude,
     },
   });
   const count = await tx.job.count({ where });

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/get.test.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/get.test.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { jobSummaryInclude } from "@sokosumi/database/types/job";
+import { jobListSummaryInclude } from "@sokosumi/database/types/job";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
@@ -97,7 +97,7 @@ describe("GET /tasks/{id}/jobs", () => {
     );
     expect(jobFindManyMock).toHaveBeenCalledWith({
       where: { taskId: "tsk_123" },
-      include: jobSummaryInclude,
+      include: jobListSummaryInclude,
       orderBy: { createdAt: "asc" },
     });
   });

--- a/apps/core/src/routes/v1/tasks/[id]/jobs/get.ts
+++ b/apps/core/src/routes/v1/tasks/[id]/jobs/get.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { jobSummaryInclude } from "@sokosumi/database/types/job";
+import { jobListSummaryInclude } from "@sokosumi/database/types/job";
 
 import { requireTaskReadForRouteVars } from "@/helpers/access-control";
 import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
@@ -40,7 +40,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       const jobsList = await tx.job.findMany({
         where: { taskId: id },
-        include: jobSummaryInclude,
+        include: jobListSummaryInclude,
         orderBy: { createdAt: "asc" },
       });
 

--- a/apps/core/src/types/job.ts
+++ b/apps/core/src/types/job.ts
@@ -1,4 +1,5 @@
 import {
+  type JobWithListSummaryRelations,
   type JobWithSokosumiStatus,
   type JobWithSummaryRelations,
 } from "@sokosumi/database";
@@ -18,12 +19,17 @@ import {
 import { mapWorkspaceSummary } from "@/helpers/workspace";
 
 function mapJobOwnerSummary(
-  job: JobWithSummaryRelations | JobWithSokosumiStatus,
+  job:
+    | JobWithSummaryRelations
+    | JobWithListSummaryRelations
+    | JobWithSokosumiStatus,
 ) {
   return userSummaryFromLoadedRelation(`Job ${job.id}`, job.ownerId, job.owner);
 }
 
-export function flattenJob(job: JobWithSummaryRelations) {
+export function flattenJob(
+  job: JobWithSummaryRelations | JobWithListSummaryRelations,
+) {
   const completedAt = getCompletedAt(job);
   const owner = mapJobOwnerSummary(job);
 

--- a/apps/core/src/types/task.ts
+++ b/apps/core/src/types/task.ts
@@ -1,10 +1,5 @@
 import { type Prisma, workspaceRelationInclude } from "@sokosumi/database";
-import {
-  jobSummaryOwnerOrganizationInclude,
-  jobWithEvents,
-  jobWithPurchase,
-  jobWithTransaction,
-} from "@sokosumi/database/types/job";
+import { jobListSummaryInclude } from "@sokosumi/database/types/job";
 
 import type { AuthenticationContext } from "@/middleware/auth";
 import {
@@ -66,13 +61,7 @@ const taskBaseInclude = {
     },
   },
   jobs: {
-    include: {
-      ...workspaceRelationInclude,
-      ...jobWithEvents,
-      ...jobWithTransaction,
-      ...jobWithPurchase,
-      ...jobSummaryOwnerOrganizationInclude,
-    },
+    include: jobListSummaryInclude,
     orderBy: {
       createdAt: "asc",
     },

--- a/packages/database/src/helpers/job.test.ts
+++ b/packages/database/src/helpers/job.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import { SokosumiJobStatus } from "@sokosumi/utils";
 import { describe, it } from "vitest";
-import { JobType } from "../generated/prisma/client.js";
-import { computeJobStatus, isJobStatusSettled } from "./job.js";
+import { AgentJobStatus, JobType } from "../generated/prisma/client.js";
+import {
+  computeJobStatus,
+  getCompletedAt,
+  getResult,
+  isJobStatusSettled,
+} from "./job.js";
 
 function createPaidJob(overrides: Record<string, unknown> = {}) {
   const now = new Date();
@@ -215,5 +220,46 @@ describe("isJobStatusSettled", () => {
       ),
       true,
     );
+  });
+});
+
+describe("getCompletedAt / getResult with lean events", () => {
+  it("reads completedAt and result without blobs, links, or full input", () => {
+    const completedAt = new Date("2026-03-01T12:00:00.000Z");
+    const job = {
+      events: [
+        {
+          status: AgentJobStatus.COMPLETED,
+          createdAt: completedAt,
+          result: "done",
+          input: { id: "input-1" },
+        },
+        {
+          status: AgentJobStatus.INITIATED,
+          createdAt: new Date("2026-03-01T11:00:00.000Z"),
+          result: null,
+          input: { id: "input-0" },
+        },
+      ],
+    };
+
+    assert.equal(getCompletedAt(job), completedAt);
+    assert.equal(getResult(job), "done");
+  });
+
+  it("returns null when no completed event exists", () => {
+    const job = {
+      events: [
+        {
+          status: AgentJobStatus.INITIATED,
+          createdAt: new Date("2026-03-01T11:00:00.000Z"),
+          result: null,
+          input: { id: "input-0" },
+        },
+      ],
+    };
+
+    assert.equal(getCompletedAt(job), null);
+    assert.equal(getResult(job), null);
   });
 });

--- a/packages/database/src/helpers/job.ts
+++ b/packages/database/src/helpers/job.ts
@@ -9,6 +9,7 @@ import {
 import type { Job } from "../generated/prisma/client.js";
 import {
   type FreeJobWithStatus,
+  type JobEventForListSummary,
   type JobEventForStatusCompute,
   type JobEventWithRelations,
   type JobForStatusCompute,
@@ -291,20 +292,22 @@ function computePaidJobStatus(job: JobForStatusCompute): SokosumiJobStatus {
   }
 }
 
-export function getCompletedEvent(
-  job: JobWithEvents,
-): JobEventWithRelations | undefined {
-  return job.events.find(
-    (event: JobEventWithRelations) => event.status === AgentJobStatus.COMPLETED,
-  );
+export function getCompletedEvent(job: {
+  events: readonly JobEventForListSummary[];
+}): JobEventForListSummary | undefined {
+  return job.events.find((event) => event.status === AgentJobStatus.COMPLETED);
 }
 
-export function getCompletedAt(job: JobWithEvents): Date | null {
+export function getCompletedAt(job: {
+  events: readonly JobEventForListSummary[];
+}): Date | null {
   const completedEvent = getCompletedEvent(job);
   return completedEvent?.createdAt ?? null;
 }
 
-export function getResult(job: JobWithEvents): string | null {
+export function getResult(job: {
+  events: readonly JobEventForListSummary[];
+}): string | null {
   const completedEvent = getCompletedEvent(job);
   return completedEvent?.result ?? null;
 }

--- a/packages/database/src/types/job.ts
+++ b/packages/database/src/types/job.ts
@@ -92,6 +92,40 @@ export type JobWithSummaryRelations = Prisma.JobGetPayload<{
   include: typeof jobSummaryInclude;
 }>;
 
+/** Lean events for list/summary: status + timestamps + result, no blobs/links/full input. */
+export const jobListEventsSelect = {
+  events: {
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      status: true,
+      createdAt: true,
+      result: true,
+      input: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export const jobListSummaryInclude = {
+  ...workspaceRelationInclude,
+  ...jobListEventsSelect,
+  ...jobWithTransaction,
+  ...jobWithPurchase,
+  ...jobSummaryOwnerOrganizationInclude,
+} as const;
+
+export type JobWithListSummaryRelations = Prisma.JobGetPayload<{
+  include: typeof jobListSummaryInclude;
+}>;
+
+export type JobEventForListSummary =
+  JobWithListSummaryRelations["events"][number];
+
 export const jobWithRefundedTransaction = {
   refundedTransaction: true,
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-719/jobs-and-task-detail-load-less-job-history-data

## Summary
- Add `jobListSummaryInclude` so list/summary paths load lean job events (status, createdAt, result, input id only)—no blobs, links, or full input bodies.
- Switch workspace/agent job lists, `GET /tasks/{id}/jobs`, task detail nested jobs, and create-reload summaries to the lean include.
- Keep `jobSummaryInclude` / `jobInclude` fat for true job detail.
- JobSummary OpenAPI contract unchanged.

## Verification
- `pnpm --filter @sokosumi/database check` + `test`
- `pnpm --filter core check` + `pnpm core:test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-719](https://linear.app/masumi/issue/SOK-719/jobs-and-task-detail-load-less-job-history-data)

<div><a href="https://cursor.com/agents/bc-dc824948-1bab-4732-8a5c-859a01bd3cbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc824948-1bab-4732-8a5c-859a01bd3cbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

