### PR TITLE
fix(chat): realign keyboard baselines after shrink

### DIFF
--- a/apps/web/src/lib/utils/__tests__/visual-viewport-keyboard.test.ts
+++ b/apps/web/src/lib/utils/__tests__/visual-viewport-keyboard.test.ts
@@ -148,4 +148,24 @@ describe("readVisualViewportKeyboardOpen", () => {
     expect(isEditableKeyboardTarget(document.activeElement)).toBe(false);
     expect(readVisualViewportKeyboardOpen()).toBe(false);
   });
+
+  it("realigns baselines after a permanent shorter viewport so focus alone is not keyboard-open", () => {
+    stubViewport(900, 900);
+    expect(readVisualViewportKeyboardOpen()).toBe(false);
+
+    // Rotation / split-screen: layout permanently shorter while idle.
+    stubViewport(600, 600);
+    expect(readVisualViewportKeyboardOpen()).toBe(false);
+
+    const textarea = document.createElement("textarea");
+    document.body.append(textarea);
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+    expect(readVisualViewportKeyboardOpen()).toBe(false);
+
+    // Soft keyboard still detected after realignment.
+    stubViewport(600, 400);
+    expect(readVisualViewportKeyboardOpen()).toBe(true);
+    textarea.remove();
+  });
 });

--- a/apps/web/src/lib/utils/visual-viewport-keyboard.ts
+++ b/apps/web/src/lib/utils/visual-viewport-keyboard.ts
@@ -5,8 +5,10 @@
  * `focusOnMount`) does not open the keyboard, and browser chrome can make
  * bare height deltas look like a keyboard (false positive → lost safe-area pb).
  *
- * When focused, compare visual/layout height to session maxima captured while
- * the keyboard was closed (and whenever the viewport grows).
+ * Baselines track the closed-keyboard viewport: sync to current heights while
+ * idle; only raise them while an editable is focused (so an open OSK does not
+ * collapse the baseline). Permanent shrinks (rotation, split-screen) therefore
+ * realign before the next focus.
  */
 export const VISUAL_VIEWPORT_KEYBOARD_OPEN_THRESHOLD_PX = 150;
 
@@ -85,13 +87,18 @@ export function readVisualViewportKeyboardOpen(): boolean {
   const visualHeight = window.visualViewport?.height ?? layoutHeight;
   const editableFocused = isEditableKeyboardTarget(document.activeElement);
 
-  // Grow baselines whenever the viewport is larger (keyboard closed / UI chrome
-  // expanded). Do not shrink baselines while the keyboard is open.
-  if (layoutHeight > maxLayoutHeightPx) {
+  // Idle: always sync baselines (rotation / split-screen). Focused: only raise
+  // so an open soft keyboard cannot erase the closed-keyboard maxima.
+  if (!editableFocused) {
     maxLayoutHeightPx = layoutHeight;
-  }
-  if (visualHeight > maxVisualHeightPx) {
     maxVisualHeightPx = visualHeight;
+  } else {
+    if (layoutHeight > maxLayoutHeightPx) {
+      maxLayoutHeightPx = layoutHeight;
+    }
+    if (visualHeight > maxVisualHeightPx) {
+      maxVisualHeightPx = visualHeight;
+    }
   }
 
   return isVisualViewportKeyboardOpen(layoutHeight, visualHeight, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a Bugbot finding on the room composer safe-area work: `readVisualViewportKeyboardOpen` only raised closed-keyboard height baselines and never realigned after a permanent shorter viewport (rotation, split-screen). Focusing the composer afterward could look like the soft keyboard was open and strip mobile bottom safe-area padding while still editing.

## Change

- While no editable is focused, sync layout/visual baselines to the current viewport heights.
- While focused, keep raise-only baselines so an open OSK cannot erase the closed-keyboard maxima.
- Regression test covers tall → shorter idle viewport, then focus (must stay closed) and a real keyboard shrink (must open).

## Verification

- `pnpm --filter web test src/lib/utils/__tests__/visual-viewport-keyboard.test.ts src/hooks/__tests__/use-keyboard-open.test.ts`
- Pre-commit: `pnpm check && pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f883e9a-8628-4777-aaa9-560e73113922?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f883e9a-8628-4777-aaa9-560e73113922&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

