### PR TITLE
fix(web): stop caching empty private sidebar chrome

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
@@ -3,12 +3,6 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-/**
- * Regression lock for empty-chrome Instant Nav bug: a secondary getSession()
- * miss inside `"use cache: private"` returned null, which Cache Components
- * can keep for cacheLife.stale while the rest of the authenticated shell
- * stayed mounted.
- */
 describe("PrivateCachedAppSidebar session contract", () => {
   const source = readFileSync(
     join(

--- a/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression lock for empty-chrome Instant Nav bug: a secondary getSession()
+ * miss inside `"use cache: private"` returned null, which Cache Components
+ * can keep for cacheLife.stale while the rest of the authenticated shell
+ * stayed mounted.
+ */
+describe("PrivateCachedAppSidebar session contract", () => {
+  const source = readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../private-cached-app-sidebar.tsx",
+    ),
+    "utf8",
+  );
+
+  it("does not re-fetch session and return null empty chrome", () => {
+    expect(source).not.toMatch(/\bgetSession\s*\(/);
+    expect(source).not.toMatch(/\breturn\s+null\b/);
+  });
+
+  it("takes sessionUser from the authenticated frame instead", () => {
+    expect(source).toMatch(/sessionUser:\s*SessionUser/);
+  });
+});

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -51,7 +51,7 @@ export default async function AuthenticatedAppFrame({
               <BreadcrumbOverrideProvider>
                 <Suspense fallback={<AppSidebarFallback />}>
                   <PrivateCachedAppSidebar
-                    userId={session.user.id}
+                    sessionUser={session.user}
                     activeOrganizationId={
                       session.session.activeOrganizationId ?? null
                     }

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -1,3 +1,4 @@
+import type { SessionUser } from "@sokosumi/utils";
 import { cacheLife, cacheTag } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import {
@@ -6,7 +7,6 @@ import {
 } from "@/app/components/account-notice-state";
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
 import { getEnvPublicConfig } from "@/config/env.public";
-import { getSession } from "@/lib/auth/auth.server";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 import { chatRoomService, userService } from "@/lib/services";
@@ -24,7 +24,7 @@ import { AccountNoticeHydrator } from "./shell-hydrators.client";
 import Sidebar, { resolveCreditUsage } from "./sidebar";
 
 interface PrivateCachedAppSidebarProps {
-  userId: string;
+  sessionUser: SessionUser;
   activeOrganizationId: string | null;
   adminMenuEnabled: boolean;
 }
@@ -36,25 +36,20 @@ interface PrivateCachedAppSidebarProps {
  * async SC children under the cached tree.
  */
 export default async function PrivateCachedAppSidebar({
-  userId,
+  sessionUser,
   activeOrganizationId,
   adminMenuEnabled,
 }: PrivateCachedAppSidebarProps) {
   "use cache: private";
   cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
-  cacheTag(privateSidebarUserTag(userId));
+  cacheTag(privateSidebarUserTag(sessionUser.id));
   if (activeOrganizationId) {
     cacheTag(privateSidebarOrgTag(activeOrganizationId));
   }
 
-  const session = await getSession();
-  if (!session || session.user.id !== userId) {
-    return null;
-  }
-
   const tCreditPromise = getTranslations("App.Header.Credit");
   const tPlanPromise = getTranslations("App.Header.Plan");
-  const hermesMenuEnabled = isHermesBetaAccessEmail(session.user.email);
+  const hermesMenuEnabled = isHermesBetaAccessEmail(sessionUser.email);
   const lowCreditsThreshold =
     getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
 
@@ -127,8 +122,8 @@ export default async function PrivateCachedAppSidebar({
   const accountNotice = resolveAccountNotice({
     credits: creditsData?.total ?? null,
     currentPlan: creditsData === null ? null : currentPlan,
-    email: session.user.email,
-    emailVerified: session.user.emailVerified,
+    email: sessionUser.email,
+    emailVerified: sessionUser.emailVerified,
     threshold: lowCreditsThreshold,
   });
 
@@ -146,13 +141,13 @@ export default async function PrivateCachedAppSidebar({
         creditsData={creditsData}
         creditUsage={resolveCreditUsage(creditsData)}
         currentTimestampMs={currentTimestampMs}
-        currentUserId={session.user.id}
+        currentUserId={sessionUser.id}
         hermesMenuEnabled={hermesMenuEnabled}
         lowCreditsThreshold={lowCreditsThreshold}
         members={members}
         planLabel={planLabel}
         planName={planName}
-        sessionUser={session.user}
+        sessionUser={sessionUser}
         showDeveloperVendors={showDeveloperVendors}
         subscriptionPeriodEndMs={subscriptionPeriodEndMs}
       />

--- a/apps/web/src/lib/auth/auth.server.ts
+++ b/apps/web/src/lib/auth/auth.server.ts
@@ -159,8 +159,8 @@ function getBetterAuthCookiePrefixFromEnv(): string {
   });
 }
 
-// Headers-only: Instant Nav sidebar may call getSession under
-// "use cache: private", where connection() is illegal (next-request-in-use-cache).
+// Headers-only: connection() is illegal under "use cache: private"
+// (next-request-in-use-cache). Keep shared auth reads safe for that boundary.
 async function getRequestHeaders(): Promise<Headers> {
   return headers();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Authenticated pages sometimes rendered with header and main content but **no sidebar**.

Root cause: `PrivateCachedAppSidebar` (Instant Nav `"use cache: private"`) called `getSession()` again and `return null` on miss/mismatch. Cache Components could keep that empty result for `cacheLife.stale` (300s) while the rest of the shell stayed mounted.

Runtime confirmation: forcing that null path left `data-app-shell` + `data-app-content` with zero `[data-slot=sidebar]` nodes.

## Fix

Pass `sessionUser` from `AuthenticatedAppFrame` (already authenticated via `getSessionOrRedirect`) into the private-cache sidebar. Remove the secondary `getSession` + `return null` gate. Drop the stale auth.server note that claimed the sidebar still called `getSession` under private cache.

## Verification

- `pnpm --filter web test` contract + private-sidebar-cache tests (exit 0)
- `pnpm check` + `pnpm typecheck` (pre-commit)
- Puppeteer: cold load and hard nav across `/agents`, `/tasks`, `/history`, `/chat` keep a visible sidebar

![Sidebar present after fix](https://cursor.com/artifacts/c/art-5fc0bfb0-2bdf-491d-a22f-5afb2d1a05ca)
![Forced null repro (before)](https://cursor.com/artifacts/c/art-b794e3aa-8627-44c1-b423-d219bb84085b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8897009c-b28b-4091-9341-8b65ff3efb66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8897009c-b28b-4091-9341-8b65ff3efb66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

