### PR TITLE
refactor(web): share account summary open state and harden tests

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-account-control.test.tsx
@@ -1,7 +1,10 @@
 import type { SessionUser } from "@sokosumi/utils";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  accountSummaryPopoverTestFlags,
+  resetAccountSummaryPopoverTestFlags,
+} from "@/app/components/sidebar/components/__tests__/account-summary-popover-test-utils";
 
 async function flushAnimationFrame() {
   await act(async () => {
@@ -27,29 +30,13 @@ vi.mock("@/components/modals/global-modals-context", () => ({
   useGlobalModalsContext: () => ({ showLogoutModal: showLogoutModalMock }),
 }));
 
-/**
- * When true, render popover children outside Radix Presence so the exit-path
- * remount (settings → root flash) is observable in jsdom.
- */
-const popoverTestFlags = { forceMount: false };
-
 vi.mock("@/components/ui/popover", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/components/ui/popover")>();
-  function PopoverContent(props: ComponentProps<typeof actual.PopoverContent>) {
-    if (popoverTestFlags.forceMount) {
-      return (
-        <div data-slot="popover-content" data-testid="forced-popover-content">
-          {props.children}
-        </div>
-      );
-    }
-    return <actual.PopoverContent {...props} />;
-  }
-  return {
-    ...actual,
-    PopoverContent,
-  };
+  const { createAccountSummaryPopoverMock } = await import(
+    "@/app/components/sidebar/components/__tests__/account-summary-popover-test-utils"
+  );
+  return createAccountSummaryPopoverMock(actual);
 });
 
 import { HeaderAccountControl } from "@/app/components/header/header-account-control.client";
@@ -111,11 +98,11 @@ function getPopoverScrollContainer(): HTMLElement {
 describe("HeaderAccountControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    popoverTestFlags.forceMount = false;
+    resetAccountSummaryPopoverTestFlags();
   });
 
   afterEach(() => {
-    popoverTestFlags.forceMount = false;
+    resetAccountSummaryPopoverTestFlags();
   });
 
   it("shows Admin and Settings before Logout when admin is enabled", () => {
@@ -173,9 +160,10 @@ describe("HeaderAccountControl", () => {
   });
 
   it("does not flash the credits root when navigating away from settings", () => {
-    // forceMount keeps content in the tree through close (same window as the
-    // real exit animation) so a remount-to-root is visible as totalBalanceLabel.
-    popoverTestFlags.forceMount = true;
+    // forceMount keeps content through close (exit-animation window). If close
+    // remounted the menu at root, totalBalanceLabel would appear — assert the
+    // settings drill stays instead.
+    accountSummaryPopoverTestFlags.forceMount = true;
     renderControl();
     openControl();
 
@@ -185,14 +173,15 @@ describe("HeaderAccountControl", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "billing" }));
 
-    // Close remounted menu at root while the popover exit animation still
-    // runs → brief credits flash. Keep drill content until unmount.
     expect(screen.queryByText("totalBalanceLabel")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
     expect(pushMock).toHaveBeenCalledWith("/billing");
   });
 
   it("starts at the root panel when reopened after closing from settings", () => {
+    // forceMount keeps the settings drill mounted across close so reopen must
+    // remount via menuInstance (open-only bump) to reach root again.
+    accountSummaryPopoverTestFlags.forceMount = true;
     renderControl();
     openControl();
 

--- a/apps/web/src/app/(app)/components/header/header-account-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-account-control.client.tsx
@@ -2,7 +2,7 @@
 
 import gravatarUrl from "gravatar-url";
 import { useTranslations } from "next-intl";
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 import {
   ACCOUNT_SUMMARY_POPOVER_CONTENT_CLASS,
   resolveAccountCreditsLabel,
@@ -15,6 +15,7 @@ import type {
   AccountSummaryCreditProps,
   AccountSummaryIdentityProps,
 } from "@/app/components/sidebar/components/account-summary-types";
+import { useAccountSummaryOpenState } from "@/app/components/sidebar/components/use-account-summary-open-state";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -53,8 +54,8 @@ export function HeaderAccountControl({
   const tBilling = useTranslations("App.Billing");
   const tPresence = useTranslations("App.Channels.Presence");
   const presence = useSelfPresence();
-  const [isOpen, setIsOpen] = useState(false);
-  const [menuInstance, setMenuInstance] = useState(0);
+  const { isOpen, menuInstance, handleOpenChange, closeMenu } =
+    useAccountSummaryOpenState();
 
   const displayName = resolveAccountDisplayName(
     sessionUser.name,
@@ -70,19 +71,6 @@ export function HeaderAccountControl({
     planAndCredits: (plan, credits) => t("planAndCredits", { plan, credits }),
     detailsUnavailable: t("detailsUnavailable"),
   });
-
-  // Remount only on open so a drill panel (e.g. settings → billing) does not
-  // flash the credits root during the popover exit animation.
-  function handleOpenChange(open: boolean) {
-    if (open) {
-      setMenuInstance((value) => value + 1);
-    }
-    setIsOpen(open);
-  }
-
-  function closeMenu() {
-    setIsOpen(false);
-  }
 
   return (
     <div

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/account-summary-popover-test-utils.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/account-summary-popover-test-utils.tsx
@@ -1,0 +1,52 @@
+import type { ComponentProps, ReactElement } from "react";
+
+/**
+ * Shared flags for account-summary shell tests. When `forceMount` is true,
+ * popover children stay in the tree through close (same window as a real exit
+ * animation) so remount-on-close vs remount-on-open is observable in jsdom.
+ */
+export const accountSummaryPopoverTestFlags = {
+  forceMount: false,
+};
+
+export function resetAccountSummaryPopoverTestFlags(): void {
+  accountSummaryPopoverTestFlags.forceMount = false;
+}
+
+type PopoverModule = typeof import("@/components/ui/popover");
+
+/**
+ * Builds a `@/components/ui/popover` mock that optionally force-mounts content.
+ * Use inside `vi.mock` factories:
+ *
+ * ```ts
+ * vi.mock("@/components/ui/popover", async (importOriginal) => {
+ *   const actual = await importOriginal<typeof import("@/components/ui/popover")>();
+ *   const { createAccountSummaryPopoverMock } = await import(
+ *     "@/app/components/sidebar/components/__tests__/account-summary-popover-test-utils"
+ *   );
+ *   return createAccountSummaryPopoverMock(actual);
+ * });
+ * ```
+ */
+export function createAccountSummaryPopoverMock(
+  actual: PopoverModule,
+): PopoverModule {
+  function PopoverContent(
+    props: ComponentProps<typeof actual.PopoverContent>,
+  ): ReactElement {
+    if (accountSummaryPopoverTestFlags.forceMount) {
+      return (
+        <div data-slot="popover-content" data-testid="forced-popover-content">
+          {props.children}
+        </div>
+      );
+    }
+    return <actual.PopoverContent {...props} />;
+  }
+
+  return {
+    ...actual,
+    PopoverContent,
+  };
+}

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/sidebar-account-chip.test.tsx
@@ -1,6 +1,5 @@
 import type { SessionUser } from "@sokosumi/utils";
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-intl", () => ({
@@ -28,33 +27,22 @@ vi.mock("@/components/ui/sidebar", () => ({
   useSidebar: () => ({ ...sidebarState }),
 }));
 
-/**
- * When true, render popover children outside Radix Presence so the exit-path
- * remount (settings → root flash) is observable in jsdom.
- */
-const popoverTestFlags = { forceMount: false };
-
 vi.mock("@/components/ui/popover", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/components/ui/popover")>();
-  function PopoverContent(props: ComponentProps<typeof actual.PopoverContent>) {
-    if (popoverTestFlags.forceMount) {
-      return (
-        <div data-slot="popover-content" data-testid="forced-popover-content">
-          {props.children}
-        </div>
-      );
-    }
-    return <actual.PopoverContent {...props} />;
-  }
-  return {
-    ...actual,
-    PopoverContent,
-  };
+  const { createAccountSummaryPopoverMock } = await import(
+    "@/app/components/sidebar/components/__tests__/account-summary-popover-test-utils"
+  );
+  return createAccountSummaryPopoverMock(actual);
 });
 
 import { SidebarAccountChip } from "@/app/components/sidebar/components/sidebar-account-chip.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
+
+import {
+  accountSummaryPopoverTestFlags,
+  resetAccountSummaryPopoverTestFlags,
+} from "./account-summary-popover-test-utils";
 
 const sessionUser: SessionUser = {
   id: "user_1",
@@ -108,11 +96,11 @@ describe("SidebarAccountChip", () => {
     vi.clearAllMocks();
     sidebarState.isMobile = false;
     sidebarState.state = "expanded";
-    popoverTestFlags.forceMount = false;
+    resetAccountSummaryPopoverTestFlags();
   });
 
   afterEach(() => {
-    popoverTestFlags.forceMount = false;
+    resetAccountSummaryPopoverTestFlags();
     vi.restoreAllMocks();
   });
 
@@ -231,9 +219,10 @@ describe("SidebarAccountChip", () => {
   });
 
   it("does not flash the credits root when navigating away from settings", () => {
-    // forceMount keeps content in the tree through close (same window as the
-    // real exit animation) so a remount-to-root is visible as totalBalanceLabel.
-    popoverTestFlags.forceMount = true;
+    // forceMount keeps content through close (exit-animation window). If close
+    // remounted the menu at root, totalBalanceLabel would appear — assert the
+    // settings drill stays instead.
+    accountSummaryPopoverTestFlags.forceMount = true;
     renderChip();
     openChip();
 
@@ -243,14 +232,15 @@ describe("SidebarAccountChip", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "billing" }));
 
-    // Close remounted menu at root while the popover exit animation still
-    // runs → brief credits flash. Keep drill content until unmount.
     expect(screen.queryByText("totalBalanceLabel")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "billing" })).toBeInTheDocument();
     expect(pushMock).toHaveBeenCalledWith("/billing");
   });
 
   it("starts at the root panel when reopened after closing from settings", () => {
+    // forceMount keeps the settings drill mounted across close so reopen must
+    // remount via menuInstance (open-only bump) to reach root again.
+    accountSummaryPopoverTestFlags.forceMount = true;
     renderChip();
     openChip();
 

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/use-account-summary-open-state.test.ts
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/use-account-summary-open-state.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useAccountSummaryOpenState } from "../use-account-summary-open-state";
+
+describe("useAccountSummaryOpenState", () => {
+  it("bumps menuInstance only when opening, not when closing", () => {
+    const { result } = renderHook(() => useAccountSummaryOpenState());
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.menuInstance).toBe(0);
+
+    act(() => {
+      result.current.handleOpenChange(true);
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.menuInstance).toBe(1);
+
+    act(() => {
+      result.current.closeMenu();
+    });
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.menuInstance).toBe(1);
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.menuInstance).toBe(1);
+
+    act(() => {
+      result.current.handleOpenChange(true);
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.menuInstance).toBe(2);
+  });
+});

--- a/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/sidebar-account-chip.client.tsx
@@ -3,7 +3,7 @@
 import gravatarUrl from "gravatar-url";
 import { AlertTriangle, ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -33,6 +33,7 @@ import type {
   AccountSummaryCreditProps,
   AccountSummaryIdentityProps,
 } from "./account-summary-types";
+import { useAccountSummaryOpenState } from "./use-account-summary-open-state";
 
 const GRAVATAR_SIZE = 80;
 
@@ -78,8 +79,8 @@ function SidebarAccountChipDesktop({
   const tPresence = useTranslations("App.Channels.Presence");
   const { state } = useSidebar();
   const presence = useSelfPresence();
-  const [isOpen, setIsOpen] = useState(false);
-  const [menuInstance, setMenuInstance] = useState(0);
+  const { isOpen, menuInstance, handleOpenChange, closeMenu } =
+    useAccountSummaryOpenState();
 
   const isCollapsed = state === "collapsed";
   const displayName = resolveAccountDisplayName(
@@ -97,19 +98,6 @@ function SidebarAccountChipDesktop({
     planAndCredits: (plan, credits) => t("planAndCredits", { plan, credits }),
     detailsUnavailable: t("detailsUnavailable"),
   });
-
-  // Remount only on open so a drill panel (e.g. settings → billing) does not
-  // flash the credits root during the popover exit animation.
-  function handleOpenChange(open: boolean) {
-    if (open) {
-      setMenuInstance((value) => value + 1);
-    }
-    setIsOpen(open);
-  }
-
-  function closeChip() {
-    setIsOpen(false);
-  }
 
   const trigger = (
     <button
@@ -191,7 +179,7 @@ function SidebarAccountChipDesktop({
         buyCreditsLabel={buyCreditsLabel}
         buyCreditsPath={buyCreditsPath}
         adminSettingsChrome={adminSettingsChrome}
-        onRequestClose={closeChip}
+        onRequestClose={closeMenu}
       />
     </PopoverContent>
   );

--- a/apps/web/src/app/(app)/components/sidebar/components/use-account-summary-open-state.ts
+++ b/apps/web/src/app/(app)/components/sidebar/components/use-account-summary-open-state.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+export interface AccountSummaryOpenState {
+  isOpen: boolean;
+  menuInstance: number;
+  handleOpenChange: (open: boolean) => void;
+  closeMenu: () => void;
+}
+
+/**
+ * Open/close state for account summary popover shells (desktop chip + mobile
+ * header). Remounts the menu (`key={menuInstance}`) only when opening so a
+ * drill panel does not flash the credits root during exit animation.
+ */
+export function useAccountSummaryOpenState(): AccountSummaryOpenState {
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuInstance, setMenuInstance] = useState(0);
+
+  function handleOpenChange(open: boolean) {
+    if (open) {
+      setMenuInstance((value) => value + 1);
+    }
+    setIsOpen(open);
+  }
+
+  function closeMenu() {
+    setIsOpen(false);
+  }
+
+  return {
+    isOpen,
+    menuInstance,
+    handleOpenChange,
+    closeMenu,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to #3702 review minors (all valid):

1. **forceMount reopen assertion** — reopen-from-settings tests keep popover content mounted so dropping open-only remount would fail (locks the exit-animation case).
2. **Shared open state + test harness** — `useAccountSummaryOpenState` used by desktop chip and mobile header; shared `account-summary-popover-test-utils` for force-mount popover mock.
3. **Comment clarity** — flash tests describe the assertion (what must not happen), not the old bug as current behavior.

Also adds a unit test for open-only `menuInstance` bumps.

## Test plan

- [x] `vitest run` on hook + `sidebar-account-chip` + `header-account-control` (31 tests)
- [ ] Spot-check Settings → Billing still has no credits flash (unchanged behavior)