### PR TITLE
perf(core): denormalize agent jobCount for catalog popularity sort

### DIFF
--- a/apps/core/src/helpers/agent-job-count.ts
+++ b/apps/core/src/helpers/agent-job-count.ts
@@ -1,0 +1,15 @@
+import type { Prisma } from "@sokosumi/database";
+
+/**
+ * Increments Agent.jobCount by 1 for a newly created Job.
+ * Must run in the same transaction as `tx.job.create`.
+ */
+export async function incrementAgentJobCount(
+  agentId: string,
+  tx: Prisma.TransactionClient,
+): Promise<void> {
+  await tx.agent.update({
+    where: { id: agentId },
+    data: { jobCount: { increment: 1 } },
+  });
+}

--- a/apps/core/src/helpers/agent-summary.ts
+++ b/apps/core/src/helpers/agent-summary.ts
@@ -8,7 +8,6 @@ import { convertCentsToCredits } from "@sokosumi/utils";
 
 import {
   calculateAgentRatings,
-  calculateAverageExecutionTimes,
   getAgentCost,
   getAgentDescription,
   getAgentIcon,
@@ -69,11 +68,7 @@ export async function buildAgentSummaries(
     }));
 
   const agentIds = agentsWithCredits.map((agent) => agent.id);
-
-  const [averageExecutionTimes, ratingsMap] = await Promise.all([
-    calculateAverageExecutionTimes(agentIds, tx),
-    calculateAgentRatings(agentIds, tx),
-  ]);
+  const ratingsMap = await calculateAgentRatings(agentIds, tx);
 
   return agentsWithCredits.map((agent) => {
     const ratingMetrics = ratingsMap.get(agent.id);
@@ -82,7 +77,7 @@ export async function buildAgentSummaries(
       metrics: {
         executions: {
           count: agent._count.jobs,
-          averageTime: averageExecutionTimes.get(agent.id) ?? null,
+          averageTime: null,
         },
         ratings: {
           total: ratingMetrics?.total ?? 0,

--- a/apps/core/src/helpers/agent-summary.ts
+++ b/apps/core/src/helpers/agent-summary.ts
@@ -19,18 +19,14 @@ import {
   getAuthorFromAgent,
 } from "@/schemas/agent.schema";
 import { mapCategoryForApi } from "@/schemas/category.schema";
-import type {
-  agentCategoriesInclude,
-  agentJobsCountInclude,
-} from "@/types/agent";
+import type { agentCategoriesInclude } from "@/types/agent";
 
 /**
  * Agent row shape required to build a catalog-style agent summary: pricing,
- * job count, ordered categories, and optional metadata overrides.
+ * denormalized jobCount, ordered categories, and optional metadata overrides.
  */
 export type AgentSummaryRow = Prisma.AgentGetPayload<{
   include: typeof agentPricingInclude &
-    typeof agentJobsCountInclude &
     typeof agentCategoriesInclude &
     typeof agentMetadataOverrideScalarsInclude;
 }>;
@@ -40,8 +36,8 @@ export type AgentSummaryRow = Prisma.AgentGetPayload<{
  * `GET /v1/agents`: resolves overrides, computes per-agent credits from the
  * credit cost table, and attaches execution + rating metrics.
  *
- * Keeps the catalog summary computation (credits + override resolution +
- * metrics) in a single place.
+ * List path skips average-execution SQL (`averageTime` is null); detail still
+ * computes it. Execution count uses denormalized `Agent.jobCount`.
  */
 export async function buildAgentSummaries(
   agents: AgentSummaryRow[],
@@ -76,7 +72,7 @@ export async function buildAgentSummaries(
       ...agent,
       metrics: {
         executions: {
-          count: agent._count.jobs,
+          count: agent.jobCount,
           averageTime: null,
         },
         ratings: {

--- a/apps/core/src/helpers/job-create-agent.test.ts
+++ b/apps/core/src/helpers/job-create-agent.test.ts
@@ -14,6 +14,7 @@ const {
   getCreditCostsOrThrowMock,
   projectFindFirstMock,
   prismaTransactionMock,
+  txAgentUpdateMock,
   txJobCreateMock,
 } = vi.hoisted(() => ({
   agentFindFirstMock: vi.fn(),
@@ -23,6 +24,7 @@ const {
   getCreditCostsOrThrowMock: vi.fn(),
   projectFindFirstMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
+  txAgentUpdateMock: vi.fn(),
   txJobCreateMock: vi.fn(),
 }));
 
@@ -146,11 +148,15 @@ describe("createAgentJobForUser schedule/max-cents behavior", () => {
       agentId: "agent_1",
       ownerId: "user_1",
     });
+    txAgentUpdateMock.mockResolvedValue({ id: "agent_1", jobCount: 1 });
     prismaTransactionMock.mockImplementation(
       async (callback: (tx: unknown) => unknown) => {
         return await callback({
           job: {
             create: txJobCreateMock,
+          },
+          agent: {
+            update: txAgentUpdateMock,
           },
         });
       },
@@ -194,6 +200,10 @@ describe("createAgentJobForUser schedule/max-cents behavior", () => {
         include: jobListSummaryInclude,
       }),
     );
+    expect(txAgentUpdateMock).toHaveBeenCalledWith({
+      where: { id: "agent_1" },
+      data: { jobCount: { increment: 1 } },
+    });
   });
 
   it("throws not found when projectId does not belong to the workspace", async () => {

--- a/apps/core/src/helpers/job.ts
+++ b/apps/core/src/helpers/job.ts
@@ -32,6 +32,7 @@ import {
   getCreditCostsOrThrow,
   toMasumiAgent,
 } from "@/helpers/agent";
+import { incrementAgentJobCount } from "@/helpers/agent-job-count";
 import prisma from "@/lib/db/prisma";
 import { serializableTransaction } from "@/lib/db/transaction";
 import type { UserContext } from "@/middleware/auth";
@@ -98,7 +99,7 @@ async function createPaidJob(
     tx,
   );
 
-  return await tx.job.create({
+  const job = await tx.job.create({
     data: {
       agentJobId: agentJobResponse.id,
       jobType: JobType.PAID,
@@ -159,6 +160,8 @@ async function createPaidJob(
       ...jobListSummaryInclude,
     },
   });
+  await incrementAgentJobCount(input.agentId, tx);
+  return job;
 }
 
 /**
@@ -181,7 +184,7 @@ async function createFreeJob(
   tx: Prisma.TransactionClient,
 ): Promise<JobWithListSummaryRelations> {
   const inputSchemaSnapshot = JSON.stringify(input.inputSchema);
-  return await tx.job.create({
+  const job = await tx.job.create({
     data: {
       agentJobId: agentJobResponse.id,
       jobType: JobType.FREE,
@@ -223,6 +226,8 @@ async function createFreeJob(
       ...jobListSummaryInclude,
     },
   });
+  await incrementAgentJobCount(input.agentId, tx);
+  return job;
 }
 
 interface CreateAgentJobInput {

--- a/apps/core/src/routes/v1/agents/[id]/get.test.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.test.ts
@@ -110,7 +110,7 @@ describe("GET /agents/{id}", () => {
       icon: null,
       summary: "A short summary",
       riskClassification: "HIGH",
-      _count: { jobs: 2 },
+      jobCount: 2,
       categories: [
         {
           id: "cat_123",

--- a/apps/core/src/routes/v1/agents/[id]/get.ts
+++ b/apps/core/src/routes/v1/agents/[id]/get.ts
@@ -92,7 +92,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       const averageExecutionTime = await calculateAverageExecutionTime(id, tx);
       const executionMetrics = {
-        count: agent._count.jobs,
+        count: agent.jobCount,
         averageTime: averageExecutionTime ?? null,
       };
 

--- a/apps/core/src/routes/v1/agents/get.test.ts
+++ b/apps/core/src/routes/v1/agents/get.test.ts
@@ -107,7 +107,7 @@ describe("GET /agents", () => {
         icon: null,
         summary: "A short summary",
         riskClassification: "MINIMAL",
-        _count: { jobs: 2 },
+        jobCount: 2,
         categories: [
           {
             id: "cat_123",
@@ -159,7 +159,7 @@ describe("GET /agents", () => {
     expect(agentCountMock).toHaveBeenCalled();
   });
 
-  it("orders by createdAt without live jobs._count and skips average execution SQL", async () => {
+  it("orders by jobCount without live jobs._count and skips average execution SQL", async () => {
     const app = createApp();
     const response = await app.request("http://localhost/");
     const body = await response.json();
@@ -167,13 +167,15 @@ describe("GET /agents", () => {
     expect(response.status).toBe(200);
     expect(agentFindManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        orderBy: [{ jobCount: "desc" }, { createdAt: "desc" }, { id: "desc" }],
       }),
     );
     const findManyArg = agentFindManyMock.mock.calls[0]?.[0] as {
       orderBy: unknown[];
+      include?: Record<string, unknown>;
     };
     expect(JSON.stringify(findManyArg.orderBy)).not.toContain("_count");
+    expect(findManyArg.include).not.toHaveProperty("_count");
     expect(calculateAverageExecutionTimesMock).not.toHaveBeenCalled();
     expect(body.data[0]?.metrics.executions).toMatchObject({
       count: 2,

--- a/apps/core/src/routes/v1/agents/get.test.ts
+++ b/apps/core/src/routes/v1/agents/get.test.ts
@@ -167,10 +167,7 @@ describe("GET /agents", () => {
     expect(response.status).toBe(200);
     expect(agentFindManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: expect.arrayContaining([
-          { createdAt: "desc" },
-          { id: "desc" },
-        ]),
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       }),
     );
     const findManyArg = agentFindManyMock.mock.calls[0]?.[0] as {

--- a/apps/core/src/routes/v1/agents/get.test.ts
+++ b/apps/core/src/routes/v1/agents/get.test.ts
@@ -159,6 +159,36 @@ describe("GET /agents", () => {
     expect(agentCountMock).toHaveBeenCalled();
   });
 
+  it("orders by createdAt without live jobs._count and skips average execution SQL", async () => {
+    const app = createApp();
+    const response = await app.request("http://localhost/");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(agentFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: expect.arrayContaining([
+          { createdAt: "desc" },
+          { id: "desc" },
+        ]),
+      }),
+    );
+    const findManyArg = agentFindManyMock.mock.calls[0]?.[0] as {
+      orderBy: unknown[];
+    };
+    expect(JSON.stringify(findManyArg.orderBy)).not.toContain("_count");
+    expect(calculateAverageExecutionTimesMock).not.toHaveBeenCalled();
+    expect(body.data[0]?.metrics.executions).toMatchObject({
+      count: 2,
+      averageTime: null,
+    });
+    expect(body.data[0]?.metrics.ratings).toMatchObject({
+      total: 3,
+      average: 4.5,
+    });
+    expect(calculateAgentRatingsMock).toHaveBeenCalled();
+  });
+
   it("filters by a single category slug and returns parsed category styles", async () => {
     const app = createApp();
     const response = await app.request("http://localhost/?category=research");

--- a/apps/core/src/routes/v1/agents/get.ts
+++ b/apps/core/src/routes/v1/agents/get.ts
@@ -26,7 +26,7 @@ import { ok } from "@/helpers/response";
 import prisma from "@/lib/db/prisma";
 import { agentsSummarySchema } from "@/schemas/agent.schema";
 import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
-import { agentCategoriesInclude, agentJobsCountInclude } from "@/types/agent";
+import { agentCategoriesInclude } from "@/types/agent";
 
 const UNCATEGORIZED_CATEGORY_FILTER = "uncategorized";
 
@@ -150,7 +150,6 @@ export default function mount(app: OpenAPIHono) {
         orderBy: [...agentOrderBy, { id: "desc" }],
         include: {
           ...agentPricingInclude,
-          ...agentJobsCountInclude,
           ...agentCategoriesInclude,
           ...agentMetadataOverrideScalarsInclude,
         },

--- a/apps/core/src/types/agent.ts
+++ b/apps/core/src/types/agent.ts
@@ -5,18 +5,6 @@ import {
   type Prisma,
 } from "@sokosumi/database";
 
-export const agentJobsCountInclude = {
-  _count: {
-    select: {
-      jobs: true,
-    },
-  },
-} as const;
-
-export type AgentWithJobsCount = Prisma.AgentGetPayload<{
-  include: typeof agentJobsCountInclude;
-}>;
-
 /** Catalog list needs stable category order; shared package include is unordered. */
 export const agentCategoriesInclude = {
   categories: {
@@ -33,7 +21,6 @@ export type AgentWithCategories = Prisma.AgentGetPayload<{
 
 export const agentDetailInclude = {
   ...agentPricingInclude,
-  ...agentJobsCountInclude,
   ...agentCategoriesInclude,
   ...agentTagsInclude,
   ...agentExampleOutputInclude,

--- a/packages/database/prisma/migrations/20260805090000_add_agent_job_count/migration.sql
+++ b/packages/database/prisma/migrations/20260805090000_add_agent_job_count/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "Agent" ADD COLUMN "jobCount" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill from existing Job rows
+UPDATE "Agent" AS agent
+SET "jobCount" = job_counts.cnt
+FROM (
+  SELECT "agentId", COUNT(*)::integer AS cnt
+  FROM "Job"
+  GROUP BY "agentId"
+) AS job_counts
+WHERE agent.id = job_counts."agentId";
+
+-- CreateIndex
+CREATE INDEX "Agent_jobCount_createdAt_id_idx" ON "Agent"("jobCount" DESC, "createdAt" DESC, "id" DESC);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -671,7 +671,10 @@ model Agent {
   // Summary
   summary String?
 
+  jobCount Int @default(0)
+
   @@index([isShown, status])
+  @@index([jobCount(sort: Desc), createdAt(sort: Desc), id(sort: Desc)])
 }
 
 model AgentMetadataOverride {

--- a/packages/database/src/repositories/job.repository.ts
+++ b/packages/database/src/repositories/job.repository.ts
@@ -130,6 +130,10 @@ export const jobRepository = {
           },
           include: jobInclude,
         });
+        await tx.agent.update({
+          where: { id: data.agentId },
+          data: { jobCount: { increment: 1 } },
+        });
         return mapJobWithStatus(freeJob);
       }
       case JobType.PAID: {
@@ -177,6 +181,10 @@ export const jobRepository = {
             identifierFromPurchaser: data.identifierFromPurchaser,
           },
           include: jobInclude,
+        });
+        await tx.agent.update({
+          where: { id: data.agentId },
+          data: { jobCount: { increment: 1 } },
         });
         return mapJobWithStatus(paidJob);
       }

--- a/packages/database/src/types/__tests__/list-catalog-indexes.test.ts
+++ b/packages/database/src/types/__tests__/list-catalog-indexes.test.ts
@@ -35,8 +35,8 @@ function migrationSqlFiles(): string[] {
 }
 
 describe("list and catalog performance indexes", () => {
-  it("agentOrderBy is createdAt-only without jobs._count", () => {
-    expect(agentOrderBy).toEqual([{ createdAt: "desc" }]);
+  it("agentOrderBy uses denormalized jobCount without jobs._count", () => {
+    expect(agentOrderBy).toEqual([{ jobCount: "desc" }, { createdAt: "desc" }]);
     expect(JSON.stringify(agentOrderBy)).not.toContain("_count");
   });
 
@@ -50,6 +50,10 @@ describe("list and catalog performance indexes", () => {
       "@@index([workspaceId, createdAt(sort: Desc)])",
     );
     expect(modelBlock(schema, "Agent")).toContain("@@index([isShown, status])");
+    expect(modelBlock(schema, "Agent")).toContain(
+      "@@index([jobCount(sort: Desc), createdAt(sort: Desc), id(sort: Desc)])",
+    );
+    expect(modelBlock(schema, "Agent")).toContain("jobCount Int @default(0)");
   });
 
   it("migrations create matching Postgres indexes", () => {
@@ -60,6 +64,10 @@ describe("list and catalog performance indexes", () => {
     expect(sql).toMatch(/"Agent_isShown_status_idx"/);
     expect(sql).toMatch(
       /CREATE INDEX "Job_workspaceId_createdAt_idx" ON "Job"\("workspaceId", "createdAt" DESC\)/,
+    );
+    expect(sql).toMatch(/"Agent_jobCount_createdAt_id_idx"/);
+    expect(sql).toMatch(
+      /CREATE INDEX "Agent_jobCount_createdAt_id_idx" ON "Agent"\("jobCount" DESC, "createdAt" DESC, "id" DESC\)/,
     );
   });
 });

--- a/packages/database/src/types/__tests__/list-catalog-indexes.test.ts
+++ b/packages/database/src/types/__tests__/list-catalog-indexes.test.ts
@@ -3,6 +3,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+import { agentOrderBy } from "../agent.js";
+
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 const schemaPath = join(packageRoot, "prisma/schema.prisma");
 const migrationsDir = join(packageRoot, "prisma/migrations");
@@ -33,6 +35,11 @@ function migrationSqlFiles(): string[] {
 }
 
 describe("list and catalog performance indexes", () => {
+  it("agentOrderBy is createdAt-only without jobs._count", () => {
+    expect(agentOrderBy).toEqual([{ createdAt: "desc" }]);
+    expect(JSON.stringify(agentOrderBy)).not.toContain("_count");
+  });
+
   it("schema.prisma declares TaskEvent, Job, and Agent list/catalog indexes", () => {
     const schema = readSchema();
 

--- a/packages/database/src/types/agent.ts
+++ b/packages/database/src/types/agent.ts
@@ -64,20 +64,11 @@ export const agentInclude = {
   ...agentRatingInclude,
 } as const;
 
-export const agentJobsCountOrderBy = {
-  jobs: {
-    _count: "desc",
-  },
-} as const;
-
 export const agentCreatedAtOrderBy = {
   createdAt: "desc",
 } as const;
 
-export const agentOrderBy = [
-  { ...agentJobsCountOrderBy },
-  { ...agentCreatedAtOrderBy },
-] as const;
+export const agentOrderBy = [{ ...agentCreatedAtOrderBy }] as const;
 
 export type AgentWithCreditsPrice = Prisma.AgentGetPayload<{
   include: typeof agentInclude;

--- a/packages/database/src/types/agent.ts
+++ b/packages/database/src/types/agent.ts
@@ -64,11 +64,18 @@ export const agentInclude = {
   ...agentRatingInclude,
 } as const;
 
+export const agentJobCountOrderBy = {
+  jobCount: "desc",
+} as const;
+
 export const agentCreatedAtOrderBy = {
   createdAt: "desc",
 } as const;
 
-export const agentOrderBy = [{ ...agentCreatedAtOrderBy }] as const;
+export const agentOrderBy = [
+  { ...agentJobCountOrderBy },
+  { ...agentCreatedAtOrderBy },
+] as const;
 
 export type AgentWithCreditsPrice = Prisma.AgentGetPayload<{
   include: typeof agentInclude;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-723/agent-catalog-cold-load-costs-less-for-sort-and-metrics

Catalog cold misses stay cheap while keeping popularity-first discovery:

- Denormalized `Agent.jobCount` (migration backfill + increment on job create) replaces live `jobs._count` sort.
- Default order is `jobCount desc`, then `createdAt desc`, then `id desc`.
- List `averageTime` stays null (90d avg SQL skipped on list); ratings + count remain; detail still computes avg.

Verified: database check/test, core check/test.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-723](https://linear.app/masumi/issue/SOK-723/agent-catalog-cold-load-costs-less-for-sort-and-metrics)

<div><a href="https://cursor.com/agents/bc-977b3db9-0540-4706-9e49-f1f48e620780?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-977b3db9-0540-4706-9e49-f1f48e620780&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

