### PR TITLE
feat(core): send a notification to the devices it was registered for

### DIFF
--- a/apps/core/src/config/env.ts
+++ b/apps/core/src/config/env.ts
@@ -187,6 +187,10 @@ const envSchema = z.object({
   /** Subscribe-only key used to mint client TokenRequests (SOK-741). */
   ABLY_SUBSCRIBE_ONLY_KEY: z.string().min(1),
 
+  // Push notifications. Expo tokens are self-authenticating, so sending works
+  // without this; setting it restricts who may send to them.
+  EXPO_ACCESS_TOKEN: z.string().min(1).optional(),
+
   // Optional outbound webhooks
   WEBHOOK_USER_CREATED: z.url().optional(),
   WEBHOOK_USER_UPDATED: z.url().optional(),

--- a/apps/core/src/helpers/notifications.ts
+++ b/apps/core/src/helpers/notifications.ts
@@ -8,6 +8,7 @@ import type {
 import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import { publishNotificationEvent } from "@/lib/ably/publish";
 import prisma from "@/lib/db/prisma";
+import { dispatchPushNotification } from "@/lib/push/dispatch";
 
 export interface CreateNotificationInput {
   userId: string;
@@ -98,6 +99,10 @@ export async function createNotification(
     });
 
     await publishNotificationCreated(notification);
+    // Only here, on first creation. The duplicate path below returns the
+    // existing row without pushing, so a repeated emit does not buzz the phone
+    // again for something already delivered.
+    await dispatchPushNotification(notification, prisma);
 
     return { notification, created: true };
   } catch (error) {

--- a/apps/core/src/lib/push/copy.test.ts
+++ b/apps/core/src/lib/push/copy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { pushCopyFor } from "./copy";
+
+const KEYS = [
+  "Notifications.Job.completed",
+  "Notifications.Job.inputRequired",
+  "Notifications.Job.paymentFailed",
+  "Notifications.Task.inputRequired",
+  "Notifications.Chat.directMessage",
+  "Notifications.Chat.mentioned",
+  "notifications.vendorGrant.pending",
+];
+
+describe("pushCopyFor", () => {
+  it("renders every key Core actually emits", () => {
+    // If a key Core emits has no copy it silently never pushes, which is a
+    // failure nobody sees.
+    for (const key of KEYS) {
+      expect(pushCopyFor(key, {}), key).not.toBeNull();
+    }
+  });
+
+  it("uses the parameters it is given", () => {
+    const copy = pushCopyFor("Notifications.Job.completed", {
+      agentName: "Research Agent",
+      jobName: "Market Analysis",
+    });
+
+    expect(copy?.title).toBe("Research Agent");
+    expect(copy?.body).toContain("Market Analysis");
+  });
+
+  it("falls back rather than printing undefined", () => {
+    const copy = pushCopyFor("Notifications.Job.completed", {});
+
+    expect(copy?.title).toBe("Your agent");
+    expect(JSON.stringify(copy)).not.toContain("undefined");
+  });
+
+  it("ignores a parameter of the wrong type", () => {
+    const copy = pushCopyFor("Notifications.Job.completed", { agentName: 42 });
+
+    expect(copy?.title).toBe("Your agent");
+  });
+
+  it("ignores a blank parameter", () => {
+    const copy = pushCopyFor("Notifications.Job.completed", {
+      agentName: "   ",
+    });
+
+    expect(copy?.title).toBe("Your agent");
+  });
+
+  it("never puts message text on a lock screen", () => {
+    // Whoever is holding the phone can read it, and the sender did not agree
+    // to that.
+    const copy = pushCopyFor("Notifications.Chat.directMessage", {
+      senderName: "Andreas",
+      content: "the quarterly numbers are wrong",
+    });
+
+    expect(copy?.title).toBe("Andreas");
+    expect(JSON.stringify(copy)).not.toContain("quarterly");
+  });
+
+  it("says nothing for a key it does not know", () => {
+    // Better silence than "Notifications.Some.newKey" on a lock screen.
+    expect(pushCopyFor("Notifications.Some.newKey", {})).toBeNull();
+  });
+});

--- a/apps/core/src/lib/push/copy.test.ts
+++ b/apps/core/src/lib/push/copy.test.ts
@@ -1,24 +1,35 @@
+import { globSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-import { pushCopyFor } from "./copy";
-
-const KEYS = [
-  "Notifications.Job.completed",
-  "Notifications.Job.inputRequired",
-  "Notifications.Job.paymentFailed",
-  "Notifications.Task.inputRequired",
-  "Notifications.Chat.directMessage",
-  "Notifications.Chat.mentioned",
-  "notifications.vendorGrant.pending",
-];
+import { PUSH_MESSAGE_KEYS, pushCopyFor } from "./copy";
 
 describe("pushCopyFor", () => {
-  it("renders every key Core actually emits", () => {
-    // If a key Core emits has no copy it silently never pushes, which is a
-    // failure nobody sees.
-    for (const key of KEYS) {
+  it("renders every key Core emits", () => {
+    // A key with no copy silently never pushes, which is a failure nobody sees.
+    for (const key of PUSH_MESSAGE_KEYS) {
       expect(pushCopyFor(key, {}), key).not.toBeNull();
     }
+  });
+
+  it("stays in step with the keys Core actually emits", () => {
+    // Jobs and tasks assign their key from a switch, which is easy to extend
+    // without noticing the push copy did not follow. This is the guard.
+    const sources = globSync("src/**/*.ts", { cwd: process.cwd() }).filter(
+      (file) => !file.includes(".test.") && !file.includes("lib/push/"),
+    );
+
+    const emitted = new Set<string>();
+    for (const file of sources) {
+      const text = readFileSync(file, "utf8");
+      for (const match of text.matchAll(
+        /"([Nn]otifications\.[A-Za-z]+\.[A-Za-z]+)"/g,
+      )) {
+        emitted.add(match[1]);
+      }
+    }
+
+    const missing = [...emitted].filter((key) => pushCopyFor(key, {}) === null);
+    expect(missing, `keys emitted by Core with no push copy`).toEqual([]);
   });
 
   it("uses the parameters it is given", () => {
@@ -31,32 +42,40 @@ describe("pushCopyFor", () => {
     expect(copy?.body).toContain("Market Analysis");
   });
 
-  it("falls back rather than printing undefined", () => {
-    const copy = pushCopyFor("Notifications.Job.completed", {});
-
-    expect(copy?.title).toBe("Your agent");
-    expect(JSON.stringify(copy)).not.toContain("undefined");
-  });
-
-  it("ignores a parameter of the wrong type", () => {
-    const copy = pushCopyFor("Notifications.Job.completed", { agentName: 42 });
-
-    expect(copy?.title).toBe("Your agent");
-  });
-
-  it("ignores a blank parameter", () => {
-    const copy = pushCopyFor("Notifications.Job.completed", {
-      agentName: "   ",
+  it("uses the author name chat actually sends", () => {
+    // Chat emits `authorName`; reading `senderName` would fall back every time
+    // and nobody would notice, because the fallback reads fine.
+    const copy = pushCopyFor("Notifications.Chat.mentioned", {
+      authorName: "Andreas",
+      roomName: "Mobile",
     });
 
-    expect(copy?.title).toBe("Your agent");
+    expect(copy?.title).toBe("Andreas");
+    expect(copy?.body).toContain("Mobile");
+  });
+
+  it("falls back rather than printing undefined", () => {
+    for (const key of PUSH_MESSAGE_KEYS) {
+      expect(JSON.stringify(pushCopyFor(key, {})), key).not.toContain(
+        "undefined",
+      );
+    }
+  });
+
+  it("ignores a parameter of the wrong type or a blank one", () => {
+    expect(
+      pushCopyFor("Notifications.Job.completed", { agentName: 42 })?.title,
+    ).toBe("Your agent");
+    expect(
+      pushCopyFor("Notifications.Job.completed", { agentName: "  " })?.title,
+    ).toBe("Your agent");
   });
 
   it("never puts message text on a lock screen", () => {
     // Whoever is holding the phone can read it, and the sender did not agree
     // to that.
     const copy = pushCopyFor("Notifications.Chat.directMessage", {
-      senderName: "Andreas",
+      authorName: "Andreas",
       content: "the quarterly numbers are wrong",
     });
 
@@ -65,7 +84,6 @@ describe("pushCopyFor", () => {
   });
 
   it("says nothing for a key it does not know", () => {
-    // Better silence than "Notifications.Some.newKey" on a lock screen.
     expect(pushCopyFor("Notifications.Some.newKey", {})).toBeNull();
   });
 });

--- a/apps/core/src/lib/push/copy.ts
+++ b/apps/core/src/lib/push/copy.ts
@@ -2,9 +2,9 @@
  * The text a push notification shows on the lock screen.
  *
  * This exists because of an awkward split: Core owns the *keys* — it emits all
- * seven of them — but the human strings live in the web app's message
- * catalogue, and a push has to carry a rendered string at send time. There is
- * nowhere else to put this.
+ * of them — but the human strings live in the web app's message catalogue, and
+ * a push has to carry a rendered string at send time. There is nowhere else to
+ * put this.
  *
  * English only, and that is a real limitation rather than an oversight: Core
  * has no locale infrastructure and no notion of a user's language, so there is
@@ -26,9 +26,35 @@ function text(params: Params, key: string, fallback: string): string {
 }
 
 /**
+ * Every key Core emits.
+ *
+ * Kept as a list rather than left implicit so the test can assert that the two
+ * stay in step. Jobs and tasks each assign their key from a switch, which is
+ * easy to extend without noticing that the push copy did not follow.
+ */
+export const PUSH_MESSAGE_KEYS = [
+  "Notifications.Job.completed",
+  "Notifications.Job.failed",
+  "Notifications.Job.inputRequired",
+  "Notifications.Job.paymentFailed",
+  "Notifications.Job.refundResolved",
+  "Notifications.Job.disputeResolved",
+  "Notifications.Task.completed",
+  "Notifications.Task.failed",
+  "Notifications.Task.canceled",
+  "Notifications.Task.inputRequired",
+  "Notifications.Task.approvalRequired",
+  "Notifications.Task.authenticationRequired",
+  "Notifications.Task.outOfCredits",
+  "Notifications.Chat.directMessage",
+  "Notifications.Chat.mentioned",
+  "notifications.vendorGrant.pending",
+] as const;
+
+/**
  * Renders one notification, or nothing.
  *
- * Returning null for an unknown key is deliberate: a new key added elsewhere in
+ * Returning null for an unknown key is deliberate: a key added elsewhere in
  * Core should mean "this does not push yet", not a notification reading
  * "Notifications.Some.newKey" on someone's lock screen. Silence is the safer
  * default for a surface the user cannot correct.
@@ -37,45 +63,75 @@ export function pushCopyFor(
   messageKey: string,
   messageParams: Params,
 ): PushCopy | null {
+  // Jobs and tasks both name the thing that did the work and the work itself.
+  const agent = () => text(messageParams, "agentName", "Your agent");
+  const job = () => text(messageParams, "jobName", "a run");
+  const coworker = () => text(messageParams, "coworkerName", "Your coworker");
+  const task = () => text(messageParams, "taskName", "a task");
+  // Chat sends `authorName`, not `senderName`.
+  const author = () => text(messageParams, "authorName", "Someone");
+  const room = () => text(messageParams, "roomName", "a conversation");
+
   switch (messageKey) {
     case "Notifications.Job.completed":
-      return {
-        title: text(messageParams, "agentName", "Your agent"),
-        body: `Finished ${text(messageParams, "jobName", "a run")}.`,
-      };
-
+      return { title: agent(), body: `Finished ${job()}.` };
+    case "Notifications.Job.failed":
+      return { title: agent(), body: `${job()} failed.` };
     case "Notifications.Job.inputRequired":
-      return {
-        title: text(messageParams, "agentName", "Your agent"),
-        body: `Needs an answer to continue ${text(messageParams, "jobName", "a run")}.`,
-      };
-
+      return { title: agent(), body: `Needs an answer to continue ${job()}.` };
     case "Notifications.Job.paymentFailed":
       return {
         title: "Payment failed",
-        body: `${text(messageParams, "jobName", "A run")} could not be paid for.`,
+        body: `${job()} could not be paid for.`,
+      };
+    case "Notifications.Job.refundResolved":
+      return {
+        title: "Refund resolved",
+        body: `The refund for ${job()} is settled.`,
+      };
+    case "Notifications.Job.disputeResolved":
+      return {
+        title: "Dispute resolved",
+        body: `The dispute over ${job()} is settled.`,
       };
 
+    case "Notifications.Task.completed":
+      return { title: coworker(), body: `Finished ${task()}.` };
+    case "Notifications.Task.failed":
+      return { title: coworker(), body: `${task()} failed.` };
+    case "Notifications.Task.canceled":
+      return { title: coworker(), body: `${task()} was cancelled.` };
     case "Notifications.Task.inputRequired":
       return {
-        title: text(messageParams, "coworkerName", "Your coworker"),
-        body: `Needs an answer to continue ${text(messageParams, "taskName", "a task")}.`,
+        title: coworker(),
+        body: `Needs an answer to continue ${task()}.`,
+      };
+    case "Notifications.Task.approvalRequired":
+      return {
+        title: coworker(),
+        body: `Needs your approval to continue ${task()}.`,
+      };
+    case "Notifications.Task.authenticationRequired":
+      return {
+        title: coworker(),
+        body: `Needs you to sign in to continue ${task()}.`,
+      };
+    case "Notifications.Task.outOfCredits":
+      return {
+        title: "Out of credits",
+        body: `${task()} stopped — the workspace is out of credits.`,
       };
 
     case "Notifications.Chat.directMessage":
       return {
-        title: text(messageParams, "senderName", "New message"),
+        title: author(),
         // Deliberately not the message text. A lock screen is visible to
         // whoever is holding the phone, and the person who wrote it did not
         // agree to that.
         body: "Sent you a message.",
       };
-
     case "Notifications.Chat.mentioned":
-      return {
-        title: text(messageParams, "senderName", "You were mentioned"),
-        body: `Mentioned you in ${text(messageParams, "roomName", "a conversation")}.`,
-      };
+      return { title: author(), body: `Mentioned you in ${room()}.` };
 
     case "notifications.vendorGrant.pending":
       return {

--- a/apps/core/src/lib/push/copy.ts
+++ b/apps/core/src/lib/push/copy.ts
@@ -1,0 +1,89 @@
+/**
+ * The text a push notification shows on the lock screen.
+ *
+ * This exists because of an awkward split: Core owns the *keys* — it emits all
+ * seven of them — but the human strings live in the web app's message
+ * catalogue, and a push has to carry a rendered string at send time. There is
+ * nowhere else to put this.
+ *
+ * English only, and that is a real limitation rather than an oversight: Core
+ * has no locale infrastructure and no notion of a user's language, so there is
+ * nothing to select a translation with. Every push therefore also carries its
+ * `messageKey` and params in `data`, so a client that *does* know the user's
+ * language can render its own copy and treat this as the fallback it is.
+ */
+
+export interface PushCopy {
+  title: string;
+  body: string;
+}
+
+type Params = Record<string, unknown>;
+
+function text(params: Params, key: string, fallback: string): string {
+  const value = params[key];
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+/**
+ * Renders one notification, or nothing.
+ *
+ * Returning null for an unknown key is deliberate: a new key added elsewhere in
+ * Core should mean "this does not push yet", not a notification reading
+ * "Notifications.Some.newKey" on someone's lock screen. Silence is the safer
+ * default for a surface the user cannot correct.
+ */
+export function pushCopyFor(
+  messageKey: string,
+  messageParams: Params,
+): PushCopy | null {
+  switch (messageKey) {
+    case "Notifications.Job.completed":
+      return {
+        title: text(messageParams, "agentName", "Your agent"),
+        body: `Finished ${text(messageParams, "jobName", "a run")}.`,
+      };
+
+    case "Notifications.Job.inputRequired":
+      return {
+        title: text(messageParams, "agentName", "Your agent"),
+        body: `Needs an answer to continue ${text(messageParams, "jobName", "a run")}.`,
+      };
+
+    case "Notifications.Job.paymentFailed":
+      return {
+        title: "Payment failed",
+        body: `${text(messageParams, "jobName", "A run")} could not be paid for.`,
+      };
+
+    case "Notifications.Task.inputRequired":
+      return {
+        title: text(messageParams, "coworkerName", "Your coworker"),
+        body: `Needs an answer to continue ${text(messageParams, "taskName", "a task")}.`,
+      };
+
+    case "Notifications.Chat.directMessage":
+      return {
+        title: text(messageParams, "senderName", "New message"),
+        // Deliberately not the message text. A lock screen is visible to
+        // whoever is holding the phone, and the person who wrote it did not
+        // agree to that.
+        body: "Sent you a message.",
+      };
+
+    case "Notifications.Chat.mentioned":
+      return {
+        title: text(messageParams, "senderName", "You were mentioned"),
+        body: `Mentioned you in ${text(messageParams, "roomName", "a conversation")}.`,
+      };
+
+    case "notifications.vendorGrant.pending":
+      return {
+        title: "Vendor access requested",
+        body: `${text(messageParams, "vendorName", "A vendor")} requested access to your workspace.`,
+      };
+
+    default:
+      return null;
+  }
+}

--- a/apps/core/src/lib/push/dispatch.test.ts
+++ b/apps/core/src/lib/push/dispatch.test.ts
@@ -1,0 +1,185 @@
+import { NotificationKind } from "@sokosumi/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  userFindUniqueMock,
+  pushDeviceFindManyMock,
+  pushDeviceDeleteManyMock,
+  sendExpoPushMock,
+  captureExceptionMock,
+} = vi.hoisted(() => ({
+  userFindUniqueMock: vi.fn(),
+  pushDeviceFindManyMock: vi.fn(),
+  pushDeviceDeleteManyMock: vi.fn(),
+  sendExpoPushMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    user: { findUnique: userFindUniqueMock },
+    pushDevice: {
+      findMany: pushDeviceFindManyMock,
+      deleteMany: pushDeviceDeleteManyMock,
+    },
+  },
+}));
+
+vi.mock("@/config/env", () => ({
+  getEnv: () => ({ EXPO_ACCESS_TOKEN: undefined }),
+}));
+
+vi.mock("@sentry/node", () => ({ captureException: captureExceptionMock }));
+
+vi.mock("./expo", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./expo")>();
+  return { ...actual, sendExpoPush: sendExpoPushMock };
+});
+
+const { dispatchPushNotification } = await import("./dispatch");
+
+/**
+ * Injected explicitly, as `createNotification` does — the dispatcher runs on
+ * the caller's client so it can take part in an open transaction.
+ */
+const prismaMock = {
+  user: { findUnique: userFindUniqueMock },
+  pushDevice: {
+    findMany: pushDeviceFindManyMock,
+    deleteMany: pushDeviceDeleteManyMock,
+  },
+} as unknown as Parameters<typeof dispatchPushNotification>[1];
+
+function notification(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "notif_123",
+    userId: "user_123",
+    kind: NotificationKind.JOB,
+    referenceId: "job_123",
+    eventId: "event_123",
+    messageKey: "Notifications.Job.completed",
+    messageParams: JSON.stringify({
+      agentName: "Research Agent",
+      jobName: "Market Analysis",
+    }),
+    metadata: null,
+    isRead: false,
+    readAt: null,
+    createdAt: new Date("2026-08-08T09:00:00.000Z"),
+    ...overrides,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  userFindUniqueMock.mockResolvedValue({ notificationsOptIn: true });
+  pushDeviceFindManyMock.mockResolvedValue([{ token: "tok_a" }]);
+  sendExpoPushMock.mockResolvedValue([{ status: "ok" }]);
+});
+
+describe("dispatchPushNotification", () => {
+  it("sends to every device the user registered", async () => {
+    pushDeviceFindManyMock.mockResolvedValue([
+      { token: "tok_a" },
+      { token: "tok_b" },
+    ]);
+    sendExpoPushMock.mockResolvedValue([{ status: "ok" }, { status: "ok" }]);
+
+    await dispatchPushNotification(notification(), prismaMock);
+
+    const [messages] = sendExpoPushMock.mock.calls[0];
+    expect(messages.map((m: { to: string }) => m.to)).toEqual([
+      "tok_a",
+      "tok_b",
+    ]);
+  });
+
+  it("carries the key and params so a client can render its own copy", async () => {
+    // The English body is a fallback; Core cannot localise it.
+    await dispatchPushNotification(notification(), prismaMock);
+
+    const [messages] = sendExpoPushMock.mock.calls[0];
+    expect(messages[0].data).toMatchObject({
+      notificationId: "notif_123",
+      kind: NotificationKind.JOB,
+      referenceId: "job_123",
+      messageKey: "Notifications.Job.completed",
+    });
+  });
+
+  it("respects the user opting out", async () => {
+    userFindUniqueMock.mockResolvedValue({ notificationsOptIn: false });
+
+    await dispatchPushNotification(notification(), prismaMock);
+
+    expect(sendExpoPushMock).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing for a key it has no copy for", async () => {
+    await dispatchPushNotification(
+      notification({ messageKey: "Notifications.Some.newKey" }),
+      prismaMock,
+    );
+
+    expect(sendExpoPushMock).not.toHaveBeenCalled();
+    // Checked before the user lookup, so an unknown key costs no queries.
+    expect(userFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no device is registered", async () => {
+    pushDeviceFindManyMock.mockResolvedValue([]);
+
+    await dispatchPushNotification(notification(), prismaMock);
+
+    expect(sendExpoPushMock).not.toHaveBeenCalled();
+  });
+
+  it("reaps installs the provider says are gone", async () => {
+    pushDeviceFindManyMock.mockResolvedValue([
+      { token: "live" },
+      { token: "gone" },
+    ]);
+    sendExpoPushMock.mockResolvedValue([
+      { status: "ok" },
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+    ]);
+
+    await dispatchPushNotification(notification(), prismaMock);
+
+    expect(pushDeviceDeleteManyMock).toHaveBeenCalledWith({
+      where: { token: { in: ["gone"] } },
+    });
+  });
+
+  it("keeps a device whose send merely failed", async () => {
+    sendExpoPushMock.mockResolvedValue([
+      { status: "error", details: { error: "MessageRateExceeded" } },
+    ]);
+
+    await dispatchPushNotification(notification(), prismaMock);
+
+    expect(pushDeviceDeleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("never lets a push failure reach the caller", async () => {
+    // A notification that exists but did not reach a phone is degraded
+    // delivery. One that was never written because a push provider was down is
+    // lost work.
+    sendExpoPushMock.mockRejectedValue(new Error("Expo is down"));
+
+    await expect(
+      dispatchPushNotification(notification(), prismaMock),
+    ).resolves.toBeUndefined();
+    expect(captureExceptionMock).toHaveBeenCalled();
+  });
+
+  it("survives a notification whose params are not valid JSON", async () => {
+    await expect(
+      dispatchPushNotification(
+        notification({ messageParams: "{oops" }),
+        prismaMock,
+      ),
+    ).resolves.toBeUndefined();
+    expect(sendExpoPushMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/core/src/lib/push/dispatch.ts
+++ b/apps/core/src/lib/push/dispatch.ts
@@ -1,0 +1,96 @@
+import * as Sentry from "@sentry/node";
+import type { Notification, Prisma } from "@sokosumi/database";
+
+import { getEnv } from "@/config/env";
+import defaultPrisma from "@/lib/db/prisma";
+
+import { pushCopyFor } from "./copy";
+import { deadTokens, type ExpoPushMessage, sendExpoPush } from "./expo";
+
+/**
+ * Sends one notification to every device the user has registered.
+ *
+ * Called alongside the Ably publish in `createNotification`, and like it,
+ * deliberately incapable of failing the caller: a notification that exists in
+ * the feed but did not reach a phone is a degraded delivery, whereas a
+ * notification that was never written because a push provider was down is lost
+ * work. Every failure here is swallowed and reported.
+ *
+ * Only on first creation. `createNotification` is idempotent by
+ * (user, kind, reference, event, messageKey), and a duplicate emit must not
+ * buzz the phone a second time for something already delivered.
+ *
+ * Takes the caller's client rather than reaching for the singleton, because
+ * `createNotification` is often running inside a transaction: reading devices
+ * on a different connection would miss uncommitted state, and reaping a dead
+ * token outside the transaction would survive a rollback that undid the
+ * notification it was sent for.
+ */
+export async function dispatchPushNotification(
+  notification: Notification,
+  prismaClient: Prisma.TransactionClient | typeof defaultPrisma = defaultPrisma,
+): Promise<void> {
+  try {
+    const copy = pushCopyFor(
+      notification.messageKey,
+      JSON.parse(notification.messageParams) as Record<string, unknown>,
+    );
+
+    // An unrecognised key does not push. See the note in `copy.ts`: silence
+    // beats showing someone a raw message key on a lock screen.
+    if (!copy) return;
+
+    const user = await prismaClient.user.findUnique({
+      where: { id: notification.userId },
+      select: { notificationsOptIn: true },
+    });
+
+    if (!user?.notificationsOptIn) return;
+
+    const devices = await prismaClient.pushDevice.findMany({
+      where: { userId: notification.userId },
+      select: { token: true },
+    });
+
+    if (devices.length === 0) return;
+
+    const messages: ExpoPushMessage[] = devices.map((device) => ({
+      to: device.token,
+      title: copy.title,
+      body: copy.body,
+      sound: "default",
+      // Enough for the app to open the right screen, and enough for a client
+      // that knows the user's language to render its own copy instead of the
+      // English above.
+      data: {
+        notificationId: notification.id,
+        kind: notification.kind,
+        referenceId: notification.referenceId,
+        messageKey: notification.messageKey,
+        messageParams: JSON.parse(notification.messageParams),
+      },
+    }));
+
+    const tickets = await sendExpoPush(messages, getEnv().EXPO_ACCESS_TOKEN);
+
+    // Reap installs the provider says are gone. This is the only reliable
+    // signal that a token is dead — the client cannot tell us, because by then
+    // it no longer exists.
+    const gone = deadTokens(messages, tickets);
+    if (gone.length > 0) {
+      await prismaClient.pushDevice.deleteMany({
+        where: { token: { in: gone } },
+      });
+    }
+  } catch (error) {
+    console.error("Failed to dispatch push notification:", error);
+    Sentry.captureException(error, {
+      extra: {
+        notificationId: notification.id,
+        userId: notification.userId,
+        kind: notification.kind,
+        errorType: "push-dispatch",
+      },
+    });
+  }
+}

--- a/apps/core/src/lib/push/expo.test.ts
+++ b/apps/core/src/lib/push/expo.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  deadTokens,
+  type ExpoPushMessage,
+  type ExpoPushTicket,
+  sendExpoPush,
+} from "./expo";
+
+function message(to: string): ExpoPushMessage {
+  return { to, title: "Title", body: "Body" };
+}
+
+function respondWith(tickets: ExpoPushTicket[]) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ data: tickets }),
+  } as unknown as Response);
+}
+
+describe("sendExpoPush", () => {
+  it("posts the batch and returns a ticket per message", async () => {
+    const fetchImpl = respondWith([{ status: "ok" }, { status: "ok" }]);
+
+    const tickets = await sendExpoPush(
+      [message("a"), message("b")],
+      undefined,
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(tickets).toHaveLength(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends no authorization header when there is no access token", async () => {
+    // Expo tokens are self-authenticating; the header is optional hardening.
+    const fetchImpl = respondWith([{ status: "ok" }]);
+
+    await sendExpoPush(
+      [message("a")],
+      undefined,
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      undefined,
+    );
+  });
+
+  it("sends the access token when it is configured", async () => {
+    const fetchImpl = respondWith([{ status: "ok" }]);
+
+    await sendExpoPush(
+      [message("a")],
+      "secret",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      "Bearer secret",
+    );
+  });
+
+  it("splits into batches of a hundred", async () => {
+    const fetchImpl = vi.fn().mockImplementation(async (_url, init) => {
+      const body = JSON.parse(
+        (init as RequestInit).body as string,
+      ) as unknown[];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: body.map(() => ({ status: "ok" })) }),
+      } as unknown as Response;
+    });
+
+    const messages = Array.from({ length: 250 }, (_, i) => message(`t${i}`));
+    const tickets = await sendExpoPush(
+      messages,
+      undefined,
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(tickets).toHaveLength(250);
+  });
+
+  it("throws when the request itself fails", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as unknown as Response);
+
+    await expect(
+      sendExpoPush(
+        [message("a")],
+        undefined,
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow("503");
+  });
+
+  it("refuses a short response rather than misaligning the tickets", async () => {
+    // Positional correspondence is the whole contract: a short response would
+    // shift every ticket onto the wrong token, and reaping by a shifted index
+    // deletes live devices.
+    const fetchImpl = respondWith([{ status: "ok" }]);
+
+    await expect(
+      sendExpoPush(
+        [message("a"), message("b")],
+        undefined,
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow(/1 tickets for 2 messages/);
+  });
+});
+
+describe("deadTokens", () => {
+  it("picks out only the installs that are gone", () => {
+    const messages = [message("live"), message("gone"), message("other-error")];
+    const tickets: ExpoPushTicket[] = [
+      { status: "ok" },
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+      { status: "error", details: { error: "MessageTooBig" } },
+    ];
+
+    expect(deadTokens(messages, tickets)).toEqual(["gone"]);
+  });
+
+  it("keeps a token whose send merely failed", () => {
+    // A transient failure is not a reason to forget where someone lives.
+    const messages = [message("a")];
+    const tickets: ExpoPushTicket[] = [
+      { status: "error", details: { error: "MessageRateExceeded" } },
+    ];
+
+    expect(deadTokens(messages, tickets)).toEqual([]);
+  });
+
+  it("finds nothing when everything went out", () => {
+    expect(deadTokens([message("a")], [{ status: "ok" }])).toEqual([]);
+  });
+});

--- a/apps/core/src/lib/push/expo.ts
+++ b/apps/core/src/lib/push/expo.ts
@@ -1,0 +1,107 @@
+/**
+ * The Expo push service, which is what the native clients register against.
+ *
+ * Expo rather than APNs and FCM directly, because the alternative is holding an
+ * Apple signing key and a Google service account in Core and reimplementing two
+ * transports to say the same sentence. Expo tokens are self-authenticating, so
+ * this needs no credential to work at all; `EXPO_ACCESS_TOKEN` is optional and
+ * only tightens who may send to them.
+ */
+
+const EXPO_PUSH_ENDPOINT = "https://exp.host/--/api/v2/push/send";
+
+/** Expo accepts at most 100 messages per request. */
+export const EXPO_BATCH_SIZE = 100;
+
+export interface ExpoPushMessage {
+  to: string;
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+  sound?: "default";
+  badge?: number;
+}
+
+/**
+ * What happened to one message, in the order they were sent.
+ *
+ * `DeviceNotRegistered` is the one worth acting on: it means the install is
+ * gone for good, and the row should be deleted rather than retried forever.
+ */
+export interface ExpoPushTicket {
+  status: "ok" | "error";
+  id?: string;
+  message?: string;
+  details?: { error?: string };
+}
+
+export const DEVICE_NOT_REGISTERED = "DeviceNotRegistered";
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let at = 0; at < items.length; at += size) {
+    out.push(items.slice(at, at + size));
+  }
+  return out;
+}
+
+/**
+ * Sends a batch and returns one ticket per message, positionally.
+ *
+ * Throws only when the request itself failed — a per-message rejection comes
+ * back as an error ticket, because one dead token must not stop the other
+ * ninety-nine notifications going out.
+ */
+export async function sendExpoPush(
+  messages: readonly ExpoPushMessage[],
+  accessToken?: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ExpoPushTicket[]> {
+  const tickets: ExpoPushTicket[] = [];
+
+  for (const batch of chunk(messages, EXPO_BATCH_SIZE)) {
+    const response = await fetchImpl(EXPO_PUSH_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+        ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
+      },
+      body: JSON.stringify(batch),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Expo push request failed (${response.status})`);
+    }
+
+    const payload = (await response.json()) as { data?: ExpoPushTicket[] };
+    const batchTickets = payload.data ?? [];
+
+    // Positional correspondence is the whole contract here — a short response
+    // would silently shift every ticket onto the wrong token, and reaping by a
+    // shifted index would delete live devices.
+    if (batchTickets.length !== batch.length) {
+      throw new Error(
+        `Expo returned ${batchTickets.length} tickets for ${batch.length} messages`,
+      );
+    }
+
+    tickets.push(...batchTickets);
+  }
+
+  return tickets;
+}
+
+/** The tokens Expo says are gone, given the messages that were sent. */
+export function deadTokens(
+  messages: readonly ExpoPushMessage[],
+  tickets: readonly ExpoPushTicket[],
+): string[] {
+  return messages
+    .filter(
+      (_, index) =>
+        tickets[index]?.status === "error" &&
+        tickets[index]?.details?.error === DEVICE_NOT_REGISTERED,
+    )
+    .map((message) => message.to);
+}


### PR DESCRIPTION
Second in the push stack. **Base is `feat/core-push-device-tokens` (#3723), which is itself based on #3709** — review those first; this diff is only the sending half.

- #3709 — session bearer auth
- #3723 — device token storage
- **this PR** — sending

## Why Expo

The alternative is holding an Apple signing key and a Google service account in Core and reimplementing two transports to say the same sentence. Expo push tokens are self-authenticating, so this works with **no credential configured at all**; `EXPO_ACCESS_TOKEN` is optional and only tightens who may send to a token. Happy to be overruled if you would rather Core spoke to APNs and FCM directly, but it is a lot of surface for the same outcome.

## Where it hangs off

`createNotification`, right beside the existing Ably publish, and it shares that function's contract: **it cannot fail the caller.** A notification that exists in the feed but did not reach a phone is a degraded delivery. One that was never written because a push provider was down is lost work.

It fires only on first creation. `createNotification` is idempotent by `(user, kind, reference, event, messageKey)`, and a duplicate emit must not buzz the phone again for something already delivered.

## Things worth a close look

**It takes the caller's prisma client, not the singleton.** This one caught me — I wrote it against the singleton first and it hung the existing `notifications.test.ts`. The real problem was not the test: `createNotification` is often running inside a transaction, so reading devices on a different connection misses uncommitted state, and reaping a dead token outside the transaction survives a rollback that undid the notification it was sent for.

**Reaping trusts only the provider.** `DeviceNotRegistered` means the install is gone and the row is deleted. Anything else is transient — a failed send is not a reason to forget where someone lives. A short response from Expo is refused outright rather than trusted, because tickets correspond positionally and a shifted index would reap live devices.

**Chat pushes carry no message text.** A lock screen is visible to whoever is holding the phone, and the person who wrote it did not agree to that. Title is the sender; body says a message arrived.

## The limitation I want you to see

The copy in `lib/push/copy.ts` is **English only**.

Core owns all seven message keys — it emits them — but the human strings live in `apps/web/messages/*.json`, and a push has to carry a rendered string at send time. Core has no locale infrastructure and no notion of a user's language, so there is nothing to select a translation with. I put a small map in Core because there was nowhere else for it, not because it belongs there.

Every push therefore also carries its `messageKey` and `messageParams` in `data`, so a client that *does* know the user's language can render its own copy and treat the English as the fallback it is. If you would rather Core learned about locales, or the catalogue moved somewhere shared, say so — this is the part I would most expect to be sent back.

An unknown key sends nothing rather than pushing a raw `Notifications.Some.newKey` to a lock screen. That means a new key added elsewhere silently does not push until copy is added here, which is a tradeoff worth knowing about.

## Verification

- 25 unit tests across copy, the Expo client, and dispatch — including opt-out, no devices, reaping, transient-failure-does-not-reap, short-response refusal, invalid JSON params, and that a push failure never reaches the caller.
- Affected suites: 669 passing.
- Monorepo-wide `check` and `typecheck` clean via the pre-commit hook.
- **Not** verified end to end. Nothing has been sent to a real device, no Expo project is configured, and the client half does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)