### PR TITLE
fix(web): match mobile header to glassy bottom nav

### DIFF
--- a/apps/web/src/app/(app)/chat/components/chat-mobile-bottom-nav.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-bottom-nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { mobileChromeSurfaceClass } from "@/app/components/mobile-chrome-surface";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
 import { cn } from "@/lib/utils";
 
@@ -42,9 +43,10 @@ export function ChatMobileBottomNav(): React.ReactElement {
       aria-label={t("ariaLabel")}
       className={cn(
         "z-40 md:hidden",
+        mobileChromeSurfaceClass(isApple),
         isApple
-          ? "bg-background/45 fixed inset-x-4 bottom-[max(0.75rem,env(safe-area-inset-bottom))] rounded-full border border-border/40 shadow-lg shadow-black/10 backdrop-blur-2xl backdrop-saturate-150 dark:bg-background/35 dark:shadow-black/40"
-          : "border-border bg-background fixed inset-x-0 bottom-0 border-t pb-[env(safe-area-inset-bottom)]",
+          ? "fixed inset-x-4 bottom-[max(0.75rem,env(safe-area-inset-bottom))] rounded-full border border-border/40 shadow-lg shadow-black/10 dark:shadow-black/40"
+          : "border-border fixed inset-x-0 bottom-0 border-t pb-[env(safe-area-inset-bottom)]",
       )}
     >
       <ul

--- a/apps/web/src/app/(app)/components/app-header-fallback.tsx
+++ b/apps/web/src/app/(app)/components/app-header-fallback.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
-import { cn } from "@/lib/utils";
 
+import { HeaderChrome } from "./header/header-chrome.client";
 import {
   HeaderLeadingBrandFallback,
   HeaderLeadingControl,
@@ -12,12 +12,7 @@ interface AppHeaderFallbackProps {
 
 export function AppHeaderFallback({ className }: AppHeaderFallbackProps) {
   return (
-    <header
-      className={cn(
-        "border-grid bg-sidebar fixed top-0 z-50 flex w-full items-center justify-between gap-2 border-b md:sticky md:items-center md:pl-6",
-        className,
-      )}
-    >
+    <HeaderChrome className={className}>
       <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
         <Suspense fallback={<HeaderLeadingBrandFallback />}>
           <HeaderLeadingControl />
@@ -37,6 +32,6 @@ export function AppHeaderFallback({ className }: AppHeaderFallbackProps) {
           <div className="bg-muted size-8 animate-pulse rounded-full" />
         </div>
       </div>
-    </header>
+    </HeaderChrome>
   );
 }

--- a/apps/web/src/app/(app)/components/app-shell-loading-frame.tsx
+++ b/apps/web/src/app/(app)/components/app-shell-loading-frame.tsx
@@ -22,7 +22,7 @@ export function AppShellLoadingFrame({ children }: AppShellLoadingFrameProps) {
           className="flex min-w-0 flex-1 flex-col overflow-clip"
           data-app-content-inner
         >
-          <AppHeaderFallback className="h-16 p-4" />
+          <AppHeaderFallback className="h-16 px-4 py-3 md:p-4" />
           <main
             className="relative flex max-h-svh min-h-svh flex-1 flex-col overflow-x-hidden overflow-y-auto p-4 pt-20 md:max-h-[calc(100svh-64px)] md:min-h-[calc(100svh-64px)] md:pt-4"
             data-app-main

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -70,7 +70,10 @@ export default async function AuthenticatedAppFrame({
                     className="flex min-w-0 flex-1 flex-col overflow-clip"
                     data-app-content-inner
                   >
-                    <Header className="h-16 p-4" session={session} />
+                    <Header
+                      className="h-16 px-4 py-3 md:p-4"
+                      session={session}
+                    />
                     <main
                       className="relative flex max-h-svh min-h-svh flex-1 flex-col overflow-x-hidden overflow-y-auto p-4 pt-20 md:max-h-[calc(100svh-64px)] md:min-h-[calc(100svh-64px)] md:pt-4"
                       data-app-main

--- a/apps/web/src/app/(app)/components/header.tsx
+++ b/apps/web/src/app/(app)/components/header.tsx
@@ -1,8 +1,8 @@
 import type { Session } from "@sokosumi/utils";
 import { Suspense } from "react";
 import { BreadcrumbNavigation } from "@/components/breadcrumb-navigation";
-import { cn } from "@/lib/utils";
 
+import { HeaderChrome } from "./header/header-chrome.client";
 import {
   HeaderLeadingBrandFallback,
   HeaderLeadingControl,
@@ -16,12 +16,7 @@ interface HeaderProps {
 
 export default function Header({ className, session }: HeaderProps) {
   return (
-    <header
-      className={cn(
-        "border-grid bg-sidebar fixed top-0 z-50 flex w-full items-center justify-between gap-2 border-b md:sticky md:items-center md:pl-6",
-        className,
-      )}
-    >
+    <HeaderChrome className={className}>
       <div className="flex size-8 shrink-0 items-center justify-center md:hidden">
         <Suspense fallback={<HeaderLeadingBrandFallback />}>
           <HeaderLeadingControl />
@@ -35,6 +30,6 @@ export default function Header({ className, session }: HeaderProps) {
       <div className="ml-auto flex min-w-0 shrink-0 items-center gap-2">
         <HeaderProfileSection session={session} />
       </div>
-    </header>
+    </HeaderChrome>
   );
 }

--- a/apps/web/src/app/(app)/components/header/header-chrome.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-chrome.client.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import useIsApplePlatform from "@/hooks/use-is-apple-platform";
+import { cn } from "@/lib/utils";
+
+import { mobileChromeSurfaceClass } from "../mobile-chrome-surface";
+
+interface HeaderChromeProps {
+  className?: string | undefined;
+  children: React.ReactNode;
+}
+
+export function HeaderChrome({ className, children }: HeaderChromeProps) {
+  const isApple = useIsApplePlatform();
+
+  return (
+    <header
+      className={cn(
+        "border-grid fixed top-0 z-50 flex w-full items-center justify-between gap-2 border-b-0 md:sticky md:items-center md:border-b md:bg-sidebar md:backdrop-blur-none md:backdrop-saturate-100 md:pl-6 dark:md:bg-sidebar",
+        mobileChromeSurfaceClass(isApple),
+        className,
+      )}
+    >
+      {children}
+    </header>
+  );
+}

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -43,7 +43,7 @@ export function HeaderLeadingControl(): React.ReactElement {
         aria-label={t("backToChats")}
         className="text-foreground hover:bg-accent inline-flex size-8 shrink-0 items-center justify-center rounded-md"
       >
-        <ArrowLeft className="size-4" aria-hidden />
+        <ChevronLeft className="size-5" aria-hidden />
       </Link>
     );
   }
@@ -55,7 +55,7 @@ export function HeaderLeadingControl(): React.ReactElement {
         aria-label={t(appBack.labelKey)}
         className="text-foreground hover:bg-accent inline-flex size-8 shrink-0 items-center justify-center rounded-md"
       >
-        <ArrowLeft className="size-4" aria-hidden />
+        <ChevronLeft className="size-5" aria-hidden />
       </Link>
     );
   }

--- a/apps/web/src/app/(app)/components/mobile-chrome-surface.ts
+++ b/apps/web/src/app/(app)/components/mobile-chrome-surface.ts
@@ -1,0 +1,10 @@
+export const MOBILE_CHROME_APPLE_SURFACE_CLASS =
+  "bg-background/45 backdrop-blur-2xl backdrop-saturate-150 dark:bg-background/35";
+
+export const MOBILE_CHROME_SOLID_SURFACE_CLASS = "bg-background";
+
+export function mobileChromeSurfaceClass(isApple: boolean): string {
+  return isApple
+    ? MOBILE_CHROME_APPLE_SURFACE_CLASS
+    : MOBILE_CHROME_SOLID_SURFACE_CLASS;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [SOK-729](https://linear.app/masumi/issue/SOK-729/match-mobile-header-to-glassy-bottom-nav).

Mobile app header now shares the bottom-nav surface treatment (Apple glass / solid), drops the bottom border, and uses one-step tighter vertical padding. Desktop header stays on the existing sidebar look via `md:` restores.

Shared fill tokens live in `mobile-chrome-surface.ts`. Thin client `HeaderChrome` owns Apple detection so server `Header` stays a content host. Loading fallback uses the same chrome.

Header back control uses Lucide `ChevronLeft` (iOS-style) instead of `ArrowLeft`.

**Verify:** `pnpm web:check`, `pnpm web:test`

### Review notes - medium (human review)

- Desktop surface relies on `md:` overrides of the shared mobile fill classes rather than `max-md:` scoping. Behavior matches Spec; a later cleanup could scope fill to `max-md:` if override fights show up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad1a86d5-c495-45d7-8d23-ce3518e91a94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad1a86d5-c495-45d7-8d23-ce3518e91a94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

