### PR TITLE
perf(core): drop interactive transaction from agent catalog list

### DIFF
--- a/apps/core/src/routes/v1/agents/get.test.ts
+++ b/apps/core/src/routes/v1/agents/get.test.ts
@@ -50,6 +50,10 @@ vi.mock("@/helpers/agent", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
+    agent: {
+      findMany: agentFindManyMock,
+      count: agentCountMock,
+    },
     $transaction: prismaTransactionMock,
   },
 }));
@@ -143,14 +147,16 @@ describe("GET /agents", () => {
       },
     ]);
     agentCountMock.mockResolvedValue(1);
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      return await callback({
-        agent: {
-          findMany: agentFindManyMock,
-          count: agentCountMock,
-        },
-      });
-    });
+  });
+
+  it("lists agents without opening an interactive transaction", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/");
+
+    expect(response.status).toBe(200);
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
+    expect(agentFindManyMock).toHaveBeenCalled();
+    expect(agentCountMock).toHaveBeenCalled();
   });
 
   it("filters by a single category slug and returns parsed category styles", async () => {

--- a/apps/core/src/routes/v1/agents/get.ts
+++ b/apps/core/src/routes/v1/agents/get.ts
@@ -128,18 +128,21 @@ export default function mount(app: OpenAPIHono) {
     const { cursor, take, skip } = parseCursorPagination(queryParams);
     const { category: categorySlugs } = queryParams;
 
-    const result = await prisma.$transaction(async (tx) => {
-      const creditCosts = await getCreditCostsOrThrow(tx);
-      const baseWhere = buildAvailableAgentWhereClause(creditCosts);
-      const categoryWhere = buildCategoryWhereClause(categorySlugs);
-      const where: Prisma.AgentWhereInput = categoryWhere
-        ? {
-            AND: [baseWhere, categoryWhere],
-          }
-        : baseWhere;
+    // Avoid interactive transaction on this read-only path — catalog list
+    // does not need a shared snapshot; interactive txs hold a pool connection
+    // and forbid Promise.all inside (#2559 / P2028).
+    const creditCosts = await getCreditCostsOrThrow(prisma);
+    const baseWhere = buildAvailableAgentWhereClause(creditCosts);
+    const categoryWhere = buildCategoryWhereClause(categorySlugs);
+    const where: Prisma.AgentWhereInput = categoryWhere
+      ? {
+          AND: [baseWhere, categoryWhere],
+        }
+      : baseWhere;
 
-      const takePlusOne = take + 1;
-      const agents = await tx.agent.findMany({
+    const takePlusOne = take + 1;
+    const [agents, count] = await Promise.all([
+      prisma.agent.findMany({
         where,
         take: takePlusOne,
         skip,
@@ -151,30 +154,24 @@ export default function mount(app: OpenAPIHono) {
           ...agentCategoriesInclude,
           ...agentMetadataOverrideScalarsInclude,
         },
-      });
-      const count = await tx.agent.count({ where });
+      }),
+      prisma.agent.count({ where }),
+    ]);
 
-      const agentsWithMetrics = await buildAgentSummaries(
-        agents.slice(0, take),
-        creditCosts,
-        tx,
-      );
-
-      return {
-        agents: agentsWithMetrics,
-        count,
-        hasMore: agents.length === takePlusOne,
-      };
-    });
+    const agentsWithMetrics = await buildAgentSummaries(
+      agents.slice(0, take),
+      creditCosts,
+      prisma,
+    );
 
     const paginationMeta = createPaginationMeta(
-      result.agents,
-      result.count,
+      agentsWithMetrics,
+      count,
       take,
-      result.hasMore,
+      agents.length === takePlusOne,
       cursor,
     );
 
-    return ok(c, agentsSummarySchema.parse(result.agents), paginationMeta);
+    return ok(c, agentsSummarySchema.parse(agentsWithMetrics), paginationMeta);
   });
 }

--- a/apps/core/src/routes/v1/agents/index.auth.test.ts
+++ b/apps/core/src/routes/v1/agents/index.auth.test.ts
@@ -75,6 +75,10 @@ vi.mock("@/helpers/agent", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
+    agent: {
+      findMany: agentFindManyMock,
+      count: agentCountMock,
+    },
     $transaction: prismaTransactionMock,
   },
 }));
@@ -98,14 +102,6 @@ describe("agents routes auth gate", () => {
     calculateAgentRatingsMock.mockResolvedValue(new Map());
     agentFindManyMock.mockResolvedValue([]);
     agentCountMock.mockResolvedValue(0);
-    prismaTransactionMock.mockImplementation(async (callback) => {
-      return await callback({
-        agent: {
-          findMany: agentFindManyMock,
-          count: agentCountMock,
-        },
-      });
-    });
   });
 
   it("allows anonymous GET /agents list", async () => {
@@ -113,6 +109,7 @@ describe("agents routes auth gate", () => {
 
     expect(response.status).toBe(200);
     expect(agentFindManyMock).toHaveBeenCalled();
+    expect(prismaTransactionMock).not.toHaveBeenCalled();
   });
 
   it("returns 422 for invalid category on composed public list route", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-721](https://linear.app/masumi/issue/SOK-721/agent-catalog-list-does-not-hold-a-database-transaction).

Removes the interactive Prisma transaction from public `GET /v1/agents` so catalog list reads no longer hold a pool connection for the whole handler (same P2028 failure mode Core already fixed for chat/org GETs).

- Credit costs load on the default client, then `findMany` + `count` run in parallel
- `buildAgentSummaries` receives default `prisma` (also fixes illegal `Promise.all` on an interactive tx client)
- Response shape, filters, and pagination unchanged; web catalog cache untouched
- Tests assert the interactive `$transaction` form is not used

Out of scope: popularity-sort / metrics redesign (SOK-723).

**Verification:** `pnpm --filter core check` + `pnpm core:test` (exit 0). CI green. headSha `dd471bd52bdcb342922481f374d4c7d51eb85451`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-721](https://linear.app/masumi/issue/SOK-721/agent-catalog-list-does-not-hold-a-database-transaction)

<div><a href="https://cursor.com/agents/bc-300086d0-c26c-4b93-b3ce-ca17181c8296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-300086d0-c26c-4b93-b3ce-ca17181c8296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved agent list retrieval by running queries concurrently.
  * Removed unnecessary transaction usage, helping listing requests complete more efficiently.

* **Bug Fixes**
  * Improved reliability of agent-list responses and pagination calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->