### PR TITLE
fix(chat): keep thread replies out of room timeline

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
@@ -16,18 +16,29 @@ describe("RoomsClient Ably island", () => {
     expect(source).toContain('<main className="relative flex min-h-0 flex-1">');
   });
 
-  it("keeps thread replies out of the main room timeline on realtime + display", () => {
+  it("routes realtime through scope helper and only merges room on top-level", () => {
     const source = readFileSync(
       join(import.meta.dirname, "../rooms-client.tsx"),
       "utf8",
     );
 
     // Regression: thread panel send must not also paint in the room list.
-    expect(source).toContain("shouldMergeRealtimeMessageIntoRoomTimeline");
-    expect(source).toContain("shouldApplyRealtimeMessageToOpenThread");
-    expect(source).toContain("isTopLevelChatRoomMessage");
+    // Assert control flow, not mere identifier presence (identifier-only can
+    // pass while setMessagesState still always runs).
+    expect(source).toContain("routeRealtimeChatRoomMessage");
+    expect(source).toContain("filterTopLevelChatRoomMessages");
+    expect(source).toContain("isReplyUnderThreadParent");
     expect(source).toMatch(
-      /messagesState\.filter\(\s*isTopLevelChatRoomMessage\s*\)/,
+      /const route = routeRealtimeChatRoomMessage\(\s*message,\s*threadParentMessageIdRef\.current,\s*\)/,
+    );
+    expect(source).toMatch(
+      /if \(route\.mergeIntoRoomTimeline\) \{\s*setMessagesState/,
+    );
+    expect(source).toMatch(
+      /if \(route\.mergeIntoOpenThread\) \{\s*setThreadMessages/,
+    );
+    expect(source).toMatch(
+      /filterTopLevelChatRoomMessages\(\s*messagesState\s*\)/,
     );
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
@@ -15,4 +15,19 @@ describe("RoomsClient Ably island", () => {
     );
     expect(source).toContain('<main className="relative flex min-h-0 flex-1">');
   });
+
+  it("keeps thread replies out of the main room timeline on realtime + display", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../rooms-client.tsx"),
+      "utf8",
+    );
+
+    // Regression: thread panel send must not also paint in the room list.
+    expect(source).toContain("shouldMergeRealtimeMessageIntoRoomTimeline");
+    expect(source).toContain("shouldApplyRealtimeMessageToOpenThread");
+    expect(source).toContain("isTopLevelChatRoomMessage");
+    expect(source).toMatch(
+      /messagesState\.filter\(\s*isTopLevelChatRoomMessage\s*\)/,
+    );
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -31,9 +31,10 @@ import {
 } from "@/app/chat/hooks/use-coworker-direct-room-stream";
 import { useStickToBottom } from "@/app/chat/hooks/use-stick-to-bottom";
 import {
+  filterTopLevelChatRoomMessages,
+  isReplyUnderThreadParent,
   isTopLevelChatRoomMessage,
-  shouldApplyRealtimeMessageToOpenThread,
-  shouldMergeRealtimeMessageIntoRoomTimeline,
+  routeRealtimeChatRoomMessage,
 } from "@/app/chat/utils/chat-room-message-scope";
 import { composeDraftKey } from "@/app/chat/utils/compose-draft-storage";
 import { formatDaySeparator } from "@/app/chat/utils/date-utils";
@@ -451,8 +452,14 @@ export function RoomsClient({
 
       // Thread replies must not enter the main room list — otherwise a send
       // from the thread panel shows in both the room transcript and the panel.
-      if (shouldMergeRealtimeMessageIntoRoomTimeline(message)) {
-        setMessagesState((current) => mergeRoomMessages(current, [message]));
+      const route = routeRealtimeChatRoomMessage(
+        message,
+        threadParentMessageIdRef.current,
+      );
+      if (route.mergeIntoRoomTimeline) {
+        setMessagesState((current) =>
+          filterTopLevelChatRoomMessages(mergeRoomMessages(current, [message])),
+        );
       }
       setThreadParentMessage((current) =>
         current?.id === message.id ? message : current,
@@ -464,8 +471,7 @@ export function RoomsClient({
         setAttentionRefreshToken((token) => token + 1);
       }
 
-      const openThreadParentId = threadParentMessageIdRef.current;
-      if (shouldApplyRealtimeMessageToOpenThread(message, openThreadParentId)) {
+      if (route.mergeIntoOpenThread) {
         setThreadMessages((current) => mergeRoomMessages(current, [message]));
       }
     },
@@ -480,9 +486,18 @@ export function RoomsClient({
   // Defense in depth: never render thread replies in the main room timeline,
   // even if stale state still holds a leaked reply from before this fix.
   const topLevelRoomMessages = useMemo(
-    () => messagesState.filter(isTopLevelChatRoomMessage),
+    () => filterTopLevelChatRoomMessages(messagesState),
     [messagesState],
   );
+
+  // Purge leaked thread replies from room state so consumers of messagesState
+  // (pending-mention poll, search props) never see them after a prior leak.
+  useEffect(() => {
+    if (topLevelRoomMessages.length === messagesState.length) {
+      return;
+    }
+    setMessagesState(topLevelRoomMessages);
+  }, [messagesState, topLevelRoomMessages]);
 
   const displayMessages = useMemo(() => {
     return mergeMessagesWithStreamOverlay(
@@ -495,8 +510,9 @@ export function RoomsClient({
     if (!threadParentMessage) {
       return [];
     }
-    return streamOverlayMessages.filter(
-      (message) => message.parentMessageId === threadParentMessage.id,
+    const parentId = threadParentMessage.id;
+    return streamOverlayMessages.filter((message) =>
+      isReplyUnderThreadParent(message, parentId),
     );
   }, [streamOverlayMessages, threadParentMessage]);
 
@@ -535,7 +551,7 @@ export function RoomsClient({
       return;
     }
     const parent =
-      messagesState.find(
+      topLevelRoomMessages.find(
         (message) => message.id === activeStreamParentMessageId,
       ) ?? null;
     if (!parent) {
@@ -547,7 +563,7 @@ export function RoomsClient({
     selectedRoom,
     activeStreamParentMessageId,
     threadParentMessage?.id,
-    messagesState,
+    topLevelRoomMessages,
   ]);
 
   // Pending draft stays in sessionStorage until stream settles successfully
@@ -754,8 +770,8 @@ export function RoomsClient({
   }, [latestVisibleMessageId, selectedRoomReadId]);
 
   const hasPendingRoomCoworkerMention = useMemo(
-    () => hasPendingCoworkerMention(messagesState),
-    [messagesState],
+    () => hasPendingCoworkerMention(topLevelRoomMessages),
+    [topLevelRoomMessages],
   );
   const hasPendingThreadCoworkerMention = useMemo(
     () => hasPendingCoworkerMention(threadMessages),
@@ -974,11 +990,17 @@ export function RoomsClient({
   ]);
 
   function mergeUpdatedMessage(updatedMessage: ChatRoomMessage) {
-    setMessagesState((current) =>
-      current.map((message) =>
-        message.id === updatedMessage.id ? updatedMessage : message,
-      ),
-    );
+    setMessagesState((current) => {
+      // Thread replies never belong in the room list (edit/delete/reaction).
+      if (!isTopLevelChatRoomMessage(updatedMessage)) {
+        return current.filter((message) => message.id !== updatedMessage.id);
+      }
+      return filterTopLevelChatRoomMessages(
+        current.map((message) =>
+          message.id === updatedMessage.id ? updatedMessage : message,
+        ),
+      );
+    });
     setThreadMessages((current) =>
       current.map((message) =>
         message.id === updatedMessage.id ? updatedMessage : message,
@@ -1392,7 +1414,7 @@ export function RoomsClient({
                   <RoomSearchPanel
                     key={selectedRoom.id}
                     roomId={selectedRoom.id}
-                    loadedMessages={messagesState}
+                    loadedMessages={topLevelRoomMessages}
                     onOpenThread={loadThreadMessages}
                     labels={{
                       open: t("RoomSearch.open"),

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -30,6 +30,11 @@ import {
   useCoworkerDirectRoomStream,
 } from "@/app/chat/hooks/use-coworker-direct-room-stream";
 import { useStickToBottom } from "@/app/chat/hooks/use-stick-to-bottom";
+import {
+  isTopLevelChatRoomMessage,
+  shouldApplyRealtimeMessageToOpenThread,
+  shouldMergeRealtimeMessageIntoRoomTimeline,
+} from "@/app/chat/utils/chat-room-message-scope";
 import { composeDraftKey } from "@/app/chat/utils/compose-draft-storage";
 import { formatDaySeparator } from "@/app/chat/utils/date-utils";
 import {
@@ -444,7 +449,11 @@ export function RoomsClient({
         return;
       }
 
-      setMessagesState((current) => mergeRoomMessages(current, [message]));
+      // Thread replies must not enter the main room list — otherwise a send
+      // from the thread panel shows in both the room transcript and the panel.
+      if (shouldMergeRealtimeMessageIntoRoomTimeline(message)) {
+        setMessagesState((current) => mergeRoomMessages(current, [message]));
+      }
       setThreadParentMessage((current) =>
         current?.id === message.id ? message : current,
       );
@@ -456,13 +465,7 @@ export function RoomsClient({
       }
 
       const openThreadParentId = threadParentMessageIdRef.current;
-      if (!openThreadParentId) {
-        return;
-      }
-      if (
-        message.id === openThreadParentId ||
-        message.parentMessageId === openThreadParentId
-      ) {
+      if (shouldApplyRealtimeMessageToOpenThread(message, openThreadParentId)) {
         setThreadMessages((current) => mergeRoomMessages(current, [message]));
       }
     },
@@ -470,19 +473,23 @@ export function RoomsClient({
   );
 
   const topLevelStreamOverlayMessages = useMemo(
-    () =>
-      streamOverlayMessages.filter(
-        (message) => message.parentMessageId == null,
-      ),
+    () => streamOverlayMessages.filter(isTopLevelChatRoomMessage),
     [streamOverlayMessages],
+  );
+
+  // Defense in depth: never render thread replies in the main room timeline,
+  // even if stale state still holds a leaked reply from before this fix.
+  const topLevelRoomMessages = useMemo(
+    () => messagesState.filter(isTopLevelChatRoomMessage),
+    [messagesState],
   );
 
   const displayMessages = useMemo(() => {
     return mergeMessagesWithStreamOverlay(
-      messagesState,
+      topLevelRoomMessages,
       topLevelStreamOverlayMessages,
     );
-  }, [messagesState, topLevelStreamOverlayMessages]);
+  }, [topLevelRoomMessages, topLevelStreamOverlayMessages]);
 
   const threadStreamOverlayMessages = useMemo(() => {
     if (!threadParentMessage) {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isTopLevelChatRoomMessage,
+  shouldApplyRealtimeMessageToOpenThread,
+  shouldMergeRealtimeMessageIntoRoomTimeline,
+} from "../chat-room-message-scope";
+
+describe("isTopLevelChatRoomMessage", () => {
+  it("treats null parent as top-level", () => {
+    expect(isTopLevelChatRoomMessage({ parentMessageId: null })).toBe(true);
+  });
+
+  it("treats missing parent as top-level", () => {
+    expect(isTopLevelChatRoomMessage({})).toBe(true);
+  });
+
+  it("treats set parent as thread reply", () => {
+    expect(isTopLevelChatRoomMessage({ parentMessageId: "parent-1" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldMergeRealtimeMessageIntoRoomTimeline", () => {
+  it("accepts top-level messages for the main room transcript", () => {
+    expect(
+      shouldMergeRealtimeMessageIntoRoomTimeline({ parentMessageId: null }),
+    ).toBe(true);
+  });
+
+  it("rejects thread replies so they do not appear in the room and thread", () => {
+    expect(
+      shouldMergeRealtimeMessageIntoRoomTimeline({
+        parentMessageId: "parent-1",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldApplyRealtimeMessageToOpenThread", () => {
+  it("returns false when no thread is open", () => {
+    expect(
+      shouldApplyRealtimeMessageToOpenThread(
+        { id: "reply-1", parentMessageId: "parent-1" },
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts the open thread root itself", () => {
+    expect(
+      shouldApplyRealtimeMessageToOpenThread(
+        { id: "parent-1", parentMessageId: null },
+        "parent-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts replies under the open thread root", () => {
+    expect(
+      shouldApplyRealtimeMessageToOpenThread(
+        { id: "reply-1", parentMessageId: "parent-1" },
+        "parent-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects replies under a different thread root", () => {
+    expect(
+      shouldApplyRealtimeMessageToOpenThread(
+        { id: "reply-1", parentMessageId: "other-parent" },
+        "parent-1",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  filterTopLevelChatRoomMessages,
+  isReplyUnderThreadParent,
   isTopLevelChatRoomMessage,
+  routeRealtimeChatRoomMessage,
   shouldApplyRealtimeMessageToOpenThread,
-  shouldMergeRealtimeMessageIntoRoomTimeline,
 } from "../chat-room-message-scope";
 
 describe("isTopLevelChatRoomMessage", () => {
@@ -22,18 +24,30 @@ describe("isTopLevelChatRoomMessage", () => {
   });
 });
 
-describe("shouldMergeRealtimeMessageIntoRoomTimeline", () => {
-  it("accepts top-level messages for the main room transcript", () => {
+describe("filterTopLevelChatRoomMessages", () => {
+  it("keeps only top-level rows and drops thread replies", () => {
+    const filtered = filterTopLevelChatRoomMessages([
+      { id: "a", parentMessageId: null },
+      { id: "b", parentMessageId: "parent-1" },
+      { id: "c" },
+    ]);
+    expect(filtered.map((message) => message.id)).toEqual(["a", "c"]);
+  });
+});
+
+describe("isReplyUnderThreadParent", () => {
+  it("matches direct replies to the parent", () => {
     expect(
-      shouldMergeRealtimeMessageIntoRoomTimeline({ parentMessageId: null }),
+      isReplyUnderThreadParent({ parentMessageId: "parent-1" }, "parent-1"),
     ).toBe(true);
   });
 
-  it("rejects thread replies so they do not appear in the room and thread", () => {
+  it("rejects top-level and other threads", () => {
     expect(
-      shouldMergeRealtimeMessageIntoRoomTimeline({
-        parentMessageId: "parent-1",
-      }),
+      isReplyUnderThreadParent({ parentMessageId: null }, "parent-1"),
+    ).toBe(false);
+    expect(
+      isReplyUnderThreadParent({ parentMessageId: "other" }, "parent-1"),
     ).toBe(false);
   });
 });
@@ -73,5 +87,64 @@ describe("shouldApplyRealtimeMessageToOpenThread", () => {
         "parent-1",
       ),
     ).toBe(false);
+  });
+});
+
+describe("routeRealtimeChatRoomMessage", () => {
+  it("routes a top-level message to the room only when no thread is open", () => {
+    expect(
+      routeRealtimeChatRoomMessage(
+        { id: "msg-1", parentMessageId: null },
+        null,
+      ),
+    ).toEqual({
+      mergeIntoRoomTimeline: true,
+      mergeIntoOpenThread: false,
+    });
+  });
+
+  it("routes a top-level open-thread parent to room and thread", () => {
+    expect(
+      routeRealtimeChatRoomMessage(
+        { id: "parent-1", parentMessageId: null },
+        "parent-1",
+      ),
+    ).toEqual({
+      mergeIntoRoomTimeline: true,
+      mergeIntoOpenThread: true,
+    });
+  });
+
+  it("routes a thread reply only to the open thread, never the room", () => {
+    expect(
+      routeRealtimeChatRoomMessage(
+        { id: "reply-1", parentMessageId: "parent-1" },
+        "parent-1",
+      ),
+    ).toEqual({
+      mergeIntoRoomTimeline: false,
+      mergeIntoOpenThread: true,
+    });
+  });
+
+  it("routes a reply under a closed/other thread nowhere", () => {
+    expect(
+      routeRealtimeChatRoomMessage(
+        { id: "reply-1", parentMessageId: "parent-1" },
+        null,
+      ),
+    ).toEqual({
+      mergeIntoRoomTimeline: false,
+      mergeIntoOpenThread: false,
+    });
+    expect(
+      routeRealtimeChatRoomMessage(
+        { id: "reply-1", parentMessageId: "parent-1" },
+        "other-parent",
+      ),
+    ).toEqual({
+      mergeIntoRoomTimeline: false,
+      mergeIntoOpenThread: false,
+    });
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -13,11 +13,19 @@ export function isTopLevelChatRoomMessage(message: {
   return message.parentMessageId == null;
 }
 
-/** Whether Ably/realtime should merge this message into the main room list. */
-export function shouldMergeRealtimeMessageIntoRoomTimeline(message: {
-  parentMessageId?: string | null;
-}): boolean {
-  return isTopLevelChatRoomMessage(message);
+/** Drop thread replies from a room-timeline candidate list. */
+export function filterTopLevelChatRoomMessages<
+  T extends { parentMessageId?: string | null },
+>(messages: readonly T[]): T[] {
+  return messages.filter(isTopLevelChatRoomMessage);
+}
+
+/** Stream overlay / reply rows under a specific thread root. */
+export function isReplyUnderThreadParent(
+  message: { parentMessageId?: string | null },
+  parentMessageId: string,
+): boolean {
+  return message.parentMessageId === parentMessageId;
 }
 
 /** Whether realtime should merge into the currently open thread panel. */
@@ -33,6 +41,33 @@ export function shouldApplyRealtimeMessageToOpenThread(
   }
   return (
     message.id === openThreadParentId ||
-    message.parentMessageId === openThreadParentId
+    isReplyUnderThreadParent(message, openThreadParentId)
   );
+}
+
+export interface RealtimeChatRoomMessageRoute {
+  /** Main room list: top-level messages only. */
+  mergeIntoRoomTimeline: boolean;
+  /** Open thread panel: parent row or its direct replies. */
+  mergeIntoOpenThread: boolean;
+}
+
+/**
+ * Decide where a realtime chat-room message should land.
+ * Single seam for rooms-client Ably handling — unit-test this, not string grep.
+ */
+export function routeRealtimeChatRoomMessage(
+  message: {
+    id: string;
+    parentMessageId?: string | null;
+  },
+  openThreadParentId: string | null,
+): RealtimeChatRoomMessageRoute {
+  return {
+    mergeIntoRoomTimeline: isTopLevelChatRoomMessage(message),
+    mergeIntoOpenThread: shouldApplyRealtimeMessageToOpenThread(
+      message,
+      openThreadParentId,
+    ),
+  };
 }

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -1,0 +1,38 @@
+/**
+ * Room timeline vs thread panel message scope.
+ *
+ * Main room transcript is top-level only (`parentMessageId == null`).
+ * Thread replies belong only in the open thread panel. Realtime must not
+ * merge replies into room state — otherwise a send from the thread panel
+ * appears in both the room and the thread.
+ */
+
+export function isTopLevelChatRoomMessage(message: {
+  parentMessageId?: string | null;
+}): boolean {
+  return message.parentMessageId == null;
+}
+
+/** Whether Ably/realtime should merge this message into the main room list. */
+export function shouldMergeRealtimeMessageIntoRoomTimeline(message: {
+  parentMessageId?: string | null;
+}): boolean {
+  return isTopLevelChatRoomMessage(message);
+}
+
+/** Whether realtime should merge into the currently open thread panel. */
+export function shouldApplyRealtimeMessageToOpenThread(
+  message: {
+    id: string;
+    parentMessageId?: string | null;
+  },
+  openThreadParentId: string | null,
+): boolean {
+  if (!openThreadParentId) {
+    return false;
+  }
+  return (
+    message.id === openThreadParentId ||
+    message.parentMessageId === openThreadParentId
+  );
+}


### PR DESCRIPTION
## Summary

- Thread replies delivered over Ably were merged into the main room message list, so a send from the thread panel also appeared in the room transcript until reload.
- Realtime handling now merges into the room timeline only for top-level messages (`parentMessageId == null`), and still routes replies into the open thread panel.
- Display filters room state to top-level messages as defense in depth against any already-leaked replies.

## Test plan

- [x] Unit tests for room/thread message scope helpers
- [x] Source regression test that rooms-client uses the scope filters
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [ ] Manually: open a coworker DM thread, send a reply → appears only in the thread panel, not in the main room timeline
- [ ] Manually: reload → still thread-only (server was already correct)
- [ ] Manually: top-level room send still appears in the room transcript
- [ ] Manually: edit a thread reply → updates in thread only, not painted as a new room row