### PR TITLE
fix(web): replace mobile header hamburger with back home

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
@@ -34,10 +34,6 @@ vi.mock("@/components/masumi-logos", () => ({
   ),
 }));
 
-vi.mock("../../sidebar/components/custom-trigger", () => ({
-  default: () => <button type="button">sidebar-trigger</button>,
-}));
-
 import { HeaderLeadingControl } from "../header-leading-control.client";
 
 describe("HeaderLeadingControl", () => {
@@ -63,5 +59,36 @@ describe("HeaderLeadingControl", () => {
     render(<HeaderLeadingControl />);
     const back = screen.getByRole("link", { name: "backToChats" });
     expect(back).toHaveAttribute("href", "/chat/chats");
+  });
+
+  it("shows back to home on account (not sidebar trigger)", () => {
+    mockPathname = "/account";
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "backToHome" });
+    expect(back).toHaveAttribute("href", "/chat");
+    expect(
+      screen.queryByRole("button", { name: "sidebar-trigger" }),
+    ).toBeNull();
+  });
+
+  it("shows back to home on billing", () => {
+    mockPathname = "/billing";
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "backToHome" });
+    expect(back).toHaveAttribute("href", "/chat");
+  });
+
+  it("shows back to home on developer", () => {
+    mockPathname = "/developer";
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "backToHome" });
+    expect(back).toHaveAttribute("href", "/chat");
+  });
+
+  it("shows hub back to home on tasks list", () => {
+    mockPathname = "/tasks";
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "backToHome" });
+    expect(back).toHaveAttribute("href", "/chat");
   });
 });

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
@@ -12,14 +12,12 @@ import {
 } from "@/app/components/mobile-app-chrome";
 import { SokosumiIcon } from "@/components/masumi-logos";
 
-import CustomTrigger from "../sidebar/components/custom-trigger";
-
 /**
  * Mobile header leading slot (`md:hidden` size-8):
  * - chat home / chats list → Sokosumi icon (no back / hamburger)
  * - chat room / draft compose → back to `/chat/chats`
  * - main hub lists + nested → back (home or list root)
- * - otherwise → sidebar CustomTrigger
+ * - otherwise → back to home
  */
 export function HeaderLeadingControl(): React.ReactElement {
   const pathname = usePathname();
@@ -60,7 +58,15 @@ export function HeaderLeadingControl(): React.ReactElement {
     );
   }
 
-  return <CustomTrigger when="invisible" />;
+  return (
+    <Link
+      href="/chat"
+      aria-label={t("backToHome")}
+      className="text-foreground hover:bg-accent inline-flex size-8 shrink-0 items-center justify-center rounded-md"
+    >
+      <ChevronLeft className="size-5" aria-hidden />
+    </Link>
+  );
 }
 
 /** Suspense fallback while search params resolve — brand, never hamburger. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-738/mobile-replace-remaining-sidebar-hamburger-with-back-home

Mobile header leading no longer falls through to the sidebar hamburger. Routes outside hub lists and chat chrome show back-to-home (`/chat`) instead.

Keeps brand on Home/Chats, room/draft back to chats, and existing hub list back targets. Desktop sidebar trigger unchanged.

**Verify:** `pnpm web:check` exit 0; `pnpm web:test` exit 0; UI `/account` and `/billing` at 390×844 show `Back to home` (no header hamburger).

[Mobile /account leading back home](https://cursor.com/agents/bc-ea19121c-1f50-407b-8e91-0ff064723c26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-738-account-mobile.png)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Test weakness | `header-leading-control.client.test.tsx` | `queryByRole("button", { name: "sidebar-trigger" })` is always null after CustomTrigger mock removal; Contract still covered by `backToHome` href asserts |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea19121c-1f50-407b-8e91-0ff064723c26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea19121c-1f50-407b-8e91-0ff064723c26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

