### PR TITLE
fix(web): unblock desktop header on credits

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/header-profile-section.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-profile-section.client.test.tsx
@@ -1,8 +1,10 @@
 import type { SessionUser } from "@sokosumi/utils";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import HeaderProfileSectionClient from "@/app/components/header/header-profile-section.client";
+import HeaderProfileSectionClient, {
+  type HeaderAccountSummary,
+} from "@/app/components/header/header-profile-section.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 
 const useSessionMock = vi.fn();
@@ -87,7 +89,7 @@ const members: MemberWithOrganization[] = [
   },
 ];
 
-const accountSummary = {
+const accountSummary: HeaderAccountSummary = {
   planName: "Pro",
   totalCredits: 1000,
   extraCredits: 0,
@@ -101,6 +103,25 @@ const accountSummary = {
   showDeveloperVendors: false,
 };
 
+async function renderProfileSection(props: {
+  sessionUser: SessionUser;
+  members: MemberWithOrganization[];
+  activeOrganizationId: string | null;
+  accountSummaryPromise?: Promise<HeaderAccountSummary>;
+}) {
+  const { accountSummaryPromise, ...rest } = props;
+  await act(async () => {
+    render(
+      <HeaderProfileSectionClient
+        {...rest}
+        accountSummaryPromise={
+          accountSummaryPromise ?? Promise.resolve(accountSummary)
+        }
+      />,
+    );
+  });
+}
+
 describe("HeaderProfileSectionClient", () => {
   beforeEach(() => {
     useWorkspaceSwitcherMock.mockReturnValue({
@@ -108,9 +129,10 @@ describe("HeaderProfileSectionClient", () => {
       handleSelectWorkspace: vi.fn(),
     });
     headerAccountControlMock.mockClear();
+    headerWorkspaceSwitchMock.mockClear();
   });
 
-  it("prefers the client session active organization when it matches the server", () => {
+  it("prefers the client session active organization when it matches the server", async () => {
     useSessionMock.mockReturnValue({
       data: {
         session: {
@@ -119,14 +141,11 @@ describe("HeaderProfileSectionClient", () => {
       },
     });
 
-    render(
-      <HeaderProfileSectionClient
-        sessionUser={sessionUser}
-        members={members}
-        activeOrganizationId="org-b"
-        accountSummary={accountSummary}
-      />,
-    );
+    await renderProfileSection({
+      sessionUser,
+      members,
+      activeOrganizationId: "org-b",
+    });
 
     expect(headerWorkspaceSwitchMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -135,7 +154,7 @@ describe("HeaderProfileSectionClient", () => {
     );
   });
 
-  it("prefers the client session active organization when client and server differ", () => {
+  it("prefers the client session active organization when client and server differ", async () => {
     useSessionMock.mockReturnValue({
       data: {
         session: {
@@ -144,14 +163,11 @@ describe("HeaderProfileSectionClient", () => {
       },
     });
 
-    render(
-      <HeaderProfileSectionClient
-        sessionUser={sessionUser}
-        members={members}
-        activeOrganizationId="org-a"
-        accountSummary={accountSummary}
-      />,
-    );
+    await renderProfileSection({
+      sessionUser,
+      members,
+      activeOrganizationId: "org-a",
+    });
 
     expect(headerWorkspaceSwitchMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -161,19 +177,16 @@ describe("HeaderProfileSectionClient", () => {
     );
   });
 
-  it("falls back to the server active organization when client session is unavailable", () => {
+  it("falls back to the server active organization when client session is unavailable", async () => {
     useSessionMock.mockReturnValue({
       data: null,
     });
 
-    render(
-      <HeaderProfileSectionClient
-        sessionUser={sessionUser}
-        members={members}
-        activeOrganizationId="org-a"
-        accountSummary={accountSummary}
-      />,
-    );
+    await renderProfileSection({
+      sessionUser,
+      members,
+      activeOrganizationId: "org-a",
+    });
 
     expect(headerWorkspaceSwitchMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -182,7 +195,7 @@ describe("HeaderProfileSectionClient", () => {
     );
   });
 
-  it("shows personal account from client session when active organization is null", () => {
+  it("shows personal account from client session when active organization is null", async () => {
     useSessionMock.mockReturnValue({
       data: {
         session: {
@@ -191,14 +204,11 @@ describe("HeaderProfileSectionClient", () => {
       },
     });
 
-    render(
-      <HeaderProfileSectionClient
-        sessionUser={sessionUser}
-        members={members}
-        activeOrganizationId="org-a"
-        accountSummary={accountSummary}
-      />,
-    );
+    await renderProfileSection({
+      sessionUser,
+      members,
+      activeOrganizationId: "org-a",
+    });
 
     expect(headerWorkspaceSwitchMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -208,7 +218,7 @@ describe("HeaderProfileSectionClient", () => {
     );
   });
 
-  it("keeps the server active organization visible while a switch is pending", () => {
+  it("keeps the server active organization visible while a switch is pending", async () => {
     useSessionMock.mockReturnValue({
       data: {
         session: {
@@ -221,14 +231,11 @@ describe("HeaderProfileSectionClient", () => {
       handleSelectWorkspace: vi.fn(),
     });
 
-    render(
-      <HeaderProfileSectionClient
-        sessionUser={sessionUser}
-        members={members}
-        activeOrganizationId="org-a"
-        accountSummary={accountSummary}
-      />,
-    );
+    await renderProfileSection({
+      sessionUser,
+      members,
+      activeOrganizationId: "org-a",
+    });
 
     expect(headerWorkspaceSwitchMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -238,7 +245,7 @@ describe("HeaderProfileSectionClient", () => {
     );
   });
 
-  it("mounts the mobile account control after the bell with admin settings", () => {
+  it("mounts the mobile account control after the bell with admin settings", async () => {
     useSessionMock.mockReturnValue({
       data: {
         session: {
@@ -247,14 +254,11 @@ describe("HeaderProfileSectionClient", () => {
       },
     });
 
-    render(
-      <HeaderProfileSectionClient
-        sessionUser={sessionUser}
-        members={members}
-        activeOrganizationId="org-a"
-        accountSummary={accountSummary}
-      />,
-    );
+    await renderProfileSection({
+      sessionUser,
+      members,
+      activeOrganizationId: "org-a",
+    });
 
     expect(headerAccountControlMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -267,5 +271,33 @@ describe("HeaderProfileSectionClient", () => {
         }),
       }),
     );
+  });
+
+  it("shows workspace switch while account summary is still pending", async () => {
+    useSessionMock.mockReturnValue({
+      data: {
+        session: {
+          activeOrganizationId: "org-a",
+        },
+      },
+    });
+
+    await act(async () => {
+      render(
+        <HeaderProfileSectionClient
+          sessionUser={sessionUser}
+          members={members}
+          activeOrganizationId="org-a"
+          accountSummaryPromise={new Promise<HeaderAccountSummary>(() => {})}
+        />,
+      );
+    });
+
+    expect(headerWorkspaceSwitchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeOrganizationId: "org-a",
+      }),
+    );
+    expect(headerAccountControlMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/components/header/header-profile-section.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { SessionUser } from "@sokosumi/utils";
+import { Suspense, use } from "react";
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
 import { useSession } from "@/lib/auth/auth.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
@@ -29,14 +30,61 @@ interface HeaderProfileSectionClientProps {
   sessionUser: SessionUser;
   members: MemberWithOrganization[];
   activeOrganizationId: string | null;
-  accountSummary: HeaderAccountSummary;
+  accountSummaryPromise: Promise<HeaderAccountSummary>;
+}
+
+function HeaderAccountControlSkeleton() {
+  return (
+    <div
+      className="bg-muted ml-0.5 size-8 animate-pulse rounded-full md:hidden"
+      aria-hidden
+    />
+  );
+}
+
+interface HeaderAccountControlSlotProps {
+  sessionUser: SessionUser;
+  members: MemberWithOrganization[];
+  activeOrganizationId: string | null;
+  accountSummaryPromise: Promise<HeaderAccountSummary>;
+}
+
+function HeaderAccountControlSlot({
+  sessionUser,
+  members,
+  activeOrganizationId,
+  accountSummaryPromise,
+}: HeaderAccountControlSlotProps) {
+  const accountSummary = use(accountSummaryPromise);
+
+  return (
+    <HeaderAccountControl
+      className="ml-0.5 md:hidden"
+      sessionUser={sessionUser}
+      planName={accountSummary.planName}
+      totalCredits={accountSummary.totalCredits}
+      extraCredits={accountSummary.extraCredits}
+      creditUsage={accountSummary.creditUsage}
+      subscriptionPeriodEndMs={accountSummary.subscriptionPeriodEndMs}
+      currentTimestampMs={accountSummary.currentTimestampMs}
+      lowCreditsThreshold={accountSummary.lowCreditsThreshold}
+      buyCreditsLabel={accountSummary.buyCreditsLabel}
+      buyCreditsPath={accountSummary.buyCreditsPath}
+      mobileAdminSettings={{
+        adminMenuEnabled: accountSummary.adminMenuEnabled,
+        members,
+        activeOrganizationId,
+        showDeveloperVendors: accountSummary.showDeveloperVendors,
+      }}
+    />
+  );
 }
 
 export default function HeaderProfileSectionClient({
   sessionUser,
   members,
   activeOrganizationId: serverActiveOrganizationId,
-  accountSummary,
+  accountSummaryPromise,
 }: HeaderProfileSectionClientProps) {
   const { data: clientSession } = useSession();
   const { isPending, handleSelectWorkspace } = useWorkspaceSwitcher();
@@ -70,25 +118,14 @@ export default function HeaderProfileSectionClient({
         onSelectWorkspace={handleSelectWorkspace}
       />
       <HeaderNotificationBell />
-      <HeaderAccountControl
-        className="ml-0.5 md:hidden"
-        sessionUser={sessionUser}
-        planName={accountSummary.planName}
-        totalCredits={accountSummary.totalCredits}
-        extraCredits={accountSummary.extraCredits}
-        creditUsage={accountSummary.creditUsage}
-        subscriptionPeriodEndMs={accountSummary.subscriptionPeriodEndMs}
-        currentTimestampMs={accountSummary.currentTimestampMs}
-        lowCreditsThreshold={accountSummary.lowCreditsThreshold}
-        buyCreditsLabel={accountSummary.buyCreditsLabel}
-        buyCreditsPath={accountSummary.buyCreditsPath}
-        mobileAdminSettings={{
-          adminMenuEnabled: accountSummary.adminMenuEnabled,
-          members,
-          activeOrganizationId,
-          showDeveloperVendors: accountSummary.showDeveloperVendors,
-        }}
-      />
+      <Suspense fallback={<HeaderAccountControlSkeleton />}>
+        <HeaderAccountControlSlot
+          sessionUser={sessionUser}
+          members={members}
+          activeOrganizationId={activeOrganizationId}
+          accountSummaryPromise={accountSummaryPromise}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/components/header/header-profile-section.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.tsx
@@ -10,7 +10,9 @@ import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 import { userService } from "@/lib/services";
 import { resolvePlanName } from "@/lib/utils/plan-label";
 
-import HeaderProfileSectionClient from "./header-profile-section.client";
+import HeaderProfileSectionClient, {
+  type HeaderAccountSummary,
+} from "./header-profile-section.client";
 
 interface HeaderProfileSectionProps {
   session: Session;
@@ -43,26 +45,17 @@ export default function HeaderProfileSection({
   );
 }
 
-async function HeaderProfileSectionInner({
-  session,
-  adminMenuEnabled,
-}: HeaderProfileSectionProps) {
-  const activeOrganizationId = session.session.activeOrganizationId ?? null;
+async function loadHeaderAccountSummary(
+  adminMenuEnabled: boolean,
+): Promise<HeaderAccountSummary> {
   const lowCreditsThreshold =
     getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
 
-  const tPlanPromise = getTranslations("App.Header.Plan");
-  const membersPromise = userService
-    .getMyMembersWithOrganizations()
-    .catch(() => [] as MemberWithOrganization[]);
-  const creditsPromise = getCachedMyCredits();
-
-  const [tPlan, members, { showVendors: showDeveloperVendors }, creditsResult] =
+  const [tPlan, { showVendors: showDeveloperVendors }, creditsResult] =
     await Promise.all([
-      tPlanPromise,
-      membersPromise,
+      getTranslations("App.Header.Plan"),
       getDeveloperVendorAdminAccess(),
-      creditsPromise,
+      getCachedMyCredits(),
     ]);
 
   const creditsData = creditsResult?.data.credits ?? null;
@@ -78,24 +71,40 @@ async function HeaderProfileSectionInner({
     : null;
   const planName = await resolvePlanName(planForLabel);
 
+  return {
+    planName,
+    totalCredits: creditsData?.total ?? null,
+    extraCredits: creditsData?.buffer ?? null,
+    creditUsage: resolveCreditUsage(creditsData),
+    subscriptionPeriodEndMs,
+    currentTimestampMs,
+    lowCreditsThreshold,
+    buyCreditsLabel: tPlan("getMoreCredits"),
+    buyCreditsPath,
+    adminMenuEnabled,
+    showDeveloperVendors,
+  };
+}
+
+async function HeaderProfileSectionInner({
+  session,
+  adminMenuEnabled,
+}: HeaderProfileSectionProps) {
+  const activeOrganizationId = session.session.activeOrganizationId ?? null;
+
+  // Start account-summary work immediately, but only await members here so
+  // desktop workspace switch + notification bell are not blocked by credits.
+  const accountSummaryPromise = loadHeaderAccountSummary(adminMenuEnabled);
+  const members = await userService
+    .getMyMembersWithOrganizations()
+    .catch(() => [] as MemberWithOrganization[]);
+
   return (
     <HeaderProfileSectionClient
       sessionUser={session.user}
       members={members}
       activeOrganizationId={activeOrganizationId}
-      accountSummary={{
-        planName,
-        totalCredits: creditsData?.total ?? null,
-        extraCredits: creditsData?.buffer ?? null,
-        creditUsage: resolveCreditUsage(creditsData),
-        subscriptionPeriodEndMs,
-        currentTimestampMs,
-        lowCreditsThreshold,
-        buyCreditsLabel: tPlan("getMoreCredits"),
-        buyCreditsPath,
-        adminMenuEnabled,
-        showDeveloperVendors,
-      }}
+      accountSummaryPromise={accountSummaryPromise}
     />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Desktop workspace switch and notification bell no longer wait on credits / vendor / plan data that only the mobile `HeaderAccountControl` needs.

- Outer profile section awaits members only, then paints workspace switch + bell
- Account summary starts in parallel and streams via `use()` + nested Suspense (same pattern as purchase-success coworker row)
- Mobile avatar shows a small skeleton until summary resolves

## Verification

- `pnpm --filter web test src/app/(app)/components/header/__tests__/header-profile-section.client.test.tsx`
- Pre-commit: `pnpm check` + `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b984318-db22-40ea-9348-0ea81bce48d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b984318-db22-40ea-9348-0ea81bce48d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

