### PR TITLE
fix(web): stop clipping sidebar account name descenders

### DIFF
--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
@@ -90,6 +90,20 @@ describe("SidebarAccountChip", () => {
     expect(screen.getByText("PT")).toBeInTheDocument();
   });
 
+  it("keeps name line-height above 1 so truncate does not clip descenders", () => {
+    renderChip({
+      sessionUser: {
+        ...sessionUser,
+        name: "Andreas Osberghaus",
+      },
+    });
+
+    const name = screen.getByText("Andreas Osberghaus");
+    expect(name.className).toContain("leading-tight");
+    expect(name.className).not.toContain("leading-none");
+    expect(name.className).toContain("truncate");
+  });
+
   it("flags a balance under the low-credits threshold", () => {
     renderChip({ totalCredits: 42 });
 

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
@@ -209,13 +209,13 @@ export function SidebarAccountChip({
       {renderAvatar({ withPresenceDot: true })}
       {isCollapsed ? null : (
         <>
-          <span className="flex min-w-0 flex-1 flex-col items-start gap-1">
-            <span className="w-full truncate text-left text-sm leading-none font-medium">
+          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+            <span className="w-full truncate text-left text-sm leading-tight font-medium">
               {displayName}
             </span>
             <span
               className={cn(
-                "flex w-full items-center gap-1 text-xs leading-none",
+                "flex w-full items-center gap-1 text-xs leading-tight",
                 isLowCredits
                   ? "text-semantic-warning"
                   : "text-muted-foreground",


### PR DESCRIPTION
## Summary
- Sidebar account chip name used `leading-none` + `truncate`, which clipped descenders (e.g. the `g` in Osberghaus).
- Switch name and plan/credits summary to `leading-tight` so glyphs stay fully visible while keeping a compact layout.

## Test plan
- [x] `pnpm --filter web test src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx`
- [ ] Open mobile sidebar account chip with a name that has descenders (`g`, `y`, `p`) and confirm the full glyph shows
- [ ] Expanded desktop sidebar chip still looks compact next to the avatar