### PR TITLE
fix(web): cancel stale AuthSessionGuard probes

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/auth-session-guard.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthSessionGuard } from "@/app/components/auth-session-guard";
@@ -18,6 +18,28 @@ vi.mock("@/lib/auth/auth.client", () => ({
   },
 }));
 
+const presentSession = {
+  data: {
+    session: {
+      activeOrganizationId: null,
+    },
+  },
+  error: null,
+};
+
+const missingSession = {
+  data: null,
+  error: null,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("AuthSessionGuard", () => {
   beforeEach(() => {
     replaceMock.mockReset();
@@ -27,14 +49,7 @@ describe("AuthSessionGuard", () => {
   });
 
   it("revalidates the session without cookie cache on mount", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: {
-        session: {
-          activeOrganizationId: null,
-        },
-      },
-      error: null,
-    });
+    vi.mocked(authClient.getSession).mockResolvedValue(presentSession);
 
     render(<AuthSessionGuard />);
 
@@ -48,10 +63,7 @@ describe("AuthSessionGuard", () => {
   });
 
   it("redirects to sign-in when the session is missing", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: null,
-      error: null,
-    });
+    vi.mocked(authClient.getSession).mockResolvedValue(missingSession);
 
     render(<AuthSessionGuard />);
 
@@ -63,14 +75,7 @@ describe("AuthSessionGuard", () => {
   });
 
   it("revalidates again on focus without redirecting when the session is present", async () => {
-    vi.mocked(authClient.getSession).mockResolvedValue({
-      data: {
-        session: {
-          activeOrganizationId: null,
-        },
-      },
-      error: null,
-    });
+    vi.mocked(authClient.getSession).mockResolvedValue(presentSession);
 
     render(<AuthSessionGuard />);
 
@@ -78,6 +83,80 @@ describe("AuthSessionGuard", () => {
 
     await waitFor(() => {
       expect(authClient.getSession).toHaveBeenCalledTimes(2);
+    });
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a slower null probe after a newer probe confirms the session", async () => {
+    const mountProbe = deferred<typeof presentSession>();
+    const staleProbe = deferred<typeof missingSession>();
+    const freshProbe = deferred<typeof presentSession>();
+
+    vi.mocked(authClient.getSession)
+      .mockImplementationOnce(() => mountProbe.promise)
+      .mockImplementationOnce(() => staleProbe.promise)
+      .mockImplementationOnce(() => freshProbe.promise);
+
+    render(<AuthSessionGuard />);
+
+    await act(async () => {
+      mountProbe.resolve(presentSession);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      freshProbe.resolve(presentSession);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      staleProbe.resolve(missingSession);
+      await Promise.resolve();
+    });
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect from an in-flight null probe after unmount", async () => {
+    const mountProbe = deferred<typeof presentSession>();
+    const resumeProbe = deferred<typeof missingSession>();
+
+    vi.mocked(authClient.getSession)
+      .mockImplementationOnce(() => mountProbe.promise)
+      .mockImplementationOnce(() => resumeProbe.promise);
+
+    const view = render(<AuthSessionGuard />);
+
+    await act(async () => {
+      mountProbe.resolve(presentSession);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+
+    await act(async () => {
+      resumeProbe.resolve(missingSession);
+      await Promise.resolve();
     });
 
     expect(replaceMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/(app)/components/auth-session-guard.tsx
+++ b/apps/web/src/app/(app)/components/auth-session-guard.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useEffectEvent, useRef } from "react";
 
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import { authClient } from "@/lib/auth/auth.client";
 import { createAuthSessionGetter } from "@/lib/auth/auth.utils";
 import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
@@ -10,6 +11,8 @@ import { getReturnUrlFromCurrentLocation } from "@/lib/utils/url";
 export function AuthSessionGuard() {
   const router = useRouter();
   const isRedirectingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const probeGenerationRef = useRef(0);
   const getFreshSession = createAuthSessionGetter(() =>
     authClient.getSession({
       query: {
@@ -23,9 +26,16 @@ export function AuthSessionGuard() {
       return;
     }
 
+    const generation = ++probeGenerationRef.current;
+
     try {
       const session = await getFreshSession();
-      if (isRedirectingRef.current || session) {
+      if (
+        !mountedRef.current ||
+        isRedirectingRef.current ||
+        generation !== probeGenerationRef.current ||
+        session
+      ) {
         return;
       }
     } catch {
@@ -37,9 +47,15 @@ export function AuthSessionGuard() {
     router.replace(`/signin?returnUrl=${returnUrl}`);
   });
 
-  useEffect(() => {
+  useMountEffect(() => {
+    mountedRef.current = true;
     void validateSession();
-  }, []);
+
+    return () => {
+      mountedRef.current = false;
+      probeGenerationRef.current += 1;
+    };
+  });
 
   useEffect(() => {
     function handleWindowFocus() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Important race on PWA resume: `focus` and `visibilitychange` both launch `AuthSessionGuard` probes. A slower null can redirect after a newer probe already confirmed a valid session; an in-flight null can also redirect after unmount.

Restores generation + mounted cancellation around async probe results (without bringing back resume/mount retries). Aligns with `apps/web/AGENTS.md` race-cleanup guidance for effect-driven fetches.

## Changes

- Bump probe generation per validate call; ignore stale results
- Track mount and invalidate generation on unmount
- Tests for overlapping probes and unmount-during-flight

## Why this matters for SOK-752

False client redirect is one path to “session dies within minutes” on mobile PWA resume, independent of cookie persistence. Retries were correctly removed after `rememberMe`; cancellation was not optional.

## Test plan

- [x] `pnpm --filter web test src/app/(app)/components/__tests__/auth-session-guard.test.tsx`
- [x] Pre-commit `pnpm check && pnpm typecheck`
- [ ] Manual: install PWA, background/resume rapidly, confirm no surprise sign-out when session still valid

Refs SOK-752

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2795f64-6d06-4dc4-933a-2e4842e4e723?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2795f64-6d06-4dc4-933a-2e4842e4e723&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

