### PR TITLE
feat(web): full-screen mobile chat home list

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4714,7 +4714,8 @@
         "home": "Start",
         "history": "Verlauf",
         "search": "Suche",
-        "ariaLabel": "Chat"
+        "ariaLabel": "Chat",
+        "backToHome": "Zurück zur Chat-Startseite"
       },
       "Actions": {
         "more": "Nachrichtenaktionen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4714,7 +4714,8 @@
         "home": "Home",
         "history": "History",
         "search": "Search",
-        "ariaLabel": "Chat"
+        "ariaLabel": "Chat",
+        "backToHome": "Back to chat home"
       },
       "Actions": {
         "more": "Message actions",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4714,7 +4714,8 @@
         "home": "Inicio",
         "history": "Historial",
         "search": "Buscar",
-        "ariaLabel": "Chat"
+        "ariaLabel": "Chat",
+        "backToHome": "Volver al inicio del chat"
       },
       "Actions": {
         "more": "Acciones del mensaje",

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
@@ -6,6 +6,7 @@ let mockPathname = "/chat";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("next-intl", () => ({

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-shell.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-shell.test.tsx
@@ -2,11 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let mockPathname = "/chat";
-let mockSearch = "";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
-  useSearchParams: () => new URLSearchParams(mockSearch),
 }));
 
 vi.mock("next-intl", () => ({
@@ -41,7 +39,6 @@ import { CHAT_MOBILE_TAB_BAR_CLEARANCE } from "../chat-mobile-tab-registry";
 describe("ChatMobileShell", () => {
   beforeEach(() => {
     mockPathname = "/chat";
-    mockSearch = "";
   });
 
   it("renders bottom nav and tab-bar clearance on chat home", () => {
@@ -70,9 +67,8 @@ describe("ChatMobileShell", () => {
     expect(wrapper?.className).not.toContain(CHAT_MOBILE_TAB_BAR_CLEARANCE);
   });
 
-  it("keeps bottom nav on draft create/dm surfaces", () => {
+  it("keeps bottom nav on /chat (drafts share this path)", () => {
     mockPathname = "/chat";
-    mockSearch = "create=channel";
 
     render(
       <ChatMobileShell>

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-shell.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-shell.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/chat";
+let mockSearch = "";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/app/components/history-search-dialog-provider", () => ({
+  useHistorySearch: () => ({
+    openHistorySearch: vi.fn(),
+    searchShortcutLabel: "Ctrl+K",
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { ChatMobileShell } from "../chat-mobile-shell";
+import { CHAT_MOBILE_TAB_BAR_CLEARANCE } from "../chat-mobile-tab-registry";
+
+describe("ChatMobileShell", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+    mockSearch = "";
+  });
+
+  it("renders bottom nav and tab-bar clearance on chat home", () => {
+    const { container } = render(
+      <ChatMobileShell>
+        <div>child</div>
+      </ChatMobileShell>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
+    const wrapper = container.firstElementChild?.firstElementChild;
+    expect(wrapper?.className).toContain(CHAT_MOBILE_TAB_BAR_CLEARANCE);
+  });
+
+  it("hides bottom nav and clearance on room surface", () => {
+    mockPathname = "/chat/rooms/room-1";
+
+    const { container } = render(
+      <ChatMobileShell>
+        <div>child</div>
+      </ChatMobileShell>,
+    );
+
+    expect(screen.queryByRole("navigation", { name: "ariaLabel" })).toBeNull();
+    const wrapper = container.firstElementChild?.firstElementChild;
+    expect(wrapper?.className).not.toContain(CHAT_MOBILE_TAB_BAR_CLEARANCE);
+  });
+
+  it("keeps bottom nav on draft create/dm surfaces", () => {
+    mockPathname = "/chat";
+    mockSearch = "create=channel";
+
+    render(
+      <ChatMobileShell>
+        <div>child</div>
+      </ChatMobileShell>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-shell.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-shell.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { classifyChatChromeSurface } from "@/app/chat/utils/chat-route-base";
 import { cn } from "@/lib/utils";
 
 import { ChatMobileBottomNav } from "./chat-mobile-bottom-nav";
@@ -10,18 +13,23 @@ export function ChatMobileShell({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const surface = classifyChatChromeSurface(pathname, searchParams);
+  const showBottomNav = surface !== "room";
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div
         className={cn(
           "flex min-h-0 flex-1 flex-col",
-          CHAT_MOBILE_TAB_BAR_CLEARANCE,
-          "md:pb-0",
+          showBottomNav && CHAT_MOBILE_TAB_BAR_CLEARANCE,
+          showBottomNav && "md:pb-0",
         )}
       >
         {children}
       </div>
-      <ChatMobileBottomNav />
+      {showBottomNav ? <ChatMobileBottomNav /> : null}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-shell.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-shell.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 
-import { classifyChatChromeSurface } from "@/app/chat/utils/chat-route-base";
+import { isChatRoomPathname } from "@/app/chat/utils/chat-route-base";
 import { cn } from "@/lib/utils";
 
 import { ChatMobileBottomNav } from "./chat-mobile-bottom-nav";
@@ -13,10 +13,8 @@ export function ChatMobileShell({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const surface = classifyChatChromeSurface(pathname, searchParams);
-  const showBottomNav = surface !== "room";
+  // Room path alone gates the tab bar; drafts share `/chat` and keep the nav.
+  const showBottomNav = !isChatRoomPathname(usePathname());
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
@@ -1,5 +1,7 @@
 import { History, Home, type LucideIcon, Search } from "lucide-react";
 
+import { isChatRoomPathname } from "@/app/chat/utils/chat-route-base";
+
 /** Tailwind padding-bottom for bar height. Applied at shell content wrapper. */
 export const CHAT_MOBILE_TAB_BAR_CLEARANCE = "pb-16" as const;
 
@@ -13,6 +15,22 @@ export const CHAT_MOBILE_TAB_BAR_BOTTOM_OFFSET =
  */
 export const CHAT_MOBILE_HEIGHT_SHELL_CLASS =
   "h-[calc(100svh-64px)] max-md:h-[calc(100svh-64px-4rem)]" as const;
+
+/**
+ * Full shell height when the mobile tab bar is hidden (room surface).
+ * Matches desktop/`md` height — no 4rem tab-bar subtraction.
+ */
+export const CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS =
+  "h-[calc(100svh-64px)]" as const;
+
+/** Height class for chat views: room path drops tab-bar offset. */
+export function chatMobileHeightShellClass(
+  pathname: string | null | undefined,
+): string {
+  return isChatRoomPathname(pathname)
+    ? CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS
+    : CHAT_MOBILE_HEIGHT_SHELL_CLASS;
+}
 
 export type ChatMobileTabId = "home" | "history" | "search";
 export type ChatMobileTabLabelKey = "home" | "history" | "search";

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2,7 +2,7 @@
 
 import { ChannelProvider } from "ably/react";
 import { Hash, Loader2, MessageCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
   useCallback,
@@ -22,7 +22,7 @@ import {
   sendRoomMessageAction,
   toggleMessageReactionAction,
 } from "@/app/chat/actions";
-import { CHAT_MOBILE_HEIGHT_SHELL_CLASS } from "@/app/chat/components/chat-mobile-tab-registry";
+import { chatMobileHeightShellClass } from "@/app/chat/components/chat-mobile-tab-registry";
 import DaySeparator from "@/app/chat/components/day-separator";
 import { RoomSearchPanel } from "@/app/chat/components/room-search-panel";
 import { UnreadThreadsPanel } from "@/app/chat/components/unread-threads-panel";
@@ -243,6 +243,7 @@ export function RoomsClient({
   const t = useTranslations("App.Channels");
   const tBreadcrumb = useTranslations("Components.Breadcrumb");
   const router = useRouter();
+  const pathname = usePathname();
   const canOpenHumanDirect = Boolean(activeOrganization);
   const [openingDirectKey, setOpeningDirectKey] = useState<string | null>(null);
   const [pendingQuote, setPendingQuote] = useState<PendingRoomQuote | null>(
@@ -1316,7 +1317,7 @@ export function RoomsClient({
     <div
       className={cn(
         "-m-4 flex min-h-0 flex-col overflow-hidden bg-background",
-        CHAT_MOBILE_HEIGHT_SHELL_CLASS,
+        chatMobileHeightShellClass(pathname),
       )}
     >
       {currentUserId ? (

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -4,9 +4,11 @@ import { Suspense } from "react";
 import { ChatLandingNotice } from "@/app/chat/components/chat-landing-notice";
 import { ChatWelcomeClient } from "@/app/chat/components/chat-welcome-client";
 import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
+import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
 import DefaultLoading from "@/components/default-loading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/auth.server";
+import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { chatRoomService, userService } from "@/lib/services";
 import { coworkerService } from "@/lib/services/coworker.service";
 
@@ -126,17 +128,55 @@ async function ChatPageContent({ searchParams }: ChatPageProps) {
     );
   }
 
-  const coworkers = (await coworkerService.listCoworkers("chat")).map(
-    mapDbCoworkerToChatCoworker,
+  const activeOrganizationId = activeOrganization?.id ?? null;
+  const chatRoomsPromise = chatRoomService.listRooms().catch(() => []);
+  const archivedChatRoomsPromise = activeOrganizationId
+    ? chatRoomService.listArchivedRooms().catch(() => [])
+    : Promise.resolve(
+        [] as Awaited<ReturnType<typeof chatRoomService.listArchivedRooms>>,
+      );
+  const membersPromise = userService
+    .getMyMembersWithOrganizations()
+    .catch(() => []);
+  const coworkersPromise = coworkerService
+    .listCoworkers("chat")
+    .then((rows) => rows.map(mapDbCoworkerToChatCoworker));
+
+  const [coworkers, chatRooms, archivedChatRooms, members] = await Promise.all([
+    coworkersPromise,
+    chatRoomsPromise,
+    archivedChatRoomsPromise,
+    membersPromise,
+  ]);
+
+  const canDeleteArchivedRooms = Boolean(
+    activeOrganizationId &&
+      members.some(
+        (membership) =>
+          membership.organizationId === activeOrganizationId &&
+          isOrganizationOwnerOrAdmin(membership.role),
+      ),
   );
 
   return (
     <>
       {landingNotice}
-      <ChatWelcomeClient
-        coworkers={coworkers}
-        userName={session?.user.name ?? undefined}
-      />
+      <div className="hidden md:contents">
+        <ChatWelcomeClient
+          coworkers={coworkers}
+          userName={session?.user.name ?? undefined}
+        />
+      </div>
+      <div className="md:hidden min-h-0 flex-1 overflow-y-auto">
+        <OrganizationChatList
+          rooms={chatRooms}
+          archivedRooms={archivedChatRooms}
+          currentUserId={session?.user.id ?? ""}
+          organizationId={activeOrganizationId}
+          canDeleteArchivedRooms={canDeleteArchivedRooms}
+          dismissSheetOnNavigate={false}
+        />
+      </div>
     </>
   );
 }

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   CHAT_API_PATH,
   CHAT_APP_ROUTE_PREFIX,
+  classifyChatChromeSurface,
+  isChatRoomPathname,
   isChatShellPathname,
 } from "../chat-route-base";
 
@@ -18,5 +20,51 @@ describe("chat-route-base", () => {
     expect(isChatShellPathname("/new-chat")).toBe(false);
     expect(isChatShellPathname("/new-chat/foo")).toBe(false);
     expect(isChatShellPathname(null)).toBe(false);
+  });
+
+  it("isChatRoomPathname matches /chat/rooms/:roomId", () => {
+    expect(isChatRoomPathname("/chat/rooms/r1")).toBe(true);
+    expect(isChatRoomPathname("/chat/rooms/r1/extra")).toBe(true);
+    expect(isChatRoomPathname("/chat/rooms/")).toBe(false);
+    expect(isChatRoomPathname("/chat")).toBe(false);
+    expect(isChatRoomPathname("/chat/rooms")).toBe(false);
+    expect(isChatRoomPathname(null)).toBe(false);
+  });
+
+  describe("classifyChatChromeSurface", () => {
+    it("returns room for room pathnames", () => {
+      expect(classifyChatChromeSurface("/chat/rooms/abc")).toBe("room");
+      expect(classifyChatChromeSurface("/chat/rooms/abc/thread")).toBe("room");
+    });
+
+    it("returns home for bare /chat", () => {
+      expect(classifyChatChromeSurface("/chat")).toBe("home");
+      expect(classifyChatChromeSurface("/chat", new URLSearchParams())).toBe(
+        "home",
+      );
+    });
+
+    it("returns other-chat for draft query on /chat", () => {
+      expect(
+        classifyChatChromeSurface(
+          "/chat",
+          new URLSearchParams("create=channel"),
+        ),
+      ).toBe("other-chat");
+      expect(
+        classifyChatChromeSurface("/chat", new URLSearchParams("dm=new")),
+      ).toBe("other-chat");
+      expect(
+        classifyChatChromeSurface("/chat", {
+          get: (k) => (k === "dm" ? "new" : null),
+        }),
+      ).toBe("other-chat");
+    });
+
+    it("returns other-chat for nested non-room chat and non-chat", () => {
+      expect(classifyChatChromeSurface("/chat/something")).toBe("other-chat");
+      expect(classifyChatChromeSurface("/tasks")).toBe("other-chat");
+      expect(classifyChatChromeSurface(null)).toBe("other-chat");
+    });
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
@@ -10,6 +10,17 @@ export const CHAT_APP_ROUTE_PREFIX = "/chat" as const;
  */
 export const CHAT_API_PATH = "/api/chat" as const;
 
+/** Mobile chrome surface for pathname-driven shell/header behavior. */
+export type ChatChromeSurface = "home" | "room" | "other-chat";
+
+const CHAT_ROOM_PATHNAME_RE = /^\/chat\/rooms\/[^/]+/;
+
+type SearchParamsLike =
+  | URLSearchParams
+  | { get?: (key: string) => string | null }
+  | null
+  | undefined;
+
 function pathMatchesChatPrefix(pathname: string): boolean {
   return (
     pathname === CHAT_APP_ROUTE_PREFIX ||
@@ -25,4 +36,51 @@ export function isChatShellPathname(
     return false;
   }
   return pathMatchesChatPrefix(pathname);
+}
+
+/** True for `/chat/rooms/:roomId` (and nested room paths). */
+export function isChatRoomPathname(
+  pathname: string | null | undefined,
+): boolean {
+  if (!pathname) {
+    return false;
+  }
+  return CHAT_ROOM_PATHNAME_RE.test(pathname);
+}
+
+function readSearchParam(
+  searchParams: SearchParamsLike,
+  key: string,
+): string | null {
+  if (!searchParams) {
+    return null;
+  }
+  if (typeof searchParams.get === "function") {
+    return searchParams.get(key);
+  }
+  return null;
+}
+
+/**
+ * Classifies chat mobile chrome by pathname (+ optional search).
+ * Callers outside chat still get `"other-chat"` (safe default).
+ */
+export function classifyChatChromeSurface(
+  pathname: string | null | undefined,
+  searchParams?: SearchParamsLike,
+): ChatChromeSurface {
+  if (isChatRoomPathname(pathname)) {
+    return "room";
+  }
+
+  if (pathname === CHAT_APP_ROUTE_PREFIX) {
+    const create = readSearchParam(searchParams, "create");
+    const dm = readSearchParam(searchParams, "dm");
+    if (create === "channel" || dm === "new") {
+      return "other-chat";
+    }
+    return "home";
+  }
+
+  return "other-chat";
 }

--- a/apps/web/src/app/(app)/components/app-header-fallback.tsx
+++ b/apps/web/src/app/(app)/components/app-header-fallback.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import { cn } from "@/lib/utils";
 
 import { HeaderLeadingControl } from "./header/header-leading-control.client";
+import CustomTrigger from "./sidebar/components/custom-trigger";
 
 interface AppHeaderFallbackProps {
   className?: string;
@@ -15,7 +17,9 @@ export function AppHeaderFallback({ className }: AppHeaderFallbackProps) {
       )}
     >
       <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
-        <HeaderLeadingControl />
+        <Suspense fallback={<CustomTrigger when="invisible" />}>
+          <HeaderLeadingControl />
+        </Suspense>
       </div>
 
       <div className="hidden min-w-0 flex-1 flex-row gap-2 sm:flex">

--- a/apps/web/src/app/(app)/components/app-header-fallback.tsx
+++ b/apps/web/src/app/(app)/components/app-header-fallback.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 
-import CustomTrigger from "./sidebar/components/custom-trigger";
+import { HeaderLeadingControl } from "./header/header-leading-control.client";
 
 interface AppHeaderFallbackProps {
   className?: string;
@@ -15,7 +15,7 @@ export function AppHeaderFallback({ className }: AppHeaderFallbackProps) {
       )}
     >
       <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
-        <CustomTrigger when="invisible" />
+        <HeaderLeadingControl />
       </div>
 
       <div className="hidden min-w-0 flex-1 flex-row gap-2 sm:flex">

--- a/apps/web/src/app/(app)/components/header.tsx
+++ b/apps/web/src/app/(app)/components/header.tsx
@@ -1,9 +1,11 @@
 import type { Session } from "@sokosumi/utils";
+import { Suspense } from "react";
 import { BreadcrumbNavigation } from "@/components/breadcrumb-navigation";
 import { cn } from "@/lib/utils";
 
 import { HeaderLeadingControl } from "./header/header-leading-control.client";
 import HeaderProfileSection from "./header/header-profile-section";
+import CustomTrigger from "./sidebar/components/custom-trigger";
 
 interface HeaderProps {
   className?: string | undefined;
@@ -19,7 +21,9 @@ export default function Header({ className, session }: HeaderProps) {
       )}
     >
       <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
-        <HeaderLeadingControl />
+        <Suspense fallback={<CustomTrigger when="invisible" />}>
+          <HeaderLeadingControl />
+        </Suspense>
       </div>
 
       <div className="hidden min-w-0 flex-1 flex-row gap-2 sm:flex">

--- a/apps/web/src/app/(app)/components/header.tsx
+++ b/apps/web/src/app/(app)/components/header.tsx
@@ -2,8 +2,8 @@ import type { Session } from "@sokosumi/utils";
 import { BreadcrumbNavigation } from "@/components/breadcrumb-navigation";
 import { cn } from "@/lib/utils";
 
+import { HeaderLeadingControl } from "./header/header-leading-control.client";
 import HeaderProfileSection from "./header/header-profile-section";
-import CustomTrigger from "./sidebar/components/custom-trigger";
 
 interface HeaderProps {
   className?: string | undefined;
@@ -19,7 +19,7 @@ export default function Header({ className, session }: HeaderProps) {
       )}
     >
       <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
-        <CustomTrigger when="invisible" />
+        <HeaderLeadingControl />
       </div>
 
       <div className="hidden min-w-0 flex-1 flex-row gap-2 sm:flex">

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+
+import { classifyChatChromeSurface } from "@/app/chat/utils/chat-route-base";
+
+import CustomTrigger from "../sidebar/components/custom-trigger";
+
+/**
+ * Mobile header leading slot (`md:hidden` size-8):
+ * - chat home → spacer (no hamburger)
+ * - chat room → back to `/chat`
+ * - otherwise → sidebar CustomTrigger
+ */
+export function HeaderLeadingControl(): React.ReactElement {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const t = useTranslations("App.Channels.MobileNav");
+  const surface = classifyChatChromeSurface(pathname, searchParams);
+
+  if (surface === "home") {
+    return <span className="size-8 shrink-0" aria-hidden />;
+  }
+
+  if (surface === "room") {
+    return (
+      <Link
+        href="/chat"
+        aria-label={t("backToHome")}
+        className="text-foreground hover:bg-accent inline-flex size-8 shrink-0 items-center justify-center rounded-md"
+      >
+        <ArrowLeft className="size-4" aria-hidden />
+      </Link>
+    );
+  }
+
+  return <CustomTrigger when="invisible" />;
+}

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -59,6 +59,8 @@ interface ChatRoomSidebarRowProps {
   isActive: boolean;
   leading: ReactNode;
   onRoomUpdated: (room: ChatRoom) => void;
+  /** When false, render plain Link (page-mounted list outside Sheet). */
+  dismissSheetOnNavigate?: boolean;
 }
 
 function MentionBadge({ count }: { count: number }) {
@@ -85,6 +87,7 @@ export function ChatRoomSidebarRow({
   isActive,
   leading,
   onRoomUpdated,
+  dismissSheetOnNavigate = true,
 }: ChatRoomSidebarRowProps) {
   const tActions = useTranslations("App.Channels.Actions");
   const router = useRouter();
@@ -143,32 +146,38 @@ export function ChatRoomSidebarRow({
     }
   }
 
+  const roomLink = (
+    <Link
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "text-tertiary-foreground dark:text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex min-h-auto w-full items-center gap-2 px-3",
+        isMuted && !isActive && "opacity-60",
+      )}
+      href={href}
+    >
+      {leading}
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate",
+          bold && "font-semibold text-foreground",
+          isMuted && !isActive && "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+      <MentionBadge count={badgeCount} />
+      <span className="size-7 shrink-0" aria-hidden />
+    </Link>
+  );
+
   return (
     <SidebarMenuItem className="group/room-row relative">
       <SidebarMenuButton asChild isActive={isActive}>
-        <SheetClose asChild>
-          <Link
-            aria-current={isActive ? "page" : undefined}
-            className={cn(
-              "text-tertiary-foreground dark:text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex min-h-auto w-full items-center gap-2 px-3",
-              isMuted && !isActive && "opacity-60",
-            )}
-            href={href}
-          >
-            {leading}
-            <span
-              className={cn(
-                "min-w-0 flex-1 truncate",
-                bold && "font-semibold text-foreground",
-                isMuted && !isActive && "text-muted-foreground",
-              )}
-            >
-              {label}
-            </span>
-            <MentionBadge count={badgeCount} />
-            <span className="size-7 shrink-0" aria-hidden />
-          </Link>
-        </SheetClose>
+        {dismissSheetOnNavigate ? (
+          <SheetClose asChild>{roomLink}</SheetClose>
+        ) : (
+          roomLink
+        )}
       </SidebarMenuButton>
       {isMuted || isPinned ? (
         <span

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -87,6 +87,11 @@ interface OrganizationChatListProps {
   currentUserId: string;
   organizationId: string | null;
   canDeleteArchivedRooms?: boolean;
+  /**
+   * Wrap room/section links in Radix `SheetClose` (sidebar Sheet).
+   * Set false when the list is page-mounted outside a Sheet.
+   */
+  dismissSheetOnNavigate?: boolean;
 }
 
 function presenceLabel(
@@ -159,15 +164,28 @@ function SectionHeader({
   isOpen,
   label,
   secondaryAction,
+  dismissSheetOnNavigate = true,
 }: {
   children: ReactNode;
   href?: string;
   isOpen: boolean;
   label?: string;
   secondaryAction?: ReactNode;
+  dismissSheetOnNavigate?: boolean;
 }) {
   const hasTrailing = Boolean(secondaryAction) || Boolean(href && label);
   const trailingCount = (secondaryAction ? 1 : 0) + (href && label ? 1 : 0);
+
+  const createLink =
+    href && label ? (
+      <Link
+        aria-label={label}
+        className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground relative flex size-7 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2 before:content-[''] sm:before:hidden"
+        href={href}
+      >
+        <Plus className="size-3.5" aria-hidden />
+      </Link>
+    ) : null;
 
   return (
     <div className="group-data-[collapsible=icon]:hidden relative flex h-8 items-center gap-1 px-3">
@@ -190,16 +208,12 @@ function SectionHeader({
       {hasTrailing ? (
         <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center">
           {secondaryAction}
-          {href && label ? (
-            <SheetClose asChild>
-              <Link
-                aria-label={label}
-                className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground relative flex size-7 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2 before:content-[''] sm:before:hidden"
-                href={href}
-              >
-                <Plus className="size-3.5" aria-hidden />
-              </Link>
-            </SheetClose>
+          {createLink ? (
+            dismissSheetOnNavigate ? (
+              <SheetClose asChild>{createLink}</SheetClose>
+            ) : (
+              createLink
+            )
           ) : null}
         </div>
       ) : null}
@@ -222,6 +236,7 @@ export function OrganizationChatList({
   currentUserId,
   organizationId,
   canDeleteArchivedRooms = false,
+  dismissSheetOnNavigate = true,
 }: OrganizationChatListProps) {
   const t = useTranslations("App.Channels");
   const tActions = useTranslations("App.Channels.Actions");
@@ -467,6 +482,7 @@ export function OrganizationChatList({
           onOpenChange={setChannelSectionOpen}
         >
           <SectionHeader
+            dismissSheetOnNavigate={dismissSheetOnNavigate}
             href={hasOrganization ? "/chat?create=channel" : undefined}
             isOpen={channelSectionOpen}
             label={t("createChannel")}
@@ -491,6 +507,7 @@ export function OrganizationChatList({
                     />
                   }
                   onRoomUpdated={handleRoomUpdated}
+                  dismissSheetOnNavigate={dismissSheetOnNavigate}
                 />
               ))}
               {namedChannels.length === 0 ? (
@@ -667,6 +684,7 @@ export function OrganizationChatList({
             with empty members (coworkers only).
           */}
           <SectionHeader
+            dismissSheetOnNavigate={dismissSheetOnNavigate}
             href="/chat?dm=new"
             isOpen={directOpen}
             label={t("Draft.title")}
@@ -689,6 +707,7 @@ export function OrganizationChatList({
                     />
                   }
                   onRoomUpdated={handleRoomUpdated}
+                  dismissSheetOnNavigate={dismissSheetOnNavigate}
                 />
               ))}
               {directMessages.length === 0 ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-726/full-screen-chat-home-channels-dms

Stacked on #3634 (`sok-725-mobile-bottom-nav-on-chat-shell-only`).

**Spec summary**
- Below `md`, `/chat` Home is full-screen Channels + DMs via existing `OrganizationChatList` (no parallel list).
- Opening a room hides the mobile bottom tab bar and shows a back control to `/chat` instead of the hamburger.
- Home has no hamburger; desktop `md+` welcome + sidebar stay unchanged.
- Pathname-driven chrome (`home` / `room` / `other-chat`); draft `?create`/`?dm` keep current UI.
- Verified: `pnpm web:check`, `pnpm web:test`; UI routes `/chat`, `/chat/rooms/<id>` (mobile).

**UI proof (mobile 390×844)**
[Mobile Home Channels+DMs list with bottom nav](https://cursor.com/agents/bc-c87e8761-0a38-41f5-8c79-b79ca41dc092/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-726%2Fhome.png)
[Room view without bottom nav; back to chat home](https://cursor.com/agents/bc-c87e8761-0a38-41f5-8c79-b79ca41dc092/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-726%2Froom.png)
[Back control returns to Home list + bottom nav](https://cursor.com/agents/bc-c87e8761-0a38-41f5-8c79-b79ca41dc092/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-726%2Fback-home.png)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Spec / perf | `chat/page.tsx` dual render | Mobile still loads welcome coworker data for `md+` branch even when viewport is mobile; happy path holds. |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c87e8761-0a38-41f5-8c79-b79ca41dc092?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c87e8761-0a38-41f5-8c79-b79ca41dc092&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

