### PR TITLE
fix(chat): show room overflow menu on touch

### DIFF
--- a/apps/web/src/app/(app)/chat/utils/__tests__/date-utils.hydration.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/date-utils.hydration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatMessageTime,
   messageDayKey,
@@ -14,6 +14,7 @@ describe("chat local calendar helpers (SOKOSUMI-A)", () => {
   const previousTz = process.env.TZ;
 
   afterEach(() => {
+    vi.useRealTimers();
     if (previousTz === undefined) {
       delete process.env.TZ;
     } else {
@@ -35,6 +36,9 @@ describe("chat local calendar helpers (SOKOSUMI-A)", () => {
   });
 
   it("formatDaySeparator label for an evening instant differs UTC vs Berlin when 'now' is fixed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00.000Z"));
+
     const evening = new Date("2026-08-05T22:30:00.000Z");
 
     process.env.TZ = "UTC";

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -48,7 +48,10 @@ import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import type { ChatRoom } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 
-/** Absolute trailing cluster: status icon (pin/mute) then overflow, so layout does not jump. */
+/**
+ * Trailing controls. Touch: pin/mute then overflow side by side.
+ * Hover-capable: one size-7 slot that swaps status ↔ overflow on hover.
+ */
 const TRAILING_CLUSTER_CLASS =
   "absolute top-1/2 right-1 z-10 flex -translate-y-1/2 items-center";
 
@@ -168,7 +171,10 @@ export function ChatRoomSidebarRow({
       </span>
       <MentionBadge count={badgeCount} />
       <span
-        className={cn("shrink-0", isMuted || isPinned ? "w-14" : "size-7")}
+        className={cn(
+          "h-7 w-7 shrink-0",
+          (isMuted || isPinned) && "[@media(hover:none)]:w-14",
+        )}
         aria-hidden
       />
     </Link>
@@ -186,7 +192,11 @@ export function ChatRoomSidebarRow({
       <div className={TRAILING_CLUSTER_CLASS}>
         {isMuted || isPinned ? (
           <span
-            className="text-muted-foreground pointer-events-none flex size-7 items-center justify-center"
+            className={cn(
+              "text-muted-foreground pointer-events-none flex size-7 items-center justify-center",
+              "[@media(hover:hover)]:absolute [@media(hover:hover)]:top-1/2 [@media(hover:hover)]:right-0 [@media(hover:hover)]:-translate-y-1/2",
+              "[@media(hover:hover)]:group-hover/room-row:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-0 group-has-[[data-state=open]]/room-row:opacity-0",
+            )}
             aria-hidden
           >
             {isMuted ? (
@@ -204,9 +214,7 @@ export function ChatRoomSidebarRow({
               size="icon"
               disabled={isPending}
               className={cn(
-                "text-muted-foreground size-7 opacity-100 data-[state=open]:opacity-100",
-                !(isMuted || isPinned) &&
-                  "[@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-100 [@media(hover:hover)]:group-hover/room-row:opacity-100",
+                "text-muted-foreground size-7 opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-100 [@media(hover:hover)]:group-hover/room-row:opacity-100 data-[state=open]:opacity-100",
               )}
               aria-label={tActions("roomMenu", { name: label })}
             >

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -48,7 +48,7 @@ import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import type { ChatRoom } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 
-/** Same absolute slot for pin/mute (rest) and overflow menu (hover) so icons never jump. */
+/** Same absolute slot for pin/mute (rest) and overflow menu so icons never jump. */
 const TRAILING_CONTROL_CLASS =
   "absolute top-1/2 right-1 z-10 flex size-7 -translate-y-1/2 items-center justify-center";
 
@@ -185,7 +185,7 @@ export function ChatRoomSidebarRow({
           className={cn(
             TRAILING_CONTROL_CLASS,
             "text-muted-foreground pointer-events-none",
-            "group-hover/room-row:opacity-0 group-focus-within/room-row:opacity-0 group-has-[[data-state=open]]/room-row:opacity-0",
+            "[@media(hover:none)]:opacity-0 [@media(hover:hover)]:group-hover/room-row:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-0 group-has-[[data-state=open]]/room-row:opacity-0",
           )}
           aria-hidden
         >
@@ -205,7 +205,7 @@ export function ChatRoomSidebarRow({
             disabled={isPending}
             className={cn(
               TRAILING_CONTROL_CLASS,
-              "text-muted-foreground opacity-0 group-focus-within/room-row:opacity-100 group-hover/room-row:opacity-100 data-[state=open]:opacity-100",
+              "text-muted-foreground opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-100 [@media(hover:hover)]:group-hover/room-row:opacity-100 data-[state=open]:opacity-100",
             )}
             aria-label={tActions("roomMenu", { name: label })}
           >

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -48,9 +48,9 @@ import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import type { ChatRoom } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 
-/** Same absolute slot for pin/mute (rest) and overflow menu so icons never jump. */
-const TRAILING_CONTROL_CLASS =
-  "absolute top-1/2 right-1 z-10 flex size-7 -translate-y-1/2 items-center justify-center";
+/** Absolute trailing cluster: status icon (pin/mute) then overflow, so layout does not jump. */
+const TRAILING_CLUSTER_CLASS =
+  "absolute top-1/2 right-1 z-10 flex -translate-y-1/2 items-center";
 
 interface ChatRoomSidebarRowProps {
   room: ChatRoom;
@@ -167,7 +167,10 @@ export function ChatRoomSidebarRow({
         {label}
       </span>
       <MentionBadge count={badgeCount} />
-      <span className="size-7 shrink-0" aria-hidden />
+      <span
+        className={cn("shrink-0", isMuted || isPinned ? "w-14" : "size-7")}
+        aria-hidden
+      />
     </Link>
   );
 
@@ -180,113 +183,112 @@ export function ChatRoomSidebarRow({
           roomLink
         )}
       </SidebarMenuButton>
-      {isMuted || isPinned ? (
-        <span
-          className={cn(
-            TRAILING_CONTROL_CLASS,
-            "text-muted-foreground pointer-events-none",
-            "[@media(hover:none)]:opacity-0 [@media(hover:hover)]:group-hover/room-row:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-0 group-has-[[data-state=open]]/room-row:opacity-0",
-          )}
-          aria-hidden
-        >
-          {isMuted ? (
-            <BellOff className="size-3.5" />
-          ) : (
-            <Pin className="size-3.5" />
-          )}
-        </span>
-      ) : null}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            disabled={isPending}
-            className={cn(
-              TRAILING_CONTROL_CLASS,
-              "text-muted-foreground opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-100 [@media(hover:hover)]:group-hover/room-row:opacity-100 data-[state=open]:opacity-100",
-            )}
-            aria-label={tActions("roomMenu", { name: label })}
-          >
-            <Ellipsis className="size-4" aria-hidden />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-44">
-          <DropdownMenuItem
-            disabled={isActive || isPending || isMuted}
-            onSelect={() => {
-              runRoomAction(markOrganizationChatRoomUnreadAction, {
-                ...room,
-                markedUnread: true,
-              });
-            }}
-          >
-            <MessageSquare className="size-4" aria-hidden />
-            {tActions("markUnread")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={isPending || isMuted}
-            onSelect={() => {
-              if (isPinned) {
-                runRoomAction(unpinOrganizationChatRoomAction, {
-                  ...room,
-                  pinnedAt: null,
-                });
-                return;
-              }
-              runRoomAction(pinOrganizationChatRoomAction, {
-                ...room,
-                pinnedAt: new Date(),
-              });
-            }}
-          >
-            {isPinned ? (
-              <PinOff className="size-4" aria-hidden />
-            ) : (
-              <Pin className="size-4" aria-hidden />
-            )}
-            {isPinned ? tActions("unpin") : tActions("pin")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={isPending || isPinned}
-            onSelect={() => {
-              if (isMuted) {
-                runRoomAction(unmuteOrganizationChatRoomAction, {
-                  ...room,
-                  mutedAt: null,
-                });
-                return;
-              }
-              runRoomAction(muteOrganizationChatRoomAction, {
-                ...room,
-                mutedAt: new Date(),
-              });
-            }}
+      <div className={TRAILING_CLUSTER_CLASS}>
+        {isMuted || isPinned ? (
+          <span
+            className="text-muted-foreground pointer-events-none flex size-7 items-center justify-center"
+            aria-hidden
           >
             {isMuted ? (
-              <Bell className="size-4" aria-hidden />
+              <BellOff className="size-3.5" />
             ) : (
-              <BellOff className="size-4" aria-hidden />
+              <Pin className="size-3.5" />
             )}
-            {isMuted ? tActions("unmute") : tActions("mute")}
-          </DropdownMenuItem>
-          {canLeave ? (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                disabled={isPending || isLeaving}
-                onSelect={() => {
-                  setLeaveConfirmOpen(true);
-                }}
-              >
-                <LogOut className="size-4" aria-hidden />
-                {tActions("leave")}
-              </DropdownMenuItem>
-            </>
-          ) : null}
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </span>
+        ) : null}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={isPending}
+              className={cn(
+                "text-muted-foreground size-7 opacity-100 data-[state=open]:opacity-100",
+                !(isMuted || isPinned) &&
+                  "[@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within/room-row:opacity-100 [@media(hover:hover)]:group-hover/room-row:opacity-100",
+              )}
+              aria-label={tActions("roomMenu", { name: label })}
+            >
+              <Ellipsis className="size-4" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem
+              disabled={isActive || isPending || isMuted}
+              onSelect={() => {
+                runRoomAction(markOrganizationChatRoomUnreadAction, {
+                  ...room,
+                  markedUnread: true,
+                });
+              }}
+            >
+              <MessageSquare className="size-4" aria-hidden />
+              {tActions("markUnread")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={isPending || isMuted}
+              onSelect={() => {
+                if (isPinned) {
+                  runRoomAction(unpinOrganizationChatRoomAction, {
+                    ...room,
+                    pinnedAt: null,
+                  });
+                  return;
+                }
+                runRoomAction(pinOrganizationChatRoomAction, {
+                  ...room,
+                  pinnedAt: new Date(),
+                });
+              }}
+            >
+              {isPinned ? (
+                <PinOff className="size-4" aria-hidden />
+              ) : (
+                <Pin className="size-4" aria-hidden />
+              )}
+              {isPinned ? tActions("unpin") : tActions("pin")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={isPending || isPinned}
+              onSelect={() => {
+                if (isMuted) {
+                  runRoomAction(unmuteOrganizationChatRoomAction, {
+                    ...room,
+                    mutedAt: null,
+                  });
+                  return;
+                }
+                runRoomAction(muteOrganizationChatRoomAction, {
+                  ...room,
+                  mutedAt: new Date(),
+                });
+              }}
+            >
+              {isMuted ? (
+                <Bell className="size-4" aria-hidden />
+              ) : (
+                <BellOff className="size-4" aria-hidden />
+              )}
+              {isMuted ? tActions("unmute") : tActions("mute")}
+            </DropdownMenuItem>
+            {canLeave ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  disabled={isPending || isLeaving}
+                  onSelect={() => {
+                    setLeaveConfirmOpen(true);
+                  }}
+                >
+                  <LogOut className="size-4" aria-hidden />
+                  {tActions("leave")}
+                </DropdownMenuItem>
+              </>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
 
       <AlertDialog
         open={leaveConfirmOpen}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://linear.app/masumi/issue/SOK-732/always-show-channel-and-dm-overflow-menu-on-mobile

On touch devices, channel and DM sidebar row overflow (⋯) stays visible. When pinned or muted on touch, the status icon sits to the left of the dots.

Desktop (hover-capable) keeps the previous single-slot swap: pin/mute at rest, overflow on hover/focus/open.

Also keeps the hydration-test fake-clock pin from `main` so the TZ label assertion does not flake.

## Spec summary

- Touch: overflow always visible; pin/mute beside overflow when set
- Desktop: hover-to-reveal overflow; pin/mute rest icon swaps with overflow in one slot
- Menu actions and APIs unchanged
- Archived trailing controls out of scope

## Verification

- `pnpm web:check` / `pnpm web:test`
- UI `/chat/chats` (mobile): pinned `#general` shows pin then ⋯

### UI proof

[Mobile: pin icon beside overflow](https://cursor.com/agents/bc-eb8000d3-7485-40d6-9cf7-c97847962027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-732-mobile-pin-and-dots.png)

### Review notes

- swarm-verify skipped (default off)
- Headless Chromium reports `(hover: hover)` as false, so desktop swap is covered by class contract + media queries rather than live desktop browser proof in this agent env


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb8000d3-7485-40d6-9cf7-c97847962027?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb8000d3-7485-40d6-9cf7-c97847962027&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

