### PR TITLE
feat(chat): keyboard-first message edit UX

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4937,8 +4937,7 @@
       },
       "Edit": {
         "action": "Bearbeiten",
-        "save": "Speichern",
-        "cancel": "Abbrechen",
+        "composerAria": "Nachricht bearbeiten. Enter speichern, Escape abbrechen, Umschalt+Enter neue Zeile.",
         "edited": "Bearbeitet"
       },
       "Browse": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4930,8 +4930,7 @@
       },
       "Edit": {
         "action": "Edit",
-        "save": "Save",
-        "cancel": "Cancel",
+        "composerAria": "Edit message. Enter to save, Escape to cancel, Shift+Enter for a new line.",
         "edited": "Edited"
       },
       "MentionAll": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4937,8 +4937,7 @@
       },
       "Edit": {
         "action": "Editar",
-        "save": "Guardar",
-        "cancel": "Cancelar",
+        "composerAria": "Editar mensaje. Intro para guardar, Escape para cancelar, Mayús+Intro para nueva línea.",
         "edited": "Editado"
       },
       "Browse": {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1113,11 +1113,32 @@ describe("ChatMessageRow", () => {
     expect(screen.getByText("Edit.edited")).toBeInTheDocument();
   });
 
-  it("renders inline editor when isEditing", async () => {
+  it("renders inline editor when isEditing without Save/Cancel buttons", () => {
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit: vi.fn(),
+    });
+
+    expect(screen.getByDisplayValue("Original fixed")).toBeInTheDocument();
+    expect(screen.queryByText("Original")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit.save" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit.cancel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saves on Enter and cancels on Escape while editing", async () => {
     const user = userEvent.setup();
     const onSaveEdit = vi.fn();
     const onCancelEdit = vi.fn();
-    const onEditDraftChange = vi.fn();
 
     renderRow({
       message: userMessage({ content: "Original" }),
@@ -1125,19 +1146,101 @@ describe("ChatMessageRow", () => {
       onStartEdit: vi.fn(),
       isEditing: true,
       editDraft: "Original fixed",
-      onEditDraftChange,
+      onEditDraftChange: vi.fn(),
       onCancelEdit,
       onSaveEdit,
     });
 
-    expect(screen.getByDisplayValue("Original fixed")).toBeInTheDocument();
-    expect(screen.queryByText("Original")).not.toBeInTheDocument();
+    const textarea = screen.getByDisplayValue("Original fixed");
+    textarea.focus();
 
-    await user.click(screen.getByRole("button", { name: "Edit.save" }));
-    expect(onSaveEdit).toHaveBeenCalled();
+    await user.keyboard("{Enter}");
+    expect(onSaveEdit).toHaveBeenCalledTimes(1);
 
-    await user.click(screen.getByRole("button", { name: "Edit.cancel" }));
-    expect(onCancelEdit).toHaveBeenCalled();
+    await user.keyboard("{Escape}");
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not save on Shift+Enter while editing", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+    });
+
+    screen.getByDisplayValue("Original fixed").focus();
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onSaveEdit).not.toHaveBeenCalled();
+  });
+
+  it("does not save on Enter when draft is unchanged", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+    });
+
+    screen.getByDisplayValue("Original").focus();
+    await user.keyboard("{Enter}");
+    expect(onSaveEdit).not.toHaveBeenCalled();
+  });
+
+  it("cancels on blur when draft is unchanged", async () => {
+    const user = userEvent.setup();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit: vi.fn(),
+    });
+
+    const textarea = screen.getByDisplayValue("Original");
+    textarea.focus();
+    await user.tab(); // move focus away → blur
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel on blur when draft is dirty", async () => {
+    const user = userEvent.setup();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit: vi.fn(),
+    });
+
+    const textarea = screen.getByDisplayValue("Original fixed");
+    textarea.focus();
+    await user.tab();
+    expect(onCancelEdit).not.toHaveBeenCalled();
   });
 
   it("shows Delete in the sheet for the author and calls onDelete after confirm", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1294,6 +1294,52 @@ describe("ChatMessageRow", () => {
     expect(onCancelEdit).not.toHaveBeenCalled();
   });
 
+  it("does not cancel on blur when live DOM is dirty but draft prop is stale", async () => {
+    const user = userEvent.setup();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit: vi.fn(),
+    });
+
+    const textarea = screen.getByDisplayValue(
+      "Original",
+    ) as HTMLTextAreaElement;
+    textarea.focus();
+    textarea.value = "Original fixed live";
+    await user.tab();
+    expect(onCancelEdit).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Enter when draft is empty", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit,
+    });
+
+    screen.getByRole("textbox").focus();
+    await user.keyboard("{Enter}");
+    expect(onSaveEdit).not.toHaveBeenCalled();
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
   it("shows Delete in the sheet for the author and calls onDelete after confirm", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn();

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -149,7 +149,7 @@ function renderRow({
   editDraft?: string;
   onEditDraftChange?: (value: string) => void;
   onCancelEdit?: () => void;
-  onSaveEdit?: () => void;
+  onSaveEdit?: (content?: string) => void;
   isSavingEdit?: boolean;
 } = {}) {
   render(
@@ -1176,6 +1176,7 @@ describe("ChatMessageRow", () => {
 
     await user.keyboard("{Enter}");
     expect(onSaveEdit).toHaveBeenCalledTimes(1);
+    expect(onSaveEdit).toHaveBeenCalledWith("Original fixed");
 
     await user.keyboard("{Escape}");
     expect(onCancelEdit).toHaveBeenCalledTimes(1);
@@ -1184,6 +1185,7 @@ describe("ChatMessageRow", () => {
   it("does not save on Shift+Enter while editing", async () => {
     const user = userEvent.setup();
     const onSaveEdit = vi.fn();
+    const onCancelEdit = vi.fn();
 
     renderRow({
       message: userMessage({ content: "Original" }),
@@ -1192,18 +1194,20 @@ describe("ChatMessageRow", () => {
       isEditing: true,
       editDraft: "Original fixed",
       onEditDraftChange: vi.fn(),
-      onCancelEdit: vi.fn(),
+      onCancelEdit,
       onSaveEdit,
     });
 
     screen.getByDisplayValue("Original fixed").focus();
     await user.keyboard("{Shift>}{Enter}{/Shift}");
     expect(onSaveEdit).not.toHaveBeenCalled();
+    expect(onCancelEdit).not.toHaveBeenCalled();
   });
 
-  it("does not save on Enter when draft is unchanged", async () => {
+  it("cancels on Enter when draft is unchanged", async () => {
     const user = userEvent.setup();
     const onSaveEdit = vi.fn();
+    const onCancelEdit = vi.fn();
 
     renderRow({
       message: userMessage({ content: "Original" }),
@@ -1212,13 +1216,40 @@ describe("ChatMessageRow", () => {
       isEditing: true,
       editDraft: "Original",
       onEditDraftChange: vi.fn(),
-      onCancelEdit: vi.fn(),
+      onCancelEdit,
       onSaveEdit,
     });
 
     screen.getByDisplayValue("Original").focus();
     await user.keyboard("{Enter}");
     expect(onSaveEdit).not.toHaveBeenCalled();
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves live textarea value on Enter even if draft prop is stale", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      // Parent draft still original (stale) while DOM has been typed into.
+      editDraft: "Original",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+    });
+
+    const textarea = screen.getByDisplayValue(
+      "Original",
+    ) as HTMLTextAreaElement;
+    textarea.focus();
+    // Bypass React onChange so the controlled prop stays stale while DOM updates.
+    textarea.value = "Original fixed live";
+    await user.keyboard("{Enter}");
+    expect(onSaveEdit).toHaveBeenCalledWith("Original fixed live");
   });
 
   it("cancels on blur when draft is unchanged", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1340,6 +1340,26 @@ describe("ChatMessageRow", () => {
     expect(onCancelEdit).toHaveBeenCalledTimes(1);
   });
 
+  it("saves on Ctrl+Enter as an alias while editing", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+    });
+
+    screen.getByDisplayValue("Original fixed").focus();
+    await user.keyboard("{Control>}{Enter}{/Control}");
+    expect(onSaveEdit).toHaveBeenCalledWith("Original fixed");
+  });
+
   it("shows Delete in the sheet for the author and calls onDelete after confirm", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn();

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1135,6 +1135,26 @@ describe("ChatMessageRow", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("places the caret at the end of the draft when edit mode opens", () => {
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit: vi.fn(),
+    });
+
+    const textarea = screen.getByDisplayValue(
+      "Original fixed",
+    ) as HTMLTextAreaElement;
+    expect(document.activeElement).toBe(textarea);
+    expect(textarea.selectionStart).toBe("Original fixed".length);
+    expect(textarea.selectionEnd).toBe("Original fixed".length);
+  });
+
   it("saves on Enter and cancels on Escape while editing", async () => {
     const user = userEvent.setup();
     const onSaveEdit = vi.fn();

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
@@ -1110,14 +1111,6 @@ function MessageEditComposer({
 }) {
   const t = useTranslations("App.Channels");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const originalContentRef = useRef(originalContent);
-  const isSavingRef = useRef(isSaving);
-  const onSaveRef = useRef(onSave);
-  const onCancelRef = useRef(onCancel);
-  originalContentRef.current = originalContent;
-  isSavingRef.current = isSaving;
-  onSaveRef.current = onSave;
-  onCancelRef.current = onCancel;
 
   // autoFocus leaves the caret at 0; place it at the end so editing continues
   // from the natural end of the message (Slack/Discord-style).
@@ -1129,52 +1122,38 @@ function MessageEditComposer({
     el.setSelectionRange(end, end);
   }, []);
 
-  // Native listener: read the live DOM value so Enter always sees the latest
-  // text (React onKeyDown can race a just-typed character's setState). Enter
-  // with no real change (or empty) exits edit mode instead of no-op
-  // (preventDefault alone felt like a broken keyboard).
-  useEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.isComposing || event.keyCode === 229) return;
-
-      if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!isSavingRef.current) onCancelRef.current();
-        return;
-      }
-
-      if (event.key !== "Enter") return;
-      // Shift+Enter → newline (default)
-      if (event.shiftKey) return;
-      // Alt+Enter ignored (leave default / no save)
-      if (event.altKey) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      if (isSavingRef.current) return;
-
-      const target = event.currentTarget;
-      if (!(target instanceof HTMLTextAreaElement)) return;
-
-      const live = target.value;
-      const liveTrimmed = live.trim();
-      const originalTrimmed = originalContentRef.current.trim();
-      if (liveTrimmed.length > 0 && liveTrimmed !== originalTrimmed) {
-        onSaveRef.current(live);
-        return;
-      }
-      onCancelRef.current();
+  // Live DOM via currentTarget: parent draft can lag the last keystroke's
+  // onChange. Enter with no real change (or empty) exits edit mode — no-op
+  // after preventDefault felt like a broken keyboard.
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLTextAreaElement>) {
+    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+      return;
     }
 
-    el.addEventListener("keydown", handleKeyDown);
-    return () => {
-      el.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (!isSaving) onCancel();
+      return;
+    }
+
+    if (event.key !== "Enter") return;
+    // Shift+Enter → newline (default)
+    if (event.shiftKey) return;
+    // Alt+Enter ignored (leave default / no save)
+    if (event.altKey) return;
+
+    event.preventDefault();
+    if (isSaving) return;
+
+    const live = event.currentTarget.value;
+    const liveTrimmed = live.trim();
+    const originalTrimmed = originalContent.trim();
+    if (liveTrimmed.length > 0 && liveTrimmed !== originalTrimmed) {
+      onSave(live);
+      return;
+    }
+    onCancel();
+  }
 
   return (
     <div className="pt-0.5">
@@ -1187,12 +1166,13 @@ function MessageEditComposer({
         disabled={isSaving}
         className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
         aria-label={t("Edit.composerAria")}
+        onKeyDown={handleKeyDown}
         onBlur={() => {
-          if (isSavingRef.current) return;
+          if (isSaving) return;
           // Live DOM (same race as Enter): prop can lag a just-typed character.
           const live = textareaRef.current?.value ?? value;
-          if (live.trim() === originalContentRef.current.trim()) {
-            onCancelRef.current();
+          if (live.trim() === originalContent.trim()) {
+            onCancel();
           }
         }}
       />

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1104,15 +1104,23 @@ function MessageEditComposer({
   value: string;
   originalContent: string;
   onChange: (value: string) => void;
-  onSave: () => void;
+  onSave: (content: string) => void;
   onCancel: () => void;
   isSaving: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const originalContentRef = useRef(originalContent);
+  const isSavingRef = useRef(isSaving);
+  const onSaveRef = useRef(onSave);
+  const onCancelRef = useRef(onCancel);
+  originalContentRef.current = originalContent;
+  isSavingRef.current = isSaving;
+  onSaveRef.current = onSave;
+  onCancelRef.current = onCancel;
+
   const trimmed = value.trim();
   const isUnchanged = trimmed === originalContent.trim();
-  const canSave = trimmed.length > 0 && !isUnchanged && !isSaving;
 
   // autoFocus leaves the caret at 0; place it at the end so editing continues
   // from the natural end of the message (Slack/Discord-style).
@@ -1122,6 +1130,53 @@ function MessageEditComposer({
     el.focus();
     const end = el.value.length;
     el.setSelectionRange(end, end);
+  }, []);
+
+  // Native listener: read the live DOM value so Enter always sees the latest
+  // text (React onKeyDown can race a just-typed character's setState). Enter
+  // with no real change exits edit mode instead of no-op (preventDefault alone
+  // felt like a broken keyboard).
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.isComposing || event.keyCode === 229) return;
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!isSavingRef.current) onCancelRef.current();
+        return;
+      }
+
+      if (event.key !== "Enter") return;
+      // Shift+Enter → newline (default)
+      if (event.shiftKey) return;
+      // Alt+Enter ignored (leave default / no save)
+      if (event.altKey) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      if (isSavingRef.current) return;
+
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLTextAreaElement)) return;
+
+      const live = target.value;
+      const liveTrimmed = live.trim();
+      const originalTrimmed = originalContentRef.current.trim();
+      if (liveTrimmed.length > 0 && liveTrimmed !== originalTrimmed) {
+        onSaveRef.current(live);
+        return;
+      }
+      onCancelRef.current();
+    }
+
+    el.addEventListener("keydown", handleKeyDown);
+    return () => {
+      el.removeEventListener("keydown", handleKeyDown);
+    };
   }, []);
 
   return (
@@ -1138,20 +1193,6 @@ function MessageEditComposer({
         onBlur={() => {
           if (isSaving) return;
           if (isUnchanged) onCancel();
-        }}
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            event.preventDefault();
-            if (!isSaving) onCancel();
-            return;
-          }
-          if (event.key !== "Enter") return;
-          // Shift+Enter → newline (default)
-          if (event.shiftKey) return;
-          // Cmd/Ctrl+Enter keeps working as save alias; Alt+Enter ignored
-          if (event.altKey) return;
-          event.preventDefault();
-          if (canSave) onSave();
         }}
       />
     </div>
@@ -1294,7 +1335,8 @@ export function ChatMessageRow({
   editDraft?: string;
   onEditDraftChange?: (value: string) => void;
   onCancelEdit?: () => void;
-  onSaveEdit?: () => void;
+  /** Optional content uses the live editor value (avoids stale draft on Enter). */
+  onSaveEdit?: (content?: string) => void;
   isSavingEdit?: boolean;
   showThreadButton?: boolean;
   showQuoteButton?: boolean;

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1119,9 +1119,6 @@ function MessageEditComposer({
   onSaveRef.current = onSave;
   onCancelRef.current = onCancel;
 
-  const trimmed = value.trim();
-  const isUnchanged = trimmed === originalContent.trim();
-
   // autoFocus leaves the caret at 0; place it at the end so editing continues
   // from the natural end of the message (Slack/Discord-style).
   useLayoutEffect(() => {
@@ -1134,8 +1131,8 @@ function MessageEditComposer({
 
   // Native listener: read the live DOM value so Enter always sees the latest
   // text (React onKeyDown can race a just-typed character's setState). Enter
-  // with no real change exits edit mode instead of no-op (preventDefault alone
-  // felt like a broken keyboard).
+  // with no real change (or empty) exits edit mode instead of no-op
+  // (preventDefault alone felt like a broken keyboard).
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
@@ -1191,8 +1188,12 @@ function MessageEditComposer({
         className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
         aria-label={t("Edit.composerAria")}
         onBlur={() => {
-          if (isSaving) return;
-          if (isUnchanged) onCancel();
+          if (isSavingRef.current) return;
+          // Live DOM (same race as Enter): prop can lag a just-typed character.
+          const live = textareaRef.current?.value ?? value;
+          if (live.trim() === originalContentRef.current.trim()) {
+            onCancelRef.current();
+          }
         }}
       />
     </div>

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1110,11 +1110,11 @@ function MessageEditComposer({
 }) {
   const t = useTranslations("App.Channels");
   const trimmed = value.trim();
-  const canSave =
-    trimmed.length > 0 && trimmed !== originalContent.trim() && !isSaving;
+  const isUnchanged = trimmed === originalContent.trim();
+  const canSave = trimmed.length > 0 && !isUnchanged && !isSaving;
 
   return (
-    <div className="space-y-2 pt-0.5">
+    <div className="pt-0.5">
       <Textarea
         value={value}
         onChange={(event) => {
@@ -1123,35 +1123,26 @@ function MessageEditComposer({
         disabled={isSaving}
         className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
         autoFocus
+        aria-label={t("Edit.composerAria")}
+        onBlur={() => {
+          if (isSaving) return;
+          if (isUnchanged) onCancel();
+        }}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();
             if (!isSaving) onCancel();
             return;
           }
-          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-            event.preventDefault();
-            if (canSave) onSave();
-          }
+          if (event.key !== "Enter") return;
+          // Shift+Enter → newline (default)
+          if (event.shiftKey) return;
+          // Cmd/Ctrl+Enter keeps working as save alias; Alt+Enter ignored
+          if (event.altKey) return;
+          event.preventDefault();
+          if (canSave) onSave();
         }}
       />
-      <div className="flex flex-wrap gap-2">
-        <Button type="button" size="sm" disabled={!canSave} onClick={onSave}>
-          {isSaving ? (
-            <Loader2 className="size-4 animate-spin" aria-hidden />
-          ) : null}
-          {t("Edit.save")}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          disabled={isSaving}
-          onClick={onCancel}
-        >
-          {t("Edit.cancel")}
-        </Button>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1109,20 +1109,31 @@ function MessageEditComposer({
   isSaving: boolean;
 }) {
   const t = useTranslations("App.Channels");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const trimmed = value.trim();
   const isUnchanged = trimmed === originalContent.trim();
   const canSave = trimmed.length > 0 && !isUnchanged && !isSaving;
 
+  // autoFocus leaves the caret at 0; place it at the end so editing continues
+  // from the natural end of the message (Slack/Discord-style).
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.focus();
+    const end = el.value.length;
+    el.setSelectionRange(end, end);
+  }, []);
+
   return (
     <div className="pt-0.5">
       <Textarea
+        ref={textareaRef}
         value={value}
         onChange={(event) => {
           onChange(event.target.value);
         }}
         disabled={isSaving}
         className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
-        autoFocus
         aria-label={t("Edit.composerAria")}
         onBlur={() => {
           if (isSaving) return;

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1210,11 +1210,12 @@ export function RoomsClient({
     setEditSession((current) => (current ? { ...current, draft } : current));
   }
 
-  function handleSaveEdit() {
+  function handleSaveEdit(contentOverride?: string) {
     if (!selectedRoom || !editSession || isSavingEdit) return;
     const roomId = selectedRoom.id;
     const { messageId, draft } = editSession;
-    const content = draft.trim();
+    // Prefer live editor text (Enter can fire before React flushes onChange).
+    const content = (contentOverride ?? draft).trim();
     if (!content) return;
 
     startSavingEditTransition(async () => {

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1216,8 +1216,19 @@ export function RoomsClient({
     const roomId = selectedRoom.id;
     const { messageId, draft } = editSession;
     // Prefer live editor text (Enter can fire before React flushes onChange).
-    const content = (contentOverride ?? draft).trim();
+    const raw = contentOverride ?? draft;
+    const content = raw.trim();
     if (!content) return;
+
+    // Keep controlled draft in sync with what we submit so a failed save still
+    // shows the text the user actually confirmed (not a stale parent draft).
+    if (contentOverride !== undefined && contentOverride !== draft) {
+      setEditSession((current) =>
+        current?.messageId === messageId
+          ? { ...current, draft: contentOverride }
+          : current,
+      );
+    }
 
     startSavingEditTransition(async () => {
       const result = await editRoomMessageAction(roomId, messageId, content);

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -94,7 +94,7 @@ export function ThreadPanel({
   editSession?: { messageId: string; draft: string } | null;
   onEditDraftChange?: (value: string) => void;
   onCancelEdit?: () => void;
-  onSaveEdit?: () => void;
+  onSaveEdit?: (content?: string) => void;
   isSavingEdit?: boolean;
   pendingQuote?: PendingRoomQuote | null;
   onClearPendingQuote?: () => void;

--- a/docs/superpowers/plans/2026-08-05-message-edit-keyboard-ux.md
+++ b/docs/superpowers/plans/2026-08-05-message-edit-keyboard-ux.md
@@ -1,0 +1,379 @@
+# Message Edit Keyboard-First UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make inline message edit keyboard-only: Enter saves, Escape cancels, Shift+Enter inserts newline; remove Save/Cancel buttons.
+
+**Architecture:** Local change to `MessageEditComposer` inside `room-message-row.tsx`. Update `onKeyDown` (plain Enter → save), add `onBlur` (cancel only when draft unchanged), delete the button footer. Parent save/cancel handlers and `canSave` rules stay the same. Tests in `room-message-row.test.tsx` drive behavior via keyboard/blur instead of button clicks.
+
+**Tech Stack:** React 19, TypeScript, Vitest + Testing Library + userEvent, next-intl (optional aria-label only).
+
+**Spec:** `docs/superpowers/specs/2026-08-05-message-edit-keyboard-ux-design.md`
+
+## Global Constraints
+
+- Scope: message edit composer only — do **not** change `EditChannelDialog`, main room composer, or link dialog
+- Enter (no Shift/Alt/Ctrl/Meta) → save when `canSave`; otherwise no-op
+- Shift+Enter → newline (do not intercept)
+- Escape → cancel when not `isSaving` (existing)
+- Cmd/Ctrl+Enter → keep as save alias when `canSave`
+- Blur: cancel if draft unchanged (trim vs original); if dirty, no-op (stay editing)
+- No auto-save on blur; no visible keyboard-hint chrome
+- `canSave` = `trimmed.length > 0 && trimmed !== originalContent.trim() && !isSaving`
+- Conventional Commits; Biome format; pin no new deps
+- When adding i18n keys, update `en.json`, `de.json`, `es.json`
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `apps/web/src/app/(app)/chat/components/room-message-row.tsx` | `MessageEditComposer`: keys, blur, remove buttons |
+| `apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx` | Keyboard + blur interaction tests |
+| `apps/web/messages/en.json` (and `de.json`, `es.json`) | Remove unused `App.Channels.Edit.save` / `cancel` if nothing else uses them; optional `composerAria` if adding aria-label |
+
+**Do not modify:** `edit-channel-dialog.tsx`, `rooms-client.tsx` save/cancel wiring (props stay), `room-composer.tsx`.
+
+---
+
+### Task 1: Keyboard + blur message edit (TDD)
+
+**Files:**
+- Modify: `apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx`
+- Modify: `apps/web/src/app/(app)/chat/components/room-message-row.tsx` (`MessageEditComposer`, ~lines 1097–1157)
+- Modify (if unused after code change): `apps/web/messages/en.json`, `de.json`, `es.json` under `App.Channels.Edit`
+
+**Interfaces:**
+- Consumes (unchanged props):
+  - `value: string`
+  - `originalContent: string`
+  - `onChange: (value: string) => void`
+  - `onSave: () => void`
+  - `onCancel: () => void`
+  - `isSaving: boolean`
+- Produces: same external props; no new exported API. Behavior only.
+
+- [ ] **Step 1: Replace button-based test with failing keyboard tests**
+
+In `apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx`, replace the existing `"renders inline editor when isEditing"` test with:
+
+```tsx
+  it("renders inline editor when isEditing without Save/Cancel buttons", () => {
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit: vi.fn(),
+    });
+
+    expect(screen.getByDisplayValue("Original fixed")).toBeInTheDocument();
+    expect(screen.queryByText("Original")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit.save" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit.cancel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saves on Enter and cancels on Escape while editing", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit,
+    });
+
+    const textarea = screen.getByDisplayValue("Original fixed");
+    textarea.focus();
+
+    await user.keyboard("{Enter}");
+    expect(onSaveEdit).toHaveBeenCalledTimes(1);
+
+    await user.keyboard("{Escape}");
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not save on Shift+Enter while editing", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+    });
+
+    screen.getByDisplayValue("Original fixed").focus();
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onSaveEdit).not.toHaveBeenCalled();
+  });
+
+  it("does not save on Enter when draft is unchanged", async () => {
+    const user = userEvent.setup();
+    const onSaveEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit: vi.fn(),
+      onSaveEdit,
+    });
+
+    screen.getByDisplayValue("Original").focus();
+    await user.keyboard("{Enter}");
+    expect(onSaveEdit).not.toHaveBeenCalled();
+  });
+
+  it("cancels on blur when draft is unchanged", async () => {
+    const user = userEvent.setup();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit: vi.fn(),
+    });
+
+    const textarea = screen.getByDisplayValue("Original");
+    textarea.focus();
+    await user.tab(); // move focus away → blur
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel on blur when draft is dirty", async () => {
+    const user = userEvent.setup();
+    const onCancelEdit = vi.fn();
+
+    renderRow({
+      message: userMessage({ content: "Original" }),
+      currentUserId: "user-1",
+      onStartEdit: vi.fn(),
+      isEditing: true,
+      editDraft: "Original fixed",
+      onEditDraftChange: vi.fn(),
+      onCancelEdit,
+      onSaveEdit: vi.fn(),
+    });
+
+    const textarea = screen.getByDisplayValue("Original fixed");
+    textarea.focus();
+    await user.tab();
+    expect(onCancelEdit).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run:
+
+```bash
+pnpm --filter web test src/app/\(app\)/chat/components/__tests__/room-message-row.test.tsx
+```
+
+Expected:
+- FAIL: Save/Cancel buttons still present (`queryByRole` finds them) and/or Enter does not call `onSaveEdit` / blur does not cancel.
+
+- [ ] **Step 3: Implement `MessageEditComposer`**
+
+Replace `MessageEditComposer` in `apps/web/src/app/(app)/chat/components/room-message-row.tsx` with:
+
+```tsx
+function MessageEditComposer({
+  value,
+  originalContent,
+  onChange,
+  onSave,
+  onCancel,
+  isSaving,
+}: {
+  value: string;
+  originalContent: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  isSaving: boolean;
+}) {
+  const t = useTranslations("App.Channels");
+  const trimmed = value.trim();
+  const isUnchanged = trimmed === originalContent.trim();
+  const canSave = trimmed.length > 0 && !isUnchanged && !isSaving;
+
+  return (
+    <div className="pt-0.5">
+      <Textarea
+        value={value}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+        disabled={isSaving}
+        className="min-h-10 max-h-40 resize-none overflow-y-auto field-sizing-content px-3 py-2.5 leading-6"
+        autoFocus
+        aria-label={t("Edit.composerAria")}
+        onBlur={() => {
+          if (isSaving) return;
+          if (isUnchanged) onCancel();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            if (!isSaving) onCancel();
+            return;
+          }
+          if (event.key !== "Enter") return;
+          // Shift+Enter → newline (default)
+          if (event.shiftKey) return;
+          // Cmd/Ctrl+Enter keeps working as save alias; Alt+Enter ignored
+          if (event.altKey) return;
+          event.preventDefault();
+          if (canSave) onSave();
+        }}
+      />
+    </div>
+  );
+}
+```
+
+Notes for implementer:
+- Remove the Save/Cancel button block entirely (`space-y-2` footer no longer needed; outer `pt-0.5` is enough).
+- Plain Enter and Cmd/Ctrl+Enter both hit the same path once `event.key === "Enter"` and `!shiftKey` (meta/ctrl still call `preventDefault` + `onSave` when `canSave`).
+- Do **not** re-introduce button chrome or a visible hint string.
+- `Loader2` on the Save button goes away; if `Loader2` is unused elsewhere in this file after the change, leave other usages alone — only remove unused imports if Biome flags them.
+- `Button` may still be used elsewhere in the file — do not remove the import if other components need it.
+
+- [ ] **Step 4: Add i18n key for aria-label; drop unused save/cancel strings**
+
+In `apps/web/messages/en.json` under `App.Channels.Edit` (today):
+
+```json
+"Edit": {
+  "action": "Edit",
+  "save": "Save",
+  "cancel": "Cancel",
+  "edited": "Edited"
+}
+```
+
+Change to:
+
+```json
+"Edit": {
+  "action": "Edit",
+  "composerAria": "Edit message. Enter to save, Escape to cancel, Shift+Enter for a new line.",
+  "edited": "Edited"
+}
+```
+
+Mirror in `de.json` and `es.json` (same structure; translate `composerAria` appropriately, e.g. DE: `"Nachricht bearbeiten. Enter speichern, Escape abbrechen, Umschalt+Enter neue Zeile."` / ES: `"Editar mensaje. Intro para guardar, Escape para cancelar, Mayús+Intro para nueva línea."`).
+
+Only remove `save` / `cancel` after confirming no remaining `t("Edit.save")` / `t("Edit.cancel")` under `App.Channels` (grep should show only the old MessageEditComposer usages, which this task deletes).
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+```bash
+pnpm --filter web test src/app/\(app\)/chat/components/__tests__/room-message-row.test.tsx
+```
+
+Expected: all tests in that file PASS.
+
+If blur tests flake because `user.tab()` does not leave the only focusable control, use:
+
+```tsx
+import { fireEvent } from "@testing-library/react";
+// ...
+fireEvent.blur(textarea);
+```
+
+Prefer `user.tab()` first; switch to `fireEvent.blur` only if tab has nowhere to go in the isolated row render.
+
+- [ ] **Step 6: Format + typecheck touched surface**
+
+```bash
+pnpm --filter web exec biome check --write src/app/\(app\)/chat/components/room-message-row.tsx src/app/\(app\)/chat/components/__tests__/room-message-row.test.tsx
+pnpm --filter web typecheck
+```
+
+Expected: clean / no new errors in touched files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  apps/web/src/app/\(app\)/chat/components/room-message-row.tsx \
+  apps/web/src/app/\(app\)/chat/components/__tests__/room-message-row.test.tsx \
+  apps/web/messages/en.json \
+  apps/web/messages/de.json \
+  apps/web/messages/es.json
+
+git commit -m "$(cat <<'EOF'
+feat(chat): keyboard-first message edit UX
+
+Enter saves, Escape cancels, Shift+Enter newlines;
+remove Save/Cancel buttons; blur cancels when unchanged.
+EOF
+)"
+```
+
+---
+
+### Task 2: Manual smoke (no code)
+
+**Files:** none
+
+- [ ] **Step 1: Manual checklist in local web**
+
+With `pnpm web:dev` (and core if needed):
+
+1. Open a room message you authored → Edit.
+2. Change text → **Enter** → message updates; edit mode exits.
+3. Edit again → **Escape** → discards, exits.
+4. Edit → **Shift+Enter** → new line appears; still editing.
+5. Edit, no changes → click elsewhere → exits edit mode.
+6. Edit, change text → click elsewhere → stays in edit mode (still dirty).
+7. Confirm channel **settings** dialog still has Save/Cancel (untouched).
+
+- [ ] **Step 2: No commit** unless manual smoke found a bug (then fix under Task 1 and amend or follow-up commit).
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+| --- | --- |
+| Remove Save/Cancel buttons | Task 1 |
+| Enter saves when `canSave` | Task 1 |
+| Escape cancels | Task 1 |
+| Shift+Enter newline | Task 1 |
+| Cmd/Ctrl+Enter alias | Task 1 (same Enter path) |
+| Blur cancel if unchanged | Task 1 |
+| Blur no-op if dirty | Task 1 |
+| Enter no-op when not `canSave` | Task 1 |
+| No visible hint chrome | Task 1 (aria only) |
+| Out of scope: channel dialog / main composer | Global constraints |
+| Tests updated | Task 1 |
+| i18n cleanup / aria | Task 1 |

--- a/docs/superpowers/specs/2026-08-05-message-edit-keyboard-ux-design.md
+++ b/docs/superpowers/specs/2026-08-05-message-edit-keyboard-ux-design.md
@@ -1,0 +1,137 @@
+# Design: Keyboard-first message edit UX
+
+**Date:** 2026-08-05  
+**Status:** Approved  
+**Scope:** `apps/web` only — inline message edit composer in chat rooms/threads.
+
+## Problem
+
+Inline message edit shows labeled **Save** and **Cancel** buttons under the textarea. That chrome is heavy for a short, focused edit. Escape already cancels; save requires a click or **Cmd/Ctrl+Enter**. Users want a keyboard-first flow: **Enter** saves, **Escape** cancels, no action buttons.
+
+## Goals
+
+- Remove Save/Cancel button row from message edit.
+- **Enter** (no modifiers) saves when the draft is valid.
+- **Escape** cancels when not saving.
+- **Shift+Enter** inserts a newline.
+- Keep existing save eligibility rules (non-empty, dirty, not in-flight).
+- Update tests to match the new interaction model.
+
+## Non-goals
+
+- Channel / room settings dialog (multi-field form keeps explicit Save/Cancel).
+- Main room composer send/newline policy.
+- Composer “Add link” dialog or other edit surfaces.
+- Visible on-screen keyboard hint text.
+- Auto-save on blur.
+- Changing edit entry points (hover/menu “Edit”), permissions, or Core edit API.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| Surface | Message edit only (`MessageEditComposer`) |
+| Buttons | Remove entirely |
+| Save key | **Enter** (no Shift/Alt/Ctrl/Meta) |
+| Newline | **Shift+Enter** |
+| Cancel key | **Escape** (already present) |
+| Cmd/Ctrl+Enter | Keep as save alias (low cost, muscle memory) |
+| Mouse-only path | Keyboard only; no icon buttons, no hint chrome |
+| Blur / click-away | Cancel if draft unchanged; if dirty, stay in edit mode (no auto-save, no discard) |
+| Enter when not `canSave` | No-op (do not cancel, do not save) |
+
+## Current behavior
+
+`MessageEditComposer` in `apps/web/src/app/(app)/chat/components/room-message-row.tsx`:
+
+- Textarea + Save / Cancel buttons.
+- Escape → cancel (if not saving).
+- Cmd/Ctrl+Enter → save when `canSave`.
+- Plain Enter → newline (default textarea).
+
+`canSave` today:
+
+```ts
+trimmed.length > 0 && trimmed !== originalContent.trim() && !isSaving
+```
+
+Parent wiring (`rooms-client`, `thread-panel`) is unchanged: still passes `onSaveEdit` / `onCancelEdit` / `editDraft` / `isSavingEdit`.
+
+## Target behavior
+
+### UI
+
+- Single auto-focused textarea (existing styles).
+- No Save/Cancel button row.
+- Optional a11y only: `aria-label` (and/or `title`) describing Enter / Escape / Shift+Enter — **no** visible hint line.
+
+### Keyboard
+
+| Key | Action |
+| --- | --- |
+| **Enter** (no Shift/Alt/Ctrl/Meta) | `preventDefault`; call `onSave` if `canSave`; otherwise no-op |
+| **Shift+Enter** | Default newline (do not intercept) |
+| **Escape** | `preventDefault`; call `onCancel` if not `isSaving` |
+| **Cmd/Ctrl+Enter** | `preventDefault`; call `onSave` if `canSave` (alias) |
+
+While `isSaving`: textarea disabled; ignore Enter/Escape save/cancel handlers (same as today for Escape).
+
+### Blur / click-away
+
+| Draft state | On blur |
+| --- | --- |
+| Unchanged vs original (trim-aware, same idea as `canSave` dirty check) | Cancel edit (`onCancel`) if not saving |
+| Dirty | No-op — stay in edit mode; user must Enter or Escape |
+
+Do **not** auto-save on blur.
+
+### Save eligibility
+
+Unchanged from product rules:
+
+- Non-empty after trim.
+- Differs from original after trim.
+- Not currently saving.
+
+Empty draft + Enter → no-op (user uses Escape to exit).
+
+## Implementation sketch
+
+1. **`MessageEditComposer`** (`room-message-row.tsx`)
+   - Delete button footer and related `Button` / `Loader2` usage if unused elsewhere in the function.
+   - Update `onKeyDown`:
+     - Escape → cancel (keep).
+     - Enter without modifiers → save when `canSave`.
+     - Keep Cmd/Ctrl+Enter → save when `canSave`.
+     - Leave Shift+Enter alone.
+   - Add `onBlur` handler for cancel-when-unchanged (guard `isSaving`).
+   - While saving, parent already sets `isSaving`; keep disabled textarea.
+   - Consider a saving affordance without buttons: rely on disabled field + existing parent toast/error paths; if a spinner was only on the Save button, omit or use a non-blocking status only if needed — prefer no new chrome.
+
+2. **Tests** (`room-message-row.test.tsx`)
+   - Replace “click Save / Cancel” with keyboard:
+     - Enter → `onSaveEdit`
+     - Escape → `onCancelEdit`
+   - Assert no `Edit.save` / `Edit.cancel` buttons when editing.
+   - Shift+Enter does not call `onSaveEdit`.
+   - Enter when draft equals original → no `onSaveEdit`.
+   - Optional: blur with unchanged draft → cancel; blur with dirty draft → no cancel.
+
+3. **i18n**
+   - `App.Channels.Edit.save` / `Edit.cancel` — remove only if unused after this change (grep). `Edit.edited` / `Edit.action` stay.
+
+## Error handling
+
+- Save failure remains parent responsibility (`handleSaveEdit` toast, stay in edit or exit per existing logic).
+- No new error UI in the composer.
+
+## Testing plan
+
+- Unit: keyboard + blur cases above in `room-message-row.test.tsx`.
+- Manual: edit message → Enter saves; Escape cancels; Shift+Enter multi-line; click away with no edits exits; click away with edits stays.
+
+## Out of scope (explicit)
+
+- `EditChannelDialog` footer buttons.
+- Thread vs room parity beyond shared `MessageEditComposer` (both already use it via row props).
+- Changing when “Edited” badge appears.

--- a/docs/superpowers/specs/2026-08-05-message-edit-keyboard-ux-design.md
+++ b/docs/superpowers/specs/2026-08-05-message-edit-keyboard-ux-design.md
@@ -38,7 +38,7 @@ Inline message edit shows labeled **Save** and **Cancel** buttons under the text
 | Cmd/Ctrl+Enter | Keep as save alias (low cost, muscle memory) |
 | Mouse-only path | Keyboard only; no icon buttons, no hint chrome |
 | Blur / click-away | Cancel if draft unchanged; if dirty, stay in edit mode (no auto-save, no discard) |
-| Enter when not `canSave` | No-op (do not cancel, do not save) |
+| Enter when not `canSave` | Cancel / exit edit (unchanged or empty) — not silent no-op |
 
 ## Current behavior
 
@@ -69,18 +69,19 @@ Parent wiring (`rooms-client`, `thread-panel`) is unchanged: still passes `onSav
 
 | Key | Action |
 | --- | --- |
-| **Enter** (no Shift/Alt/Ctrl/Meta) | `preventDefault`; call `onSave` if `canSave`; otherwise no-op |
+| **Enter** (no Shift/Alt) | `preventDefault`; call `onSave` with live textarea value if dirty + non-empty; otherwise **cancel** (exit edit). Cmd/Ctrl+Enter uses the same path (save alias when dirty). |
 | **Shift+Enter** | Default newline (do not intercept) |
 | **Escape** | `preventDefault`; call `onCancel` if not `isSaving` |
-| **Cmd/Ctrl+Enter** | `preventDefault`; call `onSave` if `canSave` (alias) |
 
 While `isSaving`: textarea disabled; ignore Enter/Escape save/cancel handlers (same as today for Escape).
+
+**Post-approval UX note:** Enter when not `canSave` was originally a no-op. That left the field silent after `preventDefault` (felt broken). Shipped behavior: Enter always exits — save when valid, cancel when unchanged or empty.
 
 ### Blur / click-away
 
 | Draft state | On blur |
 | --- | --- |
-| Unchanged vs original (trim-aware, same idea as `canSave` dirty check) | Cancel edit (`onCancel`) if not saving |
+| Unchanged vs original (trim-aware; use **live DOM** value, not only React props) | Cancel edit (`onCancel`) if not saving |
 | Dirty | No-op — stay in edit mode; user must Enter or Escape |
 
 Do **not** auto-save on blur.
@@ -93,7 +94,7 @@ Unchanged from product rules:
 - Differs from original after trim.
 - Not currently saving.
 
-Empty draft + Enter → no-op (user uses Escape to exit).
+Empty draft + Enter → cancel (exit edit, restore original message view).
 
 ## Implementation sketch
 


### PR DESCRIPTION
## Summary

- Remove Save/Cancel buttons from inline message edit (`MessageEditComposer`).
- **Enter** saves when the draft is valid; **Escape** cancels; **Shift+Enter** inserts a newline; **Cmd/Ctrl+Enter** still saves as an alias.
- Blur cancels only when the draft is unchanged; dirty edits stay open until Enter or Escape.
- i18n: `Edit.composerAria` for accessibility; drop unused `Edit.save` / `Edit.cancel` under `App.Channels.Edit` (en/de/es).

## Spec / plan

- Design: `docs/superpowers/specs/2026-08-05-message-edit-keyboard-ux-design.md`
- Plan: `docs/superpowers/plans/2026-08-05-message-edit-keyboard-ux.md`

## Test plan

- [x] `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx` (48/48)
- [ ] Manual: edit message → Enter saves; Escape cancels; Shift+Enter newline
- [ ] Manual: blur with no changes exits edit; blur with dirty draft stays editing
- [ ] Manual: channel settings dialog still has Save/Cancel (untouched)