### PR TITLE
fix(chat): paste plain text only in room composer

### DIFF
--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -309,7 +309,7 @@ describe("ComposerWysiwygEditor", () => {
     );
   });
 
-  it("strips pasted inline text colors so dark-mode text stays visible", () => {
+  it("pastes plain text only and drops rich clipboard HTML", () => {
     function Harness() {
       const [value, setValue] = useState("");
       return (
@@ -327,8 +327,8 @@ describe("ComposerWysiwygEditor", () => {
 
     const execCommand = vi.fn(
       (command: string, _showUI?: boolean, value?: string) => {
-        if (command === "insertHTML" && value) {
-          editor.innerHTML = value;
+        if (command === "insertText" && typeof value === "string") {
+          editor.textContent = (editor.textContent ?? "") + value;
           return true;
         }
         return false;
@@ -340,13 +340,13 @@ describe("ComposerWysiwygEditor", () => {
     });
 
     const html =
-      '<span style="color: rgb(10, 10, 10);">https://x.com/status/1 asdasdas</span>';
+      '<a href="https://x.com/status/1" style="color: rgb(10, 10, 10);"><strong>https://x.com/status/1</strong></a>';
     fireEvent.paste(editor, {
       clipboardData: {
         getData: (type: string) => {
           if (type === "text/html") return html;
           if (type === "text/plain") {
-            return "https://x.com/status/1 asdasdas";
+            return "https://x.com/status/1";
           }
           return "";
         },
@@ -354,15 +354,20 @@ describe("ComposerWysiwygEditor", () => {
     });
 
     expect(execCommand).toHaveBeenCalledWith(
-      "insertHTML",
+      "insertText",
       false,
-      expect.not.stringMatching(/color\s*:/i),
+      "https://x.com/status/1",
     );
-    expect(editor.innerHTML).not.toMatch(/color\s*:/i);
-    expect(editor.textContent).toContain("asdasdas");
+    expect(execCommand).not.toHaveBeenCalledWith(
+      "insertHTML",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(editor.innerHTML).not.toMatch(/<a\b|<strong\b|color\s*:/i);
+    expect(editor.textContent).toContain("https://x.com/status/1");
   });
 
-  it("falls back to DOM insert without regex HTML stripping", () => {
+  it("falls back to DOM text insert when insertText fails", () => {
     function Harness() {
       const [value, setValue] = useState("");
       return (
@@ -385,7 +390,7 @@ describe("ComposerWysiwygEditor", () => {
     });
 
     const html =
-      '<span style="color: rgb(10, 10, 10);">fallback plain path</span>';
+      '<span style="color: rgb(10, 10, 10);"><em>fallback plain path</em></span>';
     fireEvent.paste(editor, {
       clipboardData: {
         getData: (type: string) => {
@@ -396,9 +401,58 @@ describe("ComposerWysiwygEditor", () => {
       },
     });
 
-    expect(execCommand).toHaveBeenCalled();
-    expect(editor.innerHTML).not.toMatch(/color\s*:/i);
+    expect(execCommand).toHaveBeenCalledWith(
+      "insertText",
+      false,
+      "fallback plain path",
+    );
+    expect(editor.innerHTML).not.toMatch(/<em\b|color\s*:/i);
     expect(editor.textContent).toContain("fallback plain path");
+  });
+
+  it("extracts plain text from HTML when clipboard has no text/plain", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+
+    const execCommand = vi.fn(
+      (command: string, _showUI?: boolean, value?: string) => {
+        if (command === "insertText" && typeof value === "string") {
+          editor.textContent = value;
+          return true;
+        }
+        return false;
+      },
+    );
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return "<b>only html</b>";
+          }
+          return "";
+        },
+      },
+    });
+
+    expect(execCommand).toHaveBeenCalledWith("insertText", false, "only html");
+    expect(editor.textContent).toBe("only html");
   });
 
   it("strips color styles left by insertHTML on input", () => {

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -455,6 +455,46 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.textContent).toBe("only html");
   });
 
+  it("prevents default for HTML-only paste even when extractable text is empty", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.innerHTML = "";
+
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    const pasteEvent = fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return '<img src="https://example.com/x.png" alt="">';
+          }
+          return "";
+        },
+      },
+    });
+
+    // fireEvent.paste returns false when preventDefault was called
+    expect(pasteEvent).toBe(false);
+    expect(execCommand).not.toHaveBeenCalled();
+    expect(editor.innerHTML).not.toMatch(/<img\b/i);
+  });
+
   it("strips color styles left by insertHTML on input", () => {
     function Harness() {
       const [value, setValue] = useState("");

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -816,12 +816,16 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
       const plain = clipboard.getData("text/plain");
       const html = clipboard.getData("text/html");
+      // Own any text/html paste so the browser never injects rich clipboard
+      // markup. File-only pastes leave both empty and bubble to the drop zone.
+      if (!plain && !html) return;
+
+      event.preventDefault();
       // Always paste plain text — never keep rich clipboard HTML (links, bold,
       // colors). Toolbar / markdown input rules still apply after paste.
       const text = plain || (html ? composerPastedHtmlToPlainText(html) : "");
       if (!text) return;
 
-      event.preventDefault();
       const editor = editorRef.current;
       if (!editor) return;
       editor.focus();

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -48,7 +48,6 @@ import {
 } from "@/lib/utils/composer-markdown-dom";
 import {
   composerPastedHtmlToPlainText,
-  sanitizeComposerPastedHtml,
   stripComposerInlineTextColors,
 } from "@/lib/utils/composer-paste-sanitize";
 import { tryExitComposerInlineFormatOnArrow } from "@/lib/utils/composer-wysiwyg-arrow-exit";
@@ -815,65 +814,46 @@ export function ComposerWysiwygEditor<TData = unknown>({
       const clipboard = event.clipboardData;
       if (!clipboard) return;
 
-      const html = clipboard.getData("text/html");
       const plain = clipboard.getData("text/plain");
-      if (!html && !plain) return;
+      const html = clipboard.getData("text/html");
+      // Always paste plain text — never keep rich clipboard HTML (links, bold,
+      // colors). Toolbar / markdown input rules still apply after paste.
+      const text = plain || (html ? composerPastedHtmlToPlainText(html) : "");
+      if (!text) return;
 
-      // Always own paste so light-theme clipboard colors cannot stick in the DOM.
       event.preventDefault();
       const editor = editorRef.current;
       if (!editor) return;
       editor.focus();
 
-      const sanitizedHtml = html ? sanitizeComposerPastedHtml(html) : "";
-      const htmlToInsert = sanitizedHtml.trim() ? sanitizedHtml : "";
-
       let didInsert = false;
-      if (htmlToInsert) {
-        try {
-          didInsert = document.execCommand("insertHTML", false, htmlToInsert);
-        } catch {
-          didInsert = false;
-        }
-      }
-      if (!didInsert && plain) {
-        try {
-          didInsert = document.execCommand("insertText", false, plain);
-        } catch {
-          didInsert = false;
-        }
+      try {
+        didInsert = document.execCommand("insertText", false, text);
+      } catch {
+        didInsert = false;
       }
       if (!didInsert) {
-        const fallbackText =
-          plain ||
-          (htmlToInsert
-            ? composerPastedHtmlToPlainText(htmlToInsert)
-            : html
-              ? composerPastedHtmlToPlainText(html)
-              : "");
-        if (fallbackText) {
-          const selection = window.getSelection();
-          const textNode = document.createTextNode(fallbackText);
-          const range =
-            selection && selection.rangeCount > 0
-              ? selection.getRangeAt(0)
-              : null;
-          const rangeInEditor =
-            range && editor.contains(range.commonAncestorContainer)
-              ? range
-              : null;
-          if (rangeInEditor && selection) {
-            rangeInEditor.deleteContents();
-            rangeInEditor.insertNode(textNode);
-            rangeInEditor.setStartAfter(textNode);
-            rangeInEditor.collapse(true);
-            selection.removeAllRanges();
-            selection.addRange(rangeInEditor);
-          } else {
-            editor.appendChild(textNode);
-          }
-          didInsert = true;
+        const selection = window.getSelection();
+        const textNode = document.createTextNode(text);
+        const range =
+          selection && selection.rangeCount > 0
+            ? selection.getRangeAt(0)
+            : null;
+        const rangeInEditor =
+          range && editor.contains(range.commonAncestorContainer)
+            ? range
+            : null;
+        if (rangeInEditor && selection) {
+          rangeInEditor.deleteContents();
+          rangeInEditor.insertNode(textNode);
+          rangeInEditor.setStartAfter(textNode);
+          rangeInEditor.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(rangeInEditor);
+        } else {
+          editor.appendChild(textNode);
         }
+        didInsert = true;
       }
 
       if (didInsert) {

--- a/apps/web/src/lib/utils/__tests__/composer-paste-sanitize.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-paste-sanitize.test.ts
@@ -2,36 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   composerPastedHtmlToPlainText,
-  sanitizeComposerPastedHtml,
   stripComposerInlineTextColors,
 } from "@/lib/utils/composer-paste-sanitize";
-
-describe("sanitizeComposerPastedHtml", () => {
-  it("strips inline color so dark-mode paste is not invisible", () => {
-    const html =
-      '<span style="color: rgb(10, 10, 10);">https://x.com/status/1 asdasdas</span>';
-    const sanitized = sanitizeComposerPastedHtml(html);
-    expect(sanitized).not.toMatch(/color\s*:/i);
-    expect(sanitized).toContain("https://x.com/status/1 asdasdas");
-  });
-
-  it("keeps non-color styles and formatting tags", () => {
-    const html =
-      '<strong style="color: #0a0a0a; font-weight: 700">bold</strong>';
-    const sanitized = sanitizeComposerPastedHtml(html);
-    expect(sanitized).toContain("<strong");
-    expect(sanitized).toContain("font-weight: 700");
-    expect(sanitized).not.toMatch(/color\s*:/i);
-  });
-
-  it("removes font color attributes", () => {
-    const sanitized = sanitizeComposerPastedHtml(
-      '<font color="#111111">dark</font>',
-    );
-    expect(sanitized).not.toMatch(/color=/i);
-    expect(sanitized).toContain("dark");
-  });
-});
 
 describe("composerPastedHtmlToPlainText", () => {
   it("extracts text via DOMParser, not regex tag stripping", () => {
@@ -50,6 +22,25 @@ describe("composerPastedHtmlToPlainText", () => {
     );
     expect(text).toContain("visible");
     expect(text).not.toMatch(/<script/i);
+  });
+
+  it("preserves line breaks from br tags", () => {
+    expect(composerPastedHtmlToPlainText("a<br>b<br/>c")).toBe("a\nb\nc");
+  });
+
+  it("preserves line breaks between block elements", () => {
+    expect(
+      composerPastedHtmlToPlainText("<p>first</p><p>second</p>").trim(),
+    ).toBe("first\nsecond");
+  });
+
+  it("collapses excessive blank lines from nested blocks", () => {
+    const text = composerPastedHtmlToPlainText(
+      "<div><p>one</p><p>two</p></div>",
+    );
+    expect(text).not.toMatch(/\n{3,}/);
+    expect(text).toContain("one");
+    expect(text).toContain("two");
   });
 });
 

--- a/apps/web/src/lib/utils/composer-paste-sanitize.ts
+++ b/apps/web/src/lib/utils/composer-paste-sanitize.ts
@@ -1,7 +1,8 @@
 /**
- * Strip paste/typing styles that force text color. Dark-mode composers inherit
- * theme foreground; inline `color` from light-mode clipboard HTML (or retained
- * execCommand typing style) paints near-black text on a dark card until remount.
+ * Composer paste/typing helpers.
+ * - Plain-text extraction from clipboard HTML (line-break aware)
+ * - Strip forced text colors left in contentEditable (dark-mode composers
+ *   inherit theme foreground; retained execCommand colors paint near-black)
  */
 
 const COLOR_STYLE_PROPERTIES = [
@@ -11,6 +12,10 @@ const COLOR_STYLE_PROPERTIES = [
   "-webkit-text-fill-color",
   "caret-color",
 ] as const;
+
+/** Block tags that should introduce a newline when extracting plain text. */
+const PLAIN_TEXT_BLOCK_SELECTOR =
+  "p, div, li, blockquote, pre, h1, h2, h3, h4, h5, h6, tr, table, ul, ol";
 
 function removeColorDeclarations(styleValue: string): string {
   const declarations = styleValue
@@ -57,28 +62,30 @@ function stripColorStylesFromElement(element: Element): boolean {
   return changed;
 }
 
-/** Remove color-forcing attributes from a pasted HTML fragment. */
-export function sanitizeComposerPastedHtml(html: string): string {
-  if (!html) return "";
-
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
-  let node = walker.currentNode as Element | null;
-  while (node) {
-    stripColorStylesFromElement(node);
-    node = walker.nextNode() as Element | null;
-  }
-  return doc.body.innerHTML;
-}
-
 /**
  * Extract visible text from HTML without regex tag stripping (incomplete
  * multi-character sanitization). Prefer clipboard `text/plain` when available.
+ * Preserves line breaks from `<br>` and common block tags.
  */
 export function composerPastedHtmlToPlainText(html: string): string {
   if (!html) return "";
+
   const doc = new DOMParser().parseFromString(html, "text/html");
-  return doc.body.textContent ?? "";
+  const body = doc.body;
+
+  for (const br of Array.from(body.querySelectorAll("br"))) {
+    br.replaceWith(doc.createTextNode("\n"));
+  }
+  for (const block of Array.from(
+    body.querySelectorAll(PLAIN_TEXT_BLOCK_SELECTOR),
+  )) {
+    block.appendChild(doc.createTextNode("\n"));
+  }
+
+  return (body.textContent ?? "")
+    .replace(/\u00a0/g, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Room composer paste now inserts **plain text only** (never rich clipboard HTML).
- Drops accidental formatting from pastes (links, bold, colors, etc.).
- Toolbar and markdown input rules still work after paste.
- Prefer `text/plain`; if missing, extract text from HTML.

## Test plan
- [x] `pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx`
- [ ] Paste an X/Twitter link from the browser into the room composer — should appear as plain URL text (not purple/linked).
- [ ] Paste bold/colored text from a webpage — should appear unformatted.
- [ ] Confirm file paste still attaches files.
- [ ] Confirm toolbar bold/link and `**markdown**` still work after paste.