### PR TITLE
feat(core): accept Better Auth session tokens as bearer credentials

### DIFF
--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -14,6 +14,7 @@ interface AuthorizeReferenceConfig {
 
 const {
   adminPluginMock,
+  bearerPluginMock,
   apiKeyPluginMock,
   betterAuthMock,
   getBetterAuthPublicBaseUrlMock,
@@ -76,6 +77,7 @@ const {
 
   return {
     adminPluginMock: vi.fn(),
+    bearerPluginMock: vi.fn(),
     apiKeyPluginMock: vi.fn(),
     betterAuthMock: vi.fn(),
     getBetterAuthPublicBaseUrlMock: vi.fn(),
@@ -163,6 +165,7 @@ vi.mock("@better-auth/prisma-adapter", () => ({
 
 vi.mock("better-auth/plugins", () => ({
   admin: (...args: unknown[]) => adminPluginMock(...args),
+  bearer: (...args: unknown[]) => bearerPluginMock(...args),
   jwt: (...args: unknown[]) => jwtPluginMock(...args),
   lastLoginMethod: (...args: unknown[]) => lastLoginMethodPluginMock(...args),
   magicLink: (...args: unknown[]) => magicLinkPluginMock(...args),
@@ -344,6 +347,7 @@ describe("core auth config", () => {
     vi.clearAllMocks();
 
     adminPluginMock.mockReturnValue("admin-plugin");
+    bearerPluginMock.mockReturnValue("bearer-plugin");
     apiKeyPluginMock.mockReturnValue("api-key-plugin");
     i18nPluginMock.mockReturnValue("i18n-plugin");
     getEnvMock.mockReturnValue(getDefaultEnv());
@@ -559,6 +563,12 @@ describe("core auth config", () => {
       "user_123",
       "google",
     );
+  });
+
+  it("registers the bearer plugin so non-browser clients can authenticate without cookies", async () => {
+    await import("./auth");
+
+    expect(bearerPluginMock).toHaveBeenCalled();
   });
 
   it("registers the passkey plugin with the Sokosumi relying party configuration", async () => {

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -40,6 +40,7 @@ import { APIError, createAuthMiddleware } from "better-auth/api";
 import { betterAuth } from "better-auth/minimal";
 import {
   admin,
+  bearer,
   jwt,
   lastLoginMethod,
   magicLink,
@@ -584,6 +585,16 @@ export const auth = betterAuth({
     additionalFields: betterAuthUserAdditionalFields,
   },
   plugins: [
+    /**
+     * Lets non-browser clients authenticate without cookies: sign-in responses
+     * carry a `set-auth-token` header, and `Authorization: Bearer <token>` is
+     * accepted in place of the session cookie.
+     *
+     * `requireSignature` stays at its default of false — the token handed back
+     * by `set-auth-token` is the unsigned session token, which is what a mobile
+     * client stores and replays.
+     */
+    bearer(),
     magicLink({
       disableSignUp: false,
       expiresIn: 60 * 10, // 10 minutes

--- a/apps/core/src/middleware/auth.test.ts
+++ b/apps/core/src/middleware/auth.test.ts
@@ -547,6 +547,55 @@ describe("authMiddleware", () => {
     expect(response.status).toBe(401);
   });
 
+  it("authenticates a Better Auth session token presented as a bearer credential", async () => {
+    getSessionMock.mockResolvedValue({
+      session: {
+        activeOrganizationId: "org_mobile",
+      },
+      user: {
+        id: "user_mobile",
+        role: "user",
+      },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer session-token-from-mobile",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      actor: "user",
+      userId: "user_mobile",
+      organizationId: "org_mobile",
+      role: "user",
+    });
+  });
+
+  it("only falls back to the session token after the other bearer schemes", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { activeOrganizationId: null },
+      user: { id: "user_mobile", role: "user" },
+    });
+    verifyApiKeyMock.mockResolvedValue({
+      valid: true,
+      key: { userId: "user_apikey" },
+    });
+
+    const app = createApp();
+    const response = await app.request("http://localhost/", {
+      headers: {
+        authorization: "Bearer some-api-key",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    // The API key resolved first, so the session lookup never ran.
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
   it("authenticates from session when authorization header is missing", async () => {
     getSessionMock.mockResolvedValue({
       session: {

--- a/apps/core/src/middleware/auth.ts
+++ b/apps/core/src/middleware/auth.ts
@@ -506,6 +506,41 @@ async function verifyOAuthToken(
   return true;
 }
 
+/**
+ * Better Auth session token presented as a bearer credential.
+ *
+ * The `bearer` plugin rewrites `Authorization: Bearer <token>` into a session
+ * cookie inside Better Auth's own pipeline, so `getSession` resolves it exactly
+ * as it would a cookie from the browser. This is what lets a mobile client sign
+ * in with email and password and then call the API without cookies, which
+ * React Native has no usable story for.
+ *
+ * Deliberately last in the chain: it costs a session lookup, and every other
+ * scheme is cheaper to reject.
+ */
+async function verifySessionBearerToken(c: Context): Promise<boolean> {
+  const response = await auth.api
+    .getSession({ headers: c.req.raw.headers })
+    .catch(() => null);
+
+  if (!response?.session || !response.user) {
+    return false;
+  }
+
+  const { session, user } = response;
+
+  setAuthContext(c, {
+    isAuthenticated: true,
+    authContext: {
+      actor: "user",
+      userId: user.id,
+      organizationId: session.activeOrganizationId ?? null,
+      role: user.role ?? DEFAULT_USER_ROLE,
+    },
+  });
+  return true;
+}
+
 const bearerMiddleware: MiddlewareHandler<AuthEnv> = bearerAuth({
   verifyToken: async (token, c) => {
     // Check 1: Dedicated coworker API key
@@ -533,6 +568,12 @@ const bearerMiddleware: MiddlewareHandler<AuthEnv> = bearerAuth({
     // Check 4: OAuth Access Token
     const oauthTokenValid = await verifyOAuthToken(token, c);
     if (oauthTokenValid) {
+      return true;
+    }
+
+    // Check 5: Better Auth session token (mobile / other non-browser clients)
+    const sessionValid = await verifySessionBearerToken(c);
+    if (sessionValid) {
       return true;
     }
 


### PR DESCRIPTION
## Why

Web auth is entirely cookie-based, and React Native has no usable cookie story. Today a mobile client has exactly two options: register an OAuth 2.1 + PKCE client by hand per app and do a browser round trip to sign in, or nothing.

This makes a plain email/password sign-in sufficient, so the app can have a direct login screen.

## What

Two changes:

1. **Enable Better Auth's `bearer` plugin.** Sign-in responses then carry a `set-auth-token` header, and `Authorization: Bearer <token>` is accepted in place of the session cookie. `requireSignature` stays at its default of `false` — the value handed back by `set-auth-token` is the unsigned session token, which is what a client stores and replays.
2. **Add a fifth check to the Core bearer chain** that resolves a session token. This is required, not optional: `authMiddleware` routes *any* `Authorization` header down the bearer path and never reaches the cookie session handler, so without it the token is rejected with 401.

The session check is deliberately **last** in the chain — it costs a session lookup, and coworker keys, the orchestrator token, API keys and OAuth tokens are all cheaper to reject.

Client flow becomes:

```
POST /auth/sign-in/email  { email, password }
→ read the `set-auth-token` response header
→ Authorization: Bearer <that value>  on /v1 requests
```

## Trade-off worth a reviewer's opinion

A session token is longer-lived than a 2-hour OAuth access token and there is no refresh-token rotation behind it, so the device holds a more powerful credential for longer. That is the thing the OAuth route buys you.

For a first-party mobile app I think that is the right trade — it removes per-app client registration and a browser round trip from the sign-in path — but it is a real change in posture and I would rather it be an explicit decision than a silent one. Happy to gate it behind a flag, or restrict it to specific routes, if you would prefer.

Note `magicLink` is already enabled, so a passwordless mobile flow is also possible on top of this without further server work.

## Testing

- `middleware/auth.test.ts`: two new cases — a session token presented as a bearer credential authenticates and yields the right context; and the session lookup is *not* reached when an earlier scheme (API key) resolves first.
- `lib/auth.test.ts`: asserts the bearer plugin is registered.
- Full core suite: **322 passed, 1 skipped, 0 failed**.
- `pnpm check && pnpm typecheck` green across all 9 workspaces.

One test-infra update is included: `lib/auth.test.ts` mocks `better-auth/plugins` wholesale, so the new export had to be added to that mock.