### PR TITLE
feat(web): add neverthrow action wire DTO helper

### DIFF
--- a/.cursor/rules/neverthrow.mdc
+++ b/.cursor/rules/neverthrow.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 ## Result Type Convention
 
-When you need a Result type for error handling, **always use `neverthrow`**. Do not invent custom Result types.
+When you need a Result type for error handling, **always use `neverthrow`**. Do not invent custom Result types. Do **not** use or extend `@/lib/ts-res` (legacy; migration under SOK-754).
 
 ```typescript
 import { ok, err, type Result } from "neverthrow";
@@ -13,8 +13,8 @@ import { ok, err, type Result } from "neverthrow";
 
 ### Don't
 
-- Create custom `Result<T, E>` types
-- Use `{ ok: boolean, value?: T, error?: E }` patterns
+- Create custom in-process `Result<T, E>` types or `{ ok, data }` / `{ ok, error }` libraries
+- Import `@/lib/ts-res` in **new or changed** code (remaining call sites migrate under SOK-754 children; do not add new ones)
 - Import Result types from other packages (unless they re-export neverthrow)
 
 ### Do
@@ -23,6 +23,39 @@ import { ok, err, type Result } from "neverthrow";
 - Use `isOk()` / `isErr()` for type-safe checks
 - Use `.map()`, `.mapErr()`, `.andThen()` for transformations
 
+## Server actions (web) — wire DTO
+
+Next.js Flight **does not preserve** neverthrow class methods. Server actions must **not** return raw `Result` instances to the client.
+
+In-process: neverthrow. At the action return boundary, map with the shared helper:
+
+```typescript
+import { ok, err, type Result } from "neverthrow";
+import {
+  toActionResult,
+  type ActionResultDto,
+} from "@/lib/actions/action-result";
+
+export async function myAction(): Promise<ActionResultDto<Data, ActionError>> {
+  const result: Result<Data, ActionError> = /* … */;
+  return toActionResult(result);
+}
+```
+
+Wire shape:
+
+```typescript
+type ActionResultDto<T, E> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+```
+
+**Clients:** `if (!result.ok) { /* result.error */ }` and `result.value` on success. Never `result.data` (that was `@/lib/ts-res`).
+
+This plain DTO is the **only** allowed non-neverthrow Result shape — a serialization boundary, not a second Result algebra. Do not add parallel Ok/Err helpers.
+
 ## References
 
 - [neverthrow Documentation](https://github.com/supermacro/neverthrow)
+- Web helper: `apps/web/src/lib/actions/action-result.ts`
+- Epic: SOK-754 (ban ts-res; migrate batches SOK-763…768)

--- a/.cursor/rules/neverthrow.mdc
+++ b/.cursor/rules/neverthrow.mdc
@@ -13,9 +13,12 @@ import { ok, err, type Result } from "neverthrow";
 
 ### Don't
 
-- Create custom in-process `Result<T, E>` types or `{ ok, data }` / `{ ok, error }` libraries
+- Create custom in-process `Result<T, E>` types or parallel Ok/Err libraries (including `{ ok, data }` shapes)
 - Import `@/lib/ts-res` in **new or changed** code (remaining call sites migrate under SOK-754 children; do not add new ones)
 - Import Result types from other packages (unless they re-export neverthrow)
+- Return raw neverthrow `Result` instances from Next.js server actions (methods do not survive Flight)
+
+Exception: the documented **`ActionResultDto` wire shape** below is the only allowed plain Result DTO — a serialization boundary, not a second Result algebra.
 
 ### Do
 
@@ -50,9 +53,22 @@ type ActionResultDto<T, E> =
   | { ok: false; error: E };
 ```
 
-**Clients:** `if (!result.ok) { /* result.error */ }` and `result.value` on success. Never `result.data` (that was `@/lib/ts-res`).
+`T` and `E` must be plain JSON/Flight-safe values (no class instances, `Map`, functions, etc.). The mapper only projects the envelope.
 
-This plain DTO is the **only** allowed non-neverthrow Result shape — a serialization boundary, not a second Result algebra. Do not add parallel Ok/Err helpers.
+**Clients:**
+
+```typescript
+const result = await myAction();
+if (!result.ok) {
+  // result.error
+  return;
+}
+// result.value
+```
+
+Never `result.data` (that was `@/lib/ts-res`).
+
+This plain DTO is the **only** allowed non-neverthrow Result shape. Do not add parallel Ok/Err helpers.
 
 ## References
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -45,6 +45,32 @@ Next.js serializes concurrent **server actions** per session. A long action star
 - Share server-side load logic in `src/lib/` so the Route Handler (and any future callers) stay in sync (see `src/lib/hermes/skills-marketplace-data.ts` + `GET /api/personal-assistant/skills-marketplace` as the reference pattern).
 - Do **not** fire long server actions on mount of a hidden multi-step UI while later steps still call actions.
 
+### Server action Results (neverthrow + wire DTO)
+
+**In-process** error handling always uses `neverthrow` (`ok` / `err` / `Result`). See root [neverthrow rule](../../.cursor/rules/neverthrow.mdc).
+
+**Do not use `@/lib/ts-res`** in new or changed code. That helper (`Ok` / `Err` / `result.data`) is legacy; remaining call sites migrate under SOK-754. Do not add new imports.
+
+**Server action returns** must be the plain serializable DTO — neverthrow class methods do not survive Flight:
+
+```typescript
+import { ok, err, type Result } from "neverthrow";
+import {
+  toActionResult,
+  type ActionResultDto,
+} from "@/lib/actions/action-result";
+
+// wire: { ok: true; value: T } | { ok: false; error: E }
+export async function exampleAction(): Promise<
+  ActionResultDto<{ id: string }, ActionError>
+> {
+  const result: Result<{ id: string }, ActionError> = ok({ id: "…" });
+  return toActionResult(result);
+}
+```
+
+**Clients:** branch on `result.ok`; read success as `result.value` (not `result.data`). Prefer `toActionResult` over inventing another Ok/Err helper.
+
 ### Route Organization
 
 - Group related routes using parentheses: `(app)`, `(auth)`

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -51,7 +51,7 @@ Next.js serializes concurrent **server actions** per session. A long action star
 
 **Do not use `@/lib/ts-res`** in new or changed code. That helper (`Ok` / `Err` / `result.data`) is legacy; remaining call sites migrate under SOK-754. Do not add new imports.
 
-**Server action returns** must be the plain serializable DTO — neverthrow class methods do not survive Flight:
+**Server action returns** must be the plain serializable DTO — neverthrow class methods do not survive Flight. Success and error payloads (`T` / `E`) must themselves be plain JSON/Flight-safe values.
 
 ```typescript
 import { ok, err, type Result } from "neverthrow";
@@ -69,7 +69,18 @@ export async function exampleAction(): Promise<
 }
 ```
 
-**Clients:** branch on `result.ok`; read success as `result.value` (not `result.data`). Prefer `toActionResult` over inventing another Ok/Err helper.
+**Clients** (after the action returns — not neverthrow methods):
+
+```typescript
+const result = await exampleAction();
+if (!result.ok) {
+  // result.error
+  return;
+}
+// result.value — never result.data (that was @/lib/ts-res)
+```
+
+Prefer `toActionResult` over inventing another Ok/Err helper.
 
 ### Route Organization
 

--- a/apps/web/src/lib/actions/__tests__/action-result.test.ts
+++ b/apps/web/src/lib/actions/__tests__/action-result.test.ts
@@ -1,0 +1,28 @@
+import { err, ok } from "neverthrow";
+import { describe, expect, it } from "vitest";
+
+import { toActionResult } from "@/lib/actions/action-result";
+
+describe("toActionResult", () => {
+  it("maps a successful neverthrow Result to { ok: true, value }", () => {
+    const wire = toActionResult(ok({ id: "agent-1" }));
+
+    expect(wire).toEqual({ ok: true, value: { id: "agent-1" } });
+  });
+
+  it("maps a failed neverthrow Result to { ok: false, error }", () => {
+    const wire = toActionResult(err({ code: "BAD_INPUT", message: "invalid" }));
+
+    expect(wire).toEqual({
+      ok: false,
+      error: { code: "BAD_INPUT", message: "invalid" },
+    });
+  });
+
+  it("maps ok(undefined) without inventing a data field", () => {
+    const wire = toActionResult(ok(undefined));
+
+    expect(wire).toEqual({ ok: true, value: undefined });
+    expect(wire).not.toHaveProperty("data");
+  });
+});

--- a/apps/web/src/lib/actions/action-result.ts
+++ b/apps/web/src/lib/actions/action-result.ts
@@ -7,6 +7,9 @@ import type { Result } from "neverthrow";
  * neverthrow in-process, then map at the action boundary with
  * {@link toActionResult}. Clients check `result.ok` and read `result.value`
  * (not `result.data` — that was the retired `@/lib/ts-res` shape).
+ *
+ * `T` and `E` must themselves be plain JSON/Flight-safe values (no class
+ * instances, `Map`, functions, or other non-serializable payloads).
  */
 export type ActionResultDto<T, E> =
   | { ok: true; value: T }
@@ -14,6 +17,8 @@ export type ActionResultDto<T, E> =
 
 /**
  * Project a neverthrow {@link Result} onto the server-action wire DTO.
+ *
+ * Only maps the envelope; `T` and `E` must already be Flight-serializable.
  */
 export function toActionResult<T, E>(
   result: Result<T, E>,

--- a/apps/web/src/lib/actions/action-result.ts
+++ b/apps/web/src/lib/actions/action-result.ts
@@ -1,0 +1,25 @@
+import type { Result } from "neverthrow";
+
+/**
+ * Plain serializable Result for Next.js server-action returns.
+ *
+ * neverthrow class methods do not survive Flight serialization. Build with
+ * neverthrow in-process, then map at the action boundary with
+ * {@link toActionResult}. Clients check `result.ok` and read `result.value`
+ * (not `result.data` — that was the retired `@/lib/ts-res` shape).
+ */
+export type ActionResultDto<T, E> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+/**
+ * Project a neverthrow {@link Result} onto the server-action wire DTO.
+ */
+export function toActionResult<T, E>(
+  result: Result<T, E>,
+): ActionResultDto<T, E> {
+  if (result.isOk()) {
+    return { ok: true, value: result.value };
+  }
+  return { ok: false, error: result.error };
+}


### PR DESCRIPTION
## Summary

- Add shared `ActionResultDto` + `toActionResult` for server-action wire returns (neverthrow in-process; plain `{ ok, value } | { ok, error }` over Flight).
- Lock agent policy: neverthrow only; no new `@/lib/ts-res` imports (legacy call sites migrate under SOK-754 children).
- Document client pattern (`result.ok` / `result.value`, not `result.data`) in neverthrow rule + web AGENTS.

## Parent / tickets

- Closes SOK-762 (expand ticket under SOK-754)

## Test plan

- [x] `pnpm --filter web test src/lib/actions/__tests__/action-result.test.ts`
- [x] Pre-commit `pnpm check` + full typecheck
- [ ] CI green on draft PR