### PR TITLE
fix(web): stop account summary credits flash on navigate

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
@@ -1,6 +1,7 @@
 import type { SessionUser } from "@sokosumi/utils";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 async function flushAnimationFrame() {
   await act(async () => {
@@ -25,6 +26,31 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/components/modals/global-modals-context", () => ({
   useGlobalModalsContext: () => ({ showLogoutModal: showLogoutModalMock }),
 }));
+
+/**
+ * When true, render popover children outside Radix Presence so the exit-path
+ * remount (settings → root flash) is observable in jsdom.
+ */
+const popoverTestFlags = { forceMount: false };
+
+vi.mock("@/components/ui/popover", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/ui/popover")>();
+  function PopoverContent(props: ComponentProps<typeof actual.PopoverContent>) {
+    if (popoverTestFlags.forceMount) {
+      return (
+        <div data-slot="popover-content" data-testid="forced-popover-content">
+          {props.children}
+        </div>
+      );
+    }
+    return <actual.PopoverContent {...props} />;
+  }
+  return {
+    ...actual,
+    PopoverContent,
+  };
+});
 
 import { HeaderAccountControl } from "@/app/components/header/header-account-control.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
@@ -85,6 +111,11 @@ function getPopoverScrollContainer(): HTMLElement {
 describe("HeaderAccountControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    popoverTestFlags.forceMount = false;
+  });
+
+  afterEach(() => {
+    popoverTestFlags.forceMount = false;
   });
 
   it("shows Admin and Settings before Logout when admin is enabled", () => {
@@ -139,6 +170,45 @@ describe("HeaderAccountControl", () => {
     fireEvent.click(screen.getByRole("button", { name: "account" }));
 
     expect(pushMock).toHaveBeenCalledWith("/account");
+  });
+
+  it("does not flash the credits root when navigating away from settings", () => {
+    // forceMount keeps content in the tree through close (same window as the
+    // real exit animation) so a remount-to-root is visible as totalBalanceLabel.
+    popoverTestFlags.forceMount = true;
+    renderControl();
+    openControl();
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+    expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
+    expect(screen.queryByText("totalBalanceLabel")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "billing" }));
+
+    // Close remounted menu at root while the popover exit animation still
+    // runs → brief credits flash. Keep drill content until unmount.
+    expect(screen.queryByText("totalBalanceLabel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
+    expect(pushMock).toHaveBeenCalledWith("/billing");
+  });
+
+  it("starts at the root panel when reopened after closing from settings", () => {
+    renderControl();
+    openControl();
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+    expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /openSummary/ }));
+    openControl();
+
+    expect(
+      screen.getByRole("button", { name: "settings" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "back" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("totalBalanceLabel")).toBeInTheDocument();
   });
 
   it("moves keyboard focus into the settings drill when Settings is activated", async () => {

--- a/apps/web/src/app/(app)/components/header/header-account-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-account-control.client.tsx
@@ -71,8 +71,10 @@ export function HeaderAccountControl({
     detailsUnavailable: t("detailsUnavailable"),
   });
 
+  // Remount only on open so a drill panel (e.g. settings → billing) does not
+  // flash the credits root during the popover exit animation.
   function handleOpenChange(open: boolean) {
-    if (!open) {
+    if (open) {
       setMenuInstance((value) => value + 1);
     }
     setIsOpen(open);
@@ -80,7 +82,6 @@ export function HeaderAccountControl({
 
   function closeMenu() {
     setIsOpen(false);
-    setMenuInstance((value) => value + 1);
   }
 
   return (

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
@@ -1,5 +1,6 @@
 import type { SessionUser } from "@sokosumi/utils";
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-intl", () => ({
@@ -26,6 +27,31 @@ const sidebarState = {
 vi.mock("@/components/ui/sidebar", () => ({
   useSidebar: () => ({ ...sidebarState }),
 }));
+
+/**
+ * When true, render popover children outside Radix Presence so the exit-path
+ * remount (settings → root flash) is observable in jsdom.
+ */
+const popoverTestFlags = { forceMount: false };
+
+vi.mock("@/components/ui/popover", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/ui/popover")>();
+  function PopoverContent(props: ComponentProps<typeof actual.PopoverContent>) {
+    if (popoverTestFlags.forceMount) {
+      return (
+        <div data-slot="popover-content" data-testid="forced-popover-content">
+          {props.children}
+        </div>
+      );
+    }
+    return <actual.PopoverContent {...props} />;
+  }
+  return {
+    ...actual,
+    PopoverContent,
+  };
+});
 
 import { SidebarAccountChip } from "@/app/components/sidebar/components/sidebar-account-chip.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
@@ -82,9 +108,11 @@ describe("SidebarAccountChip", () => {
     vi.clearAllMocks();
     sidebarState.isMobile = false;
     sidebarState.state = "expanded";
+    popoverTestFlags.forceMount = false;
   });
 
   afterEach(() => {
+    popoverTestFlags.forceMount = false;
     vi.restoreAllMocks();
   });
 
@@ -200,6 +228,45 @@ describe("SidebarAccountChip", () => {
     fireEvent.click(screen.getByRole("button", { name: "account" }));
 
     expect(pushMock).toHaveBeenCalledWith("/account");
+  });
+
+  it("does not flash the credits root when navigating away from settings", () => {
+    // forceMount keeps content in the tree through close (same window as the
+    // real exit animation) so a remount-to-root is visible as totalBalanceLabel.
+    popoverTestFlags.forceMount = true;
+    renderChip();
+    openChip();
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+    expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
+    expect(screen.queryByText("totalBalanceLabel")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "billing" }));
+
+    // Close remounted menu at root while the popover exit animation still
+    // runs → brief credits flash. Keep drill content until unmount.
+    expect(screen.queryByText("totalBalanceLabel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
+    expect(pushMock).toHaveBeenCalledWith("/billing");
+  });
+
+  it("starts at the root panel when reopened after closing from settings", () => {
+    renderChip();
+    openChip();
+
+    fireEvent.click(screen.getByRole("button", { name: "settings" }));
+    expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /openSummary/ }));
+    openChip();
+
+    expect(
+      screen.getByRole("button", { name: "settings" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "back" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("totalBalanceLabel")).toBeInTheDocument();
   });
 
   it("buys credits and logs out from inside the summary", () => {

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
@@ -98,8 +98,10 @@ function SidebarAccountChipDesktop({
     detailsUnavailable: t("detailsUnavailable"),
   });
 
+  // Remount only on open so a drill panel (e.g. settings → billing) does not
+  // flash the credits root during the popover exit animation.
   function handleOpenChange(open: boolean) {
-    if (!open) {
+    if (open) {
       setMenuInstance((value) => value + 1);
     }
     setIsOpen(open);
@@ -107,7 +109,6 @@ function SidebarAccountChipDesktop({
 
   function closeChip() {
     setIsOpen(false);
-    setMenuInstance((value) => value + 1);
   }
 
   const trigger = (


### PR DESCRIPTION
## Summary

- Closing the account summary (desktop chip or mobile header) used to remount `AccountSummaryMenu` at the credits root while the popover was still exit-animating.
- Settings → Billing (and other drill destinations) briefly flashed the account summary with credits.
- Remount now happens only on open; close keeps the current panel until unmount. Reopen still starts at root.

## Test plan

- [x] `pnpm --filter web exec vitest run` on `sidebar-account-chip` + `header-account-control` (30 tests)
- [ ] Manual: open bottom-left account summary → Settings → Billing — no credits flash mid-close
- [ ] Manual: reopen summary after closing from settings — still shows root credits view
- [ ] Same path from mobile header account control