### PR TITLE
fix(chat): contain room message text overflow

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1255,7 +1255,7 @@ describe("ChatMessageRow", () => {
     expect(card).toHaveAttribute("target", "_blank");
     expect(card).toHaveAttribute("rel", "noopener noreferrer");
     // Hug content (thumbnail / text); do not stretch muted background full row.
-    expect(card).toHaveClass("inline-block", "w-fit", "max-w-sm");
+    expect(card).toHaveClass("inline-block", "w-fit", "max-w-full");
     expect(card).not.toHaveClass("w-full");
     expect(card).toHaveTextContent("Example");
     expect(card).toHaveTextContent("Example Article");

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -303,7 +303,7 @@ function MessageUnfurlCard({ unfurl }: { unfurl: ChatRoomMessageUnfurl }) {
       href={unfurl.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="border-border bg-muted/40 hover:bg-muted/60 focus-visible:ring-ring mt-1.5 inline-block w-fit max-w-sm overflow-hidden rounded-md border-l-2 border-l-primary/60 px-2.5 py-2 outline-none transition-colors focus-visible:ring-2"
+      className="border-border bg-muted/40 hover:bg-muted/60 focus-visible:ring-ring mt-1.5 inline-block w-fit max-w-full overflow-hidden rounded-md border-l-2 border-l-primary/60 px-2.5 py-2 outline-none transition-colors focus-visible:ring-2"
       aria-label={t("openLink", { title: unfurl.title })}
       data-testid="room-message-unfurl"
     >
@@ -424,7 +424,7 @@ function ChannelMessageText({
             return (
               <div
                 key={`files-${i}-${headLink.index}`}
-                className="my-2 flex flex-wrap gap-2"
+                className="my-2 flex min-w-0 max-w-full flex-wrap gap-2"
                 data-testid="room-message-attachment-row"
               >
                 {segment.links.map((link) => (
@@ -1329,7 +1329,7 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
+        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation
           ? "min-h-0 py-0.5"
@@ -1372,7 +1372,7 @@ export function ChatMessageRow({
       )}
       <div
         className={cn(
-          "min-w-0 flex-1",
+          "min-w-0 max-w-full flex-1 overflow-x-clip",
           isContinuation ? "space-y-1" : "space-y-1.5",
         )}
       >

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -479,7 +479,7 @@ function ChannelMessageBody({
         data-testid="room-message-body"
         data-jumbo-emoji={String(jumboEmojiCount)}
         className={cn(
-          "wrap-break-word whitespace-pre-wrap",
+          "min-w-0 max-w-full wrap-anywhere [word-break:break-word] whitespace-pre-wrap",
           jumboEmojiClassName(jumboEmojiCount),
         )}
       >
@@ -489,11 +489,12 @@ function ChannelMessageBody({
   }
 
   return (
-    <div>
+    <div className="min-w-0 max-w-full wrap-anywhere [word-break:break-word]">
       <div
         ref={contentRef}
         data-testid="room-message-body"
         className={cn(
+          "min-w-0 max-w-full",
           expanded || skipBodyClamp ? null : MESSAGE_BODY_CLAMP_CLASS,
         )}
       >
@@ -1328,7 +1329,7 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        "group relative -mx-2 flex gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
+        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 rounded-md pl-2 transition-colors hover:bg-muted/45 [@media(hover:hover)]:pr-20",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation
           ? "min-h-0 py-0.5"
@@ -1407,7 +1408,7 @@ export function ChatMessageRow({
             ) : null}
           </div>
         )}
-        <div className="text-foreground wrap-break-word text-base leading-6 md:text-sm">
+        <div className="text-foreground min-w-0 max-w-full wrap-anywhere [word-break:break-word] text-base leading-6 md:text-sm">
           {isDeleted ? (
             <p className="text-muted-foreground italic">
               {tChannels("Message.deleted")}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1531,10 +1531,10 @@ export function RoomsClient({
                 </div>
               </header>
 
-              <ScrollArea ref={scrollerRef} className="min-h-0 flex-1">
+              <ScrollArea ref={scrollerRef} className="min-h-0 min-w-0 flex-1">
                 <div
                   ref={contentRef}
-                  className="flex w-full flex-col justify-end px-5 pt-6 pb-0"
+                  className="flex min-w-0 w-full flex-col justify-end px-5 pt-6 pb-0"
                   style={
                     contentMinHeight != null
                       ? { minHeight: contentMinHeight }
@@ -1588,7 +1588,7 @@ export function RoomsClient({
                         messageDayKey(message.createdAt);
                     const isStreamOverlay = message.id.startsWith("stream:");
                     return (
-                      <div key={message.id}>
+                      <div key={message.id} className="min-w-0">
                         {showDaySeparator ? (
                           <DaySeparator
                             date={new Date(message.createdAt)}

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -189,10 +189,10 @@ export function ThreadPanel({
             <X className="size-4" aria-hidden />
           </Button>
         </header>
-        <ScrollArea ref={scrollerRef} className="min-h-0 flex-1">
+        <ScrollArea ref={scrollerRef} className="min-h-0 min-w-0 flex-1">
           <div
             ref={contentRef}
-            className="flex w-full flex-col justify-end px-4 pt-4 pb-0"
+            className="flex min-w-0 w-full flex-col justify-end px-4 pt-4 pb-0"
             style={
               contentMinHeight != null
                 ? { minHeight: contentMinHeight }

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -49,12 +49,13 @@ export default function Markdown({
   const sanitizedChildren = sanitizeMarkdown(normalizedChildren);
 
   const components: Components = {
-    a: ({ href, children, ...props }) => {
+    a: ({ href, children, className, ...props }) => {
       const sameTab = isSokosumiLink(href);
       return (
         <a
           href={href}
           {...props}
+          className={cn("wrap-anywhere [overflow-wrap:anywhere]", className)}
           {...(sameTab ? {} : { target: "_blank", rel: "noopener noreferrer" })}
         >
           {children}
@@ -71,7 +72,7 @@ export default function Markdown({
             controls
             playsInline
             preload="metadata"
-            className="h-auto w-full max-w-sm rounded-lg"
+            className="h-auto w-full max-w-full rounded-lg"
             aria-label={alt || undefined}
           />
         );
@@ -83,14 +84,19 @@ export default function Markdown({
             src={mediaSrc}
             controls
             preload="metadata"
-            className="w-full max-w-sm"
+            className="w-full max-w-full"
             aria-label={alt || undefined}
           />
         );
       }
       return (
         // eslint-disable-next-line @next/next/no-img-element
-        <img src={src} alt={alt} className="max-w-full rounded-lg" {...props} />
+        <img
+          src={src}
+          alt={alt}
+          className="h-auto max-w-full rounded-lg"
+          {...props}
+        />
       );
     },
     video: ({ children, src, autoPlay: _autoPlay, ...props }) => {
@@ -100,7 +106,7 @@ export default function Markdown({
         <video
           {...props}
           src={srcString}
-          className="h-auto w-full max-w-sm rounded-lg"
+          className="h-auto w-full max-w-full rounded-lg"
           controls
           playsInline
           preload="metadata"
@@ -116,7 +122,7 @@ export default function Markdown({
         <audio
           {...props}
           src={srcString}
-          className="w-full max-w-sm"
+          className="w-full max-w-full"
           controls
           preload="metadata"
         >

--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -112,14 +112,14 @@ describe("FileChipMiniPreviewFrame", () => {
     const imageButton = screen.getByRole("button", {
       name: "View image photo.png",
     });
-    expect(imageButton).toHaveClass("max-w-sm");
+    expect(imageButton).toHaveClass("max-w-full");
     expect(imageButton).toHaveClass("max-h-80");
     expect(imageButton).not.toHaveClass("size-20");
     expect(imageButton).not.toHaveClass("size-16");
 
     const previewImage = screen.getByRole("img", { name: "photo.png" });
     expect(previewImage).toHaveClass("object-contain");
-    expect(previewImage).toHaveClass("max-w-sm");
+    expect(previewImage).toHaveClass("max-w-full");
     expect(previewImage).toHaveClass("max-h-80");
 
     fireEvent.click(imageButton);

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -36,7 +36,8 @@ export interface FileChipMiniPreviewProps {
 const previewTriggerClassName =
   "group bg-accent/30 hover:bg-accent/50 focus-visible:ring-ring relative block shrink-0 cursor-pointer overflow-hidden rounded-xl border outline-none transition";
 
-const largeImageTriggerClassName = "max-h-80 max-w-sm";
+const largeImageTriggerClassName =
+  "min-w-0 max-h-80 w-full max-w-full shrink";
 
 function FileChipMiniPreviewTrigger({
   url,
@@ -79,7 +80,7 @@ function FileChipMiniPreviewTrigger({
           <img
             src={url}
             alt={resolvedFileName}
-            className="max-h-80 max-w-sm object-contain object-center"
+            className="max-h-80 w-full max-w-full object-contain object-center"
           />
         </button>
       );

--- a/apps/web/src/components/ui/file-chip.tsx
+++ b/apps/web/src/components/ui/file-chip.tsx
@@ -170,8 +170,8 @@ export function FileChip(props: FileChipProps) {
     return (
       <div
         className={cn(
-          // Cap like large solo image thumbs (`max-w-sm`) — not full message width.
-          "flex w-full max-w-sm flex-col gap-2 rounded-md border p-2",
+          // Stay inside the message column (thread can be narrower than 24rem).
+          "flex w-full max-w-full flex-col gap-2 rounded-md border p-2",
           className,
         )}
         title={title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes room chat message body text overflowing the right edge in the main timeline and thread replies ([SOK-728](https://linear.app/masumi/issue/SOK-728/fix-text-overflow-on-the-right-in-room-chat-messages)).

## Spec summary

- Constrain shared `ChatMessageRow` / `ChannelMessageBody` with `min-w-0`, `max-w-full`, wrap tokens, and `overflow-x-clip`.
- Timeline and thread list wrappers also get `min-w-0`.
- Links wrap; large attachments / unfurls / media use `max-w-full` so narrow thread panes cannot spill.
- Message actions and chrome unchanged.

## Verification

- `pnpm web:check` / `pnpm web:test` (exit 0)
- UI `/chat/rooms/[roomId]`: long URL + unbroken words + wide image; no `scrollWidth` spill on body, article, or viewport

## Preview (not production)

Production/main does not have this until merge. Use the PR preview to validate:

https://sokosumi-app-preprod-git-cursor-sok-728-fix-text-overflo-f22cef.preview.sokosumi.com

## Linear

https://linear.app/masumi/issue/SOK-728/fix-text-overflow-on-the-right-in-room-chat-messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0114edd1-9e7c-4721-a0e6-caea52fab401?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0114edd1-9e7c-4721-a0e6-caea52fab401&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

