### PR TITLE
fix(web): fill blank mobile /chat landing

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
@@ -11,6 +11,18 @@ describe("ChatChatsPageSkeleton", () => {
     expect(root.className).toMatch(/md:hidden/);
   });
 
+  it("omits Personal Assistant chrome (beta-gated on the real page)", () => {
+    const { container } = render(<ChatChatsPageSkeleton />);
+    // List header + rows only — no leading avatar/name PA row or separator.
+    expect(container.querySelector("ul")).not.toBeNull();
+    expect(container.querySelector("hr")).toBeNull();
+    const firstChild = container.querySelector(
+      '[data-testid="chat-chats-loading"] > *',
+    );
+    expect(firstChild?.tagName.toLowerCase()).toBe("div");
+    expect(firstChild?.className).toMatch(/justify-between/);
+  });
+
   it("renders multiple list row bones", () => {
     const { container } = render(<ChatChatsPageSkeleton />);
     const bones = container.querySelectorAll('[data-slot="skeleton"]');

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-home-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-home-loading-view.test.tsx
@@ -4,12 +4,13 @@ import { describe, expect, it } from "vitest";
 import { ChatHomePageSkeleton } from "../chat-home-loading-view";
 
 describe("ChatHomePageSkeleton", () => {
-  it("renders desktop welcome skeleton only (no mobile hub)", () => {
+  it("renders desktop welcome skeleton and mobile chats skeleton", () => {
     render(<ChatHomePageSkeleton />);
 
     const desktop = screen.getByTestId("chat-home-loading-desktop");
     expect(desktop.className).toMatch(/md:flex/);
-    expect(screen.queryByTestId("chat-home-loading-mobile")).toBeNull();
+    const mobile = screen.getByTestId("chat-chats-loading");
+    expect(mobile.className).toMatch(/md:hidden/);
   });
 
   it("uses pulse skeleton bones (no async APIs)", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/mobile-chat-home-redirect.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/mobile-chat-home-redirect.client.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const replaceMock = vi.fn();
+let mockIsMobile: boolean | undefined = undefined;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobileMedia: () => mockIsMobile,
+}));
+
+import { MobileChatHomeRedirect } from "../mobile-chat-home-redirect.client";
+
+describe("MobileChatHomeRedirect", () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    mockIsMobile = undefined;
+  });
+
+  it("shows chats skeleton while media query is unresolved", () => {
+    mockIsMobile = undefined;
+    render(<MobileChatHomeRedirect />);
+    expect(screen.getByTestId("chat-chats-loading")).toBeTruthy();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("shows chats skeleton and replaces to /chat/chats on mobile", () => {
+    mockIsMobile = true;
+    render(<MobileChatHomeRedirect />);
+    expect(screen.getByTestId("chat-chats-loading")).toBeTruthy();
+    expect(replaceMock).toHaveBeenCalledWith("/chat/chats");
+  });
+
+  it("renders nothing on desktop", () => {
+    mockIsMobile = false;
+    const { container } = render(<MobileChatHomeRedirect />);
+    expect(container).toBeEmptyDOMElement();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/chat-chats-loading-view.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-chats-loading-view.tsx
@@ -2,7 +2,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * Sync Instant Nav shell for `/chat/chats` (no cookies/`connection()`/i18n).
- * Matches mobile Chats page: PA row above OrganizationChatList.
+ * Matches the non-beta mobile Chats page: OrganizationChatList only.
+ * Personal Assistant is beta-gated and omitted here so non-beta users do not
+ * flash PA chrome that never mounts.
  */
 export function ChatChatsPageSkeleton(): React.ReactElement {
   return (
@@ -10,14 +12,6 @@ export function ChatChatsPageSkeleton(): React.ReactElement {
       data-testid="chat-chats-loading"
       className="md:hidden -m-4 min-h-0 flex-1 overflow-y-auto p-4"
     >
-      <div className="flex items-center gap-3 py-2">
-        <Skeleton className="size-8 shrink-0 rounded-full" />
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <Skeleton className="h-4 w-36" />
-          <Skeleton className="h-3 w-24" />
-        </div>
-      </div>
-      <Skeleton className="my-1 h-px w-full" />
       <div className="mb-3 flex items-center justify-between">
         <Skeleton className="h-5 w-24" />
         <Skeleton className="h-5 w-16" />

--- a/apps/web/src/app/(app)/chat/components/chat-home-loading-view.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-home-loading-view.tsx
@@ -1,25 +1,30 @@
+import { ChatChatsPageSkeleton } from "@/app/chat/components/chat-chats-loading-view";
 import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * Sync Instant Nav shell for `/chat` (no cookies/`connection()`/i18n).
- * Desktop welcome only — mobile bare home redirects to `/chat/chats`.
+ * Desktop: welcome skeleton. Mobile: chats-list skeleton (bare home redirects
+ * to `/chat/chats`).
  */
 export function ChatHomePageSkeleton(): React.ReactElement {
   return (
-    <div
-      data-testid="chat-home-loading-desktop"
-      className="mx-auto hidden w-full max-w-2xl flex-col items-center gap-6 px-4 py-12 md:flex"
-    >
-      <div className="flex w-full flex-col items-center gap-2">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-4 w-72" />
+    <>
+      <ChatChatsPageSkeleton />
+      <div
+        data-testid="chat-home-loading-desktop"
+        className="mx-auto hidden w-full max-w-2xl flex-col items-center gap-6 px-4 py-12 md:flex"
+      >
+        <div className="flex w-full flex-col items-center gap-2">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <Skeleton className="h-12 w-full max-w-xl rounded-xl" />
+        <div className="flex flex-wrap justify-center gap-2">
+          <Skeleton className="h-8 w-28 rounded-full" />
+          <Skeleton className="h-8 w-24 rounded-full" />
+          <Skeleton className="h-8 w-32 rounded-full" />
+        </div>
       </div>
-      <Skeleton className="h-12 w-full max-w-xl rounded-xl" />
-      <div className="flex flex-wrap justify-center gap-2">
-        <Skeleton className="h-8 w-28 rounded-full" />
-        <Skeleton className="h-8 w-24 rounded-full" />
-        <Skeleton className="h-8 w-32 rounded-full" />
-      </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/mobile-chat-home-redirect.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/mobile-chat-home-redirect.client.tsx
@@ -3,11 +3,15 @@
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
+import { ChatChatsPageSkeleton } from "@/app/chat/components/chat-chats-loading-view";
 import { useIsMobileMedia } from "@/hooks/use-mobile";
 
 /**
  * Mobile `<md` bare `/chat` (surface home) → `/chat/chats`.
  * Desktop keeps ChatWelcomeClient on `/chat`.
+ *
+ * While the media query is unresolved or mobile, show the chats skeleton so
+ * the Instant Nav / streamed landing is not a blank main area.
  */
 export function MobileChatHomeRedirect(): React.ReactElement | null {
   const router = useRouter();
@@ -20,15 +24,9 @@ export function MobileChatHomeRedirect(): React.ReactElement | null {
     router.replace("/chat/chats");
   }, [isMobile, router]);
 
-  if (isMobile !== true) {
+  if (isMobile === false) {
     return null;
   }
 
-  return (
-    <div
-      data-testid="mobile-chat-home-redirect"
-      className="md:hidden"
-      aria-hidden
-    />
-  );
+  return <ChatChatsPageSkeleton />;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Bugbot findings on the mobile chats landing work:

1. **Blank mobile `/chat`** — Instant Nav and `MobileChatHomeRedirect` now show the chats list skeleton while the media query resolves / `replace` runs, so mobile users no longer see an empty main area.
2. **PA skeleton flash** — `ChatChatsPageSkeleton` no longer includes Personal Assistant chrome (beta-gated on the real page), avoiding a layout jump for non-beta users.

## Test plan

- [x] `pnpm --filter web test` on chat loading/redirect tests (20 passed)
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [ ] Spot-check mobile: land on `/chat` → skeleton → `/chat/chats` without blank frame

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82538ed3-bd77-4c87-b969-1044762dc14b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82538ed3-bd77-4c87-b969-1044762dc14b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

