### PR TITLE
feat(chat): drop kicked room from membership-visible list

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,3 +23,17 @@ _Avoid_: Notification (for this cue), banner (unless referring to a specific lay
 **Workspace switcher**:
 The header control that shows the active personal or organization workspace and lets the user switch between them. This is the identity/context control, not the Notification Center entry point.
 _Avoid_: Profile menu (unless a separate account menu is introduced), notification avatar
+
+### Chat membership
+
+**Membership-visible rooms**:
+The set of chat rooms the current user is a member of and may see in the chat room list (sidebar / chats list). Losing membership removes a room from this set.
+_Avoid_: Roster (for this set), channel list (unless referring to a specific UI label)
+
+**Room roster**:
+The set of human and coworker members of one open room. Distinct from membership-visible rooms.
+_Avoid_: Sidebar rooms, room list (when meaning who is in the room)
+
+**Membership revoke**:
+The event that the current user is no longer a member of a room — by remote removal (kick / roster remove) or by voluntary leave. After revoke they must not remain in membership-visible rooms for that room.
+_Avoid_: Access revoke (when meaning coworker workspace pilot access, not room membership)

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -50,7 +50,9 @@ import { peekPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
 import { roomReadAttentionMarker } from "@/app/chat/utils/room-read-attention-marker";
 import { shouldSignalUnreadThreadsAttention } from "@/app/chat/utils/should-signal-unread-threads-attention";
 import { useHeaderRoomSlotHost } from "@/app/components/header/use-header-room-slot-host";
+import { applyChatMembershipRevokedUi } from "@/components/chat/apply-chat-membership-revoked-ui";
 import { ChannelDiscoverabilityIcon } from "@/components/chat/channel-discoverability-icon";
+import { notifyOrganizationChatRoomsChanged } from "@/components/chat/organization-chat-events";
 import { markOrganizationChatRoomReadAction } from "@/components/chat/organization-chat-list.actions";
 import { PresenceDot } from "@/components/chat/presence-dot";
 import { applyRoomReadResultToOverlay } from "@/components/chat/room-read-overlay";
@@ -147,16 +149,42 @@ const ROOM_LIVE_POLL_MS = 3000;
 function RoomMessageRealtimeBridge({
   roomIds,
   currentUserId,
+  selectedRoomId,
   onMessage,
 }: {
   roomIds: readonly string[];
   currentUserId: string;
+  selectedRoomId: string | null;
   onMessage: (event: ChatRoomMessageEventData) => void;
 }) {
+  const router = useRouter();
+  const selectedRoomIdRef = useRef(selectedRoomId);
+  selectedRoomIdRef.current = selectedRoomId;
+
+  const handleMembershipRevoked = useCallback(
+    (event: { roomId: string }) => {
+      applyChatMembershipRevokedUi({
+        roomId: event.roomId,
+        activeRoomId: selectedRoomIdRef.current,
+        replace: (href) => {
+          router.replace(href);
+        },
+        refresh: () => {
+          router.refresh();
+        },
+        notifyRemoved: (roomId) => {
+          notifyOrganizationChatRoomsChanged({ removedRoomId: roomId });
+        },
+      });
+    },
+    [router],
+  );
+
   useChatRoomRealtime({
     roomIds,
     currentUserId,
     onMessage,
+    onMembershipRevoked: handleMembershipRevoked,
     onError: (error) => {
       console.error("Ably chat room message error:", error);
     },
@@ -1679,6 +1707,7 @@ export function RoomsClient({
           <RoomMessageRealtimeBridge
             roomIds={rooms.map((room) => room.id)}
             currentUserId={currentUserId}
+            selectedRoomId={selectedRoomId}
             onMessage={handleChatRoomRealtimeMessage}
           />
         </LazyAblyProvider>

--- a/apps/web/src/components/chat/__tests__/apply-chat-membership-revoked-ui.test.ts
+++ b/apps/web/src/components/chat/__tests__/apply-chat-membership-revoked-ui.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyChatMembershipRevokedUi } from "../apply-chat-membership-revoked-ui";
+
+describe("applyChatMembershipRevokedUi", () => {
+  it("soft-removes the room and does not navigate when another room is active", () => {
+    const notifyRemoved = vi.fn();
+    const replace = vi.fn();
+    const refresh = vi.fn();
+
+    applyChatMembershipRevokedUi({
+      roomId: "room-kicked",
+      activeRoomId: "room-other",
+      replace,
+      refresh,
+      notifyRemoved,
+    });
+
+    expect(notifyRemoved).toHaveBeenCalledWith("room-kicked");
+    expect(replace).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("soft-removes and lands on /chat when the open room is revoked", () => {
+    const notifyRemoved = vi.fn();
+    const replace = vi.fn();
+    const refresh = vi.fn();
+
+    applyChatMembershipRevokedUi({
+      roomId: "room-kicked",
+      activeRoomId: "room-kicked",
+      replace,
+      refresh,
+      notifyRemoved,
+    });
+
+    expect(notifyRemoved).toHaveBeenCalledWith("room-kicked");
+    expect(replace).toHaveBeenCalledWith("/chat");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("soft-removes when no room is selected", () => {
+    const notifyRemoved = vi.fn();
+    const replace = vi.fn();
+    const refresh = vi.fn();
+
+    applyChatMembershipRevokedUi({
+      roomId: "room-kicked",
+      activeRoomId: null,
+      replace,
+      refresh,
+      notifyRemoved,
+    });
+
+    expect(notifyRemoved).toHaveBeenCalledWith("room-kicked");
+    expect(replace).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("is safe to call twice for the same room (idempotent intent)", () => {
+    const notifyRemoved = vi.fn();
+    const replace = vi.fn();
+    const refresh = vi.fn();
+
+    const options = {
+      roomId: "room-kicked",
+      activeRoomId: "room-kicked" as string | null,
+      replace,
+      refresh,
+      notifyRemoved,
+    };
+
+    applyChatMembershipRevokedUi(options);
+    applyChatMembershipRevokedUi({ ...options, activeRoomId: null });
+
+    expect(notifyRemoved).toHaveBeenCalledTimes(2);
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/chat/apply-chat-membership-revoked-ui.ts
+++ b/apps/web/src/components/chat/apply-chat-membership-revoked-ui.ts
@@ -1,0 +1,26 @@
+/**
+ * Drop a membership-visible room after the current user loses membership
+ * (SOK-746). Mirrors voluntary leave: soft-remove from the room list, then
+ * leave the room view when that room was selected — silent, no toast.
+ */
+export interface ApplyChatMembershipRevokedUiOptions {
+  roomId: string;
+  /** Room id from `/chat/rooms/[roomId]` when a room is open; else null. */
+  activeRoomId: string | null;
+  replace: (href: string) => void;
+  refresh: () => void;
+  notifyRemoved: (roomId: string) => void;
+}
+
+export function applyChatMembershipRevokedUi(
+  options: ApplyChatMembershipRevokedUiOptions,
+): void {
+  const { roomId, activeRoomId, replace, refresh, notifyRemoved } = options;
+
+  notifyRemoved(roomId);
+
+  if (activeRoomId === roomId) {
+    replace("/chat");
+    refresh();
+  }
+}

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -63,7 +63,6 @@ import { useChatMembershipRevokedControl } from "@/lib/ably/use-chat-membership-
 import type { ChatRoom, ChatRoomPresence } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
-import { applyChatMembershipRevokedUi } from "./apply-chat-membership-revoked-ui";
 import { ChannelDiscoverabilityIcon } from "./channel-discoverability-icon";
 import { compareChatRoomsByRecentActivity } from "./chat-room-activity-sort";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
@@ -268,33 +267,18 @@ function getActiveRoomIdFromPathname(pathname: string | null): string | null {
 /**
  * List-mounted control-channel UI (SOK-746). Soft-removes membership-visible
  * rooms when kicked even if the open-room Ably island is not mounted.
+ * Navigation/refresh lives only on the open-room bridge so both mounts never
+ * double `replace`/`refresh` for the same event.
  */
 function ChatMembershipRevokedListBridge({
   currentUserId,
 }: {
   currentUserId: string;
 }) {
-  const pathname = usePathname();
-  const router = useRouter();
-  const activeRoomIdRef = useRef(getActiveRoomIdFromPathname(pathname));
-  activeRoomIdRef.current = getActiveRoomIdFromPathname(pathname);
-
   useChatMembershipRevokedControl({
     currentUserId,
     onRevoked: (event) => {
-      applyChatMembershipRevokedUi({
-        roomId: event.roomId,
-        activeRoomId: activeRoomIdRef.current,
-        replace: (href) => {
-          router.replace(href);
-        },
-        refresh: () => {
-          router.refresh();
-        },
-        notifyRemoved: (roomId) => {
-          notifyOrganizationChatRoomsChanged({ removedRoomId: roomId });
-        },
-      });
+      notifyOrganizationChatRoomsChanged({ removedRoomId: event.roomId });
     },
   });
 

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -57,15 +57,19 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import LazyAblyProvider from "@/contexts/lazy-ably-provider";
 import { useChatUnreadDocumentTitle } from "@/hooks/use-chat-unread-document-title";
+import { useChatMembershipRevokedControl } from "@/lib/ably/use-chat-membership-revoked-control";
 import type { ChatRoom, ChatRoomPresence } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/text";
+import { applyChatMembershipRevokedUi } from "./apply-chat-membership-revoked-ui";
 import { ChannelDiscoverabilityIcon } from "./channel-discoverability-icon";
 import { compareChatRoomsByRecentActivity } from "./chat-room-activity-sort";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
 import { countChatRoomsWithUnreadAttention } from "./chat-unread-document-title";
 import {
+  notifyOrganizationChatRoomsChanged,
   ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
   type OrganizationChatRoomsChangedDetail,
 } from "./organization-chat-events";
@@ -261,6 +265,42 @@ function getActiveRoomIdFromPathname(pathname: string | null): string | null {
   return roomId || null;
 }
 
+/**
+ * List-mounted control-channel UI (SOK-746). Soft-removes membership-visible
+ * rooms when kicked even if the open-room Ably island is not mounted.
+ */
+function ChatMembershipRevokedListBridge({
+  currentUserId,
+}: {
+  currentUserId: string;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const activeRoomIdRef = useRef(getActiveRoomIdFromPathname(pathname));
+  activeRoomIdRef.current = getActiveRoomIdFromPathname(pathname);
+
+  useChatMembershipRevokedControl({
+    currentUserId,
+    onRevoked: (event) => {
+      applyChatMembershipRevokedUi({
+        roomId: event.roomId,
+        activeRoomId: activeRoomIdRef.current,
+        replace: (href) => {
+          router.replace(href);
+        },
+        refresh: () => {
+          router.refresh();
+        },
+        notifyRemoved: (roomId) => {
+          notifyOrganizationChatRoomsChanged({ removedRoomId: roomId });
+        },
+      });
+    },
+  });
+
+  return null;
+}
+
 export function OrganizationChatList({
   rooms,
   roomsNextCursor,
@@ -308,6 +348,13 @@ export function OrganizationChatList({
     activeRoomId,
   });
   useChatUnreadDocumentTitle(unreadRoomCount);
+
+  const membershipRevokedBridge =
+    currentUserId.length > 0 ? (
+      <LazyAblyProvider>
+        <ChatMembershipRevokedListBridge currentUserId={currentUserId} />
+      </LazyAblyProvider>
+    ) : null;
 
   // Adjust local list when RSC props change (no Effect — keep load-more history).
   if (rooms !== prevRooms || roomsNextCursor !== prevRoomsNextCursor) {
@@ -627,6 +674,7 @@ export function OrganizationChatList({
 
   return (
     <SidebarGroup className="w-full">
+      {membershipRevokedBridge}
       <SidebarGroupContent className="space-y-2">
         <Collapsible
           open={channelSectionOpen}

--- a/apps/web/src/lib/ably/__tests__/use-chat-membership-revoked-control.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-chat-membership-revoked-control.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const controlHandlers = new Map<string, (message: unknown) => void>();
+const getMock = vi.fn((name: string) => {
+  return {
+    subscribe: vi.fn((event: string, handler: (message: unknown) => void) => {
+      if (event === "chat_membership_revoked") {
+        controlHandlers.set(name, handler);
+      }
+    }),
+    unsubscribe: vi.fn(),
+  };
+});
+
+vi.mock("ably/react", () => ({
+  useAbly: () => ({
+    channels: { get: getMock },
+  }),
+}));
+
+import { useChatMembershipRevokedControl } from "../use-chat-membership-revoked-control";
+
+describe("useChatMembershipRevokedControl", () => {
+  beforeEach(() => {
+    controlHandlers.clear();
+    getMock.mockClear();
+  });
+
+  it("subscribes to the user control channel and forwards valid revokes", async () => {
+    const onRevoked = vi.fn();
+
+    renderHook(() =>
+      useChatMembershipRevokedControl({
+        currentUserId: "user_1",
+        onRevoked,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith("chat_control:user_user_1");
+    });
+
+    const handler = controlHandlers.get("chat_control:user_user_1");
+    expect(handler).toBeTypeOf("function");
+
+    act(() => {
+      handler?.({
+        data: {
+          roomId: "room-kicked",
+          reason: "left",
+          at: "2026-08-10T12:00:00.000Z",
+        },
+      });
+    });
+
+    expect(onRevoked).toHaveBeenCalledWith({
+      roomId: "room-kicked",
+      reason: "left",
+      at: "2026-08-10T12:00:00.000Z",
+    });
+  });
+
+  it("does not subscribe without a current user id", () => {
+    renderHook(() =>
+      useChatMembershipRevokedControl({
+        currentUserId: "",
+        onRevoked: vi.fn(),
+      }),
+    );
+
+    expect(getMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/use-chat-room-realtime.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-chat-room-realtime.test.tsx
@@ -436,6 +436,50 @@ describe("useChatRoomRealtime", () => {
     });
   });
 
+  it("does not re-attach a revoked room when capability falls back to props", async () => {
+    authorizeMock.mockResolvedValue(tokenWithRooms("room-a", "room-b"));
+
+    renderHook(() =>
+      useChatRoomRealtime({
+        roomIds: ["room-a", "room-b"],
+        currentUserId: "user_1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(channelFor("chat_rooms:room_room-b").subscribe).toHaveBeenCalled();
+      expect(controlSubscribeHandler()).toBeTypeOf("function");
+    });
+
+    // Post-revoke authorize returns unparseable capability so sync would
+    // otherwise fall back to stale prop roomIds including room-b.
+    authorizeMock.mockClear();
+    authorizeMock.mockResolvedValue({ capability: "not-json" });
+    getMock.mockClear();
+    channelFor("chat_rooms:room_room-b").subscribe.mockClear();
+
+    act(() => {
+      controlSubscribeHandler()?.({
+        data: {
+          roomId: "room-b",
+          reason: "removed",
+          at: "2026-08-06T12:00:00.000Z",
+        },
+      });
+    });
+
+    expect(channelFor("chat_rooms:room_room-b").detach).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(getMock).not.toHaveBeenCalledWith("chat_rooms:room_room-b");
+    expect(
+      channelFor("chat_rooms:room_room-b").subscribe,
+    ).not.toHaveBeenCalled();
+  });
+
   it("detaches all chat rooms when token grants no room channels", async () => {
     authorizeMock.mockResolvedValue(tokenWithRooms("room-a", "room-b"));
 

--- a/apps/web/src/lib/ably/__tests__/use-chat-room-realtime.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-chat-room-realtime.test.tsx
@@ -187,11 +187,13 @@ describe("useChatRoomRealtime", () => {
 
   it("on control revoke, detaches the room immediately and re-authorizes", async () => {
     authorizeMock.mockResolvedValue(tokenWithRooms("room-a", "room-b"));
+    const onMembershipRevoked = vi.fn();
 
     renderHook(() =>
       useChatRoomRealtime({
         roomIds: ["room-a", "room-b"],
         currentUserId: "user_1",
+        onMembershipRevoked,
       }),
     );
 
@@ -215,6 +217,11 @@ describe("useChatRoomRealtime", () => {
 
     expect(channelFor("chat_rooms:room_room-b").unsubscribe).toHaveBeenCalled();
     expect(channelFor("chat_rooms:room_room-b").detach).toHaveBeenCalled();
+    expect(onMembershipRevoked).toHaveBeenCalledWith({
+      roomId: "room-b",
+      reason: "removed",
+      at: "2026-08-06T12:00:00.000Z",
+    });
 
     await waitFor(() => {
       expect(authorizeMock).toHaveBeenCalledTimes(1);

--- a/apps/web/src/lib/ably/chat-membership-revoked-event.ts
+++ b/apps/web/src/lib/ably/chat-membership-revoked-event.ts
@@ -11,3 +11,8 @@ export const chatMembershipRevokedEventSchema = z.object({
   reason: z.enum(CHAT_MEMBERSHIP_REVOKE_REASONS),
   at: z.iso.datetime(),
 });
+
+/** Canonical control-channel payload for membership revoke (SOK-742 / SOK-746). */
+export type ChatMembershipRevokedEvent = z.infer<
+  typeof chatMembershipRevokedEventSchema
+>;

--- a/apps/web/src/lib/ably/use-chat-membership-revoked-control.tsx
+++ b/apps/web/src/lib/ably/use-chat-membership-revoked-control.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { makeUserChatControlChannelName } from "@sokosumi/utils";
+import type * as Ably from "ably";
+import { useAbly } from "ably/react";
+import { useEffect, useRef } from "react";
+
+import {
+  CHAT_MEMBERSHIP_REVOKED_EVENT_NAME,
+  chatMembershipRevokedEventSchema,
+} from "./chat-membership-revoked-event";
+
+export interface ChatMembershipRevokedPayload {
+  roomId: string;
+  reason: "removed" | "left";
+  at: string;
+}
+
+interface UseChatMembershipRevokedControlOptions {
+  currentUserId: string;
+  onRevoked: (event: ChatMembershipRevokedPayload) => void;
+}
+
+/**
+ * Control-channel only: `chat_membership_revoked` for UI (SOK-746).
+ * Does not attach room message channels — pair with room list mount so
+ * membership-visible rooms drop even when the open-room realtime island is off.
+ */
+export function useChatMembershipRevokedControl({
+  currentUserId,
+  onRevoked,
+}: UseChatMembershipRevokedControlOptions): void {
+  const ably = useAbly();
+  const onRevokedRef = useRef(onRevoked);
+  onRevokedRef.current = onRevoked;
+
+  useEffect(() => {
+    if (!currentUserId) {
+      return;
+    }
+
+    function handleMembershipRevoked(message: Ably.Message) {
+      const parsed = chatMembershipRevokedEventSchema.safeParse(message.data);
+      if (!parsed.success) {
+        console.error(
+          "Failed to parse chat_membership_revoked event",
+          message,
+          parsed.error,
+        );
+        return;
+      }
+      onRevokedRef.current(parsed.data);
+    }
+
+    const controlChannel = ably.channels.get(
+      makeUserChatControlChannelName(currentUserId),
+    );
+    controlChannel.subscribe(
+      CHAT_MEMBERSHIP_REVOKED_EVENT_NAME,
+      handleMembershipRevoked,
+    );
+
+    return () => {
+      controlChannel.unsubscribe(
+        CHAT_MEMBERSHIP_REVOKED_EVENT_NAME,
+        handleMembershipRevoked,
+      );
+    };
+  }, [ably, currentUserId]);
+}

--- a/apps/web/src/lib/ably/use-chat-membership-revoked-control.tsx
+++ b/apps/web/src/lib/ably/use-chat-membership-revoked-control.tsx
@@ -7,18 +7,15 @@ import { useEffect, useRef } from "react";
 
 import {
   CHAT_MEMBERSHIP_REVOKED_EVENT_NAME,
+  type ChatMembershipRevokedEvent,
   chatMembershipRevokedEventSchema,
 } from "./chat-membership-revoked-event";
 
-export interface ChatMembershipRevokedPayload {
-  roomId: string;
-  reason: "removed" | "left";
-  at: string;
-}
+export type { ChatMembershipRevokedEvent };
 
 interface UseChatMembershipRevokedControlOptions {
   currentUserId: string;
-  onRevoked: (event: ChatMembershipRevokedPayload) => void;
+  onRevoked: (event: ChatMembershipRevokedEvent) => void;
 }
 
 /**

--- a/apps/web/src/lib/ably/use-chat-room-realtime.tsx
+++ b/apps/web/src/lib/ably/use-chat-room-realtime.tsx
@@ -23,12 +23,20 @@ import { safeDetachChannel } from "./safe-detach-channel";
 
 const CHAT_ROOM_MESSAGE_EVENT_NAME = "chat_room_message";
 
+export interface ChatMembershipRevokedRealtimeEvent {
+  roomId: string;
+  reason: "removed" | "left";
+  at: string;
+}
+
 interface UseChatRoomRealtimeOptions {
   /** Membership room ids to attach (all rooms for sidebar/live parity). */
   roomIds: readonly string[];
   currentUserId: string;
   onMessage?: (event: ChatRoomMessageEventData) => void;
   onError?: (error: Error) => void;
+  /** After local detach + re-auth queue (SOK-746 membership-visible UI). */
+  onMembershipRevoked?: (event: ChatMembershipRevokedRealtimeEvent) => void;
 }
 
 /**
@@ -48,12 +56,15 @@ export function useChatRoomRealtime({
   currentUserId,
   onMessage,
   onError,
+  onMembershipRevoked,
 }: UseChatRoomRealtimeOptions) {
   const ably = useAbly();
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
+  const onMembershipRevokedRef = useRef(onMembershipRevoked);
+  onMembershipRevokedRef.current = onMembershipRevoked;
   const currentUserIdRef = useRef(currentUserId);
   currentUserIdRef.current = currentUserId;
 
@@ -203,6 +214,7 @@ export function useChatRoomRealtime({
       syncGenerationRef.current += 1;
       detachRoomLocally(parsed.data.roomId);
       void syncMembershipChannels();
+      onMembershipRevokedRef.current?.(parsed.data);
     }
 
     void syncMembershipChannels();

--- a/apps/web/src/lib/ably/use-chat-room-realtime.tsx
+++ b/apps/web/src/lib/ably/use-chat-room-realtime.tsx
@@ -15,6 +15,7 @@ import {
 
 import {
   CHAT_MEMBERSHIP_REVOKED_EVENT_NAME,
+  type ChatMembershipRevokedEvent,
   chatMembershipRevokedEventSchema,
 } from "./chat-membership-revoked-event";
 import { chatRoomIdsFromAblyCapability } from "./chat-room-ids-from-ably-capability";
@@ -23,12 +24,6 @@ import { safeDetachChannel } from "./safe-detach-channel";
 
 const CHAT_ROOM_MESSAGE_EVENT_NAME = "chat_room_message";
 
-export interface ChatMembershipRevokedRealtimeEvent {
-  roomId: string;
-  reason: "removed" | "left";
-  at: string;
-}
-
 interface UseChatRoomRealtimeOptions {
   /** Membership room ids to attach (all rooms for sidebar/live parity). */
   roomIds: readonly string[];
@@ -36,7 +31,7 @@ interface UseChatRoomRealtimeOptions {
   onMessage?: (event: ChatRoomMessageEventData) => void;
   onError?: (error: Error) => void;
   /** After local detach + re-auth queue (SOK-746 membership-visible UI). */
-  onMembershipRevoked?: (event: ChatMembershipRevokedRealtimeEvent) => void;
+  onMembershipRevoked?: (event: ChatMembershipRevokedEvent) => void;
 }
 
 /**
@@ -93,6 +88,12 @@ export function useChatRoomRealtime({
   const syncGenerationRef = useRef(0);
   const roomIdsRef = useRef(roomIds);
   roomIdsRef.current = roomIds;
+  /**
+   * Rooms detached via control-channel revoke. Kept out of `nextIds` even when
+   * capability parsing falls back to stale prop roomIds, until props drop the
+   * room (membership-visible list refreshed). Re-add later re-attaches cleanly.
+   */
+  const locallyRevokedRoomIdsRef = useRef(new Set<string>());
 
   const roomIdsKey = useMemo(
     () => [...new Set(roomIds)].sort().join("\0"),
@@ -108,6 +109,7 @@ export function useChatRoomRealtime({
     /** Coalesce focus+visibility+revoke so two applies never interleave. */
     let syncInFlight = false;
     let syncQueued = false;
+    const locallyRevokedRoomIds = locallyRevokedRoomIdsRef.current;
 
     function detachRoomLocally(roomId: string) {
       const attached = channelsRef.current;
@@ -125,6 +127,14 @@ export function useChatRoomRealtime({
       const propIds = new Set(
         [...new Set(roomIdsRef.current)].filter((id) => id.length > 0),
       );
+
+      // Membership dropped from props → clear revoke marker so a later rejoin
+      // can re-attach. Keep markers while props still list the room (stale).
+      for (const roomId of [...locallyRevokedRoomIds]) {
+        if (!propIds.has(roomId)) {
+          locallyRevokedRoomIds.delete(roomId);
+        }
+      }
 
       let tokenDetails: Ably.TokenDetails | null = null;
       try {
@@ -150,12 +160,15 @@ export function useChatRoomRealtime({
         tokenDetails?.capability,
       );
       // Capability ∩ props when parseable; props alone if capability missing
-      // (degraded — same as pre-SOK-742 attach set).
-      const nextIds =
+      // (degraded — same as pre-SOK-742 attach set). Always exclude rooms
+      // revoked on this client until membership props catch up.
+      const candidateIds =
         allowedFromToken == null
           ? propIds
           : new Set([...propIds].filter((id) => allowedFromToken.has(id)));
-
+      const nextIds = new Set(
+        [...candidateIds].filter((id) => !locallyRevokedRoomIds.has(id)),
+      );
       // Re-check before mutating channels: a newer request may have queued
       // while authorize was in flight (single-flight drains it next).
       if (generation !== syncGenerationRef.current) {
@@ -212,6 +225,7 @@ export function useChatRoomRealtime({
       // Invalidate any in-flight authorize that still holds the old room cap
       // so it cannot re-attach after this detach (before the queued re-auth).
       syncGenerationRef.current += 1;
+      locallyRevokedRoomIds.add(parsed.data.roomId);
       detachRoomLocally(parsed.data.roomId);
       void syncMembershipChannels();
       onMembershipRevokedRef.current?.(parsed.data);


### PR DESCRIPTION
## Summary

Closes [SOK-746](https://linear.app/masumi/issue/SOK-746/drop-kicked-room-from-chat-ui-when-membership-is-revoked).

- On `chat_membership_revoked` (`removed` | `left`), soft-remove the room from membership-visible list via existing leave path.
- If that room is open: silent `replace("/chat")` + `refresh()` (no toast).
- List-mounted control channel so sidebar drops even when open-room Ably island is off; open-room path still detaches Ably and applies the same UI.

## Test plan

- [x] `pnpm web:check`
- [x] `pnpm web:test`
- [x] pre-commit typecheck
- [ ] CI green
- [ ] Manual: kick user from channel → row gone; if open → land `/chat` without toast