### PR TITLE
fix(web): stop iOS Safari focus zoom on editables

### DIFF
--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -26,6 +26,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { Coworker, Member } from "@/lib/clients/generated/core";
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 import { formatTaskAttachmentMarkdown } from "@/lib/utils/task-attachments";
 import { getInitials } from "@/lib/utils/text";
@@ -395,7 +396,7 @@ export function DraftDirectMessage({
                       ? t("Draft.searchPlaceholderMore")
                       : t("Draft.searchPlaceholderReplace")
                 }
-                className="placeholder:text-muted-foreground h-9 w-full bg-transparent pr-2 pl-6 text-base outline-none md:text-sm"
+                className={`placeholder:text-muted-foreground h-9 w-full bg-transparent pr-2 pl-6 outline-none ${EDITABLE_TEXT_SIZE_CLASSNAME}`}
               />
             </div>
           </div>

--- a/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
+++ b/apps/web/src/app/(app)/chat/components/draft-direct-message.tsx
@@ -26,7 +26,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { Coworker, Member } from "@/lib/clients/generated/core";
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import { withEditableTextSize } from "@/lib/utils/editable-text-size";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 import { formatTaskAttachmentMarkdown } from "@/lib/utils/task-attachments";
 import { getInitials } from "@/lib/utils/text";
@@ -396,7 +396,9 @@ export function DraftDirectMessage({
                       ? t("Draft.searchPlaceholderMore")
                       : t("Draft.searchPlaceholderReplace")
                 }
-                className={`placeholder:text-muted-foreground h-9 w-full bg-transparent pr-2 pl-6 outline-none ${EDITABLE_TEXT_SIZE_CLASSNAME}`}
+                className={withEditableTextSize(
+                  "placeholder:text-muted-foreground h-9 w-full bg-transparent pr-2 pl-6 outline-none",
+                )}
               />
             </div>
           </div>

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state/composer.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state/composer.tsx
@@ -134,7 +134,7 @@ export function Composer({
               minHeight={44}
               autoFocus
               disabled={disabled}
-              className="placeholder:text-muted-foreground scrollbar-none grow resize-none border-0! bg-transparent p-4 text-base ring-0 outline-none [-ms-overflow-style:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
+              className="placeholder:text-muted-foreground scrollbar-none grow resize-none border-0! bg-transparent p-4 ring-0 outline-none [-ms-overflow-style:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
             />
           </FileUploadDropzone>
 

--- a/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
@@ -43,6 +43,7 @@ import type {
   HermesIntegrationStatus,
 } from "@/lib/hermes/types";
 import { cn } from "@/lib/utils";
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
 
 import ConnectInterstitial from "./connect-interstitial";
 import PanelSection from "./panel-section";
@@ -386,7 +387,10 @@ export default function SettingsPanel({
                   spellCheck={false}
                   maxLength={60}
                   disabled={nameSaving}
-                  className="border-border/60 bg-card/40 text-foreground placeholder:text-muted-foreground/60 focus-visible:ring-ring h-9 w-full rounded-lg border px-3 text-base outline-none focus-visible:ring-2 md:text-sm"
+                  className={cn(
+                    "border-border/60 bg-card/40 text-foreground placeholder:text-muted-foreground/60 focus-visible:ring-ring h-9 w-full rounded-lg border px-3 outline-none focus-visible:ring-2",
+                    EDITABLE_TEXT_SIZE_CLASSNAME,
+                  )}
                 />
                 <Button
                   type="button"

--- a/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/settings-panel.tsx
@@ -43,7 +43,7 @@ import type {
   HermesIntegrationStatus,
 } from "@/lib/hermes/types";
 import { cn } from "@/lib/utils";
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import { withEditableTextSize } from "@/lib/utils/editable-text-size";
 
 import ConnectInterstitial from "./connect-interstitial";
 import PanelSection from "./panel-section";
@@ -387,9 +387,8 @@ export default function SettingsPanel({
                   spellCheck={false}
                   maxLength={60}
                   disabled={nameSaving}
-                  className={cn(
+                  className={withEditableTextSize(
                     "border-border/60 bg-card/40 text-foreground placeholder:text-muted-foreground/60 focus-visible:ring-ring h-9 w-full rounded-lg border px-3 outline-none focus-visible:ring-2",
-                    EDITABLE_TEXT_SIZE_CLASSNAME,
                   )}
                 />
                 <Button

--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -47,6 +47,7 @@ import {
   htmlToMarkdown,
   markdownToHtml,
 } from "@/lib/utils/composer-markdown-dom";
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
 import { normalizeUrl } from "@/lib/utils/markdown-editor-utils";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 
@@ -702,7 +703,8 @@ export const MarkdownEditor = forwardRef<
         aria-multiline="true"
         className={cn(
           "markdown-compose-surface",
-          "max-h-48 min-h-32 overflow-x-hidden overflow-y-auto px-3 py-2 text-base md:text-sm",
+          "max-h-48 min-h-32 overflow-x-hidden overflow-y-auto px-3 py-2",
+          EDITABLE_TEXT_SIZE_CLASSNAME,
           "outline-none focus:outline-none",
           "wrap-anywhere [word-break:break-word] whitespace-pre-wrap",
           "empty:before:text-muted-foreground empty:before:pointer-events-none empty:before:content-[attr(data-placeholder)]",

--- a/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
+++ b/apps/web/src/app/(app)/tasks/components/markdown-editor.tsx
@@ -47,7 +47,7 @@ import {
   htmlToMarkdown,
   markdownToHtml,
 } from "@/lib/utils/composer-markdown-dom";
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import { withEditableTextSize } from "@/lib/utils/editable-text-size";
 import { normalizeUrl } from "@/lib/utils/markdown-editor-utils";
 import { slugifyMentionValue } from "@/lib/utils/mention-parser";
 
@@ -701,10 +701,9 @@ export const MarkdownEditor = forwardRef<
         data-placeholder={placeholder}
         role="textbox"
         aria-multiline="true"
-        className={cn(
+        className={withEditableTextSize(
           "markdown-compose-surface",
           "max-h-48 min-h-32 overflow-x-hidden overflow-y-auto px-3 py-2",
-          EDITABLE_TEXT_SIZE_CLASSNAME,
           "outline-none focus:outline-none",
           "wrap-anywhere [word-break:break-word] whitespace-pre-wrap",
           "empty:before:text-muted-foreground empty:before:pointer-events-none empty:before:content-[attr(data-placeholder)]",

--- a/apps/web/src/app/(auth)/oauth/callback/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/callback/page.tsx
@@ -222,7 +222,7 @@ export default function OAuthCallbackPage() {
                 <Input
                   readOnly
                   value={tokenResponse.access_token}
-                  className="font-mono text-base md:text-xs"
+                  className="font-mono"
                 />
                 <Button
                   type="button"
@@ -242,7 +242,7 @@ export default function OAuthCallbackPage() {
                   <Input
                     readOnly
                     value={tokenResponse.refresh_token}
-                    className="font-mono text-base md:text-xs"
+                    className="font-mono"
                   />
                   <Button
                     type="button"
@@ -280,7 +280,7 @@ export default function OAuthCallbackPage() {
                 <Input
                   readOnly
                   value={tokenResponse.id_token}
-                  className="font-mono text-base md:text-xs"
+                  className="font-mono"
                 />
               </div>
             )}
@@ -316,21 +316,13 @@ export default function OAuthCallbackPage() {
             <>
               <div className="space-y-2">
                 <Label>{t("authorizationCode")}</Label>
-                <Input
-                  readOnly
-                  value={code}
-                  className="font-mono text-base md:text-xs"
-                />
+                <Input readOnly value={code} className="font-mono" />
               </div>
 
               {state && (
                 <div className="space-y-2">
                   <Label>{t("state")}</Label>
-                  <Input
-                    readOnly
-                    value={state}
-                    className="font-mono text-base md:text-xs"
-                  />
+                  <Input readOnly value={state} className="font-mono" />
                 </div>
               )}
 
@@ -342,7 +334,7 @@ export default function OAuthCallbackPage() {
                   value={codeVerifier}
                   onChange={(e) => setCodeVerifier(e.target.value)}
                   placeholder={t("codeVerifierPlaceholder")}
-                  className="font-mono text-base md:text-xs"
+                  className="font-mono"
                 />
                 <p className="text-muted-foreground text-xs">
                   {t("codeVerifierHelp")}
@@ -357,7 +349,7 @@ export default function OAuthCallbackPage() {
                   value={clientId}
                   onChange={(e) => setClientId(e.target.value)}
                   placeholder={t("clientIdPlaceholder")}
-                  className="font-mono text-base md:text-xs"
+                  className="font-mono"
                 />
               </div>
 
@@ -369,7 +361,7 @@ export default function OAuthCallbackPage() {
                   value={clientSecret}
                   onChange={(e) => setClientSecret(e.target.value)}
                   placeholder={t("clientSecretPlaceholder")}
-                  className="font-mono text-base md:text-xs"
+                  className="font-mono"
                 />
                 <p className="text-muted-foreground text-xs">
                   {t("clientSecretHelp")}

--- a/apps/web/src/components/chat/multimodal-input.tsx
+++ b/apps/web/src/components/chat/multimodal-input.tsx
@@ -805,7 +805,7 @@ function PureMultimodalInput({
                     <FileUploadDropzone className="data-dragging:bg-accent/20 w-full items-stretch justify-start border-0 p-0 hover:bg-transparent">
                       <PromptInputTextarea
                         allowEnterToSubmitOnMobile={enterSubmitsOnMobile}
-                        className="placeholder:text-muted-foreground grow resize-none border-0! border-none! bg-transparent p-4 text-base ring-0 outline-none [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
+                        className="placeholder:text-muted-foreground grow resize-none border-0! border-none! bg-transparent p-4 ring-0 outline-none [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
                         data-testid="multimodal-input"
                         disableAutoResize={true}
                         maxHeight={200}
@@ -832,7 +832,7 @@ function PureMultimodalInput({
                 ) : (
                   <PromptInputTextarea
                     allowEnterToSubmitOnMobile={enterSubmitsOnMobile}
-                    className="placeholder:text-muted-foreground grow resize-none border-0! border-none! bg-transparent p-4 text-base ring-0 outline-none [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
+                    className="placeholder:text-muted-foreground grow resize-none border-0! border-none! bg-transparent p-4 ring-0 outline-none [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none [&::-webkit-scrollbar]:hidden"
                     data-testid="multimodal-input"
                     disableAutoResize={true}
                     maxHeight={200}

--- a/apps/web/src/components/chat/room-message-composer.tsx
+++ b/apps/web/src/components/chat/room-message-composer.tsx
@@ -7,9 +7,9 @@ import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
 
-export const ROOM_COMPOSER_TEXTAREA_CLASSNAME =
-  "max-h-40 min-h-10 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 pt-3.5 pb-2.5 text-base leading-6 ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-sm";
+export const ROOM_COMPOSER_TEXTAREA_CLASSNAME = `max-h-40 min-h-10 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 pt-3.5 pb-2.5 leading-6 ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent ${EDITABLE_TEXT_SIZE_CLASSNAME}`;
 
 export const ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME =
   "size-9 rounded-full sm:size-8";

--- a/apps/web/src/components/chat/room-message-composer.tsx
+++ b/apps/web/src/components/chat/room-message-composer.tsx
@@ -7,9 +7,11 @@ import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import { withEditableTextSize } from "@/lib/utils/editable-text-size";
 
-export const ROOM_COMPOSER_TEXTAREA_CLASSNAME = `max-h-40 min-h-10 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 pt-3.5 pb-2.5 leading-6 ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent ${EDITABLE_TEXT_SIZE_CLASSNAME}`;
+export const ROOM_COMPOSER_TEXTAREA_CLASSNAME = withEditableTextSize(
+  "max-h-40 min-h-10 field-sizing-content resize-none overflow-y-auto rounded-none border-0! bg-transparent px-4 pt-3.5 pb-2.5 leading-6 ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent",
+);
 
 export const ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME =
   "size-9 rounded-full sm:size-8";

--- a/apps/web/src/components/ui/color-picker.tsx
+++ b/apps/web/src/components/ui/color-picker.tsx
@@ -96,7 +96,7 @@ const ColorPicker = React.forwardRef<HTMLInputElement, ColorPickerProps>(
                   onBlur={onBlur}
                   disabled={disabled}
                   placeholder="#000000"
-                  className="flex-1 font-mono text-base md:text-sm"
+                  className="flex-1 font-mono"
                 />
               </div>
 

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -5,6 +5,7 @@ import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size"
 import {
   Dialog,
   DialogContent,
@@ -71,7 +72,8 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          EDITABLE_TEXT_SIZE_CLASSNAME,
           className
         )}
         {...props}

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -5,7 +5,7 @@ import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size"
+import { withEditableTextSize } from "@/lib/utils/editable-text-size"
 import {
   Dialog,
   DialogContent,
@@ -71,9 +71,8 @@ function CommandInput({
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
-        className={cn(
+        className={withEditableTextSize(
           "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-          EDITABLE_TEXT_SIZE_CLASSNAME,
           className
         )}
         {...props}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
 
 const Input = React.forwardRef<
   HTMLInputElement,
@@ -12,7 +13,8 @@ const Input = React.forwardRef<
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        EDITABLE_TEXT_SIZE_CLASSNAME,
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import { withEditableTextSize } from "@/lib/utils/editable-text-size";
 
 const Input = React.forwardRef<
   HTMLInputElement,
@@ -12,9 +11,8 @@ const Input = React.forwardRef<
       ref={ref}
       type={type}
       data-slot="input"
-      className={cn(
+      className={withEditableTextSize(
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        EDITABLE_TEXT_SIZE_CLASSNAME,
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/apps/web/src/components/ui/mention-textarea.tsx
+++ b/apps/web/src/components/ui/mention-textarea.tsx
@@ -13,6 +13,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { cn } from "@/lib/utils";
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
 import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
 
 import {
@@ -862,7 +863,8 @@ function MentionTextareaInner<TData = unknown>(
         onClick={handleEditorClick}
         onMouseDown={handleEditorMouseDown}
         className={cn(
-          "border-input focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 caret-foreground text-foreground field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base wrap-break-word whitespace-pre-wrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "border-input focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 caret-foreground text-foreground field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 wrap-break-word whitespace-pre-wrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+          EDITABLE_TEXT_SIZE_CLASSNAME,
           className,
         )}
       />
@@ -871,7 +873,8 @@ function MentionTextareaInner<TData = unknown>(
         <div
           aria-hidden
           className={cn(
-            "text-muted-foreground pointer-events-none absolute inset-0 rounded-md px-3 py-2 text-base wrap-break-word whitespace-pre-wrap md:text-sm",
+            "text-muted-foreground pointer-events-none absolute inset-0 rounded-md px-3 py-2 wrap-break-word whitespace-pre-wrap",
+            EDITABLE_TEXT_SIZE_CLASSNAME,
             className,
           )}
         >

--- a/apps/web/src/components/ui/mention-textarea.tsx
+++ b/apps/web/src/components/ui/mention-textarea.tsx
@@ -13,7 +13,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { cn } from "@/lib/utils";
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import { withEditableTextSize } from "@/lib/utils/editable-text-size";
 import { parseMentions, slugifyMentionValue } from "@/lib/utils/mention-parser";
 
 import {
@@ -862,9 +862,8 @@ function MentionTextareaInner<TData = unknown>(
         onFocus={handleFocus}
         onClick={handleEditorClick}
         onMouseDown={handleEditorMouseDown}
-        className={cn(
+        className={withEditableTextSize(
           "border-input focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 caret-foreground text-foreground field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 wrap-break-word whitespace-pre-wrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-          EDITABLE_TEXT_SIZE_CLASSNAME,
           className,
         )}
       />
@@ -872,9 +871,8 @@ function MentionTextareaInner<TData = unknown>(
       {!value && !isFocused && placeholder ? (
         <div
           aria-hidden
-          className={cn(
+          className={withEditableTextSize(
             "text-muted-foreground pointer-events-none absolute inset-0 rounded-md px-3 py-2 wrap-break-word whitespace-pre-wrap",
-            EDITABLE_TEXT_SIZE_CLASSNAME,
             className,
           )}
         >

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -5,7 +5,7 @@ import { Select as SelectPrimitive } from "radix-ui"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size"
+import { withEditableTextSize } from "@/lib/utils/editable-text-size"
 
 function Select({
   ...props
@@ -37,9 +37,8 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
-      className={cn(
+      className={withEditableTextSize(
         "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        EDITABLE_TEXT_SIZE_CLASSNAME,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import { Select as SelectPrimitive } from "radix-ui"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size"
 
 function Select({
   ...props
@@ -37,7 +38,8 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        EDITABLE_TEXT_SIZE_CLASSNAME,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,15 +1,13 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size"
+import { withEditableTextSize } from "@/lib/utils/editable-text-size"
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea
       data-slot="textarea"
-      className={cn(
+      className={withEditableTextSize(
         "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        EDITABLE_TEXT_SIZE_CLASSNAME,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,13 +1,15 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size"
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        EDITABLE_TEXT_SIZE_CLASSNAME,
         className
       )}
       {...props}

--- a/apps/web/src/lib/utils/__tests__/editable-text-size-primitives.test.ts
+++ b/apps/web/src/lib/utils/__tests__/editable-text-size-primitives.test.ts
@@ -4,7 +4,10 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+import {
+  EDITABLE_TEXT_SIZE_CLASSNAME,
+  withEditableTextSize,
+} from "@/lib/utils/editable-text-size";
 
 const SRC_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -22,22 +25,29 @@ const PRIMITIVE_SOURCES = [
 
 const MD_SHRINK = /md:text-(?:sm|xs)\b/;
 const FLOOR_TOKEN = "max(1rem,16px)";
-const CONSTANT_IMPORT = "EDITABLE_TEXT_SIZE_CLASSNAME";
 
 describe("editable text size primitives", () => {
-  it("exports a floor classname without md shrink", () => {
-    expect(EDITABLE_TEXT_SIZE_CLASSNAME).toContain("text-base");
+  it("exports a single floor classname without md shrink", () => {
     expect(EDITABLE_TEXT_SIZE_CLASSNAME).toContain(FLOOR_TOKEN);
     expect(EDITABLE_TEXT_SIZE_CLASSNAME).not.toContain("md:text-sm");
+    expect(EDITABLE_TEXT_SIZE_CLASSNAME).not.toMatch(/\btext-base\b/);
+  });
+
+  it("keeps the floor last when callers pass text-base or text-sm", () => {
+    const merged = withEditableTextSize("p-4 text-base", "text-sm");
+    expect(merged).toContain(EDITABLE_TEXT_SIZE_CLASSNAME);
+    expect(merged).not.toMatch(/\btext-base\b/);
+    expect(merged).not.toMatch(/\btext-sm\b/);
   });
 
   it.each(PRIMITIVE_SOURCES)(
-    "%s uses editable floor and has no md shrink on editables",
+    "%s uses withEditableTextSize / floor and has no md shrink",
     (rel) => {
       const content = readFileSync(path.join(SRC_ROOT, rel), "utf8");
       expect(content).not.toMatch(MD_SHRINK);
       expect(
-        content.includes(CONSTANT_IMPORT) || content.includes(FLOOR_TOKEN),
+        content.includes("withEditableTextSize") ||
+          content.includes(FLOOR_TOKEN),
       ).toBe(true);
     },
   );

--- a/apps/web/src/lib/utils/__tests__/editable-text-size-primitives.test.ts
+++ b/apps/web/src/lib/utils/__tests__/editable-text-size-primitives.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { EDITABLE_TEXT_SIZE_CLASSNAME } from "@/lib/utils/editable-text-size";
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+const PRIMITIVE_SOURCES = [
+  "components/ui/input.tsx",
+  "components/ui/textarea.tsx",
+  "components/ui/mention-textarea.tsx",
+  "components/ui/command.tsx",
+  "components/ui/select.tsx",
+  "components/chat/room-message-composer.tsx",
+] as const;
+
+const MD_SHRINK = /md:text-(?:sm|xs)\b/;
+const FLOOR_TOKEN = "max(1rem,16px)";
+const CONSTANT_IMPORT = "EDITABLE_TEXT_SIZE_CLASSNAME";
+
+describe("editable text size primitives", () => {
+  it("exports a floor classname without md shrink", () => {
+    expect(EDITABLE_TEXT_SIZE_CLASSNAME).toContain("text-base");
+    expect(EDITABLE_TEXT_SIZE_CLASSNAME).toContain(FLOOR_TOKEN);
+    expect(EDITABLE_TEXT_SIZE_CLASSNAME).not.toContain("md:text-sm");
+  });
+
+  it.each(PRIMITIVE_SOURCES)(
+    "%s uses editable floor and has no md shrink on editables",
+    (rel) => {
+      const content = readFileSync(path.join(SRC_ROOT, rel), "utf8");
+      expect(content).not.toMatch(MD_SHRINK);
+      expect(
+        content.includes(CONSTANT_IMPORT) || content.includes(FLOOR_TOKEN),
+      ).toBe(true);
+    },
+  );
+});

--- a/apps/web/src/lib/utils/editable-text-size.ts
+++ b/apps/web/src/lib/utils/editable-text-size.ts
@@ -1,0 +1,2 @@
+export const EDITABLE_TEXT_SIZE_CLASSNAME =
+  "text-base text-[length:max(1rem,16px)]";

--- a/apps/web/src/lib/utils/editable-text-size.ts
+++ b/apps/web/src/lib/utils/editable-text-size.ts
@@ -1,2 +1,16 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Font size for focusable text entry. Keeps rem scaling when root ≥ 16px and
+ * floors at 16px so iOS Safari does not auto-zoom on focus when Dynamic Type
+ * root is smaller. Single Tailwind font-size utility so tailwind-merge cannot
+ * drop the floor in favor of a later `text-base` / `text-sm`.
+ */
 export const EDITABLE_TEXT_SIZE_CLASSNAME =
-  "text-base text-[length:max(1rem,16px)]";
+  "text-[length:max(1rem,16px)]" as const;
+
+/** Compose classes with the editable floor last so callers cannot shrink it. */
+export function withEditableTextSize(...inputs: ClassValue[]): string {
+  return twMerge(clsx(...inputs, EDITABLE_TEXT_SIZE_CLASSNAME));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-749](https://linear.app/masumi/issue/SOK-749/stop-ios-safari-auto-zoom-on-mobile): iOS Safari still auto-zoomed on chat composer focus after #3705.

**Root cause:** `md:text-sm` (0.875rem) on editables drops computed size under Safari’s ~16px focus-zoom threshold at `md+`. Also `text-base` alone fails when Dynamic Type root is under 16px. A follow-up keeps the floor after `tailwind-merge` (callers passing `text-base` used to drop `max(1rem,16px)`).

**Fix:** `withEditableTextSize` applies a single `text-[length:max(1rem,16px)]` utility last on Input/Textarea/Mention/CommandInput/SelectTrigger/composer and one-off editables. No viewport max-scale lock. Dynamic Type 1.25× cap unchanged.

## Spec summary

- All focusable text entry stays ≥ 16px computed (floor when root &lt; 16px; rem when larger)
- Drop `md:text-sm` / `md:text-xs` on those controls
- Guard test locks primitives and merge order
- Out of scope: pinch-zoom lock, raising Dynamic Type cap, non-editable copy

## Verification

- `pnpm web:check` (exit 0 at pin)
- Targeted `editable-text-size-primitives` + `no-fixed-font-size` tests (exit 0); CI Test Web / Build / Typecheck green
- UI `/chat`: composer computed `font-size` = 16px with root forced to 14px at viewport width 1280
- Viewport meta has no `maximum-scale` / `user-scalable=no`

## Review

- `headSha`: `49c6f4fb392d8bc2628e30d828e9c809bdb1aa6b`
- `/goal`: pass
- `swarmVerify`: skipped (default off)

[Chat composer with 16px floor at 14px root](https://cursor.com/agents/bc-a08f3ec9-6f05-402b-9ebb-7163c7ebd902/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-749-composer-floor-14px-root.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a08f3ec9-6f05-402b-9ebb-7163c7ebd902?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a08f3ec9-6f05-402b-9ebb-7163c7ebd902&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

