### PR TITLE
perf(database): add list and catalog performance indexes

### DIFF
--- a/packages/database/prisma/migrations/20260804220000_add_list_catalog_performance_indexes/migration.sql
+++ b/packages/database/prisma/migrations/20260804220000_add_list_catalog_performance_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "Agent_isShown_status_idx" ON "Agent"("isShown", "status");
+
+-- CreateIndex
+CREATE INDEX "Job_workspaceId_createdAt_idx" ON "Job"("workspaceId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "taskEvent_taskId_createdAt_idx" ON "taskEvent"("taskId", "createdAt");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -670,6 +670,8 @@ model Agent {
 
   // Summary
   summary String?
+
+  @@index([isShown, status])
 }
 
 model AgentMetadataOverride {
@@ -929,6 +931,7 @@ model Job {
   @@index([projectId])
   @@index([agentId])
   @@index([agentId, createdAt])
+  @@index([workspaceId, createdAt(sort: Desc)])
 }
 
 model JobPurchase {
@@ -1587,6 +1590,7 @@ model TaskEvent {
 
   @@index([transactionId])
   @@index([orchestratorId])
+  @@index([taskId, createdAt])
   @@map("taskEvent")
 }
 

--- a/packages/database/src/types/__tests__/list-catalog-indexes.test.ts
+++ b/packages/database/src/types/__tests__/list-catalog-indexes.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const schemaPath = join(packageRoot, "prisma/schema.prisma");
+const migrationsDir = join(packageRoot, "prisma/migrations");
+
+function readSchema(): string {
+  return readFileSync(schemaPath, "utf8");
+}
+
+function modelBlock(schema: string, modelName: string): string {
+  const match = schema.match(
+    new RegExp(`model ${modelName}\\s*\\{([\\s\\S]*?)\\n\\}`),
+  );
+  expect(match, `model ${modelName} in schema.prisma`).toBeTruthy();
+  return match?.[1] ?? "";
+}
+
+function migrationSqlFiles(): string[] {
+  return readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(migrationsDir, entry.name, "migration.sql"))
+    .map((path) => {
+      try {
+        return readFileSync(path, "utf8");
+      } catch {
+        return "";
+      }
+    });
+}
+
+describe("list and catalog performance indexes", () => {
+  it("schema.prisma declares TaskEvent, Job, and Agent list/catalog indexes", () => {
+    const schema = readSchema();
+
+    expect(modelBlock(schema, "TaskEvent")).toContain(
+      "@@index([taskId, createdAt])",
+    );
+    expect(modelBlock(schema, "Job")).toContain(
+      "@@index([workspaceId, createdAt(sort: Desc)])",
+    );
+    expect(modelBlock(schema, "Agent")).toContain("@@index([isShown, status])");
+  });
+
+  it("migrations create matching Postgres indexes", () => {
+    const sql = migrationSqlFiles().join("\n");
+
+    expect(sql).toMatch(/"taskEvent_taskId_createdAt_idx"/);
+    expect(sql).toMatch(/"Job_workspaceId_createdAt_idx"/);
+    expect(sql).toMatch(/"Agent_isShown_status_idx"/);
+    expect(sql).toMatch(
+      /CREATE INDEX "Job_workspaceId_createdAt_idx" ON "Job"\("workspaceId", "createdAt" DESC\)/,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [SOK-720](https://linear.app/masumi/issue/SOK-720/database-indexes-for-jobs-task-events-and-agent-catalog).

Adds the minimum Postgres indexes for hot list/catalog access patterns:

- `taskEvent(taskId, createdAt)` — task event history by task
- `Job(workspaceId, createdAt DESC)` — workspace job lists (keeps existing `Job_workspaceId_idx`)
- `Agent(isShown, status)` — catalog availability filter

Indexes only; no API or query changes. Migration `20260804220000_add_list_catalog_performance_indexes` is additive `CREATE INDEX`. Guard test locks schema + SQL.

## Verification

- `pnpm --filter @sokosumi/database check`
- `pnpm --filter @sokosumi/database test`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-720](https://linear.app/masumi/issue/SOK-720/database-indexes-for-jobs-task-events-and-agent-catalog-filters)

<div><a href="https://cursor.com/agents/bc-5474bc48-68bb-4c2a-897d-62b262b73110?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5474bc48-68bb-4c2a-897d-62b262b73110&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

