### PR TITLE
perf(web): page sidebar rooms and agent jobs with load-more

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -509,7 +509,9 @@
       "JobsSearch": {
         "placeholder": "Jobs durchsuchen...",
         "clear": "Suche zurücksetzen",
-        "resultsCount": "{found} von {total} Ergebnissen gefunden"
+        "resultsCount": "{found} von {total} Ergebnissen gefunden",
+        "resultsCountLoaded": "{found} von {total} geladen",
+        "loadedOnlyHint": "Suche gilt für geladene Jobs. Mehr laden, um ältere einzubeziehen."
       },
       "JobsList": {
         "noExecutedJobs": "Keine ausgeführten Jobs",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -513,7 +513,10 @@
       },
       "JobsList": {
         "noExecutedJobs": "Keine ausgeführten Jobs",
-        "emptyJobs": "Noch keine Jobs."
+        "emptyJobs": "Noch keine Jobs.",
+        "loadMore": "Mehr laden",
+        "loading": "Wird geladen...",
+        "loadMoreError": "Weitere Jobs konnten nicht geladen werden"
       }
     },
     "Organizations": {
@@ -4756,6 +4759,9 @@
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",
       "directMessages": "Direct Messages",
+      "loadMore": "Mehr laden",
+      "loading": "Wird geladen...",
+      "loadMoreError": "Weitere Chats konnten nicht geladen werden",
       "composerPlaceholder": "Message this channel. Type @ to mention an AI coworker.",
       "NoOrganization": {
         "title": "Channels kommen bald",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -529,7 +529,10 @@
       },
       "JobsList": {
         "noExecutedJobs": "No executed jobs",
-        "emptyJobs": "No jobs yet."
+        "emptyJobs": "No jobs yet.",
+        "loadMore": "Load more",
+        "loading": "Loading...",
+        "loadMoreError": "Failed to load more jobs"
       }
     },
     "Organizations": {
@@ -4756,6 +4759,9 @@
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",
       "directMessages": "Direct Messages",
+      "loadMore": "Load more",
+      "loading": "Loading...",
+      "loadMoreError": "Failed to load more chats",
       "composerPlaceholder": "Message this channel. Type @ to mention an AI coworker.",
       "NoOrganization": {
         "title": "Channels coming soon",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -525,7 +525,9 @@
       "JobsSearch": {
         "placeholder": "Search jobs...",
         "clear": "Clear search",
-        "resultsCount": "{found} of {total} results found"
+        "resultsCount": "{found} of {total} results found",
+        "resultsCountLoaded": "{found} of {total} loaded",
+        "loadedOnlyHint": "Search covers loaded jobs. Load more to include older ones."
       },
       "JobsList": {
         "noExecutedJobs": "No executed jobs",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -513,7 +513,10 @@
       },
       "JobsList": {
         "noExecutedJobs": "No hay jobs ejecutados",
-        "emptyJobs": "Aún sin jobs."
+        "emptyJobs": "Aún sin jobs.",
+        "loadMore": "Cargar más",
+        "loading": "Cargando...",
+        "loadMoreError": "No se pudieron cargar más jobs"
       }
     },
     "Organizations": {
@@ -4756,6 +4759,9 @@
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflow": "and {count} more",
       "directMessages": "Direct Messages",
+      "loadMore": "Cargar más",
+      "loading": "Cargando...",
+      "loadMoreError": "No se pudieron cargar más chats",
       "composerPlaceholder": "Message this channel. Type @ to mention an AI coworker.",
       "NoOrganization": {
         "title": "Canales próximamente",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -509,7 +509,9 @@
       "JobsSearch": {
         "placeholder": "Buscar jobs...",
         "clear": "Limpiar búsqueda",
-        "resultsCount": "{found} de {total} resultados encontrados"
+        "resultsCount": "{found} de {total} resultados encontrados",
+        "resultsCountLoaded": "{found} de {total} cargados",
+        "loadedOnlyHint": "La búsqueda cubre jobs cargados. Carga más para incluir antiguos."
       },
       "JobsList": {
         "noExecutedJobs": "No hay jobs ejecutados",

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/@right/page.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/@right/page.tsx
@@ -20,16 +20,18 @@ export default async function RightSectionPage({
 
   const { agentId } = await params;
 
-  const [agent, agentJobs] = await Promise.all([
+  const [agent, agentJobsPage] = await Promise.all([
     getCoreAgentById(agentId),
     getCachedMyJobs(agentId),
   ]);
-  if (!agent && agentJobs.length === 0) {
+  if (!agent && agentJobsPage.jobs.length === 0) {
     notFound();
   }
 
-  if (agentJobs.length > 0) {
-    return <JobDetailRedirect agentId={agentId} jobId={agentJobs[0].id} />;
+  if (agentJobsPage.jobs.length > 0) {
+    return (
+      <JobDetailRedirect agentId={agentId} jobId={agentJobsPage.jobs[0].id} />
+    );
   }
 
   return (

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/_lib/__tests__/get-cached-my-jobs.test.ts
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/_lib/__tests__/get-cached-my-jobs.test.ts
@@ -14,46 +14,32 @@ describe("getCachedMyJobs", () => {
     vi.resetModules();
   });
 
-  it("walks all pages and returns jobs sorted by newest first", async () => {
-    getAgentJobsMock
-      .mockResolvedValueOnce({
-        data: [
-          { id: "job-older", createdAt: "2024-01-01T00:00:00.000Z" },
-          { id: "job-middle", createdAt: "2024-01-02T00:00:00.000Z" },
-        ],
-        meta: {
-          pagination: {
-            nextCursor: "cursor-2",
-          },
+  it("returns the first page only and does not walk nextCursor", async () => {
+    getAgentJobsMock.mockResolvedValueOnce({
+      data: [
+        { id: "job-newest", createdAt: "2024-01-03T00:00:00.000Z" },
+        { id: "job-middle", createdAt: "2024-01-02T00:00:00.000Z" },
+      ],
+      meta: {
+        pagination: {
+          nextCursor: "cursor-2",
         },
-      })
-      .mockResolvedValueOnce({
-        data: [{ id: "job-newest", createdAt: "2024-01-03T00:00:00.000Z" }],
-        meta: {
-          pagination: {
-            nextCursor: null,
-          },
-        },
-      });
+      },
+    });
 
     const { getCachedMyJobs } = await import("../get-cached-my-jobs");
-    const jobs = await getCachedMyJobs("agent-1");
+    const page = await getCachedMyJobs("agent-1");
 
-    expect(getAgentJobsMock).toHaveBeenNthCalledWith(1, "agent-1", {
-      cursor: undefined,
-      limit: 100,
+    expect(getAgentJobsMock).toHaveBeenCalledTimes(1);
+    expect(getAgentJobsMock).toHaveBeenCalledWith("agent-1", {
+      limit: 20,
       scope: "owned",
     });
-    expect(getAgentJobsMock).toHaveBeenNthCalledWith(2, "agent-1", {
-      cursor: "cursor-2",
-      limit: 100,
-      scope: "owned",
-    });
-    expect(jobs.map((job: { id: string }) => job.id)).toEqual([
+    expect(page.jobs.map((job: { id: string }) => job.id)).toEqual([
       "job-newest",
       "job-middle",
-      "job-older",
     ]);
+    expect(page.nextCursor).toBe("cursor-2");
   });
 
   it("returns an empty list when the first page is empty", async () => {
@@ -67,9 +53,41 @@ describe("getCachedMyJobs", () => {
     });
 
     const { getCachedMyJobs } = await import("../get-cached-my-jobs");
-    const jobs = await getCachedMyJobs("agent-1");
+    const page = await getCachedMyJobs("agent-1");
 
-    expect(jobs).toEqual([]);
+    expect(page.jobs).toEqual([]);
+    expect(page.nextCursor).toBeNull();
     expect(getAgentJobsMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getOwnedAgentJobsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("passes cursor for load-more", async () => {
+    getAgentJobsMock.mockResolvedValueOnce({
+      data: [{ id: "job-older", createdAt: "2024-01-01T00:00:00.000Z" }],
+      meta: {
+        pagination: {
+          nextCursor: null,
+        },
+      },
+    });
+
+    const { getOwnedAgentJobsPage } = await import("../get-cached-my-jobs");
+    const page = await getOwnedAgentJobsPage("agent-1", "cursor-2");
+
+    expect(getAgentJobsMock).toHaveBeenCalledWith("agent-1", {
+      cursor: "cursor-2",
+      limit: 20,
+      scope: "owned",
+    });
+    expect(page.jobs.map((job: { id: string }) => job.id)).toEqual([
+      "job-older",
+    ]);
+    expect(page.nextCursor).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/_lib/get-cached-my-jobs.ts
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/_lib/get-cached-my-jobs.ts
@@ -3,37 +3,31 @@ import { cache } from "react";
 import { coreClient } from "@/lib/clients/core.client";
 import type { JobSummary } from "@/lib/clients/generated/core";
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 20;
 
-function sortJobsByCreatedAtDesc(jobs: JobSummary[]): JobSummary[] {
-  return [...jobs].sort(
-    (firstJob, secondJob) =>
-      new Date(secondJob.createdAt).getTime() -
-      new Date(firstJob.createdAt).getTime(),
-  );
+export interface OwnedAgentJobsPage {
+  jobs: JobSummary[];
+  nextCursor: string | null;
 }
 
-async function getAllOwnedAgentJobs(agentId: string): Promise<JobSummary[]> {
-  const jobs: JobSummary[] = [];
-  let cursor: string | undefined;
+export async function getOwnedAgentJobsPage(
+  agentId: string,
+  cursor?: string | null,
+): Promise<OwnedAgentJobsPage> {
+  const response = await coreClient.getAgentJobs(agentId, {
+    ...(cursor ? { cursor } : {}),
+    limit: PAGE_SIZE,
+    scope: "owned",
+  });
 
-  do {
-    const response = await coreClient.getAgentJobs(agentId, {
-      cursor,
-      limit: PAGE_SIZE,
-      scope: "owned",
-    });
-
-    jobs.push(...response.data);
-
-    cursor = response.meta?.pagination?.nextCursor ?? undefined;
-  } while (cursor);
-
-  return sortJobsByCreatedAtDesc(jobs);
+  return {
+    jobs: response.data,
+    nextCursor: response.meta?.pagination?.nextCursor ?? null,
+  };
 }
 
 export const getCachedMyJobs = cache(
-  async (agentId: string): Promise<JobSummary[]> => {
-    return getAllOwnedAgentJobs(agentId);
+  async (agentId: string): Promise<OwnedAgentJobsPage> => {
+    return getOwnedAgentJobsPage(agentId);
   },
 );

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/actions.ts
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { getOwnedAgentJobsPage } from "@/app/agents/[agentId]/jobs/_lib/get-cached-my-jobs";
+
+export async function loadMoreOwnedAgentJobs(
+  agentId: string,
+  cursor: string | null,
+) {
+  const cleanAgentId = agentId.trim();
+  if (!cleanAgentId || !cursor?.trim()) {
+    return { jobs: [], nextCursor: null as string | null };
+  }
+
+  return getOwnedAgentJobsPage(cleanAgentId, cursor.trim());
+}

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
@@ -136,9 +136,7 @@ export function JobsList({
       return [...jobs, ...older];
     });
     setNextCursor((prev) =>
-      hasAppendedViaLoadMoreRef.current && prev !== null
-        ? prev
-        : jobsNextCursor,
+      hasAppendedViaLoadMoreRef.current ? prev : jobsNextCursor,
     );
   }, [jobs, jobsNextCursor]);
 

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
@@ -26,21 +26,18 @@ interface JobStatusUpdateData {
   jobStatusSettled: boolean;
 }
 
+interface JobStatusPatch {
+  status: SokosumiJobStatus;
+  jobStatusSettled: boolean;
+  completedAt?: Date;
+}
+
 interface JobsListProps {
   jobs: JobSummary[];
   jobsNextCursor: string | null;
   userId: string;
   agentId: string;
   selectedJobId?: string;
-}
-
-function appendUniqueJobs(
-  existing: JobSummary[],
-  incoming: JobSummary[],
-): JobSummary[] {
-  const existingIds = new Set(existing.map((job) => job.id));
-  const unique = incoming.filter((job) => !existingIds.has(job.id));
-  return [...existing, ...unique];
 }
 
 function JobsStatusRealtimeListener({
@@ -118,27 +115,44 @@ export function JobsList({
   const { locale } = useLocalizedDateTime();
   const routeParams = useParams<{ jobId?: string }>();
   const router = useRouter();
-  const [localJobs, setLocalJobs] = useState<JobSummary[]>(jobs);
+  /** Older pages loaded via Load more; first page stays the `jobs` prop (R7). */
+  const [appendedJobs, setAppendedJobs] = useState<JobSummary[]>([]);
+  /** `undefined` = still using SSR/prop cursor; after load-more, own the cursor. */
+  const [loadMoreCursor, setLoadMoreCursor] = useState<
+    string | null | undefined
+  >(undefined);
+  const [statusPatches, setStatusPatches] = useState(
+    () => new Map<string, JobStatusPatch>(),
+  );
   const [filteredJobs, setFilteredJobs] = useState<JobSummary[]>(jobs);
-  const [nextCursor, setNextCursor] = useState(jobsNextCursor);
   const [isLoadingMore, startLoadMoreTransition] = useTransition();
-  const hasAppendedViaLoadMoreRef = useRef(false);
   const activeJobId = selectedJobId ?? routeParams.jobId;
 
-  // Sync when jobs prop changes; keep load-more history (R7).
-  useEffect(() => {
-    setLocalJobs((prev) => {
-      if (!hasAppendedViaLoadMoreRef.current) {
-        return jobs;
+  const nextCursor =
+    loadMoreCursor === undefined ? jobsNextCursor : loadMoreCursor;
+
+  const localJobs = useMemo(() => {
+    const firstPageIds = new Set(jobs.map((job) => job.id));
+    const older = appendedJobs.filter((job) => !firstPageIds.has(job.id));
+    const merged = [...jobs, ...older];
+    if (statusPatches.size === 0) {
+      return merged;
+    }
+    return merged.map((job) => {
+      const patch = statusPatches.get(job.id);
+      if (!patch) {
+        return job;
       }
-      const firstPageIds = new Set(jobs.map((job) => job.id));
-      const older = prev.filter((job) => !firstPageIds.has(job.id));
-      return [...jobs, ...older];
+      return {
+        ...job,
+        status: patch.status,
+        jobStatusSettled: patch.jobStatusSettled,
+        ...(patch.completedAt !== undefined && job.completedAt === null
+          ? { completedAt: patch.completedAt }
+          : {}),
+      };
     });
-    setNextCursor((prev) =>
-      hasAppendedViaLoadMoreRef.current ? prev : jobsNextCursor,
-    );
-  }, [jobs, jobsNextCursor]);
+  }, [jobs, appendedJobs, statusPatches]);
 
   const dayGroups = useMemo(
     () => buildJobDayGroups(filteredJobs, locale),
@@ -152,37 +166,27 @@ export function JobsList({
       return;
     }
 
-    const latestByJobId = new Map<string, JobStatusUpdateData>();
-    for (const update of updates) {
-      latestByJobId.set(update.jobId, update);
-    }
-
     const completedAtFallback = new Date();
-    const updater = (prev: JobSummary[]) =>
-      prev.map((job) => {
-        const update = latestByJobId.get(job.id);
-        if (!update) {
-          return job;
-        }
-
-        const statusUnchanged = job.status === update.jobStatus;
+    setStatusPatches((prev) => {
+      const next = new Map(prev);
+      for (const update of updates) {
+        const existing = next.get(update.jobId);
+        const statusUnchanged = existing?.status === update.jobStatus;
         const settledUnchanged =
-          job.jobStatusSettled === update.jobStatusSettled;
-        if (statusUnchanged && settledUnchanged) {
-          return job;
+          existing?.jobStatusSettled === update.jobStatusSettled;
+        if (existing && statusUnchanged && settledUnchanged) {
+          continue;
         }
-
-        return {
-          ...job,
+        next.set(update.jobId, {
           status: update.jobStatus,
           jobStatusSettled: update.jobStatusSettled,
-          ...(update.jobStatus === SokosumiJobStatus.COMPLETED &&
-            job.completedAt === null && { completedAt: completedAtFallback }),
-        };
-      });
-
-    setLocalJobs(updater);
-    setFilteredJobs(updater);
+          ...(update.jobStatus === SokosumiJobStatus.COMPLETED
+            ? { completedAt: existing?.completedAt ?? completedAtFallback }
+            : {}),
+        });
+      }
+      return next;
+    });
   }
 
   function handleJobClick(job: JobSummary) {
@@ -199,9 +203,15 @@ export function JobsList({
     startLoadMoreTransition(async () => {
       try {
         const result = await loadMoreOwnedAgentJobs(agentId, cursor);
-        hasAppendedViaLoadMoreRef.current = true;
-        setLocalJobs((prev) => appendUniqueJobs(prev, result.jobs));
-        setNextCursor(result.nextCursor);
+        setAppendedJobs((prev) => {
+          const existingIds = new Set([
+            ...jobs.map((job) => job.id),
+            ...prev.map((job) => job.id),
+          ]);
+          const unique = result.jobs.filter((job) => !existingIds.has(job.id));
+          return [...prev, ...unique];
+        });
+        setLoadMoreCursor(result.nextCursor);
       } catch {
         toast.error(t("loadMoreError"));
       }

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
@@ -231,6 +231,7 @@ export function JobsList({
       <aside className="lg:border-border flex h-full min-h-0 w-full flex-col py-4 lg:w-72 lg:border-r">
         <JobsSearch
           jobs={localJobs}
+          hasMoreHistory={Boolean(nextCursor)}
           onFilteredChange={(nextJobs) => setFilteredJobs(nextJobs)}
         />
 

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-list.tsx
@@ -3,8 +3,11 @@
 import { ChannelProvider, useChannel } from "ably/react";
 import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { loadMoreOwnedAgentJobs } from "@/app/agents/[agentId]/jobs/actions";
 import { getJobStatusDotColorClass } from "@/components/jobs/job-status-styles";
+import { Button } from "@/components/ui/button";
 import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import { jobStatusDataSchema, makeAgentJobsChannelName } from "@/lib/ably";
 import type { JobSummary } from "@/lib/clients/generated/core";
@@ -25,9 +28,19 @@ interface JobStatusUpdateData {
 
 interface JobsListProps {
   jobs: JobSummary[];
+  jobsNextCursor: string | null;
   userId: string;
   agentId: string;
   selectedJobId?: string;
+}
+
+function appendUniqueJobs(
+  existing: JobSummary[],
+  incoming: JobSummary[],
+): JobSummary[] {
+  const existingIds = new Set(existing.map((job) => job.id));
+  const unique = incoming.filter((job) => !existingIds.has(job.id));
+  return [...existing, ...unique];
 }
 
 function JobsStatusRealtimeListener({
@@ -96,6 +109,7 @@ function JobsStatusRealtimeListener({
 
 export function JobsList({
   jobs,
+  jobsNextCursor,
   userId,
   agentId,
   selectedJobId,
@@ -106,13 +120,27 @@ export function JobsList({
   const router = useRouter();
   const [localJobs, setLocalJobs] = useState<JobSummary[]>(jobs);
   const [filteredJobs, setFilteredJobs] = useState<JobSummary[]>(jobs);
+  const [nextCursor, setNextCursor] = useState(jobsNextCursor);
+  const [isLoadingMore, startLoadMoreTransition] = useTransition();
+  const hasAppendedViaLoadMoreRef = useRef(false);
   const activeJobId = selectedJobId ?? routeParams.jobId;
 
-  // Sync local state when jobs prop changes (e.g., after revalidatePath)
+  // Sync when jobs prop changes; keep load-more history (R7).
   useEffect(() => {
-    setLocalJobs(jobs);
-    setFilteredJobs(jobs);
-  }, [jobs]);
+    setLocalJobs((prev) => {
+      if (!hasAppendedViaLoadMoreRef.current) {
+        return jobs;
+      }
+      const firstPageIds = new Set(jobs.map((job) => job.id));
+      const older = prev.filter((job) => !firstPageIds.has(job.id));
+      return [...jobs, ...older];
+    });
+    setNextCursor((prev) =>
+      hasAppendedViaLoadMoreRef.current && prev !== null
+        ? prev
+        : jobsNextCursor,
+    );
+  }, [jobs, jobsNextCursor]);
 
   const dayGroups = useMemo(
     () => buildJobDayGroups(filteredJobs, locale),
@@ -165,6 +193,23 @@ export function JobsList({
     router.push(qs ? `${base}?${qs}` : base);
   }
 
+  function handleLoadMore() {
+    if (!nextCursor || isLoadingMore) {
+      return;
+    }
+    const cursor = nextCursor;
+    startLoadMoreTransition(async () => {
+      try {
+        const result = await loadMoreOwnedAgentJobs(agentId, cursor);
+        hasAppendedViaLoadMoreRef.current = true;
+        setLocalJobs((prev) => appendUniqueJobs(prev, result.jobs));
+        setNextCursor(result.nextCursor);
+      } catch {
+        toast.error(t("loadMoreError"));
+      }
+    });
+  }
+
   return (
     <>
       <LazyAblyProvider>
@@ -206,6 +251,20 @@ export function JobsList({
               {t("emptyJobs")}
             </div>
           )}
+          {nextCursor ? (
+            <div className="flex justify-center px-2 pb-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="text-muted-foreground hover:text-foreground w-full text-xs"
+                disabled={isLoadingMore}
+                onClick={handleLoadMore}
+              >
+                {isLoadingMore ? t("loading") : t("loadMore")}
+              </Button>
+            </div>
+          ) : null}
         </div>
       </aside>
     </>

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-search.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-search.tsx
@@ -29,10 +29,16 @@ function toSearchableJob(job: JobSummary): SearchableJob {
 
 interface JobsSearchProps {
   jobs: JobSummary[];
+  /** True when older jobs exist beyond the loaded pages (load-more available). */
+  hasMoreHistory?: boolean;
   onFilteredChange?: (filtered: JobSummary[], query: string) => void;
 }
 
-export function JobsSearch({ jobs, onFilteredChange }: JobsSearchProps) {
+export function JobsSearch({
+  jobs,
+  hasMoreHistory = false,
+  onFilteredChange,
+}: JobsSearchProps) {
   const t = useTranslations("Components.Jobs.JobsSearch");
 
   const [queryParam, setQueryParam] = useQueryState("query", {
@@ -96,14 +102,19 @@ export function JobsSearch({ jobs, onFilteredChange }: JobsSearchProps) {
           </button>
         ) : null}
       </div>
-      {searchValue && (
-        <div className="text-muted-foreground px-1 text-xs whitespace-nowrap md:text-sm">
-          {t("resultsCount", {
-            found: filteredJobs.length,
-            total: jobs.length,
-          })}
+      {searchValue ? (
+        <div className="text-muted-foreground flex flex-col gap-0.5 px-1 text-xs md:items-end md:text-sm">
+          <span className="whitespace-nowrap">
+            {t(hasMoreHistory ? "resultsCountLoaded" : "resultsCount", {
+              found: filteredJobs.length,
+              total: jobs.length,
+            })}
+          </span>
+          {hasMoreHistory ? (
+            <span className="text-xs">{t("loadedOnlyHint")}</span>
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/layout.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/layout.tsx
@@ -108,6 +108,7 @@ async function JobLayoutInner({
           <div className="flex w-full flex-col gap-4 lg:flex-row lg:items-start">
             <div className="w-full px-4 lg:sticky lg:top-16 lg:h-[calc(100svh-64px)] lg:w-72 lg:flex-none">
               <JobsList
+                key={agentId}
                 jobs={agentJobsPage.jobs}
                 jobsNextCursor={agentJobsPage.nextCursor}
                 userId={session.user.id}

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/layout.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/layout.tsx
@@ -77,7 +77,7 @@ async function JobLayoutInner({
     coreAgent?.metrics.executions.averageTime ?? null;
   const disabled = !coreAgent;
 
-  const [agentJobs, canRate, existingRating, projectOptions] =
+  const [agentJobsPage, canRate, existingRating, projectOptions] =
     await Promise.all([
       getCachedMyJobs(agentId),
       coreAgent
@@ -108,7 +108,8 @@ async function JobLayoutInner({
           <div className="flex w-full flex-col gap-4 lg:flex-row lg:items-start">
             <div className="w-full px-4 lg:sticky lg:top-16 lg:h-[calc(100svh-64px)] lg:w-72 lg:flex-none">
               <JobsList
-                jobs={agentJobs}
+                jobs={agentJobsPage.jobs}
+                jobsNextCursor={agentJobsPage.nextCursor}
                 userId={session.user.id}
                 agentId={agentId}
               />

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -97,7 +97,7 @@ async function ChatPageContent({ searchParams }: ChatPageProps) {
       );
     }
 
-    const [listedRooms, membersPage, coworkers, currentMember] =
+    const [listedRoomsPage, membersPage, coworkers, currentMember] =
       await Promise.all([
         chatRoomService.listRooms(),
         loadOrganizationMembers(activeOrganization.id),
@@ -110,7 +110,7 @@ async function ChatPageContent({ searchParams }: ChatPageProps) {
         {landingNotice}
         <RoomsClient
           activeOrganization={activeOrganization}
-          rooms={listedRooms}
+          rooms={listedRoomsPage.rooms}
           organizationMembers={membersPage.members}
           currentUserId={currentMember?.userId ?? ""}
           coworkers={coworkers}

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -7,7 +7,7 @@ import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
 import DefaultLoading from "@/components/default-loading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/auth.server";
-import { chatRoomService, userService } from "@/lib/services";
+import { userService } from "@/lib/services";
 import { coworkerService } from "@/lib/services/coworker.service";
 
 import { RoomsClient } from "./components/rooms-client";
@@ -97,20 +97,20 @@ async function ChatPageContent({ searchParams }: ChatPageProps) {
       );
     }
 
-    const [listedRoomsPage, membersPage, coworkers, currentMember] =
-      await Promise.all([
-        chatRoomService.listRooms(),
-        loadOrganizationMembers(activeOrganization.id),
-        coworkerService.listCoworkers("chat"),
-        userService.getMyMemberInOrganization(activeOrganization.id),
-      ]);
+    // Create/DM drafts do not need a rooms list — RoomsClient only looks up
+    // selectedRoom by id, and sidebar already owns paginated room history.
+    const [membersPage, coworkers, currentMember] = await Promise.all([
+      loadOrganizationMembers(activeOrganization.id),
+      coworkerService.listCoworkers("chat"),
+      userService.getMyMemberInOrganization(activeOrganization.id),
+    ]);
 
     return (
       <>
         {landingNotice}
         <RoomsClient
           activeOrganization={activeOrganization}
-          rooms={listedRoomsPage.rooms}
+          rooms={[]}
           organizationMembers={membersPage.members}
           currentUserId={currentMember?.userId ?? ""}
           coworkers={coworkers}

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -9,7 +9,11 @@ import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-ven
 import { getEnvPublicConfig } from "@/config/env.public";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
-import { chatRoomService, userService } from "@/lib/services";
+import {
+  type ChatRoomsPage,
+  chatRoomService,
+  userService,
+} from "@/lib/services";
 import {
   resolvePlanName,
   resolvePlanSecondaryLabel,
@@ -28,6 +32,11 @@ interface PrivateCachedAppSidebarProps {
   activeOrganizationId: string | null;
   adminMenuEnabled: boolean;
 }
+
+const EMPTY_ROOMS_PAGE: ChatRoomsPage = {
+  rooms: [],
+  nextCursor: null,
+};
 
 /**
  * Session-aware sidebar chrome for Instant Navigations.
@@ -58,16 +67,12 @@ export default async function PrivateCachedAppSidebar({
     .catch(() => []);
   // Personal coworker directs exist with no active org; Core returns those when
   // organization context is null. Named channels still need an org (empty list then).
-  const emptyRoomsPage = {
-    rooms: [] as Awaited<ReturnType<typeof chatRoomService.listRooms>>["rooms"],
-    nextCursor: null as string | null,
-  };
   const chatRoomsPromise = chatRoomService
     .listRooms()
-    .catch(() => emptyRoomsPage);
+    .catch(() => EMPTY_ROOMS_PAGE);
   const archivedChatRoomsPromise = activeOrganizationId
-    ? chatRoomService.listArchivedRooms().catch(() => emptyRoomsPage)
-    : Promise.resolve(emptyRoomsPage);
+    ? chatRoomService.listArchivedRooms().catch(() => EMPTY_ROOMS_PAGE)
+    : Promise.resolve(EMPTY_ROOMS_PAGE);
   const activeOrganizationPromise = userService.getActiveOrganization();
   const creditsPromise = getCachedMyCredits();
 

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -58,12 +58,16 @@ export default async function PrivateCachedAppSidebar({
     .catch(() => []);
   // Personal coworker directs exist with no active org; Core returns those when
   // organization context is null. Named channels still need an org (empty list then).
-  const chatRoomsPromise = chatRoomService.listRooms().catch(() => []);
+  const emptyRoomsPage = {
+    rooms: [] as Awaited<ReturnType<typeof chatRoomService.listRooms>>["rooms"],
+    nextCursor: null as string | null,
+  };
+  const chatRoomsPromise = chatRoomService
+    .listRooms()
+    .catch(() => emptyRoomsPage);
   const archivedChatRoomsPromise = activeOrganizationId
-    ? chatRoomService.listArchivedRooms().catch(() => [])
-    : Promise.resolve(
-        [] as Awaited<ReturnType<typeof chatRoomService.listArchivedRooms>>,
-      );
+    ? chatRoomService.listArchivedRooms().catch(() => emptyRoomsPage)
+    : Promise.resolve(emptyRoomsPage);
   const activeOrganizationPromise = userService.getActiveOrganization();
   const creditsPromise = getCachedMyCredits();
 
@@ -71,8 +75,8 @@ export default async function PrivateCachedAppSidebar({
     tCredit,
     tPlan,
     members,
-    chatRooms,
-    archivedChatRooms,
+    chatRoomsPage,
+    archivedChatRoomsPage,
     { showVendors: showDeveloperVendors },
     activeOrganization,
     creditsResult,
@@ -86,6 +90,11 @@ export default async function PrivateCachedAppSidebar({
     activeOrganizationPromise,
     creditsPromise,
   ]);
+
+  const chatRooms = chatRoomsPage.rooms;
+  const chatRoomsNextCursor = chatRoomsPage.nextCursor;
+  const archivedChatRooms = archivedChatRoomsPage.rooms;
+  const archivedChatRoomsNextCursor = archivedChatRoomsPage.nextCursor;
 
   const creditsData = creditsResult?.data.credits ?? null;
   const currentPlan = creditsData?.subscription?.plan ?? "free";
@@ -134,10 +143,12 @@ export default async function PrivateCachedAppSidebar({
         activeOrganizationId={activeOrganizationId}
         adminMenuEnabled={adminMenuEnabled}
         archivedChatRooms={archivedChatRooms}
+        archivedChatRoomsNextCursor={archivedChatRoomsNextCursor}
         buyCreditsLabel={tPlan("getMoreCredits")}
         buyCreditsPath={buyCreditsPath}
         canDeleteArchivedRooms={canDeleteArchivedRooms}
         chatRooms={chatRooms}
+        chatRoomsNextCursor={chatRoomsNextCursor}
         creditsData={creditsData}
         creditUsage={resolveCreditUsage(creditsData)}
         currentTimestampMs={currentTimestampMs}

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -52,10 +52,12 @@ interface SidebarProps {
   activeOrganizationId: string | null;
   adminMenuEnabled: boolean;
   archivedChatRooms: ChatRoom[];
+  archivedChatRoomsNextCursor: string | null;
   buyCreditsLabel: string;
   buyCreditsPath: string;
   canDeleteArchivedRooms: boolean;
   chatRooms: ChatRoom[];
+  chatRoomsNextCursor: string | null;
   creditsData: SidebarCreditsData | null;
   creditUsage: CreditUsage | null;
   currentTimestampMs: number;
@@ -74,10 +76,12 @@ export default function Sidebar({
   activeOrganizationId,
   adminMenuEnabled,
   archivedChatRooms,
+  archivedChatRoomsNextCursor,
   buyCreditsLabel,
   buyCreditsPath,
   canDeleteArchivedRooms,
   chatRooms,
+  chatRoomsNextCursor,
   creditsData,
   creditUsage,
   currentTimestampMs,
@@ -115,8 +119,11 @@ export default function Sidebar({
             <AdminSettingsMenuGroup adminMenuEnabled={adminMenuEnabled} />
             <SidebarSeparator />
             <OrganizationChatList
+              key={activeOrganizationId ?? "personal"}
               rooms={chatRooms}
+              roomsNextCursor={chatRoomsNextCursor}
               archivedRooms={archivedChatRooms}
+              archivedRoomsNextCursor={archivedChatRoomsNextCursor}
               currentUserId={currentUserId}
               organizationId={activeOrganizationId}
               canDeleteArchivedRooms={canDeleteArchivedRooms}

--- a/apps/web/src/components/chat/organization-chat-list.actions.ts
+++ b/apps/web/src/components/chat/organization-chat-list.actions.ts
@@ -4,7 +4,7 @@ import type { ChatRoom } from "@/lib/clients/generated/core";
 import { chatRoomService } from "@/lib/services";
 
 type OrganizationChatListActionResult =
-  | { ok: true; data: ChatRoom[] }
+  | { ok: true; data: ChatRoom[]; nextCursor: string | null }
   | { ok: false };
 
 type OrganizationChatRoomMutationResult =
@@ -14,8 +14,8 @@ type OrganizationChatRoomMutationResult =
 export async function listOrganizationChatRoomsAction(): Promise<OrganizationChatListActionResult> {
   try {
     // With no active org, Core lists personal coworker directs only.
-    const rooms = await chatRoomService.listRooms();
-    return { ok: true, data: rooms };
+    const page = await chatRoomService.listRooms();
+    return { ok: true, data: page.rooms, nextCursor: page.nextCursor };
   } catch {
     return { ok: false };
   }
@@ -23,8 +23,44 @@ export async function listOrganizationChatRoomsAction(): Promise<OrganizationCha
 
 export async function listOrganizationArchivedChatRoomsAction(): Promise<OrganizationChatListActionResult> {
   try {
-    const rooms = await chatRoomService.listArchivedRooms();
-    return { ok: true, data: rooms };
+    const page = await chatRoomService.listArchivedRooms();
+    return { ok: true, data: page.rooms, nextCursor: page.nextCursor };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function loadMoreOrganizationChatRoomsAction(
+  cursor: string,
+): Promise<OrganizationChatListActionResult> {
+  const cleanCursor = cursor.trim();
+  if (!cleanCursor) {
+    return { ok: false };
+  }
+
+  try {
+    const page = await chatRoomService.listRooms(undefined, "active", {
+      cursor: cleanCursor,
+    });
+    return { ok: true, data: page.rooms, nextCursor: page.nextCursor };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function loadMoreOrganizationArchivedChatRoomsAction(
+  cursor: string,
+): Promise<OrganizationChatListActionResult> {
+  const cleanCursor = cursor.trim();
+  if (!cleanCursor) {
+    return { ok: false };
+  }
+
+  try {
+    const page = await chatRoomService.listArchivedRooms({
+      cursor: cleanCursor,
+    });
+    return { ok: true, data: page.rooms, nextCursor: page.nextCursor };
   } catch {
     return { ok: false };
   }

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -285,17 +285,17 @@ export function OrganizationChatList({
     setRoomRows((current) =>
       applyRoomReadOverlays(upsertFirstPageRooms(rooms, current)),
     );
+    // After any load-more, poll/RSC must not revive first-page nextCursor
+    // (would re-show Load more after history exhausted).
     setActiveNextCursor((prev) =>
-      hasAppendedActiveRef.current && prev !== null ? prev : roomsNextCursor,
+      hasAppendedActiveRef.current ? prev : roomsNextCursor,
     );
   }, [rooms, roomsNextCursor]);
 
   useEffect(() => {
     setArchivedRows((current) => upsertFirstPageRooms(archivedRooms, current));
     setArchivedNextCursor((prev) =>
-      hasAppendedArchivedRef.current && prev !== null
-        ? prev
-        : archivedRoomsNextCursor,
+      hasAppendedArchivedRef.current ? prev : archivedRoomsNextCursor,
     );
   }, [archivedRooms, archivedRoomsNextCursor]);
 
@@ -323,9 +323,7 @@ export function OrganizationChatList({
           ),
         );
         setActiveNextCursor((prev) =>
-          hasAppendedActiveRef.current && prev !== null
-            ? prev
-            : activeResult.nextCursor,
+          hasAppendedActiveRef.current ? prev : activeResult.nextCursor,
         );
       }
       if (archivedResult.ok) {
@@ -333,9 +331,7 @@ export function OrganizationChatList({
           upsertFirstPageRooms(archivedResult.data, current),
         );
         setArchivedNextCursor((prev) =>
-          hasAppendedArchivedRef.current && prev !== null
-            ? prev
-            : archivedResult.nextCursor,
+          hasAppendedArchivedRef.current ? prev : archivedResult.nextCursor,
         );
       }
     };
@@ -429,9 +425,7 @@ export function OrganizationChatList({
             ),
           );
           setActiveNextCursor((prev) =>
-            hasAppendedActiveRef.current && prev !== null
-              ? prev
-              : activeResult.nextCursor,
+            hasAppendedActiveRef.current ? prev : activeResult.nextCursor,
           );
         }
         if (archivedResult.ok) {
@@ -439,9 +433,7 @@ export function OrganizationChatList({
             upsertFirstPageRooms(archivedResult.data, current),
           );
           setArchivedNextCursor((prev) =>
-            hasAppendedArchivedRef.current && prev !== null
-              ? prev
-              : archivedResult.nextCursor,
+            hasAppendedArchivedRef.current ? prev : archivedResult.nextCursor,
           );
         }
       });

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -15,6 +15,7 @@ import {
   type ReactNode,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useTransition,
 } from "react";
@@ -68,6 +69,8 @@ import { ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT } from "./organization-chat-event
 import {
   listOrganizationArchivedChatRoomsAction,
   listOrganizationChatRoomsAction,
+  loadMoreOrganizationArchivedChatRoomsAction,
+  loadMoreOrganizationChatRoomsAction,
 } from "./organization-chat-list.actions";
 import {
   applyRoomReadOverlays,
@@ -77,13 +80,34 @@ import {
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
 
+/** Upsert first-page rooms; keep older rows previously appended via load-more. */
+function upsertFirstPageRooms(
+  firstPage: ChatRoom[],
+  existing: ChatRoom[],
+): ChatRoom[] {
+  const firstPageIds = new Set(firstPage.map((room) => room.id));
+  const older = existing.filter((room) => !firstPageIds.has(room.id));
+  return [...firstPage, ...older];
+}
+
+function appendUniqueRooms(
+  existing: ChatRoom[],
+  incoming: ChatRoom[],
+): ChatRoom[] {
+  const existingIds = new Set(existing.map((room) => room.id));
+  const unique = incoming.filter((room) => !existingIds.has(room.id));
+  return [...existing, ...unique];
+}
+
 /** Same absolute slot as live room rows so archived height matches Channels/DMs. */
 const ARCHIVED_TRAILING_CONTROL_CLASS =
   "absolute top-1/2 right-1 z-10 flex size-7 -translate-y-1/2 items-center justify-center";
 
 interface OrganizationChatListProps {
   rooms: ChatRoom[];
+  roomsNextCursor: string | null;
   archivedRooms: ChatRoom[];
+  archivedRoomsNextCursor: string | null;
   currentUserId: string;
   organizationId: string | null;
   canDeleteArchivedRooms?: boolean;
@@ -218,7 +242,9 @@ function getActiveRoomIdFromPathname(pathname: string | null): string | null {
 
 export function OrganizationChatList({
   rooms,
+  roomsNextCursor,
   archivedRooms,
+  archivedRoomsNextCursor,
   currentUserId,
   organizationId,
   canDeleteArchivedRooms = false,
@@ -230,6 +256,10 @@ export function OrganizationChatList({
   const hasOrganization = Boolean(organizationId);
   const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
   const [archivedRows, setArchivedRows] = useState(archivedRooms);
+  const [activeNextCursor, setActiveNextCursor] = useState(roomsNextCursor);
+  const [archivedNextCursor, setArchivedNextCursor] = useState(
+    archivedRoomsNextCursor,
+  );
   const [channelSectionOpen, setChannelSectionOpen] = useState(true);
   const [archivedSectionOpen, setArchivedSectionOpen] = useState(false);
   const [directOpen, setDirectOpen] = useState(true);
@@ -240,6 +270,11 @@ export function OrganizationChatList({
   );
   const [_isRestoring, startRestoreTransition] = useTransition();
   const [_isDeleting, startDeleteTransition] = useTransition();
+  const [isLoadingMoreActive, startLoadMoreActiveTransition] = useTransition();
+  const [isLoadingMoreArchived, startLoadMoreArchivedTransition] =
+    useTransition();
+  const hasAppendedActiveRef = useRef(false);
+  const hasAppendedArchivedRef = useRef(false);
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
   const unreadRoomCount = countChatRoomsWithUnreadAttention(roomRows, {
     activeRoomId,
@@ -247,12 +282,22 @@ export function OrganizationChatList({
   useChatUnreadDocumentTitle(unreadRoomCount);
 
   useEffect(() => {
-    setRoomRows(applyRoomReadOverlays(rooms));
-  }, [rooms]);
+    setRoomRows((current) =>
+      applyRoomReadOverlays(upsertFirstPageRooms(rooms, current)),
+    );
+    setActiveNextCursor((prev) =>
+      hasAppendedActiveRef.current && prev !== null ? prev : roomsNextCursor,
+    );
+  }, [rooms, roomsNextCursor]);
 
   useEffect(() => {
-    setArchivedRows(archivedRooms);
-  }, [archivedRooms]);
+    setArchivedRows((current) => upsertFirstPageRooms(archivedRooms, current));
+    setArchivedNextCursor((prev) =>
+      hasAppendedArchivedRef.current && prev !== null
+        ? prev
+        : archivedRoomsNextCursor,
+    );
+  }, [archivedRooms, archivedRoomsNextCursor]);
 
   useEffect(() => {
     let cancelled = false;
@@ -262,16 +307,36 @@ export function OrganizationChatList({
         listOrganizationChatRoomsAction(),
         hasOrganization
           ? listOrganizationArchivedChatRoomsAction()
-          : Promise.resolve({ ok: true as const, data: [] as ChatRoom[] }),
+          : Promise.resolve({
+              ok: true as const,
+              data: [] as ChatRoom[],
+              nextCursor: null as string | null,
+            }),
       ]);
       if (cancelled) {
         return;
       }
       if (activeResult.ok) {
-        setRoomRows(applyRoomReadOverlays(activeResult.data));
+        setRoomRows((current) =>
+          applyRoomReadOverlays(
+            upsertFirstPageRooms(activeResult.data, current),
+          ),
+        );
+        setActiveNextCursor((prev) =>
+          hasAppendedActiveRef.current && prev !== null
+            ? prev
+            : activeResult.nextCursor,
+        );
       }
       if (archivedResult.ok) {
-        setArchivedRows(archivedResult.data);
+        setArchivedRows((current) =>
+          upsertFirstPageRooms(archivedResult.data, current),
+        );
+        setArchivedNextCursor((prev) =>
+          hasAppendedArchivedRef.current && prev !== null
+            ? prev
+            : archivedResult.nextCursor,
+        );
       }
     };
 
@@ -348,16 +413,36 @@ export function OrganizationChatList({
         listOrganizationChatRoomsAction(),
         hasOrganization
           ? listOrganizationArchivedChatRoomsAction()
-          : Promise.resolve({ ok: true as const, data: [] as ChatRoom[] }),
+          : Promise.resolve({
+              ok: true as const,
+              data: [] as ChatRoom[],
+              nextCursor: null as string | null,
+            }),
       ]).then(([activeResult, archivedResult]) => {
         if (cancelled) {
           return;
         }
         if (activeResult.ok) {
-          setRoomRows(applyRoomReadOverlays(activeResult.data));
+          setRoomRows((current) =>
+            applyRoomReadOverlays(
+              upsertFirstPageRooms(activeResult.data, current),
+            ),
+          );
+          setActiveNextCursor((prev) =>
+            hasAppendedActiveRef.current && prev !== null
+              ? prev
+              : activeResult.nextCursor,
+          );
         }
         if (archivedResult.ok) {
-          setArchivedRows(archivedResult.data);
+          setArchivedRows((current) =>
+            upsertFirstPageRooms(archivedResult.data, current),
+          );
+          setArchivedNextCursor((prev) =>
+            hasAppendedArchivedRef.current && prev !== null
+              ? prev
+              : archivedResult.nextCursor,
+          );
         }
       });
     };
@@ -429,6 +514,42 @@ export function OrganizationChatList({
         current.map((room) => (room.id === updated.id ? updated : room)),
       ),
     );
+  }
+
+  function handleLoadMoreActiveRooms() {
+    if (!activeNextCursor || isLoadingMoreActive) {
+      return;
+    }
+    const cursor = activeNextCursor;
+    startLoadMoreActiveTransition(async () => {
+      const result = await loadMoreOrganizationChatRoomsAction(cursor);
+      if (!result.ok) {
+        toast.error(t("loadMoreError"));
+        return;
+      }
+      hasAppendedActiveRef.current = true;
+      setRoomRows((current) =>
+        applyRoomReadOverlays(appendUniqueRooms(current, result.data)),
+      );
+      setActiveNextCursor(result.nextCursor);
+    });
+  }
+
+  function handleLoadMoreArchivedRooms() {
+    if (!archivedNextCursor || isLoadingMoreArchived) {
+      return;
+    }
+    const cursor = archivedNextCursor;
+    startLoadMoreArchivedTransition(async () => {
+      const result = await loadMoreOrganizationArchivedChatRoomsAction(cursor);
+      if (!result.ok) {
+        toast.error(t("loadMoreError"));
+        return;
+      }
+      hasAppendedArchivedRef.current = true;
+      setArchivedRows((current) => appendUniqueRooms(current, result.data));
+      setArchivedNextCursor(result.nextCursor);
+    });
   }
 
   const { directMessages, namedChannels } = useMemo(() => {
@@ -612,6 +733,22 @@ export function OrganizationChatList({
                     </SidebarMenuItem>
                   );
                 })}
+                {archivedNextCursor ? (
+                  <SidebarMenuItem>
+                    <div className="group-data-[collapsible=icon]:hidden px-3 py-1">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="text-muted-foreground hover:text-foreground w-full text-xs"
+                        disabled={isLoadingMoreArchived}
+                        onClick={handleLoadMoreArchivedRooms}
+                      >
+                        {isLoadingMoreArchived ? t("loading") : t("loadMore")}
+                      </Button>
+                    </div>
+                  </SidebarMenuItem>
+                ) : null}
               </SidebarMenu>
             </CollapsibleContent>
           </Collapsible>
@@ -701,6 +838,21 @@ export function OrganizationChatList({
             </SidebarMenu>
           </CollapsibleContent>
         </Collapsible>
+
+        {activeNextCursor ? (
+          <div className="group-data-[collapsible=icon]:hidden px-3 py-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground w-full text-xs"
+              disabled={isLoadingMoreActive}
+              onClick={handleLoadMoreActiveRooms}
+            >
+              {isLoadingMoreActive ? t("loading") : t("loadMore")}
+            </Button>
+          </div>
+        ) : null}
       </SidebarGroupContent>
     </SidebarGroup>
   );

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -260,6 +260,12 @@ export function OrganizationChatList({
   const [archivedNextCursor, setArchivedNextCursor] = useState(
     archivedRoomsNextCursor,
   );
+  const [prevRooms, setPrevRooms] = useState(rooms);
+  const [prevRoomsNextCursor, setPrevRoomsNextCursor] =
+    useState(roomsNextCursor);
+  const [prevArchivedRooms, setPrevArchivedRooms] = useState(archivedRooms);
+  const [prevArchivedRoomsNextCursor, setPrevArchivedRoomsNextCursor] =
+    useState(archivedRoomsNextCursor);
   const [channelSectionOpen, setChannelSectionOpen] = useState(true);
   const [archivedSectionOpen, setArchivedSectionOpen] = useState(false);
   const [directOpen, setDirectOpen] = useState(true);
@@ -281,23 +287,26 @@ export function OrganizationChatList({
   });
   useChatUnreadDocumentTitle(unreadRoomCount);
 
-  useEffect(() => {
-    setRoomRows((current) =>
-      applyRoomReadOverlays(upsertFirstPageRooms(rooms, current)),
-    );
-    // After any load-more, poll/RSC must not revive first-page nextCursor
-    // (would re-show Load more after history exhausted).
-    setActiveNextCursor((prev) =>
-      hasAppendedActiveRef.current ? prev : roomsNextCursor,
-    );
-  }, [rooms, roomsNextCursor]);
-
-  useEffect(() => {
-    setArchivedRows((current) => upsertFirstPageRooms(archivedRooms, current));
-    setArchivedNextCursor((prev) =>
-      hasAppendedArchivedRef.current ? prev : archivedRoomsNextCursor,
-    );
-  }, [archivedRooms, archivedRoomsNextCursor]);
+  // Adjust local list when RSC props change (no Effect — keep load-more history).
+  if (rooms !== prevRooms || roomsNextCursor !== prevRoomsNextCursor) {
+    setPrevRooms(rooms);
+    setPrevRoomsNextCursor(roomsNextCursor);
+    setRoomRows(applyRoomReadOverlays(upsertFirstPageRooms(rooms, roomRows)));
+    if (!hasAppendedActiveRef.current) {
+      setActiveNextCursor(roomsNextCursor);
+    }
+  }
+  if (
+    archivedRooms !== prevArchivedRooms ||
+    archivedRoomsNextCursor !== prevArchivedRoomsNextCursor
+  ) {
+    setPrevArchivedRooms(archivedRooms);
+    setPrevArchivedRoomsNextCursor(archivedRoomsNextCursor);
+    setArchivedRows(upsertFirstPageRooms(archivedRooms, archivedRows));
+    if (!hasAppendedArchivedRef.current) {
+      setArchivedNextCursor(archivedRoomsNextCursor);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
@@ -47,15 +47,18 @@ function room(id: string) {
   };
 }
 
-function emptyPage(data: ReturnType<typeof room>[]) {
+function emptyPage(
+  data: ReturnType<typeof room>[],
+  nextCursor: string | null = null,
+) {
   return {
     data,
     meta: {
       pagination: {
         cursor: null,
-        limit: 100,
+        limit: 20,
         total: data.length,
-        nextCursor: null,
+        nextCursor,
       },
     },
   };
@@ -67,59 +70,47 @@ describe("chatRoomService.listRooms", () => {
     vi.resetModules();
   });
 
-  it("walks nextCursor until exhausted", async () => {
-    getChatRoomsMock
-      .mockResolvedValueOnce({
-        data: [room("room-1"), room("room-2")],
-        meta: {
-          pagination: {
-            cursor: null,
-            limit: 100,
-            total: 3,
-            nextCursor: "room-2",
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        data: [room("room-3")],
-        meta: {
-          pagination: {
-            cursor: "room-2",
-            limit: 100,
-            total: 3,
-            nextCursor: null,
-          },
-        },
-      });
+  it("returns a single page and does not walk nextCursor", async () => {
+    getChatRoomsMock.mockResolvedValueOnce(
+      emptyPage([room("room-1"), room("room-2")], "room-2"),
+    );
 
     const { chatRoomService } = await import("../chat-room.service");
-    const rooms = await chatRoomService.listRooms();
+    const page = await chatRoomService.listRooms();
 
-    expect(rooms.map((item) => item.id)).toEqual([
-      "room-1",
-      "room-2",
-      "room-3",
-    ]);
-    expect(getChatRoomsMock).toHaveBeenCalledTimes(2);
-    expect(getChatRoomsMock).toHaveBeenNthCalledWith(1, {
-      limit: 100,
+    expect(page.rooms.map((item) => item.id)).toEqual(["room-1", "room-2"]);
+    expect(page.nextCursor).toBe("room-2");
+    expect(getChatRoomsMock).toHaveBeenCalledTimes(1);
+    expect(getChatRoomsMock).toHaveBeenCalledWith({
+      limit: 20,
       status: "active",
     });
-    expect(getChatRoomsMock).toHaveBeenNthCalledWith(2, {
-      limit: 100,
+  });
+
+  it("passes cursor for load-more", async () => {
+    getChatRoomsMock.mockResolvedValueOnce(emptyPage([room("room-3")]));
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const page = await chatRoomService.listRooms(undefined, "active", {
+      cursor: "room-2",
+    });
+
+    expect(page.rooms.map((item) => item.id)).toEqual(["room-3"]);
+    expect(getChatRoomsMock).toHaveBeenCalledWith({
+      limit: 20,
       status: "active",
       cursor: "room-2",
     });
   });
 
-  it("passes kind filter on every page", async () => {
+  it("passes kind filter", async () => {
     getChatRoomsMock.mockResolvedValue(emptyPage([room("dm-1")]));
 
     const { chatRoomService } = await import("../chat-room.service");
     await chatRoomService.listRooms("direct");
 
     expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 100,
+      limit: 20,
       status: "active",
       kind: "direct",
     });
@@ -129,11 +120,11 @@ describe("chatRoomService.listRooms", () => {
     getChatRoomsMock.mockResolvedValue(emptyPage([room("archived-1")]));
 
     const { chatRoomService } = await import("../chat-room.service");
-    const rooms = await chatRoomService.listRooms("channel", "archived");
+    const page = await chatRoomService.listRooms("channel", "archived");
 
-    expect(rooms.map((item) => item.id)).toEqual(["archived-1"]);
+    expect(page.rooms.map((item) => item.id)).toEqual(["archived-1"]);
     expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 100,
+      limit: 20,
       status: "archived",
       kind: "channel",
     });
@@ -272,15 +263,19 @@ describe("chatRoomService.listArchivedRooms", () => {
     vi.resetModules();
   });
 
-  it("requests archived organization channels", async () => {
-    getChatRoomsMock.mockResolvedValue(emptyPage([room("archived-1")]));
+  it("requests archived organization channels as a single page", async () => {
+    getChatRoomsMock.mockResolvedValue(
+      emptyPage([room("archived-1")], "archived-1"),
+    );
 
     const { chatRoomService } = await import("../chat-room.service");
-    const rooms = await chatRoomService.listArchivedRooms();
+    const page = await chatRoomService.listArchivedRooms();
 
-    expect(rooms.map((item) => item.id)).toEqual(["archived-1"]);
+    expect(page.rooms.map((item) => item.id)).toEqual(["archived-1"]);
+    expect(page.nextCursor).toBe("archived-1");
+    expect(getChatRoomsMock).toHaveBeenCalledTimes(1);
     expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 100,
+      limit: 20,
       status: "archived",
       kind: "channel",
     });

--- a/apps/web/src/lib/services/chat-room.service.ts
+++ b/apps/web/src/lib/services/chat-room.service.ts
@@ -16,9 +16,11 @@ import type {
 } from "@/lib/clients/generated/core";
 
 const ROOM_MESSAGE_LIMIT = 100;
-/** Matches Core `LIMITS.MAX_PAGINATION_LIMIT` for room list pages. */
-const ROOM_LIST_PAGE_LIMIT = 100;
-/** Hard stop so a bad nextCursor cannot loop forever. */
+/** Cold fill / poll / load-more page size — Core default and tasks parity. */
+const ROOM_LIST_PAGE_LIMIT = 20;
+/** Discoverable browse may still walk multiple pages up to Core max page size. */
+const DISCOVERABLE_CHANNEL_PAGE_LIMIT = 100;
+/** Hard stop so a bad nextCursor cannot loop forever on discoverable walks. */
 const ROOM_LIST_MAX_PAGES = 50;
 
 export interface ChatRoomMessagesPage {
@@ -26,30 +28,28 @@ export interface ChatRoomMessagesPage {
   nextCursor: string | null;
 }
 
+export interface ChatRoomsPage {
+  rooms: ChatRoom[];
+  nextCursor: string | null;
+}
+
 export const chatRoomService = (() => {
   const listRooms = cache(async function listRooms(
     kind?: ChatRoomKind,
     status: "active" | "archived" = "active",
-  ): Promise<ChatRoom[]> {
-    const rooms: ChatRoom[] = [];
-    let cursor: string | undefined;
-
-    for (let page = 0; page < ROOM_LIST_MAX_PAGES; page += 1) {
-      const response = await coreClient.getChatRooms({
-        limit: ROOM_LIST_PAGE_LIMIT,
-        status,
-        ...(kind ? { kind } : {}),
-        ...(cursor ? { cursor } : {}),
-      });
-      rooms.push(...response.data);
-      const nextCursor = response.meta?.pagination?.nextCursor ?? null;
-      if (!nextCursor) {
-        return rooms;
-      }
-      cursor = nextCursor;
-    }
-
-    return rooms;
+    options?: { cursor?: string },
+  ): Promise<ChatRoomsPage> {
+    const cursor = options?.cursor;
+    const response = await coreClient.getChatRooms({
+      limit: ROOM_LIST_PAGE_LIMIT,
+      status,
+      ...(kind ? { kind } : {}),
+      ...(cursor ? { cursor } : {}),
+    });
+    return {
+      rooms: response.data,
+      nextCursor: response.meta?.pagination?.nextCursor ?? null,
+    };
   });
 
   async function listDiscoverableChannels(options?: {
@@ -67,7 +67,7 @@ export const chatRoomService = (() => {
 
     for (let page = 0; page < maxPages; page += 1) {
       const response = await coreClient.getDiscoverableChatRooms({
-        limit: ROOM_LIST_PAGE_LIMIT,
+        limit: DISCOVERABLE_CHANNEL_PAGE_LIMIT,
         ...(q ? { q } : {}),
         ...(cursor ? { cursor } : {}),
       });
@@ -82,10 +82,10 @@ export const chatRoomService = (() => {
     return rooms;
   }
 
-  const listArchivedRooms = cache(async function listArchivedRooms(): Promise<
-    ChatRoom[]
-  > {
-    return listRooms("channel", "archived");
+  const listArchivedRooms = cache(async function listArchivedRooms(options?: {
+    cursor?: string;
+  }): Promise<ChatRoomsPage> {
+    return listRooms("channel", "archived", options);
   });
 
   const getRoom = cache(async function getRoom(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-722](https://linear.app/masumi/issue/SOK-722/sidebar-and-jobs-list-stop-fetching-entire-histories-on).

## Summary
- Cold fill for sidebar rooms/archived and agent owned jobs now fetches **one page** (`limit: 20`) instead of walking every cursor page.
- Explicit **Load more** reaches older history (tasks-style); poll/refresh upserts first page and keeps appended older rows.
- Private sidebar cache unchanged in shape; only the cold request is lean.
- No Core/Ably/notification changes.

## Follow-up (closed in this PR)
- Removed prop→state sync Effects in `JobsList` / `OrganizationChatList` (CodeRabbit).
- Dropped unused `listRooms()` on `/chat` create/DM landing — RoomsClient only needs `selectedRoom` by id; sidebar owns history.
- Job search copy clarifies loaded-only scope when load-more remains (catalog search API stays out of scope).

## Verification
- Merged latest `main` (`a022e244` jobCount denormalize)
- CI: all checks green at pinned `headSha` `d92dd98e89578418c76aad01572802100aad90a0`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOK-722](https://linear.app/masumi/issue/SOK-722/sidebar-and-jobs-list-stop-fetching-entire-histories-on-first-paint)

<div><a href="https://cursor.com/agents/bc-42ff8d59-0191-4acb-83f9-f16b9ccaa37f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42ff8d59-0191-4acb-83f9-f16b9ccaa37f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

