### PR TITLE
fix(web): narrow open thread parent before mark-read

### DIFF
--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -479,9 +479,12 @@ export function RoomsClient({
         setThreadMessages((current) => mergeRoomMessages(current, [message]));
         // Look first, then room re-sync — mark-read effect can race if it
         // runs before look lands; open path uses the same order.
-        if (message.parentMessageId === openThreadParentId) {
-          const roomId = message.roomId;
-          void markThreadReadAction(roomId, openThreadParentId).then(
+        // Use the ref (not openThreadParentId) so this []-deps handler stays
+        // current, and narrow null before calling markThreadReadAction.
+        const openParentId = threadParentMessageIdRef.current;
+        const roomId = message.roomId;
+        if (openParentId != null && message.parentMessageId === openParentId) {
+          void markThreadReadAction(roomId, openParentId).then(
             async (result) => {
               if (!result.ok) {
                 return;


### PR DESCRIPTION
## Summary

- Fixes preprod deploy failure on `main` (`dpl_Hpgny5bMXFjo49TWQfYFisqkQGUR`): Next typecheck rejected `openThreadParentId: string | null` passed to `markThreadReadAction`.
- Realtime handler uses `threadParentMessageIdRef` (already kept current) and null-narrows before mark-read + room attention sync.
- Also avoids a stale closure: handler deps are `[]`, so reading `openThreadParentId` from render was frozen on first mount.

## Verification

- `pnpm web:build` — succeeds locally after fix
- `pnpm check` + `pnpm typecheck` (pre-commit)
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts`

## Deploy

Unblocks `sokosumi-app-preprod` production deploy of `main`.