### PR TITLE
feat(web): add mobile bottom navigation for chat routes

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1408,6 +1408,12 @@
       },
       "title": "Chat",
       "description": "Chatte mit deinen KI-Coworkern",
+      "MobileBottomNav": {
+        "ariaLabel": "Hauptnavigation",
+        "home": "Start",
+        "history": "Verlauf",
+        "search": "Suchen"
+      },
       "Chat": {
         "newChat": "Neuer Chat",
         "conversationSwitcher": "Unterhaltungen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1408,6 +1408,12 @@
       },
       "title": "Chat",
       "description": "Chat with your AI coworkers",
+      "MobileBottomNav": {
+        "ariaLabel": "Main navigation",
+        "home": "Home",
+        "history": "History",
+        "search": "Search"
+      },
       "Chat": {
         "newChat": "New Chat",
         "conversationSwitcher": "Conversations",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1408,6 +1408,12 @@
       },
       "title": "Chat",
       "description": "Chatea con tus AI Coworkers",
+      "MobileBottomNav": {
+        "ariaLabel": "Navegación principal",
+        "home": "Inicio",
+        "history": "Historial",
+        "search": "Buscar"
+      },
       "Chat": {
         "newChat": "Nuevo chat",
         "conversationSwitcher": "Conversaciones",

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-bottom-nav.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-bottom-nav.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { History, Home, Search } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useHistorySearch } from "@/app/components/history-search-dialog-provider";
+import { cn } from "@/lib/utils";
+
+/**
+ * Mobile bottom navigation for chat routes.
+ * Fixed full-width tab bar with Home, History, and Search.
+ * Visible only below md breakpoint.
+ */
+export function ChatMobileBottomNav() {
+  const t = useTranslations("App.Chat.MobileBottomNav");
+  const pathname = usePathname();
+  const { openHistorySearch } = useHistorySearch();
+
+  const isChatActive = pathname === "/chat" || pathname.startsWith("/chat/");
+  const isHistoryActive =
+    pathname === "/history" || pathname.startsWith("/history/");
+
+  const tabs = [
+    {
+      key: "home",
+      label: t("home"),
+      icon: Home,
+      href: "/chat",
+      isActive: isChatActive,
+    },
+    {
+      key: "history",
+      label: t("history"),
+      icon: History,
+      href: "/history",
+      isActive: isHistoryActive,
+    },
+    {
+      key: "search",
+      label: t("search"),
+      icon: Search,
+      onClick: () => openHistorySearch(),
+      isActive: false,
+    },
+  ];
+
+  return (
+    <nav
+      className="bg-background fixed inset-x-0 bottom-0 z-50 flex h-16 w-full items-center border-t md:hidden"
+      aria-label={t("ariaLabel")}
+    >
+      <div className="flex w-full items-center justify-around">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          const content = (
+            <>
+              <Icon
+                className={cn(
+                  "size-5",
+                  tab.isActive ? "text-primary" : "text-muted-foreground",
+                )}
+                aria-hidden
+              />
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  tab.isActive ? "text-primary" : "text-muted-foreground",
+                )}
+              >
+                {tab.label}
+              </span>
+            </>
+          );
+
+          if (tab.href) {
+            return (
+              <Link
+                key={tab.key}
+                href={tab.href}
+                className="hover:bg-muted flex flex-1 flex-col items-center justify-center gap-1 py-2 transition-colors"
+                aria-current={tab.isActive ? "page" : undefined}
+              >
+                {content}
+              </Link>
+            );
+          }
+
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={tab.onClick}
+              className="hover:bg-muted flex flex-1 flex-col items-center justify-center gap-1 py-2 transition-colors"
+            >
+              {content}
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/app/(app)/chat/layout.tsx
+++ b/apps/web/src/app/(app)/chat/layout.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import DefaultErrorBoundary from "@/components/default-error-boundary";
 
 import { ChatErrorFallback } from "./components/chat-error-fallback";
+import { ChatMobileBottomNav } from "./components/chat-mobile-bottom-nav";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("App.Channels.Metadata");
@@ -28,7 +29,11 @@ export default function ChatLayout({
 }) {
   return (
     <DefaultErrorBoundary fallback={<ChatErrorFallback />}>
-      {children}
+      <div className="flex min-h-0 flex-1 flex-col pb-0 md:pb-0">
+        {children}
+        <div className="h-16 shrink-0 md:hidden" aria-hidden />
+        <ChatMobileBottomNav />
+      </div>
     </DefaultErrorBoundary>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Implements mobile bottom navigation for chat routes as specified in SOK-725.

### What's included

- **ChatMobileBottomNav component**: Full-width tab bar with Home, History, and Search tabs
- **Mobile-only visibility**: Only shows below `md` breakpoint (768px)
- **Active route detection**: Highlights the current tab based on pathname
- **Chat layout integration**: Added to chat layout with proper bottom padding to prevent content overlap
- **Translations**: Added labels in English, German, and Spanish
- **Reuses existing patterns**: Uses existing history search dialog for Search tab

### Implementation details

**Component structure:**
- Home tab → navigates to `/chat`
- History tab → navigates to `/history`
- Search tab → opens existing history search dialog

**Styling:**
- Fixed position at bottom, full width
- Border top for visual separation
- 16px (h-16) height
- Active state with primary color
- Hover states for better UX

**Content spacing:**
- Added 16px spacer div to prevent chat content from being covered by the fixed bottom nav
- Spacer only visible on mobile (`md:hidden`)

### Testing

✅ TypeScript compilation passes
✅ Biome checks pass (linting + formatting)
✅ Translation key parity verified across all locales
✅ Component properly integrated into chat layout

### Out of scope (per SOK-725)

- Mobile chat/room list
- FAB or compose shortcuts
- Desktop navigation changes
- Bottom nav on non-chat routes

## References

- Linear issue: [SOK-725](https://linear.app/masumi/issue/SOK-725/mobile-bottom-nav-on-chat-shell-only)
- Related: [SOK-587](https://linear.app/masumi/issue/SOK-587) (history search dialog)
- Related: [SOK-537](https://linear.app/masumi/issue/SOK-537) (History destination)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-725](https://linear.app/masumi/issue/SOK-725/mobile-bottom-nav-on-chat-shell-only)

<div><a href="https://cursor.com/agents/bc-cf45297e-15a1-4031-a552-de26ed622338?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf45297e-15a1-4031-a552-de26ed622338&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

