### PR TITLE
refactor(web): type DataTable via createTableHook

### DIFF
--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import type { useFormatter, useTranslations } from "next-intl";
 import { useEffect } from "react";
 import {
+  createAppColumnHelper,
   DataTableColumnHeader,
-  type DataTableFeatures,
 } from "@/components/data-table";
 import { JobStatusBadge } from "@/components/jobs";
 import { MiddleTruncate } from "@/components/middle-truncate";
@@ -16,7 +15,7 @@ import type { JobSummary } from "@/lib/clients/generated/core";
 import { getJobStatusData } from "@/lib/helpers/job";
 import { getJobQueryKey } from "@/queries";
 
-const columnHelper = createColumnHelper<DataTableFeatures, JobSummary>();
+const columnHelper = createAppColumnHelper<JobSummary>();
 
 export function getJobColumns(
   userId: string,
@@ -45,7 +44,7 @@ export function getJobColumns(
       ),
       sortFn: "datetime",
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, JobSummary>,
+    }),
 
     statusColumn: columnHelper.accessor("status", {
       id: "status",
@@ -66,7 +65,7 @@ export function getJobColumns(
       },
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, JobSummary>,
+    }),
 
     nameColumn: columnHelper.accessor("name", {
       id: "name",
@@ -83,8 +82,23 @@ export function getJobColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, JobSummary>,
+    }),
   };
+}
+
+export function getJobTableColumns(
+  userId: string,
+  t: ReturnType<typeof useTranslations>,
+  dateFormatter: ReturnType<typeof useFormatter>,
+  highlightQuery?: string,
+) {
+  const { createdAtColumn, statusColumn, nameColumn } = getJobColumns(
+    userId,
+    t,
+    dateFormatter,
+    highlightQuery,
+  );
+  return columnHelper.columns([createdAtColumn, statusColumn, nameColumn]);
 }
 
 function JobNameCell({

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx
@@ -17,14 +17,14 @@ import { getJobQueryKey } from "@/queries";
 
 const columnHelper = createAppColumnHelper<JobSummary>();
 
-export function getJobColumns(
+export function getJobTableColumns(
   userId: string,
   t: ReturnType<typeof useTranslations>,
   dateFormatter: ReturnType<typeof useFormatter>,
   highlightQuery?: string,
 ) {
-  return {
-    createdAtColumn: columnHelper.accessor("createdAt", {
+  return columnHelper.columns([
+    columnHelper.accessor("createdAt", {
       id: "createdAt",
       minSize: 80,
       header: ({ column }) => (
@@ -45,8 +45,7 @@ export function getJobColumns(
       sortFn: "datetime",
       enableHiding: false,
     }),
-
-    statusColumn: columnHelper.accessor("status", {
+    columnHelper.accessor("status", {
       id: "status",
       minSize: 160,
       header: ({ column }) => (
@@ -66,8 +65,7 @@ export function getJobColumns(
       enableSorting: true,
       enableHiding: false,
     }),
-
-    nameColumn: columnHelper.accessor("name", {
+    columnHelper.accessor("name", {
       id: "name",
       minSize: 180,
       header: ({ column }) => (
@@ -83,22 +81,7 @@ export function getJobColumns(
       enableSorting: true,
       enableHiding: false,
     }),
-  };
-}
-
-export function getJobTableColumns(
-  userId: string,
-  t: ReturnType<typeof useTranslations>,
-  dateFormatter: ReturnType<typeof useFormatter>,
-  highlightQuery?: string,
-) {
-  const { createdAtColumn, statusColumn, nameColumn } = getJobColumns(
-    userId,
-    t,
-    dateFormatter,
-    highlightQuery,
-  );
-  return columnHelper.columns([createdAtColumn, statusColumn, nameColumn]);
+  ]);
 }
 
 function JobNameCell({

--- a/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-table.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/jobs/components/jobs-table.tsx
@@ -9,7 +9,7 @@ import type { JobSummary } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { useLocalizedDateTime } from "@/lib/utils/datetime.client";
 
-import { getJobColumns } from "./job-columns";
+import { getJobTableColumns } from "./job-columns";
 import { JobsSearch } from "./jobs-search";
 
 interface JobsTableProps {
@@ -58,7 +58,7 @@ export default function JobsTable({ jobs, userId }: JobsTableProps) {
       />
       <DataTable
         tableClassName="[&>table]:flex! [&>table]:md:table!"
-        columns={getColumns(userId, t, dateFormatter, queryParam)}
+        columns={getJobTableColumns(userId, t, dateFormatter, queryParam)}
         onRowClick={(row) => getOnRowClick(row)}
         data={filteredJobs}
         rowClassName={(row) => getRowClassName(row)}
@@ -78,19 +78,4 @@ export default function JobsTable({ jobs, userId }: JobsTableProps) {
       />
     </div>
   );
-}
-
-function getColumns(
-  userId: string,
-  t: ReturnType<typeof useTranslations>,
-  dateFormatter: ReturnType<typeof useFormatter>,
-  highlightQuery?: string,
-) {
-  const { createdAtColumn, statusColumn, nameColumn } = getJobColumns(
-    userId,
-    t,
-    dateFormatter,
-    highlightQuery,
-  );
-  return [createdAtColumn, statusColumn, nameColumn];
 }

--- a/apps/web/src/app/(app)/developer/components/api-keys/api-keys-columns.tsx
+++ b/apps/web/src/app/(app)/developer/components/api-keys/api-keys-columns.tsx
@@ -1,25 +1,24 @@
 "use client";
 
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { Eye, EyeOff, Trash2 } from "lucide-react";
 import type { useTranslations } from "next-intl";
 
 import {
+  createAppColumnHelper,
   DataTableColumnHeader,
-  type DataTableFeatures,
 } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 
 import type { ApiKeyRecord } from "./types";
 
-const columnHelper = createColumnHelper<DataTableFeatures, ApiKeyRecord>();
+const columnHelper = createAppColumnHelper<ApiKeyRecord>();
 
 export function getApiKeyColumns(
   t: ReturnType<typeof useTranslations>,
   onToggleStatus: (apiKey: ApiKeyRecord) => Promise<void>,
   onDeleteClick: (apiKey: ApiKeyRecord) => void,
 ) {
-  return [
+  return columnHelper.columns([
     columnHelper.accessor("name", {
       id: "name",
       minSize: 120,
@@ -30,7 +29,7 @@ export function getApiKeyColumns(
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
+    }),
 
     columnHelper.accessor("start", {
       id: "key",
@@ -46,7 +45,7 @@ export function getApiKeyColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
+    }),
 
     columnHelper.accessor("enabled", {
       id: "status",
@@ -68,7 +67,7 @@ export function getApiKeyColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
+    }),
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -84,7 +83,7 @@ export function getApiKeyColumns(
       ),
       enableSorting: true,
       enableHiding: true,
-    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
+    }),
 
     columnHelper.display({
       id: "actions",
@@ -130,6 +129,6 @@ export function getApiKeyColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, ApiKeyRecord>,
-  ];
+    }),
+  ]);
 }

--- a/apps/web/src/components/admin/agents/agent-list-columns.tsx
+++ b/apps/web/src/components/admin/agents/agent-list-columns.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import type { useFormatter, useTranslations } from "next-intl";
 
 import {
+  createAppColumnHelper,
   DataTableColumnHeader,
-  type DataTableFeatures,
 } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,16 +16,13 @@ const dateTimeOptions = {
   timeStyle: "short",
 } as const;
 
-const columnHelper = createColumnHelper<
-  DataTableFeatures,
-  AdminAgentListItem
->();
+const columnHelper = createAppColumnHelper<AdminAgentListItem>();
 
 export function getAgentListColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.Agents.AgentList">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<DataTableFeatures, AdminAgentListItem>[] {
-  return [
+) {
+  return columnHelper.columns([
     columnHelper.accessor("displayName", {
       id: "displayName",
       minSize: 140,
@@ -39,7 +35,7 @@ export function getAgentListColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
+    }),
 
     columnHelper.accessor("registryName", {
       id: "registryName",
@@ -55,7 +51,7 @@ export function getAgentListColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
+    }),
 
     columnHelper.accessor("hasOverride", {
       id: "hasOverride",
@@ -74,7 +70,7 @@ export function getAgentListColumns(
         ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
+    }),
 
     columnHelper.accessor("status", {
       id: "status",
@@ -86,7 +82,7 @@ export function getAgentListColumns(
       cell: ({ row }) => row.original.status,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
+    }),
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -102,7 +98,7 @@ export function getAgentListColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
+    }),
 
     columnHelper.display({
       id: "actions",
@@ -121,6 +117,6 @@ export function getAgentListColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, AdminAgentListItem>,
-  ];
+    }),
+  ]);
 }

--- a/apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx
+++ b/apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import type { useFormatter, useTranslations } from "next-intl";
 
 import {
+  createAppColumnHelper,
   DataTableColumnHeader,
-  type DataTableFeatures,
 } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,7 +16,7 @@ const dateTimeOptions = {
   timeStyle: "short",
 } as const;
 
-const columnHelper = createColumnHelper<DataTableFeatures, Coworker>();
+const columnHelper = createAppColumnHelper<Coworker>();
 
 function isArchived(coworker: Coworker): boolean {
   return coworker.archivedAt != null;
@@ -26,8 +25,8 @@ function isArchived(coworker: Coworker): boolean {
 export function getCoworkersTableColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.Coworkers.Table">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<DataTableFeatures, Coworker>[] {
-  return [
+) {
+  return columnHelper.columns([
     columnHelper.accessor("name", {
       id: "name",
       minSize: 120,
@@ -38,7 +37,7 @@ export function getCoworkersTableColumns(
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
+    }),
 
     columnHelper.accessor("slug", {
       id: "slug",
@@ -52,7 +51,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
+    }),
 
     columnHelper.accessor((row) => isArchived(row), {
       id: "status",
@@ -69,7 +68,7 @@ export function getCoworkersTableColumns(
         ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
+    }),
 
     columnHelper.accessor("isWhitelisted", {
       id: "isWhitelisted",
@@ -85,7 +84,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
+    }),
 
     columnHelper.accessor("priority", {
       id: "priority",
@@ -103,7 +102,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
+    }),
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -119,7 +118,7 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
+    }),
 
     columnHelper.display({
       id: "actions",
@@ -140,6 +139,6 @@ export function getCoworkersTableColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Coworker>,
-  ];
+    }),
+  ]);
 }

--- a/apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx
+++ b/apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import { useFormatter, useTranslations } from "next-intl";
 import { parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
@@ -11,7 +10,7 @@ import {
   buildComboboxLabels,
 } from "@/components/admin/async-search-combobox";
 import { ContractStatusBadge } from "@/components/admin/enterprise-contracts/contract-status-badge";
-import { DataTable, type DataTableFeatures } from "@/components/data-table";
+import { createAppColumnHelper, DataTable } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
@@ -46,10 +45,7 @@ const enterpriseContractFilterParsers = {
   status: parseAsStringLiteral(ENTERPRISE_CONTRACT_STATUSES),
 };
 
-const columnHelper = createColumnHelper<
-  DataTableFeatures,
-  EnterpriseContract
->();
+const columnHelper = createAppColumnHelper<EnterpriseContract>();
 
 const dateTimeOptions = {
   dateStyle: "medium",
@@ -59,8 +55,8 @@ const dateTimeOptions = {
 function getColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.EnterpriseContracts">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<DataTableFeatures, EnterpriseContract>[] {
-  return [
+) {
+  return columnHelper.columns([
     columnHelper.accessor("organizationSlug", {
       id: "organizationSlug",
       size: 180,
@@ -78,7 +74,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
+    }),
 
     columnHelper.accessor("status", {
       id: "status",
@@ -90,7 +86,7 @@ function getColumns(
       cell: ({ row }) => <ContractStatusBadge status={row.original.status} />,
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
+    }),
 
     columnHelper.accessor("seats", {
       id: "seats",
@@ -104,7 +100,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
+    }),
 
     columnHelper.accessor("creditsPerMonth", {
       id: "creditsPerMonth",
@@ -124,7 +120,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
+    }),
 
     columnHelper.accessor("periods", {
       id: "periods",
@@ -138,7 +134,7 @@ function getColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
+    }),
 
     columnHelper.accessor("endsAt", {
       id: "endsAt",
@@ -153,7 +149,7 @@ function getColumns(
           : "—",
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
+    }),
 
     columnHelper.display({
       id: "actions",
@@ -168,8 +164,8 @@ function getColumns(
           </Link>
         </Button>
       ),
-    }) as ColumnDef<DataTableFeatures, EnterpriseContract>,
-  ];
+    }),
+  ]);
 }
 
 interface ContractsTableProps {

--- a/apps/web/src/components/admin/vendors/vendors-table-columns.tsx
+++ b/apps/web/src/components/admin/vendors/vendors-table-columns.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import Link from "next/link";
 import type { useFormatter, useTranslations } from "next-intl";
 
 import {
+  createAppColumnHelper,
   DataTableColumnHeader,
-  type DataTableFeatures,
 } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import type { Vendor } from "@/lib/clients/generated/core";
@@ -16,13 +15,13 @@ const dateTimeOptions = {
   timeStyle: "short",
 } as const;
 
-const columnHelper = createColumnHelper<DataTableFeatures, Vendor>();
+const columnHelper = createAppColumnHelper<Vendor>();
 
 export function getVendorsTableColumns(
   t: ReturnType<typeof useTranslations<"App.Admin.Vendors.Table">>,
   formatter: ReturnType<typeof useFormatter>,
-): ColumnDef<DataTableFeatures, Vendor>[] {
-  return [
+) {
+  return columnHelper.columns([
     columnHelper.accessor("name", {
       id: "name",
       minSize: 140,
@@ -33,7 +32,7 @@ export function getVendorsTableColumns(
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Vendor>,
+    }),
 
     columnHelper.accessor("slug", {
       id: "slug",
@@ -47,7 +46,7 @@ export function getVendorsTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Vendor>,
+    }),
 
     columnHelper.accessor("createdAt", {
       id: "createdAt",
@@ -63,7 +62,7 @@ export function getVendorsTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Vendor>,
+    }),
 
     columnHelper.accessor("updatedAt", {
       id: "updatedAt",
@@ -79,7 +78,7 @@ export function getVendorsTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Vendor>,
+    }),
 
     columnHelper.display({
       id: "actions",
@@ -98,6 +97,6 @@ export function getVendorsTableColumns(
       ),
       enableSorting: false,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, Vendor>,
-  ];
+    }),
+  ]);
 }

--- a/apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts
+++ b/apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts
@@ -52,4 +52,24 @@ describe("create-data-table-hook", () => {
       "actions",
     ]);
   });
+
+  it("accepts mixed-value columns array from columns() into useAppTable", () => {
+    const helper = createAppColumnHelper<{
+      id: string;
+      n: number;
+      s: string;
+    }>();
+    const columns = helper.columns([
+      helper.accessor("s", { id: "s" }),
+      helper.accessor("n", { id: "n" }),
+    ]);
+    const { result } = renderHook(() =>
+      useAppTable({
+        columns,
+        data: [{ id: "1", n: 2, s: "a" }],
+        initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+      }),
+    );
+    expect(result.current.getRowModel().rows).toHaveLength(1);
+  });
 });

--- a/apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts
+++ b/apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { createAppColumnHelper, useAppTable } from "../create-data-table-hook";
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+describe("create-data-table-hook", () => {
+  it("useAppTable sorts without passing features", () => {
+    const helper = createAppColumnHelper<Row>();
+    const columns = helper.columns([helper.accessor("name", { id: "name" })]);
+
+    const { result } = renderHook(() =>
+      useAppTable({
+        columns,
+        data: [
+          { id: "2", name: "bob" },
+          { id: "1", name: "alice" },
+        ],
+        initialState: {
+          pagination: { pageIndex: 0, pageSize: 50 },
+          sorting: [{ id: "name", desc: false }],
+        },
+      }),
+    );
+
+    expect(
+      result.current.getRowModel().rows.map((row) => row.original.name),
+    ).toEqual(["alice", "bob"]);
+  });
+
+  it("createAppColumnHelper columns() needs no cast to pass into useAppTable", () => {
+    const helper = createAppColumnHelper<Row>();
+    const columns = helper.columns([
+      helper.accessor("name", { id: "name" }),
+      helper.display({ id: "actions", cell: () => null }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useAppTable({
+        columns,
+        data: [{ id: "1", name: "alice" }],
+        initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+      }),
+    );
+
+    expect(result.current.getAllColumns().map((c) => c.id)).toEqual([
+      "name",
+      "actions",
+    ]);
+  });
+});

--- a/apps/web/src/components/data-table/__tests__/data-table-features.test.ts
+++ b/apps/web/src/components/data-table/__tests__/data-table-features.test.ts
@@ -1,11 +1,7 @@
-import { createColumnHelper, useTable } from "@tanstack/react-table";
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import {
-  type DataTableFeatures,
-  dataTableFeatures,
-} from "../data-table-features";
+import { createAppColumnHelper, useAppTable } from "../create-data-table-hook";
 
 interface SortRow {
   id: string;
@@ -15,7 +11,7 @@ interface SortRow {
   startedAt: Date;
 }
 
-const columnHelper = createColumnHelper<DataTableFeatures, SortRow>();
+const columnHelper = createAppColumnHelper<SortRow>();
 
 const columns = columnHelper.columns([
   columnHelper.accessor("name", { id: "name" }),
@@ -53,8 +49,7 @@ const unsorted: SortRow[] = [
 ];
 
 function useSortTable() {
-  return useTable({
-    features: dataTableFeatures,
+  return useAppTable({
     columns,
     data: unsorted,
     // Full page so row model is not truncated while testing sort order.

--- a/apps/web/src/components/data-table/create-data-table-hook.ts
+++ b/apps/web/src/components/data-table/create-data-table-hook.ts
@@ -1,0 +1,11 @@
+import { createTableHook } from "@tanstack/react-table";
+
+import { dataTableFeatures } from "./data-table-features";
+
+/**
+ * App-wide DataTable factory. Module scope only.
+ * Features are bound; pass columns/data/state per table.
+ */
+export const { useAppTable, createAppColumnHelper } = createTableHook({
+  features: dataTableFeatures,
+});

--- a/apps/web/src/components/data-table/data-table-features.ts
+++ b/apps/web/src/components/data-table/data-table-features.ts
@@ -20,7 +20,8 @@ import {
 
 /**
  * Shared TanStack Table v9 features for app DataTables.
- * Column helpers must use `createColumnHelper<DataTableFeatures, TData>()`.
+ * Bound via `createTableHook` in `create-data-table-hook.ts` —
+ * use `createAppColumnHelper<TData>()` / `useAppTable` (not bare helpers).
  *
  * `sortFns` must include every built-in name that `sortFn: "auto"` can pick
  * (datetime / alphanumeric / text) plus basic. Case-sensitive variants are

--- a/apps/web/src/components/data-table/data-table.tsx
+++ b/apps/web/src/components/data-table/data-table.tsx
@@ -10,7 +10,6 @@ import {
   type ReactTable,
   type RowData,
   type SortingState,
-  useTable,
 } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
 import * as React from "react";
@@ -24,10 +23,8 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
-import {
-  type DataTableFeatures,
-  dataTableFeatures,
-} from "./data-table-features";
+import { useAppTable } from "./create-data-table-hook";
+import type { DataTableFeatures } from "./data-table-features";
 import DataTablePagination from "./data-table-pagination";
 
 function getMinTableWidth<TData extends RowData>(
@@ -40,8 +37,7 @@ function getMinTableWidth<TData extends RowData>(
 }
 
 interface DataTableProps<TData extends RowData> {
-  // Column cell values vary per column; use `any` so mixed column defs typecheck.
-  columns: ColumnDef<DataTableFeatures, TData, any>[];
+  columns: ColumnDef<DataTableFeatures, TData, unknown>[];
   data: TData[];
   containerClassName?: string | undefined;
   tableClassName?: string | undefined;
@@ -98,11 +94,10 @@ export default function DataTable<TData extends RowData>({
   const sorting = controlledSorting ?? internalSorting;
   const setSorting = onSortingChange ?? setInternalSorting;
 
-  // TanStack Table's useTable returns functions that can't be memoized.
+  // TanStack Table's useAppTable returns functions that can't be memoized.
   // The "use no memo" directive above tells React Compiler to skip this component.
   // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useTable({
-    features: dataTableFeatures,
+  const table = useAppTable({
     data,
     columns,
     state: {

--- a/apps/web/src/components/data-table/index.ts
+++ b/apps/web/src/components/data-table/index.ts
@@ -1,3 +1,7 @@
+export {
+  createAppColumnHelper,
+  useAppTable,
+} from "./create-data-table-hook";
 export { default as DataTable } from "./data-table";
 export { default as DataTableColumnHeader } from "./data-table-column-header";
 export {

--- a/apps/web/src/components/members-table/members-table-columns.tsx
+++ b/apps/web/src/components/members-table/members-table-columns.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
 import {
+  createAppColumnHelper,
   DataTableColumnHeader,
-  type DataTableFeatures,
 } from "@/components/data-table";
 import { OrganizationRoleBadge } from "@/components/organizations";
 import { TimeAgo } from "@/components/time-ago";
@@ -14,7 +13,7 @@ import MemberActionsDropdown from "./member-actions-dropdown";
 import { useSeatManagementContext } from "./seat-management-context";
 import type { MemberRowData } from "./types";
 
-const columnHelper = createColumnHelper<DataTableFeatures, MemberRowData>();
+const columnHelper = createAppColumnHelper<MemberRowData>();
 
 export function getMembersTableColumns(
   t: ReturnType<typeof useTranslations>,
@@ -30,7 +29,7 @@ export function getMembersTableColumns(
       cell: ({ row }) => <div className="p-2">{row.original.name}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, MemberRowData>,
+    }),
 
     emailColumn: columnHelper.accessor("email", {
       id: "email",
@@ -41,7 +40,7 @@ export function getMembersTableColumns(
       cell: ({ row }) => <div className="p-2">{row.original.email}</div>,
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, MemberRowData>,
+    }),
 
     roleColumn: columnHelper.accessor("role", {
       id: "role",
@@ -56,7 +55,7 @@ export function getMembersTableColumns(
       ),
       enableSorting: true,
       enableHiding: false,
-    }) as ColumnDef<DataTableFeatures, MemberRowData>,
+    }),
 
     lastSeenColumn: columnHelper.accessor("lastSeenAt", {
       id: "lastSeen",
@@ -84,14 +83,14 @@ export function getMembersTableColumns(
         );
       },
       enableSorting: true,
-    }) as ColumnDef<DataTableFeatures, MemberRowData>,
+    }),
 
     seatColumn: columnHelper.display({
       id: "seat",
       minSize: 120,
       header: () => <div>{t("Header.seat")}</div>,
       cell: ({ row }) => <SeatStatusCell member={row.original.member} />,
-    }) as ColumnDef<DataTableFeatures, MemberRowData>,
+    }),
 
     actionColumn: columnHelper.display({
       id: "actions",
@@ -109,8 +108,24 @@ export function getMembersTableColumns(
         }
         return null;
       },
-    }) as ColumnDef<DataTableFeatures, MemberRowData>,
+    }),
   };
+}
+
+export function getMembersTableColumnList(
+  t: ReturnType<typeof useTranslations>,
+  me: OrganizationMembershipSelf,
+  options: { showSeatManagement: boolean; includeActions: boolean },
+) {
+  const cols = getMembersTableColumns(t, me);
+  return columnHelper.columns([
+    cols.nameColumn,
+    cols.emailColumn,
+    cols.roleColumn,
+    cols.lastSeenColumn,
+    ...(options.showSeatManagement ? [cols.seatColumn] : []),
+    ...(options.includeActions ? [cols.actionColumn] : []),
+  ]);
 }
 
 function SeatStatusCell({ member }: { member: MemberRowData["member"] }) {

--- a/apps/web/src/components/members-table/members-table.tsx
+++ b/apps/web/src/components/members-table/members-table.tsx
@@ -11,7 +11,7 @@ import InvitationActionsModal from "./invitation-actions-modal";
 import { InvitationActionsModalContextProvider } from "./invitation-actions-modal-context";
 import MemberActionsModal from "./member-actions-modal";
 import { MemberActionsModalContextProvider } from "./member-actions-modal-context";
-import { getMembersTableColumns } from "./members-table-columns";
+import { getMembersTableColumnList } from "./members-table-columns";
 import { SeatManagementContextProvider } from "./seat-management-context";
 import type { MemberRowData, OrganizationMember } from "./types";
 
@@ -31,6 +31,8 @@ export default function MembersTable({
   unusedSeats = 0,
 }: MembersTableProps) {
   const t = useTranslations("Components.MembersTable");
+  const isOwnerOrAdmin =
+    me.role === MemberRole.OWNER || me.role === MemberRole.ADMIN;
 
   return (
     <SeatManagementContextProvider
@@ -40,7 +42,10 @@ export default function MembersTable({
       <MemberActionsModalContextProvider>
         <InvitationActionsModalContextProvider>
           <DataTable
-            columns={getColumns(t, me, showSeatManagement)}
+            columns={getMembersTableColumnList(t, me, {
+              showSeatManagement,
+              includeActions: isOwnerOrAdmin,
+            })}
             data={combineMembersAndPendingInvitations(
               members,
               pendingInvitations,
@@ -60,27 +65,6 @@ export default function MembersTable({
       </MemberActionsModalContextProvider>
     </SeatManagementContextProvider>
   );
-}
-
-function getColumns(
-  t: ReturnType<typeof useTranslations>,
-  me: OrganizationMembershipSelf,
-  showSeatManagement: boolean,
-) {
-  const {
-    nameColumn,
-    emailColumn,
-    roleColumn,
-    lastSeenColumn,
-    seatColumn,
-    actionColumn,
-  } = getMembersTableColumns(t, me);
-  const isOwnerOrAdmin =
-    me.role === MemberRole.OWNER || me.role === MemberRole.ADMIN;
-
-  return [nameColumn, emailColumn, roleColumn, lastSeenColumn]
-    .concat(showSeatManagement ? [seatColumn] : [])
-    .concat(isOwnerOrAdmin ? [actionColumn] : []);
 }
 
 function combineMembersAndPendingInvitations(

--- a/docs/superpowers/plans/2026-08-10-data-table-create-table-hook.md
+++ b/docs/superpowers/plans/2026-08-10-data-table-create-table-hook.md
@@ -1,0 +1,592 @@
+# DataTable createTableHook Typing Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind all Sokosumi `DataTable` consumers to a module-scope `createTableHook` factory so column helpers and hub types share `DataTableFeatures`, eliminate per-column `as ColumnDef` casts and hub `any`, and preserve runtime table behavior after #3728.
+
+**Architecture:** Keep `dataTableFeatures` as the single feature registry. Add `create-data-table-hook.ts` that calls `createTableHook({ features: dataTableFeatures })` at module scope and exports `useAppTable` + `createAppColumnHelper`. `DataTable` switches from `useTable` to `useAppTable` with the same per-call options. Every column factory uses `createAppColumnHelper` + `.columns([...])` (or cast-free named pieces with at most one assembly-boundary assertion). No AppTable/AppCell markup rewrite.
+
+**Tech Stack:** `@tanstack/react-table` 9.1.2, Next.js App Router web app (`apps/web`), Vitest + Testing Library, TypeScript, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md`
+
+## Global Constraints
+
+- Exact pin remains `@tanstack/react-table` `9.1.2` (no range, no version bump required)
+- Factory must be **module scope only** — never create inside a React render
+- Do **not** register `tableComponents` / `cellComponents` / `headerComponents` on the factory this PR (HMR / circular import risk)
+- Preserve runtime: `manualPagination: !showPagination`, `manualSorting` passthrough, `enableRowRangeSelection: false`, sort registry, grouping
+- One PR migrates **all** `DataTable` column consumers
+- Conventional commits; draft PR title: `refactor(web): type DataTable via createTableHook`
+- Prefer `function` keyword for pure helpers; two-space Biome style
+
+## File map
+
+| Path | Responsibility |
+|------|----------------|
+| `apps/web/src/components/data-table/create-data-table-hook.ts` | **Create** — `createTableHook` factory exports |
+| `apps/web/src/components/data-table/data-table.tsx` | **Modify** — `useAppTable`; columns type without `any` |
+| `apps/web/src/components/data-table/index.ts` | **Modify** — re-export factory helpers |
+| `apps/web/src/components/data-table/data-table-column-header.tsx` | **Modify only if** types need factory `Column` |
+| `apps/web/src/components/data-table/data-table-pagination.tsx` | Unchanged unless type import path changes |
+| `apps/web/src/components/data-table/data-table-features.ts` | Unchanged (features source of truth) |
+| `apps/web/src/components/data-table/__tests__/data-table-features.test.ts` | **Modify** — use factory helper if needed |
+| `apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts` | **Create** — factory + helper smoke tests |
+| `apps/web/src/components/admin/agents/agent-list-columns.tsx` | Migrate |
+| `apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx` | Migrate |
+| `apps/web/src/components/admin/vendors/vendors-table-columns.tsx` | Migrate |
+| `apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx` | Migrate inline columns |
+| `apps/web/src/app/(app)/developer/components/api-keys/api-keys-columns.tsx` | Migrate |
+| `apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx` | Migrate object map |
+| `apps/web/src/components/members-table/members-table-columns.tsx` | Migrate object map |
+
+---
+
+### Task 1: Factory module + smoke tests (TDD)
+
+**Files:**
+- Create: `apps/web/src/components/data-table/create-data-table-hook.ts`
+- Create: `apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts`
+- Modify: `apps/web/src/components/data-table/index.ts`
+
+**Interfaces:**
+- Consumes: `dataTableFeatures` from `./data-table-features`
+- Produces:
+  - `useAppTable` — bound table hook (features pre-applied)
+  - `createAppColumnHelper` — `createAppColumnHelper<TData extends RowData>()`
+  - optional: re-export types as needed
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts`:
+
+```ts
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  createAppColumnHelper,
+  useAppTable,
+} from "../create-data-table-hook";
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+describe("create-data-table-hook", () => {
+  it("useAppTable sorts without passing features", () => {
+    const helper = createAppColumnHelper<Row>();
+    const columns = helper.columns([
+      helper.accessor("name", { id: "name" }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useAppTable({
+        columns,
+        data: [
+          { id: "2", name: "bob" },
+          { id: "1", name: "alice" },
+        ],
+        initialState: {
+          pagination: { pageIndex: 0, pageSize: 50 },
+          sorting: [{ id: "name", desc: false }],
+        },
+      }),
+    );
+
+    expect(
+      result.current.getRowModel().rows.map((row) => row.original.name),
+    ).toEqual(["alice", "bob"]);
+  });
+
+  it("createAppColumnHelper columns() needs no cast to pass into useAppTable", () => {
+    const helper = createAppColumnHelper<Row>();
+    const columns = helper.columns([
+      helper.accessor("name", { id: "name" }),
+      helper.display({ id: "actions", cell: () => null }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useAppTable({
+        columns,
+        data: [{ id: "1", name: "alice" }],
+        initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+      }),
+    );
+
+    expect(result.current.getAllColumns().map((c) => c.id)).toEqual([
+      "name",
+      "actions",
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter web test src/components/data-table/__tests__/create-data-table-hook.test.ts
+```
+
+Expected: FAIL — cannot resolve `../create-data-table-hook` or exports missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/web/src/components/data-table/create-data-table-hook.ts`:
+
+```ts
+import { createTableHook } from "@tanstack/react-table";
+
+import { dataTableFeatures } from "./data-table-features";
+
+/**
+ * App-wide DataTable factory. Module scope only.
+ * Features are bound; pass columns/data/state per table.
+ */
+export const {
+  useAppTable,
+  createAppColumnHelper,
+} = createTableHook({
+  features: dataTableFeatures,
+});
+```
+
+Update `apps/web/src/components/data-table/index.ts` to export:
+
+```ts
+export {
+  createAppColumnHelper,
+  useAppTable,
+} from "./create-data-table-hook";
+```
+
+(keep existing DataTable / features / pagination exports)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pnpm --filter web test src/components/data-table/__tests__/create-data-table-hook.test.ts
+pnpm --filter web test src/components/data-table/__tests__/data-table-features.test.ts
+```
+
+Expected: PASS both files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/data-table/create-data-table-hook.ts \
+  apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts \
+  apps/web/src/components/data-table/index.ts
+git commit -m "feat(web): add DataTable createTableHook factory"
+```
+
+---
+
+### Task 2: Wire DataTable hub to useAppTable; kill hub `any`
+
+**Files:**
+- Modify: `apps/web/src/components/data-table/data-table.tsx`
+- Test: existing + Task 1 tests (no new UI test required)
+
+**Interfaces:**
+- Consumes: `useAppTable` from `./create-data-table-hook`
+- Produces: `DataTable` still accepts `columns` + `data`; column type uses `unknown` not `any`
+
+- [ ] **Step 1: Write a failing type-level expectation (document via test import)**
+
+In `create-data-table-hook.test.ts`, add a test that mirrors hub usage shape:
+
+```ts
+it("accepts mixed-value columns array from columns() into useAppTable", () => {
+  const helper = createAppColumnHelper<{ id: string; n: number; s: string }>();
+  const columns = helper.columns([
+    helper.accessor("s", { id: "s" }),
+    helper.accessor("n", { id: "n" }),
+  ]);
+  const { result } = renderHook(() =>
+    useAppTable({
+      columns,
+      data: [{ id: "1", n: 2, s: "a" }],
+      initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+    }),
+  );
+  expect(result.current.getRowModel().rows).toHaveLength(1);
+});
+```
+
+Run that test (should still pass once factory exists). This locks the columns() → useAppTable path before hub change.
+
+- [ ] **Step 2: Change DataTable implementation**
+
+In `data-table.tsx`:
+
+1. Replace `useTable` import with `useAppTable` from `./create-data-table-hook`
+2. Remove `dataTableFeatures` import usage from the hook call (features come from factory)
+3. Change props:
+
+```ts
+columns: ColumnDef<DataTableFeatures, TData, unknown>[];
+```
+
+4. Replace hook call:
+
+```ts
+const table = useAppTable({
+  data,
+  columns,
+  state: {
+    sorting,
+    columnVisibility,
+    rowSelection,
+    columnFilters,
+  },
+  initialState: {
+    pagination: {
+      pageIndex: 0,
+      pageSize: initialPageSize ?? 10,
+    },
+  },
+  enableRowSelection,
+  enableRowRangeSelection: false,
+  onRowSelectionChange: setRowSelection,
+  manualPagination: !showPagination,
+  manualSorting,
+  onSortingChange: setSorting,
+  onColumnFiltersChange: setColumnFilters,
+  onColumnVisibilityChange: setColumnVisibility,
+});
+```
+
+Keep `"use no memo"` and eslint incompatible-library comment; update comment text from `useReactTable`/`useTable` to `useAppTable` if needed.
+
+If `columns: ColumnDef<…, unknown>[]` fails typecheck against `columns()` return (`any` element type from tanstack), use:
+
+```ts
+columns: ColumnDef<DataTableFeatures, TData, any>[]; // only if unknown fails — prefer unknown first
+```
+
+Spec prefers **not** `any`. If only `any` works at hub, stop and use a named alias:
+
+```ts
+/** Mixed cell TValues; prefer createAppColumnHelper().columns() at call sites. */
+export type DataTableColumns<TData extends RowData> = ColumnDef<
+  DataTableFeatures,
+  TData,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mixed column TValue
+  any
+>[];
+```
+
+Only after proving `unknown` fails typecheck with a real consumer.
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Expected: may fail on consumers still using old helper shapes until Tasks 3–4 — hub alone should typecheck if consumers still cast. Fix only hub errors here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/data-table/data-table.tsx \
+  apps/web/src/components/data-table/__tests__/create-data-table-hook.test.ts
+git commit -m "refactor(web): DataTable uses useAppTable without feature prop"
+```
+
+---
+
+### Task 3: Migrate array-style column factories
+
+**Files:**
+- Modify: `apps/web/src/components/admin/agents/agent-list-columns.tsx`
+- Modify: `apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx`
+- Modify: `apps/web/src/components/admin/vendors/vendors-table-columns.tsx`
+- Modify: `apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx`
+- Modify: `apps/web/src/app/(app)/developer/components/api-keys/api-keys-columns.tsx`
+
+**Interfaces:**
+- Consumes: `createAppColumnHelper` from `@/components/data-table`
+- Produces: `getXColumns(...):` return type compatible with `DataTable` columns prop; **no** `as ColumnDef`
+
+- [ ] **Step 1: Pattern for each file (apply to all five)**
+
+Before:
+
+```ts
+import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { DataTableColumnHeader, type DataTableFeatures } from "@/components/data-table";
+
+const columnHelper = createColumnHelper<DataTableFeatures, Row>();
+
+export function getXColumns(...): ColumnDef<DataTableFeatures, Row>[] {
+  return [
+    columnHelper.accessor("name", { ... }) as ColumnDef<DataTableFeatures, Row>,
+    // ...
+  ];
+}
+```
+
+After:
+
+```ts
+import {
+  createAppColumnHelper,
+  DataTableColumnHeader,
+} from "@/components/data-table";
+
+const columnHelper = createAppColumnHelper<Row>();
+
+export function getXColumns(...) {
+  return columnHelper.columns([
+    columnHelper.accessor("name", { ... }),
+    // ... no casts
+  ]);
+}
+```
+
+Remove unused `ColumnDef` / `DataTableFeatures` imports when no longer needed.
+
+**contracts-table.tsx:** columns are defined inline in the same file — same pattern around `createColumnHelper` / casts.
+
+- [ ] **Step 2: Typecheck after each file or batch**
+
+```bash
+pnpm --filter web typecheck
+```
+
+Fix until green for these modules.
+
+- [ ] **Step 3: Grep gate (partial)**
+
+```bash
+rg "as ColumnDef" apps/web/src/components/admin apps/web/src/app/\(app\)/developer --glob "*.{ts,tsx}"
+```
+
+Expected: no matches under those paths.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add \
+  apps/web/src/components/admin/agents/agent-list-columns.tsx \
+  apps/web/src/components/admin/coworkers/coworkers-table-columns.tsx \
+  apps/web/src/components/admin/vendors/vendors-table-columns.tsx \
+  apps/web/src/components/admin/enterprise-contracts/contracts-table.tsx \
+  apps/web/src/app/\(app\)/developer/components/api-keys/api-keys-columns.tsx
+git commit -m "refactor(web): cast-free app column helpers for admin/api-keys tables"
+```
+
+---
+
+### Task 4: Migrate jobs + members object-map column factories
+
+**Files:**
+- Modify: `apps/web/src/app/(app)/agents/[agentId]/jobs/components/job-columns.tsx`
+- Modify: `apps/web/src/components/members-table/members-table-columns.tsx`
+- Possibly touch assemblers: `jobs-table.tsx`, `members-table.tsx` if return types break
+
+**Interfaces:**
+- Keep named column properties for conditional assembly
+- No per-column `as ColumnDef`
+- At most **one** cast at assembly return if TS requires
+
+- [ ] **Step 1: job-columns.tsx**
+
+```ts
+import { createAppColumnHelper, DataTableColumnHeader } from "@/components/data-table";
+
+const columnHelper = createAppColumnHelper<JobSummary>();
+
+export function getJobColumns(...) {
+  return {
+    createdAtColumn: columnHelper.accessor("createdAt", {
+      // keep sortFn: "datetime"
+      ...
+    }),
+    statusColumn: columnHelper.accessor("status", { ... }),
+    nameColumn: columnHelper.accessor("name", { ... }),
+  };
+}
+```
+
+In `jobs-table.tsx` `getColumns`, assemble with:
+
+```ts
+return columnHelper.columns([createdAtColumn, statusColumn, nameColumn]);
+```
+
+If `columnHelper` is not in scope in `jobs-table.tsx`, either export a small `buildJobColumnsArray(...)` from `job-columns.tsx` that returns `columnHelper.columns([...])`, or assemble array and pass to DataTable — prefer **builder in job-columns.tsx**:
+
+```ts
+export function getJobTableColumns(...args) {
+  const { createdAtColumn, statusColumn, nameColumn } = getJobColumns(...args);
+  return columnHelper.columns([createdAtColumn, statusColumn, nameColumn]);
+}
+```
+
+Update `jobs-table.tsx` to call the builder if simpler.
+
+- [ ] **Step 2: members-table-columns.tsx**
+
+Same approach: `createAppColumnHelper<MemberRowData>()`, drop casts, export either named map + assembler:
+
+```ts
+export function getMembersTableColumnList(
+  t: ...,
+  me: ...,
+  options: { showSeatManagement: boolean; includeActions: boolean },
+) {
+  const cols = getMembersTableColumns(t, me);
+  const list = [cols.nameColumn, cols.emailColumn, cols.roleColumn, cols.lastSeenColumn];
+  if (options.showSeatManagement) list.push(cols.seatColumn);
+  if (options.includeActions) list.push(cols.actionColumn);
+  return columnHelper.columns(list as [typeof cols.nameColumn, ...typeof list]);
+}
+```
+
+If tuple cast is ugly, simpler path that still meets "one boundary":
+
+```ts
+return columnHelper.columns([
+  cols.nameColumn,
+  cols.emailColumn,
+  cols.roleColumn,
+  cols.lastSeenColumn,
+  ...(options.showSeatManagement ? [cols.seatColumn] : []),
+  ...(options.includeActions ? [cols.actionColumn] : []),
+]);
+```
+
+If spread breaks `columns()` typing, build full array then:
+
+```ts
+return columnHelper.columns(selected as [
+  (typeof selected)[0],
+  ...(typeof selected),
+]);
+```
+
+**Last resort (spec-allowed):** single `as ColumnDef<DataTableFeatures, MemberRowData, unknown>[]` on the **return of the assembler only**, never on each accessor.
+
+Update `members-table.tsx` `getColumns` to use the new builder if introduced.
+
+- [ ] **Step 3: Typecheck + tests**
+
+```bash
+pnpm --filter web typecheck
+pnpm --filter web test src/components/data-table
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Grep gate (full)**
+
+```bash
+rg "as ColumnDef" apps/web/src --glob "*.{ts,tsx}"
+rg "createColumnHelper<" apps/web/src --glob "*.{ts,tsx}"
+```
+
+Expected:
+- No `as ColumnDef` (except possibly one documented assembly line — prefer zero)
+- No bare `createColumnHelper<` outside `node_modules` (tests may use factory only)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(app\)/agents/\[agentId\]/jobs/components/ \
+  apps/web/src/components/members-table/
+git commit -m "refactor(web): cast-free job and members table columns"
+```
+
+---
+
+### Task 5: Align sort unit test + final verification + PR
+
+**Files:**
+- Modify if needed: `apps/web/src/components/data-table/__tests__/data-table-features.test.ts` (prefer `createAppColumnHelper` for consistency)
+- Docs: PR body only
+
+- [ ] **Step 1: Update data-table-features.test.ts to use factory**
+
+Replace:
+
+```ts
+createColumnHelper<DataTableFeatures, SortRow>()
+```
+
+with:
+
+```ts
+createAppColumnHelper<SortRow>()
+```
+
+and `useAppTable` instead of `useTable` if the test constructs a table — keeps one path.
+
+- [ ] **Step 2: Full web verify**
+
+```bash
+pnpm --filter web typecheck
+pnpm --filter web test
+pnpm exec biome check apps/web/src/components/data-table apps/web/src/components/members-table apps/web/src/components/admin \
+  "apps/web/src/app/(app)/agents/[agentId]/jobs" \
+  "apps/web/src/app/(app)/developer/components/api-keys"
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Commit + push + draft PR**
+
+```bash
+git add -A
+git status
+git commit -m "test(web): route data-table sort tests through createTableHook factory" || true
+
+git push -u origin HEAD
+
+gh pr create --draft --title "refactor(web): type DataTable via createTableHook" --body "$(cat <<'EOF'
+## Summary
+
+Follow-up to #3728. Introduces app-wide `createTableHook` factory for DataTables so features, column helpers, and hub types share one binding.
+
+- `createAppColumnHelper` / `useAppTable` (module-scope factory)
+- Cast-free column modules via `columnHelper.columns([...])`
+- Hub no longer uses `any` for mixed cell values (or documents single alias if TS forces)
+- Runtime behavior unchanged (pagination, manualSorting, range selection off)
+
+Spec: `docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md`
+
+## Test plan
+
+- [x] `pnpm --filter web typecheck`
+- [x] `pnpm --filter web test`
+- [x] data-table unit tests (features + factory)
+- [ ] Spot-check members (pagination), vendors/coworkers (no pagination), admin agents (`manualSorting`)
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist (plan self-review)
+
+| Spec requirement | Task |
+|------------------|------|
+| `createTableHook` factory module scope | Task 1 |
+| `useAppTable` inside DataTable | Task 2 |
+| No hub `any` (prefer unknown) | Task 2 |
+| All column consumers one PR | Tasks 3–4 |
+| Zero per-column `as ColumnDef` | Tasks 3–4 grep |
+| Jobs/members named assembly | Task 4 |
+| Sort registry preserved | Task 1/5 + existing tests |
+| No App* markup | All tasks non-goal |
+| Typecheck + web tests | Task 5 |
+| Draft conventional PR | Task 5 |
+
+**Placeholder scan:** none intentional.  
+**Type names:** `useAppTable`, `createAppColumnHelper`, `dataTableFeatures`, `DataTableFeatures` consistent across tasks.

--- a/docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md
+++ b/docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md
@@ -1,0 +1,179 @@
+# Design: DataTable `createTableHook` typing cleanup
+
+**Date:** 2026-08-10  
+**Status:** Approved (conversation)  
+**PR target:** follow-up to #3728 (`@tanstack/react-table` v9)  
+**Approach:** B — factory is public API; `DataTable` remains layout shell  
+
+## Goal
+
+Make shared table types agent-clear and cast-free:
+
+- One feature-bound factory (`createTableHook`) owns `DataTableFeatures`
+- Column helpers cannot drift from hub features
+- No `as ColumnDef<…>` spray; no hub `columns: … any[]`
+- Preserve runtime behavior (pagination, manual sorting, selection, grouping)
+
+## Non-goals
+
+- Rewrite table markup to `<table.AppTable>` / AppCell / AppHeader registries
+- Nested scoped table contexts
+- Multiple feature factories
+- Product/UI changes
+
+## Success criteria
+
+1. Zero `as ColumnDef` in `apps/web` table column modules
+2. Hub column prop does not use `any` (prefer `unknown` or factory-inferred column type)
+3. All current `DataTable` consumers migrate in **one PR**
+4. Existing sort registry unit tests still pass; add a type-level or compile test that wrong-feature helper is not possible (if practical without heavy tooling)
+5. `pnpm --filter web typecheck` and `pnpm --filter web test` green
+6. Manual behavior parity: paginated members, non-paginated admin table, agent list `manualSorting`
+
+## Architecture
+
+### Module layout
+
+```
+apps/web/src/components/data-table/
+  data-table-features.ts      # existing tableFeatures + sort/filter registries
+  create-data-table-hook.ts   # NEW: createTableHook({ features: dataTableFeatures, … })
+  data-table.tsx              # layout shell; useAppTable internally OR accept table
+  data-table-column-header.tsx
+  data-table-pagination.tsx
+  index.ts                    # export factory helpers + DataTable
+```
+
+**Factory (module scope only — never inside render):**
+
+```ts
+export const {
+  useAppTable,
+  createAppColumnHelper,
+  useTableContext, // export only if a consumer needs it this PR
+} = createTableHook({
+  features: dataTableFeatures,
+  // defaults that match current DataTable behavior where stable
+});
+```
+
+Bind defaults carefully: only options that are true for every table (e.g. not `manualSorting`). Per-table options stay on each `useAppTable` / `DataTable` call.
+
+### Public API
+
+**Column modules**
+
+```ts
+const columnHelper = createAppColumnHelper<RowType>();
+
+export function getXColumns(...): DataTableColumnDef<RowType>[] {
+  return columnHelper.columns([
+    columnHelper.accessor("…", { … }),
+    columnHelper.display({ … }),
+  ]);
+}
+```
+
+Export a thin alias if useful:
+
+```ts
+type DataTableColumnDef<TData extends RowData> = ColumnDef<
+  DataTableFeatures,
+  TData,
+  unknown
+>;
+// Prefer factory-inferred return of columns() over hand-written aliases when possible.
+```
+
+**Jobs / members (named columns)**
+
+Keep named building blocks if call sites need conditional assembly, but each piece is produced without casts. Prefer:
+
+```ts
+const helper = createAppColumnHelper<MemberRowData>();
+const nameColumn = helper.accessor(…); // no cast
+// assemble: helper.columns([...selected]) OR typed array with unknown TValue
+```
+
+If named exports cannot form a homogeneous array without a single boundary assertion, allow **one** assertion at the assembly function return — not per-column.
+
+**`DataTable`**
+
+Keep primary API for one-PR churn:
+
+```tsx
+<DataTable columns={…} data={…} …props />
+```
+
+Internally: `useAppTable({ …options, columns, data })` instead of raw `useTable`.
+
+Optional advanced prop for later (YAGNI unless needed mid-implementation):
+
+```tsx
+table?: ReactTable<DataTableFeatures, TData>
+```
+
+Do not require all call sites to construct tables themselves in this PR.
+
+### Typing rules
+
+| Layer | Rule |
+|-------|------|
+| Features | Single `dataTableFeatures` object; factory binds it |
+| Column helper | Only `createAppColumnHelper` (not bare `createColumnHelper` with hand-passed features) |
+| Hub columns | `ColumnDef<DataTableFeatures, TData, unknown>[]` or factory column type — **not** `any` |
+| Casts | Forbidden per-column; single assembly boundary only if TS requires |
+| Pagination / header | Types from `DataTableFeatures` / `ReactTable` as today |
+
+### Import graph / HMR
+
+- Factory module must not import consumer column modules
+- Do not register React components on the factory this PR (avoids circular HMR issues)
+- Column modules import factory from `@/components/data-table` or relative `create-data-table-hook`
+
+### Runtime behavior (must preserve)
+
+From #3728:
+
+- `manualPagination: !showPagination`
+- `manualSorting` passthrough
+- `enableRowRangeSelection: false`
+- Controlled / internal sorting state
+- Optional grouping rows
+- Sort registry (auto + datetime + full built-ins)
+
+## Migration plan (single PR)
+
+1. Add `create-data-table-hook.ts`; re-export from `index.ts`
+2. Switch `DataTable` to `useAppTable`
+3. Migrate column modules: array factories first (agents, coworkers, vendors, contracts, api-keys), then jobs/members object maps
+4. Grep-gate: no `as ColumnDef`, no bare `createColumnHelper` under table paths (except tests if needed)
+5. Typecheck + web tests + sort unit tests
+6. Draft PR conventional title e.g. `refactor(web): type DataTable via createTableHook`
+
+## Testing
+
+- Keep `data-table-features.test.ts` (sort registry)
+- Add test (or typecheck-only assert) that `useAppTable` + `createAppColumnHelper` share features — e.g. smoke renderHook sorting still works through factory if construction path differs
+- No visual regression suite required; manual checklist in PR body
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| TS variance still forces a cast | Single cast at assembly only; document why |
+| Factory defaults wrong for one table | Keep defaults minimal; pass options per call |
+| Accidental App* rewrite scope creep | Non-goal; reject in review |
+| Dual export of features + factory confuses agents | Prefer helper/factory as canonical; features export remains for edge types |
+
+## Out of scope follow-ups
+
+- AppTable / AppCell component registry
+- External atoms for table state
+- Fine-grained `table.Subscribe` render optimization
+- Removing `DataTable` wrapper entirely
+
+## Approval
+
+- Approach B chosen in session
+- Design §1–§5 approved as written (2026-08-10)

--- a/docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md
+++ b/docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md
@@ -34,7 +34,7 @@ Make shared table types agent-clear and cast-free:
 
 ### Module layout
 
-```
+```text
 apps/web/src/components/data-table/
   data-table-features.ts      # existing tableFeatures + sort/filter registries
   create-data-table-hook.ts   # NEW: createTableHook({ features: dataTableFeatures, … })


### PR DESCRIPTION
## Summary

Follow-up to #3728. Introduces app-wide `createTableHook` factory for DataTables so features, column helpers, and hub types share one binding.

- `createAppColumnHelper` / `useAppTable` (module-scope factory)
- Cast-free column modules via `columnHelper.columns([...])`
- Hub no longer uses `any` for mixed cell values (or documents single alias if TS forces)
- Runtime behavior unchanged (pagination, manualSorting, range selection off)

Spec: `docs/superpowers/specs/2026-08-10-data-table-create-table-hook-design.md`

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web test`
- [x] data-table unit tests (features + factory)
- [ ] Spot-check members (pagination), vendors/coworkers (no pagination), admin agents (`manualSorting`)