### PR TITLE
feat(core): store the devices a user wants to be notified on

### DIFF
--- a/apps/core/src/routes/v1/notifications/devices/delete.ts
+++ b/apps/core/src/routes/v1/notifications/devices/delete.ts
@@ -1,0 +1,61 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import { requireOwnerUserContext } from "@/middleware/auth";
+import { pushDeviceTokenSchema } from "@/schemas/push-device.schema";
+
+const responseSchema = z
+  .object({
+    deleted: z.boolean().openapi({ example: true }),
+  })
+  .openapi("UnregisterPushDeviceResponse");
+
+const route = createRoute({
+  method: "delete",
+  path: "/devices",
+  description:
+    "Stop sending push notifications to this app install. Called on sign-out, so the next person to use the device does not receive the last one's notifications.",
+  tags: ["Notifications"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({ token: pushDeviceTokenSchema })
+            .openapi("UnregisterPushDeviceRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: jsonSuccessResponse(responseSchema, "Device unregistered", {
+      data: { deleted: true },
+      meta: {
+        timestamp: "2026-08-08T09:00:00.000Z",
+        requestId: "550e8400-e29b-41d4-a716-446655440000",
+      },
+    }),
+    401: jsonErrorResponse("Unauthorized"),
+    500: jsonErrorResponse("Internal Server Error"),
+  },
+});
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    const userContext = requireOwnerUserContext(c.var.authContext);
+    const { token } = c.req.valid("json");
+
+    // Scoped to this user's own row. Unregistering must not be a way to silence
+    // somebody else's device by guessing their token.
+    const result = await prisma.pushDevice.deleteMany({
+      where: { userId: userContext.userId, token },
+    });
+
+    // `deleted: false` rather than a 404: signing out twice, or signing out on
+    // a device that never registered, is not an error the app can act on.
+    return ok(c, responseSchema.parse({ deleted: result.count > 0 }));
+  });
+}

--- a/apps/core/src/routes/v1/notifications/devices/devices.test.ts
+++ b/apps/core/src/routes/v1/notifications/devices/devices.test.ts
@@ -1,0 +1,218 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import type { AuthenticationContext, AuthVariables } from "@/middleware/auth";
+
+import mountUnregisterPushDevice from "./delete";
+import mountRegisterPushDevice from "./post";
+
+const { pushDeviceUpsertMock, pushDeviceDeleteManyMock } = vi.hoisted(() => ({
+  pushDeviceUpsertMock: vi.fn(),
+  pushDeviceDeleteManyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    pushDevice: {
+      upsert: pushDeviceUpsertMock,
+      deleteMany: pushDeviceDeleteManyMock,
+    },
+  },
+}));
+
+const USER_AUTH_CONTEXT: AuthenticationContext = {
+  actor: "user",
+  userId: "user_123",
+  organizationId: "org_123",
+  role: "user",
+};
+
+const COWORKER_AUTH_CONTEXT = {
+  actor: "coworker",
+  coworkerId: "coworker_123",
+  userId: "user_123",
+  organizationId: "org_123",
+} as unknown as AuthenticationContext;
+
+const TOKEN = "ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]";
+
+function createDeviceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "0199c0f0-0000-7000-8000-000000000000",
+    userId: "user_123",
+    token: TOKEN,
+    platform: "IOS",
+    lastSeenAt: new Date("2026-08-08T09:00:00.000Z"),
+    createdAt: new Date("2026-08-08T09:00:00.000Z"),
+    updatedAt: new Date("2026-08-08T09:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createApp(
+  mount: (app: OpenAPIHonoWithAuth) => void,
+  authContext: AuthenticationContext = USER_AUTH_CONTEXT,
+) {
+  const app = new OpenAPIHono<{ Variables: AuthVariables }>();
+
+  app.use("*", async (c, next) => {
+    c.set("isAuthenticated", true);
+    c.set("authContext", authContext);
+
+    return await next();
+  });
+
+  mount(app as unknown as OpenAPIHonoWithAuth);
+  return app;
+}
+
+function post(body: unknown) {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+describe("POST /notifications/devices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers a device for the signed-in user", async () => {
+    pushDeviceUpsertMock.mockResolvedValue(createDeviceRow());
+
+    const app = createApp(mountRegisterPushDevice);
+    const response = await app.request(
+      "http://localhost/devices",
+      post({ token: TOKEN, platform: "IOS" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(pushDeviceUpsertMock).toHaveBeenCalledWith({
+      where: { userId_token: { userId: "user_123", token: TOKEN } },
+      create: { userId: "user_123", token: TOKEN, platform: "IOS" },
+      update: { platform: "IOS", lastSeenAt: expect.any(Date) },
+    });
+  });
+
+  it("refreshes rather than duplicating, so the app can register every launch", async () => {
+    pushDeviceUpsertMock.mockResolvedValue(createDeviceRow());
+
+    const app = createApp(mountRegisterPushDevice);
+    await app.request(
+      "http://localhost/devices",
+      post({ token: TOKEN, platform: "IOS" }),
+    );
+
+    const call = pushDeviceUpsertMock.mock.calls[0][0];
+    expect(call.update.lastSeenAt).toBeInstanceOf(Date);
+    expect(call.where).toEqual({
+      userId_token: { userId: "user_123", token: TOKEN },
+    });
+  });
+
+  it("never returns the token it was given", async () => {
+    // The response describes the registration, not the address. Echoing a push
+    // token back adds a way to read one out that did not otherwise exist.
+    pushDeviceUpsertMock.mockResolvedValue(createDeviceRow());
+
+    const app = createApp(mountRegisterPushDevice);
+    const response = await app.request(
+      "http://localhost/devices",
+      post({ token: TOKEN, platform: "IOS" }),
+    );
+
+    expect(JSON.stringify(await response.json())).not.toContain(TOKEN);
+  });
+
+  it("rejects an unknown platform", async () => {
+    const app = createApp(mountRegisterPushDevice);
+    const response = await app.request(
+      "http://localhost/devices",
+      post({ token: TOKEN, platform: "WINDOWS_PHONE" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(pushDeviceUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty token", async () => {
+    const app = createApp(mountRegisterPushDevice);
+    const response = await app.request(
+      "http://localhost/devices",
+      post({ token: "", platform: "IOS" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(pushDeviceUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a coworker acting on the user's behalf", async () => {
+    // A coworker must not be able to point someone's notifications at a device.
+    const app = createApp(mountRegisterPushDevice, COWORKER_AUTH_CONTEXT);
+    const response = await app.request(
+      "http://localhost/devices",
+      post({ token: TOKEN, platform: "IOS" }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(pushDeviceUpsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /notifications/devices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes only this user's row for the token", async () => {
+    // Scoped to the caller: unregistering must not be a way to silence someone
+    // else's device by guessing their token.
+    pushDeviceDeleteManyMock.mockResolvedValue({ count: 1 });
+
+    const app = createApp(mountUnregisterPushDevice);
+    const response = await app.request("http://localhost/devices", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: TOKEN }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(pushDeviceDeleteManyMock).toHaveBeenCalledWith({
+      where: { userId: "user_123", token: TOKEN },
+    });
+
+    const body = (await response.json()) as { data: { deleted: boolean } };
+    expect(body.data.deleted).toBe(true);
+  });
+
+  it("is not an error to unregister something that was never registered", async () => {
+    // Signing out twice is not a failure the app can act on.
+    pushDeviceDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    const app = createApp(mountUnregisterPushDevice);
+    const response = await app.request("http://localhost/devices", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: TOKEN }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: { deleted: boolean } };
+    expect(body.data.deleted).toBe(false);
+  });
+
+  it("refuses a coworker acting on the user's behalf", async () => {
+    const app = createApp(mountUnregisterPushDevice, COWORKER_AUTH_CONTEXT);
+    const response = await app.request("http://localhost/devices", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: TOKEN }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(pushDeviceDeleteManyMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/routes/v1/notifications/devices/post.ts
+++ b/apps/core/src/routes/v1/notifications/devices/post.ts
@@ -1,0 +1,63 @@
+import { createRoute } from "@hono/zod-openapi";
+
+import { jsonErrorResponse, jsonSuccessResponse } from "@/helpers/openapi";
+import { ok } from "@/helpers/response";
+import prisma from "@/lib/db/prisma";
+import type { OpenAPIHonoWithAuth } from "@/lib/hono";
+import { requireOwnerUserContext } from "@/middleware/auth";
+import {
+  pushDeviceSchema,
+  registerPushDeviceRequestSchema,
+} from "@/schemas/push-device.schema";
+
+const route = createRoute({
+  method: "post",
+  path: "/devices",
+  description:
+    "Register this app install to receive push notifications. Idempotent: re-registering the same token for the same user refreshes it rather than adding a second device, which is what lets the app register on every launch.",
+  tags: ["Notifications"],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: registerPushDeviceRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: jsonSuccessResponse(pushDeviceSchema, "Device registered", {
+      data: {
+        id: "0199c0f0-0000-7000-8000-000000000000",
+        platform: "IOS",
+        lastSeenAt: "2026-08-08T09:00:00.000Z",
+        createdAt: "2026-08-08T09:00:00.000Z",
+      },
+      meta: {
+        timestamp: "2026-08-08T09:00:00.000Z",
+        requestId: "550e8400-e29b-41d4-a716-446655440000",
+      },
+    }),
+    401: jsonErrorResponse("Unauthorized"),
+    500: jsonErrorResponse("Internal Server Error"),
+  },
+});
+
+export default function mount(app: OpenAPIHonoWithAuth) {
+  app.openapi(route, async (c) => {
+    // Owner context: a coworker acting on someone's behalf must not be able to
+    // point that person's notifications at a device.
+    const userContext = requireOwnerUserContext(c.var.authContext);
+    const { token, platform } = c.req.valid("json");
+
+    const device = await prisma.pushDevice.upsert({
+      where: { userId_token: { userId: userContext.userId, token } },
+      // A token can move between users on a shared device — sign out, sign in
+      // as someone else — so the same token may exist under another user. That
+      // row is left alone here and reaped when a send to it is rejected; the
+      // provider is the only thing that knows which install is still live.
+      create: { userId: userContext.userId, token, platform },
+      update: { platform, lastSeenAt: new Date() },
+    });
+
+    return ok(c, pushDeviceSchema.parse(device));
+  });
+}

--- a/apps/core/src/routes/v1/notifications/index.ts
+++ b/apps/core/src/routes/v1/notifications/index.ts
@@ -1,5 +1,7 @@
 import { OpenAPIHonoWithAuth } from "@/lib/hono";
 import mountMarkNotificationRead from "./[id]/read/patch.js";
+import mountUnregisterPushDevice from "./devices/delete.js";
+import mountRegisterPushDevice from "./devices/post.js";
 import mountGetNotifications from "./get.js";
 import mountMarkAllRead from "./read-all/patch.js";
 import mountGetUnreadCount from "./unread-count/get.js";
@@ -10,5 +12,7 @@ mountGetNotifications(app);
 mountGetUnreadCount(app);
 mountMarkNotificationRead(app);
 mountMarkAllRead(app);
+mountRegisterPushDevice(app);
+mountUnregisterPushDevice(app);
 
 export default app;

--- a/apps/core/src/schemas/push-device.schema.ts
+++ b/apps/core/src/schemas/push-device.schema.ts
@@ -1,0 +1,39 @@
+import { z } from "@hono/zod-openapi";
+
+/**
+ * The provider's address for one app install.
+ *
+ * Expo hands the app a token of the form `ExponentPushToken[…]`, and Core
+ * treats it as opaque: it is an address to send to, not a credential, and
+ * validating its shape here would only break the day Expo changes it. Length is
+ * bounded because it goes in an index.
+ */
+export const pushDeviceTokenSchema = z.string().min(1).max(512).openapi({
+  description: "Opaque push token issued to this app install by the provider",
+  example: "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]",
+});
+
+export const pushDevicePlatformSchema = z.enum(["IOS", "ANDROID"]).openapi({
+  description: "Which app store build this token came from",
+  example: "IOS",
+});
+
+export const registerPushDeviceRequestSchema = z
+  .object({
+    token: pushDeviceTokenSchema,
+    platform: pushDevicePlatformSchema,
+  })
+  .openapi("RegisterPushDeviceRequest");
+
+export const pushDeviceSchema = z
+  .object({
+    id: z.string().openapi({ example: "0199c0f0-0000-7000-8000-000000000000" }),
+    platform: pushDevicePlatformSchema,
+    lastSeenAt: z.date().openapi({ example: "2026-08-08T09:00:00.000Z" }),
+    createdAt: z.date().openapi({ example: "2026-08-08T09:00:00.000Z" }),
+  })
+  .openapi("PushDevice");
+
+export type RegisterPushDeviceRequest = z.infer<
+  typeof registerPushDeviceRequestSchema
+>;

--- a/packages/database/prisma/migrations/20260808030000_add_push_device/migration.sql
+++ b/packages/database/prisma/migrations/20260808030000_add_push_device/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "PushDevicePlatform" AS ENUM ('IOS', 'ANDROID');
+
+-- CreateTable
+CREATE TABLE "push_device" (
+    "id" UUID NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "platform" "PushDevicePlatform" NOT NULL,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "push_device_pkey" PRIMARY KEY ("id")
+);
+
+-- Re-registering the same token for the same user updates the row rather than
+-- adding a second one; the app registers on every launch.
+-- CreateIndex
+CREATE UNIQUE INDEX "push_device_userId_token_key" ON "push_device"("userId", "token");
+
+-- A send failure knows only the token, and has to find every row holding it.
+-- CreateIndex
+CREATE INDEX "push_device_token_idx" ON "push_device"("token");
+
+-- CreateIndex
+CREATE INDEX "push_device_userId_idx" ON "push_device"("userId");
+
+-- AddForeignKey
+ALTER TABLE "push_device" ADD CONSTRAINT "push_device_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -56,6 +56,7 @@ model User {
 
   // Notifications
   notificationsOptIn Boolean @default(true) // Whether the user wants to receive notifications
+  pushDevices        PushDevice[]
 
   // UTM Attribution
   utmAttribution UTMAttribution?
@@ -388,6 +389,41 @@ model Notification {
   @@index([eventId])
   @@index([kind, eventId])
   @@map("notification")
+}
+
+/// A device this user has asked to be notified on.
+///
+/// One row per (user, token). A token identifies an app install rather than a
+/// device, so reinstalling produces a new one and the old one goes stale — the
+/// push provider reports that when a send is rejected, which is when the row is
+/// removed. Nothing here is a credential: an Expo push token is a public
+/// address, safe to lose and useless without the notification payload.
+model PushDevice {
+  id       String             @id @default(uuid(7)) @db.Uuid
+  userId   String
+  user     User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  /// The provider's address for this install. Opaque to Core.
+  token    String
+  platform PushDevicePlatform
+
+  /// Set when the app last registered, so a stale install can be pruned even if
+  /// no send has failed for it yet.
+  lastSeenAt DateTime @default(now())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  /// Re-registering the same token for the same user is an update, not a second
+  /// row — the app registers on every launch.
+  @@unique([userId, token])
+  /// A send failure knows only the token, and has to find every row holding it.
+  @@index([token])
+  @@index([userId])
+  @@map("push_device")
+}
+
+enum PushDevicePlatform {
+  IOS
+  ANDROID
 }
 
 model Project {


### PR DESCRIPTION
Stacked on #3709 — **base is `feat/core-session-bearer-auth`, not `main`.** Review that one first; this diff is only the push work.

## Why

Core has no push infrastructure at all today. No device tokens, no APNs or FCM credentials, nothing in the schema — I went looking for `apns`, `firebase-admin`, `expo-server-sdk`, `web-push` and any device-token model and found none. A native client can therefore only be notified while it is open and holding a realtime connection, which is exactly when a notification is least useful.

This is the storage half of fixing that: somewhere to put the address, and two endpoints for a client to manage it. **Nothing sends yet** — that is the next change in the stack, so this one can be reviewed on its own terms.

## What

- `PushDevice`, one row per `(user, token)`, with a migration.
- `POST /v1/notifications/devices` — register, idempotent.
- `DELETE /v1/notifications/devices` — unregister, by token.

## Decisions worth checking

**A token identifies an app install, not a device.** Reinstalling produces a new one and the old one goes stale. The provider reports that when a send is rejected, which is the only reliable moment to reap it — so this schema is built to be pruned by the sender rather than to be kept perfectly accurate on write. `lastSeenAt` is refreshed on every registration so an install that simply stopped launching can be pruned too.

**Registration is an upsert** because the app registers on every launch. The OS can reissue a token at any time, so "register whatever I have now" is the only contract a client can actually honour.

**Unregistering is scoped to the caller's own row.** Otherwise it becomes a way to silence somebody else's device by guessing their token.

**Both endpoints refuse coworker actors.** A coworker acting on a user's behalf has no business pointing that user's notifications at a device.

**The response never echoes the token back.** It describes the registration, not the address — returning it would add a way to read a token out that did not otherwise exist.

## Open question for the reviewer

A token can legitimately move between users on a shared device — sign out, sign in as someone else. Registration deliberately leaves the *other* user's row alone rather than deleting rows matching the token, because the client cannot prove the old install is gone and the provider is the only thing that knows. The consequence is a window where one token has two rows and the previous user gets one more notification before the send fails and reaps it. Happy to tighten that if you would rather trust the client.

## Verification

- `pnpm --filter core run typecheck`, `check` — clean, plus the monorepo-wide pre-commit hook.
- 9 new route tests, including both coworker-refusal cases and an assertion that the token never appears in a response.
- Full core suite: 2745 passing. Two files timed out on hooks under load (`oauth-issuer-metadata`, various `organizations/[id]/…`); different files each run, and all pass in isolation. Unrelated to this change.
- **Not** verified against a real database — the migration is hand-written to match the schema and has not been applied anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)