### PR TITLE
fix(web): remount mobile chats list on workspace switch

### DIFF
--- a/apps/web/src/app/(app)/chat/chats/page.tsx
+++ b/apps/web/src/app/(app)/chat/chats/page.tsx
@@ -61,6 +61,7 @@ export default async function ChatChatsPage() {
   return (
     <div className="md:hidden -m-4 min-h-0 flex-1 overflow-y-auto">
       <OrganizationChatList
+        key={activeOrganizationId ?? "personal"}
         rooms={chatRoomsPage.rooms}
         roomsNextCursor={chatRoomsPage.nextCursor}
         archivedRooms={archivedChatRoomsPage.rooms}

--- a/apps/web/src/app/(app)/chat/utils/__tests__/date-utils.hydration.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/date-utils.hydration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatMessageTime,
   messageDayKey,
@@ -14,6 +14,7 @@ describe("chat local calendar helpers (SOKOSUMI-A)", () => {
   const previousTz = process.env.TZ;
 
   afterEach(() => {
+    vi.useRealTimers();
     if (previousTz === undefined) {
       delete process.env.TZ;
     } else {
@@ -35,6 +36,9 @@ describe("chat local calendar helpers (SOKOSUMI-A)", () => {
   });
 
   it("formatDaySeparator label for an evening instant differs UTC vs Berlin when 'now' is fixed", () => {
+    // Noon UTC keeps both zones on Aug 5 so 22:30Z is Today (UTC) vs Aug 6 (Berlin).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T12:00:00.000Z"));
     const evening = new Date("2026-08-05T22:30:00.000Z");
 
     process.env.TZ = "UTC";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SOK-731](https://linear.app/masumi/issue/SOK-731/mobile-chats-list-stays-stale-after-workspace-switch).

After a mobile workspace switch, the Chats tab remounts `OrganizationChatList` with `key={activeOrganizationId ?? "personal"}` (same as the desktop sidebar), so Channels and DMs match the new org without a full reload.

Also pins the day-separator hydration test clock so late-evening wall time cannot make UTC and Berlin both return "Today".

**Verify:** `pnpm web:check`, `pnpm web:test`

**UI proof (mobile `/chat/chats`):** Alice Fixture Org shows `# Alice Org Channel`; after soft switch to Bob Fixture Org, list shows `# Bob Org Channel` only (no prior-org rooms).

[Alice org chats list](https://cursor.com/agents/bc-54c43def-a7c8-477d-bbe1-f52510becbaa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-731%2Falice-org.png)
[Bob org chats list after switch](https://cursor.com/agents/bc-54c43def-a7c8-477d-bbe1-f52510becbaa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-731%2Fbob-org.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54c43def-a7c8-477d-bbe1-f52510becbaa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54c43def-a7c8-477d-bbe1-f52510becbaa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

