### PR TITLE
fix(tasks): match loading skeleton to view mode

### DIFF
--- a/apps/web/src/app/(app)/tasks/(root)/loading.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/loading.tsx
@@ -1,6 +1,6 @@
-import { TasksPageSkeleton } from "@/app/tasks/components/tasks-loading-view";
+import { TasksPageSkeletonHost } from "@/app/tasks/components/tasks-page-skeleton-host";
 
 /** Sync shell only — no cookies/`connection()` (Instant Nav). */
 export default function TasksRootLoading() {
-  return <TasksPageSkeleton />;
+  return <TasksPageSkeletonHost />;
 }

--- a/apps/web/src/app/(app)/tasks/(root)/page.tsx
+++ b/apps/web/src/app/(app)/tasks/(root)/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { connection } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
-import { TasksPageSkeleton } from "@/app/tasks/components/tasks-loading-view";
+import { TasksPageSkeletonHost } from "@/app/tasks/components/tasks-page-skeleton-host";
 import { TasksPendingVendorGrantBannerSlot } from "@/app/tasks/components/tasks-pending-vendor-grant-banner-slot";
 import { TasksView } from "@/app/tasks/components/tasks-view";
 import {
@@ -368,7 +368,7 @@ async function TasksPageContent({ searchParams }: TasksPageProps) {
 
 export default function TasksPage({ searchParams }: TasksPageProps) {
   return (
-    <Suspense fallback={<TasksPageSkeleton />}>
+    <Suspense fallback={<TasksPageSkeletonHost />}>
       <TasksPageContent searchParams={searchParams} />
     </Suspense>
   );

--- a/apps/web/src/app/(app)/tasks/components/__tests__/tasks-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/tasks-loading-view.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  TASKS_LOADING_DEFAULT_LABELS,
+  TasksLoadingView,
+} from "@/app/tasks/components/tasks-loading-view";
+
+describe("TasksLoadingView", () => {
+  it("renders board columns by default", () => {
+    render(<TasksLoadingView labels={TASKS_LOADING_DEFAULT_LABELS} />);
+
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+    expect(screen.getByText("Todo")).toBeInTheDocument();
+  });
+
+  it("renders list shell matching TaskListView edge-to-edge classes", () => {
+    const { container } = render(
+      <TasksLoadingView
+        viewMode="list"
+        labels={TASKS_LOADING_DEFAULT_LABELS}
+      />,
+    );
+
+    const listShell = container.querySelector(
+      ".bg-muted\\/30.border-border\\/50",
+    );
+    expect(listShell).toBeTruthy();
+    expect(listShell?.className).toContain("-mx-6");
+    expect(listShell?.className).toContain("rounded-none");
+    expect(listShell?.className).toContain("border-0");
+    expect(listShell?.className).toContain("md:mx-0");
+    expect(listShell?.className).toContain("md:rounded-xl");
+    expect(listShell?.className).toContain("md:border");
+    expect(listShell?.className).not.toContain("rounded-xl border");
+  });
+});

--- a/apps/web/src/app/(app)/tasks/components/tasks-loading-view.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-loading-view.tsx
@@ -165,7 +165,7 @@ function TasksListLoading({ labels }: { labels: TasksLoadingLabels }) {
   const orderedColumns = [...KANBAN_COLUMNS].reverse();
 
   return (
-    <div className="bg-muted/30 border-border/50 w-full overflow-hidden rounded-xl border">
+    <div className="bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border">
       <div className="divide-border/50 divide-y">
         {orderedColumns.map((column, index) => {
           const isFirstVisibleSection = index === 0;

--- a/apps/web/src/app/(app)/tasks/components/tasks-page-skeleton-host.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-page-skeleton-host.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { TasksPageSkeleton } from "@/app/tasks/components/tasks-loading-view";
+import {
+  DEFAULT_TASKS_VIEW_MODE_DESKTOP,
+  resolveTasksViewModeFromClientCookie,
+  type TasksViewMode,
+} from "@/lib/ui-preferences/tasks-view-mode";
+
+const subscribe = () => () => {};
+
+function getClientViewMode(): TasksViewMode {
+  return resolveTasksViewModeFromClientCookie(
+    document.cookie,
+    navigator.userAgent,
+  );
+}
+
+function getServerViewMode(): TasksViewMode {
+  return DEFAULT_TASKS_VIEW_MODE_DESKTOP;
+}
+
+/**
+ * Instant Nav / Suspense host: resolves view mode from cookie + UA on the
+ * client without calling cookies()/connection() in loading.tsx.
+ */
+export function TasksPageSkeletonHost() {
+  const viewMode = useSyncExternalStore(
+    subscribe,
+    getClientViewMode,
+    getServerViewMode,
+  );
+
+  return <TasksPageSkeleton viewMode={viewMode} />;
+}

--- a/apps/web/src/lib/ui-preferences/__tests__/tasks-view-mode.test.ts
+++ b/apps/web/src/lib/ui-preferences/__tests__/tasks-view-mode.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   parseTasksViewMode,
+  parseTasksViewModeCookieHeader,
   preferTasksListFromDeviceType,
+  preferTasksListFromUserAgent,
   resolveDefaultTasksViewMode,
+  resolveTasksViewModeFromClientCookie,
   serializeTasksViewModeCookie,
   TASKS_VIEW_MODE_COOKIE_MAX_AGE,
   TASKS_VIEW_MODE_COOKIE_NAME,
@@ -78,5 +81,95 @@ describe("serializeTasksViewModeCookie", () => {
     expect(serializeTasksViewModeCookie("list")).toBe(
       `${TASKS_VIEW_MODE_COOKIE_NAME}=list; path=/; max-age=${TASKS_VIEW_MODE_COOKIE_MAX_AGE}`,
     );
+  });
+});
+
+describe("preferTasksListFromUserAgent", () => {
+  it("returns true for phone and tablet UAs", () => {
+    expect(
+      preferTasksListFromUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+      ),
+    ).toBe(true);
+    expect(
+      preferTasksListFromUserAgent(
+        "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)",
+      ),
+    ).toBe(true);
+    expect(
+      preferTasksListFromUserAgent(
+        "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Mobile",
+      ),
+    ).toBe(true);
+    expect(
+      preferTasksListFromUserAgent(
+        "Mozilla/5.0 (Linux; Android 12; SM-T870) AppleWebKit/537.36",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for desktop and missing UA", () => {
+    expect(
+      preferTasksListFromUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+      ),
+    ).toBe(false);
+    expect(preferTasksListFromUserAgent(undefined)).toBe(false);
+    expect(preferTasksListFromUserAgent("")).toBe(false);
+  });
+});
+
+describe("parseTasksViewModeCookieHeader", () => {
+  it("reads tasks_view_mode from a cookie header", () => {
+    expect(
+      parseTasksViewModeCookieHeader(
+        `other=1; ${TASKS_VIEW_MODE_COOKIE_NAME}=list; theme=dark`,
+      ),
+    ).toBe("list");
+    expect(
+      parseTasksViewModeCookieHeader(`${TASKS_VIEW_MODE_COOKIE_NAME}=board`),
+    ).toBe("board");
+  });
+
+  it("returns null when missing or invalid", () => {
+    expect(parseTasksViewModeCookieHeader("theme=dark")).toBeNull();
+    expect(
+      parseTasksViewModeCookieHeader(`${TASKS_VIEW_MODE_COOKIE_NAME}=grid`),
+    ).toBeNull();
+  });
+});
+
+describe("resolveTasksViewModeFromClientCookie", () => {
+  it("prefers cookie over UA default", () => {
+    expect(
+      resolveTasksViewModeFromClientCookie(
+        `${TASKS_VIEW_MODE_COOKIE_NAME}=board`,
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+      ),
+    ).toBe("board");
+    expect(
+      resolveTasksViewModeFromClientCookie(
+        `${TASKS_VIEW_MODE_COOKIE_NAME}=list`,
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+      ),
+    ).toBe("list");
+  });
+
+  it("defaults to list on mobile UA without cookie", () => {
+    expect(
+      resolveTasksViewModeFromClientCookie(
+        "",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+      ),
+    ).toBe("list");
+  });
+
+  it("defaults to board on desktop UA without cookie", () => {
+    expect(
+      resolveTasksViewModeFromClientCookie(
+        "",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+      ),
+    ).toBe("board");
   });
 });

--- a/apps/web/src/lib/ui-preferences/tasks-view-mode.ts
+++ b/apps/web/src/lib/ui-preferences/tasks-view-mode.ts
@@ -41,6 +41,50 @@ export function preferTasksListFromDeviceType(
   return deviceType === "mobile" || deviceType === "tablet";
 }
 
+/**
+ * Client-side stand-in for Next `userAgent().device.type` mobile|tablet.
+ * Used by Instant Nav loading shells that cannot call `cookies()`/`headers()`.
+ */
+export function preferTasksListFromUserAgent(
+  userAgent: string | undefined,
+): boolean {
+  if (!userAgent) {
+    return false;
+  }
+
+  // Tablets first (Android tablet UAs omit "Mobile").
+  if (/ipad|tablet|playbook|silk|(android(?!.*mobile))/i.test(userAgent)) {
+    return true;
+  }
+
+  return /mobi|iphone|ipod|android.*mobile|windows phone/i.test(userAgent);
+}
+
+/** Read `tasks_view_mode` from a raw Cookie header / `document.cookie` string. */
+export function parseTasksViewModeCookieHeader(
+  documentCookie: string,
+): TasksViewMode | null {
+  const match = documentCookie.match(
+    new RegExp(`(?:^|;\\s*)${TASKS_VIEW_MODE_COOKIE_NAME}=([^;]*)`),
+  );
+
+  return parseTasksViewMode(match?.[1]);
+}
+
+/**
+ * Client resolve for Instant Nav / Suspense skeletons: cookie wins; else
+ * mobile/tablet UA → list, desktop → board (same as `getDefaultTasksViewMode`).
+ */
+export function resolveTasksViewModeFromClientCookie(
+  documentCookie: string,
+  userAgent: string | undefined,
+): TasksViewMode {
+  return resolveDefaultTasksViewMode({
+    persisted: parseTasksViewModeCookieHeader(documentCookie),
+    preferList: preferTasksListFromUserAgent(userAgent),
+  });
+}
+
 export function serializeTasksViewModeCookie(mode: TasksViewMode): string {
   return `${TASKS_VIEW_MODE_COOKIE_NAME}=${mode}; path=/; max-age=${TASKS_VIEW_MODE_COOKIE_MAX_AGE}`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-755/tasks-loading-skeleton-ignores-list-view-preference

## Summary
- Instant Nav / Suspense `/tasks` skeleton resolves view mode from cookie + UA (same rules as the loaded page)
- List preference or mobile/tablet default shows list skeleton; board otherwise
- List loading shell matches SOK-748 edge-to-edge mobile list (`-mx-6`, no inset card below `md`)

## Verification
- `pnpm web:check` (exit 0) at `2e3270738c9663df7a6382d8aae4dda935ff2b94`
- `pnpm web:test` (exit 0) at same SHA
- CI required checks green
- UI `/tasks`: Display = List with cookie; list shell classes present; mobile UA list shell

[Tasks Display menu List selected](https://cursor.com/agents/bc-0b083617-f081-4393-8052-c2b7c4700507/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-755-tasks-display-menu.png)
[Tasks list shell after list cookie](https://cursor.com/agents/bc-0b083617-f081-4393-8052-c2b7c4700507/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-755-tasks-after-list-cookie.png)
[Tasks mobile UA list shell](https://cursor.com/agents/bc-0b083617-f081-4393-8052-c2b7c4700507/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsok-755-tasks-mobile-list.png)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Spec | `tasks-page-skeleton-host.tsx` | Hard-nav SSR snapshot defaults board until client hydrate; Instant Nav client path reads cookie+UA. Brief board flash possible on full document load only. |
| Spec | `preferTasksListFromUserAgent` | Approximate stand-in for Next `userAgent().device.type`; edge UA strings may disagree with server. |

swarm-verify: skipped (default off)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b083617-f081-4393-8052-c2b7c4700507?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b083617-f081-4393-8052-c2b7c4700507&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

