### PR TITLE
fix(chat): stop mobile room header flash

### DIFF
--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -60,7 +60,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRegisterBreadcrumbOverride } from "@/contexts/breadcrumb-override-context";
 import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import useIsApplePlatform from "@/hooks/use-is-apple-platform";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsMobileMedia } from "@/hooks/use-mobile";
 import {
   type ChatRoomMessageEventData,
   isChatRoomMessagePatchEvent,
@@ -377,7 +377,7 @@ export function RoomsClient({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isApple = useIsApplePlatform();
-  const isMobile = useIsMobile();
+  const isMobile = useIsMobileMedia();
   const headerRoomSlotHost = useHeaderRoomSlotHost();
   // Defer local day separators / continuation until after hydrate (SOKOSUMI-A).
   const localCalendarReady = useClientLocalCalendarReady();
@@ -1637,7 +1637,10 @@ export function RoomsClient({
         chatMobileHeightShellClass(pathname, isApple, searchParams),
       )}
     >
-      {selectedRoom && isMobile && headerRoomSlotHost && roomHeaderChrome
+      {selectedRoom &&
+      isMobile === true &&
+      headerRoomSlotHost &&
+      roomHeaderChrome
         ? createPortal(roomHeaderChrome, headerRoomSlotHost)
         : null}
       {currentUserId ? (
@@ -1694,7 +1697,7 @@ export function RoomsClient({
               label={t("Toolbar.dropToAttach")}
               className="flex min-h-0 min-w-0 flex-1 flex-col"
             >
-              {!isMobile && roomHeaderChrome ? (
+              {isMobile === false && roomHeaderChrome ? (
                 <header className="flex h-16 shrink-0 items-center justify-between gap-4 border-b px-6">
                   {roomHeaderChrome}
                 </header>

--- a/apps/web/src/app/(app)/components/app-header-fallback.tsx
+++ b/apps/web/src/app/(app)/components/app-header-fallback.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { HeaderCenter } from "./header/header-center.client";
 import { HeaderChrome } from "./header/header-chrome.client";
 import {
   HeaderLeadingBrandFallback,
@@ -20,14 +21,9 @@ export function AppHeaderFallback({ className }: AppHeaderFallbackProps) {
         </Suspense>
       </div>
 
-      <div
-        data-app-header-room-slot
-        className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden md:hidden"
-      />
-
-      <div className="hidden min-w-0 flex-1 flex-row gap-2 md:flex">
+      <HeaderCenter>
         <div className="bg-muted h-4 w-40 animate-pulse rounded-md" />
-      </div>
+      </HeaderCenter>
 
       <HeaderTrailing>
         <div className="flex items-center gap-2">

--- a/apps/web/src/app/(app)/components/header.tsx
+++ b/apps/web/src/app/(app)/components/header.tsx
@@ -2,6 +2,7 @@ import type { Session } from "@sokosumi/utils";
 import { Suspense } from "react";
 import { BreadcrumbNavigation } from "@/components/breadcrumb-navigation";
 
+import { HeaderCenter } from "./header/header-center.client";
 import { HeaderChrome } from "./header/header-chrome.client";
 import {
   HeaderLeadingBrandFallback,
@@ -29,14 +30,9 @@ export default function Header({
         </Suspense>
       </div>
 
-      <div
-        data-app-header-room-slot
-        className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden md:hidden"
-      />
-
-      <div className="hidden min-w-0 flex-1 flex-row gap-2 md:flex">
+      <HeaderCenter>
         <BreadcrumbNavigation className="flex flex-1" />
-      </div>
+      </HeaderCenter>
 
       <HeaderTrailing>
         <HeaderProfileSection

--- a/apps/web/src/app/(app)/components/header/__tests__/header-center.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-center.client.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/chat";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+import { HeaderCenter } from "../header-center.client";
+
+describe("HeaderCenter", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+  });
+
+  it("keeps breadcrumbs at sm and hides empty room slot on non-room routes", () => {
+    render(
+      <HeaderCenter>
+        <span>crumbs</span>
+      </HeaderCenter>,
+    );
+
+    const roomSlot = screen.getByTestId("header-room-slot");
+    const breadcrumbs = screen.getByTestId("header-breadcrumbs");
+    const roomSlotClasses = roomSlot.className.split(/\s+/);
+    const breadcrumbClasses = breadcrumbs.className.split(/\s+/);
+
+    expect(roomSlotClasses).toContain("hidden");
+    expect(roomSlotClasses).not.toContain("flex");
+    expect(roomSlot).not.toHaveAttribute("data-mobile-room");
+
+    expect(breadcrumbs).toHaveTextContent("crumbs");
+    expect(breadcrumbClasses).toContain("sm:flex");
+    expect(breadcrumbClasses).not.toContain("max-md:hidden");
+    expect(breadcrumbs).not.toHaveAttribute("data-hide-on-mobile-room");
+  });
+
+  it("shows room slot and hides breadcrumbs below md on room routes", () => {
+    mockPathname = "/chat/rooms/room-1";
+    render(
+      <HeaderCenter>
+        <span>crumbs</span>
+      </HeaderCenter>,
+    );
+
+    const roomSlot = screen.getByTestId("header-room-slot");
+    const breadcrumbs = screen.getByTestId("header-breadcrumbs");
+    const roomSlotClasses = roomSlot.className.split(/\s+/);
+    const breadcrumbClasses = breadcrumbs.className.split(/\s+/);
+
+    expect(roomSlot).toHaveAttribute("data-mobile-room", "true");
+    expect(roomSlotClasses).toContain("flex");
+    expect(roomSlotClasses).toContain("md:hidden");
+    expect(roomSlotClasses).not.toContain("hidden");
+
+    expect(breadcrumbs).toHaveAttribute("data-hide-on-mobile-room", "true");
+    expect(breadcrumbClasses).toContain("sm:flex");
+    expect(breadcrumbClasses).toContain("max-md:hidden");
+  });
+});

--- a/apps/web/src/app/(app)/components/header/header-center.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-center.client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { isChatRoomPathname } from "@/app/chat/utils/chat-route-base";
+import { cn } from "@/lib/utils";
+
+interface HeaderCenterProps {
+  children: ReactNode;
+}
+
+/**
+ * App-header center: mobile room toolbar slot + breadcrumbs.
+ * Room slot only claims space on chat room routes below `md`.
+ * Breadcrumbs keep `sm` wayfinding on non-room pages; hidden below `md` on rooms.
+ */
+export function HeaderCenter({ children }: HeaderCenterProps) {
+  const pathname = usePathname();
+  const isMobileRoom = isChatRoomPathname(pathname);
+
+  return (
+    <>
+      <div
+        data-app-header-room-slot
+        data-testid="header-room-slot"
+        data-mobile-room={isMobileRoom ? "true" : undefined}
+        className={cn(
+          "min-w-0 flex-1 items-center gap-1.5 overflow-hidden md:hidden",
+          isMobileRoom ? "flex" : "hidden",
+        )}
+      />
+
+      <div
+        data-testid="header-breadcrumbs"
+        data-hide-on-mobile-room={isMobileRoom ? "true" : undefined}
+        className={cn(
+          "hidden min-w-0 flex-1 flex-row gap-2 sm:flex",
+          isMobileRoom && "max-md:hidden",
+        )}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/hooks/__tests__/use-mobile.test.ts
+++ b/apps/web/src/hooks/__tests__/use-mobile.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MOBILE_BREAKPOINT,
+  useIsMobile,
+  useIsMobileMedia,
+} from "../use-mobile";
+
+function mockMatchMedia(matches: boolean) {
+  const mql = {
+    matches,
+    media: `(max-width: ${MOBILE_BREAKPOINT - 1}px)`,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as MediaQueryList;
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn(() => mql),
+  });
+
+  return mql;
+}
+
+describe("useIsMobileMedia", () => {
+  const originalInnerWidth = window.innerWidth;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: originalInnerWidth,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("is undefined on the first render, then resolves from the media query", () => {
+    mockMatchMedia(true);
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: MOBILE_BREAKPOINT - 1,
+    });
+
+    const values: Array<boolean | undefined> = [];
+    const { result } = renderHook(() => {
+      const value = useIsMobileMedia();
+      values.push(value);
+      return value;
+    });
+
+    expect(values[0]).toBeUndefined();
+    expect(result.current).toBe(true);
+  });
+
+  it("resolves to false at the desktop breakpoint after mount", () => {
+    mockMatchMedia(false);
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: MOBILE_BREAKPOINT,
+    });
+
+    const { result } = renderHook(() => useIsMobileMedia());
+    expect(result.current).toBe(false);
+  });
+});
+
+describe("useIsMobile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("coerces the first unresolved render to false", () => {
+    mockMatchMedia(true);
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: MOBILE_BREAKPOINT - 1,
+    });
+
+    const values: boolean[] = [];
+    const { result } = renderHook(() => {
+      const value = useIsMobile();
+      values.push(value);
+      return value;
+    });
+
+    expect(values[0]).toBe(false);
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -2,7 +2,11 @@ import * as React from "react";
 
 export const MOBILE_BREAKPOINT = 768;
 
-export function useIsMobile() {
+/**
+ * Mobile match from `(max-width: MOBILE_BREAKPOINT - 1)`.
+ * `undefined` until the media-query subscription runs after mount.
+ */
+export function useIsMobileMedia(): boolean | undefined {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
     undefined,
   );
@@ -19,5 +23,10 @@ export function useIsMobile() {
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
-  return !!isMobile;
+  return isMobile;
+}
+
+/** Coerces unresolved media to `false` (desktop-first). Prefer `useIsMobileMedia` when layout must wait. */
+export function useIsMobile() {
+  return !!useIsMobileMedia();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two Bugbot findings on the mobile room header work:

1. **Header flash on mobile room load** — `useIsMobile()` coerced unresolved media to `false`, so rooms briefly rendered in-content chrome before portaling into the app header. Rooms now wait on `useIsMobileMedia()` (`undefined` until the query resolves) and only portal when `true` / show in-content when `false`.
2. **Missing breadcrumbs at sm–md** — the empty room slot always claimed the center below `md`, so breadcrumbs were pushed to `md:flex`. `HeaderCenter` only shows the room slot on chat room routes and restores `sm:flex` breadcrumbs (hidden below `md` on rooms).

## Test plan

- [x] `pnpm --filter web test` for `use-mobile`, `header-center`, `header-trailing`
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [ ] Manual: open a room on a phone-width viewport — no duplicate/jumping room toolbar under the fixed header
- [ ] Manual: non-room page at ~700px width — breadcrumbs still show in the header center

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e78f8df5-86c8-451a-8af9-94579e65d92c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e78f8df5-86c8-451a-8af9-94579e65d92c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

