### PR TITLE
feat(web): add mobile create FAB on Home and Chats

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4726,6 +4726,26 @@
         "backToHome": "Zurück zur Startseite",
         "back": "Zurück"
       },
+      "MobileCreateFab": {
+        "openMenu": "Erstellen",
+        "closeMenu": "Erstellen-Menü schließen",
+        "newChat": {
+          "title": "Neuer Chat",
+          "subtitle": "Gespräch mit einem Coworker starten"
+        },
+        "newTask": {
+          "title": "Neue Aufgabe",
+          "subtitle": "Aufgabe im Board erstellen"
+        },
+        "createChannel": {
+          "title": "Kanal erstellen",
+          "subtitle": "Gemeinsamen Kanal starten"
+        },
+        "newDm": {
+          "title": "Neue DM",
+          "subtitle": "Jemandem direkt schreiben"
+        }
+      },
       "Actions": {
         "more": "Nachrichtenaktionen",
         "sectionTitle": "Kanal verwalten",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4729,10 +4729,6 @@
       "MobileCreateFab": {
         "openMenu": "Erstellen",
         "closeMenu": "Erstellen-Menü schließen",
-        "newChat": {
-          "title": "Neuer Chat",
-          "subtitle": "Chat mit einem Coworker starten"
-        },
         "newTask": {
           "title": "Neue Aufgabe",
           "subtitle": "Neue langfristige Aufgabe erstellen"

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4731,19 +4731,19 @@
         "closeMenu": "Erstellen-Menü schließen",
         "newChat": {
           "title": "Neuer Chat",
-          "subtitle": "Gespräch mit einem Coworker starten"
+          "subtitle": "Chat mit einem Coworker starten"
         },
         "newTask": {
           "title": "Neue Aufgabe",
-          "subtitle": "Aufgabe im Board erstellen"
+          "subtitle": "Neue langfristige Aufgabe erstellen"
         },
         "createChannel": {
           "title": "Kanal erstellen",
-          "subtitle": "Gemeinsamen Kanal starten"
+          "subtitle": "Neuen Stream-Kanal starten"
         },
         "newDm": {
-          "title": "Neue DM",
-          "subtitle": "Jemandem direkt schreiben"
+          "title": "Neue Direktnachricht",
+          "subtitle": "Einer oder mehreren Personen schreiben"
         }
       },
       "Actions": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4726,6 +4726,26 @@
         "backToHome": "Back to home",
         "back": "Back"
       },
+      "MobileCreateFab": {
+        "openMenu": "Create",
+        "closeMenu": "Close create menu",
+        "newChat": {
+          "title": "New Chat",
+          "subtitle": "Start a conversation with a coworker"
+        },
+        "newTask": {
+          "title": "New Task",
+          "subtitle": "Create a task on the board"
+        },
+        "createChannel": {
+          "title": "Create Channel",
+          "subtitle": "Start a shared channel"
+        },
+        "newDm": {
+          "title": "New DM",
+          "subtitle": "Message someone directly"
+        }
+      },
       "Actions": {
         "more": "Message actions",
         "sectionTitle": "Manage channel",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4731,19 +4731,19 @@
         "closeMenu": "Close create menu",
         "newChat": {
           "title": "New Chat",
-          "subtitle": "Start a conversation with a coworker"
+          "subtitle": "Start a chat with a coworker"
         },
         "newTask": {
           "title": "New Task",
-          "subtitle": "Create a task on the board"
+          "subtitle": "Create a new long running task"
         },
         "createChannel": {
-          "title": "Create Channel",
-          "subtitle": "Start a shared channel"
+          "title": "Create channel",
+          "subtitle": "Start a new stream channel"
         },
         "newDm": {
-          "title": "New DM",
-          "subtitle": "Message someone directly"
+          "title": "New direct message",
+          "subtitle": "Message one or more people"
         }
       },
       "Actions": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4729,10 +4729,6 @@
       "MobileCreateFab": {
         "openMenu": "Create",
         "closeMenu": "Close create menu",
-        "newChat": {
-          "title": "New Chat",
-          "subtitle": "Start a chat with a coworker"
-        },
         "newTask": {
           "title": "New Task",
           "subtitle": "Create a new long running task"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4731,19 +4731,19 @@
         "closeMenu": "Cerrar menú de creación",
         "newChat": {
           "title": "Nuevo chat",
-          "subtitle": "Inicia una conversación con un coworker"
+          "subtitle": "Inicia un chat con un coworker"
         },
         "newTask": {
           "title": "Nueva tarea",
-          "subtitle": "Crea una tarea en el tablero"
+          "subtitle": "Crea una tarea de larga duración"
         },
         "createChannel": {
           "title": "Crear canal",
-          "subtitle": "Inicia un canal compartido"
+          "subtitle": "Inicia un nuevo canal de stream"
         },
         "newDm": {
-          "title": "Nuevo DM",
-          "subtitle": "Escribe a alguien directamente"
+          "title": "Nuevo mensaje directo",
+          "subtitle": "Escribe a una o más personas"
         }
       },
       "Actions": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4726,6 +4726,26 @@
         "backToHome": "Volver al inicio",
         "back": "Volver"
       },
+      "MobileCreateFab": {
+        "openMenu": "Crear",
+        "closeMenu": "Cerrar menú de creación",
+        "newChat": {
+          "title": "Nuevo chat",
+          "subtitle": "Inicia una conversación con un coworker"
+        },
+        "newTask": {
+          "title": "Nueva tarea",
+          "subtitle": "Crea una tarea en el tablero"
+        },
+        "createChannel": {
+          "title": "Crear canal",
+          "subtitle": "Inicia un canal compartido"
+        },
+        "newDm": {
+          "title": "Nuevo DM",
+          "subtitle": "Escribe a alguien directamente"
+        }
+      },
       "Actions": {
         "more": "Acciones del mensaje",
         "sectionTitle": "Gestionar canal",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4729,10 +4729,6 @@
       "MobileCreateFab": {
         "openMenu": "Crear",
         "closeMenu": "Cerrar menú de creación",
-        "newChat": {
-          "title": "Nuevo chat",
-          "subtitle": "Inicia un chat con un coworker"
-        },
         "newTask": {
           "title": "Nueva tarea",
           "subtitle": "Crea una tarea de larga duración"

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
@@ -48,7 +48,7 @@ describe("resolveChatMobileActiveTabId", () => {
     expect(resolveChatMobileActiveTabId("/chat/chats")).toBe("chats");
   });
 
-  it("does not mark Home active on draft create/dm query routes", () => {
+  it("does not mark Home active on draft create/dm/welcome query routes", () => {
     expect(
       resolveChatMobileActiveTabId(
         "/chat",
@@ -57,6 +57,9 @@ describe("resolveChatMobileActiveTabId", () => {
     ).toBeNull();
     expect(
       resolveChatMobileActiveTabId("/chat", new URLSearchParams("dm=new")),
+    ).toBeNull();
+    expect(
+      resolveChatMobileActiveTabId("/chat", new URLSearchParams("welcome=1")),
     ).toBeNull();
   });
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab-actions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab-actions.test.ts
@@ -11,7 +11,6 @@ import {
 describe("mobileCreateFabActions", () => {
   it("returns home actions with existing create routes", () => {
     expect(mobileCreateFabActions("home")).toEqual([
-      { id: "newChat", href: "/chat?welcome=1" },
       { id: "newTask", href: "/tasks?create=true" },
       { id: "createChannel", href: "/chat?create=channel" },
       { id: "newDm", href: "/chat?dm=new" },

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab-actions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab-actions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHAT_MOBILE_CREATE_FAB_BOTTOM,
+  CHAT_MOBILE_CREATE_FAB_BOTTOM_APPLE,
+  chatMobileCreateFabBottom,
+  chatMobileCreateFabScrimBottom,
+  mobileCreateFabActions,
+} from "../chat-mobile-create-fab-actions";
+
+describe("mobileCreateFabActions", () => {
+  it("returns home actions with existing create routes", () => {
+    expect(mobileCreateFabActions("home")).toEqual([
+      { id: "newChat", href: "/chat?welcome=1" },
+      { id: "newTask", href: "/tasks?create=true" },
+      { id: "createChannel", href: "/chat?create=channel" },
+      { id: "newDm", href: "/chat?dm=new" },
+    ]);
+  });
+
+  it("returns chats actions with channel and dm only", () => {
+    expect(mobileCreateFabActions("chats")).toEqual([
+      { id: "createChannel", href: "/chat?create=channel" },
+      { id: "newDm", href: "/chat?dm=new" },
+    ]);
+  });
+});
+
+describe("chatMobileCreateFabBottom", () => {
+  it("uses docked and Apple bottom offsets above the tab bar", () => {
+    expect(chatMobileCreateFabBottom(false)).toBe(
+      CHAT_MOBILE_CREATE_FAB_BOTTOM,
+    );
+    expect(chatMobileCreateFabBottom(true)).toBe(
+      CHAT_MOBILE_CREATE_FAB_BOTTOM_APPLE,
+    );
+    expect(chatMobileCreateFabScrimBottom(false)).toContain("4rem");
+    expect(chatMobileCreateFabScrimBottom(true)).toContain("max(0.75rem");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
@@ -18,42 +18,73 @@ vi.mock("@/hooks/use-is-apple-platform", () => ({
   default: () => mockIsApple,
 }));
 
-vi.mock("motion/react", () => ({
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
-  motion: {
-    div: ({
-      children,
-      className,
-    }: {
-      children?: React.ReactNode;
-      className?: string;
-    }) => <div className={className}>{children}</div>,
-    button: ({
-      children,
-      className,
-      onClick,
-      ...props
-    }: {
-      children?: React.ReactNode;
-      className?: string;
-      onClick?: () => void;
-    }) => (
-      <button type="button" className={className} onClick={onClick} {...props}>
-        {children}
-      </button>
+vi.mock("motion/react", () => {
+  function stripMotionProps(props: Record<string, unknown>) {
+    const {
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      transition: _transition,
+      ...rest
+    } = props;
+    return rest;
+  }
+
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
     ),
-    span: ({
-      children,
-      className,
-    }: {
-      children?: React.ReactNode;
-      className?: string;
-    }) => <span className={className}>{children}</span>,
-  },
-  useReducedMotion: () => true,
-}));
+    motion: {
+      div: ({
+        children,
+        className,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        [key: string]: unknown;
+      }) => (
+        <div className={className} {...stripMotionProps(props)}>
+          {children}
+        </div>
+      ),
+      button: ({
+        children,
+        className,
+        onClick,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        onClick?: () => void;
+        [key: string]: unknown;
+      }) => (
+        <button
+          type="button"
+          className={className}
+          onClick={onClick}
+          {...stripMotionProps(props)}
+        >
+          {children}
+        </button>
+      ),
+      span: ({
+        children,
+        className,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        [key: string]: unknown;
+      }) => (
+        <span className={className} {...stripMotionProps(props)}>
+          {children}
+        </span>
+      ),
+    },
+    useReducedMotion: () => true,
+  };
+});
 
 vi.mock("next/link", () => ({
   default: ({
@@ -81,24 +112,26 @@ describe("ChatMobileCreateFab", () => {
     mockIsApple = false;
   });
 
-  it("shows on home and opens home actions", () => {
-    render(<ChatMobileCreateFab />);
+  it("shows on home and opens overlay list menu with home actions", () => {
+    const { container } = render(<ChatMobileCreateFab />);
 
     fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
 
     expect(
-      screen.getByRole("link", { name: /newChat\.title/i }),
+      container.querySelector("[data-mobile-create-fab-menu]"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: /newChat\.title/i }),
     ).toHaveAttribute("href", "/chat?welcome=1");
     expect(
-      screen.getByRole("link", { name: /newTask\.title/i }),
+      screen.getByRole("menuitem", { name: /newTask\.title/i }),
     ).toHaveAttribute("href", "/tasks?create=true");
     expect(
-      screen.getByRole("link", { name: /createChannel\.title/i }),
+      screen.getByRole("menuitem", { name: /createChannel\.title/i }),
     ).toHaveAttribute("href", "/chat?create=channel");
-    expect(screen.getByRole("link", { name: /newDm\.title/i })).toHaveAttribute(
-      "href",
-      "/chat?dm=new",
-    );
+    expect(
+      screen.getByRole("menuitem", { name: /newDm\.title/i }),
+    ).toHaveAttribute("href", "/chat?dm=new");
   });
 
   it("shows chats actions without new chat or new task", () => {
@@ -107,12 +140,18 @@ describe("ChatMobileCreateFab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
 
-    expect(screen.queryByRole("link", { name: /newChat\.title/i })).toBeNull();
-    expect(screen.queryByRole("link", { name: /newTask\.title/i })).toBeNull();
     expect(
-      screen.getByRole("link", { name: /createChannel\.title/i }),
+      screen.queryByRole("menuitem", { name: /newChat\.title/i }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: /newTask\.title/i }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("menuitem", { name: /createChannel\.title/i }),
     ).toBeTruthy();
-    expect(screen.getByRole("link", { name: /newDm\.title/i })).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: /newDm\.title/i }),
+    ).toBeTruthy();
   });
 
   it("hides on welcome compose and draft query surfaces", () => {
@@ -142,5 +181,27 @@ describe("ChatMobileCreateFab", () => {
     expect(
       container.querySelector("[data-mobile-create-fab]")?.className,
     ).toContain("md:hidden");
+  });
+
+  it("anchors the open menu over the FAB footprint", () => {
+    render(<ChatMobileCreateFab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
+
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+    expect(screen.getByRole("menu")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "closeMenu" }));
+    expect(screen.getByRole("button", { name: "openMenu" })).toBeTruthy();
+  });
+
+  it("uses glassy surface classes on Apple", () => {
+    mockIsApple = true;
+    const { container } = render(<ChatMobileCreateFab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
+
+    const menu = container.querySelector("[data-mobile-create-fab-menu]");
+    expect(menu?.className).toContain("backdrop-blur-2xl");
+    expect(menu?.className).toContain("bg-background/45");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/chat";
+let mockSearchParams = new URLSearchParams();
+let mockIsApple = false;
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/hooks/use-is-apple-platform", () => ({
+  default: () => mockIsApple,
+}));
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: {
+    div: ({
+      children,
+      className,
+    }: {
+      children?: React.ReactNode;
+      className?: string;
+    }) => <div className={className}>{children}</div>,
+    button: ({
+      children,
+      className,
+      onClick,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      className?: string;
+      onClick?: () => void;
+    }) => (
+      <button type="button" className={className} onClick={onClick} {...props}>
+        {children}
+      </button>
+    ),
+    span: ({
+      children,
+      className,
+    }: {
+      children?: React.ReactNode;
+      className?: string;
+    }) => <span className={className}>{children}</span>,
+  },
+  useReducedMotion: () => true,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    onClick,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    onClick?: () => void;
+  }) => (
+    <a href={href} onClick={onClick} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { ChatMobileCreateFab } from "../chat-mobile-create-fab";
+
+describe("ChatMobileCreateFab", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+    mockSearchParams = new URLSearchParams();
+    mockIsApple = false;
+  });
+
+  it("shows on home and opens home actions", () => {
+    render(<ChatMobileCreateFab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
+
+    expect(
+      screen.getByRole("link", { name: /newChat\.title/i }),
+    ).toHaveAttribute("href", "/chat?welcome=1");
+    expect(
+      screen.getByRole("link", { name: /newTask\.title/i }),
+    ).toHaveAttribute("href", "/tasks?create=true");
+    expect(
+      screen.getByRole("link", { name: /createChannel\.title/i }),
+    ).toHaveAttribute("href", "/chat?create=channel");
+    expect(screen.getByRole("link", { name: /newDm\.title/i })).toHaveAttribute(
+      "href",
+      "/chat?dm=new",
+    );
+  });
+
+  it("shows chats actions without new chat or new task", () => {
+    mockPathname = "/chat/chats";
+    render(<ChatMobileCreateFab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
+
+    expect(screen.queryByRole("link", { name: /newChat\.title/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /newTask\.title/i })).toBeNull();
+    expect(
+      screen.getByRole("link", { name: /createChannel\.title/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: /newDm\.title/i })).toBeTruthy();
+  });
+
+  it("hides on welcome compose and draft query surfaces", () => {
+    mockSearchParams = new URLSearchParams("welcome=1");
+    const { unmount } = render(<ChatMobileCreateFab />);
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+    unmount();
+
+    mockSearchParams = new URLSearchParams("create=channel");
+    render(<ChatMobileCreateFab />);
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+  });
+
+  it("hides on rooms and non-hub routes", () => {
+    mockPathname = "/chat/rooms/r1";
+    const { unmount } = render(<ChatMobileCreateFab />);
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+    unmount();
+
+    mockPathname = "/tasks";
+    render(<ChatMobileCreateFab />);
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+  });
+
+  it("is marked md:hidden", () => {
+    const { container } = render(<ChatMobileCreateFab />);
+    expect(
+      container.querySelector("[data-mobile-create-fab]")?.className,
+    ).toContain("md:hidden");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
@@ -203,6 +203,24 @@ describe("ChatMobileCreateFab", () => {
     expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
   });
 
+  it("closes the menu when leaving and returning to a FAB surface", () => {
+    const { rerender } = render(<ChatMobileCreateFab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "openMenu" }));
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    mockPathname = "/tasks";
+    rerender(<ChatMobileCreateFab />);
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+
+    mockPathname = "/chat";
+    rerender(<ChatMobileCreateFab />);
+    expect(screen.getByRole("button", { name: "openMenu" })).toBeTruthy();
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.queryByRole("button", { name: "closeMenu" })).toBeNull();
+  });
+
   it("is marked md:hidden", () => {
     const { container } = render(<ChatMobileCreateFab />);
     expect(

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-create-fab.test.tsx
@@ -25,6 +25,8 @@ vi.mock("motion/react", () => {
       animate: _animate,
       exit: _exit,
       transition: _transition,
+      layout: _layout,
+      layoutDependency: _layoutDependency,
       ...rest
     } = props;
     return rest;
@@ -81,11 +83,36 @@ vi.mock("motion/react", () => {
           {children}
         </span>
       ),
+      ul: ({
+        children,
+        className,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        [key: string]: unknown;
+      }) => (
+        <ul className={className} {...stripMotionProps(props)}>
+          {children}
+        </ul>
+      ),
+      li: ({
+        children,
+        className,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        [key: string]: unknown;
+      }) => (
+        <li className={className} {...stripMotionProps(props)}>
+          {children}
+        </li>
+      ),
     },
     useReducedMotion: () => true,
   };
 });
-
 vi.mock("next/link", () => ({
   default: ({
     children,
@@ -121,8 +148,8 @@ describe("ChatMobileCreateFab", () => {
       container.querySelector("[data-mobile-create-fab-menu]"),
     ).toBeTruthy();
     expect(
-      screen.getByRole("menuitem", { name: /newChat\.title/i }),
-    ).toHaveAttribute("href", "/chat?welcome=1");
+      screen.queryByRole("menuitem", { name: /newChat\.title/i }),
+    ).toBeNull();
     expect(
       screen.getByRole("menuitem", { name: /newTask\.title/i }),
     ).toHaveAttribute("href", "/tasks?create=true");

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-tab-registry.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-tab-registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHAT_MOBILE_HEIGHT_SHELL_CLASS,
+  CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS,
+  chatMobileHeightShellClass,
+} from "../chat-mobile-tab-registry";
+
+describe("chatMobileHeightShellClass", () => {
+  it("uses no-tab-bar shell for rooms", () => {
+    expect(chatMobileHeightShellClass("/chat/rooms/r1")).toBe(
+      CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS,
+    );
+  });
+
+  it("uses no-tab-bar shell for draft DM compose", () => {
+    expect(
+      chatMobileHeightShellClass("/chat", false, new URLSearchParams("dm=new")),
+    ).toBe(CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS);
+  });
+
+  it("uses no-tab-bar shell for welcome compose", () => {
+    expect(
+      chatMobileHeightShellClass(
+        "/chat",
+        false,
+        new URLSearchParams("welcome=1"),
+      ),
+    ).toBe(CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS);
+  });
+
+  it("uses no-tab-bar shell for create-channel draft", () => {
+    expect(
+      chatMobileHeightShellClass(
+        "/chat",
+        false,
+        new URLSearchParams("create=channel"),
+      ),
+    ).toBe(CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS);
+  });
+
+  it("keeps tab-bar shell on home and chats", () => {
+    expect(chatMobileHeightShellClass("/chat")).toBe(
+      CHAT_MOBILE_HEIGHT_SHELL_CLASS,
+    );
+    expect(chatMobileHeightShellClass("/chat/chats")).toBe(
+      CHAT_MOBILE_HEIGHT_SHELL_CLASS,
+    );
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/welcome-screen.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/welcome-screen.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/chat";
+let mockSearchParams = new URLSearchParams();
+let mockIsApple = false;
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => {
+    const t = (key: string, values?: { name?: string }) => {
+      if (key === "welcomeScreen.greetingWithName") {
+        return `Welcome ${values?.name}!`;
+      }
+      if (key === "welcomeScreen.greeting") {
+        return "Welcome!";
+      }
+      if (key === "welcomeScreen.question") {
+        return "How can we help you today?";
+      }
+      if (key === "welcomeScreen.suggestionsLabel") {
+        return "Try asking";
+      }
+      if (key.startsWith("welcomeScreen.prompts.")) {
+        return null;
+      }
+      return key;
+    };
+    t.has = (key: string) => key.startsWith("welcomeScreen.prompts.") === false;
+    return t;
+  },
+}));
+
+vi.mock("@/hooks/use-is-apple-platform", () => ({
+  default: () => mockIsApple,
+}));
+
+vi.mock("@/components/chat/multimodal-input", () => ({
+  MultimodalInput: () => <div data-testid="multimodal-input" />,
+}));
+
+import WelcomeScreen from "../welcome-screen";
+
+const baseProps = {
+  isTransitioning: false,
+  input: "",
+  setInput: vi.fn(),
+  messages: [],
+  setMessages: vi.fn(),
+  sendMessage: vi.fn(),
+  status: "ready" as const,
+  stop: vi.fn(),
+  onSendMessage: vi.fn(),
+};
+
+describe("WelcomeScreen", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+    mockSearchParams = new URLSearchParams();
+    mockIsApple = false;
+  });
+
+  it("lifts composer above the mobile tab bar on home", () => {
+    render(<WelcomeScreen {...baseProps} userName="Francis" />);
+
+    const dock = document.querySelector("[data-welcome-composer-dock]");
+    expect(dock?.className).toContain(
+      "bottom-[calc(4rem+env(safe-area-inset-bottom))]",
+    );
+  });
+
+  it("pins composer to the bottom on welcome compose without tab bar", () => {
+    mockSearchParams = new URLSearchParams("welcome=1");
+    render(<WelcomeScreen {...baseProps} userName="Francis" />);
+
+    const dock = document.querySelector("[data-welcome-composer-dock]");
+    expect(dock?.className).toContain("bottom-0");
+    expect(dock?.className).not.toContain(
+      "bottom-[calc(4rem+env(safe-area-inset-bottom))]",
+    );
+  });
+
+  it("matches room composer side padding", () => {
+    mockSearchParams = new URLSearchParams("welcome=1");
+    render(<WelcomeScreen {...baseProps} userName="Francis" />);
+
+    const dock = document.querySelector("[data-welcome-composer-dock]");
+    expect(dock?.className).toContain("px-3");
+    expect(dock?.className).toContain("md:px-5");
+    expect(dock?.className).not.toContain("px-4");
+    expect(dock?.className).not.toContain("md:px-8");
+  });
+
+  it("pads the welcome message block on the sides", () => {
+    render(<WelcomeScreen {...baseProps} userName="Francis" />);
+
+    const greeting = screen.getByRole("heading", { name: /Welcome Francis/i });
+    const padded = greeting.closest(".px-4");
+    expect(padded).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab-actions.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab-actions.ts
@@ -1,10 +1,6 @@
 export type MobileCreateFabSurface = "home" | "chats";
 
-export type MobileCreateFabActionId =
-  | "newChat"
-  | "newTask"
-  | "createChannel"
-  | "newDm";
+export type MobileCreateFabActionId = "newTask" | "createChannel" | "newDm";
 
 export interface MobileCreateFabAction {
   id: MobileCreateFabActionId;
@@ -12,7 +8,6 @@ export interface MobileCreateFabAction {
 }
 
 const HOME_ACTIONS: readonly MobileCreateFabAction[] = [
-  { id: "newChat", href: "/chat?welcome=1" },
   { id: "newTask", href: "/tasks?create=true" },
   { id: "createChannel", href: "/chat?create=channel" },
   { id: "newDm", href: "/chat?dm=new" },

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab-actions.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab-actions.ts
@@ -1,0 +1,61 @@
+export type MobileCreateFabSurface = "home" | "chats";
+
+export type MobileCreateFabActionId =
+  | "newChat"
+  | "newTask"
+  | "createChannel"
+  | "newDm";
+
+export interface MobileCreateFabAction {
+  id: MobileCreateFabActionId;
+  href: string;
+}
+
+const HOME_ACTIONS: readonly MobileCreateFabAction[] = [
+  { id: "newChat", href: "/chat?welcome=1" },
+  { id: "newTask", href: "/tasks?create=true" },
+  { id: "createChannel", href: "/chat?create=channel" },
+  { id: "newDm", href: "/chat?dm=new" },
+] as const;
+
+const CHATS_ACTIONS: readonly MobileCreateFabAction[] = [
+  { id: "createChannel", href: "/chat?create=channel" },
+  { id: "newDm", href: "/chat?dm=new" },
+] as const;
+
+/** Create actions for the mobile FAB speed-dial (existing routes only). */
+export function mobileCreateFabActions(
+  surface: MobileCreateFabSurface,
+): readonly MobileCreateFabAction[] {
+  return surface === "home" ? HOME_ACTIONS : CHATS_ACTIONS;
+}
+
+/**
+ * FAB sits above the docked tab bar with a small gap.
+ * Full static Tailwind strings (dynamic class assembly would break purge).
+ */
+export const CHAT_MOBILE_CREATE_FAB_BOTTOM =
+  "bottom-[calc(4rem+env(safe-area-inset-bottom)+0.75rem)]" as const;
+
+/** FAB above the floating Apple tab bar. */
+export const CHAT_MOBILE_CREATE_FAB_BOTTOM_APPLE =
+  "bottom-[calc(4rem+max(0.75rem,env(safe-area-inset-bottom))+0.75rem)]" as const;
+
+export function chatMobileCreateFabBottom(isApple: boolean): string {
+  return isApple
+    ? CHAT_MOBILE_CREATE_FAB_BOTTOM_APPLE
+    : CHAT_MOBILE_CREATE_FAB_BOTTOM;
+}
+
+/** Scrim ends above the docked tab bar so tab hit targets stay free. */
+export const CHAT_MOBILE_CREATE_FAB_SCRIM_BOTTOM =
+  "bottom-[calc(4rem+env(safe-area-inset-bottom))]" as const;
+
+export const CHAT_MOBILE_CREATE_FAB_SCRIM_BOTTOM_APPLE =
+  "bottom-[calc(4rem+max(0.75rem,env(safe-area-inset-bottom)))]" as const;
+
+export function chatMobileCreateFabScrimBottom(isApple: boolean): string {
+  return isApple
+    ? CHAT_MOBILE_CREATE_FAB_SCRIM_BOTTOM_APPLE
+    : CHAT_MOBILE_CREATE_FAB_SCRIM_BOTTOM;
+}

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab-actions.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab-actions.ts
@@ -23,7 +23,7 @@ const CHATS_ACTIONS: readonly MobileCreateFabAction[] = [
   { id: "newDm", href: "/chat?dm=new" },
 ] as const;
 
-/** Create actions for the mobile FAB speed-dial (existing routes only). */
+/** Create actions for the mobile FAB overlay menu (existing routes only). */
 export function mobileCreateFabActions(
   surface: MobileCreateFabSurface,
 ): readonly MobileCreateFabAction[] {

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
@@ -21,6 +21,7 @@ import {
   chatMobileCreateFabBottom,
   chatMobileCreateFabScrimBottom,
   type MobileCreateFabActionId,
+  type MobileCreateFabSurface,
   mobileCreateFabActions,
 } from "./chat-mobile-create-fab-actions";
 
@@ -43,19 +44,17 @@ const SHELL_SPRING = {
 /**
  * Mobile create FAB for Home and Chats (md:hidden).
  * One shell morphs from the circular dial into the overlay list panel.
+ *
+ * Menu state lives in a child that only mounts on FAB surfaces so hub tab
+ * switches clear an open overlay instead of restoring it later.
  */
 export function ChatMobileCreateFab(): React.ReactElement | null {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const t = useTranslations("App.Channels.MobileCreateFab");
-  const isApple = useIsApplePlatform();
-  const reduceMotion = useReducedMotion();
-  const [open, setOpen] = useState(false);
-  // Panel paint stays through the close morph; dial purple applies after.
-  const [panelChrome, setPanelChrome] = useState(false);
-  const openRef = useRef(false);
-
-  const surface = shouldShowMobileCreateFab(pathname, searchParams)
+  const surface: MobileCreateFabSurface | null = shouldShowMobileCreateFab(
+    pathname,
+    searchParams,
+  )
     ? pathname === "/chat/chats"
       ? "chats"
       : "home"
@@ -64,6 +63,24 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
   if (!surface) {
     return null;
   }
+
+  return <ChatMobileCreateFabMenu key={surface} surface={surface} />;
+}
+
+interface ChatMobileCreateFabMenuProps {
+  surface: MobileCreateFabSurface;
+}
+
+function ChatMobileCreateFabMenu({
+  surface,
+}: ChatMobileCreateFabMenuProps): React.ReactElement {
+  const t = useTranslations("App.Channels.MobileCreateFab");
+  const isApple = useIsApplePlatform();
+  const reduceMotion = useReducedMotion();
+  const [open, setOpen] = useState(false);
+  // Panel paint stays through the close morph; dial purple applies after.
+  const [panelChrome, setPanelChrome] = useState(false);
+  const openRef = useRef(false);
 
   const actions = mobileCreateFabActions(surface);
 

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
@@ -3,8 +3,8 @@
 import {
   Hash,
   ListTodo,
-  MessageCircle,
   MessageSquarePlus,
+  MessagesSquare,
   Plus,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -31,12 +31,12 @@ const ACTION_ICONS: Record<
   newChat: MessageSquarePlus,
   newTask: ListTodo,
   createChannel: Hash,
-  newDm: MessageCircle,
+  newDm: MessagesSquare,
 };
 
 /**
- * Mobile speed-dial create FAB for Home and Chats (md:hidden).
- * Mounted outside MobileHomeHub Sheet; sits above the bottom tab bar.
+ * Mobile create FAB for Home and Chats (md:hidden).
+ * Open state is an overlay list menu anchored over the `+` (same footprint).
  */
 export function ChatMobileCreateFab(): React.ReactElement | null {
   const pathname = usePathname();
@@ -69,7 +69,7 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
   return (
     <div
       className={cn(
-        "pointer-events-none fixed right-4 z-50 flex flex-col items-end md:hidden",
+        "pointer-events-none fixed inset-x-4 z-50 md:hidden",
         chatMobileCreateFabBottom(isApple),
       )}
       data-mobile-create-fab
@@ -81,7 +81,7 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
             type="button"
             aria-label={t("closeMenu")}
             className={cn(
-              "pointer-events-auto fixed inset-x-0 top-0 z-40 bg-background/40 md:hidden",
+              "pointer-events-auto fixed inset-x-0 top-0 z-40 bg-background/50 md:hidden",
               chatMobileCreateFabScrimBottom(isApple),
             )}
             initial={reduceMotion ? false : { opacity: 0 }}
@@ -93,76 +93,84 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
         ) : null}
       </AnimatePresence>
 
-      <div className="relative z-50 flex flex-col items-end gap-3">
+      {/*
+        Footprint stays FAB-sized. Open menu is absolute bottom-anchored so it
+        grows upward over the `+` instead of stacking extra vertical space.
+      */}
+      <div className="relative z-50 flex h-14 justify-end">
         <AnimatePresence>
-          {open
-            ? actions.map((action, index) => {
-                const Icon = ACTION_ICONS[action.id];
-                const delay = reduceMotion
-                  ? 0
-                  : (actions.length - 1 - index) * 0.04;
-                return (
-                  <motion.div
-                    key={action.id}
-                    initial={
-                      reduceMotion ? false : { opacity: 0, y: 12, scale: 0.92 }
-                    }
-                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                    exit={
-                      reduceMotion
-                        ? undefined
-                        : { opacity: 0, y: 8, scale: 0.92 }
-                    }
-                    transition={
-                      reduceMotion
-                        ? { duration: 0 }
-                        : { duration: 0.18, delay, ease: "easeOut" }
-                    }
-                    className="pointer-events-auto"
-                  >
-                    <Link
-                      href={action.href}
-                      onClick={handleClose}
-                      className="bg-card text-card-foreground border-border flex max-w-[min(18rem,calc(100vw-5.5rem))] items-center gap-3 rounded-full border py-2 pr-4 pl-2 shadow-md"
-                    >
-                      <span className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-full">
-                        <Icon className="size-5" aria-hidden />
-                      </span>
-                      <span className="min-w-0 text-left">
-                        <span className="block truncate text-sm font-medium">
-                          {t(`${action.id}.title`)}
+          {open ? (
+            <motion.div
+              key="menu"
+              role="menu"
+              aria-label={t("openMenu")}
+              data-mobile-create-fab-menu
+              initial={
+                reduceMotion ? false : { opacity: 0, y: 12, scale: 0.98 }
+              }
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={
+                reduceMotion ? undefined : { opacity: 0, y: 8, scale: 0.98 }
+              }
+              transition={
+                reduceMotion
+                  ? { duration: 0 }
+                  : { duration: 0.2, ease: "easeOut" }
+              }
+              className={cn(
+                "pointer-events-auto text-card-foreground absolute inset-x-0 bottom-0 rounded-3xl p-2",
+                isApple
+                  ? "border-border/40 bg-background/45 shadow-lg shadow-black/10 backdrop-blur-2xl backdrop-saturate-150 dark:bg-background/35 dark:shadow-black/40 border"
+                  : "border-border bg-card shadow-lg border",
+              )}
+            >
+              <ul className="flex flex-col">
+                {actions.map((action) => {
+                  const Icon = ACTION_ICONS[action.id];
+                  return (
+                    <li key={action.id} role="none">
+                      <Link
+                        role="menuitem"
+                        href={action.href}
+                        onClick={handleClose}
+                        className="hover:bg-muted/70 flex items-start gap-3 rounded-2xl px-3 py-3 transition-colors"
+                      >
+                        <span className="text-foreground mt-0.5 flex size-6 shrink-0 items-center justify-center">
+                          <Icon
+                            className="size-5"
+                            aria-hidden
+                            strokeWidth={1.75}
+                          />
                         </span>
-                        <span className="text-muted-foreground block truncate text-xs">
-                          {t(`${action.id}.subtitle`)}
+                        <span className="min-w-0 flex-1 text-left">
+                          <span className="text-foreground block text-base font-semibold tracking-tight">
+                            {t(`${action.id}.title`)}
+                          </span>
+                          <span className="text-muted-foreground mt-0.5 block text-sm leading-snug">
+                            {t(`${action.id}.subtitle`)}
+                          </span>
                         </span>
-                      </span>
-                    </Link>
-                  </motion.div>
-                );
-              })
-            : null}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </motion.div>
+          ) : null}
         </AnimatePresence>
 
-        <button
-          type="button"
-          aria-expanded={open}
-          aria-label={open ? t("closeMenu") : t("openMenu")}
-          onClick={handleToggle}
-          className={cn(
-            "pointer-events-auto flex size-14 items-center justify-center rounded-full shadow-lg transition-colors",
-            open
-              ? "bg-secondary text-secondary-foreground"
-              : "bg-primary text-primary-foreground",
-          )}
-        >
-          <motion.span
-            animate={reduceMotion ? undefined : { rotate: open ? 45 : 0 }}
-            transition={reduceMotion ? { duration: 0 } : { duration: 0.15 }}
-            className="flex"
+        {!open ? (
+          <button
+            type="button"
+            aria-expanded={false}
+            aria-haspopup="menu"
+            aria-label={t("openMenu")}
+            onClick={handleToggle}
+            className="bg-primary text-primary-foreground pointer-events-auto flex size-14 items-center justify-center rounded-full shadow-lg"
           >
             <Plus className="size-6" aria-hidden />
-          </motion.span>
-        </button>
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import {
-  Hash,
-  ListTodo,
-  MessageSquarePlus,
-  MessagesSquare,
-  Plus,
-} from "lucide-react";
+import { Hash, ListTodo, MessagesSquare, Plus } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type ComponentType, type SVGProps, useState } from "react";
+import {
+  type ComponentType,
+  type KeyboardEvent,
+  type SVGProps,
+  useRef,
+  useState,
+} from "react";
 
 import { shouldShowMobileCreateFab } from "@/app/components/mobile-app-chrome";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
@@ -28,15 +28,21 @@ const ACTION_ICONS: Record<
   MobileCreateFabActionId,
   ComponentType<SVGProps<SVGSVGElement>>
 > = {
-  newChat: MessageSquarePlus,
   newTask: ListTodo,
   createChannel: Hash,
   newDm: MessagesSquare,
 };
 
+const SHELL_SPRING = {
+  type: "spring" as const,
+  stiffness: 420,
+  damping: 32,
+  mass: 0.85,
+};
+
 /**
  * Mobile create FAB for Home and Chats (md:hidden).
- * Open state is an overlay list menu anchored over the `+` (same footprint).
+ * One shell morphs from the circular dial into the overlay list panel.
  */
 export function ChatMobileCreateFab(): React.ReactElement | null {
   const pathname = usePathname();
@@ -45,6 +51,9 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
   const isApple = useIsApplePlatform();
   const reduceMotion = useReducedMotion();
   const [open, setOpen] = useState(false);
+  // Panel paint stays through the close morph; dial purple applies after.
+  const [panelChrome, setPanelChrome] = useState(false);
+  const openRef = useRef(false);
 
   const surface = shouldShowMobileCreateFab(pathname, searchParams)
     ? pathname === "/chat/chats"
@@ -58,12 +67,40 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
 
   const actions = mobileCreateFabActions(surface);
 
+  function setMenuOpen(next: boolean) {
+    openRef.current = next;
+    setOpen(next);
+    if (next) {
+      setPanelChrome(true);
+      return;
+    }
+    if (reduceMotion) {
+      setPanelChrome(false);
+    }
+  }
+
   function handleToggle() {
-    setOpen((current) => !current);
+    setMenuOpen(!openRef.current);
   }
 
   function handleClose() {
-    setOpen(false);
+    setMenuOpen(false);
+  }
+
+  function handleLayoutAnimationComplete() {
+    if (!openRef.current) {
+      setPanelChrome(false);
+    }
+  }
+
+  function handleShellKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (open) {
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleToggle();
+    }
   }
 
   return (
@@ -94,41 +131,72 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
       </AnimatePresence>
 
       {/*
-        Footprint stays FAB-sized. Open menu is absolute bottom-anchored so it
-        grows upward over the `+` instead of stacking extra vertical space.
+        Footprint stays FAB-sized when closed. Open shell is absolute
+        bottom-anchored so the same surface grows upward into the menu.
       */}
       <div className="relative z-50 flex h-14 justify-end">
-        <AnimatePresence>
-          {open ? (
-            <motion.div
-              key="menu"
-              role="menu"
-              aria-label={t("openMenu")}
-              data-mobile-create-fab-menu
-              initial={
-                reduceMotion ? false : { opacity: 0, y: 12, scale: 0.98 }
-              }
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={
-                reduceMotion ? undefined : { opacity: 0, y: 8, scale: 0.98 }
-              }
-              transition={
-                reduceMotion
-                  ? { duration: 0 }
-                  : { duration: 0.2, ease: "easeOut" }
-              }
-              className={cn(
-                "pointer-events-auto text-card-foreground absolute inset-x-0 bottom-0 rounded-3xl p-2",
-                isApple
-                  ? "border-border/40 bg-background/45 shadow-lg shadow-black/10 backdrop-blur-2xl backdrop-saturate-150 dark:bg-background/35 dark:shadow-black/40 border"
-                  : "border-border bg-card shadow-lg border",
-              )}
-            >
-              <ul className="flex flex-col">
-                {actions.map((action) => {
+        <motion.div
+          layout={!reduceMotion}
+          role={open ? "menu" : "button"}
+          tabIndex={open ? undefined : 0}
+          aria-expanded={open ? undefined : false}
+          aria-haspopup={open ? undefined : "menu"}
+          aria-label={t("openMenu")}
+          data-mobile-create-fab-menu={open ? "" : undefined}
+          transition={reduceMotion ? { duration: 0 } : SHELL_SPRING}
+          onLayoutAnimationComplete={handleLayoutAnimationComplete}
+          onClick={open ? undefined : handleToggle}
+          onKeyDown={handleShellKeyDown}
+          className={cn(
+            "pointer-events-auto overflow-hidden shadow-lg",
+            open
+              ? "absolute inset-x-0 bottom-0 rounded-3xl p-2"
+              : "flex size-14 cursor-pointer items-center justify-center rounded-full",
+            panelChrome
+              ? cn(
+                  "text-card-foreground",
+                  isApple
+                    ? "border-border/40 bg-background/45 shadow-black/10 backdrop-blur-2xl backdrop-saturate-150 dark:bg-background/35 dark:shadow-black/40 border"
+                    : "border-border bg-card border",
+                )
+              : "bg-primary text-primary-foreground",
+          )}
+          style={{
+            borderRadius: open ? 24 : 9999,
+          }}
+        >
+          <AnimatePresence initial={false} mode="popLayout">
+            {open ? (
+              <motion.ul
+                key="menu-list"
+                className="flex flex-col"
+                initial={reduceMotion ? false : { opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={reduceMotion ? undefined : { opacity: 0 }}
+                transition={
+                  reduceMotion
+                    ? { duration: 0 }
+                    : { duration: 0.15, delay: 0.06 }
+                }
+              >
+                {actions.map((action, index) => {
                   const Icon = ACTION_ICONS[action.id];
                   return (
-                    <li key={action.id} role="none">
+                    <motion.li
+                      key={action.id}
+                      role="none"
+                      initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={
+                        reduceMotion
+                          ? { duration: 0 }
+                          : {
+                              duration: 0.18,
+                              delay: 0.08 + index * 0.04,
+                              ease: "easeOut",
+                            }
+                      }
+                    >
                       <Link
                         role="menuitem"
                         href={action.href}
@@ -151,26 +219,24 @@ export function ChatMobileCreateFab(): React.ReactElement | null {
                           </span>
                         </span>
                       </Link>
-                    </li>
+                    </motion.li>
                   );
                 })}
-              </ul>
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
-
-        {!open ? (
-          <button
-            type="button"
-            aria-expanded={false}
-            aria-haspopup="menu"
-            aria-label={t("openMenu")}
-            onClick={handleToggle}
-            className="bg-primary text-primary-foreground pointer-events-auto flex size-14 items-center justify-center rounded-full shadow-lg"
-          >
-            <Plus className="size-6" aria-hidden />
-          </button>
-        ) : null}
+              </motion.ul>
+            ) : (
+              <motion.span
+                key="dial-icon"
+                className="flex size-full items-center justify-center"
+                initial={reduceMotion ? false : { opacity: 0, scale: 0.85 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={reduceMotion ? undefined : { opacity: 0, scale: 0.85 }}
+                transition={reduceMotion ? { duration: 0 } : { duration: 0.12 }}
+              >
+                <Plus className="size-6" aria-hidden />
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </motion.div>
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-create-fab.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import {
+  Hash,
+  ListTodo,
+  MessageCircle,
+  MessageSquarePlus,
+  Plus,
+} from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { type ComponentType, type SVGProps, useState } from "react";
+
+import { shouldShowMobileCreateFab } from "@/app/components/mobile-app-chrome";
+import useIsApplePlatform from "@/hooks/use-is-apple-platform";
+import { cn } from "@/lib/utils";
+
+import {
+  chatMobileCreateFabBottom,
+  chatMobileCreateFabScrimBottom,
+  type MobileCreateFabActionId,
+  mobileCreateFabActions,
+} from "./chat-mobile-create-fab-actions";
+
+const ACTION_ICONS: Record<
+  MobileCreateFabActionId,
+  ComponentType<SVGProps<SVGSVGElement>>
+> = {
+  newChat: MessageSquarePlus,
+  newTask: ListTodo,
+  createChannel: Hash,
+  newDm: MessageCircle,
+};
+
+/**
+ * Mobile speed-dial create FAB for Home and Chats (md:hidden).
+ * Mounted outside MobileHomeHub Sheet; sits above the bottom tab bar.
+ */
+export function ChatMobileCreateFab(): React.ReactElement | null {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const t = useTranslations("App.Channels.MobileCreateFab");
+  const isApple = useIsApplePlatform();
+  const reduceMotion = useReducedMotion();
+  const [open, setOpen] = useState(false);
+
+  const surface = shouldShowMobileCreateFab(pathname, searchParams)
+    ? pathname === "/chat/chats"
+      ? "chats"
+      : "home"
+    : null;
+
+  if (!surface) {
+    return null;
+  }
+
+  const actions = mobileCreateFabActions(surface);
+
+  function handleToggle() {
+    setOpen((current) => !current);
+  }
+
+  function handleClose() {
+    setOpen(false);
+  }
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none fixed right-4 z-50 flex flex-col items-end md:hidden",
+        chatMobileCreateFabBottom(isApple),
+      )}
+      data-mobile-create-fab
+    >
+      <AnimatePresence>
+        {open ? (
+          <motion.button
+            key="scrim"
+            type="button"
+            aria-label={t("closeMenu")}
+            className={cn(
+              "pointer-events-auto fixed inset-x-0 top-0 z-40 bg-background/40 md:hidden",
+              chatMobileCreateFabScrimBottom(isApple),
+            )}
+            initial={reduceMotion ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={reduceMotion ? undefined : { opacity: 0 }}
+            transition={reduceMotion ? { duration: 0 } : { duration: 0.15 }}
+            onClick={handleClose}
+          />
+        ) : null}
+      </AnimatePresence>
+
+      <div className="relative z-50 flex flex-col items-end gap-3">
+        <AnimatePresence>
+          {open
+            ? actions.map((action, index) => {
+                const Icon = ACTION_ICONS[action.id];
+                const delay = reduceMotion
+                  ? 0
+                  : (actions.length - 1 - index) * 0.04;
+                return (
+                  <motion.div
+                    key={action.id}
+                    initial={
+                      reduceMotion ? false : { opacity: 0, y: 12, scale: 0.92 }
+                    }
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={
+                      reduceMotion
+                        ? undefined
+                        : { opacity: 0, y: 8, scale: 0.92 }
+                    }
+                    transition={
+                      reduceMotion
+                        ? { duration: 0 }
+                        : { duration: 0.18, delay, ease: "easeOut" }
+                    }
+                    className="pointer-events-auto"
+                  >
+                    <Link
+                      href={action.href}
+                      onClick={handleClose}
+                      className="bg-card text-card-foreground border-border flex max-w-[min(18rem,calc(100vw-5.5rem))] items-center gap-3 rounded-full border py-2 pr-4 pl-2 shadow-md"
+                    >
+                      <span className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-full">
+                        <Icon className="size-5" aria-hidden />
+                      </span>
+                      <span className="min-w-0 text-left">
+                        <span className="block truncate text-sm font-medium">
+                          {t(`${action.id}.title`)}
+                        </span>
+                        <span className="text-muted-foreground block truncate text-xs">
+                          {t(`${action.id}.subtitle`)}
+                        </span>
+                      </span>
+                    </Link>
+                  </motion.div>
+                );
+              })
+            : null}
+        </AnimatePresence>
+
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-label={open ? t("closeMenu") : t("openMenu")}
+          onClick={handleToggle}
+          className={cn(
+            "pointer-events-auto flex size-14 items-center justify-center rounded-full shadow-lg transition-colors",
+            open
+              ? "bg-secondary text-secondary-foreground"
+              : "bg-primary text-primary-foreground",
+          )}
+        >
+          <motion.span
+            animate={reduceMotion ? undefined : { rotate: open ? 45 : 0 }}
+            transition={reduceMotion ? { duration: 0 } : { duration: 0.15 }}
+            className="flex"
+          >
+            <Plus className="size-6" aria-hidden />
+          </motion.span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
@@ -97,8 +97,9 @@ export const CHAT_MOBILE_TABS: readonly ChatMobileTab[] = [
     labelKey: "home",
     icon: Home,
     isActive: (pathname, searchParams) => {
-      // Draft flows (`?create=channel`, `?dm=new`) share pathname `/chat` but
-      // are not Home — classifyChatChromeSurface returns "other-chat".
+      // Draft/welcome flows (`?create=channel`, `?dm=new`, `?welcome=1`) share
+      // pathname `/chat` but are not Home — classifyChatChromeSurface returns
+      // "other-chat".
       if (classifyChatChromeSurface(pathname, searchParams) === "home") {
         return true;
       }

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
@@ -1,9 +1,6 @@
 import { Home, type LucideIcon, MessageCircle, Search } from "lucide-react";
 
-import {
-  classifyChatChromeSurface,
-  isChatRoomPathname,
-} from "@/app/chat/utils/chat-route-base";
+import { classifyChatChromeSurface } from "@/app/chat/utils/chat-route-base";
 import { isMainAppMobileChromePathname } from "@/app/components/mobile-app-chrome";
 
 type SearchParamsLike =
@@ -60,18 +57,20 @@ export const CHAT_MOBILE_HEIGHT_SHELL_CLASS =
   "h-[calc(100svh-64px)] max-md:h-full" as const;
 
 /**
- * Full shell height when the mobile tab bar is hidden (room surface).
+ * Full shell height when the mobile tab bar is hidden (room / draft compose).
  * Matches desktop/`md` height — no tab-bar spacer below.
  */
 export const CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS =
   "h-[calc(100svh-64px)]" as const;
 
-/** Height class for chat views: room path drops tab-bar spacer offset. */
+/** Height class for chat views: room and draft compose drop tab-bar spacer offset. */
 export function chatMobileHeightShellClass(
   pathname: string | null | undefined,
   _isApple = false,
+  searchParams?: SearchParamsLike,
 ): string {
-  if (isChatRoomPathname(pathname)) {
+  const surface = classifyChatChromeSurface(pathname, searchParams);
+  if (surface === "room" || surface === "draft") {
     return CHAT_MOBILE_HEIGHT_SHELL_NO_TAB_BAR_CLASS;
   }
   return CHAT_MOBILE_HEIGHT_SHELL_CLASS;
@@ -99,7 +98,7 @@ export const CHAT_MOBILE_TABS: readonly ChatMobileTab[] = [
     isActive: (pathname, searchParams) => {
       // Draft/welcome flows (`?create=channel`, `?dm=new`, `?welcome=1`) share
       // pathname `/chat` but are not Home — classifyChatChromeSurface returns
-      // "other-chat".
+      // "draft".
       if (classifyChatChromeSurface(pathname, searchParams) === "home") {
         return true;
       }

--- a/apps/web/src/app/(app)/chat/components/chat-welcome-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-welcome-client.tsx
@@ -2,7 +2,7 @@
 
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
@@ -22,7 +22,7 @@ import type {
 import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 import { cn } from "@/lib/utils";
 
-import { CHAT_MOBILE_HEIGHT_SHELL_CLASS } from "./chat-mobile-tab-registry";
+import { chatMobileHeightShellClass } from "./chat-mobile-tab-registry";
 
 function composeMessageText(message: ChatComposeMessage): string {
   if (typeof message === "string") {
@@ -50,6 +50,8 @@ export function ChatWelcomeClient({
 }: ChatWelcomeClientProps) {
   const t = useTranslations("App.Chat.Chat");
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState<UIMessage[]>([]);
   const [selectedCoworker, setSelectedCoworker] = useState<
@@ -117,7 +119,7 @@ export function ChatWelcomeClient({
     <div
       className={cn(
         "-m-4 flex min-h-0 flex-col overflow-hidden bg-background",
-        CHAT_MOBILE_HEIGHT_SHELL_CLASS,
+        chatMobileHeightShellClass(pathname, false, searchParams),
       )}
     >
       <WelcomeScreen

--- a/apps/web/src/app/(app)/chat/components/mobile-home-hub.tsx
+++ b/apps/web/src/app/(app)/chat/components/mobile-home-hub.tsx
@@ -97,7 +97,7 @@ export async function MobileHomeHub({
           >
             <PersonalAssistantNav enabled={hermesMenuEnabled} />
             {hermesMenuEnabled ? <SidebarSeparator className="-mt-px" /> : null}
-            <MenuItems hideHistory />
+            <MenuItems hideHistory hideNewTask />
             <SidebarSeparator />
             <AdminSettingsMenuGroup adminMenuEnabled={adminMenuEnabled} />
           </SidebarNav>

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2,7 +2,7 @@
 
 import { ChannelProvider } from "ably/react";
 import { Hash, Loader2, MessageCircle } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
   useCallback,
@@ -252,6 +252,7 @@ export function RoomsClient({
   const tBreadcrumb = useTranslations("Components.Breadcrumb");
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const isApple = useIsApplePlatform();
   const canOpenHumanDirect = Boolean(activeOrganization);
   const [openingDirectKey, setOpeningDirectKey] = useState<string | null>(null);
@@ -1400,7 +1401,7 @@ export function RoomsClient({
     <div
       className={cn(
         "-m-4 flex min-h-0 flex-col overflow-hidden bg-background",
-        chatMobileHeightShellClass(pathname, isApple),
+        chatMobileHeightShellClass(pathname, isApple, searchParams),
       )}
     >
       {currentUserId ? (

--- a/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
+++ b/apps/web/src/app/(app)/chat/components/welcome-screen.tsx
@@ -3,6 +3,7 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { ChevronRight, Loader2 } from "lucide-react";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type Dispatch, type SetStateAction } from "react";
 import type {
@@ -10,6 +11,7 @@ import type {
   ChatComposeSubmitOptions,
   Coworker,
 } from "@/app/chat/utils/types";
+import { shouldShowMobileBottomNav } from "@/app/components/mobile-app-chrome";
 import { MultimodalInput } from "@/components/chat/multimodal-input";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
 import { cn } from "@/lib/utils";
@@ -62,7 +64,10 @@ export default function WelcomeScreen({
   onCoworkerChange,
 }: WelcomeScreenProps) {
   const t = useTranslations("App.Chat.Chat");
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const isApple = useIsApplePlatform();
+  const liftAboveTabBar = shouldShowMobileBottomNav(pathname, searchParams);
   const promptKey =
     initialCoworker?.slug?.toLowerCase() ||
     initialCoworker?.id?.toLowerCase() ||
@@ -91,10 +96,10 @@ export default function WelcomeScreen({
       aria-busy={isOpeningRoom || undefined}
     >
       {showGreetingAndSuggestions ? (
-        <div className="mt-[-200px] flex flex-1 flex-col items-center justify-center text-center">
+        <div className="mt-[-200px] flex flex-1 flex-col items-center justify-center px-4 text-center sm:px-6">
           <div
             className={cn(
-              "welcome-message-block transition-all duration-300 ease-out",
+              "welcome-message-block w-full max-w-[33.6rem] transition-all duration-300 ease-out",
               isOpeningRoom && "opacity-60",
             )}
           >
@@ -174,9 +179,11 @@ export default function WelcomeScreen({
         className="from-background via-background/60 pointer-events-none absolute right-0 bottom-0 left-0 z-5 h-32 bg-linear-to-t to-transparent"
       />
       <div
+        data-welcome-composer-dock
         className={cn(
-          "bg-background/80 fixed inset-x-0 z-10 mx-auto flex w-full shrink-0 justify-center overflow-visible px-8 pb-[max(0.25rem,env(safe-area-inset-bottom))] backdrop-blur-sm md:absolute md:inset-x-0",
-          chatMobileTabBarBottomOffset(isApple),
+          // Match room composer outer inset (`room-composer.tsx`).
+          "bg-background/80 fixed inset-x-0 z-10 mx-auto flex w-full shrink-0 justify-center overflow-visible px-3 pb-[max(0.25rem,env(safe-area-inset-bottom))] backdrop-blur-sm md:absolute md:inset-x-0 md:bottom-0 md:px-5",
+          liftAboveTabBar ? chatMobileTabBarBottomOffset(isApple) : "bottom-0",
         )}
       >
         <div className="w-full max-w-4xl overflow-visible">

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -17,6 +17,7 @@ interface ChatPageProps {
   searchParams: Promise<{
     create?: string | string[];
     dm?: string | string[];
+    welcome?: string | string[];
     notice?: string | string[];
   }>;
 }
@@ -30,7 +31,8 @@ export const instant = false;
 /**
  * `/chat` landing: mobile Home hub (sidebar minus Channels/DMs); desktop
  * classic coworker welcome. Draft modes via query: `?create=channel`,
- * `?dm=new`. Open rooms: `/chat/rooms/[roomId]`.
+ * `?dm=new`, `?welcome=1` (mobile coworker compose). Open rooms:
+ * `/chat/rooms/[roomId]`.
  *
  * Fully async, no route `loading.tsx` — soft nav keeps the previous screen
  * (same as `/history`). Opening a room uses `rooms/[roomId]/loading.tsx`.
@@ -49,6 +51,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
 
   const isCreateChannelRequested = firstSearchValue(query.create) === "channel";
   const isNewDirectMessage = firstSearchValue(query.dm) === "new";
+  const isWelcomeCompose = firstSearchValue(query.welcome) === "1";
   const notice = firstSearchValue(query.notice);
   const landingNotice = <ChatLandingNotice notice={notice} />;
 
@@ -134,6 +137,18 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
   const coworkers = (await coworkerService.listCoworkers("chat")).map(
     mapDbCoworkerToChatCoworker,
   );
+
+  if (isWelcomeCompose) {
+    return (
+      <>
+        {landingNotice}
+        <ChatWelcomeClient
+          coworkers={coworkers}
+          userName={session?.user.name ?? undefined}
+        />
+      </>
+    );
+  }
 
   if (!session?.user) {
     return (

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
@@ -75,6 +75,17 @@ describe("chat-route-base", () => {
       ).toBe("other-chat");
     });
 
+    it("returns other-chat for welcome compose on /chat", () => {
+      expect(
+        classifyChatChromeSurface("/chat", new URLSearchParams("welcome=1")),
+      ).toBe("other-chat");
+      expect(
+        classifyChatChromeSurface("/chat", {
+          get: (k) => (k === "welcome" ? "1" : null),
+        }),
+      ).toBe("other-chat");
+    });
+
     it("returns other-chat for nested non-room chat and non-chat", () => {
       expect(classifyChatChromeSurface("/chat/something")).toBe("other-chat");
       expect(classifyChatChromeSurface("/tasks")).toBe("other-chat");

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
@@ -58,32 +58,32 @@ describe("chat-route-base", () => {
       );
     });
 
-    it("returns other-chat for draft query on /chat", () => {
+    it("returns draft for compose query on /chat", () => {
       expect(
         classifyChatChromeSurface(
           "/chat",
           new URLSearchParams("create=channel"),
         ),
-      ).toBe("other-chat");
+      ).toBe("draft");
       expect(
         classifyChatChromeSurface("/chat", new URLSearchParams("dm=new")),
-      ).toBe("other-chat");
+      ).toBe("draft");
       expect(
         classifyChatChromeSurface("/chat", {
           get: (k) => (k === "dm" ? "new" : null),
         }),
-      ).toBe("other-chat");
+      ).toBe("draft");
     });
 
-    it("returns other-chat for welcome compose on /chat", () => {
+    it("returns draft for welcome compose on /chat", () => {
       expect(
         classifyChatChromeSurface("/chat", new URLSearchParams("welcome=1")),
-      ).toBe("other-chat");
+      ).toBe("draft");
       expect(
         classifyChatChromeSurface("/chat", {
           get: (k) => (k === "welcome" ? "1" : null),
         }),
-      ).toBe("other-chat");
+      ).toBe("draft");
     });
 
     it("returns other-chat for nested non-room chat and non-chat", () => {

--- a/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
@@ -11,7 +11,12 @@ export const CHAT_APP_ROUTE_PREFIX = "/chat" as const;
 export const CHAT_API_PATH = "/api/chat" as const;
 
 /** Mobile chrome surface for pathname-driven shell/header behavior. */
-export type ChatChromeSurface = "home" | "chats" | "room" | "other-chat";
+export type ChatChromeSurface =
+  | "home"
+  | "chats"
+  | "room"
+  | "draft"
+  | "other-chat";
 
 const CHAT_ROOM_PATHNAME_RE = /^\/chat\/rooms\/[^/]+/;
 const CHAT_CHATS_PATH = `${CHAT_APP_ROUTE_PREFIX}/chats` as const;
@@ -92,8 +97,9 @@ export function classifyChatChromeSurface(
     const create = readSearchParam(searchParams, "create");
     const dm = readSearchParam(searchParams, "dm");
     const welcome = readSearchParam(searchParams, "welcome");
+    // Compose flows share `/chat` but use room-style chrome (no tab bar, back).
     if (create === "channel" || dm === "new" || welcome === "1") {
-      return "other-chat";
+      return "draft";
     }
     return "home";
   }

--- a/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
@@ -91,7 +91,8 @@ export function classifyChatChromeSurface(
   if (pathname === CHAT_APP_ROUTE_PREFIX) {
     const create = readSearchParam(searchParams, "create");
     const dm = readSearchParam(searchParams, "dm");
-    if (create === "channel" || dm === "new") {
+    const welcome = readSearchParam(searchParams, "welcome");
+    if (create === "channel" || dm === "new" || welcome === "1") {
       return "other-chat";
     }
     return "home";

--- a/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
@@ -56,7 +56,7 @@ describe("AppMobileChrome", () => {
     mockIsApple = false;
   });
 
-  it("renders bottom nav and tab-bar clearance spacer on chat home", () => {
+  it("renders bottom nav, create FAB, and tab-bar clearance spacer on chat home", () => {
     const { container } = render(
       <AppMobileChrome>
         <div>child</div>
@@ -64,6 +64,7 @@ describe("AppMobileChrome", () => {
     );
 
     expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "openMenu" })).toBeTruthy();
     const spacer = getTabBarSpacer(container);
     expect(spacer?.className).toContain(CHAT_MOBILE_TAB_BAR_CLEARANCE);
   });
@@ -81,7 +82,7 @@ describe("AppMobileChrome", () => {
     expect(spacer?.className).not.toContain(CHAT_MOBILE_TAB_BAR_CLEARANCE);
   });
 
-  it("keeps bottom nav on /chat/chats", () => {
+  it("keeps bottom nav and create FAB on /chat/chats", () => {
     mockPathname = "/chat/chats";
 
     render(
@@ -91,9 +92,10 @@ describe("AppMobileChrome", () => {
     );
 
     expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "openMenu" })).toBeTruthy();
   });
 
-  it("shows bottom nav on main hub list routes", () => {
+  it("shows bottom nav without create FAB on main hub list routes", () => {
     mockPathname = "/tasks";
 
     const { container } = render(
@@ -103,6 +105,7 @@ describe("AppMobileChrome", () => {
     );
 
     expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
     expect(getTabBarSpacer(container)?.className).toContain(
       CHAT_MOBILE_TAB_BAR_CLEARANCE,
     );

--- a/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
@@ -2,11 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let mockPathname = "/chat";
+let mockSearchParams = new URLSearchParams();
 let mockIsApple = false;
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("next-intl", () => ({
@@ -53,6 +54,7 @@ function getTabBarSpacer(container: HTMLElement): Element | null {
 describe("AppMobileChrome", () => {
   beforeEach(() => {
     mockPathname = "/chat";
+    mockSearchParams = new URLSearchParams();
     mockIsApple = false;
   });
 
@@ -124,6 +126,21 @@ describe("AppMobileChrome", () => {
     expect(getTabBarSpacer(container)).toBeNull();
   });
 
+  it("hides bottom nav and clearance on draft DM compose", () => {
+    mockPathname = "/chat";
+    mockSearchParams = new URLSearchParams("dm=new");
+
+    const { container } = render(
+      <AppMobileChrome>
+        <div>child</div>
+      </AppMobileChrome>,
+    );
+
+    expect(screen.queryByRole("navigation", { name: "ariaLabel" })).toBeNull();
+    expect(getTabBarSpacer(container)).toBeNull();
+    expect(screen.queryByRole("button", { name: "openMenu" })).toBeNull();
+  });
+
   it("hides bottom nav on nested detail routes", () => {
     mockPathname = "/agents/agent-1";
 
@@ -136,7 +153,7 @@ describe("AppMobileChrome", () => {
     expect(screen.queryByRole("navigation", { name: "ariaLabel" })).toBeNull();
   });
 
-  it("keeps bottom nav on /chat (drafts share this path)", () => {
+  it("keeps bottom nav on bare /chat home", () => {
     mockPathname = "/chat";
 
     render(

--- a/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
@@ -5,6 +5,7 @@ import {
   resolveMobileAppBackTarget,
   shouldShowMobileBottomNav,
   shouldShowMobileBrandLeading,
+  shouldShowMobileCreateFab,
 } from "../mobile-app-chrome";
 
 describe("mobile-app-chrome", () => {
@@ -132,8 +133,35 @@ describe("mobile-app-chrome", () => {
           new URLSearchParams("create=channel"),
         ),
       ).toBe(false);
+      expect(
+        shouldShowMobileBrandLeading("/chat", new URLSearchParams("welcome=1")),
+      ).toBe(false);
       expect(shouldShowMobileBrandLeading("/tasks/t1")).toBe(false);
       expect(shouldShowMobileBrandLeading("/account")).toBe(false);
+    });
+  });
+
+  describe("shouldShowMobileCreateFab", () => {
+    it("shows on home and chats only", () => {
+      expect(shouldShowMobileCreateFab("/chat")).toBe(true);
+      expect(shouldShowMobileCreateFab("/chat/chats")).toBe(true);
+      expect(shouldShowMobileCreateFab("/tasks")).toBe(false);
+      expect(shouldShowMobileCreateFab("/chat/rooms/r1")).toBe(false);
+    });
+
+    it("hides for drafts and welcome compose", () => {
+      expect(
+        shouldShowMobileCreateFab(
+          "/chat",
+          new URLSearchParams("create=channel"),
+        ),
+      ).toBe(false);
+      expect(
+        shouldShowMobileCreateFab("/chat", new URLSearchParams("dm=new")),
+      ).toBe(false);
+      expect(
+        shouldShowMobileCreateFab("/chat", new URLSearchParams("welcome=1")),
+      ).toBe(false);
     });
   });
 });

--- a/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
@@ -93,10 +93,22 @@ describe("mobile-app-chrome", () => {
   });
 
   describe("shouldShowMobileBottomNav", () => {
-    it("shows on chat shell except rooms", () => {
+    it("shows on chat shell except rooms and drafts", () => {
       expect(shouldShowMobileBottomNav("/chat")).toBe(true);
       expect(shouldShowMobileBottomNav("/chat/chats")).toBe(true);
       expect(shouldShowMobileBottomNav("/chat/rooms/r1")).toBe(false);
+      expect(
+        shouldShowMobileBottomNav("/chat", new URLSearchParams("dm=new")),
+      ).toBe(false);
+      expect(
+        shouldShowMobileBottomNav(
+          "/chat",
+          new URLSearchParams("create=channel"),
+        ),
+      ).toBe(false);
+      expect(
+        shouldShowMobileBottomNav("/chat", new URLSearchParams("welcome=1")),
+      ).toBe(false);
     });
 
     it("shows on main hub list routes", () => {
@@ -132,6 +144,9 @@ describe("mobile-app-chrome", () => {
           "/chat",
           new URLSearchParams("create=channel"),
         ),
+      ).toBe(false);
+      expect(
+        shouldShowMobileBrandLeading("/chat", new URLSearchParams("dm=new")),
       ).toBe(false);
       expect(
         shouldShowMobileBrandLeading("/chat", new URLSearchParams("welcome=1")),

--- a/apps/web/src/app/(app)/components/app-mobile-chrome.client.tsx
+++ b/apps/web/src/app/(app)/components/app-mobile-chrome.client.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import { Suspense } from "react";
 
 import { ChatMobileBottomNav } from "@/app/chat/components/chat-mobile-bottom-nav";
+import { ChatMobileCreateFab } from "@/app/chat/components/chat-mobile-create-fab";
 import { chatMobileTabBarClearance } from "@/app/chat/components/chat-mobile-tab-registry";
 import { shouldShowMobileBottomNav } from "@/app/components/mobile-app-chrome";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
@@ -45,6 +46,9 @@ export function AppMobileChrome({
           />
           <Suspense fallback={null}>
             <ChatMobileBottomNav />
+          </Suspense>
+          <Suspense fallback={null}>
+            <ChatMobileCreateFab />
           </Suspense>
         </>
       ) : null}

--- a/apps/web/src/app/(app)/components/app-mobile-chrome.client.tsx
+++ b/apps/web/src/app/(app)/components/app-mobile-chrome.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 
 import { ChatMobileBottomNav } from "@/app/chat/components/chat-mobile-bottom-nav";
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 
 /**
  * App-wide mobile chrome: Home/Chats/Search tab bar + content clearance.
- * Visible on chat shell (except rooms) and main Home-hub list routes.
+ * Visible on chat shell (except rooms/drafts) and main Home-hub list routes.
  *
  * Clearance is an in-flow spacer under `{children}` so main's overflow scroll
  * can reach past the last content item (padding on a height-locked flex child
@@ -23,9 +23,6 @@ export function AppMobileChrome({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
-  const showBottomNav = shouldShowMobileBottomNav(usePathname());
-  const isApple = useIsApplePlatform();
-
   return (
     <div className="flex min-h-full flex-1 flex-col">
       {/*
@@ -34,24 +31,39 @@ export function AppMobileChrome({
         use an explicit height + their own min-h-0 chain for inner scroll.
       */}
       <div className="flex flex-1 flex-col">{children}</div>
-      {showBottomNav ? (
-        <>
-          <div
-            aria-hidden
-            data-mobile-bottom-nav-spacer
-            className={cn(
-              "pointer-events-none shrink-0 md:hidden",
-              chatMobileTabBarClearance(isApple),
-            )}
-          />
-          <Suspense fallback={null}>
-            <ChatMobileBottomNav />
-          </Suspense>
-          <Suspense fallback={null}>
-            <ChatMobileCreateFab />
-          </Suspense>
-        </>
-      ) : null}
+      <Suspense fallback={null}>
+        <AppMobileBottomChrome />
+      </Suspense>
     </div>
+  );
+}
+
+function AppMobileBottomChrome(): React.ReactElement | null {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const showBottomNav = shouldShowMobileBottomNav(pathname, searchParams);
+  const isApple = useIsApplePlatform();
+
+  if (!showBottomNav) {
+    return null;
+  }
+
+  return (
+    <>
+      <div
+        aria-hidden
+        data-mobile-bottom-nav-spacer
+        className={cn(
+          "pointer-events-none shrink-0 md:hidden",
+          chatMobileTabBarClearance(isApple),
+        )}
+      />
+      <Suspense fallback={null}>
+        <ChatMobileBottomNav />
+      </Suspense>
+      <Suspense fallback={null}>
+        <ChatMobileCreateFab />
+      </Suspense>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/chat";
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/masumi-logos", () => ({
+  SokosumiIcon: ({ className }: { className?: string }) => (
+    <span data-testid="sokosumi-icon" className={className} />
+  ),
+}));
+
+vi.mock("../../sidebar/components/custom-trigger", () => ({
+  default: () => <button type="button">sidebar-trigger</button>,
+}));
+
+import { HeaderLeadingControl } from "../header-leading-control.client";
+
+describe("HeaderLeadingControl", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("shows brand on home", () => {
+    render(<HeaderLeadingControl />);
+    expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
+  });
+
+  it("shows back to chats on room", () => {
+    mockPathname = "/chat/rooms/r1";
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "backToChats" });
+    expect(back).toHaveAttribute("href", "/chat/chats");
+  });
+
+  it("shows back to chats on draft DM compose", () => {
+    mockSearchParams = new URLSearchParams("dm=new");
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "backToChats" });
+    expect(back).toHaveAttribute("href", "/chat/chats");
+  });
+});

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
@@ -17,7 +17,7 @@ import CustomTrigger from "../sidebar/components/custom-trigger";
 /**
  * Mobile header leading slot (`md:hidden` size-8):
  * - chat home / chats list → Sokosumi icon (no back / hamburger)
- * - chat room → back to `/chat/chats`
+ * - chat room / draft compose → back to `/chat/chats`
  * - main hub lists + nested → back (home or list root)
  * - otherwise → sidebar CustomTrigger
  */
@@ -36,7 +36,7 @@ export function HeaderLeadingControl(): React.ReactElement {
     );
   }
 
-  if (surface === "room") {
+  if (surface === "room" || surface === "draft") {
     return (
       <Link
         href="/chat/chats"

--- a/apps/web/src/app/(app)/components/mobile-app-chrome.ts
+++ b/apps/web/src/app/(app)/components/mobile-app-chrome.ts
@@ -77,15 +77,21 @@ export function resolveMobileAppBackTarget(
 }
 
 /**
- * Fixed Home/Chats/Search tab bar: chat shell (except rooms) + main hub list routes.
+ * Fixed Home/Chats/Search tab bar: chat shell (except rooms/drafts) + main hub
+ * list routes. Drafts (`?dm=new`, `?create=channel`, `?welcome=1`) share `/chat`
+ * but hide the tab bar like rooms.
  */
 export function shouldShowMobileBottomNav(
   pathname: string | null | undefined,
+  searchParams?: SearchParamsLike,
 ): boolean {
   if (!pathname) {
     return false;
   }
   if (isChatRoomPathname(pathname)) {
+    return false;
+  }
+  if (classifyChatChromeSurface(pathname, searchParams) === "draft") {
     return false;
   }
   if (isChatShellPathname(pathname)) {

--- a/apps/web/src/app/(app)/components/mobile-app-chrome.ts
+++ b/apps/web/src/app/(app)/components/mobile-app-chrome.ts
@@ -104,3 +104,14 @@ export function shouldShowMobileBrandLeading(
   const surface = classifyChatChromeSurface(pathname, searchParams);
   return surface === "home" || surface === "chats";
 }
+
+/**
+ * Floating create FAB: Home hub and Chats list only (not drafts / welcome).
+ */
+export function shouldShowMobileCreateFab(
+  pathname: string | null | undefined,
+  searchParams?: SearchParamsLike,
+): boolean {
+  const surface = classifyChatChromeSurface(pathname, searchParams);
+  return surface === "home" || surface === "chats";
+}

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/menu-items.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/menu-items.test.tsx
@@ -117,4 +117,19 @@ describe("MenuItems search action", () => {
 
     expect(screen.queryByRole("link", { name: /history/i })).toBeNull();
   });
+
+  it("shows New Task by default", () => {
+    render(<MenuItems />);
+
+    expect(screen.getByRole("link", { name: /newTask/i })).toHaveAttribute(
+      "href",
+      "/tasks?create=true",
+    );
+  });
+
+  it("hides New Task when hideNewTask is set", () => {
+    render(<MenuItems hideNewTask />);
+
+    expect(screen.queryByRole("link", { name: /newTask/i })).toBeNull();
+  });
 });

--- a/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
@@ -41,9 +41,14 @@ interface MenuItemConfig {
 interface MenuItemsProps {
   /** Mobile Home hub: History lives on the Search tab, so omit the leaf item. */
   hideHistory?: boolean;
+  /** Mobile Home hub: New Task lives on the create FAB, so omit the leaf item. */
+  hideNewTask?: boolean;
 }
 
-export default function MenuItems({ hideHistory = false }: MenuItemsProps) {
+export default function MenuItems({
+  hideHistory = false,
+  hideNewTask = false,
+}: MenuItemsProps) {
   const t = useTranslations("App.Sidebar.Content.MenuItems");
   const pathname = usePathname();
   // Soft read: `/chat` MobileHomeHub can SSR under AppShellLoadingFrame before
@@ -67,13 +72,17 @@ export default function MenuItems({ hideHistory = false }: MenuItemsProps) {
   };
 
   const items: MenuItemConfig[] = [
-    {
-      key: "new-task",
-      href: "/tasks?create=true",
-      label: t("newTask"),
-      Icon: Plus,
-      separatorAfter: true,
-    },
+    ...(hideNewTask
+      ? []
+      : [
+          {
+            key: "new-task",
+            href: "/tasks?create=true",
+            label: t("newTask"),
+            Icon: Plus,
+            separatorAfter: true,
+          } satisfies MenuItemConfig,
+        ]),
     {
       key: "search",
       label: t("search"),

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -196,27 +196,32 @@ function SectionHeader({
   secondaryAction?: ReactNode;
   dismissSheetOnNavigate?: boolean;
 }) {
-  const hasTrailing = Boolean(secondaryAction) || Boolean(href && label);
-  const trailingCount = (secondaryAction ? 1 : 0) + (href && label ? 1 : 0);
+  // Create `+` is desktop-only (mobile uses the create FAB); Browse stays.
+  const createHref = href && label ? href : null;
+  const mobileTrailingCount = secondaryAction ? 1 : 0;
+  const desktopTrailingCount = (secondaryAction ? 1 : 0) + (createHref ? 1 : 0);
+  const hasTrailing = mobileTrailingCount > 0 || desktopTrailingCount > 0;
 
-  const createLink =
-    href && label ? (
-      <Link
-        aria-label={label}
-        className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground relative flex size-7 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2 before:content-[''] sm:before:hidden"
-        href={href}
-      >
-        <Plus className="size-4 md:size-3.5" aria-hidden />
-      </Link>
-    ) : null;
+  const createLink = createHref ? (
+    <Link
+      aria-label={label}
+      className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground relative hidden size-7 items-center justify-center rounded-md transition-colors before:absolute before:-inset-2 before:content-[''] sm:before:hidden md:flex"
+      href={createHref}
+    >
+      <Plus className="size-4 md:size-3.5" aria-hidden />
+    </Link>
+  ) : null;
 
   return (
     <div className="group-data-[collapsible=icon]:hidden relative flex h-10 items-center gap-1 px-3 md:h-8">
       <CollapsibleTrigger
         className={cn(
           "text-muted-foreground hover:text-foreground flex min-w-0 flex-1 items-center gap-1 rounded-md text-left text-base font-medium transition-colors md:text-xs",
-          trailingCount === 1 && "pr-8",
-          trailingCount >= 2 && "pr-14",
+          mobileTrailingCount === 1 && "pr-8",
+          mobileTrailingCount >= 2 && "pr-14",
+          desktopTrailingCount === 0 && "md:pr-0",
+          desktopTrailingCount === 1 && "md:pr-8",
+          desktopTrailingCount >= 2 && "md:pr-14",
         )}
       >
         <ChevronDown


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-727/mobile-create-fab-on-home-and-chats

## Spec summary
- Mobile (`md:hidden`) speed-dial create FAB on Home (`/chat`) and Chats (`/chat/chats`) only
- Home: New Chat (`?welcome=1`), New Task, Create Channel, New DM; Chats: Channel + DM
- `?welcome=1` shows coworker welcome on mobile; chrome treats it as non-hub
- Hide mobile New Task in Home hub MenuItems; hide Channels/DMs section `+` below `md`
- Desktop create UX unchanged; existing routes only (no new backends)
- Verify: `pnpm web:check`, `pnpm web:test`

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Spec copy | `messages/*/MobileCreateFab` | Action titles/subtitles differ from Requirement wording (e.g. "New DM" vs "New direct message"; task/channel subtitle paraphrases). Behavior/hrefs match Contract. |
<!-- CURSOR_AGENT_PR_BODY_END -->