### PR TITLE
feat(chat): type Ably chat_room_message with eventType

### DIFF
--- a/apps/core/src/helpers/chat-room-message-realtime.test.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.test.ts
@@ -83,7 +83,7 @@ describe("publishChatRoomMessageRealtime", () => {
       { userId: "user_b" },
     ]);
 
-    await publishChatRoomMessageRealtime(baseMessage as never);
+    await publishChatRoomMessageRealtime(baseMessage as never, "create");
 
     expect(findManyMembersMock).toHaveBeenCalledWith({
       where: { roomId: baseMessage.roomId },
@@ -97,6 +97,7 @@ describe("publishChatRoomMessageRealtime", () => {
         roomId: baseMessage.roomId,
         forUser: "user_a",
       },
+      eventType: "create",
     });
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
       userId: "user_b",
@@ -105,6 +106,7 @@ describe("publishChatRoomMessageRealtime", () => {
         roomId: baseMessage.roomId,
         forUser: "user_b",
       },
+      eventType: "create",
     });
   });
 
@@ -113,7 +115,7 @@ describe("publishChatRoomMessageRealtime", () => {
     publishChatRoomMessageEventMock.mockRejectedValue(new Error("ably down"));
 
     await expect(
-      publishChatRoomMessageRealtime(baseMessage as never),
+      publishChatRoomMessageRealtime(baseMessage as never, "create"),
     ).resolves.toBeUndefined();
   });
 
@@ -131,7 +133,7 @@ describe("publishChatRoomMessageRealtime", () => {
     );
 
     await expect(
-      publishChatRoomMessageRealtime(baseMessage as never),
+      publishChatRoomMessageRealtime(baseMessage as never, "reaction"),
     ).resolves.toBeUndefined();
 
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledTimes(2);
@@ -142,6 +144,7 @@ describe("publishChatRoomMessageRealtime", () => {
         roomId: baseMessage.roomId,
         forUser: "user_b",
       },
+      eventType: "reaction",
     });
   });
 });
@@ -164,7 +167,7 @@ describe("publishChatRoomMessageRealtimeById", () => {
     findUniqueMessageMock.mockResolvedValue(baseMessage);
     findManyMembersMock.mockResolvedValue([{ userId: "user_a" }]);
 
-    await publishChatRoomMessageRealtimeById(baseMessage.id);
+    await publishChatRoomMessageRealtimeById(baseMessage.id, "unfurl");
 
     expect(findUniqueMessageMock).toHaveBeenCalledWith({
       where: { id: baseMessage.id },
@@ -177,13 +180,14 @@ describe("publishChatRoomMessageRealtimeById", () => {
         roomId: baseMessage.roomId,
         forUser: "user_a",
       },
+      eventType: "unfurl",
     });
   });
 
   it("no-ops when the message is missing", async () => {
     findUniqueMessageMock.mockResolvedValue(null);
 
-    await publishChatRoomMessageRealtimeById(baseMessage.id);
+    await publishChatRoomMessageRealtimeById(baseMessage.id, "create");
 
     expect(publishChatRoomMessageEventMock).not.toHaveBeenCalled();
   });

--- a/apps/core/src/helpers/chat-room-message-realtime.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/node";
 import type { Prisma } from "@sokosumi/database";
 
+import type { ChatRoomMessageEventType } from "@/lib/ably/chat-room-message-event-type";
 import { publishChatRoomMessageEvent } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
@@ -15,6 +16,7 @@ type ChatRoomMessageWithInclude = Prisma.ChatRoomMessageGetPayload<{
 
 export async function publishChatRoomMessageRealtime(
   message: ChatRoomMessageWithInclude,
+  eventType: ChatRoomMessageEventType,
 ): Promise<void> {
   try {
     const members = await prisma.chatRoomUserMember.findMany({
@@ -32,6 +34,7 @@ export async function publishChatRoomMessageRealtime(
         await publishChatRoomMessageEvent({
           userId,
           message: dto,
+          eventType,
         });
       }),
     );
@@ -69,6 +72,7 @@ export async function publishChatRoomMessageRealtime(
 
 export async function publishChatRoomMessageRealtimeById(
   messageId: string,
+  eventType: ChatRoomMessageEventType,
 ): Promise<void> {
   try {
     const message = await prisma.chatRoomMessage.findUnique({
@@ -78,7 +82,7 @@ export async function publishChatRoomMessageRealtimeById(
     if (!message) {
       return;
     }
-    await publishChatRoomMessageRealtime(message);
+    await publishChatRoomMessageRealtime(message, eventType);
   } catch (error) {
     console.error("Failed to load chat room message for Ably publish:", error);
     Sentry.captureException(error, {

--- a/apps/core/src/helpers/chat-room-message-realtime.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.ts
@@ -1,7 +1,8 @@
 import * as Sentry from "@sentry/node";
 import type { Prisma } from "@sokosumi/database";
 
-import type { ChatRoomMessageEventType } from "@/lib/ably/chat-room-message-event-type";
+import type { ChatRoomMessageEventType } from "@sokosumi/utils";
+
 import { publishChatRoomMessageEvent } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {

--- a/apps/core/src/helpers/persist-assistant-to-chat-room.ts
+++ b/apps/core/src/helpers/persist-assistant-to-chat-room.ts
@@ -133,7 +133,7 @@ export async function persistAssistantToChatRoom(params: {
       responseId,
     );
     if (existing) {
-      await publishChatRoomMessageRealtimeById(existing.id);
+      await publishChatRoomMessageRealtimeById(existing.id, "create");
       return { id: existing.id };
     }
   }
@@ -166,7 +166,7 @@ export async function persistAssistantToChatRoom(params: {
       });
       return message;
     });
-    await publishChatRoomMessageRealtimeById(created.id);
+    await publishChatRoomMessageRealtimeById(created.id, "create");
     return { id: created.id };
   } catch (error) {
     if (!responseId || !isPrismaUniqueViolation(error)) {
@@ -178,7 +178,7 @@ export async function persistAssistantToChatRoom(params: {
       responseId,
     );
     if (raced) {
-      await publishChatRoomMessageRealtimeById(raced.id);
+      await publishChatRoomMessageRealtimeById(raced.id, "create");
       return { id: raced.id };
     }
     throw error;
@@ -225,7 +225,7 @@ export async function persistUserMessageToChatRoom(params: {
   if (clientId) {
     const existing = await findUserByClientMessageId(roomId, clientId);
     if (existing) {
-      await publishChatRoomMessageRealtimeById(existing.id);
+      await publishChatRoomMessageRealtimeById(existing.id, "create");
       return { id: existing.id };
     }
   }
@@ -258,7 +258,7 @@ export async function persistUserMessageToChatRoom(params: {
       return message;
     });
 
-    await publishChatRoomMessageRealtimeById(created.id);
+    await publishChatRoomMessageRealtimeById(created.id, "create");
     return { id: created.id };
   } catch (error) {
     if (!clientId || !isPrismaUniqueViolation(error)) {
@@ -267,7 +267,7 @@ export async function persistUserMessageToChatRoom(params: {
     // Interactive tx aborted after failed create — re-read on root client.
     const raced = await findUserByClientMessageId(roomId, clientId);
     if (raced) {
-      await publishChatRoomMessageRealtimeById(raced.id);
+      await publishChatRoomMessageRealtimeById(raced.id, "create");
       return { id: raced.id };
     }
     throw error;

--- a/apps/core/src/lib/ably/chat-room-message-event-type.ts
+++ b/apps/core/src/lib/ably/chat-room-message-event-type.ts
@@ -1,0 +1,16 @@
+/**
+ * Stable intent for Ably `chat_room_message` publishes.
+ * Full message DTO is still the payload body; this field removes client
+ * guesswork about create vs edit vs reaction vs unfurl (SOK-736).
+ */
+export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
+  "create",
+  "update",
+  "delete",
+  "reaction",
+  "unfurl",
+  "mention_status",
+] as const;
+
+export type ChatRoomMessageEventType =
+  (typeof CHAT_ROOM_MESSAGE_EVENT_TYPES)[number];

--- a/apps/core/src/lib/ably/publish.test.ts
+++ b/apps/core/src/lib/ably/publish.test.ts
@@ -124,9 +124,13 @@ describe("publishChatRoomMessageEvent", () => {
     await publishChatRoomMessageEvent({
       userId: "user_123",
       message,
+      eventType: "create",
     });
 
     expect(getMock).toHaveBeenCalledWith("chat_rooms:all:user_user_123");
-    expect(publishMock).toHaveBeenCalledWith("chat_room_message", { message });
+    expect(publishMock).toHaveBeenCalledWith("chat_room_message", {
+      eventType: "create",
+      message,
+    });
   });
 });

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -9,6 +9,7 @@ import {
 
 import type { ChatRoomMessage } from "@/schemas/chat-room.schema";
 
+import type { ChatRoomMessageEventType } from "./chat-room-message-event-type";
 import { getRestClient } from "./client";
 
 interface JobStatusData {
@@ -92,13 +93,15 @@ export async function publishNotificationEvent({
 interface PublishChatRoomMessageEventInput {
   userId: string;
   message: ChatRoomMessage;
+  eventType: ChatRoomMessageEventType;
 }
 
 export async function publishChatRoomMessageEvent({
   userId,
   message,
+  eventType,
 }: PublishChatRoomMessageEventInput) {
   const client = getRestClient();
   const channel = client.channels.get(makeUserChatRoomsChannelName(userId));
-  await channel.publish("chat_room_message", { message });
+  await channel.publish("chat_room_message", { eventType, message });
 }

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -1,5 +1,6 @@
 import { NotificationKind } from "@sokosumi/database";
 import {
+  type ChatRoomMessageEventType,
   makeAgentJobsChannelName,
   makeUserChatRoomsChannelName,
   makeUserNotificationsChannelName,
@@ -9,7 +10,6 @@ import {
 
 import type { ChatRoomMessage } from "@/schemas/chat-room.schema";
 
-import type { ChatRoomMessageEventType } from "./chat-room-message-event-type";
 import { getRestClient } from "./client";
 
 interface JobStatusData {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.test.ts
@@ -228,6 +228,7 @@ describe("DELETE /chats/rooms/{id}/members/me", () => {
     );
     expect(publishChatRoomMessageRealtimeMock).toHaveBeenCalledWith(
       MEMBERSHIP_MESSAGE,
+      "create",
     );
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/delete.ts
@@ -141,7 +141,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     });
 
     for (const message of statusMessages) {
-      await publishChatRoomMessageRealtime(message);
+      await publishChatRoomMessageRealtime(message, "create");
     }
 
     return ok(c, leftChatRoomSchema.parse(result));

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.test.ts
@@ -225,6 +225,7 @@ describe("POST /chats/rooms/{id}/members/me", () => {
     );
     expect(publishChatRoomMessageRealtimeMock).toHaveBeenCalledWith(
       MEMBERSHIP_MESSAGE,
+      "create",
     );
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/members/me/post.ts
@@ -156,7 +156,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     });
 
     for (const message of statusMessages) {
-      await publishChatRoomMessageRealtime(message);
+      await publishChatRoomMessageRealtime(message, "create");
     }
 
     return ok(c, chatRoomSchema.parse(mapChatRoom(room, userContext.userId)));

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/delete.ts
@@ -123,7 +123,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       return updated;
     });
 
-    await publishChatRoomMessageRealtime(message);
+    await publishChatRoomMessageRealtime(message, "delete");
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/patch.ts
@@ -121,7 +121,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       });
     });
 
-    await publishChatRoomMessageRealtime(message);
+    await publishChatRoomMessageRealtime(message, "update");
 
     if (contentChanged) {
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/[messageId]/reactions/post.ts
@@ -130,7 +130,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       });
     });
 
-    await publishChatRoomMessageRealtime(message);
+    await publishChatRoomMessageRealtime(message, "reaction");
 
     return ok(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -123,7 +123,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         return message;
       });
 
-      await publishChatRoomMessageRealtime(message);
+      await publishChatRoomMessageRealtime(message, "create");
 
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
 
@@ -329,7 +329,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           "clientMessageId already used by another sender in this room",
         );
       }
-      await publishChatRoomMessageRealtime(raced);
+      await publishChatRoomMessageRealtime(raced, "create");
 
       return created(
         c,
@@ -390,7 +390,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
     }
 
-    await publishChatRoomMessageRealtime(message);
+    await publishChatRoomMessageRealtime(message, "create");
 
     return created(
       c,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
@@ -258,7 +258,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       });
 
       for (const message of statusMessages) {
-        await publishChatRoomMessageRealtime(message);
+        await publishChatRoomMessageRealtime(message, "create");
       }
 
       return ok(

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -462,9 +462,11 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
   if (publishedMessageIds) {
     await publishChatRoomMessageRealtimeById(
       publishedMessageIds.responseMessageId,
+      "create",
     );
     await publishChatRoomMessageRealtimeById(
       publishedMessageIds.sourceMessageId,
+      "mention_status",
     );
   }
 }

--- a/apps/core/src/services/chat-room-message-unfurl.service.test.ts
+++ b/apps/core/src/services/chat-room-message-unfurl.service.test.ts
@@ -128,7 +128,7 @@ describe("scheduleChatRoomMessageUnfurls", () => {
       },
     });
     expect(deleteMetadataKeysMock).not.toHaveBeenCalled();
-    expect(publishByIdMock).toHaveBeenCalledWith(MESSAGE_ID);
+    expect(publishByIdMock).toHaveBeenCalledWith(MESSAGE_ID, "unfurl");
   });
 
   it("skips persist when content changed during scrape (stale)", async () => {
@@ -202,7 +202,7 @@ describe("scheduleChatRoomMessageUnfurls", () => {
       contentMustEqual: "no urls left",
     });
     expect(mergeMetadataKeysMock).not.toHaveBeenCalled();
-    expect(publishByIdMock).toHaveBeenCalledWith(MESSAGE_ID);
+    expect(publishByIdMock).toHaveBeenCalledWith(MESSAGE_ID, "unfurl");
   });
 
   it("does not publish when atomic update matches zero rows", async () => {

--- a/apps/core/src/services/chat-room-message-unfurl.service.ts
+++ b/apps/core/src/services/chat-room-message-unfurl.service.ts
@@ -85,7 +85,7 @@ export async function scheduleChatRoomMessageUnfurls(
       return { messageId, attempted: urls.length, persisted: 0 };
     }
 
-    await publishChatRoomMessageRealtimeById(messageId);
+    await publishChatRoomMessageRealtimeById(messageId, "unfurl");
 
     return {
       messageId,

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-ably-island.test.ts
@@ -29,7 +29,7 @@ describe("RoomsClient Ably island", () => {
     expect(source).toContain("filterTopLevelChatRoomMessages");
     expect(source).toContain("isReplyUnderThreadParent");
     expect(source).toMatch(
-      /const route = routeRealtimeChatRoomMessage\(\s*message,\s*threadParentMessageIdRef\.current,\s*\)/,
+      /const route = routeRealtimeChatRoomMessage\(\s*message,\s*threadParentMessageIdRef\.current,\s*event\.eventType,\s*\)/,
     );
     expect(source).toMatch(
       /if \(route\.mergeIntoRoomTimeline\) \{\s*setMessagesState/,

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -467,6 +467,7 @@ export function RoomsClient({
       const route = routeRealtimeChatRoomMessage(
         message,
         threadParentMessageIdRef.current,
+        event.eventType,
       );
       if (route.mergeIntoRoomTimeline) {
         setMessagesState((current) =>

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
@@ -1,6 +1,5 @@
+import type { ChatRoomMessageEventType } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
-
-import type { ChatRoomMessageEventType } from "@/lib/ably/schema";
 
 import {
   filterTopLevelChatRoomMessages,

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import type { ChatRoomMessageEventType } from "@/lib/ably/schema";
+
 import {
-  type ChatRoomMessageEventType,
   filterTopLevelChatRoomMessages,
   isReplyUnderThreadParent,
   isTopLevelChatRoomMessage,

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-room-message-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  type ChatRoomMessageEventType,
   filterTopLevelChatRoomMessages,
   isReplyUnderThreadParent,
   isTopLevelChatRoomMessage,
@@ -93,11 +94,18 @@ describe("shouldApplyRealtimeMessageToOpenThread", () => {
 });
 
 describe("routeRealtimeChatRoomMessage", () => {
+  const landingEventTypes: ChatRoomMessageEventType[] = [
+    "create",
+    "update",
+    "reaction",
+  ];
+
   it("routes a top-level message to the room only when no thread is open", () => {
     expect(
       routeRealtimeChatRoomMessage(
         { id: "msg-1", parentMessageId: null },
         null,
+        "create",
       ),
     ).toEqual({
       mergeIntoRoomTimeline: true,
@@ -107,35 +115,44 @@ describe("routeRealtimeChatRoomMessage", () => {
 
   // Reaction/edit on open-thread parent: room timeline + parent row only.
   // Never mergeIntoOpenThread — that list is replies only.
-  it("routes open-thread parent to room only, not reply list", () => {
-    expect(
-      routeRealtimeChatRoomMessage(
-        { id: "parent-1", parentMessageId: null },
-        "parent-1",
-      ),
-    ).toEqual({
-      mergeIntoRoomTimeline: true,
-      mergeIntoOpenThread: false,
-    });
-  });
+  it.each(landingEventTypes)(
+    "routes open-thread parent to room only, not reply list (%s)",
+    (eventType) => {
+      expect(
+        routeRealtimeChatRoomMessage(
+          { id: "parent-1", parentMessageId: null },
+          "parent-1",
+          eventType,
+        ),
+      ).toEqual({
+        mergeIntoRoomTimeline: true,
+        mergeIntoOpenThread: false,
+      });
+    },
+  );
 
-  it("routes a thread reply only to the open thread, never the room", () => {
-    expect(
-      routeRealtimeChatRoomMessage(
-        { id: "reply-1", parentMessageId: "parent-1" },
-        "parent-1",
-      ),
-    ).toEqual({
-      mergeIntoRoomTimeline: false,
-      mergeIntoOpenThread: true,
-    });
-  });
+  it.each(landingEventTypes)(
+    "routes a thread reply only to the open thread, never the room (%s)",
+    (eventType) => {
+      expect(
+        routeRealtimeChatRoomMessage(
+          { id: "reply-1", parentMessageId: "parent-1" },
+          "parent-1",
+          eventType,
+        ),
+      ).toEqual({
+        mergeIntoRoomTimeline: false,
+        mergeIntoOpenThread: true,
+      });
+    },
+  );
 
   it("routes a reply under a closed/other thread nowhere", () => {
     expect(
       routeRealtimeChatRoomMessage(
         { id: "reply-1", parentMessageId: "parent-1" },
         null,
+        "create",
       ),
     ).toEqual({
       mergeIntoRoomTimeline: false,
@@ -145,6 +162,7 @@ describe("routeRealtimeChatRoomMessage", () => {
       routeRealtimeChatRoomMessage(
         { id: "reply-1", parentMessageId: "parent-1" },
         "other-parent",
+        "update",
       ),
     ).toEqual({
       mergeIntoRoomTimeline: false,

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -8,7 +8,38 @@
  *
  * Open-thread parent updates (reaction/edit) update `threadParentMessage` and
  * the room timeline — never the replies array (that would duplicate the root).
+ *
+ * ## Realtime routing table (SOK-736)
+ *
+ * Ably `chat_room_message` carries `eventType` + full message DTO. Landing
+ * (where the upsert goes) is decided by parent vs reply + open thread id;
+ * `eventType` documents mutation intent (create/update/reaction/…) so clients
+ * do not guess from DTO shape alone. v1 apply is still full-DTO upsert for
+ * every type.
+ *
+ * | eventType (any) | message shape              | open thread        | room timeline | open thread replies | thread parent row* |
+ * |-----------------|----------------------------|--------------------|---------------|---------------------|--------------------|
+ * | *               | top-level (`parent` null)  | none / other       | yes           | no                  | no                 |
+ * | *               | top-level (`parent` null)  | this message id    | yes           | **no** (not reply)  | yes (id match)     |
+ * | *               | reply under open parent    | that parent        | no            | yes                 | no                 |
+ * | *               | reply under other parent   | none / other       | no            | no                  | no                 |
+ *
+ * \* Parent row updates are `setThreadParentMessage` when `current.id === message.id`,
+ * not via `mergeIntoOpenThread`.
  */
+
+/** Mirrors Core Ably `eventType` on `chat_room_message` publishes. */
+export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
+  "create",
+  "update",
+  "delete",
+  "reaction",
+  "unfurl",
+  "mention_status",
+] as const;
+
+export type ChatRoomMessageEventType =
+  (typeof CHAT_ROOM_MESSAGE_EVENT_TYPES)[number];
 
 export function isTopLevelChatRoomMessage(message: {
   parentMessageId?: string | null;
@@ -64,6 +95,10 @@ export interface RealtimeChatRoomMessageRoute {
 /**
  * Decide where a realtime chat-room message should land.
  * Single seam for rooms-client Ably handling — unit-test this, not string grep.
+ *
+ * `eventType` is part of the contract (validated upstream). Landing for v1 is
+ * parent/reply based for every type; keep the param so tests lock create /
+ * update / reaction matrices and future type-specific apply can extend here.
  */
 export function routeRealtimeChatRoomMessage(
   message: {
@@ -71,6 +106,7 @@ export function routeRealtimeChatRoomMessage(
     parentMessageId?: string | null;
   },
   openThreadParentId: string | null,
+  _eventType: ChatRoomMessageEventType,
 ): RealtimeChatRoomMessageRoute {
   return {
     mergeIntoRoomTimeline: isTopLevelChatRoomMessage(message),

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -28,7 +28,7 @@
  * not via `mergeIntoOpenThread`.
  */
 
-import type { ChatRoomMessageEventType } from "@/lib/ably/schema";
+import type { ChatRoomMessageEventType } from "@sokosumi/utils";
 
 export function isTopLevelChatRoomMessage(message: {
   parentMessageId?: string | null;

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -28,18 +28,7 @@
  * not via `mergeIntoOpenThread`.
  */
 
-/** Mirrors Core Ably `eventType` on `chat_room_message` publishes. */
-export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
-  "create",
-  "update",
-  "delete",
-  "reaction",
-  "unfurl",
-  "mention_status",
-] as const;
-
-export type ChatRoomMessageEventType =
-  (typeof CHAT_ROOM_MESSAGE_EVENT_TYPES)[number];
+import type { ChatRoomMessageEventType } from "@/lib/ably/schema";
 
 export function isTopLevelChatRoomMessage(message: {
   parentMessageId?: string | null;
@@ -106,8 +95,10 @@ export function routeRealtimeChatRoomMessage(
     parentMessageId?: string | null;
   },
   openThreadParentId: string | null,
-  _eventType: ChatRoomMessageEventType,
+  eventType: ChatRoomMessageEventType,
 ): RealtimeChatRoomMessageRoute {
+  // Contract param: Ably schema validates; v1 landing is parent/reply only.
+  void eventType;
   return {
     mergeIntoRoomTimeline: isTopLevelChatRoomMessage(message),
     mergeIntoOpenThread: shouldApplyRealtimeMessageToOpenThread(

--- a/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
+++ b/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
@@ -1,0 +1,55 @@
+import { CHAT_ROOM_MESSAGE_EVENT_TYPES } from "@sokosumi/utils";
+import { describe, expect, it } from "vitest";
+
+import { chatRoomMessageEventDataSchema } from "../schema";
+
+const baseMessage = {
+  id: "msg-1",
+  roomId: "room-1",
+  parentMessageId: null,
+  content: "hello",
+  createdAt: "2026-08-06T12:00:00.000Z",
+  deletedAt: null,
+  editedAt: null,
+  sender: { type: "user" },
+  mentions: [],
+  reactions: [],
+  threadReplyCount: 0,
+  threadLastReplyAt: null,
+  metadata: null,
+  quote: null,
+  membership: null,
+  unfurls: null,
+};
+
+describe("chatRoomMessageEventDataSchema", () => {
+  it.each([...CHAT_ROOM_MESSAGE_EVENT_TYPES])(
+    "accepts eventType %s with a full message DTO",
+    (eventType) => {
+      const parsed = chatRoomMessageEventDataSchema.safeParse({
+        eventType,
+        message: baseMessage,
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.eventType).toBe(eventType);
+        expect(parsed.data.message.id).toBe("msg-1");
+      }
+    },
+  );
+
+  it("rejects a missing eventType", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      message: baseMessage,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects an invalid eventType", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "not_a_real_type",
+      message: baseMessage,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -43,7 +43,22 @@ const chatRoomMessageUnfurlEventSchema = z.object({
   siteName: z.string().nullable(),
 });
 
+/** Stable Ably intent; keep in sync with Core `ChatRoomMessageEventType`. */
+export const chatRoomMessageEventTypeSchema = z.enum([
+  "create",
+  "update",
+  "delete",
+  "reaction",
+  "unfurl",
+  "mention_status",
+]);
+
+export type ChatRoomMessageEventType = z.infer<
+  typeof chatRoomMessageEventTypeSchema
+>;
+
 export const chatRoomMessageEventDataSchema = z.object({
+  eventType: chatRoomMessageEventTypeSchema,
   message: z
     .object({
       id: z.string().min(1),

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -1,3 +1,4 @@
+import { CHAT_ROOM_MESSAGE_EVENT_TYPES } from "@sokosumi/utils";
 import * as z from "zod";
 import {
   NotificationKind,
@@ -42,23 +43,6 @@ const chatRoomMessageUnfurlEventSchema = z.object({
   imageUrl: z.string().nullable(),
   siteName: z.string().nullable(),
 });
-
-/**
- * Stable Ably intent for `chat_room_message`.
- * Keep values in sync with Core `CHAT_ROOM_MESSAGE_EVENT_TYPES`
- * (`apps/core/src/lib/ably/chat-room-message-event-type.ts`).
- */
-export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
-  "create",
-  "update",
-  "delete",
-  "reaction",
-  "unfurl",
-  "mention_status",
-] as const;
-
-export type ChatRoomMessageEventType =
-  (typeof CHAT_ROOM_MESSAGE_EVENT_TYPES)[number];
 
 export const chatRoomMessageEventTypeSchema = z.enum(
   CHAT_ROOM_MESSAGE_EVENT_TYPES,

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -43,19 +43,26 @@ const chatRoomMessageUnfurlEventSchema = z.object({
   siteName: z.string().nullable(),
 });
 
-/** Stable Ably intent; keep in sync with Core `ChatRoomMessageEventType`. */
-export const chatRoomMessageEventTypeSchema = z.enum([
+/**
+ * Stable Ably intent for `chat_room_message`.
+ * Keep values in sync with Core `CHAT_ROOM_MESSAGE_EVENT_TYPES`
+ * (`apps/core/src/lib/ably/chat-room-message-event-type.ts`).
+ */
+export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
   "create",
   "update",
   "delete",
   "reaction",
   "unfurl",
   "mention_status",
-]);
+] as const;
 
-export type ChatRoomMessageEventType = z.infer<
-  typeof chatRoomMessageEventTypeSchema
->;
+export type ChatRoomMessageEventType =
+  (typeof CHAT_ROOM_MESSAGE_EVENT_TYPES)[number];
+
+export const chatRoomMessageEventTypeSchema = z.enum(
+  CHAT_ROOM_MESSAGE_EVENT_TYPES,
+);
 
 export const chatRoomMessageEventDataSchema = z.object({
   eventType: chatRoomMessageEventTypeSchema,

--- a/packages/utils/src/__tests__/chat-room-message-event-type.test.ts
+++ b/packages/utils/src/__tests__/chat-room-message-event-type.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { CHAT_ROOM_MESSAGE_EVENT_TYPES } from "../chat-room-message-event-type";
+
+describe("CHAT_ROOM_MESSAGE_EVENT_TYPES", () => {
+  it("lists the stable Ably chat_room_message intents", () => {
+    expect([...CHAT_ROOM_MESSAGE_EVENT_TYPES]).toEqual([
+      "create",
+      "update",
+      "delete",
+      "reaction",
+      "unfurl",
+      "mention_status",
+    ]);
+  });
+});

--- a/packages/utils/src/chat-room-message-event-type.ts
+++ b/packages/utils/src/chat-room-message-event-type.ts
@@ -1,7 +1,8 @@
 /**
  * Stable intent for Ably `chat_room_message` publishes.
- * Full message DTO is still the payload body; this field removes client
- * guesswork about create vs edit vs reaction vs unfurl (SOK-736).
+ * Full message DTO remains the payload body; this field is the shared
+ * publisher/consumer contract so clients do not guess create vs edit vs
+ * reaction vs unfurl (SOK-736).
  */
 export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
   "create",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,6 +39,10 @@ export {
   isOwnedUserChatRoomFileUrl,
 } from "./chat-room-file-upload.js";
 export {
+  CHAT_ROOM_MESSAGE_EVENT_TYPES,
+  type ChatRoomMessageEventType,
+} from "./chat-room-message-event-type.js";
+export {
   buildQuoteSnippet,
   buildRoomQuoteSnippetParts,
   type ChatRoomQuoteAttachment,


### PR DESCRIPTION
## Summary

- Core Ably `chat_room_message` payload now includes stable `eventType` (`create` | `update` | `delete` | `reaction` | `unfurl` | `mention_status`) on every publish.
- Web Zod schema requires `eventType`; rooms-client passes it into `routeRealtimeChatRoomMessage`.
- Documented routing table at the scope seam; unit tests cover create/update/reaction for open-thread parent vs reply (parent never enters replies list).

Closes [SOK-736](https://linear.app/masumi/issue/SOK-736/typed-ably-chat-room-message-events-reduce-client-routing)

## Spec summary

- Full message DTO retained (no partial patches).
- Landing still parent/reply based; eventType is contract + test dimension for v1.
- Out of scope: new channels, partial payloads, multi-device, fan-out redesign.

## Test plan

- [x] `pnpm --filter core check` + `pnpm core:test`
- [x] `pnpm web:check` + `pnpm web:test`
- [ ] CI green