### PR TITLE
fix(web): size video player to aspect ratio not full row

### DIFF
--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -208,16 +208,17 @@ describe("FileChipMiniPreviewFrame", () => {
     expect(video).toHaveClass("absolute", "inset-0", "size-full", "object-contain");
     expect(screen.getByTestId("file-chip-video")).toHaveClass(
       "min-w-0",
-      "w-full",
+      "w-fit",
       "max-w-sm",
       "overflow-hidden",
       "shrink",
     );
     expect(screen.getByTestId("file-chip-video")).not.toHaveClass("basis-full");
+    expect(screen.getByTestId("file-chip-video")).not.toHaveClass("w-full");
     expect(screen.getByTestId("file-chip-video-frame")).toHaveClass(
       "relative",
       "min-w-0",
-      "w-full",
+      "max-w-full",
       "overflow-hidden",
     );
   });

--- a/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip-mini-preview.test.tsx
@@ -209,15 +209,15 @@ describe("FileChipMiniPreviewFrame", () => {
     expect(screen.getByTestId("file-chip-video")).toHaveClass(
       "min-w-0",
       "w-full",
-      "max-w-full",
-      "basis-full",
+      "max-w-sm",
       "overflow-hidden",
       "shrink",
     );
+    expect(screen.getByTestId("file-chip-video")).not.toHaveClass("basis-full");
     expect(screen.getByTestId("file-chip-video-frame")).toHaveClass(
       "relative",
       "min-w-0",
-      "max-h-80",
+      "w-full",
       "overflow-hidden",
     );
   });

--- a/apps/web/src/components/ui/__tests__/file-chip.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip.test.tsx
@@ -167,17 +167,16 @@ describe("FileChip", () => {
     expect(screen.getByTestId("file-chip-video")).toHaveClass(
       "min-w-0",
       "w-full",
-      "max-w-full",
+      "max-w-sm",
       "overflow-hidden",
     );
-    expect(screen.getByTestId("file-chip-video-frame")).toHaveClass(
-      "relative",
-      "min-w-0",
-      "w-full",
-      "max-w-full",
-      "max-h-80",
-      "overflow-hidden",
-    );
+    const frame = screen.getByTestId("file-chip-video-frame");
+    expect(frame).toHaveClass("relative", "min-w-0", "w-full", "overflow-hidden");
+    // Default 16:9: maxWidth = 20rem * 16/9 (above max-w-sm → fills chip).
+    // happy-dom normalizes aspect-ratio to "N / 1".
+    expect(frame.style.aspectRatio).toMatch(/^1\.7777777777777777(\s*\/\s*1)?$/);
+    expect(frame.style.maxHeight).toBe("20rem");
+    expect(frame.style.maxWidth).toBe(`${(20 * 16) / 9}rem`);
     // download secondary still available (exact name avoids nested media fallback)
     expect(screen.getByRole("link", { name: /^download$/i })).toHaveAttribute(
       "href",
@@ -205,9 +204,13 @@ describe("FileChip", () => {
     });
     fireEvent.loadedMetadata(video!);
 
-    expect(screen.getByTestId("file-chip-video-frame")).toHaveStyle({
-      aspectRatio: "0.5625",
-    });
+    // Portrait 9:16 → width shrinks with max-height so the player is not a
+    // full-row letterbox (controls spanning the message column).
+    const portraitFrame = screen.getByTestId("file-chip-video-frame");
+    expect(portraitFrame.style.aspectRatio).toMatch(/^0\.5625(\s*\/\s*1)?$/);
+    // 20rem × 9/16 → ~11.25rem player (not full message column letterbox)
+    expect(portraitFrame.style.maxWidth).toBe(`${20 * 0.5625}rem`);
+    expect(portraitFrame.style.maxHeight).toBe("20rem");
 
     rerender(
       <FileChip
@@ -217,9 +220,11 @@ describe("FileChip", () => {
     );
 
     // key={mediaSrc} remounts the frame so stale portrait ratio cannot stick.
-    expect(screen.getByTestId("file-chip-video-frame")).toHaveStyle({
-      aspectRatio: String(16 / 9),
-    });
+    const landscapeFrame = screen.getByTestId("file-chip-video-frame");
+    expect(landscapeFrame.style.aspectRatio).toMatch(
+      /^1\.7777777777777777(\s*\/\s*1)?$/,
+    );
+    expect(landscapeFrame.style.maxWidth).toBe(`${(20 * 16) / 9}rem`);
     expect(container.querySelector("video")).toHaveAttribute(
       "src",
       "https://blob.example.com/uploads/landscape.mp4",

--- a/apps/web/src/components/ui/__tests__/file-chip.test.tsx
+++ b/apps/web/src/components/ui/__tests__/file-chip.test.tsx
@@ -166,17 +166,20 @@ describe("FileChip", () => {
     expect(video).toHaveClass("absolute", "inset-0", "size-full", "object-contain");
     expect(screen.getByTestId("file-chip-video")).toHaveClass(
       "min-w-0",
-      "w-full",
+      "w-fit",
       "max-w-sm",
       "overflow-hidden",
     );
     const frame = screen.getByTestId("file-chip-video-frame");
-    expect(frame).toHaveClass("relative", "min-w-0", "w-full", "overflow-hidden");
-    // Default 16:9: maxWidth = 20rem * 16/9 (above max-w-sm → fills chip).
+    expect(frame).toHaveClass("relative", "min-w-0", "max-w-full", "overflow-hidden");
+    // Default 16:9: width = 20rem * 16/9 (chip max-w-sm caps via maxWidth 100%).
     // happy-dom normalizes aspect-ratio to "N / 1".
     expect(frame.style.aspectRatio).toMatch(/^1\.7777777777777777(\s*\/\s*1)?$/);
     expect(frame.style.maxHeight).toBe("20rem");
-    expect(frame.style.maxWidth).toBe(`${(20 * 16) / 9}rem`);
+    // happy-dom may drop trailing zeros on rem lengths
+    expect(parseFloat(frame.style.width)).toBeCloseTo((20 * 16) / 9, 3);
+    expect(frame.style.width).toMatch(/rem$/);
+    expect(frame.style.maxWidth).toBe("100%");
     // download secondary still available (exact name avoids nested media fallback)
     expect(screen.getByRole("link", { name: /^download$/i })).toHaveAttribute(
       "href",
@@ -208,8 +211,10 @@ describe("FileChip", () => {
     // full-row letterbox (controls spanning the message column).
     const portraitFrame = screen.getByTestId("file-chip-video-frame");
     expect(portraitFrame.style.aspectRatio).toMatch(/^0\.5625(\s*\/\s*1)?$/);
-    // 20rem × 9/16 → ~11.25rem player (not full message column letterbox)
-    expect(portraitFrame.style.maxWidth).toBe(`${20 * 0.5625}rem`);
+    // 20rem × 9/16 → ~11.25rem; w-fit chip hugs this width
+    expect(parseFloat(portraitFrame.style.width)).toBeCloseTo(20 * 0.5625, 3);
+    expect(portraitFrame.style.width).toMatch(/rem$/);
+    expect(portraitFrame.style.maxWidth).toBe("100%");
     expect(portraitFrame.style.maxHeight).toBe("20rem");
 
     rerender(
@@ -224,7 +229,9 @@ describe("FileChip", () => {
     expect(landscapeFrame.style.aspectRatio).toMatch(
       /^1\.7777777777777777(\s*\/\s*1)?$/,
     );
-    expect(landscapeFrame.style.maxWidth).toBe(`${(20 * 16) / 9}rem`);
+    expect(parseFloat(landscapeFrame.style.width)).toBeCloseTo((20 * 16) / 9, 3);
+    expect(landscapeFrame.style.width).toMatch(/rem$/);
+    expect(landscapeFrame.style.maxWidth).toBe("100%");
     expect(container.querySelector("video")).toHaveAttribute(
       "src",
       "https://blob.example.com/uploads/landscape.mp4",

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -237,8 +237,9 @@ export function FileChipMiniPreviewFrame(props: FileChipMiniPreviewProps) {
         mediaType={props.mediaType}
         size={props.size}
         className={cn(
-          // Match FileChip media cap; avoid basis-full (forces full message row).
-          "min-w-0 w-full max-w-sm shrink",
+          // Video uses FileChip w-fit; only pass shrink so flex rows can wrap.
+          // Avoid basis-full / w-full (forces full message row).
+          "min-w-0 max-w-sm shrink",
           props.className,
         )}
       />

--- a/apps/web/src/components/ui/file-chip-mini-preview.tsx
+++ b/apps/web/src/components/ui/file-chip-mini-preview.tsx
@@ -237,7 +237,8 @@ export function FileChipMiniPreviewFrame(props: FileChipMiniPreviewProps) {
         mediaType={props.mediaType}
         size={props.size}
         className={cn(
-          "min-w-0 w-full max-w-full basis-full shrink",
+          // Match FileChip media cap; avoid basis-full (forces full message row).
+          "min-w-0 w-full max-w-sm shrink",
           props.className,
         )}
       />

--- a/apps/web/src/components/ui/file-chip.tsx
+++ b/apps/web/src/components/ui/file-chip.tsx
@@ -32,14 +32,19 @@ export interface FileChipProps extends React.ComponentPropsWithoutRef<"a"> {
   iconPx?: number;
 }
 
+/** Matches Tailwind `max-h-80` (20rem). Used to derive width from aspect ratio. */
+const VIDEO_FRAME_MAX_HEIGHT_REM = 20;
+
 /**
  * Native `<video controls>` reports a large min-content width (~476–570px in
  * Chromium). Inside Radix ScrollArea's `display:table` content wrapper that
  * floor becomes the message column's minimum and Chrome device mode appears
  * to "stop resizing". Absolutely positioning the video removes it from
  * min-content; chat message ScrollAreas also pass `shrinkContent` so the
- * table wrapper can shrink. The frame keeps width from the row and height
- * from aspect-ratio (capped like large image previews).
+ * table wrapper can shrink.
+ *
+ * `maxWidth = max-height × aspect-ratio` so portrait clips shrink the box
+ * instead of letterboxing inside a full-row frame when height hits max-h-80.
  */
 function FileChipVideoFrame({
   src,
@@ -49,12 +54,19 @@ function FileChipVideoFrame({
   fileName: string;
 }) {
   const [aspectRatio, setAspectRatio] = useState<number | undefined>(undefined);
+  const resolvedAspectRatio = aspectRatio ?? 16 / 9;
 
   return (
     <div
       data-testid="file-chip-video-frame"
-      className="relative min-w-0 w-full max-w-full max-h-80 overflow-hidden rounded-lg bg-black/20"
-      style={{ aspectRatio: aspectRatio ?? 16 / 9 }}
+      className="relative min-w-0 w-full overflow-hidden rounded-lg bg-black/20"
+      style={{
+        aspectRatio: resolvedAspectRatio,
+        maxHeight: `${VIDEO_FRAME_MAX_HEIGHT_REM}rem`,
+        // Portrait: cap width so the box matches the video (no side bars).
+        // Landscape: cap is above max-w-sm chip, so frame fills the chip.
+        maxWidth: `${VIDEO_FRAME_MAX_HEIGHT_REM * resolvedAspectRatio}rem`,
+      }}
     >
       <video
         src={src}
@@ -212,9 +224,9 @@ export function FileChip(props: FileChipProps) {
     return (
       <div
         className={cn(
-          // min-w-0 lets the chip shrink in flex message rows (large images do
-          // the same); overflow-hidden clamps native video control min-width.
-          "flex min-w-0 w-full max-w-full flex-col gap-2 overflow-hidden rounded-md border p-2",
+          // Cap like large solo image thumbs (`max-w-sm`) — not full message
+          // column. min-w-0 + overflow-hidden clamps native control min-width.
+          "flex min-w-0 w-full max-w-sm flex-col gap-2 overflow-hidden rounded-md border p-2",
           className,
         )}
         title={title}

--- a/apps/web/src/components/ui/file-chip.tsx
+++ b/apps/web/src/components/ui/file-chip.tsx
@@ -43,8 +43,9 @@ const VIDEO_FRAME_MAX_HEIGHT_REM = 20;
  * min-content; chat message ScrollAreas also pass `shrinkContent` so the
  * table wrapper can shrink.
  *
- * `maxWidth = max-height × aspect-ratio` so portrait clips shrink the box
- * instead of letterboxing inside a full-row frame when height hits max-h-80.
+ * Explicit width from max-height × aspect-ratio so a `w-fit` chip hugs the
+ * video (portrait ≈ phone width). `maxWidth: 100%` still fits narrow columns;
+ * height stays capped at max-h-80.
  */
 function FileChipVideoFrame({
   src,
@@ -55,17 +56,20 @@ function FileChipVideoFrame({
 }) {
   const [aspectRatio, setAspectRatio] = useState<number | undefined>(undefined);
   const resolvedAspectRatio = aspectRatio ?? 16 / 9;
+  // Fixed precision so style stays stable across engines (happy-dom rounds).
+  const frameWidthRem = (
+    VIDEO_FRAME_MAX_HEIGHT_REM * resolvedAspectRatio
+  ).toFixed(4);
 
   return (
     <div
       data-testid="file-chip-video-frame"
-      className="relative min-w-0 w-full overflow-hidden rounded-lg bg-black/20"
+      className="relative min-w-0 max-w-full overflow-hidden rounded-lg bg-black/20"
       style={{
         aspectRatio: resolvedAspectRatio,
+        width: `${frameWidthRem}rem`,
+        maxWidth: "100%",
         maxHeight: `${VIDEO_FRAME_MAX_HEIGHT_REM}rem`,
-        // Portrait: cap width so the box matches the video (no side bars).
-        // Landscape: cap is above max-w-sm chip, so frame fills the chip.
-        maxWidth: `${VIDEO_FRAME_MAX_HEIGHT_REM * resolvedAspectRatio}rem`,
       }}
     >
       <video
@@ -224,15 +228,21 @@ export function FileChip(props: FileChipProps) {
     return (
       <div
         className={cn(
-          // Cap like large solo image thumbs (`max-w-sm`) — not full message
-          // column. min-w-0 + overflow-hidden clamps native control min-width.
-          "flex min-w-0 w-full max-w-sm flex-col gap-2 overflow-hidden rounded-md border p-2",
+          // Video: w-fit so the card hugs the frame (chat-bubble style).
+          // Audio: w-full for usable native controls. Both cap at max-w-sm.
+          // overflow-hidden clamps native control min-width in ScrollAreas.
+          "flex min-w-0 max-w-sm flex-col gap-2 overflow-hidden rounded-md border p-2",
+          isVideo ? "w-fit" : "w-full",
           className,
         )}
         title={title}
         data-testid={isVideo ? "file-chip-video" : "file-chip-audio"}
       >
-        <div className="flex min-w-0 items-center gap-3">
+        {/*
+          w-0 min-w-full: size header to the video frame, not the full filename
+          max-content (keeps long names truncated inside a portrait chip).
+        */}
+        <div className="flex w-0 min-w-full items-center gap-3">
           <div
             className={cn(
               "bg-accent/50 relative flex shrink-0 items-center justify-center rounded",


### PR DESCRIPTION
## Summary

- Portrait chat video chips letterboxed inside a full-width `max-h-80` frame (player chrome wider than the video).
- Size the video frame with explicit width from `max-height × aspect-ratio` (and `maxWidth: 100%`) so portrait clips match the phone box instead of letterboxing.
- Hug the media card to that frame with `w-fit max-w-sm` (chat-bubble style); header uses `w-0 min-w-full` so long filenames truncate inside the chip and do not re-widen dead space.
- Drop `basis-full` / full-row stretch on the sent-message frame. Audio stays `w-full max-w-sm` for usable native controls. Absolute `<video>` + overflow clamp kept so ScrollArea min-content does not blow out (#3677).

## Test plan

- [x] `pnpm --filter web exec vitest run src/components/ui/__tests__/file-chip.test.tsx src/components/ui/__tests__/file-chip-mini-preview.test.tsx` (28/28)
- [x] Pre-commit `pnpm check` + `pnpm typecheck`
- [ ] Chat: attach/open a portrait screen recording — chip hugs phone aspect (no empty strip beside the video)
- [ ] Chat: long filename on a portrait clip truncates; does not stretch the card past the video
- [ ] Chat: landscape video still usable up to `max-w-sm` without overflow
- [ ] Narrow thread / mobile: no horizontal scroll from native video controls
- [ ] Audio attachment still has a usable control bar width