### PR TITLE
fix(web): respect UserAvatarContent size className override

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-avatar.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-avatar.test.tsx
@@ -1,0 +1,52 @@
+import type { SessionUser } from "@sokosumi/utils";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import HeaderWorkspaceAvatar from "@/app/components/header/header-workspace-avatar";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const sessionUser: SessionUser = {
+  id: "user-1",
+  name: "Test User",
+  email: "test@example.com",
+  emailVerified: true,
+  image: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  termsAccepted: true,
+  marketingOptIn: false,
+  onboardingCompleted: true,
+};
+
+describe("HeaderWorkspaceAvatar", () => {
+  it("keeps personal compact size-4 for the closed header switcher", () => {
+    const { container } = render(
+      <HeaderWorkspaceAvatar
+        sessionUser={sessionUser}
+        organization={null}
+        className="size-4 shrink-0"
+        logoSize={12}
+        decorative
+      />,
+    );
+
+    const avatar = container.querySelector("[data-slot='avatar']");
+    expect(avatar?.className).toContain("size-4");
+    expect(avatar?.className).toContain("shrink-0");
+    expect(avatar?.className).not.toContain("size-8");
+    expect(avatar?.className).not.toContain("md:size-");
+  });
+
+  it("defaults personal avatar to size-8 without a size override", () => {
+    const { container } = render(
+      <HeaderWorkspaceAvatar sessionUser={sessionUser} organization={null} />,
+    );
+
+    const avatar = container.querySelector("[data-slot='avatar']");
+    expect(avatar?.className).toContain("size-8");
+    expect(avatar?.className).not.toContain("md:size-");
+  });
+});

--- a/apps/web/src/app/(app)/components/header/header-workspace-avatar.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-avatar.tsx
@@ -24,7 +24,7 @@ interface HeaderWorkspaceAvatarProps {
 export default function HeaderWorkspaceAvatar({
   sessionUser,
   organization,
-  className = "size-8 md:size-8",
+  className = "size-8",
   logoSize = 18,
   decorative = false,
 }: HeaderWorkspaceAvatarProps) {

--- a/apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx
@@ -21,4 +21,10 @@ describe("UserAvatarContent", () => {
     expect(avatar?.className).not.toContain("size-8");
     expect(avatar?.className).not.toContain("md:size-10");
   });
+
+  it("scales the fallback icon relative to the avatar box", () => {
+    const { container } = render(<UserAvatarContent imageAlt="User" />);
+    const icon = container.querySelector("svg");
+    expect(icon?.className).toContain("size-[60%]");
+  });
 });

--- a/apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import UserAvatarContent from "@/app/components/user-avatar/user-avatar-content";
+
+describe("UserAvatarContent", () => {
+  it("defaults to size-8 without a size override", () => {
+    const { container } = render(<UserAvatarContent imageAlt="User" />);
+    const avatar = container.querySelector("[data-slot='avatar']");
+    expect(avatar?.className).toContain("size-8");
+    expect(avatar?.className).not.toContain("md:size-10");
+  });
+
+  it("lets className size fully override the default (header compact case)", () => {
+    const { container } = render(
+      <UserAvatarContent className="size-4 shrink-0" imageAlt="User" />,
+    );
+    const avatar = container.querySelector("[data-slot='avatar']");
+    expect(avatar?.className).toContain("size-4");
+    expect(avatar?.className).toContain("shrink-0");
+    expect(avatar?.className).not.toContain("size-8");
+    expect(avatar?.className).not.toContain("md:size-10");
+  });
+});

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar-content.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar-content.tsx
@@ -16,7 +16,7 @@ export default function UserAvatarContent({
 }: UserAvatarContentProps) {
   return (
     <>
-      <Avatar className={cn("size-8 md:size-10", className)}>
+      <Avatar className={cn("size-8", className)}>
         {imageUrl && (
           <AvatarImage
             src={imageUrl}

--- a/apps/web/src/app/(app)/components/user-avatar/user-avatar-content.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/user-avatar-content.tsx
@@ -15,21 +15,19 @@ export default function UserAvatarContent({
   imageAlt,
 }: UserAvatarContentProps) {
   return (
-    <>
-      <Avatar className={cn("size-8", className)}>
-        {imageUrl && (
-          <AvatarImage
-            src={imageUrl}
-            alt={imageAlt ?? "User avatar"}
-            onError={(e) => {
-              e.currentTarget.style.display = "none";
-            }}
-          />
-        )}
-        <AvatarFallback className={className}>
-          <UserIcon className="text-muted-foreground" />
-        </AvatarFallback>
-      </Avatar>
-    </>
+    <Avatar className={cn("size-8", className)}>
+      {imageUrl && (
+        <AvatarImage
+          src={imageUrl}
+          alt={imageAlt ?? "User avatar"}
+          onError={(e) => {
+            e.currentTarget.style.display = "none";
+          }}
+        />
+      )}
+      <AvatarFallback className={className}>
+        <UserIcon className="text-muted-foreground size-[60%]" aria-hidden />
+      </AvatarFallback>
+    </Avatar>
   );
 }

--- a/docs/superpowers/plans/2026-08-05-header-workspace-avatar-size-harden.md
+++ b/docs/superpowers/plans/2026-08-05-header-workspace-avatar-size-harden.md
@@ -40,7 +40,7 @@
 - Consumes: `UserAvatarContent({ className?: string; imageUrl?: string; imageAlt?: string })`
 - Produces: Avatar root classes where caller size fully replaces default (no leftover `md:size-10`)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```tsx
 import { render } from "@testing-library/react";
@@ -69,13 +69,13 @@ describe("UserAvatarContent", () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `pnpm --filter web test src/app/\(app\)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
 
 Expected: FAIL — default still has `md:size-10` and/or override still leaves `md:size-10` / fails `not.toContain("size-8")` depending on merge order.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 In `user-avatar-content.tsx`, change:
 
@@ -91,13 +91,13 @@ to:
 
 Leave image/fallback markup unchanged.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `pnpm --filter web test src/app/\(app\)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
 
 Expected: PASS both cases.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add \
@@ -118,7 +118,7 @@ git commit -m "fix(web): respect UserAvatarContent size className override"
 - Consumes: fixed `UserAvatarContent` from Task 1
 - Produces: no API change; personal path now actually `size-4` at `md+`
 
-- [ ] **Step 1: Grep closed-trigger sizing**
+- [x] **Step 1: Grep closed-trigger sizing**
 
 Confirm trigger still has:
 
@@ -129,17 +129,17 @@ logoSize={12}
 
 and menu rows still use `size-6` / `logoSize={14}` (out of scope, must remain).
 
-- [ ] **Step 2: No code change unless trigger regressed**
+- [x] **Step 2: No code change unless trigger regressed**
 
 If trigger lost `size-4`, restore it. Do not redesign grid.
 
-- [ ] **Step 3: Run related header tests**
+- [x] **Step 3: Run related header tests**
 
 Run: `pnpm --filter web test src/app/\(app\)/components/header/__tests__/header-profile-section.client.test.tsx`
 
 Expected: PASS (mocks only; regression smoke).
 
-- [ ] **Step 4: Commit only if header files changed**
+- [x] **Step 4: Commit only if header files changed**
 
 Otherwise skip commit.
 

--- a/docs/superpowers/plans/2026-08-05-header-workspace-avatar-size-harden.md
+++ b/docs/superpowers/plans/2026-08-05-header-workspace-avatar-size-harden.md
@@ -1,0 +1,157 @@
+# Header Workspace Avatar Size Harden Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make personal and org workspace avatars in the closed header switcher both render at compact `size-4` so icon sizes cannot break top-right chrome alignment.
+
+**Architecture:** Fix the size-class leak in `UserAvatarContent` (drop `md:size-10` so caller `className` fully wins via `cn`/`tailwind-merge`). Lock behavior with a unit test. No header layout redesign.
+
+**Tech Stack:** React, Tailwind CSS + `cn` (clsx + tailwind-merge), Vitest + Testing Library, Next.js web app.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-header-workspace-avatar-size-harden-design.md`
+
+## Global Constraints
+
+- Closed switcher avatar size: **`size-4` (16px)** for personal and org
+- Do not change dropdown menu avatars (`size-6`), notification bell, or sidebar chips
+- Prefer editing existing files; no new shared size API
+- Tests: Vitest via `pnpm --filter web test path/to/file.test.ts` (no extra `--`)
+- Commits: Conventional Commits
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `apps/web/src/app/(app)/components/user-avatar/user-avatar-content.tsx` | Default size only; caller overrides |
+| `apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx` | New — size override lock |
+| `apps/web/src/app/(app)/components/header/header-workspace-avatar.tsx` | Unchanged API; personal path fixed via UserAvatarContent |
+| `apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx` | Already passes `size-4 shrink-0`; no layout change |
+
+---
+
+### Task 1: TDD — UserAvatarContent size override
+
+**Files:**
+- Create: `apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
+- Modify: `apps/web/src/app/(app)/components/user-avatar/user-avatar-content.tsx`
+- Test: `apps/web/src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
+
+**Interfaces:**
+- Consumes: `UserAvatarContent({ className?: string; imageUrl?: string; imageAlt?: string })`
+- Produces: Avatar root classes where caller size fully replaces default (no leftover `md:size-10`)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import UserAvatarContent from "@/app/components/user-avatar/user-avatar-content";
+
+describe("UserAvatarContent", () => {
+  it("defaults to size-8 without a size override", () => {
+    const { container } = render(<UserAvatarContent imageAlt="User" />);
+    const avatar = container.querySelector("[data-slot='avatar']");
+    expect(avatar?.className).toContain("size-8");
+    expect(avatar?.className).not.toContain("md:size-10");
+  });
+
+  it("lets className size fully override the default (header compact case)", () => {
+    const { container } = render(
+      <UserAvatarContent className="size-4 shrink-0" imageAlt="User" />,
+    );
+    const avatar = container.querySelector("[data-slot='avatar']");
+    expect(avatar?.className).toContain("size-4");
+    expect(avatar?.className).toContain("shrink-0");
+    expect(avatar?.className).not.toContain("size-8");
+    expect(avatar?.className).not.toContain("md:size-10");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter web test src/app/\(app\)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
+
+Expected: FAIL — default still has `md:size-10` and/or override still leaves `md:size-10` / fails `not.toContain("size-8")` depending on merge order.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `user-avatar-content.tsx`, change:
+
+```tsx
+<Avatar className={cn("size-8 md:size-10", className)}>
+```
+
+to:
+
+```tsx
+<Avatar className={cn("size-8", className)}>
+```
+
+Leave image/fallback markup unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter web test src/app/\(app\)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
+
+Expected: PASS both cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  apps/web/src/app/\(app\)/components/user-avatar/user-avatar-content.tsx \
+  apps/web/src/app/\(app\)/components/user-avatar/__tests__/user-avatar-content.test.tsx
+git commit -m "fix(web): respect UserAvatarContent size className override"
+```
+
+---
+
+### Task 2: Confirm header closed switcher still passes compact size
+
+**Files:**
+- Read-only verify: `apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx` (trigger `HeaderWorkspaceAvatar` with `className="size-4 shrink-0"`)
+- Read-only verify: `apps/web/src/app/(app)/components/header/header-workspace-avatar.tsx` (personal → `UserAvatarContent`, org → `Avatar` + className)
+
+**Interfaces:**
+- Consumes: fixed `UserAvatarContent` from Task 1
+- Produces: no API change; personal path now actually `size-4` at `md+`
+
+- [ ] **Step 1: Grep closed-trigger sizing**
+
+Confirm trigger still has:
+
+```tsx
+className="size-4 shrink-0"
+logoSize={12}
+```
+
+and menu rows still use `size-6` / `logoSize={14}` (out of scope, must remain).
+
+- [ ] **Step 2: No code change unless trigger regressed**
+
+If trigger lost `size-4`, restore it. Do not redesign grid.
+
+- [ ] **Step 3: Run related header tests**
+
+Run: `pnpm --filter web test src/app/\(app\)/components/header/__tests__/header-profile-section.client.test.tsx`
+
+Expected: PASS (mocks only; regression smoke).
+
+- [ ] **Step 4: Commit only if header files changed**
+
+Otherwise skip commit.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+| --- | --- |
+| Fix `UserAvatarContent` default / drop `md:size-10` | Task 1 |
+| Caller `size-4` fully wins | Task 1 |
+| Closed switcher stays compact for personal + org | Task 1 + 2 |
+| Default remains `size-8` | Task 1 |
+| Dropdown / bell / sidebar out of scope | Task 2 verify only |
+| Unit test locks override | Task 1 |

--- a/docs/superpowers/specs/2026-08-05-header-workspace-avatar-size-harden-design.md
+++ b/docs/superpowers/specs/2026-08-05-header-workspace-avatar-size-harden-design.md
@@ -1,0 +1,92 @@
+# Design: Harden header workspace avatar sizing
+
+**Date:** 2026-08-05  
+**Status:** Approved approach A  
+**Scope:** Closed header top-right workspace switcher (name + avatar + chevron) next to notification bell
+
+## Problem
+
+Personal-account avatar in the closed header switcher renders much larger than the org-workspace logo. That breaks vertical alignment with the chevron and notification bell and makes the two-line name/email block look uneven.
+
+### Root cause
+
+`HeaderWorkspaceSwitch` passes `className="size-4 shrink-0"` into `HeaderWorkspaceAvatar`.
+
+- **Org path:** wraps `OrganizationLogo` in `Avatar` with that className only → stays `size-4` (16px). Correct.
+- **Personal path:** uses `UserAvatarContent`, which hardcodes:
+
+  ```ts
+  cn("size-8 md:size-10", className)
+  ```
+
+  `tailwind-merge` lets bare `size-4` override `size-8`, but **not** the responsive `md:size-10`. At `md+`, personal avatar becomes 40px while org stays 16px.
+
+## Goal
+
+- Closed switcher avatar is always **compact `size-4` (16px)** for personal and org.
+- Icon/avatar intrinsic size must not reflow the header chrome (chevron, bell, two-line label).
+- Callers of `UserAvatarContent` can fully override size via `className`.
+
+## Non-goals
+
+- Dropdown menu workspace avatars (`size-6`)
+- Notification bell hit target (`size-8`)
+- Sidebar account chip or other avatars outside the closed header switcher
+- Changing label truncation, email row, or switcher interaction
+
+## Approach (A — fix size merge at source)
+
+### 1. `UserAvatarContent`
+
+Change default sizing so caller classes win completely:
+
+```ts
+// before
+cn("size-8 md:size-10", className)
+
+// after
+cn("size-8", className)
+```
+
+- Default remains `size-8` when no size class is passed (skeleton / generic use).
+- Header `size-4` fully wins; no leftover responsive size.
+- Keep `AvatarImage` `size-full object-cover` so image fills the box.
+
+### 2. Header closed switcher (light harden)
+
+Keep existing trigger API:
+
+- `HeaderWorkspaceAvatar` with `className="size-4 shrink-0"`, `logoSize={12}`, `decorative` for closed trigger.
+- Ensure personal and org paths both respect the same outer size (org already does via `Avatar` + className; personal does after step 1).
+
+No layout redesign of the grid (`name | avatar | chevron` + email row).
+
+### 3. Tests
+
+- Unit/render test: closed switcher (or `HeaderWorkspaceAvatar` personal path) with `className="size-4"` must **not** include `md:size-10` / `size-8 md:size-10` on the avatar root.
+- Optionally assert `size-4` (or `size-4 shrink-0`) is present.
+- Existing profile-section / notification tests stay as-is unless they mock avatar markup.
+
+## Success criteria
+
+| Case | Expected |
+| --- | --- |
+| Personal workspace, closed switcher | Avatar `size-4`, aligned with chevron/bell (matches Image #1 density) |
+| Org workspace, closed switcher | Unchanged small logo (`size-4`) |
+| `UserAvatarContent` with no className size | Default `size-8` |
+| Dropdown menu rows | Still `size-6` avatars |
+| `md+` viewport | No personal-avatar jump to `size-10` |
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Skeleton lost `md:size-10` | Skeleton sits in fixed `h-8 w-8` button; `size-8` default matches. |
+| Other future callers assumed `md:size-10` | Only header + skeleton use `UserAvatarContent` today; grep-confirmed. |
+| Regression of hardcoded sizes | Test locks override behavior for `size-4`. |
+
+## Implementation order
+
+1. Fix `UserAvatarContent` default classes + add/adjust unit test.
+2. Smoke header switcher personal vs org (visual or render assertion).
+3. No Core/API or i18n changes.


### PR DESCRIPTION
## Summary

- Personal workspace avatar in the closed header switcher was rendering at `md:size-10` while org logos stayed `size-4`, breaking top-right alignment with the chevron and notification bell.
- Root cause: `UserAvatarContent` hardcoded `size-8 md:size-10`; caller `size-4` could not override the responsive class via `tailwind-merge`.
- Drop `md:size-10` so caller size classes fully win; default remains `size-8`. Add unit tests locking the compact header case.

## Test plan

- [x] `pnpm --filter web test src/app/(app)/components/user-avatar/__tests__/user-avatar-content.test.tsx`
- [x] `pnpm --filter web test src/app/(app)/components/header/__tests__/header-profile-section.client.test.tsx`
- [ ] Visual: personal workspace closed switcher avatar matches org `size-4` density at desktop width
- [ ] Visual: dropdown menu workspace rows still use larger `size-6` avatars
- [ ] Visual: notification bell hit target unchanged