### PR TITLE
fix(web): keep PWA scope at site root

### DIFF
--- a/apps/web/src/app/__tests__/manifest.test.ts
+++ b/apps/web/src/app/__tests__/manifest.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import manifest from "../manifest";
+
+describe("web app manifest", () => {
+  it("keeps the whole origin in PWA scope with a same-origin start URL", () => {
+    const result = manifest();
+
+    expect(result.scope).toBe("/");
+    expect(result.start_url).toBe("/");
+    expect(result.start_url).not.toMatch(/^https?:\/\//);
+    expect(result.display).toBe("standalone");
+  });
+});

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,12 +1,18 @@
 import type { MetadataRoute } from "next";
 
+/**
+ * `scope: "/"` is required: default scope is the directory of `start_url`, so
+ * install from `/chat/chats` would scope to `/chat/` and tab links (`/tasks`,
+ * …) open outside the PWA. Keep `start_url` origin-relative for preview hosts.
+ */
 export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "Sokosumi",
     short_name: "Sokosumi",
     description:
       "Hire yourself an agent to finish the most time consuming tasks",
-    start_url: "https://app.sokosumi.com",
+    start_url: "/",
+    scope: "/",
     display: "standalone",
     background_color: "#6400FF",
     icons: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Installing the PWA from `/chat/chats` opened other bottom-nav tabs in Safari (browser chrome) instead of staying standalone. Other install routes were fine.

**Cause:** Manifest had no `scope`, and `start_url` was hardcoded to `https://app.sokosumi.com`. On preview hosts that absolute URL is ignored, so install fell back to the document URL. Default scope is the directory of `start_url` → `/chat/` for `/chat/chats`. Links to `/tasks`, `/agents`, `/projects`, `/history` left that scope and opened externally. Single-segment routes like `/tasks` defaulted scope to `/`, so they worked.

**Fix:** Relative `start_url: "/"` and explicit `scope: "/"`.

Refs [SOK-756](https://linear.app/masumi/issue/SOK-756/mobile-nav-chats-landing-drop-home-hub).

## Test plan

- [x] `pnpm --filter web test src/app/__tests__/manifest.test.ts`
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [ ] On iPhone: delete the home-screen app installed from `/chat/chats`, reinstall from that route, open tabs — should stay standalone (no Safari chrome)
- [ ] Same check after install from `/tasks` (still works)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d175f6e-32be-4c96-bb6c-85b1c0462d79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d175f6e-32be-4c96-bb6c-85b1c0462d79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

