### PR TITLE
fix(web): stop iOS Safari focus zoom on inputs

### DIFF
--- a/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
@@ -386,7 +386,7 @@ export default function SettingsPanel({
                   spellCheck={false}
                   maxLength={60}
                   disabled={nameSaving}
-                  className="border-border/60 bg-card/40 text-foreground placeholder:text-muted-foreground/60 focus-visible:ring-ring h-9 w-full rounded-lg border px-3 text-sm outline-none focus-visible:ring-2"
+                  className="border-border/60 bg-card/40 text-foreground placeholder:text-muted-foreground/60 focus-visible:ring-ring h-9 w-full rounded-lg border px-3 text-base outline-none focus-visible:ring-2 md:text-sm"
                 />
                 <Button
                   type="button"

--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -702,7 +702,7 @@ export const MarkdownEditor = forwardRef<
         aria-multiline="true"
         className={cn(
           "markdown-compose-surface",
-          "max-h-48 min-h-32 overflow-x-hidden overflow-y-auto px-3 py-2 text-sm",
+          "max-h-48 min-h-32 overflow-x-hidden overflow-y-auto px-3 py-2 text-base md:text-sm",
           "outline-none focus:outline-none",
           "wrap-anywhere [word-break:break-word] whitespace-pre-wrap",
           "empty:before:text-muted-foreground empty:before:pointer-events-none empty:before:content-[attr(data-placeholder)]",

--- a/apps/web/src/app/(auth)/oauth/callback/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/callback/page.tsx
@@ -222,7 +222,7 @@ export default function OAuthCallbackPage() {
                 <Input
                   readOnly
                   value={tokenResponse.access_token}
-                  className="font-mono text-xs"
+                  className="font-mono text-base md:text-xs"
                 />
                 <Button
                   type="button"
@@ -242,7 +242,7 @@ export default function OAuthCallbackPage() {
                   <Input
                     readOnly
                     value={tokenResponse.refresh_token}
-                    className="font-mono text-xs"
+                    className="font-mono text-base md:text-xs"
                   />
                   <Button
                     type="button"
@@ -280,7 +280,7 @@ export default function OAuthCallbackPage() {
                 <Input
                   readOnly
                   value={tokenResponse.id_token}
-                  className="font-mono text-xs"
+                  className="font-mono text-base md:text-xs"
                 />
               </div>
             )}
@@ -316,13 +316,21 @@ export default function OAuthCallbackPage() {
             <>
               <div className="space-y-2">
                 <Label>{t("authorizationCode")}</Label>
-                <Input readOnly value={code} className="font-mono text-xs" />
+                <Input
+                  readOnly
+                  value={code}
+                  className="font-mono text-base md:text-xs"
+                />
               </div>
 
               {state && (
                 <div className="space-y-2">
                   <Label>{t("state")}</Label>
-                  <Input readOnly value={state} className="font-mono text-xs" />
+                  <Input
+                    readOnly
+                    value={state}
+                    className="font-mono text-base md:text-xs"
+                  />
                 </div>
               )}
 
@@ -334,7 +342,7 @@ export default function OAuthCallbackPage() {
                   value={codeVerifier}
                   onChange={(e) => setCodeVerifier(e.target.value)}
                   placeholder={t("codeVerifierPlaceholder")}
-                  className="font-mono text-xs"
+                  className="font-mono text-base md:text-xs"
                 />
                 <p className="text-muted-foreground text-xs">
                   {t("codeVerifierHelp")}
@@ -349,7 +357,7 @@ export default function OAuthCallbackPage() {
                   value={clientId}
                   onChange={(e) => setClientId(e.target.value)}
                   placeholder={t("clientIdPlaceholder")}
-                  className="font-mono text-xs"
+                  className="font-mono text-base md:text-xs"
                 />
               </div>
 
@@ -361,7 +369,7 @@ export default function OAuthCallbackPage() {
                   value={clientSecret}
                   onChange={(e) => setClientSecret(e.target.value)}
                   placeholder={t("clientSecretPlaceholder")}
-                  className="font-mono text-xs"
+                  className="font-mono text-base md:text-xs"
                 />
                 <p className="text-muted-foreground text-xs">
                   {t("clientSecretHelp")}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import * as Sentry from "@sentry/nextjs";
 import { DEFAULT_LOCALE } from "@sokosumi/utils";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Suspense } from "react";
@@ -23,6 +23,11 @@ const inter = Inter({
   fallback: ["sans-serif"],
   variable: "--font-inter",
 });
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export function generateMetadata(): Metadata {
   const isMainnet = getEnvPublicConfig().NEXT_PUBLIC_NETWORK === "Mainnet";

--- a/apps/web/src/components/ui/color-picker.tsx
+++ b/apps/web/src/components/ui/color-picker.tsx
@@ -96,7 +96,7 @@ const ColorPicker = React.forwardRef<HTMLInputElement, ColorPickerProps>(
                   onBlur={onBlur}
                   disabled={disabled}
                   placeholder="#000000"
-                  className="flex-1 font-mono text-sm"
+                  className="flex-1 font-mono text-base md:text-sm"
                 />
               </div>
 

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -71,7 +71,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         {...props}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-749](https://linear.app/masumi/issue/SOK-749/stop-ios-safari-auto-zoom-on-mobile): iOS Safari no longer auto-zooms when focusing common text controls.

## Spec summary

- Mobile focusable text controls use `text-base` (≥1rem); `md+` may use `text-sm` / `text-xs`.
- Shared `CommandInput` matches `Input` / `Textarea` pattern.
- Settings name field, task markdown editor, color picker, and OAuth callback Inputs updated.
- Root viewport exports `width=device-width` + `initialScale: 1` only (no max-scale lock).
- Dynamic Type 1.25× cap unchanged; pinch-zoom stays available.

## Verification

- `pnpm web:check` (exit 0)
- `pnpm web:test` (exit 0; 2916 passed)
- CI green on `670a5651a4dc203393eeb395665ec2618df121e8`
- UI (iPhone 14): `/signin` inputs `16px`; `/chat` composer `16px`; viewport meta has no max-scale lock

[Signin mobile](https://cursor.com/agents/bc-0b790582-fe3a-4b03-a3cc-58eff8312380/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-749-signin-iphone14.png)
[Chat composer mobile](https://cursor.com/agents/bc-0b790582-fe3a-4b03-a3cc-58eff8312380/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-749-chat-composer-focus.png)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| UI evidence | `/personal-assistant` | Hermes settings sheet not runtime-verified here. Free fixture hits paid-plan / empty-catalog path; settings `text-base md:text-sm` change is source-only. |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b790582-fe3a-4b03-a3cc-58eff8312380?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b790582-fe3a-4b03-a3cc-58eff8312380&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

