### PR TITLE
feat(chat): partial Ably payloads for high-chatter message events

### DIFF
--- a/apps/core/src/helpers/chat-room-message-realtime.test.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.test.ts
@@ -73,7 +73,11 @@ describe("publishChatRoomMessageRealtime", () => {
     mapChatRoomMessageMock.mockImplementation((_message, userId: string) => ({
       id: baseMessage.id,
       roomId: baseMessage.roomId,
+      parentMessageId: null,
       forUser: userId,
+      reactions: [],
+      mentions: [],
+      unfurls: null,
     }));
   });
 
@@ -92,21 +96,29 @@ describe("publishChatRoomMessageRealtime", () => {
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledTimes(2);
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
       userId: "user_a",
+      eventType: "create",
       message: {
         id: baseMessage.id,
         roomId: baseMessage.roomId,
+        parentMessageId: null,
         forUser: "user_a",
+        reactions: [],
+        mentions: [],
+        unfurls: null,
       },
-      eventType: "create",
     });
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
       userId: "user_b",
+      eventType: "create",
       message: {
         id: baseMessage.id,
         roomId: baseMessage.roomId,
+        parentMessageId: null,
         forUser: "user_b",
+        reactions: [],
+        mentions: [],
+        unfurls: null,
       },
-      eventType: "create",
     });
   });
 
@@ -139,12 +151,119 @@ describe("publishChatRoomMessageRealtime", () => {
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledTimes(2);
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
       userId: "user_b",
-      message: {
-        id: baseMessage.id,
-        roomId: baseMessage.roomId,
-        forUser: "user_b",
-      },
       eventType: "reaction",
+      messageId: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: null,
+      patch: { reactions: [] },
+    });
+  });
+
+  it("publishes a reaction patch, not a full message DTO", async () => {
+    findManyMembersMock.mockResolvedValue([{ userId: "user_a" }]);
+    mapChatRoomMessageMock.mockReturnValue({
+      id: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: null,
+      content: "hello",
+      reactions: [
+        {
+          emoji: "👍",
+          count: 1,
+          reactedByCurrentUser: true,
+          reactors: [{ id: "user_a", name: "Alice" }],
+        },
+      ],
+      mentions: [],
+      unfurls: null,
+    });
+
+    await publishChatRoomMessageRealtime(baseMessage as never, "reaction");
+
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_a",
+      eventType: "reaction",
+      messageId: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: null,
+      patch: {
+        reactions: [
+          {
+            emoji: "👍",
+            count: 1,
+            reactedByCurrentUser: true,
+            reactors: [{ id: "user_a", name: "Alice" }],
+          },
+        ],
+      },
+    });
+  });
+
+  it("publishes an unfurl patch with unfurls only", async () => {
+    findManyMembersMock.mockResolvedValue([{ userId: "user_a" }]);
+    const unfurls = [
+      {
+        url: "https://example.com",
+        title: "Example",
+        description: null,
+        imageUrl: null,
+        siteName: null,
+      },
+    ];
+    mapChatRoomMessageMock.mockReturnValue({
+      id: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: "parent-1",
+      content: "link",
+      reactions: [],
+      mentions: [],
+      unfurls,
+    });
+
+    await publishChatRoomMessageRealtime(baseMessage as never, "unfurl");
+
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_a",
+      eventType: "unfurl",
+      messageId: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: "parent-1",
+      patch: { unfurls },
+    });
+  });
+
+  it("publishes a mention_status patch with mentions only", async () => {
+    findManyMembersMock.mockResolvedValue([{ userId: "user_a" }]);
+    const mentions = [
+      {
+        id: "men-1",
+        coworkerId: "cow-1",
+        status: "completed",
+        responseMessageId: "resp-1",
+      },
+    ];
+    mapChatRoomMessageMock.mockReturnValue({
+      id: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: null,
+      content: "hey",
+      reactions: [],
+      mentions,
+      unfurls: null,
+    });
+
+    await publishChatRoomMessageRealtime(
+      baseMessage as never,
+      "mention_status",
+    );
+
+    expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
+      userId: "user_a",
+      eventType: "mention_status",
+      messageId: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: null,
+      patch: { mentions },
     });
   });
 });
@@ -159,7 +278,11 @@ describe("publishChatRoomMessageRealtimeById", () => {
     mapChatRoomMessageMock.mockImplementation((_message, userId: string) => ({
       id: baseMessage.id,
       roomId: baseMessage.roomId,
+      parentMessageId: null,
       forUser: userId,
+      reactions: [],
+      mentions: [],
+      unfurls: null,
     }));
   });
 
@@ -175,12 +298,11 @@ describe("publishChatRoomMessageRealtimeById", () => {
     });
     expect(publishChatRoomMessageEventMock).toHaveBeenCalledWith({
       userId: "user_a",
-      message: {
-        id: baseMessage.id,
-        roomId: baseMessage.roomId,
-        forUser: "user_a",
-      },
       eventType: "unfurl",
+      messageId: baseMessage.id,
+      roomId: baseMessage.roomId,
+      parentMessageId: null,
+      patch: { unfurls: null },
     });
   });
 

--- a/apps/core/src/helpers/chat-room-message-realtime.ts
+++ b/apps/core/src/helpers/chat-room-message-realtime.ts
@@ -3,17 +3,50 @@ import type { Prisma } from "@sokosumi/database";
 
 import type { ChatRoomMessageEventType } from "@sokosumi/utils";
 
-import { publishChatRoomMessageEvent } from "@/lib/ably/publish";
+import {
+  type ChatRoomMessageEventPatch,
+  type ChatRoomMessagePatchEventType,
+  publishChatRoomMessageEvent,
+} from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
 import {
   chatRoomMessageInclude,
   mapChatRoomMessage,
 } from "@/routes/v1/chats/rooms/helpers";
-import { chatRoomMessageSchema } from "@/schemas/chat-room.schema";
+import {
+  type ChatRoomMessage,
+  chatRoomMessageSchema,
+} from "@/schemas/chat-room.schema";
 
 type ChatRoomMessageWithInclude = Prisma.ChatRoomMessageGetPayload<{
   include: typeof chatRoomMessageInclude;
 }>;
+
+const PATCH_EVENT_TYPES = new Set<ChatRoomMessageEventType>([
+  "reaction",
+  "unfurl",
+  "mention_status",
+]);
+
+function isPatchEventType(
+  eventType: ChatRoomMessageEventType,
+): eventType is ChatRoomMessagePatchEventType {
+  return PATCH_EVENT_TYPES.has(eventType);
+}
+
+function buildChatRoomMessagePatch(
+  eventType: ChatRoomMessagePatchEventType,
+  dto: ChatRoomMessage,
+): ChatRoomMessageEventPatch {
+  switch (eventType) {
+    case "reaction":
+      return { reactions: dto.reactions };
+    case "unfurl":
+      return { unfurls: dto.unfurls };
+    case "mention_status":
+      return { mentions: dto.mentions };
+  }
+}
 
 export async function publishChatRoomMessageRealtime(
   message: ChatRoomMessageWithInclude,
@@ -32,10 +65,21 @@ export async function publishChatRoomMessageRealtime(
         const dto = chatRoomMessageSchema.parse(
           mapChatRoomMessage(message, userId),
         );
+        if (isPatchEventType(eventType)) {
+          await publishChatRoomMessageEvent({
+            userId,
+            eventType,
+            messageId: dto.id,
+            roomId: dto.roomId,
+            parentMessageId: dto.parentMessageId,
+            patch: buildChatRoomMessagePatch(eventType, dto),
+          });
+          return;
+        }
         await publishChatRoomMessageEvent({
           userId,
-          message: dto,
           eventType,
+          message: dto,
         });
       }),
     );

--- a/apps/core/src/lib/ably/publish.test.ts
+++ b/apps/core/src/lib/ably/publish.test.ts
@@ -123,14 +123,44 @@ describe("publishChatRoomMessageEvent", () => {
 
     await publishChatRoomMessageEvent({
       userId: "user_123",
-      message,
       eventType: "create",
+      message,
     });
 
     expect(getMock).toHaveBeenCalledWith("chat_rooms:all:user_user_123");
     expect(publishMock).toHaveBeenCalledWith("chat_room_message", {
       eventType: "create",
       message,
+    });
+  });
+
+  it("publishes a patch envelope for reaction events", async () => {
+    const patch = {
+      reactions: [
+        {
+          emoji: "👍",
+          count: 1,
+          reactedByCurrentUser: true,
+          reactors: [{ id: "user_123", name: "Alice" }],
+        },
+      ],
+    };
+
+    await publishChatRoomMessageEvent({
+      userId: "user_123",
+      eventType: "reaction",
+      messageId: "550e8400-e29b-41d4-a716-446655440000",
+      roomId: "660e8400-e29b-41d4-a716-446655440000",
+      parentMessageId: null,
+      patch,
+    });
+
+    expect(publishMock).toHaveBeenCalledWith("chat_room_message", {
+      eventType: "reaction",
+      messageId: "550e8400-e29b-41d4-a716-446655440000",
+      roomId: "660e8400-e29b-41d4-a716-446655440000",
+      parentMessageId: null,
+      patch,
     });
   });
 });

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -90,18 +90,85 @@ export async function publishNotificationEvent({
   await channel.publish("notification_created", notification);
 }
 
-interface PublishChatRoomMessageEventInput {
+/** Full DTO body for create / update / delete. */
+export type ChatRoomMessageFullEventType = Extract<
+  ChatRoomMessageEventType,
+  "create" | "update" | "delete"
+>;
+
+/** Patch body for high-chatter slices (SOK-737). */
+export type ChatRoomMessagePatchEventType = Extract<
+  ChatRoomMessageEventType,
+  "reaction" | "unfurl" | "mention_status"
+>;
+
+export type ChatRoomMessageReactionPatch = {
+  reactions: ChatRoomMessage["reactions"];
+};
+
+export type ChatRoomMessageUnfurlPatch = {
+  unfurls: ChatRoomMessage["unfurls"];
+};
+
+export type ChatRoomMessageMentionStatusPatch = {
+  mentions: ChatRoomMessage["mentions"];
+};
+
+export type ChatRoomMessageEventPatch =
+  | ChatRoomMessageReactionPatch
+  | ChatRoomMessageUnfurlPatch
+  | ChatRoomMessageMentionStatusPatch;
+
+interface PublishChatRoomMessageFullEventInput {
   userId: string;
+  eventType: ChatRoomMessageFullEventType;
   message: ChatRoomMessage;
-  eventType: ChatRoomMessageEventType;
 }
 
-export async function publishChatRoomMessageEvent({
-  userId,
-  message,
-  eventType,
-}: PublishChatRoomMessageEventInput) {
+interface PublishChatRoomMessagePatchEventInput {
+  userId: string;
+  eventType: ChatRoomMessagePatchEventType;
+  messageId: string;
+  roomId: string;
+  parentMessageId: string | null;
+  patch: ChatRoomMessageEventPatch;
+}
+
+export type PublishChatRoomMessageEventInput =
+  | PublishChatRoomMessageFullEventInput
+  | PublishChatRoomMessagePatchEventInput;
+
+function isPatchEventInput(
+  input: PublishChatRoomMessageEventInput,
+): input is PublishChatRoomMessagePatchEventInput {
+  return (
+    input.eventType === "reaction" ||
+    input.eventType === "unfurl" ||
+    input.eventType === "mention_status"
+  );
+}
+
+export async function publishChatRoomMessageEvent(
+  input: PublishChatRoomMessageEventInput,
+) {
   const client = getRestClient();
-  const channel = client.channels.get(makeUserChatRoomsChannelName(userId));
-  await channel.publish("chat_room_message", { eventType, message });
+  const channel = client.channels.get(
+    makeUserChatRoomsChannelName(input.userId),
+  );
+
+  if (isPatchEventInput(input)) {
+    await channel.publish("chat_room_message", {
+      eventType: input.eventType,
+      messageId: input.messageId,
+      roomId: input.roomId,
+      parentMessageId: input.parentMessageId,
+      patch: input.patch,
+    });
+    return;
+  }
+
+  await channel.publish("chat_room_message", {
+    eventType: input.eventType,
+    message: input.message,
+  });
 }

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -60,8 +60,10 @@ import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
 import {
   type ChatRoomMessageEventData,
+  isChatRoomMessagePatchEvent,
   makeUserChatRoomsChannelName,
 } from "@/lib/ably";
+import { applyChatRoomMessagePatch } from "@/lib/ably/apply-chat-room-message-patch";
 import { hydrateChatRoomMessageFromRealtime } from "@/lib/ably/hydrate-chat-room-message";
 import { useChatRoomRealtime } from "@/lib/ably/use-chat-room-realtime";
 import type {
@@ -451,14 +453,70 @@ export function RoomsClient({
 
   const handleChatRoomRealtimeMessage = useCallback(
     (event: ChatRoomMessageEventData) => {
-      const message = hydrateChatRoomMessageFromRealtime(event.message);
-      if (message.roomId !== selectedRoomIdRef.current) {
-        return;
-      }
       if (
         skipRealtimeWhileStreamingRef.current &&
         isCoworkerStreamingRef.current
       ) {
+        return;
+      }
+
+      // SOK-737: high-chatter types arrive as field patches — merge by id.
+      // Missing local id → no-op (do not invent a row). Patches are not new
+      // messages, so skip unread-threads attention (full create path still does).
+      if (isChatRoomMessagePatchEvent(event)) {
+        if (event.roomId !== selectedRoomIdRef.current) {
+          return;
+        }
+
+        const route = routeRealtimeChatRoomMessage(
+          {
+            id: event.messageId,
+            parentMessageId: event.parentMessageId,
+          },
+          threadParentMessageIdRef.current,
+          event.eventType,
+        );
+
+        if (route.mergeIntoRoomTimeline) {
+          setMessagesState((current) => {
+            const existing = current.find(
+              (message) => message.id === event.messageId,
+            );
+            if (!existing) {
+              return current;
+            }
+            const merged = applyChatRoomMessagePatch(existing, event);
+            return filterTopLevelChatRoomMessages(
+              mergeRoomMessages(current, [merged]),
+            );
+          });
+        }
+
+        setThreadParentMessage((current) => {
+          if (current?.id !== event.messageId) {
+            return current;
+          }
+          return applyChatRoomMessagePatch(current, event);
+        });
+
+        if (route.mergeIntoOpenThread) {
+          setThreadMessages((current) => {
+            const existing = current.find(
+              (message) => message.id === event.messageId,
+            );
+            if (!existing) {
+              return current;
+            }
+            return mergeRoomMessages(current, [
+              applyChatRoomMessagePatch(existing, event),
+            ]);
+          });
+        }
+        return;
+      }
+
+      const message = hydrateChatRoomMessageFromRealtime(event.message);
+      if (message.roomId !== selectedRoomIdRef.current) {
         return;
       }
 

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -11,11 +11,11 @@
  *
  * ## Realtime routing table (SOK-736)
  *
- * Ably `chat_room_message` carries `eventType` + full message DTO. Landing
- * (where the upsert goes) is decided by parent vs reply + open thread id;
- * `eventType` documents mutation intent (create/update/reaction/…) so clients
- * do not guess from DTO shape alone. v1 apply is still full-DTO upsert for
- * every type.
+ * Ably `chat_room_message` carries `eventType` plus either a full message DTO
+ * (create/update/delete) or a field patch (reaction/unfurl/mention_status,
+ * SOK-737). Landing (where the apply goes) is decided by parent vs reply +
+ * open thread id; `eventType` documents mutation intent so clients do not
+ * guess from payload shape alone.
  *
  * | eventType (any) | message shape              | open thread        | room timeline | open thread replies | thread parent row* |
  * |-----------------|----------------------------|--------------------|---------------|---------------------|--------------------|

--- a/apps/web/src/lib/ably/__tests__/apply-chat-room-message-patch.test.ts
+++ b/apps/web/src/lib/ably/__tests__/apply-chat-room-message-patch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import { applyChatRoomMessagePatch } from "../apply-chat-room-message-patch";
+
+function baseMessage(
+  overrides: Partial<ChatRoomMessage> = {},
+): ChatRoomMessage {
+  return {
+    id: "msg-1",
+    roomId: "room-1",
+    parentMessageId: null,
+    content: "hello world",
+    createdAt: new Date("2026-08-06T12:00:00.000Z"),
+    deletedAt: null,
+    editedAt: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Alice",
+        email: "alice@example.com",
+        image: null,
+        presence: "online",
+      },
+    },
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: { keep: true },
+    quote: null,
+    membership: null,
+    unfurls: null,
+    ...overrides,
+  };
+}
+
+describe("applyChatRoomMessagePatch", () => {
+  it("merges reactions without clobbering content or metadata", () => {
+    const existing = baseMessage({
+      content: "keep me",
+      metadata: { keep: true },
+    });
+    const reactions = [
+      {
+        emoji: "👍",
+        count: 2,
+        reactedByCurrentUser: true,
+        reactors: [{ id: "user-1", name: "Alice" }],
+      },
+    ];
+
+    const merged = applyChatRoomMessagePatch(existing, {
+      eventType: "reaction",
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: null,
+      patch: { reactions },
+    });
+
+    expect(merged.content).toBe("keep me");
+    expect(merged.metadata).toEqual({ keep: true });
+    expect(merged.reactions).toEqual(reactions);
+    expect(merged.sender).toEqual(existing.sender);
+  });
+
+  it("merges unfurls only", () => {
+    const unfurls = [
+      {
+        url: "https://example.com",
+        title: "Example",
+        description: null,
+        imageUrl: null,
+        siteName: null,
+      },
+    ];
+    const merged = applyChatRoomMessagePatch(baseMessage(), {
+      eventType: "unfurl",
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: null,
+      patch: { unfurls },
+    });
+
+    expect(merged.unfurls).toEqual(unfurls);
+    expect(merged.content).toBe("hello world");
+  });
+
+  it("merges mentions only", () => {
+    const mentions = [
+      {
+        id: "men-1",
+        coworkerId: "cow-1",
+        status: "completed" as const,
+        responseMessageId: "resp-1",
+      },
+    ];
+    const merged = applyChatRoomMessagePatch(baseMessage(), {
+      eventType: "mention_status",
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: null,
+      patch: { mentions },
+    });
+
+    expect(merged.mentions).toEqual(mentions);
+    expect(merged.reactions).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
+++ b/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
@@ -1,7 +1,9 @@
-import { CHAT_ROOM_MESSAGE_EVENT_TYPES } from "@sokosumi/utils";
 import { describe, expect, it } from "vitest";
 
-import { chatRoomMessageEventDataSchema } from "../schema";
+import {
+  chatRoomMessageEventDataSchema,
+  isChatRoomMessagePatchEvent,
+} from "../schema";
 
 const baseMessage = {
   id: "msg-1",
@@ -22,8 +24,10 @@ const baseMessage = {
   unfurls: null,
 };
 
+const fullEventTypes = ["create", "update", "delete"] as const;
+
 describe("chatRoomMessageEventDataSchema", () => {
-  it.each([...CHAT_ROOM_MESSAGE_EVENT_TYPES])(
+  it.each([...fullEventTypes])(
     "accepts eventType %s with a full message DTO",
     (eventType) => {
       const parsed = chatRoomMessageEventDataSchema.safeParse({
@@ -33,10 +37,86 @@ describe("chatRoomMessageEventDataSchema", () => {
       expect(parsed.success).toBe(true);
       if (parsed.success) {
         expect(parsed.data.eventType).toBe(eventType);
-        expect(parsed.data.message.id).toBe("msg-1");
+        expect(isChatRoomMessagePatchEvent(parsed.data)).toBe(false);
+        if (!isChatRoomMessagePatchEvent(parsed.data)) {
+          expect(parsed.data.message.id).toBe("msg-1");
+        }
       }
     },
   );
+
+  it("accepts a reaction patch envelope", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "reaction",
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: null,
+      patch: {
+        reactions: [
+          {
+            emoji: "👍",
+            count: 1,
+            reactedByCurrentUser: true,
+            reactors: [],
+          },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(isChatRoomMessagePatchEvent(parsed.data)).toBe(true);
+      expect(parsed.data.eventType).toBe("reaction");
+    }
+  });
+
+  it("accepts an unfurl patch envelope", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "unfurl",
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: "parent-1",
+      patch: {
+        unfurls: [
+          {
+            url: "https://example.com",
+            title: "Example",
+            description: null,
+            imageUrl: null,
+            siteName: null,
+          },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a mention_status patch envelope", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "mention_status",
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: null,
+      patch: {
+        mentions: [
+          {
+            id: "men-1",
+            coworkerId: "cow-1",
+            status: "completed",
+            responseMessageId: "resp-1",
+          },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a full message DTO on reaction events", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "reaction",
+      message: baseMessage,
+    });
+    expect(parsed.success).toBe(false);
+  });
 
   it("rejects a missing eventType", () => {
     const parsed = chatRoomMessageEventDataSchema.safeParse({
@@ -49,6 +129,14 @@ describe("chatRoomMessageEventDataSchema", () => {
     const parsed = chatRoomMessageEventDataSchema.safeParse({
       eventType: "not_a_real_type",
       message: baseMessage,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a patch missing routing keys", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "reaction",
+      patch: { reactions: [] },
     });
     expect(parsed.success).toBe(false);
   });

--- a/apps/web/src/lib/ably/apply-chat-room-message-patch.ts
+++ b/apps/web/src/lib/ably/apply-chat-room-message-patch.ts
@@ -1,0 +1,29 @@
+import type { ChatRoomMessagePatchEventData } from "@/lib/ably/schema";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+/**
+ * Merge a high-chatter Ably patch into an existing client message.
+ * Only the patch slice overwrites; all other fields stay.
+ */
+export function applyChatRoomMessagePatch(
+  existing: ChatRoomMessage,
+  event: ChatRoomMessagePatchEventData,
+): ChatRoomMessage {
+  switch (event.eventType) {
+    case "reaction":
+      return {
+        ...existing,
+        reactions: event.patch.reactions as ChatRoomMessage["reactions"],
+      };
+    case "unfurl":
+      return {
+        ...existing,
+        unfurls: event.patch.unfurls as ChatRoomMessage["unfurls"],
+      };
+    case "mention_status":
+      return {
+        ...existing,
+        mentions: event.patch.mentions as ChatRoomMessage["mentions"],
+      };
+  }
+}

--- a/apps/web/src/lib/ably/hydrate-chat-room-message.ts
+++ b/apps/web/src/lib/ably/hydrate-chat-room-message.ts
@@ -1,4 +1,4 @@
-import type { ChatRoomMessageEventData } from "@/lib/ably/schema";
+import type { ChatRoomMessageFullEventData } from "@/lib/ably/schema";
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 
 function toDate(value: string): Date {
@@ -11,9 +11,10 @@ function toNullableDate(value: string | null): Date | null {
 
 /**
  * Ably JSON carries ISO strings; Core client DTOs use Date for the same fields.
+ * Only for full create/update/delete envelopes (SOK-737 patches merge in place).
  */
 export function hydrateChatRoomMessageFromRealtime(
-  message: ChatRoomMessageEventData["message"],
+  message: ChatRoomMessageFullEventData["message"],
 ): ChatRoomMessage {
   return {
     id: message.id,

--- a/apps/web/src/lib/ably/index.ts
+++ b/apps/web/src/lib/ably/index.ts
@@ -1,2 +1,3 @@
+export * from "./apply-chat-room-message-patch";
 export * from "./schema";
 export * from "./utils";

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -48,30 +48,93 @@ export const chatRoomMessageEventTypeSchema = z.enum(
   CHAT_ROOM_MESSAGE_EVENT_TYPES,
 );
 
-export const chatRoomMessageEventDataSchema = z.object({
-  eventType: chatRoomMessageEventTypeSchema,
-  message: z
-    .object({
-      id: z.string().min(1),
-      roomId: z.string().min(1),
-      parentMessageId: z.string().nullable(),
-      content: z.string(),
-      createdAt: z.string(),
-      deletedAt: z.string().nullable(),
-      editedAt: z.string().nullable(),
-      sender: z.unknown(),
-      mentions: z.array(z.unknown()),
-      reactions: z.array(z.unknown()),
-      threadReplyCount: z.number().int().min(0),
-      threadLastReplyAt: z.string().nullable(),
-      metadata: z.record(z.string(), z.unknown()).nullable(),
-      quote: z.unknown().nullable(),
-      membership: z.unknown().nullable(),
-      unfurls: z.array(chatRoomMessageUnfurlEventSchema).max(3).nullable(),
-    })
-    .passthrough(),
+/** Full message DTO carried on create / update / delete Ably events. */
+export const chatRoomMessageFullEventMessageSchema = z
+  .object({
+    id: z.string().min(1),
+    roomId: z.string().min(1),
+    parentMessageId: z.string().nullable(),
+    content: z.string(),
+    createdAt: z.string(),
+    deletedAt: z.string().nullable(),
+    editedAt: z.string().nullable(),
+    sender: z.unknown(),
+    mentions: z.array(z.unknown()),
+    reactions: z.array(z.unknown()),
+    threadReplyCount: z.number().int().min(0),
+    threadLastReplyAt: z.string().nullable(),
+    metadata: z.record(z.string(), z.unknown()).nullable(),
+    quote: z.unknown().nullable(),
+    membership: z.unknown().nullable(),
+    unfurls: z.array(chatRoomMessageUnfurlEventSchema).max(3).nullable(),
+  })
+  .passthrough();
+
+const chatRoomMessageFullEventSchema = z.object({
+  eventType: z.enum(["create", "update", "delete"]),
+  message: chatRoomMessageFullEventMessageSchema,
 });
+
+const chatRoomMessageReactionEventSchema = z.object({
+  eventType: z.literal("reaction"),
+  messageId: z.string().min(1),
+  roomId: z.string().min(1),
+  parentMessageId: z.string().nullable(),
+  patch: z.object({
+    reactions: z.array(z.unknown()),
+  }),
+});
+
+const chatRoomMessageUnfurlEventDataSchema = z.object({
+  eventType: z.literal("unfurl"),
+  messageId: z.string().min(1),
+  roomId: z.string().min(1),
+  parentMessageId: z.string().nullable(),
+  patch: z.object({
+    unfurls: z.array(chatRoomMessageUnfurlEventSchema).max(3).nullable(),
+  }),
+});
+
+const chatRoomMessageMentionStatusEventSchema = z.object({
+  eventType: z.literal("mention_status"),
+  messageId: z.string().min(1),
+  roomId: z.string().min(1),
+  parentMessageId: z.string().nullable(),
+  patch: z.object({
+    mentions: z.array(z.unknown()),
+  }),
+});
+
+/**
+ * Ably `chat_room_message` body (SOK-736 + SOK-737).
+ * Full DTO for create/update/delete; field patch for reaction/unfurl/mention_status.
+ */
+export const chatRoomMessageEventDataSchema = z.union([
+  chatRoomMessageFullEventSchema,
+  chatRoomMessageReactionEventSchema,
+  chatRoomMessageUnfurlEventDataSchema,
+  chatRoomMessageMentionStatusEventSchema,
+]);
 
 export type ChatRoomMessageEventData = z.infer<
   typeof chatRoomMessageEventDataSchema
 >;
+
+export type ChatRoomMessageFullEventData = z.infer<
+  typeof chatRoomMessageFullEventSchema
+>;
+
+export type ChatRoomMessagePatchEventData = Exclude<
+  ChatRoomMessageEventData,
+  ChatRoomMessageFullEventData
+>;
+
+export function isChatRoomMessagePatchEvent(
+  event: ChatRoomMessageEventData,
+): event is ChatRoomMessagePatchEventData {
+  return (
+    event.eventType === "reaction" ||
+    event.eventType === "unfurl" ||
+    event.eventType === "mention_status"
+  );
+}

--- a/packages/utils/src/chat-room-message-event-type.ts
+++ b/packages/utils/src/chat-room-message-event-type.ts
@@ -1,8 +1,7 @@
 /**
- * Stable intent for Ably `chat_room_message` publishes.
- * Full message DTO remains the payload body; this field is the shared
- * publisher/consumer contract so clients do not guess create vs edit vs
- * reaction vs unfurl (SOK-736).
+ * Stable intent for Ably `chat_room_message` publishes (SOK-736).
+ * create/update/delete carry a full message DTO; reaction/unfurl/
+ * mention_status carry a field patch (SOK-737).
  */
 export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [
   "create",


### PR DESCRIPTION
## Summary

Implements [SOK-737](https://linear.app/masumi/issue/SOK-737/partial-ably-payloads-for-chat-room-message-updates): high-chatter Ably `chat_room_message` types (`reaction`, `unfurl`, `mention_status`) publish typed field patches instead of full DTOs; web merges by id after SOK-736 landing.

- Core: map full DTO then emit `{ eventType, messageId, roomId, parentMessageId, patch }` for patch types; keep full `{ eventType, message }` for create/update/delete
- Web: Zod accepts the discriminated shapes; rejects full DTO on patch types
- Web: `applyChatRoomMessagePatch` field-merge; missing local id is a no-op
- Landing rules unchanged from SOK-736

## Spec summary

- Co-deploy Core publisher + web consumer
- Patch slices: reaction→reactions, unfurl→unfurls, mention_status→mentions
- Out of scope: new channels, multi-device sync, UX changes, content `update` patches

## Test plan

- [x] `pnpm --filter core check` / `pnpm core:test`
- [x] `pnpm --filter web check` / `pnpm web:test`
- [x] `pnpm --filter @sokosumi/utils check` / test / build
- [ ] Manual: react in open room + open thread parent; unfurl completes; mention status updates without full re-paint of content