### PR TITLE
fix(chat): tolerate Ably chat_room_message without eventType

### DIFF
--- a/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
+++ b/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
@@ -38,11 +38,25 @@ describe("chatRoomMessageEventDataSchema", () => {
     },
   );
 
-  it("rejects a missing eventType", () => {
+  it("defaults missing eventType to update (pre-SOK-736 Core publishers)", () => {
     const parsed = chatRoomMessageEventDataSchema.safeParse({
       message: baseMessage,
     });
-    expect(parsed.success).toBe(false);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.eventType).toBe("update");
+    }
+  });
+
+  it("defaults empty eventType to update", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "",
+      message: baseMessage,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.eventType).toBe("update");
+    }
   });
 
   it("rejects an invalid eventType", () => {

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -48,8 +48,19 @@ export const chatRoomMessageEventTypeSchema = z.enum(
   CHAT_ROOM_MESSAGE_EVENT_TYPES,
 );
 
+/**
+ * Rollout-safe: Core may still publish `{ message }` without `eventType` while
+ * web already requires the SOK-736 contract. Default to `update` (full DTO
+ * upsert) so room realtime does not drop events during mixed deploys.
+ * Invalid non-empty eventType values still fail validation.
+ */
+const chatRoomMessageEventTypeFieldSchema = z.preprocess(
+  (value) => (value == null || value === "" ? "update" : value),
+  chatRoomMessageEventTypeSchema,
+);
+
 export const chatRoomMessageEventDataSchema = z.object({
-  eventType: chatRoomMessageEventTypeSchema,
+  eventType: chatRoomMessageEventTypeFieldSchema,
   message: z
     .object({
       id: z.string().min(1),


### PR DESCRIPTION
## Summary

After #3684, web Zod required `eventType` on every Ably `chat_room_message`. If Core (or in-flight messages) still publish `{ message }` only, the client drops the event and logs the console error seen on the branch preview.

- Preprocess missing/empty `eventType` → `"update"` (full DTO upsert; same landing behavior).
- Still reject unknown non-empty event types.
- Tests cover legacy payload shape.

## Test plan

- [x] `pnpm --filter web test src/lib/ably/__tests__/chat-room-message-event-schema.test.ts`
- [x] `pnpm web:check`
- [ ] Preview: open chat room, send message, no Ably parse error; message appears live