### PR TITLE
feat(chat): convert emoticons live in room composer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "docx": "9.7.1",
     "dompurify": "3.4.13",
     "embla-carousel-react": "8.6.0",
+    "emoticon": "4.1.0",
     "fake-indexeddb": "6.2.5",
     "gemoji": "8.1.0",
     "gravatar-url": "4.0.2",

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -812,6 +812,37 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.textContent).not.toContain("😄");
   });
 
+  it("does not convert emoticon match range inside code when caret is outside", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    // serialize flattens to "hello:D "; caret after outer space must not
+    // rewrite the `:D` still living inside <code>.
+    editor.innerHTML = "hello<code>:D</code> ";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(editor.textContent).toContain(":D");
+    expect(editor.textContent).not.toContain("😄");
+    expect(editor.querySelector("code")?.textContent).toBe(":D");
+  });
+
   it("converts bare trailing emoticon on blur (flush)", () => {
     function Harness() {
       const [value, setValue] = useState("");

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -958,6 +958,39 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.querySelector("code")?.textContent).toBe(":D");
   });
 
+  it("still converts emoticons after a mention chip", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{
+            alice: { value: "Alice" },
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    // Mention chip then plain ":D " — convert must apply only to plain text.
+    editor.innerHTML =
+      '<span data-mention-key="alice" data-mention-slug="alice" contenteditable="false">@Alice</span> :D ';
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(editor.textContent).toContain("😄");
+    expect(editor.textContent).not.toContain(":D");
+    expect(editor.querySelector("[data-mention-key='alice']")).not.toBeNull();
+  });
+
   it("converts bare trailing emoticon on blur (flush)", () => {
     function Harness() {
       const [value, setValue] = useState("");

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -811,4 +811,73 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.textContent).toContain(":D");
     expect(editor.textContent).not.toContain("😄");
   });
+
+  it("converts bare trailing emoticon on blur (flush)", async () => {
+    vi.useFakeTimers();
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ":)";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+    // Live mode should not convert without boundary
+    expect(editor.textContent).toContain(":)");
+
+    fireEvent.blur(editor);
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(editor.textContent).toContain("😃");
+    expect(editor.textContent).not.toContain(":)");
+    vi.useRealTimers();
+  });
+
+  it("converts bare trailing emoticon before submit shortcut", () => {
+    const onSubmitShortcut = vi.fn();
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+          onSubmitShortcut={onSubmitShortcut}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ";)";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(editor.textContent).toContain("😉");
+    expect(onSubmitShortcut).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -752,4 +752,63 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.innerHTML).not.toMatch(/color\s*:/i);
     expect(editor.textContent).toBe("stuck dark");
   });
+
+  it("converts :D to emoji after trailing space", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ":D ";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(editor.textContent).toContain("😄");
+    expect(editor.textContent).not.toContain(":D");
+  });
+
+  it("does not convert emoticons inside inline code", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.innerHTML = "<code>:D </code>";
+    const code = editor.querySelector("code");
+    expect(code).toBeTruthy();
+    const textNode = code!.firstChild as Text;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode, textNode.length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(editor.textContent).toContain(":D");
+    expect(editor.textContent).not.toContain("😄");
+  });
 });

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -887,6 +887,13 @@ describe("ComposerWysiwygEditor", () => {
 
     expect(editor.textContent).toContain("😄");
     expect(editor.textContent).not.toContain(":D");
+    // Boundary space kept; caret after it so the next word needs no second space.
+    expect(editor.textContent).toBe("😄 ");
+    const caretRange = window.getSelection()?.getRangeAt(0);
+    expect(caretRange?.collapsed).toBe(true);
+    expect(caretRange?.startOffset).toBe(
+      caretRange?.startContainer.textContent?.length,
+    );
   });
 
   it("does not convert emoticons inside inline code", () => {

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -812,8 +812,7 @@ describe("ComposerWysiwygEditor", () => {
     expect(editor.textContent).not.toContain("😄");
   });
 
-  it("converts bare trailing emoticon on blur (flush)", async () => {
-    vi.useFakeTimers();
+  it("converts bare trailing emoticon on blur (flush)", () => {
     function Harness() {
       const [value, setValue] = useState("");
       return (
@@ -839,14 +838,11 @@ describe("ComposerWysiwygEditor", () => {
     // Live mode should not convert without boundary
     expect(editor.textContent).toContain(":)");
 
+    // Sync blur flush — no timer advance needed for convert
     fireEvent.blur(editor);
-    await act(async () => {
-      vi.advanceTimersByTime(200);
-    });
 
     expect(editor.textContent).toContain("😃");
     expect(editor.textContent).not.toContain(":)");
-    vi.useRealTimers();
   });
 
   it("converts bare trailing emoticon before submit shortcut", () => {
@@ -879,5 +875,87 @@ describe("ComposerWysiwygEditor", () => {
 
     expect(editor.textContent).toContain("😉");
     expect(onSubmitShortcut).toHaveBeenCalled();
+  });
+
+  it("submits flushed emoticon markdown to parent state", () => {
+    const onSubmitted = vi.fn();
+    function Harness() {
+      const [value, setValue] = useState("");
+      const formRef = useRef<HTMLFormElement>(null);
+      return (
+        <form
+          ref={formRef}
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmitted(value);
+          }}
+        >
+          <ComposerWysiwygEditor
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+            onSubmitShortcut={() => formRef.current?.requestSubmit()}
+          />
+        </form>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ";)";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSubmitted).toHaveBeenCalledWith(expect.stringContaining("😉"));
+    expect(onSubmitted).not.toHaveBeenCalledWith(expect.stringContaining(";)"));
+  });
+
+  it("updates parent value on blur flush before form submit", () => {
+    const onSubmitted = vi.fn();
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmitted(value);
+          }}
+        >
+          <ComposerWysiwygEditor
+            value={value}
+            onChange={setValue}
+            mentions={{}}
+          />
+          <button type="submit">Send</button>
+        </form>
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ";)";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    // Blur (sync flush + flushSync) then Submit click — no timer advance
+    fireEvent.blur(editor);
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSubmitted).toHaveBeenCalledWith(expect.stringContaining("😉"));
+    expect(onSubmitted).not.toHaveBeenCalledWith(expect.stringContaining(";)"));
   });
 });

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -473,12 +473,17 @@ export function ComposerWysiwygEditor<TData = unknown>({
       return;
     }
 
-    // Emoticon live convert: boundary char stays after `end` — insert emoji only.
+    // Emoticon live convert: include the closing boundary (space/punct) in the
+    // replace so caret lands after it — otherwise typing glues to the emoji and
+    // the user needs a second space for the next word.
     const emoticonMatch = matchEmoticonClosedAtBoundary(text, caret);
     if (emoticonMatch && editorRef.current) {
       const editor = editorRef.current;
+      // Live path: caret is just after the boundary char at match.end.
+      const boundarySuffix = text.slice(emoticonMatch.end, caret);
+      const deleteEnd = emoticonMatch.end + boundarySuffix.length;
       const startPos = findPositionForOffset(editor, emoticonMatch.start);
-      const endPos = findPositionForOffset(editor, emoticonMatch.end);
+      const endPos = findPositionForOffset(editor, deleteEnd);
       // Gate on match range (not only caret): serialize flattens text so a
       // caret after `</code>` can still match `:D` inside CODE.
       if (
@@ -490,9 +495,10 @@ export function ComposerWysiwygEditor<TData = unknown>({
         range.setEnd(endPos.node, endPos.offset);
         range.deleteContents();
 
-        const textNode = document.createTextNode(emoticonMatch.emoji);
+        const textNode = document.createTextNode(
+          `${emoticonMatch.emoji}${boundarySuffix}`,
+        );
         range.insertNode(textNode);
-        // Caret after emoji, before trailing boundary still in DOM
         setCaretAfterNode(editor, textNode);
         // Commit parent value before any same-tick submit (e.g. Enter send).
         flushSync(() => {

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -46,6 +46,7 @@ import {
   type ComposerFormatCommand,
   getComposerActiveFormats,
 } from "@/lib/utils/composer-active-formats";
+import { matchEmoticonClosedAtBoundary } from "@/lib/utils/composer-emoticons";
 import {
   htmlToMarkdown,
   markdownToHtml,
@@ -66,6 +67,23 @@ import {
 } from "@/lib/utils/emoji-shortcodes";
 import { normalizeUrl } from "@/lib/utils/markdown-editor-utils";
 import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
+
+const COMPOSER_PROTECTED_TAGS = new Set(["CODE", "PRE"]);
+
+function isInsideComposerProtectedContext(
+  node: Node | null,
+  root: HTMLElement,
+): boolean {
+  let current: Node | null = node;
+  while (current && current !== root) {
+    if (current instanceof HTMLElement) {
+      if (COMPOSER_PROTECTED_TAGS.has(current.tagName)) return true;
+      if (current.dataset.mentionKey) return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+}
 
 type SuggestionUiState =
   | { open: false }
@@ -446,6 +464,42 @@ export function ComposerWysiwygEditor<TData = unknown>({
         : exactEmoji.emoji;
       const textNode = document.createTextNode(insert);
       range.insertNode(textNode);
+      setCaretAfterNode(editorRef.current, textNode);
+      isInternalChange.current = true;
+      syncFromEditor();
+      closeSuggestions();
+      return;
+    }
+
+    // Emoticon live convert: boundary char stays after `end` — insert emoji only.
+    const selection = window.getSelection();
+    const anchorNode =
+      selection && selection.rangeCount > 0
+        ? selection.getRangeAt(0).startContainer
+        : null;
+
+    const emoticonMatch = matchEmoticonClosedAtBoundary(text, caret);
+    if (
+      emoticonMatch &&
+      editorRef.current &&
+      !isInsideComposerProtectedContext(anchorNode, editorRef.current)
+    ) {
+      const startPos = findPositionForOffset(
+        editorRef.current,
+        emoticonMatch.start,
+      );
+      const endPos = findPositionForOffset(
+        editorRef.current,
+        emoticonMatch.end,
+      );
+      const range = document.createRange();
+      range.setStart(startPos.node, startPos.offset);
+      range.setEnd(endPos.node, endPos.offset);
+      range.deleteContents();
+
+      const textNode = document.createTextNode(emoticonMatch.emoji);
+      range.insertNode(textNode);
+      // Caret after emoji, before trailing boundary still in DOM
       setCaretAfterNode(editorRef.current, textNode);
       isInternalChange.current = true;
       syncFromEditor();

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -976,6 +976,35 @@ export function ComposerWysiwygEditor<TData = unknown>({
     [handleInput],
   );
 
+  const tryFlushTrailingEmoticon = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const { text } = serializeEditor(editor);
+    const match = matchEmoticonClosedAtBoundary(text, text.length, {
+      flush: true,
+    });
+    if (!match) return;
+
+    const selection = window.getSelection();
+    const anchor =
+      selection && selection.rangeCount > 0
+        ? selection.getRangeAt(0).startContainer
+        : editor;
+    if (isInsideComposerProtectedContext(anchor, editor)) return;
+
+    const startPos = findPositionForOffset(editor, match.start);
+    const endPos = findPositionForOffset(editor, match.end);
+    const range = document.createRange();
+    range.setStart(startPos.node, startPos.offset);
+    range.setEnd(endPos.node, endPos.offset);
+    range.deleteContents();
+    const textNode = document.createTextNode(match.emoji);
+    range.insertNode(textNode);
+    setCaretAfterNode(editor, textNode);
+    isInternalChange.current = true;
+    syncFromEditor();
+  }, [syncFromEditor]);
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       const key = event.key.toLowerCase();
@@ -1064,6 +1093,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
         if (isOpen) closeSuggestions();
 
         if (action === "submit") {
+          tryFlushTrailingEmoticon();
           onSubmitShortcut?.();
           return;
         }
@@ -1088,6 +1118,7 @@ export function ComposerWysiwygEditor<TData = unknown>({
       selectableMentions,
       setActiveSuggestionIndex,
       suggestionKind,
+      tryFlushTrailingEmoticon,
       visibleSuggestionCount,
     ],
   );
@@ -1095,12 +1126,13 @@ export function ComposerWysiwygEditor<TData = unknown>({
   const handleBlur = useCallback(() => {
     blurTimeoutRef.current = setTimeout(() => {
       if (!isSelectingRef.current) {
+        tryFlushTrailingEmoticon();
         closeSuggestions();
       }
       isSelectingRef.current = false;
       publishActiveFormats();
     }, 150);
-  }, [closeSuggestions, publishActiveFormats]);
+  }, [closeSuggestions, publishActiveFormats, tryFlushTrailingEmoticon]);
 
   useEffect(() => {
     const onSelectionChange = () => {

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/lib/utils/composer-paste-sanitize";
 import { tryExitComposerInlineFormatOnArrow } from "@/lib/utils/composer-wysiwyg-arrow-exit";
 import { toggleComposerInlineCode } from "@/lib/utils/composer-wysiwyg-code-format";
+import { replaceComposerTextRange } from "@/lib/utils/composer-wysiwyg-dom";
 import {
   resolveComposerEnterAction,
   tryApplyComposerInputRuleAtCaret,
@@ -69,23 +70,6 @@ import {
 } from "@/lib/utils/emoji-shortcodes";
 import { normalizeUrl } from "@/lib/utils/markdown-editor-utils";
 import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
-
-const COMPOSER_PROTECTED_TAGS = new Set(["CODE", "PRE"]);
-
-function isInsideComposerProtectedContext(
-  node: Node | null,
-  root: HTMLElement,
-): boolean {
-  let current: Node | null = node;
-  while (current && current !== root) {
-    if (current instanceof HTMLElement) {
-      if (COMPOSER_PROTECTED_TAGS.has(current.tagName)) return true;
-      if (current.dataset.mentionKey) return true;
-    }
-    current = current.parentNode;
-  }
-  return false;
-}
 
 type SuggestionUiState =
   | { open: false }
@@ -450,61 +434,46 @@ export function ComposerWysiwygEditor<TData = unknown>({
 
     const exactEmoji = matchExactEmojiShortcodeClosed(text, caret);
     if (exactEmoji) {
-      const startPos = findPositionForOffset(
-        editorRef.current,
-        exactEmoji.triggerStart,
-      );
-      const endPos = findPositionForOffset(editorRef.current, exactEmoji.end);
-      const range = document.createRange();
-      range.setStart(startPos.node, startPos.offset);
-      range.setEnd(endPos.node, endPos.offset);
-      range.deleteContents();
-
       const nextChar = text[exactEmoji.end];
       const insert = shouldAppendTrailingSpace(nextChar)
         ? `${exactEmoji.emoji} `
         : exactEmoji.emoji;
-      const textNode = document.createTextNode(insert);
-      range.insertNode(textNode);
-      setCaretAfterNode(editorRef.current, textNode);
-      isInternalChange.current = true;
-      syncFromEditor();
-      closeSuggestions();
-      return;
+      if (
+        replaceComposerTextRange(
+          editorRef.current,
+          exactEmoji.triggerStart,
+          exactEmoji.end,
+          insert,
+        )
+      ) {
+        isInternalChange.current = true;
+        syncFromEditor();
+        closeSuggestions();
+        return;
+      }
     }
 
     // Emoticon live convert: include the closing boundary (space/punct) in the
     // replace so caret lands after it — otherwise typing glues to the emoji and
     // the user needs a second space for the next word.
+    // Converts only at the caret boundary (not a full-document scan); paste of
+    // multiple mid-string emoticons still converts on send via remark-emoji.
     const emoticonMatch = matchEmoticonClosedAtBoundary(text, caret);
     if (emoticonMatch && editorRef.current) {
-      const editor = editorRef.current;
-      // Live path: caret is just after the boundary char at match.end.
       const boundarySuffix = text.slice(emoticonMatch.end, caret);
       const deleteEnd = emoticonMatch.end + boundarySuffix.length;
-      const startPos = findPositionForOffset(editor, emoticonMatch.start);
-      const endPos = findPositionForOffset(editor, deleteEnd);
-      // Gate on match range (not only caret): serialize flattens text so a
-      // caret after `</code>` can still match `:D` inside CODE.
       if (
-        !isInsideComposerProtectedContext(startPos.node, editor) &&
-        !isInsideComposerProtectedContext(endPos.node, editor)
-      ) {
-        const range = document.createRange();
-        range.setStart(startPos.node, startPos.offset);
-        range.setEnd(endPos.node, endPos.offset);
-        range.deleteContents();
-
-        const textNode = document.createTextNode(
+        replaceComposerTextRange(
+          editorRef.current,
+          emoticonMatch.start,
+          deleteEnd,
           `${emoticonMatch.emoji}${boundarySuffix}`,
-        );
-        range.insertNode(textNode);
-        setCaretAfterNode(editor, textNode);
-        // Commit parent value before any same-tick submit (e.g. Enter send).
-        flushSync(() => {
-          isInternalChange.current = true;
-          syncFromEditor();
-        });
+        )
+      ) {
+        // Live path: no flushSync — next keystroke/blur/submit sees state.
+        // flushSync reserved for tryFlushTrailingEmoticon (same-tick submit).
+        isInternalChange.current = true;
+        syncFromEditor();
         closeSuggestions();
         return;
       }
@@ -1018,23 +987,11 @@ export function ComposerWysiwygEditor<TData = unknown>({
     });
     if (!match) return;
 
-    const startPos = findPositionForOffset(editor, match.start);
-    const endPos = findPositionForOffset(editor, match.end);
-    // Gate on match range (not only caret): flush can match across CODE/PRE.
     if (
-      isInsideComposerProtectedContext(startPos.node, editor) ||
-      isInsideComposerProtectedContext(endPos.node, editor)
+      !replaceComposerTextRange(editor, match.start, match.end, match.emoji)
     ) {
       return;
     }
-
-    const range = document.createRange();
-    range.setStart(startPos.node, startPos.offset);
-    range.setEnd(endPos.node, endPos.offset);
-    range.deleteContents();
-    const textNode = document.createTextNode(match.emoji);
-    range.insertNode(textNode);
-    setCaretAfterNode(editor, textNode);
     // flushSync so parent composerValue updates before requestSubmit/onSubmit.
     flushSync(() => {
       isInternalChange.current = true;

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 
 import {
   type ComposerSuggestion,
@@ -501,8 +501,11 @@ export function ComposerWysiwygEditor<TData = unknown>({
       range.insertNode(textNode);
       // Caret after emoji, before trailing boundary still in DOM
       setCaretAfterNode(editorRef.current, textNode);
-      isInternalChange.current = true;
-      syncFromEditor();
+      // Commit parent value before any same-tick submit (e.g. Enter send).
+      flushSync(() => {
+        isInternalChange.current = true;
+        syncFromEditor();
+      });
       closeSuggestions();
       return;
     }
@@ -1001,8 +1004,11 @@ export function ComposerWysiwygEditor<TData = unknown>({
     const textNode = document.createTextNode(match.emoji);
     range.insertNode(textNode);
     setCaretAfterNode(editor, textNode);
-    isInternalChange.current = true;
-    syncFromEditor();
+    // flushSync so parent composerValue updates before requestSubmit/onSubmit.
+    flushSync(() => {
+      isInternalChange.current = true;
+      syncFromEditor();
+    });
   }, [syncFromEditor]);
 
   const handleKeyDown = useCallback(
@@ -1124,9 +1130,11 @@ export function ComposerWysiwygEditor<TData = unknown>({
   );
 
   const handleBlur = useCallback(() => {
+    // Sync flush so Send click (blur → submit same tick) sees emoji in parent state.
+    // Suggestion-close stays deferred so listbox mousedown can set isSelectingRef.
+    tryFlushTrailingEmoticon();
     blurTimeoutRef.current = setTimeout(() => {
       if (!isSelectingRef.current) {
-        tryFlushTrailingEmoticon();
         closeSuggestions();
       }
       isSelectingRef.current = false;

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -472,42 +472,34 @@ export function ComposerWysiwygEditor<TData = unknown>({
     }
 
     // Emoticon live convert: boundary char stays after `end` — insert emoji only.
-    const selection = window.getSelection();
-    const anchorNode =
-      selection && selection.rangeCount > 0
-        ? selection.getRangeAt(0).startContainer
-        : null;
-
     const emoticonMatch = matchEmoticonClosedAtBoundary(text, caret);
-    if (
-      emoticonMatch &&
-      editorRef.current &&
-      !isInsideComposerProtectedContext(anchorNode, editorRef.current)
-    ) {
-      const startPos = findPositionForOffset(
-        editorRef.current,
-        emoticonMatch.start,
-      );
-      const endPos = findPositionForOffset(
-        editorRef.current,
-        emoticonMatch.end,
-      );
-      const range = document.createRange();
-      range.setStart(startPos.node, startPos.offset);
-      range.setEnd(endPos.node, endPos.offset);
-      range.deleteContents();
+    if (emoticonMatch && editorRef.current) {
+      const editor = editorRef.current;
+      const startPos = findPositionForOffset(editor, emoticonMatch.start);
+      const endPos = findPositionForOffset(editor, emoticonMatch.end);
+      // Gate on match range (not only caret): serialize flattens text so a
+      // caret after `</code>` can still match `:D` inside CODE.
+      if (
+        !isInsideComposerProtectedContext(startPos.node, editor) &&
+        !isInsideComposerProtectedContext(endPos.node, editor)
+      ) {
+        const range = document.createRange();
+        range.setStart(startPos.node, startPos.offset);
+        range.setEnd(endPos.node, endPos.offset);
+        range.deleteContents();
 
-      const textNode = document.createTextNode(emoticonMatch.emoji);
-      range.insertNode(textNode);
-      // Caret after emoji, before trailing boundary still in DOM
-      setCaretAfterNode(editorRef.current, textNode);
-      // Commit parent value before any same-tick submit (e.g. Enter send).
-      flushSync(() => {
-        isInternalChange.current = true;
-        syncFromEditor();
-      });
-      closeSuggestions();
-      return;
+        const textNode = document.createTextNode(emoticonMatch.emoji);
+        range.insertNode(textNode);
+        // Caret after emoji, before trailing boundary still in DOM
+        setCaretAfterNode(editor, textNode);
+        // Commit parent value before any same-tick submit (e.g. Enter send).
+        flushSync(() => {
+          isInternalChange.current = true;
+          syncFromEditor();
+        });
+        closeSuggestions();
+        return;
+      }
     }
 
     if (manualMentionOpenRef.current && normalizedMentions.length > 0) {
@@ -988,15 +980,16 @@ export function ComposerWysiwygEditor<TData = unknown>({
     });
     if (!match) return;
 
-    const selection = window.getSelection();
-    const anchor =
-      selection && selection.rangeCount > 0
-        ? selection.getRangeAt(0).startContainer
-        : editor;
-    if (isInsideComposerProtectedContext(anchor, editor)) return;
-
     const startPos = findPositionForOffset(editor, match.start);
     const endPos = findPositionForOffset(editor, match.end);
+    // Gate on match range (not only caret): flush can match across CODE/PRE.
+    if (
+      isInsideComposerProtectedContext(startPos.node, editor) ||
+      isInsideComposerProtectedContext(endPos.node, editor)
+    ) {
+      return;
+    }
+
     const range = document.createRange();
     range.setStart(startPos.node, startPos.offset);
     range.setEnd(endPos.node, endPos.offset);

--- a/apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { matchEmoticonClosedAtBoundary } from "@/lib/utils/composer-emoticons";
+
+describe("matchEmoticonClosedAtBoundary", () => {
+  it("converts :D before a trailing space", () => {
+    const text = "hi :D ";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).toEqual({
+      start: 3,
+      end: 5,
+      emoji: "😄",
+    });
+  });
+
+  it("converts wink before sentence punctuation", () => {
+    const text = "wink ;).";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).toEqual({
+      start: 5,
+      end: 7,
+      emoji: "😉",
+    });
+  });
+
+  it("prefers longest match :-)", () => {
+    const text = ":-) ";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).toEqual({
+      start: 0,
+      end: 3,
+      emoji: "😃",
+    });
+  });
+
+  it("returns null without a boundary (live mode)", () => {
+    const text = ":D";
+    expect(matchEmoticonClosedAtBoundary(text, text.length)).toBeNull();
+    expect(matchEmoticonClosedAtBoundary(":Dfoo", 5)).toBeNull();
+  });
+
+  it("matches at end-of-input in flush mode", () => {
+    const text = "ok :)";
+    expect(
+      matchEmoticonClosedAtBoundary(text, text.length, { flush: true }),
+    ).toEqual({
+      start: 3,
+      end: 5,
+      emoji: "😃",
+    });
+  });
+
+  it("does not match mid-URL (left guard)", () => {
+    const text = "http:// ";
+    expect(matchEmoticonClosedAtBoundary(text, text.length)).toBeNull();
+  });
+
+  it("keeps boundary character outside [start, end)", () => {
+    const text = ":D ";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).not.toBeNull();
+    expect(text.slice(match!.start, match!.end)).toBe(":D");
+    expect(text[match!.end]).toBe(" ");
+  });
+});

--- a/apps/web/src/lib/utils/__tests__/composer-wysiwyg-dom.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-wysiwyg-dom.test.ts
@@ -69,4 +69,36 @@ describe("replaceComposerTextRange", () => {
 
     document.body.removeChild(editor);
   });
+
+  it("skips replace when range fully encloses a mention chip", () => {
+    const editor = document.createElement("div");
+    // "a " + mention token @alice:alice (12 chars) + " b" → total serialized length
+    // Token length = "@alice:alice".length = 12
+    editor.innerHTML =
+      'a <span data-mention-key="alice" data-mention-slug="alice" contenteditable="false">@Alice</span> b';
+    document.body.appendChild(editor);
+
+    // Range covering "a " (0-2) through end of mention (2+12=14) into " b"
+    // would wipe the chip if we only checked endpoints.
+    expect(replaceComposerTextRange(editor, 0, 14, "gone")).toBe(false);
+    expect(editor.querySelector("[data-mention-key='alice']")).not.toBeNull();
+    expect(editor.textContent).toContain("@Alice");
+
+    document.body.removeChild(editor);
+  });
+
+  it("allows replace of plain text after a mention chip", () => {
+    const editor = document.createElement("div");
+    editor.innerHTML =
+      '<span data-mention-key="alice" data-mention-slug="alice" contenteditable="false">@Alice</span> :D ';
+    document.body.appendChild(editor);
+
+    // serialize: "@alice:alice :D " — ":D " starts after 12-char token + space = 13
+    expect(replaceComposerTextRange(editor, 13, 16, "😄 ")).toBe(true);
+    expect(editor.querySelector("[data-mention-key='alice']")).not.toBeNull();
+    expect(editor.textContent).toContain("😄");
+    expect(editor.textContent).not.toContain(":D");
+
+    document.body.removeChild(editor);
+  });
 });

--- a/apps/web/src/lib/utils/__tests__/composer-wysiwyg-dom.test.ts
+++ b/apps/web/src/lib/utils/__tests__/composer-wysiwyg-dom.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isInsideComposerProtectedContext,
+  replaceComposerTextRange,
+} from "@/lib/utils/composer-wysiwyg-dom";
+
+describe("isInsideComposerProtectedContext", () => {
+  it("returns true for nodes inside CODE/PRE", () => {
+    const root = document.createElement("div");
+    const code = document.createElement("code");
+    const text = document.createTextNode(":D ");
+    code.appendChild(text);
+    root.appendChild(code);
+
+    expect(isInsideComposerProtectedContext(text, root)).toBe(true);
+    expect(isInsideComposerProtectedContext(code, root)).toBe(true);
+  });
+
+  it("returns true for nodes inside a mention chip", () => {
+    const root = document.createElement("div");
+    const mention = document.createElement("span");
+    mention.dataset.mentionKey = "alice";
+    mention.dataset.mentionSlug = "alice";
+    const text = document.createTextNode("@Alice");
+    mention.appendChild(text);
+    root.appendChild(mention);
+
+    expect(isInsideComposerProtectedContext(text, root)).toBe(true);
+    expect(isInsideComposerProtectedContext(mention, root)).toBe(true);
+  });
+
+  it("returns false for plain text under root", () => {
+    const root = document.createElement("div");
+    const text = document.createTextNode("hi :D ");
+    root.appendChild(text);
+
+    expect(isInsideComposerProtectedContext(text, root)).toBe(false);
+    expect(isInsideComposerProtectedContext(root, root)).toBe(false);
+  });
+});
+
+describe("replaceComposerTextRange", () => {
+  it("replaces a plain range and leaves caret after insert", () => {
+    const editor = document.createElement("div");
+    editor.textContent = "hi :D ";
+    document.body.appendChild(editor);
+
+    expect(replaceComposerTextRange(editor, 3, 6, "😄 ")).toBe(true);
+    expect(editor.textContent).toBe("hi 😄 ");
+
+    const selection = window.getSelection();
+    const range = selection?.getRangeAt(0);
+    expect(range?.collapsed).toBe(true);
+    expect(range?.startOffset).toBe(range?.startContainer.textContent?.length);
+
+    document.body.removeChild(editor);
+  });
+
+  it("skips replace when range endpoints sit in CODE", () => {
+    const editor = document.createElement("div");
+    editor.innerHTML = "hello<code>:D</code> ";
+    document.body.appendChild(editor);
+
+    // serialize "hello:D " — `:D` is at 5..7
+    expect(replaceComposerTextRange(editor, 5, 7, "😄")).toBe(false);
+    expect(editor.querySelector("code")?.textContent).toBe(":D");
+    expect(editor.textContent).toContain(":D");
+
+    document.body.removeChild(editor);
+  });
+});

--- a/apps/web/src/lib/utils/composer-emoticons.ts
+++ b/apps/web/src/lib/utils/composer-emoticons.ts
@@ -1,0 +1,69 @@
+import { emoticon } from "emoticon";
+
+export interface ComposerEmoticonMatch {
+  start: number;
+  end: number;
+  emoji: string;
+}
+
+const BOUNDARY_PUNCT = new Set([".", "!", "?", ",", ";", ":"]);
+
+/** Longest-first emoticon → emoji map from the same source as remark-emoji. */
+const EMOTICON_ENTRIES: ReadonlyArray<{ text: string; emoji: string }> =
+  (() => {
+    const byText = new Map<string, string>();
+    for (const entry of emoticon) {
+      for (const ascii of entry.emoticons) {
+        if (!byText.has(ascii)) {
+          byText.set(ascii, entry.emoji);
+        }
+      }
+    }
+    return [...byText.entries()]
+      .map(([text, emoji]) => ({ text, emoji }))
+      .sort((a, b) => b.text.length - a.text.length);
+  })();
+
+function isWhitespace(char: string | undefined): boolean {
+  return char != null && char.trim() === "";
+}
+
+function isLiveBoundaryChar(char: string | undefined): boolean {
+  if (char == null || char === "") return false;
+  return isWhitespace(char) || BOUNDARY_PUNCT.has(char);
+}
+
+/**
+ * Match a complete ASCII emoticon closed at caret by a boundary (or flush).
+ * `end` is exclusive of the emoticon only — boundary char is not consumed.
+ */
+export function matchEmoticonClosedAtBoundary(
+  text: string,
+  caret: number,
+  options?: { flush?: boolean },
+): ComposerEmoticonMatch | null {
+  const clampedCaret = Math.max(0, Math.min(caret, text.length));
+  const flush = options?.flush === true;
+
+  let windowEnd: number;
+  if (flush && clampedCaret === text.length) {
+    windowEnd = clampedCaret;
+  } else if (clampedCaret > 0 && isLiveBoundaryChar(text[clampedCaret - 1])) {
+    windowEnd = clampedCaret - 1;
+  } else {
+    return null;
+  }
+
+  if (windowEnd <= 0) return null;
+  const window = text.slice(0, windowEnd);
+
+  for (const entry of EMOTICON_ENTRIES) {
+    if (!window.endsWith(entry.text)) continue;
+    const start = windowEnd - entry.text.length;
+    const charBefore = start > 0 ? text[start - 1] : undefined;
+    if (start > 0 && !isWhitespace(charBefore)) continue;
+    return { start, end: windowEnd, emoji: entry.emoji };
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/utils/composer-wysiwyg-dom.ts
+++ b/apps/web/src/lib/utils/composer-wysiwyg-dom.ts
@@ -25,8 +25,32 @@ export function isInsideComposerProtectedContext(
 }
 
 /**
+ * True when `range` intersects a CODE/PRE/mention element under `root`.
+ * Endpoint-only checks miss a range that fully encloses a protected chip.
+ */
+export function rangeIntersectsComposerProtected(
+  range: Range,
+  root: HTMLElement,
+): boolean {
+  if (
+    isInsideComposerProtectedContext(range.startContainer, root) ||
+    isInsideComposerProtectedContext(range.endContainer, root)
+  ) {
+    return true;
+  }
+
+  const protectedNodes = root.querySelectorAll("code, pre, [data-mention-key]");
+  for (const node of protectedNodes) {
+    if (range.intersectsNode(node)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Replace serialized offset range `[start, end)` with `insertText`.
- * Skips when either range endpoint is in a protected context.
+ * Skips when the range intersects CODE/PRE/mention (endpoints or enclosed).
  * Leaves caret after the inserted text node. Returns false if skipped.
  */
 export function replaceComposerTextRange(
@@ -39,16 +63,15 @@ export function replaceComposerTextRange(
 
   const startPos = findPositionForOffset(editor, start);
   const endPos = findPositionForOffset(editor, end);
-  if (
-    isInsideComposerProtectedContext(startPos.node, editor) ||
-    isInsideComposerProtectedContext(endPos.node, editor)
-  ) {
-    return false;
-  }
 
   const range = document.createRange();
   range.setStart(startPos.node, startPos.offset);
   range.setEnd(endPos.node, endPos.offset);
+
+  if (rangeIntersectsComposerProtected(range, editor)) {
+    return false;
+  }
+
   range.deleteContents();
 
   const textNode = document.createTextNode(insertText);

--- a/apps/web/src/lib/utils/composer-wysiwyg-dom.ts
+++ b/apps/web/src/lib/utils/composer-wysiwyg-dom.ts
@@ -1,0 +1,58 @@
+import {
+  findPositionForOffset,
+  setCaretAfterNode,
+} from "@/components/ui/mention-textarea-utils";
+
+const COMPOSER_PROTECTED_TAGS = new Set(["CODE", "PRE"]);
+
+/**
+ * True when `node` sits inside CODE/PRE or a mention chip within `root`.
+ * Used by input rules, shortcode replace, and emoticon convert.
+ */
+export function isInsideComposerProtectedContext(
+  node: Node | null,
+  root: HTMLElement,
+): boolean {
+  let current: Node | null = node;
+  while (current && current !== root) {
+    if (current instanceof HTMLElement) {
+      if (COMPOSER_PROTECTED_TAGS.has(current.tagName)) return true;
+      if (current.dataset.mentionKey) return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+}
+
+/**
+ * Replace serialized offset range `[start, end)` with `insertText`.
+ * Skips when either range endpoint is in a protected context.
+ * Leaves caret after the inserted text node. Returns false if skipped.
+ */
+export function replaceComposerTextRange(
+  editor: HTMLElement,
+  start: number,
+  end: number,
+  insertText: string,
+): boolean {
+  if (start < 0 || end < start) return false;
+
+  const startPos = findPositionForOffset(editor, start);
+  const endPos = findPositionForOffset(editor, end);
+  if (
+    isInsideComposerProtectedContext(startPos.node, editor) ||
+    isInsideComposerProtectedContext(endPos.node, editor)
+  ) {
+    return false;
+  }
+
+  const range = document.createRange();
+  range.setStart(startPos.node, startPos.offset);
+  range.setEnd(endPos.node, endPos.offset);
+  range.deleteContents();
+
+  const textNode = document.createTextNode(insertText);
+  range.insertNode(textNode);
+  setCaretAfterNode(editor, textNode);
+  return true;
+}

--- a/apps/web/src/lib/utils/composer-wysiwyg-input-rules.ts
+++ b/apps/web/src/lib/utils/composer-wysiwyg-input-rules.ts
@@ -1,4 +1,5 @@
 import { placeComposerCaretAfterMark } from "@/lib/utils/composer-wysiwyg-arrow-exit";
+import { isInsideComposerProtectedContext } from "@/lib/utils/composer-wysiwyg-dom";
 
 export type ComposerInputRuleFormat = "italic" | "bold" | "strike" | "code";
 
@@ -95,23 +96,6 @@ export function resolveComposerEnterAction(options: {
   }
   if (options.isNarrowViewport) return "newline";
   return "submit";
-}
-
-const PROTECTED_TAGS = new Set(["CODE", "PRE"]);
-
-function isInsideComposerProtectedContext(
-  node: Node | null,
-  root: HTMLElement,
-): boolean {
-  let current: Node | null = node;
-  while (current && current !== root) {
-    if (current instanceof HTMLElement) {
-      if (PROTECTED_TAGS.has(current.tagName)) return true;
-      if (current.dataset.mentionKey) return true;
-    }
-    current = current.parentNode;
-  }
-  return false;
 }
 
 /**

--- a/docs/superpowers/plans/2026-08-07-composer-emoticon-live-convert.md
+++ b/docs/superpowers/plans/2026-08-07-composer-emoticon-live-convert.md
@@ -1,0 +1,672 @@
+# Live Composer Emoticon Conversion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert classic ASCII emoticons (`:D`, `;)`, `:-)`, etc.) to Unicode emoji in the room WYSIWYG composer when closed by a boundary, using the same `emoticon` map as post-send `remark-emoji`.
+
+**Architecture:** Pure `matchEmoticonClosedAtBoundary` util builds a longest-first map from the `emoticon` package. `ComposerWysiwygEditor.handleInput` runs it after shortcode auto-insert and replaces the match in the contentEditable the same way shortcodes do. Blur and submit flush bare trailing emoticons with `flush: true`.
+
+**Tech Stack:** TypeScript, React 19, Vitest + Testing Library, `emoticon@4.1.0`, existing composer WYSIWYG utilities.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-composer-emoticon-live-convert-design.md`
+
+## Global Constraints
+
+- Surface: room/coworker `ComposerWysiwygEditor` only — do **not** change `MultimodalInput` / `PromptInputTextarea`
+- Timing: convert only on boundary (whitespace or `. ! ? , ; :`) or flush at end-of-input (blur/send)
+- Emoticon set: full `emoticon` package list (parity with `remark-emoji` `{ emoticon: true }`)
+- Shortcode closed match runs **before** emoticon match
+- Skip `CODE` / `PRE` / mention spans
+- Pin exact versions (no `^`/`~`); `emoticon` direct dep at lockfile version `4.1.0`
+- Conventional Commits; Biome format; TDD (failing test → implement → pass → commit)
+- Do not change post-send `Markdown` / `remark-emoji` options
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `apps/web/package.json` | Pin direct `emoticon@4.1.0` dependency |
+| `apps/web/src/lib/utils/composer-emoticons.ts` | Pure boundary matcher + map from `emoticon` |
+| `apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts` | Unit tests for matcher |
+| `apps/web/src/components/chat/composer-wysiwyg-editor.tsx` | Wire live replace + blur/submit flush |
+| `apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx` | Integration tests for typing / code / flush |
+
+**Do not modify:** `markdown.tsx`, `multimodal-input.tsx`, `prompt-input.tsx`, Core API, database.
+
+---
+
+### Task 1: Pure matcher + pin `emoticon`
+
+**Files:**
+- Modify: `apps/web/package.json` (add `"emoticon": "4.1.0"` under `dependencies`, alphabetically near `embla-carousel-react` / `fake-indexeddb`)
+- Create: `apps/web/src/lib/utils/composer-emoticons.ts`
+- Create: `apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts`
+
+**Interfaces:**
+- Consumes: `{ emoticon }` from `emoticon@4.1.0`
+- Produces:
+
+```ts
+export interface ComposerEmoticonMatch {
+  start: number;
+  end: number;
+  emoji: string;
+}
+
+export function matchEmoticonClosedAtBoundary(
+  text: string,
+  caret: number,
+  options?: { flush?: boolean },
+): ComposerEmoticonMatch | null;
+```
+
+- [ ] **Step 1: Pin dependency**
+
+In `apps/web/package.json` `dependencies`, add:
+
+```json
+"emoticon": "4.1.0",
+```
+
+Run from repo root:
+
+```bash
+pnpm install --filter web
+```
+
+Expected: lockfile updates if needed; `emoticon@4.1.0` resolvable from web.
+
+- [ ] **Step 2: Write failing unit tests**
+
+Create `apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { matchEmoticonClosedAtBoundary } from "@/lib/utils/composer-emoticons";
+
+describe("matchEmoticonClosedAtBoundary", () => {
+  it("converts :D before a trailing space", () => {
+    const text = "hi :D ";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).toEqual({
+      start: 3,
+      end: 5,
+      emoji: "😄",
+    });
+  });
+
+  it("converts wink before sentence punctuation", () => {
+    const text = "wink ;).";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).toEqual({
+      start: 5,
+      end: 7,
+      emoji: "😉",
+    });
+  });
+
+  it("prefers longest match :-)", () => {
+    const text = ":-) ";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).toEqual({
+      start: 0,
+      end: 3,
+      emoji: "😃",
+    });
+  });
+
+  it("returns null without a boundary (live mode)", () => {
+    const text = ":D";
+    expect(matchEmoticonClosedAtBoundary(text, text.length)).toBeNull();
+    expect(matchEmoticonClosedAtBoundary(":Dfoo", 5)).toBeNull();
+  });
+
+  it("matches at end-of-input in flush mode", () => {
+    const text = "ok :)";
+    expect(matchEmoticonClosedAtBoundary(text, text.length, { flush: true })).toEqual({
+      start: 3,
+      end: 5,
+      emoji: "😃",
+    });
+  });
+
+  it("does not match mid-URL (left guard)", () => {
+    const text = "http:// ";
+    expect(matchEmoticonClosedAtBoundary(text, text.length)).toBeNull();
+  });
+
+  it("keeps boundary character outside [start, end)", () => {
+    const text = ":D ";
+    const match = matchEmoticonClosedAtBoundary(text, text.length);
+    expect(match).not.toBeNull();
+    expect(text.slice(match!.start, match!.end)).toBe(":D");
+    expect(text[match!.end]).toBe(" ");
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — expect FAIL**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts
+```
+
+Expected: FAIL (module not found / function undefined).
+
+- [ ] **Step 4: Implement matcher**
+
+Create `apps/web/src/lib/utils/composer-emoticons.ts`:
+
+```ts
+import { emoticon } from "emoticon";
+
+export interface ComposerEmoticonMatch {
+  start: number;
+  end: number;
+  emoji: string;
+}
+
+const BOUNDARY_PUNCT = new Set([".", "!", "?", ",", ";", ":"]);
+
+/** Longest-first emoticon → emoji map from the same source as remark-emoji. */
+const EMOTICON_ENTRIES: ReadonlyArray<{ text: string; emoji: string }> = (() => {
+  const byText = new Map<string, string>();
+  for (const entry of emoticon) {
+    for (const ascii of entry.emoticons) {
+      if (!byText.has(ascii)) {
+        byText.set(ascii, entry.emoji);
+      }
+    }
+  }
+  return [...byText.entries()]
+    .map(([text, emoji]) => ({ text, emoji }))
+    .sort((a, b) => b.text.length - a.text.length);
+})();
+
+function isWhitespace(char: string | undefined): boolean {
+  return char != null && char.trim() === "";
+}
+
+function isLiveBoundaryChar(char: string | undefined): boolean {
+  if (char == null || char === "") return false;
+  return isWhitespace(char) || BOUNDARY_PUNCT.has(char);
+}
+
+/**
+ * Match a complete ASCII emoticon closed at caret by a boundary (or flush).
+ * `end` is exclusive of the emoticon only — boundary char is not consumed.
+ */
+export function matchEmoticonClosedAtBoundary(
+  text: string,
+  caret: number,
+  options?: { flush?: boolean },
+): ComposerEmoticonMatch | null {
+  const clampedCaret = Math.max(0, Math.min(caret, text.length));
+  const flush = options?.flush === true;
+
+  let windowEnd: number;
+  if (flush && clampedCaret === text.length) {
+    windowEnd = clampedCaret;
+  } else if (clampedCaret > 0 && isLiveBoundaryChar(text[clampedCaret - 1])) {
+    windowEnd = clampedCaret - 1;
+  } else {
+    return null;
+  }
+
+  if (windowEnd <= 0) return null;
+  const window = text.slice(0, windowEnd);
+
+  for (const entry of EMOTICON_ENTRIES) {
+    if (!window.endsWith(entry.text)) continue;
+    const start = windowEnd - entry.text.length;
+    const charBefore = start > 0 ? text[start - 1] : undefined;
+    if (start > 0 && !isWhitespace(charBefore)) continue;
+    return { start, end: windowEnd, emoji: entry.emoji };
+  }
+
+  return null;
+}
+```
+
+Notes for implementer:
+- Emoji glyphs (`😄` for `:D`, `😃` for `:)`, `😉` for `;)`) come from `emoticon` package; if a test glyph drifts, assert against `match` from the package rather than inventing alternates.
+- First-writer-wins when the same ASCII appears on multiple entries (map uses first `emoticon` list order).
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+```bash
+pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml apps/web/src/lib/utils/composer-emoticons.ts apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts
+git commit -m "$(cat <<'EOF'
+feat(chat): add composer emoticon boundary matcher
+
+Pure matchEmoticonClosedAtBoundary using the emoticon package
+map for live conversion parity with remark-emoji.
+EOF
+)"
+```
+
+---
+
+### Task 2: Live replace in `handleInput`
+
+**Files:**
+- Modify: `apps/web/src/components/chat/composer-wysiwyg-editor.tsx`
+- Modify: `apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx`
+
+**Interfaces:**
+- Consumes: `matchEmoticonClosedAtBoundary` from `@/lib/utils/composer-emoticons`
+- Consumes (existing): `findPositionForOffset`, `setCaretAfterNode`, `serializeEditor` / `syncFromEditor`, shortcode replace pattern in `handleInput`
+- Produces: no new exported API; live emoticon conversion on input
+
+- [ ] **Step 1: Write failing integration tests**
+
+Append to `apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx` (same patterns as emoji shortcode popup tests — set `textContent`, collapse selection to end, `fireEvent.input`):
+
+```tsx
+  it("converts :D to emoji after trailing space", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ":D ";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(editor.textContent).toContain("😄");
+    expect(editor.textContent).not.toContain(":D");
+  });
+
+  it("does not convert emoticons inside inline code", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.innerHTML = "<code>:D </code>";
+    const code = editor.querySelector("code");
+    expect(code).toBeTruthy();
+    const textNode = code!.firstChild as Text;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode, textNode.length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    expect(editor.textContent).toContain(":D");
+    expect(editor.textContent).not.toContain("😄");
+  });
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+```
+
+Expected: FAIL on “converts :D…” (still shows `:D`).
+
+- [ ] **Step 3: Wire replace after shortcode block**
+
+In `composer-wysiwyg-editor.tsx`:
+
+1. Import:
+
+```ts
+import { matchEmoticonClosedAtBoundary } from "@/lib/utils/composer-emoticons";
+```
+
+2. Add a small protected-context helper near the top of the file (or colocated private function), mirroring input-rules:
+
+```ts
+const COMPOSER_PROTECTED_TAGS = new Set(["CODE", "PRE"]);
+
+function isInsideComposerProtectedContext(
+  node: Node | null,
+  root: HTMLElement,
+): boolean {
+  let current: Node | null = node;
+  while (current && current !== root) {
+    if (current instanceof HTMLElement) {
+      if (COMPOSER_PROTECTED_TAGS.has(current.tagName)) return true;
+      if (current.dataset.mentionKey) return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+}
+```
+
+3. Extract a shared replace helper used by shortcode + emoticon (optional but preferred to avoid duplication):
+
+```ts
+function replaceRangeWithEmoji(
+  editor: HTMLElement,
+  start: number,
+  end: number,
+  emoji: string,
+  nextChar: string | undefined,
+): void {
+  const startPos = findPositionForOffset(editor, start);
+  const endPos = findPositionForOffset(editor, end);
+  const range = document.createRange();
+  range.setStart(startPos.node, startPos.offset);
+  range.setEnd(endPos.node, endPos.offset);
+  range.deleteContents();
+
+  const insert = shouldAppendTrailingSpace(nextChar)
+    ? `${emoji} `
+    : emoji;
+  const textNode = document.createTextNode(insert);
+  range.insertNode(textNode);
+  setCaretAfterNode(editor, textNode);
+}
+```
+
+**Important:** For emoticons the boundary character already remains in the DOM **after** `end`. Shortcode path uses `shouldAppendTrailingSpace` because it consumes the closing `:` with no trailing space guaranteed. Emoticon path must **not** delete the boundary and should insert **only** `emoji` (no extra space) so `"😄 "` does not become `"😄  "` when the typed space is still present.
+
+So for emoticon specifically:
+
+```ts
+const insert = match.emoji; // do not append space; boundary stays
+```
+
+4. In `handleInput`, after the shortcode block succeeds-or-not, before suggestions:
+
+```ts
+    const selection = window.getSelection();
+    const anchorNode =
+      selection && selection.rangeCount > 0
+        ? selection.getRangeAt(0).startContainer
+        : null;
+
+    const emoticonMatch = matchEmoticonClosedAtBoundary(text, caret);
+    if (
+      emoticonMatch &&
+      editorRef.current &&
+      !isInsideComposerProtectedContext(anchorNode, editorRef.current)
+    ) {
+      const startPos = findPositionForOffset(
+        editorRef.current,
+        emoticonMatch.start,
+      );
+      const endPos = findPositionForOffset(
+        editorRef.current,
+        emoticonMatch.end,
+      );
+      const range = document.createRange();
+      range.setStart(startPos.node, startPos.offset);
+      range.setEnd(endPos.node, endPos.offset);
+      range.deleteContents();
+
+      const textNode = document.createTextNode(emoticonMatch.emoji);
+      range.insertNode(textNode);
+      // Place caret after emoji but before any trailing boundary already in DOM
+      setCaretAfterNode(editorRef.current, textNode);
+      isInternalChange.current = true;
+      syncFromEditor();
+      closeSuggestions();
+      return;
+    }
+```
+
+Keep shortcode block unchanged (still first).
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+```
+
+Expected: new tests PASS; existing suite still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/chat/composer-wysiwyg-editor.tsx apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(chat): convert emoticons live in room composer
+
+After boundary, replace ASCII emoticons with emoji in the
+WYSIWYG editor; skip code and mention protected contexts.
+EOF
+)"
+```
+
+---
+
+### Task 3: Flush on blur and before submit
+
+**Files:**
+- Modify: `apps/web/src/components/chat/composer-wysiwyg-editor.tsx`
+- Modify: `apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx`
+
+**Interfaces:**
+- Consumes: `matchEmoticonClosedAtBoundary(text, caret, { flush: true })`
+- Produces: flush conversion on blur timeout and on Enter-submit path
+
+- [ ] **Step 1: Write failing flush tests**
+
+```tsx
+  it("converts bare trailing emoticon on blur (flush)", async () => {
+    vi.useFakeTimers();
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ":)";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+    // Live mode should not convert without boundary
+    expect(editor.textContent).toContain(":)");
+
+    fireEvent.blur(editor);
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(editor.textContent).toContain("😃");
+    expect(editor.textContent).not.toContain(":)");
+    vi.useRealTimers();
+  });
+
+  it("converts bare trailing emoticon before submit shortcut", () => {
+    const onSubmitShortcut = vi.fn();
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+          onSubmitShortcut={onSubmitShortcut}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const editor = screen.getByRole("textbox");
+    editor.focus();
+    editor.textContent = ";)";
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    fireEvent.input(editor);
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(editor.textContent).toContain("😉");
+    expect(onSubmitShortcut).toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+```
+
+Expected: FAIL on flush/blur or submit conversion.
+
+- [ ] **Step 3: Implement flush helper and call sites**
+
+In `composer-wysiwyg-editor.tsx`, extract a `tryFlushEmoticonAtEnd` (or reuse replace logic) that:
+
+1. Serializes editor text + caret at end.
+2. Calls `matchEmoticonClosedAtBoundary(text, text.length, { flush: true })`.
+3. If match and not in protected context at caret, replaces range with emoji and `syncFromEditor()`.
+
+**Blur:** inside existing `handleBlur` timeout (same 150ms path that closes suggestions), call flush **before** `closeSuggestions()` so bare `:)` converts when leaving the field.
+
+**Submit:** in the Enter key handler branch where `action === "submit"`, call flush **before** `onSubmitShortcut?.()` so the parent reads converted markdown from the latest `onChange`.
+
+Pseudo:
+
+```ts
+  const tryFlushTrailingEmoticon = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const { text } = serializeEditor(editor);
+    const match = matchEmoticonClosedAtBoundary(text, text.length, {
+      flush: true,
+    });
+    if (!match) return;
+
+    const selection = window.getSelection();
+    const anchor =
+      selection && selection.rangeCount > 0
+        ? selection.getRangeAt(0).startContainer
+        : editor;
+    if (isInsideComposerProtectedContext(anchor, editor)) return;
+
+    const startPos = findPositionForOffset(editor, match.start);
+    const endPos = findPositionForOffset(editor, match.end);
+    const range = document.createRange();
+    range.setStart(startPos.node, startPos.offset);
+    range.setEnd(endPos.node, endPos.offset);
+    range.deleteContents();
+    const textNode = document.createTextNode(match.emoji);
+    range.insertNode(textNode);
+    setCaretAfterNode(editor, textNode);
+    isInternalChange.current = true;
+    syncFromEditor();
+  }, [syncFromEditor]);
+```
+
+Wire:
+
+```ts
+// handleBlur timeout:
+tryFlushTrailingEmoticon();
+closeSuggestions();
+// ...
+
+// handleKeyDown submit branch:
+tryFlushTrailingEmoticon();
+onSubmitShortcut?.();
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx src/lib/utils/__tests__/composer-emoticons.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Format / typecheck touched surface**
+
+```bash
+pnpm --filter web exec biome check --write src/lib/utils/composer-emoticons.ts src/lib/utils/__tests__/composer-emoticons.test.ts src/components/chat/composer-wysiwyg-editor.tsx src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+pnpm --filter web typecheck
+```
+
+Expected: clean check; typecheck OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/chat/composer-wysiwyg-editor.tsx apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(chat): flush trailing emoticons on blur and send
+
+Convert bare end-of-input emoticons when leaving the room
+composer or submitting so send matches typed intent.
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+| --- | --- |
+| Boundary conversion (space / punct) | Task 1 + 2 |
+| Same `emoticon` set as remark-emoji | Task 1 (`emoticon` package) |
+| Room WYSIWYG only | Task 2–3 (only `composer-wysiwyg-editor`) |
+| Shortcode first | Task 2 (order in `handleInput`) |
+| Unicode in stored value | Task 2 (sync after DOM replace) |
+| Skip CODE/PRE/mention | Task 2 protected check + test |
+| Flush blur/send | Task 3 |
+| Unit + integration tests | Task 1–3 |
+| Pin direct `emoticon` dep | Task 1 |
+| No MultimodalInput / Markdown changes | File map “Do not modify” |
+
+## Self-review notes
+
+- No TBD/placeholder steps; signatures stable across tasks (`start`/`end`/`emoji`, `flush?: boolean`).
+- Emoticon replace must **not** double-append spaces (boundary already in DOM).
+- Emoji codepoints asserted in tests match `emoticon@4.1.0` (`:D`→😄, `:)`→😃, `;)`→😉, `:-)`→😃).

--- a/docs/superpowers/plans/2026-08-07-composer-emoticon-live-convert.md
+++ b/docs/superpowers/plans/2026-08-07-composer-emoticon-live-convert.md
@@ -60,7 +60,7 @@ export function matchEmoticonClosedAtBoundary(
 ): ComposerEmoticonMatch | null;
 ```
 
-- [ ] **Step 1: Pin dependency**
+- [x] **Step 1: Pin dependency**
 
 In `apps/web/package.json` `dependencies`, add:
 
@@ -76,7 +76,7 @@ pnpm install --filter web
 
 Expected: lockfile updates if needed; `emoticon@4.1.0` resolvable from web.
 
-- [ ] **Step 2: Write failing unit tests**
+- [x] **Step 2: Write failing unit tests**
 
 Create `apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts`:
 
@@ -146,7 +146,7 @@ describe("matchEmoticonClosedAtBoundary", () => {
 });
 ```
 
-- [ ] **Step 3: Run tests — expect FAIL**
+- [x] **Step 3: Run tests — expect FAIL**
 
 ```bash
 pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts
@@ -154,7 +154,7 @@ pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts
 
 Expected: FAIL (module not found / function undefined).
 
-- [ ] **Step 4: Implement matcher**
+- [x] **Step 4: Implement matcher**
 
 Create `apps/web/src/lib/utils/composer-emoticons.ts`:
 
@@ -233,7 +233,7 @@ Notes for implementer:
 - Emoji glyphs (`😄` for `:D`, `😃` for `:)`, `😉` for `;)`) come from `emoticon` package; if a test glyph drifts, assert against `match` from the package rather than inventing alternates.
 - First-writer-wins when the same ASCII appears on multiple entries (map uses first `emoticon` list order).
 
-- [ ] **Step 5: Run tests — expect PASS**
+- [x] **Step 5: Run tests — expect PASS**
 
 ```bash
 pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts
@@ -241,7 +241,7 @@ pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts
 
 Expected: all PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add apps/web/package.json pnpm-lock.yaml apps/web/src/lib/utils/composer-emoticons.ts apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts
@@ -267,7 +267,7 @@ EOF
 - Consumes (existing): `findPositionForOffset`, `setCaretAfterNode`, `serializeEditor` / `syncFromEditor`, shortcode replace pattern in `handleInput`
 - Produces: no new exported API; live emoticon conversion on input
 
-- [ ] **Step 1: Write failing integration tests**
+- [x] **Step 1: Write failing integration tests**
 
 Append to `apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx` (same patterns as emoji shortcode popup tests — set `textContent`, collapse selection to end, `fireEvent.input`):
 
@@ -332,7 +332,7 @@ Append to `apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.t
   });
 ```
 
-- [ ] **Step 2: Run tests — expect FAIL**
+- [x] **Step 2: Run tests — expect FAIL**
 
 ```bash
 pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -340,7 +340,7 @@ pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.tes
 
 Expected: FAIL on “converts :D…” (still shows `:D`).
 
-- [ ] **Step 3: Wire replace after shortcode block**
+- [x] **Step 3: Wire replace after shortcode block**
 
 In `composer-wysiwyg-editor.tsx`:
 
@@ -446,7 +446,7 @@ const insert = match.emoji; // do not append space; boundary stays
 
 Keep shortcode block unchanged (still first).
 
-- [ ] **Step 4: Run tests — expect PASS**
+- [x] **Step 4: Run tests — expect PASS**
 
 ```bash
 pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -454,7 +454,7 @@ pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.tes
 
 Expected: new tests PASS; existing suite still green.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/web/src/components/chat/composer-wysiwyg-editor.tsx apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -479,7 +479,7 @@ EOF
 - Consumes: `matchEmoticonClosedAtBoundary(text, caret, { flush: true })`
 - Produces: flush conversion on blur timeout and on Enter-submit path
 
-- [ ] **Step 1: Write failing flush tests**
+- [x] **Step 1: Write failing flush tests**
 
 ```tsx
   it("converts bare trailing emoticon on blur (flush)", async () => {
@@ -552,7 +552,7 @@ EOF
   });
 ```
 
-- [ ] **Step 2: Run tests — expect FAIL**
+- [x] **Step 2: Run tests — expect FAIL**
 
 ```bash
 pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -560,7 +560,7 @@ pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.tes
 
 Expected: FAIL on flush/blur or submit conversion.
 
-- [ ] **Step 3: Implement flush helper and call sites**
+- [x] **Step 3: Implement flush helper and call sites**
 
 In `composer-wysiwyg-editor.tsx`, extract a `tryFlushEmoticonAtEnd` (or reuse replace logic) that:
 
@@ -618,7 +618,7 @@ tryFlushTrailingEmoticon();
 onSubmitShortcut?.();
 ```
 
-- [ ] **Step 4: Run tests — expect PASS**
+- [x] **Step 4: Run tests — expect PASS**
 
 ```bash
 pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx src/lib/utils/__tests__/composer-emoticons.test.ts
@@ -626,7 +626,7 @@ pnpm --filter web test src/components/chat/__tests__/composer-wysiwyg-editor.tes
 
 Expected: all PASS.
 
-- [ ] **Step 5: Format / typecheck touched surface**
+- [x] **Step 5: Format / typecheck touched surface**
 
 ```bash
 pnpm --filter web exec biome check --write src/lib/utils/composer-emoticons.ts src/lib/utils/__tests__/composer-emoticons.test.ts src/components/chat/composer-wysiwyg-editor.tsx src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -635,7 +635,7 @@ pnpm --filter web typecheck
 
 Expected: clean check; typecheck OK.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add apps/web/src/components/chat/composer-wysiwyg-editor.tsx apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx

--- a/docs/superpowers/specs/2026-08-07-composer-emoticon-live-convert-design.md
+++ b/docs/superpowers/specs/2026-08-07-composer-emoticon-live-convert-design.md
@@ -1,0 +1,166 @@
+# Design: Live emoticon conversion in room composer
+
+**Date:** 2026-08-07  
+**Status:** Approved  
+**Scope:** `apps/web` only — room / coworker WYSIWYG message composer (`ComposerWysiwygEditor`).
+
+## Problem
+
+Sent chat messages convert classic ASCII emoticons (`:D`, `;)`, `:-)`, etc.) to Unicode emoji via `remark-emoji` with `{ emoticon: true }` in the `Markdown` renderer. The room composer does **not** convert them while typing: the user sees raw ASCII until after send. Emoji **shortcodes** (`:smile:`) already auto-insert in the composer; emoticons should feel the same once complete.
+
+## Goals
+
+- Convert classic emoticons to Unicode emoji **in the composer** as the user types.
+- Trigger only when the emoticon is complete and closed by a **boundary** (space, sentence punctuation, or end-of-input on blur/send).
+- Use the **same emoticon set** as post-send render (`emoticon` package used by `remark-emoji`).
+- Persist Unicode in the composer markdown value (same as shortcode auto-insert).
+- Skip conversion inside code/pre/mention protected contexts.
+- Keep shortcode auto-insert behavior unchanged and first in line.
+
+## Non-goals
+
+- Agent/job plain textarea (`MultimodalInput` / `PromptInputTextarea`).
+- Display-only overlay that leaves ASCII in the stored value.
+- Changing post-send `Markdown` / `remark-emoji` rendering.
+- A custom or reduced emoticon list (parity with render is intentional).
+- Special undo beyond normal browser undo of the text insert.
+- Live conversion of emoticons mid-word or without a boundary.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| Timing | Convert when emoticon is complete **and** followed by space / sentence punct, or flush at end-of-input on blur/send |
+| Emoticon set | Full `emoticon` package list (same source `remark-emoji` uses when `emoticon: true`) |
+| Surface | Room / coworker **WYSIWYG** composer only (`ComposerWysiwygEditor`) |
+| Approach | Pure boundary matcher + DOM replace next to existing shortcode auto-insert in `handleInput` |
+| Stored value | Unicode emoji in markdown string |
+| Shortcode order | Shortcode closed match runs **before** emoticon match |
+
+## Current behavior
+
+**After send** (`apps/web/src/components/markdown.tsx`):
+
+```ts
+[remarkEmoji, { emoticon: true }]
+```
+
+`remark-emoji@5` uses the `emoticon` package and a short-pattern scan so `:)`, `;-)`, `:D`, etc. become emoji in rendered messages (skipped in fenced code).
+
+**In composer** (`ComposerWysiwygEditor.handleInput`):
+
+1. Strip pasted inline colors.
+2. Apply markdown input rules (`**bold**`, `_italic_`, etc.).
+3. Sync editor → markdown value.
+4. If exact closed shortcode (`:name:`) at caret → replace with emoji.
+5. Open/close mention or shortcode suggestions.
+
+Classic emoticons never hit step 4; they remain ASCII until `Markdown` renders the sent message.
+
+## Target behavior
+
+| Input | Composer result |
+| --- | --- |
+| `hello :D` + space | `hello 😄 ` (space kept) |
+| `wink ;)` then `.` | `wink 😉.` |
+| Bare `:)` at end, then blur or send | `😃` (flush / end-of-input boundary) |
+| Inside inline/fenced code or mention chip | No conversion |
+| `:smile:` shortcode | Unchanged existing path |
+| `http://` | No conversion (left guard) |
+| `:Dfoo` (no boundary) | No conversion |
+
+Exact emoji characters follow the `emoticon` package (e.g. `:D` → 😄, `:)` → 😃, `;)` → 😉). Tests should assert against that map, not hardcode alternate glyphs that only appear in older docs.
+
+## Architecture
+
+### Pure util
+
+**File:** `apps/web/src/lib/utils/composer-emoticons.ts`
+
+- Import `{ emoticon }` from the `emoticon` package.
+- Build a module-level map `emoticon string → emoji`, with keys ordered **longest-first**.
+- Export:
+
+```ts
+matchEmoticonClosedAtBoundary(
+  text: string,
+  caret: number,
+  options?: { flush?: boolean },
+): { start: number; end: number; emoji: string } | null
+```
+
+- `end` is exclusive end of the emoticon only; the boundary character is **not** consumed.
+- Pin `emoticon` as a **direct** dependency of `apps/web` at the exact version already in the lockfile (`4.1.0` at design time), per pinned-dependencies rules. Do not rely on transitive access alone.
+
+### Integration
+
+**File:** `apps/web/src/components/chat/composer-wysiwyg-editor.tsx`
+
+In `handleInput`, after the existing shortcode replace block:
+
+1. Call `matchEmoticonClosedAtBoundary(text, caret)`.
+2. If match and caret is not in a protected context (`CODE` / `PRE` / mention), replace via the same DOM path as shortcodes: `findPositionForOffset` → range delete → insert emoji text node → set caret → `syncFromEditor` → close suggestions.
+
+**Order in `handleInput`:**
+
+1. Color strip + input rules  
+2. Sync  
+3. Shortcode closed → replace (existing)  
+4. **Emoticon at boundary → replace (new)**  
+5. Suggestions  
+
+**Flush:** On blur and immediately before submit, if the serialized value ends with a complete emoticon with no trailing boundary, run the matcher with `flush: true` (caret = text length counts as boundary) and apply the same replace/sync path so bare trailing `:)` still converts.
+
+### Protected contexts
+
+Do not convert when the caret (or the matched range) sits inside:
+
+- `CODE` / `PRE`
+- Mention spans (`data-mention-key`)
+
+Reuse the same protected-context idea as `tryApplyComposerInputRuleAtCaret` (DOM ancestry check before applying the replace).
+
+## Match algorithm
+
+1. **Boundary at caret**
+   - **Live:** character before caret is whitespace **or** sentence punctuation (`. ! ? , ; :`).
+   - **Flush:** caret at `text.length` counts as boundary with no trailing character.
+
+2. **Window:** text before the boundary character (live: `text.slice(0, caret - 1)`; flush: full `text` up to caret).
+
+3. **Longest suffix:** among map keys that are suffixes of the window, pick the longest.
+
+4. **Left guard** (parity with `remark-emoji`’s `(^|\s)`): match start index must be `0` **or** the previous character must be whitespace. Prevents mid-token / mid-URL matches (`http://`).
+
+5. Return `{ start, end, emoji }` for the emoticon span only.
+
+**False positives** (e.g. `8)` → sunglasses after a space) are accepted for parity with post-send `remark-emoji` behavior.
+
+## Testing
+
+### Unit: `apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts`
+
+- `:D ` / `;)` / `:-)` produce the correct emoji and ranges.
+- Longest match: `:-)` wins over `:)`.
+- Left guard: no match inside `http://`.
+- No boundary → null.
+- Flush mode matches at end-of-input.
+- Boundary character is outside `[start, end)`.
+
+### Integration: extend `composer-wysiwyg-editor` tests
+
+- Typing `:D` then space updates editor content / serialized markdown to include the emoji.
+- No conversion inside inline code.
+- Closed shortcode `:smile:` still converts via the existing path.
+
+## Out of scope (reminders)
+
+- Other composers (agent multimodal plain textarea).
+- Changing render-side `remark-emoji` options or maps.
+- Partial emoticon lists or user settings to disable auto-convert.
+
+## Implementation notes
+
+- Prefer pure functions + unit tests first; thin DOM wiring second (TDD-friendly).
+- Do not hand-edit generated Core clients or unrelated packages.
+- After substantial edits, run Biome check on touched files and the new/updated tests via `pnpm --filter web test` on the relevant paths.

--- a/docs/superpowers/specs/2026-08-07-composer-emoticon-live-convert-design.md
+++ b/docs/superpowers/specs/2026-08-07-composer-emoticon-live-convert-design.md
@@ -61,7 +61,7 @@ Classic emoticons never hit step 4; they remain ASCII until `Markdown` renders t
 
 | Input | Composer result |
 | --- | --- |
-| `hello :D` + space | `hello 😄 ` (space kept) |
+| `hello :D` + space | `hello 😄` + space (space kept) |
 | `wink ;)` then `.` | `wink 😉.` |
 | Bare `:)` at end, then blur or send | `😃` (flush / end-of-input boundary) |
 | Inside inline/fenced code or mention chip | No conversion |
@@ -140,7 +140,7 @@ Reuse the same protected-context idea as `tryApplyComposerInputRuleAtCaret` (DOM
 
 ### Unit: `apps/web/src/lib/utils/__tests__/composer-emoticons.test.ts`
 
-- `:D ` / `;)` / `:-)` produce the correct emoji and ranges.
+- `:D` + space / `;)` / `:-)` produce the correct emoji and ranges.
 - Longest match: `:-)` wins over `:)`.
 - Left guard: no match inside `http://`.
 - No boundary → null.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,22 +44,22 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 1.6.26
-        version: 1.6.26(0b9db56c97d00fb6b437f7c63915f021)
+        version: 1.6.26(2768145af16d29ff6867661553a1ba1e)
       '@better-auth/i18n':
         specifier: 1.6.26
-        version: 1.6.26(60f9ff63ec59bebea1ed87923199fcf0)
+        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2)))
       '@better-auth/oauth-provider':
         specifier: 1.6.26
-        version: 1.6.26(b6ba9e416645bae83f97203995619cd1)
+        version: 1.6.26(fbeac99ffbf8c383373ebf677464a492)
       '@better-auth/passkey':
         specifier: 1.6.26
         version: 1.6.26(761e8686b9301b2b6a75ffaf77e665ab)
       '@better-auth/prisma-adapter':
         specifier: 1.6.26
-        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
       '@better-auth/stripe':
         specifier: 1.6.26
-        version: 1.6.26(c4a4b1b25f4a54243d46b207cdc43ded)
+        version: 1.6.26(c91bf00d55b5effa7eb482df4c7a1f2e)
       '@better-auth/utils':
         specifier: 0.4.2
         version: 0.4.2
@@ -125,7 +125,7 @@ importers:
         version: 7.0.56(zod@4.4.3)
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
       cron-parser:
         specifier: 5.7.0
         version: 5.7.0
@@ -189,19 +189,19 @@ importers:
         version: 4.0.59(react@19.2.8)(zod@4.4.3)
       '@better-auth/api-key':
         specifier: 1.6.26
-        version: 1.6.26(0b9db56c97d00fb6b437f7c63915f021)
+        version: 1.6.26(2768145af16d29ff6867661553a1ba1e)
       '@better-auth/i18n':
         specifier: 1.6.26
-        version: 1.6.26(60f9ff63ec59bebea1ed87923199fcf0)
+        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2)))
       '@better-auth/oauth-provider':
         specifier: 1.6.26
-        version: 1.6.26(b6ba9e416645bae83f97203995619cd1)
+        version: 1.6.26(fbeac99ffbf8c383373ebf677464a492)
       '@better-auth/passkey':
         specifier: 1.6.26
         version: 1.6.26(761e8686b9301b2b6a75ffaf77e665ab)
       '@better-auth/stripe':
         specifier: 1.6.26
-        version: 1.6.26(c4a4b1b25f4a54243d46b207cdc43ded)
+        version: 1.6.26(c91bf00d55b5effa7eb482df4c7a1f2e)
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -279,7 +279,7 @@ importers:
         version: 7.0.56(zod@4.4.3)
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -304,6 +304,9 @@ importers:
       embla-carousel-react:
         specifier: 8.6.0
         version: 8.6.0(react@19.2.8)
+      emoticon:
+        specifier: 4.1.0
+        version: 4.1.0
       fake-indexeddb:
         specifier: 6.2.5
         version: 6.2.5
@@ -554,7 +557,7 @@ importers:
         version: 7.9.1
       '@prisma/client':
         specifier: 7.9.1
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       '@sokosumi/masumi':
         specifier: workspace:*
         version: link:../masumi
@@ -7180,11 +7183,6 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  lucide-react@1.28.0:
-    resolution: {integrity: sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   lucide-react@1.29.0:
     resolution: {integrity: sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg==}
     peerDependencies:
@@ -9830,11 +9828,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@better-auth/api-key@1.6.26(0b9db56c97d00fb6b437f7c63915f021)':
+  '@better-auth/api-key@1.6.26(2768145af16d29ff6867661553a1ba1e)':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -9857,10 +9855,10 @@ snapshots:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/i18n@1.6.26(60f9ff63ec59bebea1ed87923199fcf0)':
+  '@better-auth/i18n@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2)))':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
 
   '@better-auth/kysely-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -9879,12 +9877,12 @@ snapshots:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.26(b6ba9e416645bae83f97203995619cd1)':
+  '@better-auth/oauth-provider@1.6.26(fbeac99ffbf8c383373ebf677464a492)':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       zod: 4.4.3
@@ -9896,23 +9894,23 @@ snapshots:
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))':
+  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
 
-  '@better-auth/stripe@1.6.26(c4a4b1b25f4a54243d46b207cdc43ded)':
+  '@better-auth/stripe@1.6.26(c91bf00d55b5effa7eb482df4c7a1f2e)':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       stripe: 22.4.0(@types/node@24.13.3)
@@ -10605,7 +10603,7 @@ snapshots:
       immer: 11.1.8
       katex: 0.16.47
       leva: 0.10.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      lucide-react: 1.28.0(react@19.2.8)
+      lucide-react: 1.29.0(react@19.2.8)
       marked: 17.0.6
       mermaid: 11.15.0
       motion: 13.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -11057,7 +11055,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.9.1': {}
 
-  '@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)':
+  '@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.1
     optionalDependencies:
@@ -13922,7 +13920,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.25
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -14344,14 +14342,14 @@ snapshots:
 
   baseline-browser-mapping@2.11.12: {}
 
-  better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2)):
+  better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.40(typescript@7.0.2)):
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/kysely-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
       '@better-auth/telemetry': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -14364,7 +14362,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       mysql2: 3.15.3
       next: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.22.0
@@ -16193,10 +16191,6 @@ snapshots:
       react: 19.2.8
 
   lucide-react@0.562.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-
-  lucide-react@1.28.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
## Summary

- Convert classic ASCII emoticons (`:D`, `;)`, `:-)`, etc.) to Unicode emoji **in the room/coworker WYSIWYG composer** when closed by a space or sentence punctuation, using the same `emoticon` map as post-send `remark-emoji`.
- Flush bare trailing emoticons on blur and before Enter-send, with `flushSync` so parent form state gets the emoji before submit.
- Skip conversion when the match range sits in `CODE` / `PRE` / mention chips; shortcode auto-insert (`:smile:`) stays first.

## Spec / plan

- Design: `docs/superpowers/specs/2026-08-07-composer-emoticon-live-convert-design.md`
- Plan: `docs/superpowers/plans/2026-08-07-composer-emoticon-live-convert.md`

## Test plan

- [ ] `pnpm --filter web test src/lib/utils/__tests__/composer-emoticons.test.ts src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx`
- [ ] Room composer: type `:D ` / `;)` / `:-)` → emoji appears before send
- [ ] Bare `:)` then blur or Enter → emoji in draft / sent body
- [ ] Inside inline code: `` `:D` `` stays ASCII
- [ ] `:smile:` shortcode still auto-inserts as before
- [ ] Click Send with bare trailing emoticon still converts (blur flush path)