### PR TITLE
chore(web): migrate @tanstack/react-table to v9

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,7 @@
     "@sokosumi/utils": "workspace:*",
     "@sparticuz/chromium-min": "149.0.0",
     "@tanstack/react-query": "5.101.4",
-    "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-table": "9.1.2",
     "@vercel/analytics": "2.0.1",
     "@vercel/blob": "2.7.0",
     "@vercel/related-projects": "1.1.1",

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
@@ -4,7 +4,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import type { useFormatter, useTranslations } from "next-intl";
 import { useEffect } from "react";
-import { DataTableColumnHeader } from "@/components/data-table";
+import {
+  DataTableColumnHeader,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { JobStatusBadge } from "@/components/jobs";
 import { MiddleTruncate } from "@/components/middle-truncate";
 import { HighlightedText } from "@/components/ui/highlighted-text";
@@ -13,7 +16,7 @@ import type { JobSummary } from "@/lib/clients/generated/core";
 import { getJobStatusData } from "@/lib/helpers/job";
 import { getJobQueryKey } from "@/queries";
 
-const columnHelper = createColumnHelper<JobSummary>();
+const columnHelper = createColumnHelper<DataTableFeatures, JobSummary>();
 
 export function getJobColumns(
   userId: string,
@@ -40,9 +43,9 @@ export function getJobColumns(
           })}
         </div>
       ),
-      sortingFn: "datetime",
+      sortFn: "datetime",
       enableHiding: false,
-    }) as ColumnDef<JobSummary>,
+    }) as ColumnDef<DataTableFeatures, JobSummary>,
 
     statusColumn: columnHelper.accessor("status", {
       id: "status",
@@ -63,7 +66,7 @@ export function getJobColumns(
       },
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<JobSummary>,
+    }) as ColumnDef<DataTableFeatures, JobSummary>,
 
     nameColumn: columnHelper.accessor("name", {
       id: "name",
@@ -80,7 +83,7 @@ export function getJobColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<JobSummary>,
+    }) as ColumnDef<DataTableFeatures, JobSummary>,
   };
 }
 

--- a/apps/web/src/app/(app)/developer/components/api-keys/api-keys-columns.tsx
+++ b/apps/web/src/app/(app)/developer/components/api-keys/api-keys-columns.tsx
@@ -4,12 +4,15 @@ import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { Eye, EyeOff, Trash2 } from "lucide-react";
 import type { useTranslations } from "next-intl";
 
-import { DataTableColumnHeader } from "@/components/data-table";
+import {
+  DataTableColumnHeader,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 
 import type { ApiKeyRecord } from "./types";
 
-const columnHelper = createColumnHelper<ApiKeyRecord>();
+const columnHelper = createColumnHelper<DataTableFeatures, ApiKeyRecord>();
 
 export function getApiKeyColumns(
   t: ReturnType<typeof useTranslations>,
@@ -27,7 +30,7 @@ export function getApiKeyColumns(
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<ApiKeyRecord>,
+    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
 
     columnHelper.accessor("start", {
       id: "key",
@@ -43,7 +46,7 @@ export function getApiKeyColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<ApiKeyRecord>,
+    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
 
     columnHelper.accessor("enabled", {
       id: "status",
@@ -65,7 +68,7 @@ export function getApiKeyColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<ApiKeyRecord>,
+    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -81,7 +84,7 @@ export function getApiKeyColumns(
       ),
       enableSorting: true,
       enableHiding: true,
-    }) as ColumnDef<ApiKeyRecord>,
+    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
 
     columnHelper.display({
       id: "actions",
@@ -127,6 +130,6 @@ export function getApiKeyColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<ApiKeyRecord>,
+    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
   ];
 }

--- a/apps/web/src/components/admin/agents/agent-list-columns.tsx
+++ b/apps/web/src/components/admin/agents/agent-list-columns.tsx
@@ -4,7 +4,10 @@ import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import type { useFormatter, useTranslations } from "next-intl";
 
-import { DataTableColumnHeader } from "@/components/data-table";
+import {
+  DataTableColumnHeader,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { AdminAgentListItem } from "@/lib/clients/generated/core/types.gen";
@@ -14,12 +17,15 @@ const dateTimeOptions = {
   timeStyle: "short",
 } as const;
 
-const columnHelper = createColumnHelper<AdminAgentListItem>();
+const columnHelper = createColumnHelper<
+  DataTableFeatures,
+  AdminAgentListItem
+>();
 
 export function getAgentListColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.Agents.AgentList">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<AdminAgentListItem>[] {
+): ColumnDef<DataTableFeatures, AdminAgentListItem>[] {
   return [
     columnHelper.accessor("displayName", {
       id: "displayName",
@@ -33,7 +39,7 @@ export function getAgentListColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<AdminAgentListItem>,
+    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
 
     columnHelper.accessor("registryName", {
       id: "registryName",
@@ -49,7 +55,7 @@ export function getAgentListColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<AdminAgentListItem>,
+    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
 
     columnHelper.accessor("hasOverride", {
       id: "hasOverride",
@@ -68,7 +74,7 @@ export function getAgentListColumns(
         ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<AdminAgentListItem>,
+    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
 
     columnHelper.accessor("status", {
       id: "status",
@@ -80,7 +86,7 @@ export function getAgentListColumns(
       cell: ({ row }) => row.original.status,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<AdminAgentListItem>,
+    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -96,7 +102,7 @@ export function getAgentListColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<AdminAgentListItem>,
+    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
 
     columnHelper.display({
       id: "actions",
@@ -115,6 +121,6 @@ export function getAgentListColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<AdminAgentListItem>,
+    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
   ];
 }

--- a/apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx
+++ b/apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx
@@ -4,7 +4,10 @@ import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import type { useFormatter, useTranslations } from "next-intl";
 
-import { DataTableColumnHeader } from "@/components/data-table";
+import {
+  DataTableColumnHeader,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { Coworker } from "@/lib/clients/generated/core/types.gen";
@@ -14,7 +17,7 @@ const dateTimeOptions = {
   timeStyle: "short",
 } as const;
 
-const columnHelper = createColumnHelper<Coworker>();
+const columnHelper = createColumnHelper<DataTableFeatures, Coworker>();
 
 function isArchived(coworker: Coworker): boolean {
   return coworker.archivedAt != null;
@@ -23,7 +26,7 @@ function isArchived(coworker: Coworker): boolean {
 export function getCoworkersTableColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.Coworkers.Table">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<Coworker>[] {
+): ColumnDef<DataTableFeatures, Coworker>[] {
   return [
     columnHelper.accessor("name", {
       id: "name",
@@ -35,7 +38,7 @@ export function getCoworkersTableColumns(
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
 
     columnHelper.accessor("slug", {
       id: "slug",
@@ -49,7 +52,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
 
     columnHelper.accessor((row) => isArchived(row), {
       id: "status",
@@ -66,7 +69,7 @@ export function getCoworkersTableColumns(
         ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
 
     columnHelper.accessor("isWhitelisted", {
       id: "isWhitelisted",
@@ -82,7 +85,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
 
     columnHelper.accessor("priority", {
       id: "priority",
@@ -100,7 +103,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -116,7 +119,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
 
     columnHelper.display({
       id: "actions",
@@ -137,6 +140,6 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<Coworker>,
+    }) as ColumnDef<DataTableFeatures, Coworker>,
   ];
 }

--- a/apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx
+++ b/apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx
@@ -11,7 +11,7 @@ import {
   buildComboboxLabels,
 } from "@/components/admin/async-search-combobox";
 import { ContractStatusBadge } from "@/components/admin/enterprise-contracts/contract-status-badge";
-import { DataTable } from "@/components/data-table";
+import { DataTable, type DataTableFeatures } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
@@ -46,7 +46,10 @@ const enterpriseContractFilterParsers = {
   status: parseAsStringLiteral(ENTERPRISE_CONTRACT_STATUSES),
 };
 
-const columnHelper = createColumnHelper<EnterpriseContract>();
+const columnHelper = createColumnHelper<
+  DataTableFeatures,
+  EnterpriseContract
+>();
 
 const dateTimeOptions = {
   dateStyle: "medium",
@@ -56,7 +59,7 @@ const dateTimeOptions = {
 function getColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.EnterpriseContracts">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<EnterpriseContract>[] {
+): ColumnDef<DataTableFeatures, EnterpriseContract>[] {
   return [
     columnHelper.accessor("organizationSlug", {
       id: "organizationSlug",
@@ -75,7 +78,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
 
     columnHelper.accessor("status", {
       id: "status",
@@ -87,7 +90,7 @@ function getColumns(
       cell: ({ row }) => <ContractStatusBadge status={row.original.status} />,
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
 
     columnHelper.accessor("seats", {
       id: "seats",
@@ -101,7 +104,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
 
     columnHelper.accessor("creditsPerMonth", {
       id: "creditsPerMonth",
@@ -121,7 +124,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
 
     columnHelper.accessor("periods", {
       id: "periods",
@@ -135,7 +138,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
 
     columnHelper.accessor("endsAt", {
       id: "endsAt",
@@ -150,7 +153,7 @@ function getColumns(
           : "—",
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
 
     columnHelper.display({
       id: "actions",
@@ -165,7 +168,7 @@ function getColumns(
           </Link>
         </Button>
       ),
-    }) as ColumnDef<EnterpriseContract>,
+    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
   ];
 }
 

--- a/apps/web/src/components/admin/vendors/vendors-table-columns.tsx
+++ b/apps/web/src/components/admin/vendors/vendors-table-columns.tsx
@@ -4,7 +4,10 @@ import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import type { useFormatter, useTranslations } from "next-intl";
 
-import { DataTableColumnHeader } from "@/components/data-table";
+import {
+  DataTableColumnHeader,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import type { Vendor } from "@/lib/clients/generated/core";
 
@@ -13,12 +16,12 @@ const dateTimeOptions = {
   timeStyle: "short",
 } as const;
 
-const columnHelper = createColumnHelper<Vendor>();
+const columnHelper = createColumnHelper<DataTableFeatures, Vendor>();
 
 export function getVendorsTableColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.Vendors.Table">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<Vendor>[] {
+): ColumnDef<DataTableFeatures, Vendor>[] {
   return [
     columnHelper.accessor("name", {
       id: "name",
@@ -30,7 +33,7 @@ export function getVendorsTableColumns(
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Vendor>,
+    }) as ColumnDef<DataTableFeatures, Vendor>,
 
     columnHelper.accessor("slug", {
       id: "slug",
@@ -44,7 +47,7 @@ export function getVendorsTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Vendor>,
+    }) as ColumnDef<DataTableFeatures, Vendor>,
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -60,7 +63,7 @@ export function getVendorsTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Vendor>,
+    }) as ColumnDef<DataTableFeatures, Vendor>,
 
     columnHelper.accessor("updatedAt", {
       id: "updatedAt",
@@ -76,7 +79,7 @@ export function getVendorsTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<Vendor>,
+    }) as ColumnDef<DataTableFeatures, Vendor>,
 
     columnHelper.display({
       id: "actions",
@@ -95,6 +98,6 @@ export function getVendorsTableColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<Vendor>,
+    }) as ColumnDef<DataTableFeatures, Vendor>,
   ];
 }

--- a/apps/web/src/components/data-table/__tests__/data-table-features.test.ts
+++ b/apps/web/src/components/data-table/__tests__/data-table-features.test.ts
@@ -1,0 +1,122 @@
+import { createColumnHelper, useTable } from "@tanstack/react-table";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  type DataTableFeatures,
+  dataTableFeatures,
+} from "../data-table-features";
+
+interface SortRow {
+  id: string;
+  name: string;
+  score: number;
+  createdAt: string;
+  startedAt: Date;
+}
+
+const columnHelper = createColumnHelper<DataTableFeatures, SortRow>();
+
+const columns = columnHelper.columns([
+  columnHelper.accessor("name", { id: "name" }),
+  columnHelper.accessor("score", { id: "score" }),
+  // ISO strings: auto picks text/alphanumeric; explicit datetime also supported.
+  columnHelper.accessor("createdAt", { id: "createdAt" }),
+  columnHelper.accessor("startedAt", {
+    id: "startedAt",
+    sortFn: "datetime",
+  }),
+]);
+
+const unsorted: SortRow[] = [
+  {
+    id: "3",
+    name: "charlie",
+    score: 5,
+    createdAt: "2024-03-01T00:00:00.000Z",
+    startedAt: new Date("2024-03-01T00:00:00.000Z"),
+  },
+  {
+    id: "1",
+    name: "alice",
+    score: 20,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    startedAt: new Date("2024-01-01T00:00:00.000Z"),
+  },
+  {
+    id: "2",
+    name: "bob",
+    score: 10,
+    createdAt: "2024-02-01T00:00:00.000Z",
+    startedAt: new Date("2024-02-01T00:00:00.000Z"),
+  },
+];
+
+function useSortTable() {
+  return useTable({
+    features: dataTableFeatures,
+    columns,
+    data: unsorted,
+    // Full page so row model is not truncated while testing sort order.
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 50 },
+    },
+  });
+}
+
+describe("dataTableFeatures sort registry", () => {
+  it("sorts strings with default auto sortFn", () => {
+    const { result } = renderHook(() => useSortTable());
+    result.current.setSorting([{ id: "name", desc: false }]);
+
+    expect(
+      result.current.getRowModel().rows.map((row) => row.original.name),
+    ).toEqual(["alice", "bob", "charlie"]);
+  });
+
+  it("sorts numbers with default auto sortFn", () => {
+    const { result } = renderHook(() => useSortTable());
+    result.current.setSorting([{ id: "score", desc: false }]);
+
+    expect(
+      result.current.getRowModel().rows.map((row) => row.original.score),
+    ).toEqual([5, 10, 20]);
+  });
+
+  it("sorts ISO date strings with default auto sortFn", () => {
+    const { result } = renderHook(() => useSortTable());
+    result.current.setSorting([{ id: "createdAt", desc: false }]);
+
+    expect(
+      result.current.getRowModel().rows.map((row) => row.original.createdAt),
+    ).toEqual([
+      "2024-01-01T00:00:00.000Z",
+      "2024-02-01T00:00:00.000Z",
+      "2024-03-01T00:00:00.000Z",
+    ]);
+  });
+
+  it("sorts Date values with named datetime sortFn", () => {
+    const { result } = renderHook(() => useSortTable());
+    result.current.setSorting([{ id: "startedAt", desc: false }]);
+
+    expect(
+      result.current
+        .getRowModel()
+        .rows.map((row) => row.original.startedAt.getTime()),
+    ).toEqual([
+      new Date("2024-01-01T00:00:00.000Z").getTime(),
+      new Date("2024-02-01T00:00:00.000Z").getTime(),
+      new Date("2024-03-01T00:00:00.000Z").getTime(),
+    ]);
+  });
+
+  it("supports descending multi-toggle style sort", () => {
+    const { result } = renderHook(() => useSortTable());
+    result.current.setSorting([{ id: "name", desc: true }]);
+
+    expect(
+      result.current.getRowModel().rows.map((row) => row.original.name),
+    ).toEqual(["charlie", "bob", "alice"]);
+  });
+});

--- a/apps/web/src/components/data-table/data-table-column-header.tsx
+++ b/apps/web/src/components/data-table/data-table-column-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Column } from "@tanstack/react-table";
+import type { Column, RowData } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ChevronsUpDown, EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -14,13 +14,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
-interface DataTableColumnHeaderProps<TData, TValue>
+import type { DataTableFeatures } from "./data-table-features";
+
+interface DataTableColumnHeaderProps<TData extends RowData, TValue>
   extends React.HTMLAttributes<HTMLDivElement> {
-  column: Column<TData, TValue>;
+  column: Column<DataTableFeatures, TData, TValue>;
   title: string;
 }
 
-export default function DataTableColumnHeader<TData, TValue>({
+export default function DataTableColumnHeader<TData extends RowData, TValue>({
   column,
   title,
   className,
@@ -51,18 +53,18 @@ export default function DataTableColumnHeader<TData, TValue>({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
         <DropdownMenuItem onClick={() => column.toggleSorting(false)}>
-          <ArrowUp className="text-muted-foreground/70 h-4 w-4" />
+          <ArrowUp className="text-muted-foreground/70 size-4" />
           {t("ascending")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => column.toggleSorting(true)}>
-          <ArrowDown className="text-muted-foreground/70 h-4 w-4" />
+          <ArrowDown className="text-muted-foreground/70 size-4" />
           {t("descending")}
         </DropdownMenuItem>
         {column.getCanHide() && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
-              <EyeOff className="text-muted-foreground/70 h-4 w-4" />
+              <EyeOff className="text-muted-foreground/70 size-4" />
               {t("hide")}
             </DropdownMenuItem>
           </>

--- a/apps/web/src/components/data-table/data-table-features.ts
+++ b/apps/web/src/components/data-table/data-table-features.ts
@@ -10,15 +10,21 @@ import {
   rowSelectionFeature,
   rowSortingFeature,
   sortFn_alphanumeric,
+  sortFn_alphanumericCaseSensitive,
   sortFn_basic,
   sortFn_datetime,
   sortFn_text,
+  sortFn_textCaseSensitive,
   tableFeatures,
 } from "@tanstack/react-table";
 
 /**
  * Shared TanStack Table v9 features for app DataTables.
  * Column helpers must use `createColumnHelper<DataTableFeatures, TData>()`.
+ *
+ * `sortFns` must include every built-in name that `sortFn: "auto"` can pick
+ * (datetime / alphanumeric / text) plus basic. Case-sensitive variants are
+ * registered so named column defs stay resolvable.
  */
 export const dataTableFeatures = tableFeatures({
   columnSizingFeature,
@@ -32,9 +38,11 @@ export const dataTableFeatures = tableFeatures({
   paginatedRowModel: createPaginatedRowModel(),
   sortFns: {
     alphanumeric: sortFn_alphanumeric,
+    alphanumericCaseSensitive: sortFn_alphanumericCaseSensitive,
     basic: sortFn_basic,
     datetime: sortFn_datetime,
     text: sortFn_text,
+    textCaseSensitive: sortFn_textCaseSensitive,
   },
   filterFns: {
     includesString: filterFn_includesString,

--- a/apps/web/src/components/data-table/data-table-features.ts
+++ b/apps/web/src/components/data-table/data-table-features.ts
@@ -1,0 +1,44 @@
+import {
+  columnFilteringFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  createFilteredRowModel,
+  createPaginatedRowModel,
+  createSortedRowModel,
+  filterFn_includesString,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_basic,
+  sortFn_datetime,
+  sortFn_text,
+  tableFeatures,
+} from "@tanstack/react-table";
+
+/**
+ * Shared TanStack Table v9 features for app DataTables.
+ * Column helpers must use `createColumnHelper<DataTableFeatures, TData>()`.
+ */
+export const dataTableFeatures = tableFeatures({
+  columnSizingFeature,
+  columnVisibilityFeature,
+  columnFilteringFeature,
+  rowSortingFeature,
+  rowSelectionFeature,
+  rowPaginationFeature,
+  filteredRowModel: createFilteredRowModel(),
+  sortedRowModel: createSortedRowModel(),
+  paginatedRowModel: createPaginatedRowModel(),
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+    basic: sortFn_basic,
+    datetime: sortFn_datetime,
+    text: sortFn_text,
+  },
+  filterFns: {
+    includesString: filterFn_includesString,
+  },
+});
+
+export type DataTableFeatures = typeof dataTableFeatures;

--- a/apps/web/src/components/data-table/data-table-pagination.tsx
+++ b/apps/web/src/components/data-table/data-table-pagination.tsx
@@ -1,7 +1,7 @@
 "use client";
 "use no memo";
 
-import type { Table } from "@tanstack/react-table";
+import type { ReactTable, RowData } from "@tanstack/react-table";
 import {
   ChevronLeft,
   ChevronRight,
@@ -19,18 +19,21 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-interface DataTablePaginationProps<TData> {
-  table: Table<TData>;
+import type { DataTableFeatures } from "./data-table-features";
+
+interface DataTablePaginationProps<TData extends RowData> {
+  table: ReactTable<DataTableFeatures, TData>;
   enableRowSelection?: boolean;
   showRowsPerPage?: boolean;
 }
 
-export default function DataTablePagination<TData>({
+export default function DataTablePagination<TData extends RowData>({
   table,
   enableRowSelection = true,
   showRowsPerPage = true,
 }: DataTablePaginationProps<TData>) {
   const t = useTranslations("Components.DataTable.Pagination");
+  const { pageIndex, pageSize } = table.state.pagination;
 
   return (
     <div className="flex items-center justify-between px-2">
@@ -46,20 +49,18 @@ export default function DataTablePagination<TData>({
           <div className="flex items-center space-x-2">
             <p className="text-sm">{t("rowsPerPage")}</p>
             <Select
-              value={`${table.getState().pagination.pageSize}`}
+              value={`${pageSize}`}
               onValueChange={(value) => {
                 table.setPageSize(Number(value));
               }}
             >
               <SelectTrigger className="h-8 w-[70px]">
-                <SelectValue
-                  placeholder={table.getState().pagination.pageSize}
-                />
+                <SelectValue placeholder={pageSize} />
               </SelectTrigger>
               <SelectContent side="top">
-                {[5, 10, 20, 30, 40, 50].map((pageSize) => (
-                  <SelectItem key={pageSize} value={`${pageSize}`}>
-                    {pageSize}
+                {[5, 10, 20, 30, 40, 50].map((size) => (
+                  <SelectItem key={size} value={`${size}`}>
+                    {size}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -68,7 +69,7 @@ export default function DataTablePagination<TData>({
         )}
         <div className="flex w-[100px] items-center justify-center text-sm font-medium">
           {t("page", {
-            page: table.getState().pagination.pageIndex + 1,
+            page: pageIndex + 1,
             totalPages: table.getPageCount(),
           })}
         </div>

--- a/apps/web/src/components/data-table/data-table.tsx
+++ b/apps/web/src/components/data-table/data-table.tsx
@@ -4,17 +4,13 @@
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type ColumnVisibilityState,
   flexRender,
-  getCoreRowModel,
-  getFacetedRowModel,
-  getFacetedUniqueValues,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   type OnChangeFn,
+  type ReactTable,
+  type RowData,
   type SortingState,
-  useReactTable,
-  type VisibilityState,
+  useTable,
 } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
 import * as React from "react";
@@ -28,10 +24,14 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
+import {
+  type DataTableFeatures,
+  dataTableFeatures,
+} from "./data-table-features";
 import DataTablePagination from "./data-table-pagination";
 
-function getMinTableWidth<TData>(
-  table: ReturnType<typeof useReactTable<TData>>,
+function getMinTableWidth<TData extends RowData>(
+  table: ReactTable<DataTableFeatures, TData>,
 ) {
   return table.getVisibleLeafColumns().reduce((total, column) => {
     const minSize = column.columnDef.minSize ?? 0;
@@ -39,8 +39,9 @@ function getMinTableWidth<TData>(
   }, 0);
 }
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
+interface DataTableProps<TData extends RowData> {
+  // Column cell values vary per column; use `any` so mixed column defs typecheck.
+  columns: ColumnDef<DataTableFeatures, TData, any>[];
   data: TData[];
   containerClassName?: string | undefined;
   tableClassName?: string | undefined;
@@ -62,7 +63,7 @@ interface DataTableProps<TData, TValue> {
   renderGroupHeader?: (groupKey: string) => React.ReactNode;
 }
 
-export default function DataTable<TData, TValue>({
+export default function DataTable<TData extends RowData>({
   columns,
   data,
   containerClassName,
@@ -82,12 +83,12 @@ export default function DataTable<TData, TValue>({
   rowClassName,
   getGroupKey,
   renderGroupHeader,
-}: DataTableProps<TData, TValue>) {
+}: DataTableProps<TData>) {
   const t = useTranslations("Components.DataTable.Data");
 
   const [rowSelection, setRowSelection] = React.useState({});
   const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({});
+    React.useState<ColumnVisibilityState>({});
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     [],
   );
@@ -97,10 +98,11 @@ export default function DataTable<TData, TValue>({
   const sorting = controlledSorting ?? internalSorting;
   const setSorting = onSortingChange ?? setInternalSorting;
 
-  // TanStack Table's useReactTable returns functions that can't be memoized.
+  // TanStack Table's useTable returns functions that can't be memoized.
   // The "use no memo" directive above tells React Compiler to skip this component.
   // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  const table = useTable({
+    features: dataTableFeatures,
     data,
     columns,
     state: {
@@ -111,21 +113,20 @@ export default function DataTable<TData, TValue>({
     },
     initialState: {
       pagination: {
+        pageIndex: 0,
         pageSize: initialPageSize ?? 10,
       },
     },
     enableRowSelection,
+    // Disable Shift range selection on row toggles.
+    enableRowRangeSelection: false,
     onRowSelectionChange: setRowSelection,
+    // When pagination UI is off, skip client page slicing (show all rows).
+    manualPagination: !showPagination,
     manualSorting,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getSortedRowModel: manualSorting ? undefined : getSortedRowModel(),
-    getFacetedRowModel: getFacetedRowModel(),
-    getFacetedUniqueValues: getFacetedUniqueValues(),
-    getPaginationRowModel: showPagination ? getPaginationRowModel() : undefined,
   });
 
   const rowModel = table.getRowModel();

--- a/apps/web/src/components/data-table/index.ts
+++ b/apps/web/src/components/data-table/index.ts
@@ -1,3 +1,7 @@
 export { default as DataTable } from "./data-table";
 export { default as DataTableColumnHeader } from "./data-table-column-header";
+export {
+  type DataTableFeatures,
+  dataTableFeatures,
+} from "./data-table-features";
 export { default as DataTablePagination } from "./data-table-pagination";

--- a/apps/web/src/components/members-table/members-table-columns.tsx
+++ b/apps/web/src/components/members-table/members-table-columns.tsx
@@ -2,7 +2,10 @@
 
 import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
-import { DataTableColumnHeader } from "@/components/data-table";
+import {
+  DataTableColumnHeader,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { OrganizationRoleBadge } from "@/components/organizations";
 import { TimeAgo } from "@/components/time-ago";
 import type { OrganizationMembershipSelf } from "@/lib/types/core-dto";
@@ -11,7 +14,7 @@ import MemberActionsDropdown from "./member-actions-dropdown";
 import { useSeatManagementContext } from "./seat-management-context";
 import type { MemberRowData } from "./types";
 
-const columnHelper = createColumnHelper<MemberRowData>();
+const columnHelper = createColumnHelper<DataTableFeatures, MemberRowData>();
 
 export function getMembersTableColumns(
   t: ReturnType<typeof useTranslations>,
@@ -27,7 +30,7 @@ export function getMembersTableColumns(
       cell: ({ row }) => <div className="p-2">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<MemberRowData>,
+    }) as ColumnDef<DataTableFeatures, MemberRowData>,
 
     emailColumn: columnHelper.accessor("email", {
       id: "email",
@@ -38,7 +41,7 @@ export function getMembersTableColumns(
       cell: ({ row }) => <div className="p-2">{row.original.email}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<MemberRowData>,
+    }) as ColumnDef<DataTableFeatures, MemberRowData>,
 
     roleColumn: columnHelper.accessor("role", {
       id: "role",
@@ -53,7 +56,7 @@ export function getMembersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<MemberRowData>,
+    }) as ColumnDef<DataTableFeatures, MemberRowData>,
 
     lastSeenColumn: columnHelper.accessor("lastSeenAt", {
       id: "lastSeen",
@@ -81,14 +84,14 @@ export function getMembersTableColumns(
         );
       },
       enableSorting: true,
-    }) as ColumnDef<MemberRowData>,
+    }) as ColumnDef<DataTableFeatures, MemberRowData>,
 
     seatColumn: columnHelper.display({
       id: "seat",
       minSize: 120,
       header: () => <div>{t("Header.seat")}</div>,
       cell: ({ row }) => <SeatStatusCell member={row.original.member} />,
-    }) as ColumnDef<MemberRowData>,
+    }) as ColumnDef<DataTableFeatures, MemberRowData>,
 
     actionColumn: columnHelper.display({
       id: "actions",
@@ -106,7 +109,7 @@ export function getMembersTableColumns(
         }
         return null;
       },
-    }) as ColumnDef<MemberRowData>,
+    }) as ColumnDef<DataTableFeatures, MemberRowData>,
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,16 +47,16 @@ importers:
         version: 1.6.26(b6390e13dbb09b12106a21b41a25460c)
       '@better-auth/i18n':
         specifier: 1.6.26
-        version: 1.6.26(78263bba352ed8e34e8b1a183eb7af5b)
+        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2)))
       '@better-auth/oauth-provider':
         specifier: 1.6.26
-        version: 1.6.26(df8cfc1fd70fa93969e8722a8f39c85b)
+        version: 1.6.26(ea14a3d32487da7f12cfbab11d3f8959)
       '@better-auth/passkey':
         specifier: 1.6.26
-        version: 1.6.26(2401fbcb06101414479e7bb5a0ff402e)
+        version: 1.6.26(4291b8185f27b24bc4c1b071be0d45e2)
       '@better-auth/prisma-adapter':
         specifier: 1.6.26
-        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
       '@better-auth/stripe':
         specifier: 1.6.26
         version: 1.6.26(236bbc75b564fef9ac3d57c162a77a39)
@@ -125,7 +125,7 @@ importers:
         version: 7.0.58(zod@4.4.3)
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
       cron-parser:
         specifier: 5.8.1
         version: 5.8.1
@@ -192,13 +192,13 @@ importers:
         version: 1.6.26(b6390e13dbb09b12106a21b41a25460c)
       '@better-auth/i18n':
         specifier: 1.6.26
-        version: 1.6.26(78263bba352ed8e34e8b1a183eb7af5b)
+        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2)))
       '@better-auth/oauth-provider':
         specifier: 1.6.26
-        version: 1.6.26(df8cfc1fd70fa93969e8722a8f39c85b)
+        version: 1.6.26(ea14a3d32487da7f12cfbab11d3f8959)
       '@better-auth/passkey':
         specifier: 1.6.26
-        version: 1.6.26(2401fbcb06101414479e7bb5a0ff402e)
+        version: 1.6.26(4291b8185f27b24bc4c1b071be0d45e2)
       '@better-auth/stripe':
         specifier: 1.6.26
         version: 1.6.26(236bbc75b564fef9ac3d57c162a77a39)
@@ -257,8 +257,8 @@ importers:
         specifier: 5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-table':
-        specifier: 8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
@@ -279,7 +279,7 @@ importers:
         version: 7.0.58(zod@4.4.3)
       better-auth:
         specifier: 1.6.26
-        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+        version: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -557,7 +557,7 @@ importers:
         version: 7.9.1
       '@prisma/client':
         specifier: 7.9.1
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       '@sokosumi/masumi':
         specifier: workspace:*
         version: link:../masumi
@@ -4440,16 +4440,24 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
+  '@tanstack/react-table@9.1.2':
+    resolution: {integrity: sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=18'
+
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==}
+
+  '@tanstack/table-core@9.1.2':
+    resolution: {integrity: sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==}
+    engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
@@ -9847,7 +9855,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -9870,10 +9878,10 @@ snapshots:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/i18n@1.6.26(78263bba352ed8e34e8b1a183eb7af5b)':
+  '@better-auth/i18n@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2)))':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
 
   '@better-auth/kysely-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -9892,40 +9900,40 @@ snapshots:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.26(df8cfc1fd70fa93969e8722a8f39c85b)':
+  '@better-auth/oauth-provider@1.6.26(ea14a3d32487da7f12cfbab11d3f8959)':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       zod: 4.4.3
 
-  '@better-auth/passkey@1.6.26(2401fbcb06101414479e7bb5a0ff402e)':
+  '@better-auth/passkey@1.6.26(4291b8185f27b24bc4c1b071be0d45e2)':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))':
+  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
 
   '@better-auth/stripe@1.6.26(236bbc75b564fef9ac3d57c162a77a39)':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
+      better-auth: 1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))
       better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       stripe: 22.4.0(@types/node@24.13.3)
@@ -11070,7 +11078,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.9.1': {}
 
-  '@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)':
+  '@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.1
     optionalDependencies:
@@ -13346,13 +13354,26 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-store@0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/store': 0.11.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.1.2
+      react: 19.2.8
+    transitivePeerDependencies:
+      - react-dom
+
+  '@tanstack/store@0.11.1': {}
+
+  '@tanstack/table-core@9.1.2':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@tanstack/virtual-core@3.17.7': {}
 
@@ -14359,14 +14380,14 @@ snapshots:
 
   baseline-browser-mapping@2.11.12: {}
 
-  better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2)):
+  better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2)):
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/kysely-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
       '@better-auth/telemetry': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -14379,7 +14400,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       mysql2: 3.15.3
       next: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.23.0


### PR DESCRIPTION
## Summary

Migrates `@tanstack/react-table` from **v8.21.3 → v9.1.2**, the major intentionally skipped in #3726.

- Shared `dataTableFeatures` + `useTable` in `DataTable` (modular features: sorting, filtering, pagination, selection, sizing, visibility)
- Column helpers updated to `createColumnHelper<DataTableFeatures, TData>`
- Behavior preserved: `manualPagination: !showPagination`, `manualSorting` passthrough, `enableRowRangeSelection: false`
- `sortingFn` → `sortFn`; pagination reads `table.state.pagination`

## Test plan

- [x] `pnpm check` + monorepo typecheck (pre-commit)
- [x] `pnpm --filter web test` (460 files / 3006 tests)
- [ ] Spot-check a paginated table (members) and a non-paginated admin table (vendors/coworkers)
- [ ] Spot-check server-side sorting on admin agent list (`manualSorting`)