### PR TITLE
feat(web): wire Apple Dynamic Type root size and 1.25x cap

### DIFF
--- a/.cursor/rules/dynamic-type.mdc
+++ b/.cursor/rules/dynamic-type.mdc
@@ -1,0 +1,16 @@
+---
+description: "Apple Dynamic Type and no fixed px font sizes in apps/web"
+alwaysApply: true
+---
+
+## Dynamic Type (iOS / macOS)
+
+Sokosumi web opts into Apple Dynamic Type for whole-UI rem scaling.
+
+1. **Root size** may come from `-apple-system-body` on `html` (see `apps/web/src/app/globals.css`). Brand face stays **Inter** (`next/font`).
+2. **Cap is 1.25×** default (`DYNAMIC_TYPE_MAX_SCALE = 1.25`, max root **20px** when default is 16px). Implemented in `apps/web/src/lib/utils/dynamic-type.ts` + `DynamicTypeRootCap`. Do not raise the cap without product decision.
+3. **No fixed `px` font sizes** in product UI. Use Tailwind `text-*` or `rem`/`em` (e.g. `text-[0.625rem]` not `text-[10px]`). Guard: `apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts`.
+4. Do **not** set viewport `maximum-scale=1` or `user-scalable=no`.
+5. Do **not** set `html`/`body` `font-size` to a fixed `px` that kills Dynamic Type, except the documented 20px cap path.
+
+Allowlist for px font sizes: true non-interactive export/print only (e.g. PDF Puppeteer chrome), named in the guard test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ sokosumi/
 - **Colors**: Use semantic colors from `globals.css`; never hardcode hex values
 - **Sizing**: Use `size-4` instead of `h-4 w-4`
 - **Themes**: Ensure compatibility with both dark and light modes
+- **Dynamic Type (iOS/macOS)**: Root rem may track Apple Dynamic Type (`-apple-system-body`); Inter stays the face; scale capped at **1.25×** (max 20px root). See `.cursor/rules/dynamic-type.mdc` and `apps/web/src/lib/utils/dynamic-type.ts`.
+- **Font sizes**: Never use fixed `px` type in product UI (`text-[10px]`, `font-size: 12px`, `fontSize: 14`). Use Tailwind `text-*` or `rem`/`em` so type scales with root.
 
 ### TypeScript Usage
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -317,6 +317,8 @@ Env vars that must be set per environment (web): `STRIPE_SECRET_KEY`, `STRIPE_CR
 - Use semantic colors from `globals.css`
 - Ensure dark/light mode compatibility
 - Use `size-*` utilities instead of `h-* w-*`
+- **Dynamic Type (iOS/macOS)**: Root rem may track Apple Dynamic Type (`-apple-system-body`); Inter stays the face; scale capped at **1.25×** (max 20px root). See `.cursor/rules/dynamic-type.mdc` and `apps/web/src/lib/utils/dynamic-type.ts`.
+- **Font sizes**: Never use fixed `px` type in product UI (`text-[10px]`, `font-size: 12px`, `fontSize: 14`). Use Tailwind `text-*` or `rem`/`em` so type scales with root.
 
 ## Development Workflow
 

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -337,7 +337,7 @@ export function DraftDirectMessage({
               >
                 <Avatar className="size-5">
                   <AvatarImage src={target.image ?? undefined} alt="" />
-                  <AvatarFallback className="text-[9px]">
+                  <AvatarFallback className="text-[0.5625rem]">
                     {getInitials(target.name)}
                   </AvatarFallback>
                 </Avatar>

--- a/apps/web/src/app/(app)/chat/components/participant-checkboxes.tsx
+++ b/apps/web/src/app/(app)/chat/components/participant-checkboxes.tsx
@@ -92,7 +92,7 @@ export function ParticipantCheckboxes({
             </div>
           ) : filteredMembers.length > 0 ? (
             <div className="pb-2">
-              <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[11px] font-medium">
+              <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[0.6875rem] font-medium">
                 {t("Dialog.humans")}
               </div>
               <div className="space-y-0.5">
@@ -146,7 +146,7 @@ export function ParticipantCheckboxes({
 
           {filteredCoworkers.length > 0 ? (
             <div className="pt-1">
-              <div className="text-muted-foreground flex items-center gap-1.5 px-2 pt-1 pb-1.5 text-[11px] font-medium">
+              <div className="text-muted-foreground flex items-center gap-1.5 px-2 pt-1 pb-1.5 text-[0.6875rem] font-medium">
                 <Bot className="size-3" aria-hidden />
                 {t("Dialog.coworkers")}
               </div>

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -98,7 +98,7 @@ function RoomMentionSuggestion({
       ) : (
         <Avatar className="size-6">
           <AvatarImage src={mention.data?.image ?? undefined} alt="" />
-          <AvatarFallback className="text-[10px]">
+          <AvatarFallback className="text-[0.625rem]">
             {getInitials(mention.value)}
           </AvatarFallback>
         </Avatar>

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -157,7 +157,7 @@ export function DirectDraftTargetRow({
     >
       <Avatar className="size-7 shrink-0">
         <AvatarImage src={target.image ?? undefined} alt="" />
-        <AvatarFallback className="text-[10px]">
+        <AvatarFallback className="text-[0.625rem]">
           {getInitials(target.name)}
         </AvatarFallback>
       </Avatar>
@@ -214,7 +214,7 @@ export function DirectDraftTargetList({
       {humans.length > 0 ? (
         <div className={coworkerTargets.length > 0 ? "pb-1" : undefined}>
           {showSectionLabels ? (
-            <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[11px] font-medium">
+            <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[0.6875rem] font-medium">
               {t("Dialog.humans")}
             </div>
           ) : null}
@@ -235,7 +235,7 @@ export function DirectDraftTargetList({
       {coworkerTargets.length > 0 ? (
         <div>
           {showSectionLabels ? (
-            <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[11px] font-medium">
+            <div className="text-muted-foreground px-2 pt-1 pb-1.5 text-[0.6875rem] font-medium">
               {t("Dialog.coworkers")}
             </div>
           ) : null}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -337,7 +337,7 @@ function MessageUnfurlCard({ unfurl }: { unfurl: ChatRoomMessageUnfurl }) {
       data-testid="room-message-unfurl"
     >
       {siteLabel ? (
-        <div className="text-muted-foreground truncate text-[11px] font-medium tracking-wide uppercase">
+        <div className="text-muted-foreground truncate text-[0.6875rem] font-medium tracking-wide uppercase">
           {siteLabel}
         </div>
       ) : null}
@@ -1370,7 +1370,7 @@ export function ChatMessageRow({
         <div className="flex w-8 shrink-0 justify-center pt-0.5">
           <MessageWallClockTime
             value={message.createdAt}
-            className="text-muted-foreground whitespace-nowrap text-[10px] leading-4 tabular-nums opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+            className="text-muted-foreground whitespace-nowrap text-[0.625rem] leading-4 tabular-nums opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
           />
         </div>
       ) : (

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -208,7 +208,7 @@ function RoomParticipantStack({
                 <AvatarImage src={participant.image ?? undefined} alt="" />
                 <AvatarFallback
                   className={cn(
-                    "text-[10px]",
+                    "text-[0.625rem]",
                     participant.kind === "coworker"
                       ? "bg-primary/10 text-primary"
                       : "bg-muted text-muted-foreground",

--- a/apps/web/src/app/(app)/components/header/header-notification-bell.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-notification-bell.client.tsx
@@ -74,7 +74,7 @@ export function HeaderNotificationBell() {
                 <span
                   data-testid="notification-unread-badge"
                   className={cn(
-                    "absolute -top-0.5 -right-0.5 inline-flex min-w-4.5 items-center justify-center rounded-full px-0.5 text-[10px] leading-4 font-semibold tabular-nums ring-2 ring-background",
+                    "absolute -top-0.5 -right-0.5 inline-flex min-w-4.5 items-center justify-center rounded-full px-0.5 text-[0.625rem] leading-4 font-semibold tabular-nums ring-2 ring-background",
                     getNotificationIndicatorClassName(indicator.tone),
                   )}
                   aria-hidden

--- a/apps/web/src/app/(app)/components/onboarding-dialog.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog.tsx
@@ -124,7 +124,7 @@ function ChatVisual({
             phase >= 1 ? "translate-y-0 opacity-100" : "translate-y-3 opacity-0"
           }`}
         >
-          <div className="bg-primary text-primary-foreground max-w-[85%] rounded-2xl rounded-br-sm px-4 py-2.5 text-[13px]">
+          <div className="bg-primary text-primary-foreground max-w-[85%] rounded-2xl rounded-br-sm px-4 py-2.5 text-[0.8125rem]">
             {userMessage}
           </div>
         </div>
@@ -162,7 +162,7 @@ function ChatVisual({
               className="object-cover"
             />
           </div>
-          <div className="bg-background max-w-[85%] rounded-2xl rounded-bl-sm border px-4 py-2.5 text-[13px]">
+          <div className="bg-background max-w-[85%] rounded-2xl rounded-bl-sm border px-4 py-2.5 text-[0.8125rem]">
             {coworkerReply}
           </div>
         </div>
@@ -231,7 +231,7 @@ function OrchestrationVisual({
           <div className="bg-border relative h-px w-16">
             <span className="bg-primary absolute top-1/2 left-0 size-1.5 -translate-y-1/2 animate-[slide_2s_ease-in-out_infinite] rounded-full" />
           </div>
-          <span className="text-muted-foreground text-[10px]">
+          <span className="text-muted-foreground text-[0.625rem]">
             {hiresLabel}
           </span>
         </div>
@@ -250,7 +250,9 @@ function OrchestrationVisual({
               <div className="bg-background flex size-8 items-center justify-center rounded-full border shadow-sm">
                 <Bot className="text-muted-foreground size-3.5" />
               </div>
-              <span className="text-muted-foreground text-[11px]">{name}</span>
+              <span className="text-muted-foreground text-[0.6875rem]">
+                {name}
+              </span>
             </div>
           ))}
         </div>
@@ -263,7 +265,7 @@ function OrchestrationVisual({
         }`}
       >
         <div className="bg-border h-px w-6" />
-        <div className="bg-primary/10 text-primary rounded-full px-3 py-1 text-[11px] font-medium">
+        <div className="bg-primary/10 text-primary rounded-full px-3 py-1 text-[0.6875rem] font-medium">
           {workDeliveredLabel}
         </div>
         <div className="bg-border h-px w-6" />
@@ -712,7 +714,7 @@ export function OnboardingDialog({
                   <h2 className="mt-8 text-2xl font-semibold tracking-tight">
                     {introSteps[0].title}
                   </h2>
-                  <p className="text-muted-foreground mt-3 max-w-md text-[15px] leading-relaxed">
+                  <p className="text-muted-foreground mt-3 max-w-md text-[0.9375rem] leading-relaxed">
                     {introSteps[0].description}
                   </p>
                   <div className="mt-8 flex items-center gap-3">
@@ -756,7 +758,7 @@ export function OnboardingDialog({
                   <h2 className="text-2xl font-semibold tracking-tight">
                     {introSteps[step].title}
                   </h2>
-                  <p className="text-muted-foreground mx-auto mt-3 max-w-sm text-[15px] leading-relaxed md:mx-0">
+                  <p className="text-muted-foreground mx-auto mt-3 max-w-sm text-[0.9375rem] leading-relaxed md:mx-0">
                     {introSteps[step].description}
                   </p>
                 </div>
@@ -768,7 +770,7 @@ export function OnboardingDialog({
                     <h2 className="text-2xl font-semibold tracking-tight">
                       {introSteps[step].title}
                     </h2>
-                    <p className="text-muted-foreground mx-auto max-w-2xl text-[15px] leading-relaxed">
+                    <p className="text-muted-foreground mx-auto max-w-2xl text-[0.9375rem] leading-relaxed">
                       {introSteps[step].description}
                     </p>
                   </div>

--- a/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
@@ -143,7 +143,7 @@ export default function MenuItems({ hideHistory = false }: MenuItemsProps) {
                     {badge ? (
                       <span
                         className={cn(
-                          "border-border/60 text-tertiary-foreground dark:text-muted-foreground rounded border px-1 py-0 text-[10px] font-medium uppercase tracking-wide leading-4",
+                          "border-border/60 text-tertiary-foreground dark:text-muted-foreground rounded border px-1 py-0 text-[0.625rem] font-medium uppercase tracking-wide leading-4",
                           isActive &&
                             "border-primary-foreground/30 text-primary-foreground",
                         )}
@@ -154,7 +154,7 @@ export default function MenuItems({ hideHistory = false }: MenuItemsProps) {
                     {showUnread ? (
                       <span
                         aria-label={`${unreadDisplay} unread`}
-                        className="bg-primary text-primary-foreground inline-flex min-w-4.5 shrink-0 items-center justify-center rounded-full px-1 text-[10px] font-semibold leading-4 tabular-nums"
+                        className="bg-primary text-primary-foreground inline-flex min-w-4.5 shrink-0 items-center justify-center rounded-full px-1 text-[0.625rem] font-semibold leading-4 tabular-nums"
                       >
                         {unreadDisplay}
                       </span>

--- a/apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
@@ -129,7 +129,7 @@ export default function PersonalAssistantNav({
             {showNewBadge ? (
               <span
                 aria-hidden
-                className="bg-primary text-primary-foreground pointer-events-none absolute -top-1.5 -right-1 z-10 rounded-full px-1.5 py-px text-[9px] font-bold tracking-widest uppercase group-data-[collapsible=icon]:hidden"
+                className="bg-primary text-primary-foreground pointer-events-none absolute -top-1.5 -right-1 z-10 rounded-full px-1.5 py-px text-[0.5625rem] font-bold tracking-widest uppercase group-data-[collapsible=icon]:hidden"
               >
                 {t("hermesNew")}
               </span>

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
@@ -180,7 +180,7 @@ export function SidebarAccountChip({
             }
             alt=""
           />
-          <AvatarFallback className="bg-muted text-muted-foreground text-[11px] font-medium">
+          <AvatarFallback className="bg-muted text-muted-foreground text-[0.6875rem] font-medium">
             {getInitials(displayName)}
           </AvatarFallback>
         </Avatar>
@@ -263,7 +263,7 @@ export function SidebarAccountChip({
           {presenceLabel}
         </span>
         {planName !== null ? (
-          <span className="bg-muted rounded-full px-2 py-0.5 text-[11px] font-medium">
+          <span className="bg-muted rounded-full px-2 py-0.5 text-[0.6875rem] font-medium">
             <span className="sr-only">{`${t("planLabel")}: `}</span>
             {planName}
           </span>

--- a/apps/web/src/app/(app)/history/components/history-list-item.tsx
+++ b/apps/web/src/app/(app)/history/components/history-list-item.tsx
@@ -178,7 +178,7 @@ function HistoryTypeColumn({
       >
         <HistoryTypeIcon item={item} />
       </span>
-      <span className="text-muted-foreground w-full rounded-full px-1.5 py-0.5 text-[10px] font-medium tracking-wider uppercase hidden sm:block">
+      <span className="text-muted-foreground w-full rounded-full px-1.5 py-0.5 text-[0.625rem] font-medium tracking-wider uppercase hidden sm:block">
         {labels.kind[item.kind]}
       </span>
     </div>

--- a/apps/web/src/app/(app)/personal-assistant/README.md
+++ b/apps/web/src/app/(app)/personal-assistant/README.md
@@ -361,8 +361,8 @@ web generate:core:snapshot`.
 ## Conventions
 
 - **No em-dashes** in user-visible copy. Use periods, commas, or colons.
-- **No ad-hoc text sizes** (no `text-[10px]`, `text-[15px]`). Stick to the
-  Tailwind scale.
+- **No fixed `px` font sizes** (no `text-[10px]`, `fontSize: 14`). Prefer
+  Tailwind `text-*` or rem (`text-[0.625rem]`) so type tracks Dynamic Type.
 - **Color is reserved for status** — success (emerald), warning (amber),
   destructive (red). The five accent colors (violet/cyan/amber/emerald/rose)
   are for section eyebrows + per-tier accents only; don't sprinkle them.

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state/confirmation-card.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state/confirmation-card.tsx
@@ -86,7 +86,7 @@ function CoworkerRefChip({
           className="border-border size-4 shrink-0 rounded-full border"
         />
       ) : (
-        <span className="bg-muted text-muted-foreground inline-flex size-4 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold">
+        <span className="bg-muted text-muted-foreground inline-flex size-4 shrink-0 items-center justify-center rounded-full text-[0.625rem] font-semibold">
           {coworker.name.charAt(0).toUpperCase()}
         </span>
       )}

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state/message-row.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state/message-row.tsx
@@ -72,7 +72,7 @@ export function MessageRow({
           </div>
           <time
             dateTime={message.createdAt}
-            className="text-tertiary-foreground px-1 text-[10px] tabular-nums opacity-0 transition-opacity group-hover/message:opacity-100"
+            className="text-tertiary-foreground px-1 text-[0.625rem] tabular-nums opacity-0 transition-opacity group-hover/message:opacity-100"
           >
             {timestamp}
           </time>
@@ -186,13 +186,13 @@ export function MessageRow({
             />
           ) : null}
           {durationMs !== undefined && !isStreaming ? (
-            <span className="text-tertiary-foreground text-[10px] tabular-nums opacity-0 transition-opacity group-hover/message:opacity-100">
+            <span className="text-tertiary-foreground text-[0.625rem] tabular-nums opacity-0 transition-opacity group-hover/message:opacity-100">
               {t("answeredIn", { seconds: Math.round(durationMs / 1000) })}
             </span>
           ) : null}
           <time
             dateTime={message.createdAt}
-            className="text-tertiary-foreground text-[10px] tabular-nums opacity-0 transition-opacity group-hover/message:opacity-100"
+            className="text-tertiary-foreground text-[0.625rem] tabular-nums opacity-0 transition-opacity group-hover/message:opacity-100"
           >
             {timestamp}
           </time>
@@ -282,7 +282,7 @@ export function CopyButton({
           setTimeout(() => setCopied(false), 1500);
         });
       }}
-      className="text-muted-foreground hover:text-foreground hover:bg-muted/60 border-border/70 focus-visible:ring-primary/40 inline-flex items-center gap-1 rounded-md border px-1.5 py-1 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      className="text-muted-foreground hover:text-foreground hover:bg-muted/60 border-border/70 focus-visible:ring-primary/40 inline-flex items-center gap-1 rounded-md border px-1.5 py-1 text-[0.6875rem] font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
     >
       {copied ? (
         <>

--- a/apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
@@ -655,7 +655,7 @@ function SkillCard({
         </p>
       ) : null}
       {item.installs !== null ? (
-        <div className="text-tertiary-foreground flex items-center gap-1 text-[11px]">
+        <div className="text-tertiary-foreground flex items-center gap-1 text-[0.6875rem]">
           <Download className="size-3" />
           {formatter.number(item.installs)}
         </div>

--- a/apps/web/src/app/(app)/tasks/components/job-list-item.tsx
+++ b/apps/web/src/app/(app)/tasks/components/job-list-item.tsx
@@ -70,7 +70,7 @@ export function JobListItem({ job, agentPreview, labels }: JobListItemProps) {
               className="object-cover"
             />
           ) : null}
-          <AvatarFallback className="text-[10px] font-medium">
+          <AvatarFallback className="text-[0.625rem] font-medium">
             {coworkerName.slice(0, 1).toUpperCase()}
           </AvatarFallback>
         </Avatar>

--- a/apps/web/src/app/(app)/tasks/components/task-activity.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-activity.tsx
@@ -579,7 +579,7 @@ export function TaskActivitySection({
                       {actorImage ? (
                         <AvatarImage src={actorImage} alt={actorName} />
                       ) : null}
-                      <AvatarFallback className="bg-muted text-[10px]">
+                      <AvatarFallback className="bg-muted text-[0.625rem]">
                         {getInitials(actorName)}
                       </AvatarFallback>
                     </Avatar>

--- a/apps/web/src/app/(app)/tasks/components/task-created-celebration.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-created-celebration.tsx
@@ -122,7 +122,7 @@ export function TaskCreatedCelebration({
                   >
                     <span
                       className={cn(
-                        "inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[9px] font-medium",
+                        "inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[0.5625rem] font-medium",
                         cardStyles.badge,
                       )}
                     >
@@ -135,11 +135,11 @@ export function TaskCreatedCelebration({
                       />
                       {statusLabel}
                     </span>
-                    <p className="text-foreground line-clamp-2 text-[11px] leading-snug font-medium">
+                    <p className="text-foreground line-clamp-2 text-[0.6875rem] leading-snug font-medium">
                       {name}
                     </p>
                     {isQueued && scheduleLabel ? (
-                      <div className="text-muted-foreground flex min-w-0 items-center gap-1 text-[9px] leading-none">
+                      <div className="text-muted-foreground flex min-w-0 items-center gap-1 text-[0.5625rem] leading-none">
                         <Clock className="size-2.5 shrink-0" aria-hidden />
                         <span className="truncate">{scheduleLabel}</span>
                       </div>

--- a/apps/web/src/app/(app)/tasks/components/task-design-md-attachment.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-design-md-attachment.tsx
@@ -98,7 +98,7 @@ export function TaskDesignMdAttachmentField({
           className="object-cover"
         />
       ) : null}
-      <AvatarFallback className="text-[10px] font-medium">
+      <AvatarFallback className="text-[0.625rem] font-medium">
         {defaultAttachment.owner.name.slice(0, 1).toUpperCase()}
       </AvatarFallback>
     </Avatar>

--- a/apps/web/src/app/(app)/tasks/components/task-meta.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-meta.tsx
@@ -42,7 +42,7 @@ function AssigneeAvatar({
           }}
         />
       ) : null}
-      <AvatarFallback className="bg-muted text-[10px] font-medium">
+      <AvatarFallback className="bg-muted text-[0.625rem] font-medium">
         {assignee?.name?.slice(0, 1).toUpperCase() ?? (
           <UserCog className="size-3" aria-hidden />
         )}
@@ -120,12 +120,14 @@ export function TaskMetaDetails({
         {commentsCount > 0 && (
           <div className="flex items-center gap-1">
             <MessageSquare className="size-3" aria-hidden />
-            <span className="text-[10px] tabular-nums">{commentsCount}</span>
+            <span className="text-[0.625rem] tabular-nums">
+              {commentsCount}
+            </span>
           </div>
         )}
         <div className="flex items-center gap-1">
           <Calendar className="size-3" aria-hidden />
-          <span className="text-[10px] tabular-nums">
+          <span className="text-[0.625rem] tabular-nums">
             {formatShortDate(createdAt)}
           </span>
         </div>

--- a/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+++ b/apps/web/src/app/(app)/tasks/components/task-metadata.tsx
@@ -195,7 +195,7 @@ export function TaskMetadata({
                   className="object-cover"
                 />
               ) : null}
-              <AvatarFallback className="bg-muted text-[10px]">
+              <AvatarFallback className="bg-muted text-[0.625rem]">
                 {task.assignee?.name?.slice(0, 1).toUpperCase() ?? "?"}
               </AvatarFallback>
             </Avatar>
@@ -288,7 +288,7 @@ function MetadataAvatarValue({
             {image ? (
               <AvatarImage src={image} alt={name} className="object-cover" />
             ) : null}
-            <AvatarFallback className="bg-muted text-[10px]">
+            <AvatarFallback className="bg-muted text-[0.625rem]">
               {fallback.slice(0, 1).toUpperCase()}
             </AvatarFallback>
           </Avatar>

--- a/apps/web/src/app/(app)/tasks/components/tasks-empty-state-overlay.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-empty-state-overlay.tsx
@@ -288,7 +288,7 @@ export function TasksEmptyStateOverlay({
         {layout && !isGetStartedStep ? (
           <div
             key={`${currentStep}-hint`}
-            className="text-primary bg-background border-primary/30 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 absolute rounded-full border px-2.5 py-1 text-[11px] font-medium shadow-sm transition-opacity duration-200"
+            className="text-primary bg-background border-primary/30 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 absolute rounded-full border px-2.5 py-1 text-[0.6875rem] font-medium shadow-sm transition-opacity duration-200"
             style={{
               left: layout.label.x,
               top: layout.label.y,
@@ -398,7 +398,7 @@ export function TasksEmptyStateOverlay({
 
         {mobileLayout && !isGetStartedStep ? (
           <div
-            className="text-primary bg-background border-primary/30 absolute rounded-full border px-2.5 py-1 text-[11px] font-medium shadow-sm"
+            className="text-primary bg-background border-primary/30 absolute rounded-full border px-2.5 py-1 text-[0.6875rem] font-medium shadow-sm"
             style={{
               left: mobileLayout.label.x,
               top: mobileLayout.label.y,

--- a/apps/web/src/app/(auth)/components/social-buttons.tsx
+++ b/apps/web/src/app/(auth)/components/social-buttons.tsx
@@ -244,7 +244,7 @@ export default function SocialButtons({
             {isLastUsed && (
               <span
                 aria-hidden="true"
-                className="text-primary/70 pointer-events-none absolute top-1.5 right-2 z-10 text-[10px] font-medium"
+                className="text-primary/70 pointer-events-none absolute top-1.5 right-2 z-10 text-[0.625rem] font-medium"
               >
                 {t("lastUsed")}
               </span>
@@ -268,7 +268,7 @@ export default function SocialButtons({
           {lastUsedMethod === "passkey" && (
             <span
               aria-hidden="true"
-              className="text-primary/70 pointer-events-none absolute top-1.5 right-2 z-10 text-[10px] font-medium"
+              className="text-primary/70 pointer-events-none absolute top-1.5 right-2 z-10 text-[0.625rem] font-medium"
             >
               {t("lastUsed")}
             </span>
@@ -301,7 +301,7 @@ export default function SocialButtons({
           {lastUsedMethod === "magic-link" && (
             <span
               aria-hidden="true"
-              className="text-primary/70 pointer-events-none absolute top-1.5 right-2 z-10 text-[10px] font-medium"
+              className="text-primary/70 pointer-events-none absolute top-1.5 right-2 z-10 text-[0.625rem] font-medium"
             >
               {t("lastUsed")}
             </span>

--- a/apps/web/src/app/(auth)/signin/components/form.tsx
+++ b/apps/web/src/app/(auth)/signin/components/form.tsx
@@ -155,7 +155,7 @@ export default function SignInForm({
           {isLastUsedEmailLogin && (
             <span
               aria-hidden="true"
-              className="bg-background text-foreground border-border pointer-events-none absolute top-1/2 right-2 z-10 -translate-y-1/2 rounded-full border px-2 py-0.5 text-[10px] font-medium"
+              className="bg-background text-foreground border-border pointer-events-none absolute top-1/2 right-2 z-10 -translate-y-1/2 rounded-full border px-2 py-0.5 text-[0.625rem] font-medium"
             >
               {t("lastUsed")}
             </span>

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -24,7 +24,7 @@ const nextErrorLayoutStyles = {
     lineHeight: "48px",
   },
   h2: {
-    fontSize: 14,
+    fontSize: "0.875rem",
     fontWeight: 400,
     lineHeight: "28px",
     margin: 0,

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -21,12 +21,12 @@ const nextErrorLayoutStyles = {
     justifyContent: "center",
   },
   desc: {
-    lineHeight: "48px",
+    lineHeight: "3rem",
   },
   h2: {
     fontSize: "0.875rem",
     fontWeight: 400,
-    lineHeight: "28px",
+    lineHeight: "1.75rem",
     margin: 0,
   },
   wrap: {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -472,6 +472,22 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /*
+   * Apple Dynamic Type (iOS/macOS Safari / PWA): map system body size to root
+   * rem. Inter stays the face via next/font class on <html>; re-declare family
+   * after the `font` shorthand so it is not replaced by the system text face.
+   * Cap (>20px) is applied in DynamicTypeRootCap — do not hardcode px here.
+   */
+  @supports (font: -apple-system-body) {
+    html {
+      font: -apple-system-body;
+      font-family:
+        var(--font-inter), ui-sans-serif, system-ui, sans-serif,
+        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+        "Noto Color Emoji";
+    }
+  }
 }
 
 /*

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Suspense } from "react";
 
 import { ClientAnalytics } from "@/components/analytics/client-analytics";
 import { DeploymentRefreshHandler } from "@/components/deployment-refresh-handler";
+import { DynamicTypeRootCap } from "@/components/dynamic-type-root-cap";
 import { ApplePwaHead } from "@/components/pwa/apple-pwa-head";
 import { getEnvPublicConfig } from "@/config/env.public";
 import { ThemeProvider } from "@/contexts/theme-context";
@@ -20,6 +21,7 @@ const inter = Inter({
   subsets: ["latin"],
   display: "swap",
   fallback: ["sans-serif"],
+  variable: "--font-inter",
 });
 
 export function generateMetadata(): Metadata {
@@ -50,7 +52,7 @@ export default function RootLayout({
     <html
       lang={DEFAULT_LOCALE}
       suppressHydrationWarning
-      className={inter.className}
+      className={`${inter.className} ${inter.variable}`}
     >
       <head>
         <ApplePwaHead />
@@ -58,6 +60,7 @@ export default function RootLayout({
       {gtmId && <GoogleTagManager gtmId={gtmId} />}
       {gaId && <GoogleAnalytics gaId={gaId} />}
       <body className="bg-background min-h-svh max-w-dvw antialiased">
+        <DynamicTypeRootCap />
         <NuqsAdapter>
           <ThemeProvider>
             <Suspense fallback={<div className="bg-background min-h-svh" />}>

--- a/apps/web/src/app/share/components/shared-task-view.tsx
+++ b/apps/web/src/app/share/components/shared-task-view.tsx
@@ -103,7 +103,7 @@ export async function SharedTaskView({ task }: SharedTaskViewProps) {
                     alt={task.assignee.name}
                   />
                 ) : null}
-                <AvatarFallback className="text-[10px]">
+                <AvatarFallback className="text-[0.625rem]">
                   {getInitials(task.assignee?.name ?? "C")}
                 </AvatarFallback>
               </Avatar>
@@ -352,7 +352,7 @@ export async function SharedTaskView({ task }: SharedTaskViewProps) {
                                     alt={actorName}
                                   />
                                 ) : null}
-                                <AvatarFallback className="bg-muted text-[10px]">
+                                <AvatarFallback className="bg-muted text-[0.625rem]">
                                   {getInitials(actorName)}
                                 </AvatarFallback>
                               </Avatar>

--- a/apps/web/src/components/agents/rating-list-item.tsx
+++ b/apps/web/src/components/agents/rating-list-item.tsx
@@ -37,7 +37,7 @@ export function RatingListItem({ rating }: RatingListItemProps) {
       <div className="flex items-start gap-4">
         <Avatar className="size-6 shrink-0 self-start">
           <AvatarImage src={rating.user.image ?? undefined} />
-          <AvatarFallback className="bg-muted text-[10px]">
+          <AvatarFallback className="bg-muted text-[0.625rem]">
             {userInitials}
           </AvatarFallback>
         </Avatar>

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -73,7 +73,7 @@ function MentionBadge({ count }: { count: number }) {
   return (
     <span
       aria-label={`${label} mentions`}
-      className="bg-primary text-primary-foreground group-data-[collapsible=icon]:hidden inline-flex min-w-4.5 shrink-0 items-center justify-center rounded-full px-1 text-[10px] leading-4 font-semibold tabular-nums"
+      className="bg-primary text-primary-foreground group-data-[collapsible=icon]:hidden inline-flex min-w-4.5 shrink-0 items-center justify-center rounded-full px-1 text-[0.625rem] leading-4 font-semibold tabular-nums"
     >
       {label}
     </span>

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -147,7 +147,7 @@ function DirectAvatarStack({
 
   if (participants.length === 0) {
     return (
-      <span className="bg-muted text-muted-foreground flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium">
+      <span className="bg-muted text-muted-foreground flex size-5 shrink-0 items-center justify-center rounded-full text-[0.625rem] font-medium">
         <MessageCircle className="size-3" aria-hidden />
       </span>
     );
@@ -166,7 +166,7 @@ function DirectAvatarStack({
               alt={participant.name}
               src={participant.image ?? undefined}
             />
-            <AvatarFallback className="text-[9px] font-medium">
+            <AvatarFallback className="text-[0.5625rem] font-medium">
               {getInitials(participant.name)}
             </AvatarFallback>
           </Avatar>

--- a/apps/web/src/components/chat/preview-attachment.tsx
+++ b/apps/web/src/components/chat/preview-attachment.tsx
@@ -65,7 +65,7 @@ export const PreviewAttachment = ({
         </Button>
       )}
 
-      <div className="absolute inset-x-0 bottom-0 truncate bg-linear-to-t from-black/80 to-transparent px-1 py-0.5 text-[10px] text-white">
+      <div className="absolute inset-x-0 bottom-0 truncate bg-linear-to-t from-black/80 to-transparent px-1 py-0.5 text-[0.625rem] text-white">
         {name}
       </div>
     </div>

--- a/apps/web/src/components/common/filter-dropdown-menu.tsx
+++ b/apps/web/src/components/common/filter-dropdown-menu.tsx
@@ -223,7 +223,7 @@ function FilterDropdownMenuOptionAvatar({
       {option.image ? (
         <AvatarImage src={option.image} alt={option.avatarLabel} />
       ) : null}
-      <AvatarFallback className="bg-muted text-[10px] font-medium">
+      <AvatarFallback className="bg-muted text-[0.625rem] font-medium">
         {fallback}
       </AvatarFallback>
     </Avatar>

--- a/apps/web/src/components/dynamic-type-root-cap.tsx
+++ b/apps/web/src/components/dynamic-type-root-cap.tsx
@@ -8,16 +8,21 @@ export function DynamicTypeRootCap() {
   useEffect(() => {
     applyDynamicTypeRootCap();
 
-    function handleResume() {
+    function handlePageshow() {
       applyDynamicTypeRootCap();
     }
 
-    window.addEventListener("pageshow", handleResume);
-    document.addEventListener("visibilitychange", handleResume);
+    function handleVisibilityChange() {
+      if (document.visibilityState !== "visible") return;
+      applyDynamicTypeRootCap();
+    }
+
+    window.addEventListener("pageshow", handlePageshow);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      window.removeEventListener("pageshow", handleResume);
-      document.removeEventListener("visibilitychange", handleResume);
+      window.removeEventListener("pageshow", handlePageshow);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);
 

--- a/apps/web/src/components/dynamic-type-root-cap.tsx
+++ b/apps/web/src/components/dynamic-type-root-cap.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { applyDynamicTypeRootCap } from "@/lib/utils/dynamic-type";
+
+export function DynamicTypeRootCap() {
+  useEffect(() => {
+    applyDynamicTypeRootCap();
+
+    function handleResume() {
+      applyDynamicTypeRootCap();
+    }
+
+    window.addEventListener("pageshow", handleResume);
+    document.addEventListener("visibilitychange", handleResume);
+
+    return () => {
+      window.removeEventListener("pageshow", handleResume);
+      document.removeEventListener("visibilitychange", handleResume);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/jobs/agent-job-status-badge.tsx
+++ b/apps/web/src/components/jobs/agent-job-status-badge.tsx
@@ -24,7 +24,7 @@ export function AgentJobStatusBadge({
     return (
       <span
         className={cn(
-          "text-muted-foreground text-[10px] font-medium tracking-wider uppercase",
+          "text-muted-foreground text-[0.625rem] font-medium tracking-wider uppercase",
           className,
         )}
       >
@@ -39,7 +39,7 @@ export function AgentJobStatusBadge({
         className={cn("size-1.5 shrink-0 rounded-full", dotClass)}
         aria-hidden
       />
-      <span className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
+      <span className="text-muted-foreground text-[0.625rem] font-medium tracking-wider uppercase">
         {label}
       </span>
     </div>

--- a/apps/web/src/components/jobs/job-details/job-details-view.tsx
+++ b/apps/web/src/components/jobs/job-details/job-details-view.tsx
@@ -432,7 +432,7 @@ function JobDetailsContent({
                 {actor.imageUrl ? (
                   <AvatarImage src={actor.imageUrl} alt={actor.name} />
                 ) : null}
-                <AvatarFallback className="bg-muted text-[10px]">
+                <AvatarFallback className="bg-muted text-[0.625rem]">
                   {getInitials(actor.name)}
                 </AvatarFallback>
               </Avatar>

--- a/apps/web/src/components/onboarding/taskboard-visual.tsx
+++ b/apps/web/src/components/onboarding/taskboard-visual.tsx
@@ -33,7 +33,7 @@ export function TaskboardVisual({
 
   const taskCard = (
     <div className="bg-background rounded-md border p-2.5 shadow-sm">
-      <p className="text-[11px] font-medium">{taskTitle}</p>
+      <p className="text-[0.6875rem] font-medium">{taskTitle}</p>
       <div className="mt-1.5 flex items-center gap-1.5">
         <div className="relative size-4 overflow-hidden rounded-full">
           <Image
@@ -43,7 +43,7 @@ export function TaskboardVisual({
             className="object-cover"
           />
         </div>
-        <span className="text-muted-foreground text-[10px]">
+        <span className="text-muted-foreground text-[0.625rem]">
           {coworkerName}
         </span>
       </div>
@@ -56,7 +56,7 @@ export function TaskboardVisual({
         <div className="flex-1">
           <div className="mb-2.5 flex items-center gap-1.5">
             <span className="bg-muted-foreground/40 size-1.5 rounded-full" />
-            <span className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
+            <span className="text-muted-foreground text-[0.625rem] font-medium tracking-wider uppercase">
               {todoLabel}
             </span>
           </div>
@@ -78,7 +78,7 @@ export function TaskboardVisual({
         <div className="flex-1">
           <div className="mb-2.5 flex items-center gap-1.5">
             <span className="bg-primary size-1.5 rounded-full" />
-            <span className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
+            <span className="text-muted-foreground text-[0.625rem] font-medium tracking-wider uppercase">
               {inProgressLabel}
             </span>
           </div>

--- a/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
+++ b/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
@@ -122,7 +122,7 @@ function OrgInitialTile({ control }: { control: Control<DetailsFormValues> }) {
   return (
     <div className="bg-muted flex size-24 items-center justify-center rounded-lg border transition-colors duration-200">
       {name ? (
-        <span className="text-muted-foreground text-[36px] leading-none font-semibold tracking-tight">
+        <span className="text-muted-foreground text-[2.25rem] leading-none font-semibold tracking-tight">
           {name.charAt(0).toUpperCase()}
         </span>
       ) : (
@@ -612,7 +612,7 @@ export function CreateOrganizationWizard({
               </span>
             ))}
           </div>
-          <span className="text-muted-foreground/60 text-[11px] font-medium tracking-[0.16em] tabular-nums">
+          <span className="text-muted-foreground/60 text-[0.6875rem] font-medium tracking-[0.16em] tabular-nums">
             {String(step + 1).padStart(2, "0")} /{" "}
             {String(TOTAL_STEPS).padStart(2, "0")}
           </span>
@@ -637,10 +637,10 @@ export function CreateOrganizationWizard({
                   <div className="flex min-h-24 flex-none items-center justify-center">
                     <OrgInitialTile control={form.control} />
                   </div>
-                  <h2 className="mt-8 text-[26px] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[30px]">
+                  <h2 className="mt-8 text-[1.625rem] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[1.875rem]">
                     {t("Details.title")}
                   </h2>
-                  <p className="text-muted-foreground mx-auto mt-3 max-w-[46ch] text-[15px] leading-[1.6] text-balance">
+                  <p className="text-muted-foreground mx-auto mt-3 max-w-[46ch] text-[0.9375rem] leading-[1.6] text-balance">
                     {t("Details.subtitle")}
                   </p>
 
@@ -651,7 +651,7 @@ export function CreateOrganizationWizard({
                         name="name"
                         render={({ field }) => (
                           <FormItem className="focus-within:bg-accent/40 grid grid-cols-[88px_1fr] items-center gap-3 space-y-0 px-4 transition-colors">
-                            <FormLabel className="text-muted-foreground text-[13px] font-normal">
+                            <FormLabel className="text-muted-foreground text-[0.8125rem] font-normal">
                               {t("Details.nameLabel")}
                             </FormLabel>
                             <FormControl
@@ -664,7 +664,7 @@ export function CreateOrganizationWizard({
                               <Input
                                 autoFocus
                                 placeholder={t("Details.namePlaceholder")}
-                                className="placeholder:text-muted-foreground/50 h-14 dark:bg-transparent border-0 bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0"
+                                className="placeholder:text-muted-foreground/50 h-14 dark:bg-transparent border-0 bg-transparent px-0 text-[0.9375rem] shadow-none focus-visible:ring-0"
                                 {...field}
                               />
                             </FormControl>
@@ -676,7 +676,7 @@ export function CreateOrganizationWizard({
                         name="url"
                         render={({ field }) => (
                           <FormItem className="focus-within:bg-accent/40 grid grid-cols-[88px_1fr] items-center gap-3 space-y-0 px-4 transition-colors">
-                            <FormLabel className="text-muted-foreground text-[13px] font-normal">
+                            <FormLabel className="text-muted-foreground text-[0.8125rem] font-normal">
                               {t("Details.urlLabel")}
                             </FormLabel>
                             <FormControl
@@ -689,7 +689,7 @@ export function CreateOrganizationWizard({
                               <Input
                                 inputMode="url"
                                 placeholder={t("Details.urlPlaceholder")}
-                                className="placeholder:text-muted-foreground/50 h-14 dark:bg-transparent border-0 bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0"
+                                className="placeholder:text-muted-foreground/50 h-14 dark:bg-transparent border-0 bg-transparent px-0 text-[0.9375rem] shadow-none focus-visible:ring-0"
                                 {...field}
                               />
                             </FormControl>
@@ -706,13 +706,13 @@ export function CreateOrganizationWizard({
                       <p
                         id={detailsErrorId}
                         role="alert"
-                        className="text-destructive text-[13px]"
+                        className="text-destructive text-[0.8125rem]"
                       >
                         {form.formState.errors.name?.message ??
                           form.formState.errors.url?.message}
                       </p>
                     </div>
-                    <p className="text-muted-foreground/70 text-left text-[13px]">
+                    <p className="text-muted-foreground/70 text-left text-[0.8125rem]">
                       {t("Details.urlHint")}
                     </p>
                   </div>
@@ -741,10 +741,10 @@ export function CreateOrganizationWizard({
                     />
                   )}
                 </div>
-                <h2 className="mt-8 text-[26px] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[30px]">
+                <h2 className="mt-8 text-[1.625rem] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[1.875rem]">
                   {t("Logo.title")}
                 </h2>
-                <p className="text-muted-foreground mx-auto mt-3 max-w-[46ch] text-[15px] leading-[1.6] text-balance">
+                <p className="text-muted-foreground mx-auto mt-3 max-w-[46ch] text-[0.9375rem] leading-[1.6] text-balance">
                   {isResolvingLogo
                     ? t("Logo.generating")
                     : logoUrl
@@ -788,7 +788,7 @@ export function CreateOrganizationWizard({
                         </Button>
                       </FileUploadTrigger>
                     </FileUpload>
-                    <p className="text-muted-foreground/70 text-[13px]">
+                    <p className="text-muted-foreground/70 text-[0.8125rem]">
                       {t("Logo.uploadHint")}
                     </p>
                   </div>
@@ -815,11 +815,11 @@ export function CreateOrganizationWizard({
                   )}
                 </div>
 
-                <h2 className="mt-8 text-[26px] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[30px]">
+                <h2 className="mt-8 text-[1.625rem] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[1.875rem]">
                   {t("Brand.title")}
                 </h2>
 
-                <p className="text-muted-foreground mx-auto mt-3 max-w-[46ch] text-[15px] leading-[1.6] text-balance">
+                <p className="text-muted-foreground mx-auto mt-3 max-w-[46ch] text-[0.9375rem] leading-[1.6] text-balance">
                   {brand.status === "completed"
                     ? brandDomain
                       ? t("Brand.generated", { domain: brandDomain })
@@ -846,7 +846,7 @@ export function CreateOrganizationWizard({
                 </p>
 
                 {brand.status !== "completed" && (
-                  <p className="text-muted-foreground/70 mt-3 text-[13px]">
+                  <p className="text-muted-foreground/70 mt-3 text-[0.8125rem]">
                     {brand.status === "failed"
                       ? t("Brand.failedSubtitle")
                       : t("Brand.skipHint")}
@@ -857,9 +857,11 @@ export function CreateOrganizationWizard({
                   <div className="mt-10">
                     <div className="bg-muted/60 text-muted-foreground mx-auto flex w-fit items-center gap-2 rounded-xl border px-3 py-2">
                       <FileText className="size-4" />
-                      <span className="font-mono text-[13px]">DESIGN.md</span>
+                      <span className="font-mono text-[0.8125rem]">
+                        DESIGN.md
+                      </span>
                     </div>
-                    <p className="text-muted-foreground/70 mt-4 text-[13px]">
+                    <p className="text-muted-foreground/70 mt-4 text-[0.8125rem]">
                       {t("Brand.editHint")}
                     </p>
                   </div>
@@ -899,12 +901,12 @@ export function CreateOrganizationWizard({
                     <Check className="text-primary animate-in fade-in-0 size-6 duration-200" />
                   </div>
                 </div>
-                <h2 className="mt-4 text-[26px] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[30px]">
+                <h2 className="mt-4 text-[1.625rem] leading-[1.15] font-semibold tracking-[-0.02em] text-balance sm:text-[1.875rem]">
                   {organizationName
                     ? t("Invite.title", { organization: organizationName })
                     : t("Invite.titleFallback")}
                 </h2>
-                <p className="text-muted-foreground mx-auto mt-2 max-w-[46ch] text-[15px] leading-[1.6] text-balance">
+                <p className="text-muted-foreground mx-auto mt-2 max-w-[46ch] text-[0.9375rem] leading-[1.6] text-balance">
                   {t("Invite.subtitle")}
                 </p>
 
@@ -918,7 +920,7 @@ export function CreateOrganizationWizard({
                         readOnly
                         value={inviteLink ?? ""}
                         onFocus={(event) => event.currentTarget.select()}
-                        className="text-muted-foreground h-auto min-w-0 flex-1 truncate dark:bg-transparent border-0 bg-transparent px-0 font-mono text-[13px] shadow-none focus-visible:ring-0"
+                        className="text-muted-foreground h-auto min-w-0 flex-1 truncate dark:bg-transparent border-0 bg-transparent px-0 font-mono text-[0.8125rem] shadow-none focus-visible:ring-0"
                       />
                     )}
                     {linkFailed && !inviteLink ? (
@@ -958,7 +960,7 @@ export function CreateOrganizationWizard({
                       </Button>
                     )}
                   </div>
-                  <p className="text-muted-foreground/70 mt-2 text-left text-[13px]">
+                  <p className="text-muted-foreground/70 mt-2 text-left text-[0.8125rem]">
                     {t("Invite.linkHint")}
                   </p>
 
@@ -969,10 +971,10 @@ export function CreateOrganizationWizard({
                     value={emails}
                     onChange={(event) => setEmails(event.target.value)}
                     placeholder={t("Invite.emailsPlaceholder")}
-                    className="bg-muted/60 dark:bg-muted/60 min-h-14 resize-none rounded-xl border px-4 py-3 text-[15px] shadow-none"
+                    className="bg-muted/60 dark:bg-muted/60 min-h-14 resize-none rounded-xl border px-4 py-3 text-[0.9375rem] shadow-none"
                   />
                   <div className="mt-2 flex items-center justify-between gap-3">
-                    <p className="text-muted-foreground/70 text-left text-[13px]">
+                    <p className="text-muted-foreground/70 text-left text-[0.8125rem]">
                       {t("Invite.emailsHint")}
                     </p>
                     <Button

--- a/apps/web/src/components/ui/document-text-preview.tsx
+++ b/apps/web/src/components/ui/document-text-preview.tsx
@@ -34,8 +34,8 @@ export function DocumentTextPreview({
             className={cn(
               "prose-h2:text-xl prose-h2:mb-3 prose-h2:tracking-tight",
               "prose-h3:text-foreground prose-h3:mt-7 prose-h3:mb-2 prose-h3:text-base",
-              "prose-p:text-foreground/90 prose-p:text-[15px] prose-p:leading-7",
-              "prose-li:text-foreground/90 prose-li:my-1.5 prose-li:text-[15px] prose-li:leading-7",
+              "prose-p:text-foreground/90 prose-p:text-[0.9375rem] prose-p:leading-7",
+              "prose-li:text-foreground/90 prose-li:my-1.5 prose-li:text-[0.9375rem] prose-li:leading-7",
               "prose-ul:my-3 prose-ol:my-3 prose-strong:text-foreground",
             )}
           >

--- a/apps/web/src/components/ui/file-upload.tsx
+++ b/apps/web/src/components/ui/file-upload.tsx
@@ -1158,7 +1158,7 @@ function FileUploadItemMetadata(props: FileUploadItemMetadataProps) {
             id={itemContext.nameId}
             className={cn(
               "truncate font-medium text-sm",
-              size === "sm" && "font-normal text-[13px] leading-snug",
+              size === "sm" && "font-normal text-[0.8125rem] leading-snug",
             )}
           >
             {itemContext.fileState.file.name}
@@ -1167,7 +1167,7 @@ function FileUploadItemMetadata(props: FileUploadItemMetadataProps) {
             id={itemContext.sizeId}
             className={cn(
               "truncate text-muted-foreground text-xs",
-              size === "sm" && "text-[11px] leading-snug",
+              size === "sm" && "text-[0.6875rem] leading-snug",
             )}
           >
             {formatBytes(itemContext.fileState.file.size)}

--- a/apps/web/src/components/user/user-profile-avatar.tsx
+++ b/apps/web/src/components/user/user-profile-avatar.tsx
@@ -43,7 +43,7 @@ export function UserProfileAvatar({
             }}
           />
         ) : null}
-        <AvatarFallback className="bg-muted text-[10px] font-medium">
+        <AvatarFallback className="bg-muted text-[0.625rem] font-medium">
           {userName.slice(0, 1).toUpperCase() || (
             <User className="size-3" aria-hidden />
           )}

--- a/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
+++ b/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
@@ -46,40 +46,71 @@ describe("shouldApplyRootFontSizeInline", () => {
 });
 
 describe("applyDynamicTypeRootCap", () => {
-  it("sets inline 20px when computed size is over cap", () => {
+  it("sets inline 20px when natural computed size is over cap", () => {
     const el = document.createElement("div");
-    el.style.fontSize = "28px";
     document.body.appendChild(el);
-    // Stub getComputedStyle for this element
     const original = globalThis.getComputedStyle;
-    globalThis.getComputedStyle = ((target: Element) => {
-      if (target === el) {
-        return { fontSize: "28px" } as CSSStyleDeclaration;
-      }
-      return original(target);
-    }) as typeof getComputedStyle;
+    try {
+      // After clear, measure natural size (stub always reports over-cap).
+      globalThis.getComputedStyle = ((target: Element) => {
+        if (target === el) {
+          return { fontSize: "28px" } as CSSStyleDeclaration;
+        }
+        return original(target);
+      }) as typeof getComputedStyle;
 
-    applyDynamicTypeRootCap(el);
-    expect(el.style.fontSize).toBe("20px");
-
-    globalThis.getComputedStyle = original;
-    el.remove();
+      applyDynamicTypeRootCap(el);
+      expect(el.style.fontSize).toBe("20px");
+    } finally {
+      globalThis.getComputedStyle = original;
+      el.remove();
+    }
   });
 
-  it("clears inline size when at or under cap", () => {
+  it("leaves inline empty when natural size is at or under cap", () => {
     const el = document.createElement("div");
     el.style.fontSize = "20px";
     const original = globalThis.getComputedStyle;
-    globalThis.getComputedStyle = ((target: Element) => {
-      if (target === el) {
-        return { fontSize: "17px" } as CSSStyleDeclaration;
-      }
-      return original(target);
-    }) as typeof getComputedStyle;
+    try {
+      globalThis.getComputedStyle = ((target: Element) => {
+        if (target === el) {
+          return { fontSize: "17px" } as CSSStyleDeclaration;
+        }
+        return original(target);
+      }) as typeof getComputedStyle;
 
-    applyDynamicTypeRootCap(el);
-    expect(el.style.fontSize).toBe("");
+      applyDynamicTypeRootCap(el);
+      expect(el.style.fontSize).toBe("");
+    } finally {
+      globalThis.getComputedStyle = original;
+    }
+  });
 
-    globalThis.getComputedStyle = original;
+  it("re-applies cap on re-run when prior inline 20px masked larger natural size", () => {
+    const el = document.createElement("div");
+    // Simulate prior successful cap still on the element.
+    el.style.fontSize = "20px";
+    document.body.appendChild(el);
+    const original = globalThis.getComputedStyle;
+    try {
+      // Return natural over-cap only after clear (style empty); if stub saw 20px
+      // without clear, old bug would drop the cap.
+      globalThis.getComputedStyle = ((target: Element) => {
+        if (target === el) {
+          const inline = (target as HTMLElement).style.fontSize;
+          if (inline === "" || inline == null) {
+            return { fontSize: "28px" } as CSSStyleDeclaration;
+          }
+          return { fontSize: inline } as CSSStyleDeclaration;
+        }
+        return original(target);
+      }) as typeof getComputedStyle;
+
+      applyDynamicTypeRootCap(el);
+      expect(el.style.fontSize).toBe("20px");
+    } finally {
+      globalThis.getComputedStyle = original;
+      el.remove();
+    }
   });
 });

--- a/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
+++ b/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampRootFontSizePx,
+  DYNAMIC_TYPE_DEFAULT_ROOT_PX,
+  DYNAMIC_TYPE_MAX_ROOT_PX,
+  DYNAMIC_TYPE_MAX_SCALE,
+  shouldApplyRootFontSizeInline,
+} from "@/lib/utils/dynamic-type";
+
+describe("dynamic-type constants", () => {
+  it("caps at 1.25× of 16px → 20px", () => {
+    expect(DYNAMIC_TYPE_MAX_SCALE).toBe(1.25);
+    expect(DYNAMIC_TYPE_DEFAULT_ROOT_PX).toBe(16);
+    expect(DYNAMIC_TYPE_MAX_ROOT_PX).toBe(20);
+  });
+});
+
+describe("clampRootFontSizePx", () => {
+  it("leaves sizes at or under 20px unchanged", () => {
+    expect(clampRootFontSizePx(16)).toBe(16);
+    expect(clampRootFontSizePx(17)).toBe(17);
+    expect(clampRootFontSizePx(20)).toBe(20);
+  });
+
+  it("clamps sizes above 20px to 20", () => {
+    expect(clampRootFontSizePx(21)).toBe(20);
+    expect(clampRootFontSizePx(28)).toBe(20);
+    expect(clampRootFontSizePx(100)).toBe(20);
+  });
+
+  it("falls back to 16 for invalid input", () => {
+    expect(clampRootFontSizePx(Number.NaN)).toBe(16);
+    expect(clampRootFontSizePx(0)).toBe(16);
+    expect(clampRootFontSizePx(-4)).toBe(16);
+  });
+});
+
+describe("shouldApplyRootFontSizeInline", () => {
+  it("is true only when over cap", () => {
+    expect(shouldApplyRootFontSizeInline(16)).toBe(false);
+    expect(shouldApplyRootFontSizeInline(20)).toBe(false);
+    expect(shouldApplyRootFontSizeInline(20.1)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
+++ b/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyDynamicTypeRootCap,
   clampRootFontSizePx,
   DYNAMIC_TYPE_DEFAULT_ROOT_PX,
   DYNAMIC_TYPE_MAX_ROOT_PX,
@@ -41,5 +42,44 @@ describe("shouldApplyRootFontSizeInline", () => {
     expect(shouldApplyRootFontSizeInline(16)).toBe(false);
     expect(shouldApplyRootFontSizeInline(20)).toBe(false);
     expect(shouldApplyRootFontSizeInline(20.1)).toBe(true);
+  });
+});
+
+describe("applyDynamicTypeRootCap", () => {
+  it("sets inline 20px when computed size is over cap", () => {
+    const el = document.createElement("div");
+    el.style.fontSize = "28px";
+    document.body.appendChild(el);
+    // Stub getComputedStyle for this element
+    const original = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = ((target: Element) => {
+      if (target === el) {
+        return { fontSize: "28px" } as CSSStyleDeclaration;
+      }
+      return original(target);
+    }) as typeof getComputedStyle;
+
+    applyDynamicTypeRootCap(el);
+    expect(el.style.fontSize).toBe("20px");
+
+    globalThis.getComputedStyle = original;
+    el.remove();
+  });
+
+  it("clears inline size when at or under cap", () => {
+    const el = document.createElement("div");
+    el.style.fontSize = "20px";
+    const original = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = ((target: Element) => {
+      if (target === el) {
+        return { fontSize: "17px" } as CSSStyleDeclaration;
+      }
+      return original(target);
+    }) as typeof getComputedStyle;
+
+    applyDynamicTypeRootCap(el);
+    expect(el.style.fontSize).toBe("");
+
+    globalThis.getComputedStyle = original;
   });
 });

--- a/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
+++ b/apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
@@ -113,4 +113,20 @@ describe("applyDynamicTypeRootCap", () => {
       el.remove();
     }
   });
+
+  it("leaves root uncapped when measurement throws", () => {
+    const el = document.createElement("div");
+    el.style.fontSize = "20px";
+    const original = globalThis.getComputedStyle;
+    try {
+      globalThis.getComputedStyle = (() => {
+        throw new Error("computed style unavailable");
+      }) as typeof getComputedStyle;
+
+      expect(() => applyDynamicTypeRootCap(el)).not.toThrow();
+      expect(el.style.fontSize).toBe("");
+    } finally {
+      globalThis.getComputedStyle = original;
+    }
+  });
 });

--- a/apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts
+++ b/apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts
@@ -1,0 +1,66 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+/** Paths relative to apps/web/src that may keep px font sizes (non-product UI). */
+const ALLOWLIST = new Set(["app/api/export/pdf/route.ts"]);
+
+const TEXT_PX_CLASS = /text-\[\d+px\]/;
+const FONT_SIZE_PX = /font-size:\s*\d+px/i;
+const FONT_SIZE_STYLE_NUM = /fontSize:\s*\d+\b/;
+const FONT_SIZE_STYLE_PX = /fontSize:\s*["']\d+px["']/;
+
+const EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules" || name === ".next") continue;
+    const full = path.join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (EXTENSIONS.has(path.extname(name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("no fixed px font sizes in product UI", () => {
+  it("has no text-[Npx], font-size: Npx, or fontSize: N outside allowlist", () => {
+    const violations: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      const rel = path.relative(SRC_ROOT, file).split(path.sep).join("/");
+      if (ALLOWLIST.has(rel)) continue;
+      // Skip this test file and the dynamic-type helper (cap uses "20px" string intentionally)
+      if (rel.endsWith("no-fixed-font-size.test.ts")) continue;
+      if (rel === "lib/utils/dynamic-type.ts") continue;
+      if (rel.endsWith("dynamic-type.test.ts")) continue;
+
+      const content = readFileSync(file, "utf8");
+      const lines = content.split("\n");
+      lines.forEach((line, i) => {
+        if (
+          TEXT_PX_CLASS.test(line) ||
+          FONT_SIZE_PX.test(line) ||
+          FONT_SIZE_STYLE_NUM.test(line) ||
+          FONT_SIZE_STYLE_PX.test(line)
+        ) {
+          violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts
+++ b/apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts
@@ -12,10 +12,12 @@ const SRC_ROOT = path.resolve(
 /** Paths relative to apps/web/src that may keep px font sizes (non-product UI). */
 const ALLOWLIST = new Set(["app/api/export/pdf/route.ts"]);
 
-const TEXT_PX_CLASS = /text-\[\d+px\]/;
-const FONT_SIZE_PX = /font-size:\s*\d+px/i;
-const FONT_SIZE_STYLE_NUM = /fontSize:\s*\d+\b/;
-const FONT_SIZE_STYLE_PX = /fontSize:\s*["']\d+px["']/;
+// Decimal px allowed in the pattern (e.g. text-[10.5px]). Intentional limits:
+// does not scan template assignments like root.style.fontSize = `${n}px`.
+const TEXT_PX_CLASS = /text-\[\d+(?:\.\d+)?px\]/;
+const FONT_SIZE_PX = /font-size:\s*\d+(?:\.\d+)?px/i;
+const FONT_SIZE_STYLE_NUM = /fontSize:\s*\d+(?:\.\d+)?\b/;
+const FONT_SIZE_STYLE_PX = /fontSize:\s*["']\d+(?:\.\d+)?px["']/;
 
 const EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
 
@@ -42,9 +44,8 @@ describe("no fixed px font sizes in product UI", () => {
     for (const file of walk(SRC_ROOT)) {
       const rel = path.relative(SRC_ROOT, file).split(path.sep).join("/");
       if (ALLOWLIST.has(rel)) continue;
-      // Skip this test file and the dynamic-type helper (cap uses "20px" string intentionally)
+      // Self + apply unit tests mock { fontSize: "28px" } style objects.
       if (rel.endsWith("no-fixed-font-size.test.ts")) continue;
-      if (rel === "lib/utils/dynamic-type.ts") continue;
       if (rel.endsWith("dynamic-type.test.ts")) continue;
 
       const content = readFileSync(file, "utf8");

--- a/apps/web/src/lib/utils/dynamic-type.ts
+++ b/apps/web/src/lib/utils/dynamic-type.ts
@@ -16,13 +16,22 @@ export function shouldApplyRootFontSizeInline(computedPx: number): boolean {
 export function applyDynamicTypeRootCap(
   root: HTMLElement = document.documentElement,
 ): void {
-  // Clear first so re-runs (pageshow / visibilitychange) measure natural size,
-  // not a prior 20px cap that would incorrectly drop the override.
-  root.style.fontSize = "";
-  const computedPx = Number.parseFloat(
-    globalThis.getComputedStyle(root).fontSize,
-  );
-  if (shouldApplyRootFontSizeInline(computedPx)) {
-    root.style.fontSize = `${DYNAMIC_TYPE_MAX_ROOT_PX}px`;
+  try {
+    // Clear first so re-runs (pageshow / visibilitychange) measure natural size,
+    // not a prior 20px cap that would incorrectly drop the override.
+    root.style.fontSize = "";
+    const computedPx = Number.parseFloat(
+      globalThis.getComputedStyle(root).fontSize,
+    );
+    if (shouldApplyRootFontSizeInline(computedPx)) {
+      root.style.fontSize = `${clampRootFontSizePx(computedPx)}px`;
+    }
+  } catch {
+    // Spec: leave CSS Dynamic Type uncapped rather than force a wrong size.
+    try {
+      root.style.fontSize = "";
+    } catch {
+      // ignore secondary failure (detached node, etc.)
+    }
   }
 }

--- a/apps/web/src/lib/utils/dynamic-type.ts
+++ b/apps/web/src/lib/utils/dynamic-type.ts
@@ -1,0 +1,27 @@
+export const DYNAMIC_TYPE_MAX_SCALE = 1.25 as const;
+export const DYNAMIC_TYPE_DEFAULT_ROOT_PX = 16 as const;
+export const DYNAMIC_TYPE_MAX_ROOT_PX = 20 as const; // 16 * 1.25
+
+export function clampRootFontSizePx(computedPx: number): number {
+  if (!Number.isFinite(computedPx) || computedPx <= 0) {
+    return DYNAMIC_TYPE_DEFAULT_ROOT_PX;
+  }
+  return Math.min(computedPx, DYNAMIC_TYPE_MAX_ROOT_PX);
+}
+
+export function shouldApplyRootFontSizeInline(computedPx: number): boolean {
+  return Number.isFinite(computedPx) && computedPx > DYNAMIC_TYPE_MAX_ROOT_PX;
+}
+
+export function applyDynamicTypeRootCap(
+  root: HTMLElement = document.documentElement,
+): void {
+  const computedPx = Number.parseFloat(
+    globalThis.getComputedStyle(root).fontSize,
+  );
+  if (shouldApplyRootFontSizeInline(computedPx)) {
+    root.style.fontSize = `${DYNAMIC_TYPE_MAX_ROOT_PX}px`;
+    return;
+  }
+  root.style.fontSize = "";
+}

--- a/apps/web/src/lib/utils/dynamic-type.ts
+++ b/apps/web/src/lib/utils/dynamic-type.ts
@@ -16,12 +16,13 @@ export function shouldApplyRootFontSizeInline(computedPx: number): boolean {
 export function applyDynamicTypeRootCap(
   root: HTMLElement = document.documentElement,
 ): void {
+  // Clear first so re-runs (pageshow / visibilitychange) measure natural size,
+  // not a prior 20px cap that would incorrectly drop the override.
+  root.style.fontSize = "";
   const computedPx = Number.parseFloat(
     globalThis.getComputedStyle(root).fontSize,
   );
   if (shouldApplyRootFontSizeInline(computedPx)) {
     root.style.fontSize = `${DYNAMIC_TYPE_MAX_ROOT_PX}px`;
-    return;
   }
-  root.style.fontSize = "";
 }

--- a/apps/web/src/lib/utils/file-upload-progress-toast.tsx
+++ b/apps/web/src/lib/utils/file-upload-progress-toast.tsx
@@ -131,7 +131,7 @@ function FileUploadProgressToastContent({
                 {Math.round(item.percentage).toString()}%
               </span>
             </div>
-            <div className="text-muted-foreground text-[11px]">
+            <div className="text-muted-foreground text-[0.6875rem]">
               {formatBytes(item.loaded)} / {formatBytes(item.total)}
             </div>
           </div>

--- a/docs/superpowers/plans/2026-08-05-dynamic-type.md
+++ b/docs/superpowers/plans/2026-08-05-dynamic-type.md
@@ -1,0 +1,673 @@
+# Apple Dynamic Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Sokosumi web respect Apple Dynamic Type (iOS/macOS) for whole-UI rem scale, keep Inter, cap at 1.25× (max 20px root), purge all product-UI fixed `px` font sizes, and document the rule for agents.
+
+**Architecture:** Opt into `-apple-system-body` on `html` under `@supports` in `globals.css`, re-apply Inter from `next/font`, clamp root size with a pure helper + early client bootstrap, convert every product `text-[Npx]` / `font-size: Npx` to rem-based type, and guard with a Vitest scan plus `.cursor/rules/dynamic-type.mdc` + `AGENTS.md`.
+
+**Tech Stack:** Next.js App Router (`apps/web`), React 19 client components, Tailwind CSS v4, Vitest, Biome. No new npm dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-dynamic-type-design.md`
+
+## Global Constraints
+
+- Cap: `DYNAMIC_TYPE_MAX_SCALE = 1.25`, default root `16px`, max root `20px`
+- Brand face: Inter only (size from Dynamic Type; no SF Pro switch)
+- Whole UI scales via root rem
+- **No fixed `px` font sizes** in product UI (allowlist only true non-UI export/print if unavoidable)
+- Do not set `maximum-scale=1` / `user-scalable=no`
+- Do not set fixed `px` on `html`/`body` except the documented 20px cap path
+- Web-only; no Core API / schema / new deps
+- Conventional Commits; Biome format; pin no registry ranges
+- Prefer pure helpers testable without DOM where possible
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `apps/web/src/lib/utils/dynamic-type.ts` | Constants + pure cap helpers (`clampRootFontSizePx`, `applyDynamicTypeRootCap`) |
+| `apps/web/src/lib/utils/__tests__/dynamic-type.test.ts` | Unit tests for clamp math |
+| `apps/web/src/components/dynamic-type-root-cap.tsx` | Early client bootstrap: apply cap, listen `pageshow` / `visibilitychange` |
+| `apps/web/src/app/layout.tsx` | Mount `<DynamicTypeRootCap />` next to other root clients |
+| `apps/web/src/app/globals.css` | `@supports (font: -apple-system-body)` block on `html` |
+| ~37 product TSX files under `apps/web/src` | Replace `text-[Npx]` with rem / Tailwind `text-*` |
+| `apps/web/src/app/global-error.tsx` | Replace numeric `fontSize: 14` (React px) with rem |
+| `apps/web/src/app/api/export/pdf/route.ts` | Allowlisted exception: keep or document print `font-size: 10px` |
+| `apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts` | Repo scan: fail if product UI reintroduces `px` font sizes |
+| `.cursor/rules/dynamic-type.mdc` | Normative agent rule |
+| `AGENTS.md` | UI & Styling pointer to Dynamic Type + no px fonts |
+| `apps/web/AGENTS.md` | Short Styling pointer (if typography is local) |
+
+**Mapping guide (16px root):**
+
+| Old | Prefer |
+| --- | --- |
+| `text-[9px]` | `text-[0.5625rem]` |
+| `text-[10px]` | `text-[0.625rem]` |
+| `text-[11px]` | `text-[0.6875rem]` |
+| `text-[13px]` | `text-[0.8125rem]` |
+| `text-[15px]` | `text-sm` (0.875rem) only if 14px is acceptable; else `text-[0.9375rem]` |
+| `text-[26px]` | `text-[1.625rem]` |
+| `text-[30px]` | `text-3xl` (1.875rem) or `text-[1.875rem]` |
+| `text-[36px]` | `text-4xl` (2.25rem) or `text-[2.25rem]` |
+
+Use exact rem when micro-type fidelity matters (badges, uppercase labels). Do not leave any `text-[Npx]`.
+
+---
+
+### Task 1: Cap helper + unit tests (TDD)
+
+**Files:**
+- Create: `apps/web/src/lib/utils/dynamic-type.ts`
+- Create: `apps/web/src/lib/utils/__tests__/dynamic-type.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `DYNAMIC_TYPE_MAX_SCALE = 1.25` (as const)
+  - `DYNAMIC_TYPE_DEFAULT_ROOT_PX = 16` (as const)
+  - `DYNAMIC_TYPE_MAX_ROOT_PX = 20` (as const) — `16 * 1.25`
+  - `clampRootFontSizePx(computedPx: number): number` — returns `min(computedPx, DYNAMIC_TYPE_MAX_ROOT_PX)`; if `computedPx` is NaN/non-finite/≤0, return `DYNAMIC_TYPE_DEFAULT_ROOT_PX`
+  - `shouldApplyRootFontSizeInline(computedPx: number): boolean` — `true` only when `computedPx > DYNAMIC_TYPE_MAX_ROOT_PX`
+  - `applyDynamicTypeRootCap(root: HTMLElement = document.documentElement): void` — reads computed font-size; if over cap sets `root.style.fontSize = "20px"`; else sets `root.style.fontSize = ""` (clear override)
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+import { describe, expect, it } from "vitest";
+
+import {
+  clampRootFontSizePx,
+  DYNAMIC_TYPE_DEFAULT_ROOT_PX,
+  DYNAMIC_TYPE_MAX_ROOT_PX,
+  DYNAMIC_TYPE_MAX_SCALE,
+  shouldApplyRootFontSizeInline,
+} from "@/lib/utils/dynamic-type";
+
+describe("dynamic-type constants", () => {
+  it("caps at 1.25× of 16px → 20px", () => {
+    expect(DYNAMIC_TYPE_MAX_SCALE).toBe(1.25);
+    expect(DYNAMIC_TYPE_DEFAULT_ROOT_PX).toBe(16);
+    expect(DYNAMIC_TYPE_MAX_ROOT_PX).toBe(20);
+  });
+});
+
+describe("clampRootFontSizePx", () => {
+  it("leaves sizes at or under 20px unchanged", () => {
+    expect(clampRootFontSizePx(16)).toBe(16);
+    expect(clampRootFontSizePx(17)).toBe(17);
+    expect(clampRootFontSizePx(20)).toBe(20);
+  });
+
+  it("clamps sizes above 20px to 20", () => {
+    expect(clampRootFontSizePx(21)).toBe(20);
+    expect(clampRootFontSizePx(28)).toBe(20);
+    expect(clampRootFontSizePx(100)).toBe(20);
+  });
+
+  it("falls back to 16 for invalid input", () => {
+    expect(clampRootFontSizePx(Number.NaN)).toBe(16);
+    expect(clampRootFontSizePx(0)).toBe(16);
+    expect(clampRootFontSizePx(-4)).toBe(16);
+  });
+});
+
+describe("shouldApplyRootFontSizeInline", () => {
+  it("is true only when over cap", () => {
+    expect(shouldApplyRootFontSizeInline(16)).toBe(false);
+    expect(shouldApplyRootFontSizeInline(20)).toBe(false);
+    expect(shouldApplyRootFontSizeInline(20.1)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/dynamic-type.test.ts
+```
+
+Expected: FAIL (module missing or exports missing).
+
+- [ ] **Step 3: Implement helper**
+
+```typescript
+export const DYNAMIC_TYPE_MAX_SCALE = 1.25 as const;
+export const DYNAMIC_TYPE_DEFAULT_ROOT_PX = 16 as const;
+export const DYNAMIC_TYPE_MAX_ROOT_PX = 20 as const; // 16 * 1.25
+
+export function clampRootFontSizePx(computedPx: number): number {
+  if (!Number.isFinite(computedPx) || computedPx <= 0) {
+    return DYNAMIC_TYPE_DEFAULT_ROOT_PX;
+  }
+  return Math.min(computedPx, DYNAMIC_TYPE_MAX_ROOT_PX);
+}
+
+export function shouldApplyRootFontSizeInline(computedPx: number): boolean {
+  return (
+    Number.isFinite(computedPx) && computedPx > DYNAMIC_TYPE_MAX_ROOT_PX
+  );
+}
+
+export function applyDynamicTypeRootCap(
+  root: HTMLElement = document.documentElement,
+): void {
+  const computedPx = Number.parseFloat(
+    globalThis.getComputedStyle(root).fontSize,
+  );
+  if (shouldApplyRootFontSizeInline(computedPx)) {
+    root.style.fontSize = `${DYNAMIC_TYPE_MAX_ROOT_PX}px`;
+    return;
+  }
+  root.style.fontSize = "";
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/dynamic-type.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/utils/dynamic-type.ts apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
+git commit -m "feat(web): add Dynamic Type root size cap helper"
+```
+
+---
+
+### Task 2: CSS Dynamic Type opt-in + client bootstrap
+
+**Files:**
+- Modify: `apps/web/src/app/globals.css` (`@layer base` near `body` rules ~469–475)
+- Create: `apps/web/src/components/dynamic-type-root-cap.tsx`
+- Modify: `apps/web/src/app/layout.tsx`
+
+**Interfaces:**
+- Consumes: `applyDynamicTypeRootCap` from `@/lib/utils/dynamic-type`
+- Produces: `<DynamicTypeRootCap />` client component (renders `null`)
+
+- [ ] **Step 1: Add CSS under `@layer base`**
+
+In `apps/web/src/app/globals.css`, inside `@layer base` after the existing `body` rule:
+
+```css
+  /*
+   * Apple Dynamic Type (iOS/macOS Safari / PWA): map system body size to root
+   * rem. Inter stays the face via next/font class on <html>; re-declare family
+   * after the `font` shorthand so it is not replaced by the system text face.
+   * Cap (>20px) is applied in DynamicTypeRootCap — do not hardcode px here.
+   */
+  @supports (font: -apple-system-body) {
+    html {
+      font: -apple-system-body;
+      font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif,
+        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+        "Noto Color Emoji";
+    }
+  }
+```
+
+**Inter variable:** `next/font` Inter currently only sets `className` on `<html>`, not a CSS variable. Update `layout.tsx` Inter config to expose a variable:
+
+```typescript
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  fallback: ["sans-serif"],
+  variable: "--font-inter",
+});
+```
+
+And on `<html>`:
+
+```tsx
+className={`${inter.className} ${inter.variable}`}
+```
+
+If computed family still drifts, keep both `className` and `variable` as above (required).
+
+- [ ] **Step 2: Create client bootstrap**
+
+`apps/web/src/components/dynamic-type-root-cap.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+
+import { applyDynamicTypeRootCap } from "@/lib/utils/dynamic-type";
+
+export function DynamicTypeRootCap() {
+  useEffect(() => {
+    applyDynamicTypeRootCap();
+
+    function handleResume() {
+      applyDynamicTypeRootCap();
+    }
+
+    window.addEventListener("pageshow", handleResume);
+    document.addEventListener("visibilitychange", handleResume);
+
+    return () => {
+      window.removeEventListener("pageshow", handleResume);
+      document.removeEventListener("visibilitychange", handleResume);
+    };
+  }, []);
+
+  return null;
+}
+```
+
+- [ ] **Step 3: Mount in root layout**
+
+In `apps/web/src/app/layout.tsx`, import and render next to other root clients (inside `<body>`, siblings of `ClientAnalytics`):
+
+```tsx
+import { DynamicTypeRootCap } from "@/components/dynamic-type-root-cap";
+// ...
+<body className="bg-background min-h-svh max-w-dvw antialiased">
+  <DynamicTypeRootCap />
+  {/* existing providers */}
+```
+
+- [ ] **Step 4: Optional unit test for apply with mock DOM**
+
+Append to `dynamic-type.test.ts` (happy-dom / jsdom already available in web Vitest):
+
+```typescript
+import { applyDynamicTypeRootCap } from "@/lib/utils/dynamic-type";
+
+describe("applyDynamicTypeRootCap", () => {
+  it("sets inline 20px when computed size is over cap", () => {
+    const el = document.createElement("div");
+    el.style.fontSize = "28px";
+    document.body.appendChild(el);
+    // Stub getComputedStyle for this element
+    const original = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = ((target: Element) => {
+      if (target === el) {
+        return { fontSize: "28px" } as CSSStyleDeclaration;
+      }
+      return original(target);
+    }) as typeof getComputedStyle;
+
+    applyDynamicTypeRootCap(el);
+    expect(el.style.fontSize).toBe("20px");
+
+    globalThis.getComputedStyle = original;
+    el.remove();
+  });
+
+  it("clears inline size when at or under cap", () => {
+    const el = document.createElement("div");
+    el.style.fontSize = "20px";
+    const original = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = ((target: Element) => {
+      if (target === el) {
+        return { fontSize: "17px" } as CSSStyleDeclaration;
+      }
+      return original(target);
+    }) as typeof getComputedStyle;
+
+    applyDynamicTypeRootCap(el);
+    expect(el.style.fontSize).toBe("");
+
+    globalThis.getComputedStyle = original;
+  });
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/dynamic-type.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/globals.css apps/web/src/app/layout.tsx \
+  apps/web/src/components/dynamic-type-root-cap.tsx \
+  apps/web/src/lib/utils/__tests__/dynamic-type.test.ts
+git commit -m "feat(web): wire Apple Dynamic Type root size and 1.25x cap"
+```
+
+---
+
+### Task 3: Purge product-UI fixed font sizes
+
+**Files:** All product files currently matching `text-[Npx]` or React/`font-size` px (inventory at plan time):
+
+```
+apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+apps/web/src/app/(app)/chat/components/participant-checkboxes.tsx
+apps/web/src/app/(app)/chat/components/room-composer.tsx
+apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+apps/web/src/app/(app)/chat/components/room-message-row.tsx
+apps/web/src/app/(app)/chat/components/rooms-client.tsx
+apps/web/src/app/(app)/components/header/header-notification-bell.client.tsx
+apps/web/src/app/(app)/components/onboarding-dialog.tsx
+apps/web/src/app/(app)/components/sidebar/components/menu-items.tsx
+apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
+apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
+apps/web/src/app/(app)/history/components/history-list-item.tsx
+apps/web/src/app/(app)/personal-assistant/components/running-state/confirmation-card.tsx
+apps/web/src/app/(app)/personal-assistant/components/running-state/message-row.tsx
+apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
+apps/web/src/app/(app)/tasks/components/job-list-item.tsx
+apps/web/src/app/(app)/tasks/components/task-activity.tsx
+apps/web/src/app/(app)/tasks/components/task-created-celebration.tsx
+apps/web/src/app/(app)/tasks/components/task-design-md-attachment.tsx
+apps/web/src/app/(app)/tasks/components/task-meta.tsx
+apps/web/src/app/(app)/tasks/components/task-metadata.tsx
+apps/web/src/app/(app)/tasks/components/tasks-empty-state-overlay.tsx
+apps/web/src/app/(auth)/components/social-buttons.tsx
+apps/web/src/app/(auth)/signin/components/form.tsx
+apps/web/src/app/share/components/shared-task-view.tsx
+apps/web/src/components/agents/rating-list-item.tsx
+apps/web/src/components/chat/chat-room-sidebar-row.tsx
+apps/web/src/components/chat/organization-chat-list.client.tsx
+apps/web/src/components/chat/preview-attachment.tsx
+apps/web/src/components/common/filter-dropdown-menu.tsx
+apps/web/src/components/jobs/agent-job-status-badge.tsx
+apps/web/src/components/jobs/job-details/job-details-view.tsx
+apps/web/src/components/onboarding/taskboard-visual.tsx
+apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
+apps/web/src/components/ui/document-text-preview.tsx
+apps/web/src/components/ui/file-upload.tsx
+apps/web/src/components/user/user-profile-avatar.tsx
+apps/web/src/lib/utils/file-upload-progress-toast.tsx
+apps/web/src/app/global-error.tsx
+```
+
+**Allowlist (do not convert, document in test):**
+
+- `apps/web/src/app/api/export/pdf/route.ts` — Puppeteer print chrome (`font-size: 10px` in HTML string). Not interactive browser UI.
+
+**Interfaces:** None new. Mechanical class renames per mapping guide.
+
+- [ ] **Step 1: Replace every product `text-[Npx]`**
+
+For each file in the list above, replace using the mapping guide. Prefer project-wide search:
+
+```bash
+rg -n 'text-\[[0-9]+px\]' apps/web/src --glob '*.{tsx,ts,css}'
+```
+
+Example replacements:
+
+- `text-[10px]` → `text-[0.625rem]`
+- `text-[9px]` → `text-[0.5625rem]`
+- `text-[11px]` → `text-[0.6875rem]`
+- `text-[13px]` → `text-[0.8125rem]`
+- `text-[15px]` → `text-[0.9375rem]`
+- `text-[26px]` → `text-[1.625rem]`
+- `text-[30px]` → `text-[1.875rem]`
+- `text-[36px]` → `text-[2.25rem]`
+
+- [ ] **Step 2: Fix non-Tailwind px font sizes in product UI**
+
+`apps/web/src/app/global-error.tsx` — React `fontSize: 14` is pixels. Change to rem string:
+
+```typescript
+fontSize: "0.875rem",
+```
+
+Search also:
+
+```bash
+rg -n 'fontSize:\s*[0-9]+|font-size:\s*[0-9]+px|fontSize:\s*["'\''][0-9]+px' apps/web/src --glob '*.{tsx,ts,css}'
+```
+
+Convert any product hits; leave only the PDF export allowlist.
+
+- [ ] **Step 3: Verify purge**
+
+```bash
+rg -n 'text-\[[0-9]+px\]' apps/web/src --glob '*.{tsx,ts,css}'
+# Expected: no matches
+
+rg -n 'font-size:\s*[0-9]+px' apps/web/src --glob '*.{tsx,ts,css}'
+# Expected: only apps/web/src/app/api/export/pdf/route.ts (or zero if you moved that to rem too)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src
+git commit -m "fix(web): replace fixed px font sizes with rem for Dynamic Type"
+```
+
+---
+
+### Task 4: Guardrail test — no fixed product font sizes
+
+**Files:**
+- Create: `apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts`
+
+**Interfaces:**
+- Consumes: filesystem under `apps/web/src`
+- Allowlist paths (relative to `apps/web/src`):
+  - `app/api/export/pdf/route.ts`
+
+- [ ] **Step 1: Write the scan test**
+
+```typescript
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+/** Paths relative to apps/web/src that may keep px font sizes (non-product UI). */
+const ALLOWLIST = new Set(["app/api/export/pdf/route.ts"]);
+
+const TEXT_PX_CLASS = /text-\[\d+px\]/;
+const FONT_SIZE_PX = /font-size:\s*\d+px/i;
+const FONT_SIZE_STYLE_NUM = /fontSize:\s*\d+\b/;
+const FONT_SIZE_STYLE_PX = /fontSize:\s*["']\d+px["']/;
+
+const EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules" || name === ".next") continue;
+    const full = path.join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (EXTENSIONS.has(path.extname(name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("no fixed px font sizes in product UI", () => {
+  it("has no text-[Npx], font-size: Npx, or fontSize: N outside allowlist", () => {
+    const violations: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      const rel = path.relative(SRC_ROOT, file).split(path.sep).join("/");
+      if (ALLOWLIST.has(rel)) continue;
+      // Skip this test file and the dynamic-type helper (cap uses "20px" string intentionally)
+      if (rel.endsWith("no-fixed-font-size.test.ts")) continue;
+      if (rel === "lib/utils/dynamic-type.ts") continue;
+      if (rel.endsWith("dynamic-type.test.ts")) continue;
+
+      const content = readFileSync(file, "utf8");
+      const lines = content.split("\n");
+      lines.forEach((line, i) => {
+        if (
+          TEXT_PX_CLASS.test(line) ||
+          FONT_SIZE_PX.test(line) ||
+          FONT_SIZE_STYLE_NUM.test(line) ||
+          FONT_SIZE_STYLE_PX.test(line)
+        ) {
+          violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+```
+
+Note: `dynamic-type.ts` is allowlisted in the skip list because it intentionally writes `"20px"` for the cap. That is the only runtime root override; product components must not use px type.
+
+- [ ] **Step 2: Run test — expect PASS after Task 3**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/no-fixed-font-size.test.ts
+```
+
+If FAIL, fix remaining product files (Task 3 residual) then re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts
+git commit -m "test(web): guard against fixed px font sizes in product UI"
+```
+
+---
+
+### Task 5: Agent rules (`AGENTS.md` + `.cursor/rules`)
+
+**Files:**
+- Create: `.cursor/rules/dynamic-type.mdc`
+- Modify: `AGENTS.md` (UI & Styling section ~lines 61–67)
+- Modify: `apps/web/AGENTS.md` (Styling section ~line 315 area — add short bullets)
+
+- [ ] **Step 1: Create `.cursor/rules/dynamic-type.mdc`**
+
+```markdown
+---
+description: "Apple Dynamic Type and no fixed px font sizes in apps/web"
+alwaysApply: true
+---
+
+## Dynamic Type (iOS / macOS)
+
+Sokosumi web opts into Apple Dynamic Type for whole-UI rem scaling.
+
+1. **Root size** may come from `-apple-system-body` on `html` (see `apps/web/src/app/globals.css`). Brand face stays **Inter** (`next/font`).
+2. **Cap is 1.25×** default (`DYNAMIC_TYPE_MAX_SCALE = 1.25`, max root **20px** when default is 16px). Implemented in `apps/web/src/lib/utils/dynamic-type.ts` + `DynamicTypeRootCap`. Do not raise the cap without product decision.
+3. **No fixed `px` font sizes** in product UI. Use Tailwind `text-*` or `rem`/`em` (e.g. `text-[0.625rem]` not `text-[10px]`). Guard: `apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts`.
+4. Do **not** set viewport `maximum-scale=1` or `user-scalable=no`.
+5. Do **not** set `html`/`body` `font-size` to a fixed `px` that kills Dynamic Type, except the documented 20px cap path.
+
+Allowlist for px font sizes: true non-interactive export/print only (e.g. PDF Puppeteer chrome), named in the guard test.
+```
+
+- [ ] **Step 2: Update root `AGENTS.md` UI & Styling**
+
+After the existing Themes bullet, add:
+
+```markdown
+- **Dynamic Type (iOS/macOS)**: Root rem may track Apple Dynamic Type (`-apple-system-body`); Inter stays the face; scale capped at **1.25×** (max 20px root). See `.cursor/rules/dynamic-type.mdc` and `apps/web/src/lib/utils/dynamic-type.ts`.
+- **Font sizes**: Never use fixed `px` type in product UI (`text-[10px]`, `font-size: 12px`, `fontSize: 14`). Use Tailwind `text-*` or `rem`/`em` so type scales with root.
+```
+
+- [ ] **Step 3: Update `apps/web/AGENTS.md` Styling**
+
+Under `### Styling`, add the same two bullets (or a one-liner pointing at root `AGENTS.md` + `.cursor/rules/dynamic-type.mdc`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .cursor/rules/dynamic-type.mdc AGENTS.md apps/web/AGENTS.md
+git commit -m "docs(agents): require Dynamic Type-safe typography (no px fonts)"
+```
+
+---
+
+### Task 6: Verification pass
+
+**Files:** none new (run commands only).
+
+- [ ] **Step 1: Unit + guard tests**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/dynamic-type.test.ts
+pnpm --filter web test src/lib/utils/__tests__/no-fixed-font-size.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Typecheck web**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Biome on touched paths**
+
+```bash
+pnpm exec biome check apps/web/src/lib/utils/dynamic-type.ts \
+  apps/web/src/lib/utils/__tests__/dynamic-type.test.ts \
+  apps/web/src/lib/utils/__tests__/no-fixed-font-size.test.ts \
+  apps/web/src/components/dynamic-type-root-cap.tsx \
+  apps/web/src/app/layout.tsx \
+  apps/web/src/app/globals.css
+```
+
+Fix any issues with `pnpm exec biome check --write …` as needed.
+
+- [ ] **Step 4: Manual checklist (Apple)**
+
+On iOS Safari and/or macOS Safari (simulator OK):
+
+1. Default text size — app looks like today (root ~16px).
+2. Increase Dynamic Type several steps — body and UI type grow; Inter still used.
+3. Push past ~1.25× — growth stops (root ≤ 20px); layout remains usable.
+4. Spot-check chat, agents list, auth — no clipped labels from residual fixed type.
+5. Non-Apple browser (Chrome desktop) — default zoom unchanged.
+
+- [ ] **Step 5: Final commit only if verification fixed anything**
+
+```bash
+git status
+# commit residual fixes if any
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+| --- | --- |
+| `-apple-system-body` on html under `@supports` | Task 2 |
+| Inter preserved | Task 2 (`--font-inter` + className) |
+| Cap 1.25× / max 20px | Task 1–2 |
+| Re-apply on pageshow / visibilitychange | Task 2 |
+| Whole UI rem scale | Task 2 + 3 |
+| No product `px` fonts | Task 3–4 |
+| PDF export allowlist | Task 3–4 |
+| `.cursor/rules/dynamic-type.mdc` | Task 5 |
+| `AGENTS.md` pointer | Task 5 |
+| Unit tests for cap | Task 1 |
+| Guard test | Task 4 |
+| Manual Apple verify | Task 6 |
+
+## Execution notes
+
+- Prefer a feature branch (not committing design-only work onto diverged `main` without pull); worktree already used for this session.
+- Task 3 is large but mechanical — one commit is fine; split by area (chat / tasks / auth / shared) only if review needs smaller diffs.
+- Do not hand-edit generated clients.
+- After implementation, human merges; open draft PR with Conventional Commit title matching primary commit subject if shipping via PR.

--- a/docs/superpowers/specs/2026-08-05-dynamic-type-design.md
+++ b/docs/superpowers/specs/2026-08-05-dynamic-type-design.md
@@ -1,0 +1,155 @@
+# Design: Apple Dynamic Type (iOS / macOS) for Sokosumi web
+
+**Date:** 2026-08-05  
+**Status:** Approved  
+**Scope:** `apps/web` only (root typography, font-size purge, agent rules). No Core API or schema changes.
+
+## Problem
+
+Sokosumi web uses Inter via `next/font` and Tailwind rem-based utilities, but does **not** opt into Apple Dynamic Type. On iOS and macOS Safari (and home-screen PWA), the user’s Accessibility **text size** preference often does not scale product UI the way native apps do.
+
+Additionally, many surfaces use fixed pixel type (`text-[10px]`, inline `font-size: Npx`, etc.). Those sizes ignore root rem scaling even after Dynamic Type is wired, so large-text users still see tiny labels and badges.
+
+## Goals
+
+- Respect **Apple Dynamic Type** for whole-app UI scale on supporting Safari / WKWebView.
+- Keep **Inter** as the brand face; only the **size** comes from Dynamic Type.
+- **Cap** scale at **1.25×** the default root size so dense chrome stays usable.
+- **Eliminate fixed `px` font sizes** in product UI so all user-visible type tracks root rem.
+- Encode the convention in **agent rules** (`AGENTS.md` + `.cursor/rules`) so future work does not reintroduce fixed type or break Dynamic Type.
+
+## Non-goals
+
+- Switching to SF Pro / system UI font on Apple (Inter stays).
+- Supporting non-Apple OS text-size APIs beyond normal browser rem/zoom behavior.
+- Full layout redesign for Accessibility sizes beyond the 1.25× cap.
+- Changing icon pixel sizes or non-text fixed dimensions unless they clip scaled text (prefer `min-h` + padding when fixing clip).
+- Core, email, or PDF print pipelines as primary surfaces (export/print may keep absolute sizes when not interactive browser UI; document any exception).
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| Scope of scaling | Whole UI (root rem drives Tailwind text/spacing) |
+| Typeface | Keep Inter; size from Dynamic Type only |
+| Max scale | **1.25×** default root size |
+| Approach | A: `-apple-system-body` on `html` + Inter re-apply + client cap |
+| Fixed fonts | None remain in product UI |
+| Agent convention | New rule file + short `AGENTS.md` pointer |
+
+## Architecture
+
+```
+System Dynamic Type (Safari / WKWebView / PWA)
+        ↓
+@supports (font: -apple-system-body)
+  html { font: -apple-system-body; … Inter family preserved }
+        ↓
+Client cap: computed root font-size ≤ 1.25 × default
+        ↓
+1rem = capped body size
+        ↓
+Tailwind text-* / rem spacing / rem heights scale together
+```
+
+### CSS (`apps/web/src/app/globals.css`)
+
+Under `@layer base`, inside `@supports (font: -apple-system-body)`:
+
+1. Set `html { font: -apple-system-body; }`.
+2. Immediately restore brand family after the `font` shorthand so Inter from `next/font` on `<html>` is not replaced by the system text face. Implementation must verify computed `font-family` still resolves to Inter (re-declare family after shorthand if the class alone is insufficient).
+3. Do **not** set a fixed `px` `font-size` on `html`/`body` outside the documented cap path.
+
+Non-supporting browsers: no change; UA default root size remains.
+
+### Cap client
+
+- Constants: `DYNAMIC_TYPE_MAX_SCALE = 1.25`, `DYNAMIC_TYPE_DEFAULT_ROOT_PX = 16`, max root = **20px**.
+- Early client bootstrap (minimal component or script mounted from root layout):
+  - Read `computedPx` from `getComputedStyle(document.documentElement).fontSize`.
+  - If `computedPx > 20`, set `document.documentElement.style.fontSize = "20px"`.
+  - If `computedPx ≤ 20`, clear any previous inline override so CSS Dynamic Type remains in control.
+- Re-run on `pageshow` and `visibilitychange` so Settings changes while backgrounded are picked up.
+- No React state for the size; imperative DOM only.
+- Failure mode: if script throws, leave CSS Dynamic Type uncapped rather than forcing a wrong size.
+
+### Inter / layout
+
+- Keep `Inter` from `next/font/google` on `<html className={inter.className}>` in `apps/web/src/app/layout.tsx`.
+- Do not add viewport locks (`maximum-scale`, `user-scalable=no`). Existing chat `interactiveWidget: "resizes-content"` stays.
+
+### Fixed font purge
+
+Sweep `apps/web` product UI:
+
+| Pattern | Action |
+| --- | --- |
+| `text-[Npx]` | Map to nearest Tailwind `text-*` step or arbitrary rem (e.g. `text-[0.625rem]`) |
+| Inline `font-size: Npx` / `style={{ fontSize: "…px" }}` | rem, em, or Tailwind class |
+| `font-size: Npx` in CSS modules / globals for UI | rem / theme tokens |
+
+**Rule:** user-visible Sokosumi browser UI text must use rem, em, or Tailwind rem-based `text-*`. No bare `px` font-size in product surfaces.
+
+**Allowlisted exceptions (must be named in PR if any remain):**
+
+- True print/PDF export chrome not shown as interactive app UI.
+- Third-party embeds we do not control.
+
+A verification grep (or unit/lint test) must fail the build or test suite if new `text-[Npx]` / `font-size: Npx` appears outside the allowlist.
+
+## Agent rules (same PR)
+
+### `.cursor/rules/dynamic-type.mdc` (new)
+
+Normative rule for agents:
+
+1. Root size may come from Apple Dynamic Type (`-apple-system-body`); brand face stays Inter.
+2. Cap is **1.25×** default (max root **20px** when default is 16px) — do not raise without product decision.
+3. **No fixed `px` font sizes** in product UI — use Tailwind `text-*` or `rem`/`em`.
+4. Do not set `maximum-scale=1` / `user-scalable=no` on the viewport.
+5. Do not override `html`/`body` `font-size` with a fixed `px` that kills Dynamic Type, except the documented 1.25× cap path.
+
+### `AGENTS.md` (and `apps/web/AGENTS.md` if typography is local)
+
+Under **UI & Styling** (or equivalent), add a short bullet block that points at Dynamic Type + no `px` font sizes and references `.cursor/rules/dynamic-type.mdc` for full detail.
+
+## Error handling & edge cases
+
+| Case | Behavior |
+| --- | --- |
+| Non-Apple / no `@supports` | CSS skipped; cap is no-op when size ≤ 20px |
+| Cap script fails | Leave CSS Dynamic Type; no forced wrong size |
+| User changes text size mid-session | Re-clamp on `visibilitychange` / `pageshow` |
+| `font` shorthand vs Inter | Family restored so Inter remains |
+| FOUC | Brief flash acceptable; prefer early client mount over blocking HTML |
+| Layout clip at 1.25× | Prefer `min-h` + wrap over shrinking type below Dynamic Type size |
+| PDF / server print | Absolute sizes allowed only as documented non-UI exceptions |
+
+No user-facing error UI for this feature.
+
+## Testing
+
+| Layer | What |
+| --- | --- |
+| Unit | Cap helper: sizes above 20px clamp to 20px; at/below leave unchanged |
+| Static check | Grep/test: no product-UI `text-[Npx]` / `font-size: …px` outside allowlist |
+| Manual (Apple) | iOS Safari + macOS Safari: Dynamic Type steps; UI scales; growth stops at ~1.25×; Inter still used |
+| Regression smoke | Chat, agents, auth shells at default and max cap for overflow/clip |
+
+## Implementation sketch (for planning)
+
+1. Add cap helper + unit tests (`DYNAMIC_TYPE_MAX_SCALE = 1.25`, max 20px).
+2. Mount early client bootstrap from root layout.
+3. Add `@supports (font: -apple-system-body)` block in `globals.css`; preserve Inter.
+4. Purge all product-UI fixed font sizes to rem/Tailwind.
+5. Add verification test or CI-friendly grep for px font sizes.
+6. Add `.cursor/rules/dynamic-type.mdc` + `AGENTS.md` (and web AGENTS if needed) pointers.
+7. Manual verify on Apple devices/simulators where available.
+
+## Success criteria
+
+- On supporting Safari, increasing system text size increases app UI type up to **1.25×**, then stops.
+- Inter remains the UI face.
+- No fixed `px` font sizes remain in product UI (allowlist empty or documented).
+- Agent docs forbid reintroducing fixed type and document the cap.
+- Non-Apple browsers look unchanged at default zoom.


### PR DESCRIPTION
## Summary

- Opt into Apple Dynamic Type on iOS/macOS Safari/PWA via `-apple-system-body` on `html`, keeping **Inter** as the brand face.
- Cap root scale at **1.25×** (max **20px** when default is 16px) with client re-measure on `pageshow` / `visibilitychange`.
- Replace product-UI fixed `px` font sizes with rem so type tracks root rem.
- Guardrail Vitest scan + agent rules (`.cursor/rules/dynamic-type.mdc`, root/`apps/web` `AGENTS.md`).

Spec: `docs/superpowers/specs/2026-08-05-dynamic-type-design.md`  
Plan: `docs/superpowers/plans/2026-08-05-dynamic-type.md`

## Test plan

- [x] `pnpm --filter web test src/lib/utils/__tests__/dynamic-type.test.ts` (8/8)
- [x] `pnpm --filter web test src/lib/utils/__tests__/no-fixed-font-size.test.ts` (1/1)
- [x] `pnpm --filter web typecheck`
- [x] Biome check on touched Dynamic Type paths
- [ ] **Manual (Apple):** iOS Safari + macOS Safari — increase Dynamic Type; UI scales; growth stops at ~1.25×; Inter still used; smoke chat / agents / auth
- [ ] Non-Apple browser default zoom still looks normal

## Notes

- PDF export chrome may keep `font-size: 10px` (allowlisted non-interactive print surface).
- Manual Apple checklist was not run in the agent environment — please verify before marking ready for review.