### PR TITLE
perf(chat): drop Ably cap re-auth interval after control revoke

### DIFF
--- a/apps/web/src/lib/ably/__tests__/use-chat-room-realtime.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-chat-room-realtime.test.tsx
@@ -30,10 +30,7 @@ vi.mock("ably/react", () => ({
   useAbly: () => ablyClient,
 }));
 
-import {
-  CHAT_ROOM_CAP_REAUTH_INTERVAL_MS,
-  useChatRoomRealtime,
-} from "../use-chat-room-realtime";
+import { useChatRoomRealtime } from "../use-chat-room-realtime";
 
 function channelFor(name: string) {
   let channel = channelsByName.get(name);
@@ -326,7 +323,7 @@ describe("useChatRoomRealtime", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("re-authorizes on the thin backstop interval while mounted", async () => {
+  it("does not re-authorize on a timer while mounted (control + focus/visibility only)", async () => {
     vi.useFakeTimers();
     authorizeMock.mockResolvedValue(tokenWithRooms("room-a"));
 
@@ -342,15 +339,16 @@ describe("useChatRoomRealtime", () => {
     });
     expect(authorizeMock).toHaveBeenCalledTimes(1);
 
+    // Former 120s interval and multi-minute span must not mint again.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(CHAT_ROOM_CAP_REAUTH_INTERVAL_MS);
+      await vi.advanceTimersByTimeAsync(120_000);
     });
-    expect(authorizeMock).toHaveBeenCalledTimes(2);
+    expect(authorizeMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(CHAT_ROOM_CAP_REAUTH_INTERVAL_MS);
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
     });
-    expect(authorizeMock).toHaveBeenCalledTimes(3);
+    expect(authorizeMock).toHaveBeenCalledTimes(1);
   });
 
   it("re-authorizes when the document becomes visible", async () => {

--- a/apps/web/src/lib/ably/use-chat-room-realtime.tsx
+++ b/apps/web/src/lib/ably/use-chat-room-realtime.tsx
@@ -22,13 +22,6 @@ import { personalizeChatRoomMessageEvent } from "./personalize-chat-room-message
 
 const CHAT_ROOM_MESSAGE_EVENT_NAME = "chat_room_message";
 
-/**
- * Thin backstop re-auth while chat realtime is mounted (missed revoke events,
- * long-lived tabs). Primary path is the chat control channel revoke signal
- * (SOK-742).
- */
-export const CHAT_ROOM_CAP_REAUTH_INTERVAL_MS = 120_000;
-
 interface UseChatRoomRealtimeOptions {
   /** Membership room ids to attach (all rooms for sidebar/live parity). */
   roomIds: readonly string[];
@@ -46,8 +39,8 @@ interface UseChatRoomRealtimeOptions {
  *
  * Remote membership revoke (SOK-742): Core publishes
  * `chat_membership_revoked` on `chat_control:user_{id}`; client detaches the
- * room immediately then re-authorizes so token caps drop. Thin backstop:
- * focus, visibility→visible, and a long interval.
+ * room immediately then re-authorizes so token caps drop. Thin backstop
+ * (SOK-747): focus and visibility→visible only — no periodic re-auth interval.
  */
 export function useChatRoomRealtime({
   roomIds,
@@ -100,7 +93,7 @@ export function useChatRoomRealtime({
     }
 
     const handleMessage = handleMessageRef.current;
-    /** Coalesce focus+visibility+interval+revoke so two applies never interleave. */
+    /** Coalesce focus+visibility+revoke so two applies never interleave. */
     let syncInFlight = false;
     let syncQueued = false;
 
@@ -221,10 +214,6 @@ export function useChatRoomRealtime({
       handleMembershipRevoked,
     );
 
-    const intervalId = window.setInterval(() => {
-      void syncMembershipChannels();
-    }, CHAT_ROOM_CAP_REAUTH_INTERVAL_MS);
-
     const onFocus = () => {
       void syncMembershipChannels();
     };
@@ -240,7 +229,6 @@ export function useChatRoomRealtime({
     return () => {
       syncGenerationRef.current += 1;
       syncQueued = false;
-      window.clearInterval(intervalId);
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       controlChannel.unsubscribe(


### PR DESCRIPTION
## Summary

- Closes [SOK-747](https://linear.app/masumi/issue/SOK-747/drop-or-lengthen-ably-chat-cap-re-auth-interval-after-control-channel)
- Removes the 120s `setInterval` re-auth while `useChatRoomRealtime` is mounted
- Keeps control-channel `chat_membership_revoked` as primary revoke path
- Keeps focus + visibility→visible as thin backstops; single-flight authorize + capability ∩ props unchanged

## Spec summary

Mounted chat no longer mints Ably tokens on a timer. Revoke isolation stays prompt via control channel; residual isolation if a control event is missed is until the next focus edge, visibility→visible, or membership prop change.

## Verification

- `pnpm web:check` — exit 0
- `pnpm web:test` — exit 0 (2803 passed)
- `pnpm --filter web test src/lib/ably/__tests__/use-chat-room-realtime.test.tsx` — exit 0

## Test plan

- [ ] Unit: no timer-driven re-auth; focus/visibility/revoke paths still re-auth
- [ ] (Ops) Confirm Ably keys allow `chat_control:*` and live kick smoke still works post-deploy