### PR TITLE
fix(chat): stop thread parent duplicating on reaction

### DIFF
--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -546,11 +546,14 @@ export function RoomsClient({
   }, [streamOverlayMessages, threadParentMessage]);
 
   const displayThreadMessages = useMemo(() => {
-    return mergeMessagesWithStreamOverlay(
-      threadMessages,
-      threadStreamOverlayMessages,
-    );
-  }, [threadMessages, threadStreamOverlayMessages]);
+    // Defense: parent is rendered above the divider — never as a reply row.
+    const parentId = threadParentMessage?.id;
+    const replies =
+      parentId == null
+        ? threadMessages
+        : threadMessages.filter((message) => message.id !== parentId);
+    return mergeMessagesWithStreamOverlay(replies, threadStreamOverlayMessages);
+  }, [threadMessages, threadStreamOverlayMessages, threadParentMessage?.id]);
 
   // Draft coworker DM stashes text then navigates — auto-stream once room opens.
   // Keep sessionStorage until stream actually starts so Strict Mode remount
@@ -1041,11 +1044,19 @@ export function RoomsClient({
         ),
       );
     });
-    setThreadMessages((current) =>
-      current.map((message) =>
-        message.id === updatedMessage.id ? updatedMessage : message,
-      ),
-    );
+    // Parent lives in threadParentMessage only — never in the replies list.
+    // Purge any prior leak (e.g. pre-fix Ably merge of the root).
+    if (isTopLevelChatRoomMessage(updatedMessage)) {
+      setThreadMessages((current) =>
+        current.filter((message) => message.id !== updatedMessage.id),
+      );
+    } else {
+      setThreadMessages((current) =>
+        current.map((message) =>
+          message.id === updatedMessage.id ? updatedMessage : message,
+        ),
+      );
+    }
     setThreadParentMessage((current) =>
       current?.id === updatedMessage.id ? updatedMessage : current,
     );

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
@@ -62,13 +62,15 @@ describe("shouldApplyRealtimeMessageToOpenThread", () => {
     ).toBe(false);
   });
 
-  it("accepts the open thread root itself", () => {
+  // Parent is rendered from threadParentMessage, not the replies list.
+  // Merging the root into threadMessages duplicates it (e.g. after reaction).
+  it("rejects the open thread root itself (parent is not a reply)", () => {
     expect(
       shouldApplyRealtimeMessageToOpenThread(
         { id: "parent-1", parentMessageId: null },
         "parent-1",
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("accepts replies under the open thread root", () => {
@@ -103,7 +105,9 @@ describe("routeRealtimeChatRoomMessage", () => {
     });
   });
 
-  it("routes a top-level open-thread parent to room and thread", () => {
+  // Reaction/edit on open-thread parent: room timeline + parent row only.
+  // Never mergeIntoOpenThread — that list is replies only.
+  it("routes open-thread parent to room only, not reply list", () => {
     expect(
       routeRealtimeChatRoomMessage(
         { id: "parent-1", parentMessageId: null },
@@ -111,7 +115,7 @@ describe("routeRealtimeChatRoomMessage", () => {
       ),
     ).toEqual({
       mergeIntoRoomTimeline: true,
-      mergeIntoOpenThread: true,
+      mergeIntoOpenThread: false,
     });
   });
 

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -5,6 +5,9 @@
  * Thread replies belong only in the open thread panel. Realtime must not
  * merge replies into room state — otherwise a send from the thread panel
  * appears in both the room and the thread.
+ *
+ * Open-thread parent updates (reaction/edit) update `threadParentMessage` and
+ * the room timeline — never the replies array (that would duplicate the root).
  */
 
 export function isTopLevelChatRoomMessage(message: {
@@ -28,7 +31,13 @@ export function isReplyUnderThreadParent(
   return message.parentMessageId === parentMessageId;
 }
 
-/** Whether realtime should merge into the currently open thread panel. */
+/**
+ * Whether realtime should merge into the open thread *replies* list.
+ *
+ * Replies only. The thread root is rendered from `threadParentMessage` and
+ * must never enter the replies array — otherwise a parent reaction/edit Ably
+ * event duplicates the root under the divider (SOK thread-parent reaction bug).
+ */
 export function shouldApplyRealtimeMessageToOpenThread(
   message: {
     id: string;
@@ -39,16 +48,16 @@ export function shouldApplyRealtimeMessageToOpenThread(
   if (!openThreadParentId) {
     return false;
   }
-  return (
-    message.id === openThreadParentId ||
-    isReplyUnderThreadParent(message, openThreadParentId)
-  );
+  return isReplyUnderThreadParent(message, openThreadParentId);
 }
 
 export interface RealtimeChatRoomMessageRoute {
   /** Main room list: top-level messages only. */
   mergeIntoRoomTimeline: boolean;
-  /** Open thread panel: parent row or its direct replies. */
+  /**
+   * Open thread replies list only (never the parent row).
+   * Parent updates use `threadParentMessage` / room timeline separately.
+   */
   mergeIntoOpenThread: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Open-thread parent Ably events (reaction/edit) no longer merge into the replies list — only replies do.
- Parent updates still apply via `threadParentMessage` and the room timeline.
- Defense: purge leaked parent ids from `threadMessages` and filter them out of `displayThreadMessages`.

## Problem
Reacting on the thread root duplicated that message under the divider (header row + first reply).

## Root cause
`shouldApplyRealtimeMessageToOpenThread` treated the open parent as mergeable into `threadMessages`. Parent is rendered separately from `threadParentMessage`.

## Test plan
- [x] Unit: scope routing rejects parent for `mergeIntoOpenThread`
- [x] Unit: Ably island wiring still present
- [ ] Manual: open thread → react on root → single parent with reaction, no duplicate under divider
- [ ] Manual: edit parent content with thread open → one parent row, no dupe
- [ ] Manual: react on a reply still works in-place