### PR TITLE
feat(web): Instant Nav skeletons for hub settings routes

### DIFF
--- a/apps/web/src/app/(app)/__tests__/hub-instant-loading-contract.test.ts
+++ b/apps/web/src/app/(app)/__tests__/hub-instant-loading-contract.test.ts
@@ -6,9 +6,12 @@ import { describe, expect, it } from "vitest";
 const here = dirname(fileURLToPath(import.meta.url));
 const appDir = join(here, "..");
 
-/** Dynamic APIs that must not appear in Instant loading shell *code*. */
+/**
+ * Dynamic APIs that must not appear in Instant loading shell *code*.
+ * Includes Next request APIs and next-intl server helpers that suspend/dynamicize.
+ */
 const DYNAMIC_SHELL_API_RE =
-  /\bcookies\s*\(|\bconnection\s*\(|\bgetTranslations\s*\(|\bgetSession\s*\(/;
+  /\b(?:cookies|headers|draftMode|connection|getTranslations|getFormatter|getLocale|getMessages|getSession)\s*\(/;
 
 function readApp(rel: string): string {
   return readFileSync(join(appDir, rel), "utf8");
@@ -17,6 +20,21 @@ function readApp(rel: string): string {
 /** Drop comments so "no connection()" docs do not false-positive the scan. */
 function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+/**
+ * Require default export's *only* body statement to be `return <SkeletonName />`.
+ * Thin Instant loaders must not hide a different return behind helpers/branches.
+ */
+function assertDefaultReturnsSkeleton(
+  source: string,
+  skeletonName: string,
+): void {
+  const code = stripComments(source);
+  const pattern = new RegExp(
+    String.raw`export\s+default\s+function\s+\w+\s*\([^)]*\)\s*\{\s*return\s+<\s*${skeletonName}\s*\/>\s*;?\s*\}`,
+  );
+  expect(code).toMatch(pattern);
 }
 
 const pages = [
@@ -84,54 +102,51 @@ describe("hub Instant Nav skeleton contract", () => {
   }
 
   it("notifications/loading.tsx returns NotificationsPageSkeleton", () => {
-    const code = stripComments(readApp("notifications/loading.tsx"));
-    expect(code).toMatch(
-      /export\s+default\s+function[\s\S]*?return\s+<\s*NotificationsPageSkeleton\s*\/>/,
+    assertDefaultReturnsSkeleton(
+      readApp("notifications/loading.tsx"),
+      "NotificationsPageSkeleton",
     );
   });
 
   it("connections/loading.tsx returns ConnectionsPageSkeleton", () => {
-    const code = stripComments(readApp("connections/loading.tsx"));
-    expect(code).toMatch(
-      /export\s+default\s+function[\s\S]*?return\s+<\s*ConnectionsPageSkeleton\s*\/>/,
+    assertDefaultReturnsSkeleton(
+      readApp("connections/loading.tsx"),
+      "ConnectionsPageSkeleton",
     );
   });
 
   for (const rel of cardSectionLoadings) {
     it(`${rel} returns DeveloperSectionPageSkeleton`, () => {
-      const code = stripComments(readApp(rel));
-      expect(code).toMatch(
-        /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperSectionPageSkeleton\s*\/>/,
+      assertDefaultReturnsSkeleton(
+        readApp(rel),
+        "DeveloperSectionPageSkeleton",
       );
     });
   }
 
   for (const rel of listSectionLoadings) {
     it(`${rel} returns DeveloperListPageSkeleton`, () => {
-      const code = stripComments(readApp(rel));
-      expect(code).toMatch(
-        /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperListPageSkeleton\s*\/>/,
-      );
+      assertDefaultReturnsSkeleton(readApp(rel), "DeveloperListPageSkeleton");
     });
   }
 
   for (const rel of formDetailLoadings) {
     it(`${rel} returns DeveloperDetailPageSkeleton`, () => {
-      const code = stripComments(readApp(rel));
-      expect(code).toMatch(
-        /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperDetailPageSkeleton\s*\/>/,
-      );
+      assertDefaultReturnsSkeleton(readApp(rel), "DeveloperDetailPageSkeleton");
     });
   }
 
   it(`${taskDetailLoading} returns DeveloperTaskDetailPageSkeleton`, () => {
-    const code = stripComments(readApp(taskDetailLoading));
-    expect(code).toMatch(
-      /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperTaskDetailPageSkeleton\s*\/>/,
+    assertDefaultReturnsSkeleton(
+      readApp(taskDetailLoading),
+      "DeveloperTaskDetailPageSkeleton",
     );
   });
 
-  it("developer root has no loading.tsx (redirect-only segment)", () => {
+  it("developer root is redirect-only with no loading.tsx", () => {
+    const code = stripComments(readApp("developer/page.tsx"));
+    expect(code).toMatch(/\bredirect\s*\(/);
+    expect(code).toMatch(/DEVELOPER_DEFAULT_HREF/);
     expect(() => readApp("developer/loading.tsx")).toThrow();
   });
 });

--- a/apps/web/src/app/(app)/__tests__/hub-instant-loading-contract.test.ts
+++ b/apps/web/src/app/(app)/__tests__/hub-instant-loading-contract.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appDir = join(here, "..");
+
+/** Dynamic APIs that must not appear in Instant loading shell *code*. */
+const DYNAMIC_SHELL_API_RE =
+  /\bcookies\s*\(|\bconnection\s*\(|\bgetTranslations\s*\(|\bgetSession\s*\(/;
+
+function readApp(rel: string): string {
+  return readFileSync(join(appDir, rel), "utf8");
+}
+
+/** Drop comments so "no connection()" docs do not false-positive the scan. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+const pages = [
+  "notifications/page.tsx",
+  "connections/page.tsx",
+  "developer/page.tsx",
+  "developer/api-keys/page.tsx",
+  "developer/oauth-clients/page.tsx",
+  "developer/docs/page.tsx",
+  "developer/coworkers/page.tsx",
+  "developer/tasks/page.tsx",
+  "developer/vendors/page.tsx",
+] as const;
+
+const sectionLoadings = [
+  "notifications/loading.tsx",
+  "connections/loading.tsx",
+  "developer/loading.tsx",
+  "developer/api-keys/loading.tsx",
+  "developer/oauth-clients/loading.tsx",
+  "developer/docs/loading.tsx",
+  "developer/coworkers/loading.tsx",
+  "developer/tasks/loading.tsx",
+  "developer/vendors/loading.tsx",
+] as const;
+
+const detailLoadings = [
+  "developer/coworkers/[id]/loading.tsx",
+  "developer/tasks/[taskId]/loading.tsx",
+  "developer/vendors/[id]/loading.tsx",
+] as const;
+
+const shellViews = [
+  "notifications/components/notifications-loading-view.tsx",
+  "connections/components/connections-loading-view.tsx",
+  "developer/components/developer-loading-view.tsx",
+] as const;
+
+describe("hub Instant Nav skeleton contract", () => {
+  for (const rel of pages) {
+    it(`${rel} does not soft-nav opt out of Instant`, () => {
+      const source = readApp(rel);
+      expect(source).not.toMatch(/export\s+const\s+instant\s*=\s*false/);
+    });
+  }
+
+  for (const rel of [...sectionLoadings, ...detailLoadings, ...shellViews]) {
+    it(`${rel} stays sync (no cookies/connection/session/i18n)`, () => {
+      const code = stripComments(readApp(rel));
+      expect(code).not.toMatch(DYNAMIC_SHELL_API_RE);
+    });
+  }
+
+  it("notifications/loading.tsx returns NotificationsPageSkeleton", () => {
+    const code = stripComments(readApp("notifications/loading.tsx"));
+    expect(code).toMatch(
+      /export\s+default\s+function[\s\S]*?return\s+<\s*NotificationsPageSkeleton\s*\/>/,
+    );
+  });
+
+  it("connections/loading.tsx returns ConnectionsPageSkeleton", () => {
+    const code = stripComments(readApp("connections/loading.tsx"));
+    expect(code).toMatch(
+      /export\s+default\s+function[\s\S]*?return\s+<\s*ConnectionsPageSkeleton\s*\/>/,
+    );
+  });
+
+  for (const rel of sectionLoadings.filter((path) =>
+    path.startsWith("developer/"),
+  )) {
+    it(`${rel} returns DeveloperSectionPageSkeleton`, () => {
+      const code = stripComments(readApp(rel));
+      expect(code).toMatch(
+        /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperSectionPageSkeleton\s*\/>/,
+      );
+    });
+  }
+
+  for (const rel of detailLoadings) {
+    it(`${rel} returns DeveloperDetailPageSkeleton`, () => {
+      const code = stripComments(readApp(rel));
+      expect(code).toMatch(
+        /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperDetailPageSkeleton\s*\/>/,
+      );
+    });
+  }
+});

--- a/apps/web/src/app/(app)/__tests__/hub-instant-loading-contract.test.ts
+++ b/apps/web/src/app/(app)/__tests__/hub-instant-loading-contract.test.ts
@@ -27,26 +27,39 @@ const pages = [
   "developer/oauth-clients/page.tsx",
   "developer/docs/page.tsx",
   "developer/coworkers/page.tsx",
+  "developer/coworkers/[id]/page.tsx",
   "developer/tasks/page.tsx",
+  "developer/tasks/[taskId]/page.tsx",
   "developer/vendors/page.tsx",
+  "developer/vendors/[id]/page.tsx",
 ] as const;
 
-const sectionLoadings = [
-  "notifications/loading.tsx",
-  "connections/loading.tsx",
-  "developer/loading.tsx",
+const cardSectionLoadings = [
   "developer/api-keys/loading.tsx",
   "developer/oauth-clients/loading.tsx",
   "developer/docs/loading.tsx",
+] as const;
+
+const listSectionLoadings = [
   "developer/coworkers/loading.tsx",
   "developer/tasks/loading.tsx",
   "developer/vendors/loading.tsx",
 ] as const;
 
-const detailLoadings = [
+const formDetailLoadings = [
   "developer/coworkers/[id]/loading.tsx",
-  "developer/tasks/[taskId]/loading.tsx",
   "developer/vendors/[id]/loading.tsx",
+] as const;
+
+const taskDetailLoading = "developer/tasks/[taskId]/loading.tsx" as const;
+
+const hubLoadings = [
+  "notifications/loading.tsx",
+  "connections/loading.tsx",
+  ...cardSectionLoadings,
+  ...listSectionLoadings,
+  ...formDetailLoadings,
+  taskDetailLoading,
 ] as const;
 
 const shellViews = [
@@ -63,7 +76,7 @@ describe("hub Instant Nav skeleton contract", () => {
     });
   }
 
-  for (const rel of [...sectionLoadings, ...detailLoadings, ...shellViews]) {
+  for (const rel of [...hubLoadings, ...shellViews]) {
     it(`${rel} stays sync (no cookies/connection/session/i18n)`, () => {
       const code = stripComments(readApp(rel));
       expect(code).not.toMatch(DYNAMIC_SHELL_API_RE);
@@ -84,9 +97,7 @@ describe("hub Instant Nav skeleton contract", () => {
     );
   });
 
-  for (const rel of sectionLoadings.filter((path) =>
-    path.startsWith("developer/"),
-  )) {
+  for (const rel of cardSectionLoadings) {
     it(`${rel} returns DeveloperSectionPageSkeleton`, () => {
       const code = stripComments(readApp(rel));
       expect(code).toMatch(
@@ -95,7 +106,16 @@ describe("hub Instant Nav skeleton contract", () => {
     });
   }
 
-  for (const rel of detailLoadings) {
+  for (const rel of listSectionLoadings) {
+    it(`${rel} returns DeveloperListPageSkeleton`, () => {
+      const code = stripComments(readApp(rel));
+      expect(code).toMatch(
+        /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperListPageSkeleton\s*\/>/,
+      );
+    });
+  }
+
+  for (const rel of formDetailLoadings) {
     it(`${rel} returns DeveloperDetailPageSkeleton`, () => {
       const code = stripComments(readApp(rel));
       expect(code).toMatch(
@@ -103,4 +123,15 @@ describe("hub Instant Nav skeleton contract", () => {
       );
     });
   }
+
+  it(`${taskDetailLoading} returns DeveloperTaskDetailPageSkeleton`, () => {
+    const code = stripComments(readApp(taskDetailLoading));
+    expect(code).toMatch(
+      /export\s+default\s+function[\s\S]*?return\s+<\s*DeveloperTaskDetailPageSkeleton\s*\/>/,
+    );
+  });
+
+  it("developer root has no loading.tsx (redirect-only segment)", () => {
+    expect(() => readApp("developer/loading.tsx")).toThrow();
+  });
 });

--- a/apps/web/src/app/(app)/connections/components/__tests__/connections-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/connections/components/__tests__/connections-loading-view.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ConnectionsPageSkeleton } from "../connections-loading-view";
+
+describe("ConnectionsPageSkeleton", () => {
+  it("renders social, tabs, and content skeleton regions", () => {
+    render(<ConnectionsPageSkeleton />);
+
+    expect(screen.getByTestId("connections-loading")).toBeTruthy();
+    expect(screen.getByTestId("connections-loading-social")).toBeTruthy();
+    expect(screen.getByTestId("connections-loading-tabs")).toBeTruthy();
+    expect(screen.getByTestId("connections-loading-content")).toBeTruthy();
+  });
+
+  it("renders multiple skeleton bones", () => {
+    const { container } = render(<ConnectionsPageSkeleton />);
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/apps/web/src/app/(app)/connections/components/connections-loading-view.tsx
+++ b/apps/web/src/app/(app)/connections/components/connections-loading-view.tsx
@@ -1,0 +1,56 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Sync Instant Nav shell for `/connections` (no cookies/`connection()`/i18n).
+ * Mirrors social-account rows + tab strip + list card.
+ */
+export function ConnectionsPageSkeleton(): React.ReactElement {
+  return (
+    <div data-testid="connections-loading" className="min-h-full w-full">
+      <div className="mx-auto max-w-4xl space-y-8 px-4">
+        <div className="space-y-6">
+          <div
+            data-testid="connections-loading-social"
+            className="flex flex-col divide-y rounded-xl border p-2"
+          >
+            {Array.from({ length: 2 }, (_, index) => (
+              <div key={index} className="flex items-center gap-2 px-2 py-4">
+                <Skeleton className="size-6 shrink-0 rounded-full" />
+                <Skeleton className="h-4 flex-1 max-w-40" />
+                <Skeleton className="size-9 shrink-0 rounded-md" />
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-col gap-5">
+            <div
+              data-testid="connections-loading-tabs"
+              className="bg-muted/50 flex w-full max-w-xs items-center gap-1 self-start rounded-lg p-1"
+            >
+              <Skeleton className="h-8 flex-1 rounded-md" />
+              <Skeleton className="h-8 flex-1 rounded-md" />
+            </div>
+
+            <div
+              data-testid="connections-loading-content"
+              className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border"
+            >
+              <div className="divide-border/50 divide-y">
+                {Array.from({ length: 4 }, (_, index) => (
+                  <div key={index} className="flex items-center gap-3 p-4">
+                    <Skeleton className="size-8 shrink-0 rounded-md" />
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <Skeleton className="h-4 w-48" />
+                      <Skeleton className="h-3 w-32" />
+                    </div>
+                    <Skeleton className="h-8 w-20 shrink-0 rounded-md" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/connections/loading.tsx
+++ b/apps/web/src/app/(app)/connections/loading.tsx
@@ -1,0 +1,6 @@
+import { ConnectionsPageSkeleton } from "@/app/connections/components/connections-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function ConnectionsLoading() {
+  return <ConnectionsPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/api-keys/loading.tsx
+++ b/apps/web/src/app/(app)/developer/api-keys/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperApiKeysLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/components/__tests__/developer-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/developer/components/__tests__/developer-loading-view.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  DeveloperDetailPageSkeleton,
+  DeveloperSectionPageSkeleton,
+} from "../developer-loading-view";
+
+describe("DeveloperSectionPageSkeleton", () => {
+  it("renders section header and list skeleton regions", () => {
+    render(<DeveloperSectionPageSkeleton />);
+
+    expect(screen.getByTestId("developer-section-loading")).toBeTruthy();
+    expect(screen.getByTestId("developer-section-loading-list")).toBeTruthy();
+  });
+
+  it("renders multiple skeleton bones", () => {
+    const { container } = render(<DeveloperSectionPageSkeleton />);
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("DeveloperDetailPageSkeleton", () => {
+  it("renders detail skeleton region", () => {
+    render(<DeveloperDetailPageSkeleton />);
+
+    expect(screen.getByTestId("developer-detail-loading")).toBeTruthy();
+  });
+
+  it("renders multiple skeleton bones", () => {
+    const { container } = render(<DeveloperDetailPageSkeleton />);
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/apps/web/src/app/(app)/developer/components/__tests__/developer-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/developer/components/__tests__/developer-loading-view.test.tsx
@@ -3,13 +3,15 @@ import { describe, expect, it } from "vitest";
 
 import {
   DeveloperDetailPageSkeleton,
+  DeveloperListPageSkeleton,
   DeveloperSectionContentSkeleton,
   DeveloperSectionPageSkeleton,
   DeveloperSectionRowsSkeleton,
+  DeveloperTaskDetailPageSkeleton,
 } from "../developer-loading-view";
 
 describe("DeveloperSectionPageSkeleton", () => {
-  it("renders section header and list skeleton regions", () => {
+  it("renders card section header and list skeleton regions", () => {
     render(<DeveloperSectionPageSkeleton />);
 
     expect(screen.getByTestId("developer-section-loading")).toBeTruthy();
@@ -20,6 +22,18 @@ describe("DeveloperSectionPageSkeleton", () => {
     const { container } = render(<DeveloperSectionPageSkeleton />);
     const bones = container.querySelectorAll('[data-slot="skeleton"]');
     expect(bones.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("DeveloperListPageSkeleton", () => {
+  it("renders non-card list skeleton regions", () => {
+    render(<DeveloperListPageSkeleton />);
+
+    expect(screen.getByTestId("developer-list-loading")).toBeTruthy();
+    expect(
+      screen.getByTestId("developer-section-content-loading"),
+    ).toBeTruthy();
+    expect(screen.getByTestId("developer-section-loading-list")).toBeTruthy();
   });
 });
 
@@ -45,15 +59,27 @@ describe("DeveloperSectionRowsSkeleton", () => {
 });
 
 describe("DeveloperDetailPageSkeleton", () => {
-  it("renders detail skeleton region", () => {
-    render(<DeveloperDetailPageSkeleton />);
+  it("renders form detail skeleton at max-w-3xl", () => {
+    const { container } = render(<DeveloperDetailPageSkeleton />);
 
     expect(screen.getByTestId("developer-detail-loading")).toBeTruthy();
+    expect(container.querySelector(".max-w-3xl")).toBeTruthy();
   });
 
   it("renders multiple skeleton bones", () => {
     const { container } = render(<DeveloperDetailPageSkeleton />);
     const bones = container.querySelectorAll('[data-slot="skeleton"]');
     expect(bones.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe("DeveloperTaskDetailPageSkeleton", () => {
+  it("renders meta bar and task section skeleton regions", () => {
+    const { container } = render(<DeveloperTaskDetailPageSkeleton />);
+
+    expect(screen.getByTestId("developer-task-detail-loading")).toBeTruthy();
+    expect(container.querySelector(".max-w-4xl")).toBeTruthy();
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBeGreaterThanOrEqual(12);
   });
 });

--- a/apps/web/src/app/(app)/developer/components/__tests__/developer-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/developer/components/__tests__/developer-loading-view.test.tsx
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   DeveloperDetailPageSkeleton,
+  DeveloperSectionContentSkeleton,
   DeveloperSectionPageSkeleton,
+  DeveloperSectionRowsSkeleton,
 } from "../developer-loading-view";
 
 describe("DeveloperSectionPageSkeleton", () => {
@@ -18,6 +20,27 @@ describe("DeveloperSectionPageSkeleton", () => {
     const { container } = render(<DeveloperSectionPageSkeleton />);
     const bones = container.querySelectorAll('[data-slot="skeleton"]');
     expect(bones.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("DeveloperSectionContentSkeleton", () => {
+  it("renders content and list skeleton regions", () => {
+    render(<DeveloperSectionContentSkeleton />);
+
+    expect(
+      screen.getByTestId("developer-section-content-loading"),
+    ).toBeTruthy();
+    expect(screen.getByTestId("developer-section-loading-list")).toBeTruthy();
+  });
+});
+
+describe("DeveloperSectionRowsSkeleton", () => {
+  it("renders list rows only", () => {
+    const { container } = render(<DeveloperSectionRowsSkeleton rows={3} />);
+
+    expect(screen.getByTestId("developer-section-loading-list")).toBeTruthy();
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBeGreaterThanOrEqual(6);
   });
 });
 

--- a/apps/web/src/app/(app)/developer/components/api-keys/api-keys-list.tsx
+++ b/apps/web/src/app/(app)/developer/components/api-keys/api-keys-list.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 
+import { DeveloperSectionRowsSkeleton } from "@/app/developer/components/developer-loading-view";
 import { DataTable } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 
@@ -25,11 +26,7 @@ export function ApiKeysList({
   );
 
   if (isInitialLoading) {
-    return (
-      <div className="text-muted-foreground py-8 text-center">
-        {t("loading")}
-      </div>
-    );
+    return <DeveloperSectionRowsSkeleton />;
   }
 
   // Full error UI only when there is nothing useful to show. If a later

--- a/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
+++ b/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
@@ -30,6 +30,7 @@ export function DeveloperSectionRowsSkeleton({
 /**
  * Content-only shell for Suspense fallbacks inside DeveloperSectionShell
  * (avoids double max-w-4xl wrapper after Instant `loading.tsx` resolves).
+ * Matches non-card sections (title + description + list).
  */
 export function DeveloperSectionContentSkeleton(): React.ReactElement {
   return (
@@ -44,8 +45,7 @@ export function DeveloperSectionContentSkeleton(): React.ReactElement {
 }
 
 /**
- * Sync Instant Nav shell for developer list sections (no cookies/`connection()`/i18n).
- * Matches DeveloperSectionShell + card header + table/list rows.
+ * Instant shell for card-style developer sections (API keys, OAuth, docs).
  */
 export function DeveloperSectionPageSkeleton(): React.ReactElement {
   return (
@@ -72,16 +72,32 @@ export function DeveloperSectionPageSkeleton(): React.ReactElement {
 }
 
 /**
- * Sync Instant Nav shell for developer detail/edit routes.
+ * Instant shell for non-card list sections (coworkers, tasks, vendors).
+ */
+export function DeveloperListPageSkeleton(): React.ReactElement {
+  return (
+    <div data-testid="developer-list-loading" className="min-h-full w-full">
+      <div className="mx-auto max-w-4xl space-y-8 px-4 py-2">
+        <DeveloperSectionContentSkeleton />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Instant shell for coworker / vendor edit routes (`max-w-3xl` matches pages).
  */
 export function DeveloperDetailPageSkeleton(): React.ReactElement {
   return (
     <div data-testid="developer-detail-loading" className="min-h-full w-full">
-      <div className="mx-auto max-w-4xl space-y-6 px-4 py-2">
-        <Skeleton className="h-9 w-28 rounded-md" />
-        <div className="bg-muted/40 space-y-2 rounded-md border px-3 py-2">
-          <Skeleton className="h-4 w-48" />
-          <Skeleton className="h-3 w-64 max-w-full" />
+      <div className="mx-auto max-w-3xl space-y-6 px-4 py-2">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-8 w-52" />
+            <Skeleton className="h-4 w-full max-w-md" />
+            <Skeleton className="h-3 w-28" />
+          </div>
+          <Skeleton className="h-9 w-28 shrink-0 rounded-md" />
         </div>
         <div className="space-y-4 rounded-xl border p-6">
           <Skeleton className="h-6 w-52" />
@@ -98,5 +114,64 @@ export function DeveloperDetailPageSkeleton(): React.ReactElement {
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * Instant shell for developer task detail — meta bar + task sections
+ * (mirrors `/tasks/[taskId]/loading.tsx` + owner strip).
+ */
+export function DeveloperTaskDetailPageSkeleton(): React.ReactElement {
+  return (
+    <div
+      data-testid="developer-task-detail-loading"
+      className="min-h-full w-full"
+    >
+      <div className="mx-auto max-w-4xl px-4 pt-2">
+        <div className="bg-muted/40 flex flex-wrap items-center justify-between gap-3 rounded-md border px-3 py-2">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          <Skeleton className="h-8 w-24 shrink-0 rounded-md" />
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-4xl px-4 pb-8">
+        <div className="mt-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-9 w-24" />
+            <Skeleton className="size-9" />
+          </div>
+          <Skeleton className="h-7 w-2/3" />
+        </div>
+
+        <div className="mt-6 space-y-8">
+          <TaskSectionSkeleton name="description" rows={3} />
+          <TaskSectionSkeleton name="properties" rows={4} />
+          <TaskSectionSkeleton name="activity" rows={3} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TaskSectionSkeleton({
+  name,
+  rows,
+}: {
+  name: string;
+  rows: number;
+}): React.ReactElement {
+  return (
+    <section className="space-y-4">
+      <Skeleton className="h-3 w-24" />
+      <div className="space-y-3">
+        {Array.from({ length: rows }, (_, index) => (
+          <Skeleton key={`${name}-${index}`} className="h-4 w-full" />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
+++ b/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
@@ -1,6 +1,49 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 /**
+ * Row bones only — safe inside CardContent / list sections while client data loads.
+ * Sync only (no cookies/`connection()`/i18n).
+ */
+export function DeveloperSectionRowsSkeleton({
+  rows = 5,
+}: {
+  rows?: number;
+}): React.ReactElement {
+  return (
+    <div data-testid="developer-section-loading-list" className="space-y-3">
+      {Array.from({ length: rows }, (_, index) => (
+        <div
+          key={index}
+          className="flex items-center gap-3 rounded-lg border border-border/40 p-3"
+        >
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-4 w-44" />
+            <Skeleton className="h-3 w-64 max-w-full" />
+          </div>
+          <Skeleton className="h-8 w-16 shrink-0 rounded-md" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Content-only shell for Suspense fallbacks inside DeveloperSectionShell
+ * (avoids double max-w-4xl wrapper after Instant `loading.tsx` resolves).
+ */
+export function DeveloperSectionContentSkeleton(): React.ReactElement {
+  return (
+    <div data-testid="developer-section-content-loading" className="space-y-4">
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-4 w-full max-w-md" />
+      </div>
+      <DeveloperSectionRowsSkeleton />
+    </div>
+  );
+}
+
+/**
  * Sync Instant Nav shell for developer list sections (no cookies/`connection()`/i18n).
  * Matches DeveloperSectionShell + card header + table/list rows.
  */
@@ -19,22 +62,8 @@ export function DeveloperSectionPageSkeleton(): React.ReactElement {
               <Skeleton className="h-9 w-28 shrink-0 rounded-md" />
             </div>
           </div>
-          <div
-            data-testid="developer-section-loading-list"
-            className="space-y-3 px-6 pb-6"
-          >
-            {Array.from({ length: 5 }, (_, index) => (
-              <div
-                key={index}
-                className="flex items-center gap-3 rounded-lg border border-border/40 p-3"
-              >
-                <div className="min-w-0 flex-1 space-y-2">
-                  <Skeleton className="h-4 w-44" />
-                  <Skeleton className="h-3 w-64 max-w-full" />
-                </div>
-                <Skeleton className="h-8 w-16 shrink-0 rounded-md" />
-              </div>
-            ))}
+          <div className="px-6 pb-6">
+            <DeveloperSectionRowsSkeleton />
           </div>
         </div>
       </div>

--- a/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
+++ b/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
@@ -1,14 +1,21 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
+interface DeveloperSectionRowsSkeletonProps {
+  rows?: number;
+}
+
+interface TaskSectionSkeletonProps {
+  name: string;
+  rows: number;
+}
+
 /**
  * Row bones only — safe inside CardContent / list sections while client data loads.
  * Sync only (no cookies/`connection()`/i18n).
  */
 export function DeveloperSectionRowsSkeleton({
   rows = 5,
-}: {
-  rows?: number;
-}): React.ReactElement {
+}: DeveloperSectionRowsSkeletonProps): React.ReactElement {
   return (
     <div data-testid="developer-section-loading-list" className="space-y-3">
       {Array.from({ length: rows }, (_, index) => (
@@ -160,10 +167,7 @@ export function DeveloperTaskDetailPageSkeleton(): React.ReactElement {
 function TaskSectionSkeleton({
   name,
   rows,
-}: {
-  name: string;
-  rows: number;
-}): React.ReactElement {
+}: TaskSectionSkeletonProps): React.ReactElement {
   return (
     <section className="space-y-4">
       <Skeleton className="h-3 w-24" />

--- a/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
+++ b/apps/web/src/app/(app)/developer/components/developer-loading-view.tsx
@@ -1,0 +1,73 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Sync Instant Nav shell for developer list sections (no cookies/`connection()`/i18n).
+ * Matches DeveloperSectionShell + card header + table/list rows.
+ */
+export function DeveloperSectionPageSkeleton(): React.ReactElement {
+  return (
+    <div data-testid="developer-section-loading" className="min-h-full w-full">
+      <div className="mx-auto max-w-4xl space-y-8 px-4 py-2">
+        <div className="bg-card text-card-foreground rounded-xl border shadow-sm">
+          <div className="flex flex-col gap-1.5 p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-6 w-40" />
+                <Skeleton className="h-4 w-full max-w-md" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+              <Skeleton className="h-9 w-28 shrink-0 rounded-md" />
+            </div>
+          </div>
+          <div
+            data-testid="developer-section-loading-list"
+            className="space-y-3 px-6 pb-6"
+          >
+            {Array.from({ length: 5 }, (_, index) => (
+              <div
+                key={index}
+                className="flex items-center gap-3 rounded-lg border border-border/40 p-3"
+              >
+                <div className="min-w-0 flex-1 space-y-2">
+                  <Skeleton className="h-4 w-44" />
+                  <Skeleton className="h-3 w-64 max-w-full" />
+                </div>
+                <Skeleton className="h-8 w-16 shrink-0 rounded-md" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Sync Instant Nav shell for developer detail/edit routes.
+ */
+export function DeveloperDetailPageSkeleton(): React.ReactElement {
+  return (
+    <div data-testid="developer-detail-loading" className="min-h-full w-full">
+      <div className="mx-auto max-w-4xl space-y-6 px-4 py-2">
+        <Skeleton className="h-9 w-28 rounded-md" />
+        <div className="bg-muted/40 space-y-2 rounded-md border px-3 py-2">
+          <Skeleton className="h-4 w-48" />
+          <Skeleton className="h-3 w-64 max-w-full" />
+        </div>
+        <div className="space-y-4 rounded-xl border p-6">
+          <Skeleton className="h-6 w-52" />
+          {Array.from({ length: 4 }, (_, index) => (
+            <div key={index} className="space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+          ))}
+          <div className="flex justify-end gap-2 pt-2">
+            <Skeleton className="h-9 w-24 rounded-md" />
+            <Skeleton className="h-9 w-28 rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/developer/components/oauth-clients/oauth-clients-list.tsx
+++ b/apps/web/src/app/(app)/developer/components/oauth-clients/oauth-clients-list.tsx
@@ -7,6 +7,7 @@ import {
 import { KeyRound, Pencil, Trash2 } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 
+import { DeveloperSectionRowsSkeleton } from "@/app/developer/components/developer-loading-view";
 import { Button } from "@/components/ui/button";
 
 import type { OAuthClientsListProps } from "./types";
@@ -24,11 +25,7 @@ export function OAuthClientsList({
   const format = useFormatter();
 
   if (isInitialLoading) {
-    return (
-      <div className="text-muted-foreground py-8 text-center">
-        {t("loading")}
-      </div>
-    );
+    return <DeveloperSectionRowsSkeleton />;
   }
 
   // Full error UI only when there is nothing useful to show. If a later

--- a/apps/web/src/app/(app)/developer/coworkers/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/developer/coworkers/[id]/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperDetailPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperCoworkerDetailLoading() {
+  return <DeveloperDetailPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/coworkers/loading.tsx
+++ b/apps/web/src/app/(app)/developer/coworkers/loading.tsx
@@ -1,6 +1,6 @@
-import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+import { DeveloperListPageSkeleton } from "@/app/developer/components/developer-loading-view";
 
 /** Sync shell only — no cookies/`connection()` (Instant Nav). */
 export default function DeveloperCoworkersLoading() {
-  return <DeveloperSectionPageSkeleton />;
+  return <DeveloperListPageSkeleton />;
 }

--- a/apps/web/src/app/(app)/developer/coworkers/loading.tsx
+++ b/apps/web/src/app/(app)/developer/coworkers/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperCoworkersLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/coworkers/page.tsx
+++ b/apps/web/src/app/(app)/developer/coworkers/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { DeveloperCoworkersSection } from "@/app/developer/components/coworkers";
+import { DeveloperSectionContentSkeleton } from "@/app/developer/components/developer-loading-view";
 import { DeveloperSectionShell } from "@/app/developer/components/developer-section-shell";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -13,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default function DeveloperCoworkersPage() {
   return (
     <DeveloperSectionShell>
-      <Suspense fallback={null}>
+      <Suspense fallback={<DeveloperSectionContentSkeleton />}>
         <DeveloperCoworkersSection />
       </Suspense>
     </DeveloperSectionShell>

--- a/apps/web/src/app/(app)/developer/docs/loading.tsx
+++ b/apps/web/src/app/(app)/developer/docs/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperDocsLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/docs/page.tsx
+++ b/apps/web/src/app/(app)/developer/docs/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
+import { DeveloperSectionContentSkeleton } from "@/app/developer/components/developer-loading-view";
 import { DeveloperSectionShell } from "@/app/developer/components/developer-section-shell";
 import { DocsSection } from "@/app/developer/components/docs-section";
 
@@ -13,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default function DeveloperDocsPage() {
   return (
     <DeveloperSectionShell>
-      <Suspense fallback={null}>
+      <Suspense fallback={<DeveloperSectionContentSkeleton />}>
         <DocsSection />
       </Suspense>
     </DeveloperSectionShell>

--- a/apps/web/src/app/(app)/developer/loading.tsx
+++ b/apps/web/src/app/(app)/developer/loading.tsx
@@ -1,6 +1,0 @@
-import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
-
-/** Sync shell only — no cookies/`connection()` (Instant Nav). */
-export default function DeveloperLoading() {
-  return <DeveloperSectionPageSkeleton />;
-}

--- a/apps/web/src/app/(app)/developer/loading.tsx
+++ b/apps/web/src/app/(app)/developer/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/oauth-clients/loading.tsx
+++ b/apps/web/src/app/(app)/developer/oauth-clients/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperOAuthClientsLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/tasks/[taskId]/loading.tsx
+++ b/apps/web/src/app/(app)/developer/tasks/[taskId]/loading.tsx
@@ -1,6 +1,6 @@
-import { DeveloperDetailPageSkeleton } from "@/app/developer/components/developer-loading-view";
+import { DeveloperTaskDetailPageSkeleton } from "@/app/developer/components/developer-loading-view";
 
 /** Sync shell only — no cookies/`connection()` (Instant Nav). */
 export default function DeveloperTaskDetailLoading() {
-  return <DeveloperDetailPageSkeleton />;
+  return <DeveloperTaskDetailPageSkeleton />;
 }

--- a/apps/web/src/app/(app)/developer/tasks/[taskId]/loading.tsx
+++ b/apps/web/src/app/(app)/developer/tasks/[taskId]/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperDetailPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperTaskDetailLoading() {
+  return <DeveloperDetailPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/tasks/loading.tsx
+++ b/apps/web/src/app/(app)/developer/tasks/loading.tsx
@@ -1,6 +1,6 @@
-import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+import { DeveloperListPageSkeleton } from "@/app/developer/components/developer-loading-view";
 
 /** Sync shell only — no cookies/`connection()` (Instant Nav). */
 export default function DeveloperTasksLoading() {
-  return <DeveloperSectionPageSkeleton />;
+  return <DeveloperListPageSkeleton />;
 }

--- a/apps/web/src/app/(app)/developer/tasks/loading.tsx
+++ b/apps/web/src/app/(app)/developer/tasks/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperTasksLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/tasks/page.tsx
+++ b/apps/web/src/app/(app)/developer/tasks/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
+import { DeveloperSectionContentSkeleton } from "@/app/developer/components/developer-loading-view";
 import { DeveloperSectionShell } from "@/app/developer/components/developer-section-shell";
 import { DeveloperTasksSection } from "@/app/developer/components/tasks";
 
@@ -13,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default function DeveloperTasksPage() {
   return (
     <DeveloperSectionShell>
-      <Suspense fallback={null}>
+      <Suspense fallback={<DeveloperSectionContentSkeleton />}>
         <DeveloperTasksSection />
       </Suspense>
     </DeveloperSectionShell>

--- a/apps/web/src/app/(app)/developer/vendors/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/developer/vendors/[id]/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperDetailPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperVendorDetailLoading() {
+  return <DeveloperDetailPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/vendors/loading.tsx
+++ b/apps/web/src/app/(app)/developer/vendors/loading.tsx
@@ -1,6 +1,6 @@
-import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+import { DeveloperListPageSkeleton } from "@/app/developer/components/developer-loading-view";
 
 /** Sync shell only — no cookies/`connection()` (Instant Nav). */
 export default function DeveloperVendorsLoading() {
-  return <DeveloperSectionPageSkeleton />;
+  return <DeveloperListPageSkeleton />;
 }

--- a/apps/web/src/app/(app)/developer/vendors/loading.tsx
+++ b/apps/web/src/app/(app)/developer/vendors/loading.tsx
@@ -1,0 +1,6 @@
+import { DeveloperSectionPageSkeleton } from "@/app/developer/components/developer-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function DeveloperVendorsLoading() {
+  return <DeveloperSectionPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/developer/vendors/page.tsx
+++ b/apps/web/src/app/(app)/developer/vendors/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { DEVELOPER_DEFAULT_HREF } from "@/app/components/sidebar/components/developer-menu-config";
+import { DeveloperSectionContentSkeleton } from "@/app/developer/components/developer-loading-view";
 import { DeveloperSectionShell } from "@/app/developer/components/developer-section-shell";
 import { DeveloperVendorsSection } from "@/app/developer/components/vendors";
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
@@ -21,7 +22,7 @@ export default async function DeveloperVendorsPage() {
 
   return (
     <DeveloperSectionShell>
-      <Suspense fallback={null}>
+      <Suspense fallback={<DeveloperSectionContentSkeleton />}>
         <DeveloperVendorsSection adminVendors={adminVendors} />
       </Suspense>
     </DeveloperSectionShell>

--- a/apps/web/src/app/(app)/notifications/components/__tests__/notifications-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/notifications/components/__tests__/notifications-loading-view.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NotificationsPageSkeleton } from "../notifications-loading-view";
+
+describe("NotificationsPageSkeleton", () => {
+  it("renders list skeleton region", () => {
+    render(<NotificationsPageSkeleton />);
+
+    expect(screen.getByTestId("notifications-loading")).toBeTruthy();
+    expect(screen.getByTestId("notifications-loading-list")).toBeTruthy();
+  });
+
+  it("renders multiple skeleton bones", () => {
+    const { container } = render(<NotificationsPageSkeleton />);
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/apps/web/src/app/(app)/notifications/components/__tests__/notifications-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/notifications/components/__tests__/notifications-loading-view.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { NotificationsPageSkeleton } from "../notifications-loading-view";
+import {
+  NotificationsListSkeleton,
+  NotificationsPageSkeleton,
+} from "../notifications-loading-view";
 
 describe("NotificationsPageSkeleton", () => {
   it("renders list skeleton region", () => {
@@ -15,5 +18,15 @@ describe("NotificationsPageSkeleton", () => {
     const { container } = render(<NotificationsPageSkeleton />);
     const bones = container.querySelectorAll('[data-slot="skeleton"]');
     expect(bones.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe("NotificationsListSkeleton", () => {
+  it("renders shared list bones", () => {
+    const { container } = render(<NotificationsListSkeleton />);
+
+    expect(screen.getByTestId("notifications-loading-list")).toBeTruthy();
+    const bones = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(bones.length).toBe(10);
   });
 });

--- a/apps/web/src/app/(app)/notifications/components/notifications-loading-view.tsx
+++ b/apps/web/src/app/(app)/notifications/components/notifications-loading-view.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Sync Instant Nav shell for `/notifications` (no cookies/`connection()`/i18n).
+ * Mirrors the in-page list loading card (5 rows).
+ */
+export function NotificationsPageSkeleton(): React.ReactElement {
+  return (
+    <div
+      data-testid="notifications-loading"
+      className="flex flex-col gap-5 pb-4"
+    >
+      <div className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border">
+        <div
+          data-testid="notifications-loading-list"
+          className="divide-border/50 divide-y"
+        >
+          {Array.from({ length: 5 }, (_, index) => (
+            <div key={index} className="flex flex-col gap-2 p-4">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/notifications/components/notifications-loading-view.tsx
+++ b/apps/web/src/app/(app)/notifications/components/notifications-loading-view.tsx
@@ -1,8 +1,29 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 /**
- * Sync Instant Nav shell for `/notifications` (no cookies/`connection()`/i18n).
- * Mirrors the in-page list loading card (5 rows).
+ * List card bones shared by Instant `loading.tsx` and in-page client fetch.
+ * Sync only (no cookies/`connection()`/i18n).
+ */
+export function NotificationsListSkeleton(): React.ReactElement {
+  return (
+    <div className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border">
+      <div
+        data-testid="notifications-loading-list"
+        className="divide-border/50 divide-y"
+      >
+        {Array.from({ length: 5 }, (_, index) => (
+          <div key={index} className="flex flex-col gap-2 p-4">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/4" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Sync Instant Nav shell for `/notifications`.
  */
 export function NotificationsPageSkeleton(): React.ReactElement {
   return (
@@ -10,19 +31,7 @@ export function NotificationsPageSkeleton(): React.ReactElement {
       data-testid="notifications-loading"
       className="flex flex-col gap-5 pb-4"
     >
-      <div className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border">
-        <div
-          data-testid="notifications-loading-list"
-          className="divide-border/50 divide-y"
-        >
-          {Array.from({ length: 5 }, (_, index) => (
-            <div key={index} className="flex flex-col gap-2 p-4">
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-3 w-1/4" />
-            </div>
-          ))}
-        </div>
-      </div>
+      <NotificationsListSkeleton />
     </div>
   );
 }

--- a/apps/web/src/app/(app)/notifications/loading.tsx
+++ b/apps/web/src/app/(app)/notifications/loading.tsx
@@ -1,0 +1,6 @@
+import { NotificationsPageSkeleton } from "@/app/notifications/components/notifications-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function NotificationsLoading() {
+  return <NotificationsPageSkeleton />;
+}

--- a/apps/web/src/app/(app)/notifications/page-content.tsx
+++ b/apps/web/src/app/(app)/notifications/page-content.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { AccountNoticeRow } from "@/app/components/account-notice-row";
 import { NotificationBrowserPermissionPrimer } from "@/app/components/notification-browser-permission-primer";
 import { useWorkspaceSwitcher } from "@/app/components/user-avatar/workspace-switcher";
+import { NotificationsListSkeleton } from "@/app/notifications/components/notifications-loading-view";
 import { VendorGrantNotificationActions } from "@/components/notifications/vendor-grant-notification-actions";
 import { Button } from "@/components/ui/button";
 import { useAccountNotice } from "@/contexts/account-notice-provider";
@@ -246,16 +247,7 @@ export function NotificationsPageContent({
       ) : null}
 
       {isLoading && notifications.length === 0 ? (
-        <div className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border">
-          <div className="divide-border/50 divide-y">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex flex-col gap-2 p-4">
-                <div className="bg-muted h-4 w-3/4 animate-pulse rounded" />
-                <div className="bg-muted h-3 w-1/4 animate-pulse rounded" />
-              </div>
-            ))}
-          </div>
-        </div>
+        <NotificationsListSkeleton />
       ) : hasFetchError && notifications.length === 0 ? (
         <div className="bg-muted/30 border-border/50 flex flex-col items-center justify-center gap-3 rounded-xl border p-8">
           <p className="text-muted-foreground text-center">


### PR DESCRIPTION
## Summary

- Add sync Instant Nav `loading.tsx` skeletons for `/notifications`, `/connections`, and developer hub list + detail routes.
- Reuse shared developer section/detail shells; keep shells free of cookies/`connection()`/session/async i18n.
- Add unit tests and a source contract so soft-nav opt-out is not introduced on these hubs.

Auth, admin, and personal-assistant stay soft-nav (`instant = false`) by design.

## Test plan

- [x] Unit: notifications / connections / developer skeleton structure tests
- [x] Contract: hub pages no `instant = false`; loading shells sync + wire correct skeletons
- [ ] Manual: navigate to Notifications, Connections, Developer tabs — skeleton then content; app chrome stays mounted
- [ ] Manual: open a developer detail route — detail-shaped skeleton
- [ ] Manual: auth/admin/Hermes still soft-nav