### PR TITLE
fix(chat): clear room unread when thread replies are looked

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/read/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/read/post.test.ts
@@ -21,6 +21,7 @@ const {
   threadReadUpdateManyMock,
   threadReadDeleteManyMock,
   prismaTransactionMock,
+  queryRawUnsafeMock,
 } = vi.hoisted(() => ({
   roomFindFirstMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
@@ -32,11 +33,13 @@ const {
   threadReadUpdateManyMock: vi.fn(),
   threadReadDeleteManyMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
+  queryRawUnsafeMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   default: {
     $transaction: prismaTransactionMock,
+    $queryRawUnsafe: queryRawUnsafeMock,
   },
 }));
 
@@ -121,6 +124,8 @@ beforeEach(() => {
   readStateUpsertMock.mockResolvedValue({});
   notificationUpdateManyMock.mockResolvedValue({ count: 2 });
   membershipFindUniqueMock.mockResolvedValue({ pinnedAt: null, mutedAt: null });
+  // Dual-baseline unread: room mark-read leaves unlooked thread replies.
+  queryRawUnsafeMock.mockResolvedValue([]);
 });
 
 describe("POST /chats/rooms/{id}/read", () => {
@@ -167,10 +172,29 @@ describe("POST /chats/rooms/{id}/read", () => {
       markedUnread: false,
       pinnedAt: null,
     });
+    expect(queryRawUnsafeMock).toHaveBeenCalled();
 
     // Room mark-read must not touch per-thread look state.
     expect(threadReadUpsertMock).not.toHaveBeenCalled();
     expect(threadReadUpdateManyMock).not.toHaveBeenCalled();
     expect(threadReadDeleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns remaining thread unreadCount after room mark-read", async () => {
+    queryRawUnsafeMock.mockResolvedValue([{ roomId: ROOM_ID, unreadCount: 2 }]);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/read`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      id: ROOM_ID,
+      unreadCount: 2,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/read/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/read/post.ts
@@ -11,7 +11,11 @@ import {
 import { requireUserAuthContext } from "@/middleware/auth";
 import { chatRoomSchema } from "@/schemas/chat-room.schema";
 
-import { mapChatRoom, requireChatRoomUserAccess } from "../../helpers";
+import {
+  getChatRoomUnreadCounts,
+  mapChatRoom,
+  requireChatRoomUserAccess,
+} from "../../helpers";
 
 const paramsSchema = z.object({
   id: z
@@ -27,7 +31,8 @@ const route = withGlobalHeaderParameters(
   createRoute({
     method: "post",
     path: "/{id}/read",
-    description: "Mark an organization chat room as read for the current user.",
+    description:
+      "Mark an organization chat room as read for the current user. Advances room lastReadAt and clears CHAT notifications. Does not clear per-thread look state — remaining unread thread replies still contribute to unreadCount.",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
@@ -103,11 +108,20 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       },
     );
 
+    // Top-level unreads are cleared by lastReadAt; thread replies still use
+    // look baseline. Return the real dual-baseline count so the sidebar does
+    // not optimistically hide unlooked threads.
+    const unreadCounts = await getChatRoomUnreadCounts(
+      [room.id],
+      userContext.userId,
+      prisma,
+    );
+
     return ok(
       c,
       chatRoomSchema.parse(
         mapChatRoom(room, userContext.userId, {
-          unreadCount: 0,
+          unreadCount: unreadCounts.get(room.id) ?? 0,
           unreadMentionCount: 0,
           pinnedAt,
           mutedAt,

--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -11,6 +11,7 @@ import {
   canPermanentlyDeleteChatRoom,
   contentIncludesRoomAllMention,
   getChatRoomThreadAggregates,
+  getChatRoomUnreadCounts,
   getChatRoomUnreadMentionCounts,
   mapChatRoomMessage,
   mergeChatRoomMessageMetadata,
@@ -351,6 +352,32 @@ describe("mergeUnfurlsIntoMessageMetadata", () => {
 
   it("returns null when clearing the only key", () => {
     expect(mergeUnfurlsIntoMessageMetadata({ unfurls: [card] }, [])).toBeNull();
+  });
+});
+
+describe("getChatRoomUnreadCounts", () => {
+  it("counts top-level by room lastReadAt and thread replies by look baseline", async () => {
+    const queryRawUnsafe = vi
+      .fn()
+      .mockResolvedValue([{ roomId: "room-a", unreadCount: 3 }]);
+    const tx = { $queryRawUnsafe: queryRawUnsafe } as never;
+
+    const counts = await getChatRoomUnreadCounts(["room-a"], "user_1", tx);
+
+    expect(counts.get("room-a")).toBe(3);
+    const sql = String(queryRawUnsafe.mock.calls[0]?.[0]);
+    // Top-level leg uses room lastReadAt
+    expect(sql).toContain('message."parentMessageId" IS NULL');
+    expect(sql).toMatch(/read_state\."lastReadAt"/);
+    // Thread leg uses look baseline, not room lastReadAt
+    expect(sql).toContain('thread_read."lastReadAt"');
+    expect(sql).toContain('room_read."createdAt"');
+    expect(sql).toContain('reply."parentMessageId" IS NOT NULL');
+    expect(sql).not.toMatch(
+      /reply\."createdAt" > COALESCE\(\s*read_state\."lastReadAt"/,
+    );
+    expect(sql).toContain('message."deletedAt" IS NULL');
+    expect(sql).toContain('reply."deletedAt" IS NULL');
   });
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -127,6 +127,18 @@ function resolveUserPresence(
   return "offline";
 }
 
+/**
+ * Per-room unread message counts for sidebar attention.
+ *
+ * Dual baseline (matches the two read-state tables):
+ * - Top-level messages (`parentMessageId IS NULL`): after room `lastReadAt`
+ * - Thread replies: after per-thread look baseline
+ *   (`ChatRoomThreadReadState.lastReadAt`, else room read-state `createdAt`,
+ *   else -infinity) — same as `getChatRoomThreadAggregates`. Room mark-read
+ *   must not clear thread look contribution; looking a thread must.
+ *
+ * Soft-deleted messages and the viewer's own user messages are excluded.
+ */
 export async function getChatRoomUnreadCounts(
   roomIds: readonly string[],
   userId: string,
@@ -147,16 +159,46 @@ export async function getChatRoomUnreadCounts(
   >(
     `
     SELECT
-      message."roomId" AS "roomId",
+      combined."roomId" AS "roomId",
       COUNT(*)::int AS "unreadCount"
-    FROM "chat_room_message" message
-    LEFT JOIN "chat_room_read_state" read_state
-      ON read_state."roomId" = message."roomId"
-      AND read_state."userId" = ${userIdPlaceholder}
-    WHERE message."roomId" IN (${roomIdPlaceholders})
-      AND message."createdAt" > COALESCE(read_state."lastReadAt", '-infinity'::timestamp)
-      AND (message."senderUserId" IS NULL OR message."senderUserId" <> ${userIdPlaceholder})
-    GROUP BY message."roomId"
+    FROM (
+      SELECT message.id, message."roomId"
+      FROM "chat_room_message" message
+      LEFT JOIN "chat_room_read_state" read_state
+        ON read_state."roomId" = message."roomId"
+        AND read_state."userId" = ${userIdPlaceholder}
+      WHERE message."roomId" IN (${roomIdPlaceholders})
+        AND message."parentMessageId" IS NULL
+        AND message."deletedAt" IS NULL
+        AND message."createdAt" > COALESCE(read_state."lastReadAt", '-infinity'::timestamp)
+        AND (message."senderUserId" IS NULL OR message."senderUserId" <> ${userIdPlaceholder})
+
+      UNION ALL
+
+      SELECT reply.id, reply."roomId"
+      FROM "chat_room_message" reply
+      INNER JOIN "chat_room_message" parent
+        ON parent.id = reply."parentMessageId"
+        AND parent."roomId" = reply."roomId"
+      LEFT JOIN "chat_room_thread_read_state" thread_read
+        ON thread_read."parentMessageId" = parent.id
+        AND thread_read."userId" = ${userIdPlaceholder}
+      LEFT JOIN "chat_room_read_state" room_read
+        ON room_read."roomId" = reply."roomId"
+        AND room_read."userId" = ${userIdPlaceholder}
+      WHERE reply."roomId" IN (${roomIdPlaceholders})
+        AND reply."parentMessageId" IS NOT NULL
+        AND reply."deletedAt" IS NULL
+        AND parent."deletedAt" IS NULL
+        AND parent."parentMessageId" IS NULL
+        AND reply."createdAt" > COALESCE(
+          thread_read."lastReadAt",
+          room_read."createdAt",
+          '-infinity'::timestamp
+        )
+        AND (reply."senderUserId" IS NULL OR reply."senderUserId" <> ${userIdPlaceholder})
+    ) combined
+    GROUP BY combined."roomId"
   `,
     ...uniqueRoomIds,
     userId,

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -74,7 +74,7 @@ export const chatRoomSchema = z
     updatedAt: dateTimeSchema,
     unreadCount: z.number().int().min(0).openapi({
       description:
-        "Messages sent by others after the current user's read marker.",
+        "Unread messages from others: top-level after room lastReadAt, plus thread replies after per-thread look baseline (thread lastReadAt, else room read-state createdAt). Soft-deleted excluded.",
       example: 2,
     }),
     unreadMentionCount: z.number().int().min(0).openapi({

--- a/apps/web/src/app/(app)/chat/components/__tests__/unread-threads-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/unread-threads-panel.test.tsx
@@ -90,6 +90,7 @@ function unreadThreadItem(
 interface RenderPanelOptions {
   attentionRefreshToken?: number;
   onOpenThread?: (parent: ChatRoomMessage) => boolean | Promise<boolean>;
+  onAllThreadsLooked?: () => void;
 }
 
 function renderPanel(options: RenderPanelOptions = {}) {
@@ -99,6 +100,7 @@ function renderPanel(options: RenderPanelOptions = {}) {
       labels={labels}
       attentionRefreshToken={options.attentionRefreshToken ?? 0}
       onOpenThread={options.onOpenThread ?? vi.fn().mockResolvedValue(true)}
+      onAllThreadsLooked={options.onAllThreadsLooked}
     />,
   );
 }
@@ -198,7 +200,8 @@ describe("UnreadThreadsPanel", () => {
   });
 
   it("marks all unread threads as read and clears badge", async () => {
-    renderPanel();
+    const onAllThreadsLooked = vi.fn();
+    renderPanel({ onAllThreadsLooked });
 
     expect(
       await screen.findByTestId("unread-threads-badge"),
@@ -218,6 +221,7 @@ describe("UnreadThreadsPanel", () => {
     expect(
       screen.queryByTestId("unread-threads-mark-all-read"),
     ).not.toBeInTheDocument();
+    expect(onAllThreadsLooked).toHaveBeenCalledTimes(1);
   });
 
   it("ignores mark-all result after the panel is closed", async () => {

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -37,11 +37,15 @@ import {
   mergeRoomMessages,
 } from "@/app/chat/utils/merge-room-messages";
 import { peekPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
+import { roomReadAttentionMarker } from "@/app/chat/utils/room-read-attention-marker";
 import { shouldSignalUnreadThreadsAttention } from "@/app/chat/utils/should-signal-unread-threads-attention";
 import { ChannelDiscoverabilityIcon } from "@/components/chat/channel-discoverability-icon";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
 import { PresenceDot } from "@/components/chat/presence-dot";
-import { rememberRoomRead } from "@/components/chat/room-read-overlay";
+import {
+  forgetRoomRead,
+  rememberRoomRead,
+} from "@/components/chat/room-read-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
@@ -464,6 +468,18 @@ export function RoomsClient({
         message.parentMessageId === openThreadParentId
       ) {
         setThreadMessages((current) => mergeRoomMessages(current, [message]));
+        // Keep look state current while the panel is open so dual-baseline
+        // room unreadCount drops this reply after leave/poll.
+        if (message.parentMessageId === openThreadParentId) {
+          const roomId = message.roomId;
+          void markThreadReadAction(roomId, openThreadParentId).then(
+            (result) => {
+              if (result.ok) {
+                setAttentionRefreshToken((token) => token + 1);
+              }
+            },
+          );
+        }
       }
     },
     [],
@@ -708,7 +724,9 @@ export function RoomsClient({
     );
   }, [messages, messagesNextCursor, selectedRoomId]);
 
-  const latestVisibleMessageId = displayMessages.at(-1)?.id ?? "empty";
+  const latestTopLevelMessageId = displayMessages.at(-1)?.id ?? null;
+  const latestOpenThreadMessageId = displayThreadMessages.at(-1)?.id ?? null;
+  const openThreadParentId = threadParentMessage?.id ?? null;
   const selectedRoomReadId = selectedRoom?.id ?? null;
 
   useEffect(() => {
@@ -716,7 +734,14 @@ export function RoomsClient({
       return;
     }
 
-    const marker = `${selectedRoomReadId}:${latestVisibleMessageId}`;
+    // Include open-thread activity: thread replies count toward room unread
+    // via look baseline, but top-level-only markers never re-fired mark-read.
+    const marker = roomReadAttentionMarker({
+      roomId: selectedRoomReadId,
+      latestTopLevelMessageId,
+      openThreadParentId,
+      latestOpenThreadMessageId,
+    });
     if (readMarkerRef.current === marker) {
       return;
     }
@@ -727,10 +752,16 @@ export function RoomsClient({
       if (!result.ok) {
         return;
       }
-      // Persist before the cancelled check: mobile Sheet unmounts the sidebar
-      // list so the event below often has no listener, and remount would
-      // otherwise rehydrate unread from stale RSC props.
-      rememberRoomRead(result.data);
+      // Only overlay full-clear when dual-baseline count is actually 0.
+      // Room mark-read does not clear unlooked threads — do not hide them.
+      if (
+        result.data.unreadCount === 0 &&
+        result.data.unreadMentionCount === 0
+      ) {
+        rememberRoomRead(result.data);
+      } else {
+        forgetRoomRead(result.data.id);
+      }
       if (cancelled) {
         return;
       }
@@ -744,7 +775,12 @@ export function RoomsClient({
     return () => {
       cancelled = true;
     };
-  }, [latestVisibleMessageId, selectedRoomReadId]);
+  }, [
+    latestOpenThreadMessageId,
+    latestTopLevelMessageId,
+    openThreadParentId,
+    selectedRoomReadId,
+  ]);
 
   const hasPendingRoomCoworkerMention = useMemo(
     () => hasPendingCoworkerMention(messagesState),
@@ -1001,6 +1037,26 @@ export function RoomsClient({
     );
   }
 
+  async function syncRoomAttentionAfterThreadLook(roomId: string) {
+    const roomResult = await markOrganizationChatRoomReadAction(roomId);
+    if (!roomResult.ok) {
+      return;
+    }
+    if (
+      roomResult.data.unreadCount === 0 &&
+      roomResult.data.unreadMentionCount === 0
+    ) {
+      rememberRoomRead(roomResult.data);
+    } else {
+      forgetRoomRead(roomResult.data.id);
+    }
+    window.dispatchEvent(
+      new CustomEvent("organization-chat-room-read", {
+        detail: { room: roomResult.data, roomId },
+      }),
+    );
+  }
+
   async function loadThreadMessages(
     parentMessage: ChatRoomMessage,
   ): Promise<boolean> {
@@ -1011,8 +1067,13 @@ export function RoomsClient({
     setThreadParentMessage(parentMessage);
     setThreadMessages([]);
     setThreadOlderNextCursor(null);
-    // Thread look state is independent of room mark-read.
+    // Look state first, then room mark-read so dual-baseline unreadCount
+    // already excludes this thread when the sidebar event lands.
     const markResult = await markThreadReadAction(roomId, parentMessage.id);
+    if (markResult.ok) {
+      setAttentionRefreshToken((token) => token + 1);
+      await syncRoomAttentionAfterThreadLook(roomId);
+    }
     startThreadLoadingTransition(async () => {
       const result = await listThreadMessagesAction(roomId, parentMessage.id);
       if (!result.ok) {
@@ -1402,6 +1463,9 @@ export function RoomsClient({
                     roomId={selectedRoom.id}
                     attentionRefreshToken={attentionRefreshToken}
                     onOpenThread={loadThreadMessages}
+                    onAllThreadsLooked={() => {
+                      void syncRoomAttentionAfterThreadLook(selectedRoom.id);
+                    }}
                     labels={{
                       open: t("UnreadThreads.open"),
                       title: t("UnreadThreads.title"),

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -42,10 +42,7 @@ import { shouldSignalUnreadThreadsAttention } from "@/app/chat/utils/should-sign
 import { ChannelDiscoverabilityIcon } from "@/components/chat/channel-discoverability-icon";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
 import { PresenceDot } from "@/components/chat/presence-dot";
-import {
-  forgetRoomRead,
-  rememberRoomRead,
-} from "@/components/chat/room-read-overlay";
+import { applyRoomReadResultToOverlay } from "@/components/chat/room-read-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
@@ -296,6 +293,9 @@ export function RoomsClient({
   selectedRoomIdRef.current = selectedRoomId;
   const currentUserIdRef = useRef(currentUserId);
   currentUserIdRef.current = currentUserId;
+  const syncRoomAttentionAfterThreadLookRef = useRef<
+    (roomId: string) => Promise<void>
+  >(async () => {});
   const [attentionRefreshToken, setAttentionRefreshToken] = useState(0);
   const [syncedAttentionRoomId, setSyncedAttentionRoomId] =
     useState(selectedRoomId);
@@ -468,15 +468,17 @@ export function RoomsClient({
         message.parentMessageId === openThreadParentId
       ) {
         setThreadMessages((current) => mergeRoomMessages(current, [message]));
-        // Keep look state current while the panel is open so dual-baseline
-        // room unreadCount drops this reply after leave/poll.
+        // Look first, then room re-sync — mark-read effect can race if it
+        // runs before look lands; open path uses the same order.
         if (message.parentMessageId === openThreadParentId) {
           const roomId = message.roomId;
           void markThreadReadAction(roomId, openThreadParentId).then(
-            (result) => {
-              if (result.ok) {
-                setAttentionRefreshToken((token) => token + 1);
+            async (result) => {
+              if (!result.ok) {
+                return;
               }
+              setAttentionRefreshToken((token) => token + 1);
+              await syncRoomAttentionAfterThreadLookRef.current(roomId);
             },
           );
         }
@@ -752,16 +754,7 @@ export function RoomsClient({
       if (!result.ok) {
         return;
       }
-      // Only overlay full-clear when dual-baseline count is actually 0.
-      // Room mark-read does not clear unlooked threads — do not hide them.
-      if (
-        result.data.unreadCount === 0 &&
-        result.data.unreadMentionCount === 0
-      ) {
-        rememberRoomRead(result.data);
-      } else {
-        forgetRoomRead(result.data.id);
-      }
+      applyRoomReadResultToOverlay(result.data);
       if (cancelled) {
         return;
       }
@@ -1042,20 +1035,15 @@ export function RoomsClient({
     if (!roomResult.ok) {
       return;
     }
-    if (
-      roomResult.data.unreadCount === 0 &&
-      roomResult.data.unreadMentionCount === 0
-    ) {
-      rememberRoomRead(roomResult.data);
-    } else {
-      forgetRoomRead(roomResult.data.id);
-    }
+    applyRoomReadResultToOverlay(roomResult.data);
     window.dispatchEvent(
       new CustomEvent("organization-chat-room-read", {
         detail: { room: roomResult.data, roomId },
       }),
     );
   }
+  syncRoomAttentionAfterThreadLookRef.current =
+    syncRoomAttentionAfterThreadLook;
 
   async function loadThreadMessages(
     parentMessage: ChatRoomMessage,

--- a/apps/web/src/app/(app)/chat/components/unread-threads-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/unread-threads-panel.tsx
@@ -43,6 +43,8 @@ interface UnreadThreadsPanelProps {
   attentionRefreshToken: number;
   /** Returns true when thread look-state was persisted successfully. */
   onOpenThread: (parent: ChatRoomMessage) => boolean | Promise<boolean>;
+  /** After mark-all look succeeds — parent re-syncs room sidebar attention. */
+  onAllThreadsLooked?: () => void;
 }
 
 const ATTENTION_REFRESH_DEBOUNCE_MS = 300;
@@ -70,6 +72,7 @@ export function UnreadThreadsPanel({
   labels,
   attentionRefreshToken,
   onOpenThread,
+  onAllThreadsLooked,
 }: UnreadThreadsPanelProps) {
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<ChatRoomThread[]>([]);
@@ -176,6 +179,7 @@ export function UnreadThreadsPanel({
     setItems([]);
     setBadgeCount(0);
     setIsMarkingAllRead(false);
+    onAllThreadsLooked?.();
   }
 
   const showEmpty = !isLoading && !error && items.length === 0;

--- a/apps/web/src/app/(app)/chat/utils/__tests__/room-read-attention-marker.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/room-read-attention-marker.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { roomReadAttentionMarker } from "@/app/chat/utils/room-read-attention-marker";
+
+describe("roomReadAttentionMarker", () => {
+  it("changes when an open thread parent is set so room mark-read re-fires", () => {
+    const before = roomReadAttentionMarker({
+      roomId: "room-1",
+      latestTopLevelMessageId: "msg-top",
+      openThreadParentId: null,
+      latestOpenThreadMessageId: null,
+    });
+    const after = roomReadAttentionMarker({
+      roomId: "room-1",
+      latestTopLevelMessageId: "msg-top",
+      openThreadParentId: "msg-top",
+      latestOpenThreadMessageId: null,
+    });
+
+    expect(before).not.toBe(after);
+    expect(after).toContain("msg-top:msg-top:none");
+  });
+
+  it("changes when a new reply lands in the open thread", () => {
+    const before = roomReadAttentionMarker({
+      roomId: "room-1",
+      latestTopLevelMessageId: "msg-top",
+      openThreadParentId: "msg-top",
+      latestOpenThreadMessageId: "reply-1",
+    });
+    const after = roomReadAttentionMarker({
+      roomId: "room-1",
+      latestTopLevelMessageId: "msg-top",
+      openThreadParentId: "msg-top",
+      latestOpenThreadMessageId: "reply-2",
+    });
+
+    expect(before).not.toBe(after);
+  });
+
+  it("stays stable when only unrelated fields are absent the same way", () => {
+    expect(
+      roomReadAttentionMarker({
+        roomId: "room-1",
+        latestTopLevelMessageId: undefined,
+        openThreadParentId: undefined,
+        latestOpenThreadMessageId: undefined,
+      }),
+    ).toBe("room-1:empty:none:none");
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/room-read-attention-marker.ts
+++ b/apps/web/src/app/(app)/chat/utils/room-read-attention-marker.ts
@@ -1,0 +1,18 @@
+/**
+ * Stable key for the room mark-read effect.
+ *
+ * Includes open-thread activity so looking a thread (or a new reply while the
+ * panel is open) re-fires room mark-read. Top-level-only markers miss thread
+ * replies, which still contribute to room unreadCount via thread look state.
+ */
+export function roomReadAttentionMarker(options: {
+  roomId: string;
+  latestTopLevelMessageId: string | null | undefined;
+  openThreadParentId: string | null | undefined;
+  latestOpenThreadMessageId: string | null | undefined;
+}): string {
+  const topLevel = options.latestTopLevelMessageId ?? "empty";
+  const threadParent = options.openThreadParentId ?? "none";
+  const threadMessage = options.latestOpenThreadMessageId ?? "none";
+  return `${options.roomId}:${topLevel}:${threadParent}:${threadMessage}`;
+}

--- a/apps/web/src/components/chat/__tests__/room-read-overlay.test.ts
+++ b/apps/web/src/components/chat/__tests__/room-read-overlay.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyRoomReadOverlays,
+  applyRoomReadResultToOverlay,
   clearRoomReadOverlays,
   forgetRoomRead,
   rememberRoomRead,
@@ -85,5 +86,43 @@ describe("room-read-overlay", () => {
     ]);
 
     expect(rows[0]?.markedUnread).toBe(true);
+  });
+
+  it("applyRoomReadResultToOverlay only sticky-clears fully clear rooms", () => {
+    applyRoomReadResultToOverlay(
+      room({
+        unreadCount: 2,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+
+    const stillUnread = applyRoomReadOverlays([
+      room({
+        unreadCount: 2,
+        unreadMentionCount: 0,
+      }),
+    ]);
+    expect(stillUnread[0]).toMatchObject({ unreadCount: 2 });
+
+    applyRoomReadResultToOverlay(
+      room({
+        unreadCount: 0,
+        unreadMentionCount: 0,
+        markedUnread: false,
+      }),
+    );
+
+    const cleared = applyRoomReadOverlays([
+      room({
+        unreadCount: 4,
+        unreadMentionCount: 1,
+      }),
+    ]);
+    expect(cleared[0]).toMatchObject({
+      unreadCount: 0,
+      unreadMentionCount: 0,
+      markedUnread: false,
+    });
   });
 });

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -74,8 +74,7 @@ import {
 } from "./organization-chat-list.actions";
 import {
   applyRoomReadOverlays,
-  forgetRoomRead,
-  rememberRoomRead,
+  applyRoomReadResultToOverlay,
 } from "./room-read-overlay";
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
@@ -372,7 +371,9 @@ export function OrganizationChatList({
       }
 
       if (detail.room) {
-        rememberRoomRead(detail.room);
+        // Dual-baseline: room mark-read may still leave unlooked threads.
+        // Only sticky-clear when the server row is fully clear.
+        applyRoomReadResultToOverlay(detail.room);
       }
 
       setRoomRows((current) =>
@@ -505,11 +506,7 @@ export function OrganizationChatList({
   }
 
   function handleRoomUpdated(updated: ChatRoom) {
-    if (updated.markedUnread) {
-      forgetRoomRead(updated.id);
-    } else if (updated.unreadCount === 0 && updated.unreadMentionCount === 0) {
-      rememberRoomRead(updated);
-    }
+    applyRoomReadResultToOverlay(updated);
     setRoomRows((current) =>
       applyRoomReadOverlays(
         current.map((room) => (room.id === updated.id ? updated : room)),

--- a/apps/web/src/components/chat/room-read-overlay.ts
+++ b/apps/web/src/components/chat/room-read-overlay.ts
@@ -32,6 +32,29 @@ export function forgetRoomRead(roomId: string): void {
   overlaysByRoomId.delete(roomId);
 }
 
+/**
+ * Persist full-clear overlay only when dual-baseline attention is actually
+ * clear. Partial room mark-read (top-level only; unlooked threads remain)
+ * must forget any sticky overlay so the real unreadCount stays visible.
+ */
+export function applyRoomReadResultToOverlay(room: {
+  id: string;
+  updatedAt: string | Date;
+  unreadCount: number;
+  unreadMentionCount: number;
+  markedUnread?: boolean;
+}): void {
+  if (
+    room.unreadCount === 0 &&
+    room.unreadMentionCount === 0 &&
+    room.markedUnread !== true
+  ) {
+    rememberRoomRead(room);
+    return;
+  }
+  forgetRoomRead(room.id);
+}
+
 export function clearRoomReadOverlays(): void {
   overlaysByRoomId.clear();
 }


### PR DESCRIPTION
## Summary

- Room sidebar unread used a single `lastReadAt` over **all** messages (including thread replies), but opening a thread only updated per-thread look state — so channels flipped back to unread after switching away when the only new activity was in a thread.
- Core `getChatRoomUnreadCounts` now uses a dual baseline: top-level after room `lastReadAt`, thread replies after per-thread look state (same as the unread-threads panel). Soft-deleted messages excluded.
- Room mark-read returns the real dual-baseline `unreadCount` (no longer forced to 0) so unlooked threads stay visible.
- Web: after looking a thread (or mark-all / live open-thread replies), re-sync room attention and update the sidebar; room mark-read marker includes open-thread activity; sticky clear overlay only when dual-count is fully 0.

## User-facing impact

Reading a thread clears that thread’s contribution to channel unread. Switching away no longer resurrects unread solely because of already-read thread replies.

**Note:** never-looked threads now use the same look baseline as the unread-threads panel (`thread lastReadAt` else room read-state **createdAt**). That can surface historical unlooked thread activity on the channel badge where the old all-`lastReadAt` count would not after a recent room visit — intentional alignment with thread look state.

## Review follow-ups (landed)

- Sidebar list no longer always `rememberRoomRead` on mark-read events (would wipe remaining unlooked threads).
- Live open-thread re-look re-syncs room attention after look succeeds.
- Shared `applyRoomReadResultToOverlay` for dual-baseline overlay rules.

## Test plan

- [x] `pnpm --filter core test` helpers + room read route tests
- [x] `pnpm --filter web test` room-read-attention-marker + room-read-overlay + unread-threads-panel
- [x] Pre-commit `pnpm check` + `pnpm typecheck`
- [ ] Manual: open channel with only a new thread reply → open thread → switch channel → sidebar should stay read
- [ ] Manual: room with unlooked thread + viewed main timeline → room mark-read should still bold until thread is looked
- [ ] Manual: mark-all unread threads → sidebar attention clears when no top-level unreads remain
- [ ] Manual: live reply while thread open → leave room → no sticky unread for that reply