### PR TITLE
feat(chat): add unread dot on mobile Chats tab

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4717,6 +4717,7 @@
       "MobileNav": {
         "home": "Start",
         "chats": "Chats",
+        "chatsUnread": "Ungelesene Chats",
         "search": "Suche",
         "ariaLabel": "Hauptnavigation",
         "backToChats": "Zurück zu Chats",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4717,6 +4717,7 @@
       "MobileNav": {
         "home": "Home",
         "chats": "Chats",
+        "chatsUnread": "Unread chats",
         "search": "Search",
         "ariaLabel": "Main navigation",
         "backToChats": "Back to chats",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4717,6 +4717,7 @@
       "MobileNav": {
         "home": "Inicio",
         "chats": "Chats",
+        "chatsUnread": "Chats no leídos",
         "search": "Buscar",
         "ariaLabel": "Navegación principal",
         "backToChats": "Volver a chats",

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 let mockPathname = "/chat";
 let mockSearchParams = new URLSearchParams();
 let mockIsApple = false;
+let mockShowUnreadDot = false;
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
@@ -16,6 +17,10 @@ vi.mock("next-intl", () => ({
 
 vi.mock("@/hooks/use-is-apple-platform", () => ({
   default: () => mockIsApple,
+}));
+
+vi.mock("../use-chat-tab-unread-presence", () => ({
+  useChatTabUnreadPresence: () => ({ showUnreadDot: mockShowUnreadDot }),
 }));
 
 vi.mock("next/link", () => ({
@@ -83,6 +88,7 @@ describe("ChatMobileBottomNav", () => {
     mockPathname = "/chat";
     mockSearchParams = new URLSearchParams();
     mockIsApple = false;
+    mockShowUnreadDot = false;
   });
 
   it("renders Home, Chats, and Search as links — Search goes to /history", () => {
@@ -190,5 +196,26 @@ describe("ChatMobileBottomNav", () => {
     render(<ChatMobileBottomNav />);
 
     expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
+  });
+
+  it("shows an unread presence dot on the Chats tab when attention exists", () => {
+    mockShowUnreadDot = true;
+    render(<ChatMobileBottomNav />);
+
+    expect(screen.getByLabelText("chatsUnread")).toBeTruthy();
+    expect(screen.getByLabelText("chatsUnread").className).toContain(
+      "bg-primary",
+    );
+    expect(screen.getByLabelText("chatsUnread").className).toContain(
+      "size-1.5",
+    );
+    expect(screen.getByRole("link", { name: /chats/i })).toBeTruthy();
+  });
+
+  it("hides the unread presence dot when no attention remains", () => {
+    mockShowUnreadDot = false;
+    render(<ChatMobileBottomNav />);
+
+    expect(screen.queryByLabelText("chatsUnread")).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/use-chat-tab-unread-presence.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/use-chat-tab-unread-presence.test.tsx
@@ -1,0 +1,171 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatRoom } from "@/lib/clients/generated/core";
+
+let mockPathname = "/chat";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock("@/components/chat/organization-chat-list.actions", () => ({
+  listOrganizationChatRoomsAction: vi.fn(),
+}));
+
+import { listOrganizationChatRoomsAction } from "@/components/chat/organization-chat-list.actions";
+import { clearRoomReadOverlays } from "@/components/chat/room-read-overlay";
+
+import {
+  getActiveRoomIdFromPathname,
+  useChatTabUnreadPresence,
+} from "../use-chat-tab-unread-presence";
+
+const listRoomsMock = vi.mocked(listOrganizationChatRoomsAction);
+
+function room(partial: Partial<ChatRoom> & Pick<ChatRoom, "id">): ChatRoom {
+  return {
+    name: partial.name ?? partial.id,
+    type: "channel",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    markedUnread: false,
+    mutedAt: null,
+    userMembers: [],
+    ...partial,
+  } as ChatRoom;
+}
+
+function Harness() {
+  const { showUnreadDot } = useChatTabUnreadPresence();
+  return (
+    <div data-testid="presence" data-show={showUnreadDot ? "yes" : "no"} />
+  );
+}
+
+describe("getActiveRoomIdFromPathname", () => {
+  it("extracts the room id from /chat/rooms/[id]", () => {
+    expect(getActiveRoomIdFromPathname("/chat/rooms/room-1")).toBe("room-1");
+  });
+
+  it("returns null outside room routes", () => {
+    expect(getActiveRoomIdFromPathname("/chat")).toBeNull();
+    expect(getActiveRoomIdFromPathname("/chat/chats")).toBeNull();
+    expect(getActiveRoomIdFromPathname(null)).toBeNull();
+  });
+});
+
+describe("useChatTabUnreadPresence", () => {
+  beforeEach(() => {
+    mockPathname = "/chat";
+    clearRoomReadOverlays();
+    listRoomsMock.mockReset();
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+      nextCursor: null,
+    });
+  });
+
+  afterEach(() => {
+    clearRoomReadOverlays();
+  });
+
+  it("shows unread when a non-active room has attention", async () => {
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      data: [room({ id: "a", unreadCount: 2 })],
+      nextCursor: null,
+    });
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("presence")).toHaveAttribute(
+        "data-show",
+        "yes",
+      );
+    });
+  });
+
+  it("hides unread for the active room even when that room reports attention", async () => {
+    mockPathname = "/chat/rooms/a";
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      data: [room({ id: "a", unreadCount: 2 })],
+      nextCursor: null,
+    });
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(listRoomsMock).toHaveBeenCalled();
+    });
+    expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "no");
+  });
+
+  it("keeps previous presence when a later poll fails", async () => {
+    listRoomsMock
+      .mockResolvedValueOnce({
+        ok: true,
+        data: [room({ id: "a", unreadCount: 1 })],
+        nextCursor: null,
+      })
+      .mockResolvedValueOnce({ ok: false });
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("presence")).toHaveAttribute(
+        "data-show",
+        "yes",
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => {
+      expect(listRoomsMock).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "yes");
+  });
+
+  it("clears presence after a room-read event for the last unread room", async () => {
+    const unread = room({ id: "a", unreadCount: 3 });
+    listRoomsMock.mockResolvedValue({
+      ok: true,
+      data: [unread],
+      nextCursor: null,
+    });
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("presence")).toHaveAttribute(
+        "data-show",
+        "yes",
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("organization-chat-room-read", {
+          detail: {
+            roomId: "a",
+            room: room({
+              id: "a",
+              unreadCount: 0,
+              unreadMentionCount: 0,
+              markedUnread: false,
+            }),
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByTestId("presence")).toHaveAttribute("data-show", "no");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-bottom-nav.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-bottom-nav.tsx
@@ -11,6 +11,7 @@ import {
   CHAT_MOBILE_TABS,
   type ChatMobileTabId,
 } from "./chat-mobile-tab-registry";
+import { useChatTabUnreadPresence } from "./use-chat-tab-unread-presence";
 
 type SearchParamsLike =
   | URLSearchParams
@@ -37,6 +38,7 @@ export function ChatMobileBottomNav(): React.ReactElement {
   const t = useTranslations("App.Channels.MobileNav");
   const activeTabId = resolveChatMobileActiveTabId(pathname, searchParams);
   const isApple = useIsApplePlatform();
+  const { showUnreadDot } = useChatTabUnreadPresence();
 
   return (
     <nav
@@ -59,6 +61,7 @@ export function ChatMobileBottomNav(): React.ReactElement {
           const Icon = tab.icon;
           const label = t(tab.labelKey);
           const isActive = activeTabId === tab.id;
+          const showChatsUnreadDot = tab.id === "chats" && showUnreadDot;
 
           return (
             <li key={tab.id} className="flex min-w-0 flex-1">
@@ -76,7 +79,15 @@ export function ChatMobileBottomNav(): React.ReactElement {
                     : "text-muted-foreground hover:text-foreground",
                 )}
               >
-                <Icon className="size-5" aria-hidden />
+                <span className="relative">
+                  <Icon className="size-5" aria-hidden />
+                  {showChatsUnreadDot ? (
+                    <span
+                      aria-label={t("chatsUnread")}
+                      className="bg-primary ring-background absolute -top-0.5 -right-0.5 size-1.5 rounded-full ring-2"
+                    />
+                  ) : null}
+                </span>
                 <span className="truncate">{label}</span>
               </Link>
             </li>

--- a/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
+++ b/apps/web/src/app/(app)/chat/components/use-chat-tab-unread-presence.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { countChatRoomsWithUnreadAttention } from "@/components/chat/chat-unread-document-title";
+import {
+  ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+  type OrganizationChatRoomsChangedDetail,
+} from "@/components/chat/organization-chat-events";
+import { listOrganizationChatRoomsAction } from "@/components/chat/organization-chat-list.actions";
+import {
+  applyRoomReadOverlays,
+  applyRoomReadResultToOverlay,
+} from "@/components/chat/room-read-overlay";
+import type { ChatRoom } from "@/lib/clients/generated/core";
+
+const CHAT_TAB_UNREAD_POLL_MS = 15_000;
+
+export function getActiveRoomIdFromPathname(
+  pathname: string | null,
+): string | null {
+  if (!pathname?.startsWith("/chat/rooms/")) {
+    return null;
+  }
+
+  const roomId = pathname.split("/")[3];
+  return roomId || null;
+}
+
+interface UseChatTabUnreadPresenceResult {
+  showUnreadDot: boolean;
+}
+
+export function useChatTabUnreadPresence(): UseChatTabUnreadPresenceResult {
+  const pathname = usePathname();
+  const activeRoomId = getActiveRoomIdFromPathname(pathname);
+  const [rooms, setRooms] = useState<ChatRoom[]>([]);
+
+  const showUnreadDot =
+    countChatRoomsWithUnreadAttention(rooms, { activeRoomId }) > 0;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refreshRooms = async () => {
+      const result = await listOrganizationChatRoomsAction();
+      if (cancelled || !result.ok) {
+        return;
+      }
+      setRooms(applyRoomReadOverlays(result.data));
+    };
+
+    void refreshRooms();
+
+    const intervalId = window.setInterval(
+      refreshRooms,
+      CHAT_TAB_UNREAD_POLL_MS,
+    );
+    window.addEventListener("focus", refreshRooms);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshRooms);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleRoomRead = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{ room?: ChatRoom; roomId?: string }>
+      ).detail;
+      if (!detail?.roomId) {
+        return;
+      }
+
+      if (detail.room) {
+        applyRoomReadResultToOverlay(detail.room);
+      }
+
+      setRooms((current) =>
+        applyRoomReadOverlays(
+          current.map((room) =>
+            room.id === detail.roomId
+              ? (detail.room ?? {
+                  ...room,
+                  unreadCount: 0,
+                  unreadMentionCount: 0,
+                  markedUnread: false,
+                })
+              : room,
+          ),
+        ),
+      );
+    };
+
+    window.addEventListener("organization-chat-room-read", handleRoomRead);
+    return () => {
+      window.removeEventListener("organization-chat-room-read", handleRoomRead);
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const handleRoomsChanged = (event: Event) => {
+      const detail = (event as CustomEvent<OrganizationChatRoomsChangedDetail>)
+        .detail;
+      const removedRoomId = detail?.removedRoomId;
+      if (removedRoomId) {
+        setRooms((current) =>
+          applyRoomReadOverlays(
+            current.filter((row) => row.id !== removedRoomId),
+          ),
+        );
+        return;
+      }
+
+      const room = detail?.room;
+      if (room) {
+        setRooms((current) => {
+          const without = current.filter((row) => row.id !== room.id);
+          return applyRoomReadOverlays([room, ...without]);
+        });
+        return;
+      }
+
+      void listOrganizationChatRoomsAction().then((result) => {
+        if (cancelled || !result.ok) {
+          return;
+        }
+        setRooms(applyRoomReadOverlays(result.data));
+      });
+    };
+
+    window.addEventListener(
+      ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+      handleRoomsChanged,
+    );
+    return () => {
+      cancelled = true;
+      window.removeEventListener(
+        ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
+        handleRoomsChanged,
+      );
+    };
+  }, []);
+
+  return { showUnreadDot };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://linear.app/masumi/issue/SOK-750/unread-dot-badge-on-chats-tab

Mobile Chats tab shows a presence-only unread dot when any channel or DM has the same attention as sidebar bold (`countChatRoomsWithUnreadAttention`). Clears when none remain.

Nav-owned poll hook (15s + focus + room events + read overlays) so the badge works when the mobile sidebar Sheet has unmounted the room list. No Core, Hermes, mention, or sidebar-bold changes.

## Spec summary

- Dot only (not a count) on Chats tab
- Channels + DMs; mute / marked-unread / active-room via existing helper
- Web-only; reuse list action + overlays
- Out of scope: numeric counts, Hermes PA badge, notification bell, Core

## Verification

- `pnpm web:check` (exit 0) at pinned SHA
- `pnpm web:test` (CI + local; proving tests for hook + nav)
- UI: mobile `/chat` and `/chat/chats` bottom nav present; no false-positive unread aria on empty account
- CI: all required checks green

### Review notes - medium (human review)

- Live browser could not seed a second-party unread room in this environment; show-dot path is covered by unit tests (`use-chat-tab-unread-presence`, bottom-nav mock).
- Hook duplicates `OrganizationChatList` poll/event refresh (accepted Candidate A tradeoff). Shared store later if a third consumer appears.
- `getActiveRoomIdFromPathname` is colocated next to the hook rather than exported from the list module.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9ebc8-c992-4dd9-ad3d-06a3e1a03947?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9ebc8-c992-4dd9-ad3d-06a3e1a03947&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

