### PR TITLE
fix(web): restore focus on account settings drill

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
@@ -1,6 +1,14 @@
 import type { SessionUser } from "@sokosumi/utils";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function flushAnimationFrame() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, values?: Record<string, unknown>) =>
@@ -123,6 +131,41 @@ describe("HeaderAccountControl", () => {
     fireEvent.click(screen.getByRole("button", { name: "account" }));
 
     expect(pushMock).toHaveBeenCalledWith("/account");
+  });
+
+  it("moves keyboard focus into the settings drill when Settings is activated", async () => {
+    renderControl();
+    openControl();
+
+    const settings = screen.getByRole("button", { name: "settings" });
+    settings.focus();
+    expect(settings).toHaveFocus();
+
+    fireEvent.click(settings);
+    await flushAnimationFrame();
+
+    const back = screen.getByRole("button", { name: "back" });
+    const active = document.activeElement;
+    expect(active).not.toBeNull();
+    expect(active).not.toBe(settings);
+    expect(active?.contains(back)).toBe(true);
+  });
+
+  it("moves keyboard focus into nested drill panels", async () => {
+    renderControl();
+    openControl();
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+    await flushAnimationFrame();
+
+    fireEvent.click(screen.getByRole("button", { name: "developer" }));
+    await flushAnimationFrame();
+
+    const back = screen.getByRole("button", { name: "back" });
+    const active = document.activeElement;
+    expect(active).not.toBeNull();
+    expect(active?.contains(back)).toBe(true);
+    expect(screen.getByRole("button", { name: "apiKeys" })).toBeInTheDocument();
   });
 
   it("navigates to Admin from the root panel", () => {

--- a/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
@@ -74,6 +74,14 @@ function openControl() {
   fireEvent.click(screen.getByRole("button", { name: /openSummary/ }));
 }
 
+function getPopoverScrollContainer(): HTMLElement {
+  const content = document.querySelector("[data-slot='popover-content']");
+  if (!(content instanceof HTMLElement)) {
+    throw new Error("Expected popover content scroll container");
+  }
+  return content;
+}
+
 describe("HeaderAccountControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -186,5 +194,32 @@ describe("HeaderAccountControl", () => {
     fireEvent.click(screen.getByRole("button", { name: "apiKeys" }));
 
     expect(pushMock).toHaveBeenCalledWith("/developer/api-keys");
+  });
+
+  it("resets popover scroll on every panel forward and back transition", () => {
+    renderControl();
+    openControl();
+
+    const scrollContainer = getPopoverScrollContainer();
+    scrollContainer.scrollTop = 180;
+    expect(scrollContainer.scrollTop).toBe(180);
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+    expect(scrollContainer.scrollTop).toBe(0);
+
+    scrollContainer.scrollTop = 96;
+    fireEvent.click(screen.getByRole("button", { name: "developer" }));
+    expect(scrollContainer.scrollTop).toBe(0);
+
+    scrollContainer.scrollTop = 64;
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    expect(scrollContainer.scrollTop).toBe(0);
+
+    scrollContainer.scrollTop = 48;
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    expect(scrollContainer.scrollTop).toBe(0);
+    expect(
+      screen.getByRole("button", { name: "settings" }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/components/sidebar/components/account-popover-drill.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/account-popover-drill.client.tsx
@@ -8,8 +8,9 @@ import {
   Scale,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { ReactElement } from "react";
+import { type ReactElement, useRef } from "react";
 import { Button } from "@/components/ui/button";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 
 import {
@@ -69,12 +70,24 @@ export function AccountPopoverDrill({
   onNavigateRoute,
   onOpenExternal,
 }: AccountPopoverDrillProps): ReactElement {
+  const panelRef = useRef<HTMLDivElement>(null);
   const tMenu = useTranslations("App.Sidebar.Content.MenuItems");
   const tUserAvatar = useTranslations("Components.UserAvatar");
   const tOrganizationSwitcher = useTranslations(
     "Components.OrganizationSwitcher",
   );
   const tDeveloper = useTranslations("App.Developer.tabs");
+
+  // Settings → drill unmounts the focused trigger; keep keyboard focus inside
+  // the non-modal popover (same rAF + tabIndex=-1 pattern as SidebarSubmenu).
+  useMountEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      panelRef.current?.focus();
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  });
 
   function getAccountItemLabel(translationKey: string): string {
     if (translationKey === "organizationsHeading") {
@@ -103,7 +116,11 @@ export function AccountPopoverDrill({
     panel.kind === "settings" ? { kind: "root" } : { kind: "settings" };
 
   return (
-    <div className="space-y-2 text-left">
+    <div
+      ref={panelRef}
+      tabIndex={-1}
+      className="space-y-2 text-left outline-hidden"
+    >
       <div className="flex items-center gap-1">
         <Button
           type="button"

--- a/apps/web/src/app/(app)/components/sidebar/components/account-summary-menu.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/account-summary-menu.client.tsx
@@ -131,6 +131,7 @@ export function AccountSummaryMenu({
   if (mobileAdminSettings && panel.kind !== "root") {
     return (
       <AccountPopoverDrill
+        key={panel.kind}
         panel={panel}
         members={mobileAdminSettings.members}
         activeOrganizationId={mobileAdminSettings.activeOrganizationId}

--- a/apps/web/src/app/(app)/components/sidebar/components/account-summary-menu.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/account-summary-menu.client.tsx
@@ -5,7 +5,7 @@ import gravatarUrl from "gravatar-url";
 import { Coins, LogOut, Settings, ShieldCheck } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useRef, useState } from "react";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { useGlobalModalsContext } from "@/components/modals/global-modals-context";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -57,6 +57,7 @@ export function AccountSummaryMenu({
   const { showLogoutModal } = useGlobalModalsContext();
   const router = useRouter();
   const presence = useSelfPresence();
+  const menuRootRef = useRef<HTMLDivElement>(null);
   const [panel, setPanel] = useState<AccountPopoverPanel>({ kind: "root" });
 
   const displayName = sessionUser.name.trim() || sessionUser.email;
@@ -126,168 +127,180 @@ export function AccountSummaryMenu({
     window.open(url, "_blank", "noopener,noreferrer");
   }
 
-  const renewalLabel = resolveRenewalLabel();
-
-  if (mobileAdminSettings && panel.kind !== "root") {
-    return (
-      <AccountPopoverDrill
-        key={panel.kind}
-        panel={panel}
-        members={mobileAdminSettings.members}
-        activeOrganizationId={mobileAdminSettings.activeOrganizationId}
-        showDeveloperVendors={mobileAdminSettings.showDeveloperVendors}
-        onNavigatePanel={setPanel}
-        onNavigateRoute={handleNavigateRoute}
-        onOpenExternal={handleOpenExternal}
-      />
+  // PopoverContent stays mounted across root ↔ drill swaps; short viewports
+  // often leave scrollTop mid-summary, hiding the incoming panel header.
+  function handleNavigatePanel(next: AccountPopoverPanel) {
+    setPanel(next);
+    const scrollContainer = menuRootRef.current?.closest(
+      "[data-slot='popover-content']",
     );
+    if (scrollContainer instanceof HTMLElement) {
+      scrollContainer.scrollTop = 0;
+    }
   }
 
+  const renewalLabel = resolveRenewalLabel();
+
   return (
-    <div className="space-y-3 text-left">
-      <div className="flex items-center gap-2.5">
-        <AccountSummaryAvatar
-          sessionUser={sessionUser}
-          displayName={displayName}
+    <div ref={menuRootRef}>
+      {mobileAdminSettings && panel.kind !== "root" ? (
+        <AccountPopoverDrill
+          key={panel.kind}
+          panel={panel}
+          members={mobileAdminSettings.members}
+          activeOrganizationId={mobileAdminSettings.activeOrganizationId}
+          showDeveloperVendors={mobileAdminSettings.showDeveloperVendors}
+          onNavigatePanel={handleNavigatePanel}
+          onNavigateRoute={handleNavigateRoute}
+          onOpenExternal={handleOpenExternal}
         />
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm leading-tight font-medium">
-            {displayName}
-          </p>
-          <p className="text-muted-foreground truncate text-xs leading-tight">
-            {sessionUser.email}
-          </p>
-        </div>
-      </div>
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
-          <span aria-hidden="true">
-            <PresenceDot
-              presence={presence}
-              label={presenceLabel}
-              className="size-2 border-0"
+      ) : (
+        <div className="space-y-3 text-left">
+          <div className="flex items-center gap-2.5">
+            <AccountSummaryAvatar
+              sessionUser={sessionUser}
+              displayName={displayName}
             />
-          </span>
-          {presenceLabel}
-        </span>
-        {planName !== null ? (
-          <span className="bg-muted rounded-full px-2 py-0.5 text-[0.6875rem] font-medium">
-            <span className="sr-only">{`${t("planLabel")}: `}</span>
-            {planName}
-          </span>
-        ) : null}
-      </div>
-      <div className="bg-border h-px" />
-      <div className="space-y-1">
-        <p className="text-lg leading-none font-semibold tracking-tight tabular-nums">
-          {creditsLabel ?? t("detailsUnavailable")}
-        </p>
-        <p className="text-muted-foreground text-xs">
-          {tCredit("totalBalanceLabel")}
-        </p>
-      </div>
-      {usage ? (
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium">{t("monthlyCredits")}</p>
-          <Progress
-            className={cn(
-              "h-1.5",
-              isLowCredits ? "bg-semantic-warning/20" : "bg-primary/20",
-            )}
-            value={usage.percentageUsed}
-            aria-label={tCredit("creditsConsumedProgressAria")}
-            indicatorClassName={
-              isLowCredits ? "bg-semantic-warning" : "bg-primary"
-            }
-          />
-          <p className="text-muted-foreground text-xs">
-            {tCredit("creditsUsedOfTotal", {
-              used: formatCreditsForDisplay(usage.used),
-              total: formatCreditsForDisplay(usage.total),
-            })}
-          </p>
-          {renewalLabel !== null ? (
-            <p className="text-muted-foreground text-xs">{renewalLabel}</p>
-          ) : null}
-        </div>
-      ) : null}
-      {showExtraCredits ? (
-        <>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm leading-tight font-medium">
+                {displayName}
+              </p>
+              <p className="text-muted-foreground truncate text-xs leading-tight">
+                {sessionUser.email}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <span aria-hidden="true">
+                <PresenceDot
+                  presence={presence}
+                  label={presenceLabel}
+                  className="size-2 border-0"
+                />
+              </span>
+              {presenceLabel}
+            </span>
+            {planName !== null ? (
+              <span className="bg-muted rounded-full px-2 py-0.5 text-[0.6875rem] font-medium">
+                <span className="sr-only">{`${t("planLabel")}: `}</span>
+                {planName}
+              </span>
+            ) : null}
+          </div>
           <div className="bg-border h-px" />
           <div className="space-y-1">
-            <p className="text-muted-foreground text-xs">
-              {tCredit("extraCredits")}
-            </p>
-            <p className="text-sm leading-none font-medium tabular-nums">
-              {tBilling("balanceCreditsLabel", {
-                credits: displayExtraCredits,
-              })}
+            <p className="text-lg leading-none font-semibold tracking-tight tabular-nums">
+              {creditsLabel ?? t("detailsUnavailable")}
             </p>
             <p className="text-muted-foreground text-xs">
-              {tCredit("extraCreditsDescription")}
+              {tCredit("totalBalanceLabel")}
             </p>
           </div>
-        </>
-      ) : null}
-      <div className="bg-border h-px" />
-      <div className="space-y-2">
-        <Button
-          type="button"
-          size="sm"
-          onClick={handleBuyCredits}
-          className="h-11 w-full justify-center gap-1.5 md:h-8"
-        >
-          <Coins className="size-4 shrink-0" aria-hidden />
-          {buyCreditsLabel}
-        </Button>
-        {mobileAdminSettings ? (
-          <div className="divide-border divide-y">
-            {mobileAdminSettings.adminMenuEnabled ? (
+          {usage ? (
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium">{t("monthlyCredits")}</p>
+              <Progress
+                className={cn(
+                  "h-1.5",
+                  isLowCredits ? "bg-semantic-warning/20" : "bg-primary/20",
+                )}
+                value={usage.percentageUsed}
+                aria-label={tCredit("creditsConsumedProgressAria")}
+                indicatorClassName={
+                  isLowCredits ? "bg-semantic-warning" : "bg-primary"
+                }
+              />
+              <p className="text-muted-foreground text-xs">
+                {tCredit("creditsUsedOfTotal", {
+                  used: formatCreditsForDisplay(usage.used),
+                  total: formatCreditsForDisplay(usage.total),
+                })}
+              </p>
+              {renewalLabel !== null ? (
+                <p className="text-muted-foreground text-xs">{renewalLabel}</p>
+              ) : null}
+            </div>
+          ) : null}
+          {showExtraCredits ? (
+            <>
+              <div className="bg-border h-px" />
+              <div className="space-y-1">
+                <p className="text-muted-foreground text-xs">
+                  {tCredit("extraCredits")}
+                </p>
+                <p className="text-sm leading-none font-medium tabular-nums">
+                  {tBilling("balanceCreditsLabel", {
+                    credits: displayExtraCredits,
+                  })}
+                </p>
+                <p className="text-muted-foreground text-xs">
+                  {tCredit("extraCreditsDescription")}
+                </p>
+              </div>
+            </>
+          ) : null}
+          <div className="bg-border h-px" />
+          <div className="space-y-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleBuyCredits}
+              className="h-11 w-full justify-center gap-1.5 md:h-8"
+            >
+              <Coins className="size-4 shrink-0" aria-hidden />
+              {buyCreditsLabel}
+            </Button>
+            {mobileAdminSettings ? (
+              <div className="divide-border divide-y">
+                {mobileAdminSettings.adminMenuEnabled ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleAdmin}
+                    className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
+                  >
+                    <ShieldCheck className="size-4 shrink-0" aria-hidden />
+                    {tMenu("admin")}
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleNavigatePanel({ kind: "settings" })}
+                  className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
+                >
+                  <Settings className="size-4 shrink-0" aria-hidden />
+                  {tMenu("settings")}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleLogout}
+                  className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
+                >
+                  <LogOut className="size-4 shrink-0" aria-hidden />
+                  {tCredit("logout")}
+                </Button>
+              </div>
+            ) : (
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={handleAdmin}
-                className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
+                onClick={handleLogout}
+                className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 font-normal md:h-8"
               >
-                <ShieldCheck className="size-4 shrink-0" aria-hidden />
-                {tMenu("admin")}
+                <LogOut className="size-4 shrink-0" aria-hidden />
+                {tCredit("logout")}
               </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setPanel({ kind: "settings" })}
-              className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
-            >
-              <Settings className="size-4 shrink-0" aria-hidden />
-              {tMenu("settings")}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={handleLogout}
-              className="text-muted-foreground hover:text-foreground h-10 w-full justify-start gap-2 rounded-none font-normal"
-            >
-              <LogOut className="size-4 shrink-0" aria-hidden />
-              {tCredit("logout")}
-            </Button>
+            )}
           </div>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleLogout}
-            className="text-muted-foreground hover:text-foreground h-11 w-full justify-start gap-2 font-normal md:h-8"
-          >
-            <LogOut className="size-4 shrink-0" aria-hidden />
-            {tCredit("logout")}
-          </Button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two mobile account-popover drill bugs from SOK-734:

1. **Focus.** Activating Settings unmounted the focused button without moving focus into the drill. Non-modal popover left keyboard focus on the page.
2. **Scroll.** On short viewports, users scroll the root summary to reach Settings. Drill replaces the menu body but keeps the same `PopoverContent` scroller, so old `scrollTop` hid the incoming header/back control.

## Fix

- Focus the drill container on mount with `useMountEffect` + `requestAnimationFrame` and `tabIndex={-1}` (same pattern as `SidebarSubmenu`)
- Remount nested drill panels with `key={panel.kind}`
- Reset `PopoverContent.scrollTop` in the shared panel navigation handler on every forward/back transition

## Test plan

- [x] `pnpm --filter web test src/app/(app)/components/header/__tests__/header-account-control.test.tsx`
- [ ] Keyboard: open header account control → Tab to Settings → Enter → focus lands in drill → Tab reaches first row
- [ ] Nested: Settings → Developer → focus returns to the new drill panel
- [ ] Short viewport: scroll root to Settings → open → header/back visible at top; same for nested forward/back

Related: SOK-734
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d89bc0e-4f09-46a8-89a5-aae53ceccd03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d89bc0e-4f09-46a8-89a5-aae53ceccd03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

