### PR TITLE
fix(web): show brand logo on mobile tab roots

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
@@ -130,14 +130,16 @@ describe("mobile-app-chrome", () => {
   });
 
   describe("shouldShowMobileBrandLeading", () => {
-    it("shows brand only on home and chats", () => {
+    it("shows brand on chats and every bottom-nav tab root", () => {
       expect(shouldShowMobileBrandLeading("/chat")).toBe(true);
       expect(shouldShowMobileBrandLeading("/chat/chats")).toBe(true);
-      expect(shouldShowMobileBrandLeading("/tasks")).toBe(false);
-      expect(shouldShowMobileBrandLeading("/agents")).toBe(false);
+      expect(shouldShowMobileBrandLeading("/tasks")).toBe(true);
+      expect(shouldShowMobileBrandLeading("/agents")).toBe(true);
+      expect(shouldShowMobileBrandLeading("/projects")).toBe(true);
+      expect(shouldShowMobileBrandLeading("/history")).toBe(true);
     });
 
-    it("hides brand for rooms, drafts, and nested detail", () => {
+    it("hides brand for rooms, drafts, hubs, and nested detail", () => {
       expect(shouldShowMobileBrandLeading("/chat/rooms/r1")).toBe(false);
       expect(
         shouldShowMobileBrandLeading(
@@ -152,6 +154,7 @@ describe("mobile-app-chrome", () => {
         shouldShowMobileBrandLeading("/chat", new URLSearchParams("welcome=1")),
       ).toBe(false);
       expect(shouldShowMobileBrandLeading("/tasks/t1")).toBe(false);
+      expect(shouldShowMobileBrandLeading("/personal-assistant")).toBe(false);
       expect(shouldShowMobileBrandLeading("/account")).toBe(false);
     });
   });

--- a/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
@@ -91,11 +91,21 @@ describe("HeaderLeadingControl", () => {
     expect(back).toHaveAttribute("href", "/chat/chats");
   });
 
-  it("shows no leading back on tasks list root", () => {
+  it("shows brand on tasks list root", () => {
     mockPathname = "/tasks";
     render(<HeaderLeadingControl />);
     expect(screen.queryByRole("link")).toBeNull();
-    expect(screen.queryByTestId("sokosumi-icon")).toBeNull();
+    expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
+  });
+
+  it("shows brand on agents, projects, and search tab roots", () => {
+    for (const path of ["/agents", "/projects", "/history"]) {
+      mockPathname = path;
+      const { unmount } = render(<HeaderLeadingControl />);
+      expect(screen.queryByRole("link")).toBeNull();
+      expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
+      unmount();
+    }
   });
 
   it("shows back to chats on personal-assistant root", () => {

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from "next-intl";
 
 import { classifyChatChromeSurface } from "@/app/chat/utils/chat-route-base";
 import {
-  isMainAppMobileChromePathname,
   resolveMobileAppBackTarget,
   shouldShowMobileBrandLeading,
 } from "@/app/components/mobile-app-chrome";
@@ -15,9 +14,8 @@ import { SokosumiIcon } from "@/components/masumi-logos";
 
 /**
  * Mobile header leading slot (`md:hidden` size-8):
- * - chat home / chats list → Sokosumi icon (no back / hamburger)
+ * - chats + bottom-nav tab roots → Sokosumi icon (no back / hamburger)
  * - chat room / draft compose → back to `/chat/chats`
- * - tab list roots → empty (no back)
  * - non-tab hub roots + nested → back (chats or list root)
  * - otherwise → back to chats
  */
@@ -58,10 +56,6 @@ export function HeaderLeadingControl(): React.ReactElement {
         <ChevronLeft className="size-5" aria-hidden />
       </Link>
     );
-  }
-
-  if (isMainAppMobileChromePathname(pathname)) {
-    return <span className="inline-flex size-8 shrink-0" aria-hidden />;
   }
 
   return (

--- a/apps/web/src/app/(app)/components/mobile-app-chrome.ts
+++ b/apps/web/src/app/(app)/components/mobile-app-chrome.ts
@@ -118,14 +118,21 @@ export function shouldShowMobileBottomNav(
 }
 
 /**
- * Leading slot shows Sokosumi brand only on Home surface and Chats list.
+ * Leading slot shows Sokosumi brand on Chats list and every bottom-nav tab
+ * root (Tasks / Agents / Projects / Search). Nested pages keep back.
  */
 export function shouldShowMobileBrandLeading(
   pathname: string | null | undefined,
   searchParams?: SearchParamsLike,
 ): boolean {
   const surface = classifyChatChromeSurface(pathname, searchParams);
-  return surface === "home" || surface === "chats";
+  if (surface === "home" || surface === "chats") {
+    return true;
+  }
+  if (!pathname) {
+    return false;
+  }
+  return MOBILE_TAB_LIST_PATH_SET.has(pathname);
 }
 
 /** Floating create FAB: Chats list only (not drafts / welcome / bare home). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mobile header showed the Sokosumi logo only on Chats. Tasks, Agents, Projects, and Search tab roots left an empty leading slot.

## Fix

`shouldShowMobileBrandLeading` now includes every bottom-nav tab list root (`/tasks`, `/agents`, `/projects`, `/history`), same as Chats. Nested pages still get back. Dead empty-span branch removed from `HeaderLeadingControl`.

## Verify

- `pnpm --filter web test` on `mobile-app-chrome.test.ts` + `header-leading-control.client.test.tsx` (23 passed)
- Pre-commit: `pnpm check` + `pnpm typecheck`

Refs SOK-756

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60c81ec6-c2ae-4c5d-9d8c-2318bce76a04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60c81ec6-c2ae-4c5d-9d8c-2318bce76a04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

