### PR TITLE
feat(web): migrate coworker early-access to neverthrow

### DIFF
--- a/apps/web/src/app/(app)/developer/components/coworkers/developer-coworker-early-access.tsx
+++ b/apps/web/src/app/(app)/developer/components/coworkers/developer-coworker-early-access.tsx
@@ -72,7 +72,7 @@ export function DeveloperCoworkerEarlyAccess({
       setOrganizationSlug("");
       setEmail("");
       toast.success(
-        result.data.status === "PENDING" ? t("pendingSuccess") : t("success"),
+        result.value.status === "PENDING" ? t("pendingSuccess") : t("success"),
       );
       router.refresh();
     } finally {

--- a/apps/web/src/components/coworker-access/coworker-access-list.tsx
+++ b/apps/web/src/components/coworker-access/coworker-access-list.tsx
@@ -14,13 +14,13 @@ import {
   denyMyCoworkerAccess,
   revokeMyCoworkerAccess,
 } from "@/lib/actions/account/coworker-access-action";
+import type { ActionResultDto } from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
 import {
   approveOrganizationCoworkerAccess,
   denyOrganizationCoworkerAccess,
   revokeOrganizationCoworkerAccess,
 } from "@/lib/actions/organization";
-import type { Result } from "@/lib/ts-res";
 import {
   type CoworkerAccessEntry,
   coworkerAccessStatusMessageKey,
@@ -147,7 +147,7 @@ function CoworkerAccessCardActions({
 
   async function approveAccess(
     accessId: string,
-  ): Promise<Result<{ accessId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ accessId: string }, ActionError>> {
     if (mode === "organization") {
       const id = requireOrganizationId();
       if (!id) {
@@ -163,7 +163,7 @@ function CoworkerAccessCardActions({
 
   async function denyAccess(
     accessId: string,
-  ): Promise<Result<{ accessId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ accessId: string }, ActionError>> {
     if (mode === "organization") {
       const id = requireOrganizationId();
       if (!id) {
@@ -179,7 +179,7 @@ function CoworkerAccessCardActions({
 
   async function revokeAccess(
     accessId: string,
-  ): Promise<Result<{ accessId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ accessId: string }, ActionError>> {
     if (mode === "organization") {
       const id = requireOrganizationId();
       if (!id) {
@@ -195,7 +195,7 @@ function CoworkerAccessCardActions({
 
   async function runAction(
     action: CoworkerAccessCardAction,
-    step: () => Promise<Result<unknown, ActionError>>,
+    step: () => Promise<ActionResultDto<unknown, ActionError>>,
     successKey: "approveSuccess" | "denySuccess" | "revokeSuccess",
     errorKey: "approveError" | "denyError" | "revokeError",
   ) {

--- a/apps/web/src/lib/actions/account/coworker-access-action.ts
+++ b/apps/web/src/lib/actions/account/coworker-access-action.ts
@@ -1,11 +1,15 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
 
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import { coworkerAccessService } from "@/lib/services/coworker-access.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -24,21 +28,21 @@ type PersonalAccessMutation = "approve" | "deny" | "revoke";
 function personalCoworkerAccessAction(method: PersonalAccessMutation) {
   return withSession<
     CoworkerAccessMutationParameters,
-    Result<{ accessId: string }, ActionError>
+    ActionResultDto<{ accessId: string }, ActionError>
   >(async ({ accessId }) => {
     const parsed = coworkerAccessActionSchema.safeParse({ accessId });
     if (!parsed.success) {
-      return Err({ code: CommonErrorCode.BAD_INPUT });
+      return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
     }
 
     try {
       const access = await coworkerAccessService[method](parsed.data.accessId, {
         type: "personal",
       });
-      return Ok({ accessId: access.id });
+      return toActionResult(ok({ accessId: access.id }));
     } catch (error) {
       console.error(`Failed to ${method} personal coworker access`, error);
-      return Err(toCoreApiActionError(error));
+      return toActionResult(err(toCoreApiActionError(error)));
     }
   });
 }

--- a/apps/web/src/lib/actions/coworkers/__tests__/workspace-access.action.test.ts
+++ b/apps/web/src/lib/actions/coworkers/__tests__/workspace-access.action.test.ts
@@ -45,7 +45,7 @@ describe("grantDeveloperCoworkerEarlyAccessAction", () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.data).toEqual({
+      expect(result.value).toEqual({
         accessId: "access-1",
         status: "GRANTED",
       });

--- a/apps/web/src/lib/actions/coworkers/__tests__/workspace-access.action.test.ts
+++ b/apps/web/src/lib/actions/coworkers/__tests__/workspace-access.action.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/middleware/auth-middleware", () => ({
 import {
   grantDeveloperCoworkerEarlyAccessAction,
   revokeDeveloperCoworkerEarlyAccessAction,
-} from "../workspace-access.action";
+} from "@/lib/actions/coworkers/workspace-access.action";
 
 const COWORKER_ID = "11111111-1111-4111-8111-111111111111";
 const WORKSPACE_ID = "22222222-2222-4222-8222-222222222222";

--- a/apps/web/src/lib/actions/coworkers/__tests__/workspace-access.action.test.ts
+++ b/apps/web/src/lib/actions/coworkers/__tests__/workspace-access.action.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { CommonErrorCode } from "@/lib/actions/errors";
+import { CoreApiRequestError } from "@/lib/clients/core.client";
+
 const createForCoworkerMock = vi.fn();
+const forceRevokeForCoworkerMock = vi.fn();
 const revalidatePathMock = vi.fn();
 
 vi.mock("server-only", () => ({}));
@@ -12,6 +16,8 @@ vi.mock("next/cache", () => ({
 vi.mock("@/lib/services/coworker-access.service", () => ({
   coworkerAccessService: {
     createForCoworker: (...args: unknown[]) => createForCoworkerMock(...args),
+    forceRevokeForCoworker: (...args: unknown[]) =>
+      forceRevokeForCoworkerMock(...args),
   },
 }));
 
@@ -24,7 +30,13 @@ vi.mock("@/middleware/auth-middleware", () => ({
       handler({ ...args, session: { user: { id: "user_1" } } }),
 }));
 
-import { grantDeveloperCoworkerEarlyAccessAction } from "../workspace-access.action";
+import {
+  grantDeveloperCoworkerEarlyAccessAction,
+  revokeDeveloperCoworkerEarlyAccessAction,
+} from "../workspace-access.action";
+
+const COWORKER_ID = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE_ID = "22222222-2222-4222-8222-222222222222";
 
 describe("grantDeveloperCoworkerEarlyAccessAction", () => {
   beforeEach(() => {
@@ -38,7 +50,7 @@ describe("grantDeveloperCoworkerEarlyAccessAction", () => {
     });
 
     const result = await grantDeveloperCoworkerEarlyAccessAction({
-      coworkerId: "11111111-1111-4111-8111-111111111111",
+      coworkerId: COWORKER_ID,
       targetType: "organization",
       targetValue: "acme-corp",
     });
@@ -50,12 +62,11 @@ describe("grantDeveloperCoworkerEarlyAccessAction", () => {
         status: "GRANTED",
       });
     }
-    expect(createForCoworkerMock).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { organizationSlug: "acme-corp" },
-    );
+    expect(createForCoworkerMock).toHaveBeenCalledWith(COWORKER_ID, {
+      organizationSlug: "acme-corp",
+    });
     expect(revalidatePathMock).toHaveBeenCalledWith(
-      "/developer/coworkers/11111111-1111-4111-8111-111111111111",
+      `/developer/coworkers/${COWORKER_ID}`,
     );
   });
 
@@ -66,26 +77,105 @@ describe("grantDeveloperCoworkerEarlyAccessAction", () => {
     });
 
     const result = await grantDeveloperCoworkerEarlyAccessAction({
-      coworkerId: "11111111-1111-4111-8111-111111111111",
+      coworkerId: COWORKER_ID,
       targetType: "user",
       targetValue: "pilot@example.com",
     });
 
     expect(result.ok).toBe(true);
-    expect(createForCoworkerMock).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { email: "pilot@example.com" },
-    );
+    expect(createForCoworkerMock).toHaveBeenCalledWith(COWORKER_ID, {
+      email: "pilot@example.com",
+    });
   });
 
-  it("rejects invalid email", async () => {
+  it("rejects invalid email with BAD_INPUT shape", async () => {
     const result = await grantDeveloperCoworkerEarlyAccessAction({
-      coworkerId: "11111111-1111-4111-8111-111111111111",
+      coworkerId: COWORKER_ID,
       targetType: "user",
       targetValue: "not-an-email",
     });
 
     expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatchObject({
+        code: CommonErrorCode.BAD_INPUT,
+        message: "Enter a valid email address",
+      });
+    }
     expect(createForCoworkerMock).not.toHaveBeenCalled();
+  });
+
+  it("maps service failures through toCoreApiActionError", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    createForCoworkerMock.mockRejectedValue(
+      new CoreApiRequestError("Core backend timeout", { status: 503 }),
+    );
+
+    try {
+      const result = await grantDeveloperCoworkerEarlyAccessAction({
+        coworkerId: COWORKER_ID,
+        targetType: "organization",
+        targetValue: "acme-corp",
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatchObject({
+          code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+          message: "The service is currently unavailable.",
+        });
+      }
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+describe("revokeDeveloperCoworkerEarlyAccessAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("revokes access by workspace id", async () => {
+    forceRevokeForCoworkerMock.mockResolvedValue({
+      id: "access-3",
+      status: "REVOKED",
+    });
+
+    const result = await revokeDeveloperCoworkerEarlyAccessAction({
+      coworkerId: COWORKER_ID,
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        accessId: "access-3",
+        status: "REVOKED",
+      });
+    }
+    expect(forceRevokeForCoworkerMock).toHaveBeenCalledWith(COWORKER_ID, {
+      workspaceId: WORKSPACE_ID,
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith(
+      `/developer/coworkers/${COWORKER_ID}`,
+    );
+  });
+
+  it("rejects invalid workspace id", async () => {
+    const result = await revokeDeveloperCoworkerEarlyAccessAction({
+      coworkerId: COWORKER_ID,
+      workspaceId: "not-a-uuid",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatchObject({
+        code: CommonErrorCode.BAD_INPUT,
+      });
+    }
+    expect(forceRevokeForCoworkerMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/actions/coworkers/workspace-access.action.ts
+++ b/apps/web/src/lib/actions/coworkers/workspace-access.action.ts
@@ -1,12 +1,16 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import * as z from "zod";
 
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import { coworkerAccessService } from "@/lib/services/coworker-access.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -43,7 +47,7 @@ function toAccessTargetBody(parsed: {
  */
 export const grantDeveloperCoworkerEarlyAccessAction = withSession<
   GrantDeveloperCoworkerEarlyAccessParameters,
-  Result<{ accessId: string; status: string }, ActionError>
+  ActionResultDto<{ accessId: string; status: string }, ActionError>
 >(async ({ coworkerId, targetType, targetValue }) => {
   const parsed = grantCoworkerEarlyAccessSchema.safeParse({
     coworkerId,
@@ -51,7 +55,7 @@ export const grantDeveloperCoworkerEarlyAccessAction = withSession<
     targetValue,
   });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   if (parsed.data.targetType === "user") {
@@ -60,10 +64,12 @@ export const grantDeveloperCoworkerEarlyAccessAction = withSession<
       .email()
       .safeParse(parsed.data.targetValue.trim());
     if (!emailCheck.success) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "Enter a valid email address",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: "Enter a valid email address",
+        }),
+      );
     }
   }
 
@@ -75,10 +81,10 @@ export const grantDeveloperCoworkerEarlyAccessAction = withSession<
 
     revalidatePath(`/developer/coworkers/${parsed.data.coworkerId}`);
     revalidatePath("/developer/coworkers");
-    return Ok({ accessId: access.id, status: access.status });
+    return toActionResult(ok({ accessId: access.id, status: access.status }));
   } catch (error) {
     console.error("Failed to grant developer coworker early access", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
@@ -96,14 +102,14 @@ interface RevokeDeveloperCoworkerEarlyAccessParameters
 /** Revoke GRANTED access for a list row (vendor admin of the coworker). */
 export const revokeDeveloperCoworkerEarlyAccessAction = withSession<
   RevokeDeveloperCoworkerEarlyAccessParameters,
-  Result<{ accessId: string; status: string }, ActionError>
+  ActionResultDto<{ accessId: string; status: string }, ActionError>
 >(async ({ coworkerId, workspaceId }) => {
   const parsed = revokeCoworkerEarlyAccessByWorkspaceSchema.safeParse({
     coworkerId,
     workspaceId,
   });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -114,9 +120,9 @@ export const revokeDeveloperCoworkerEarlyAccessAction = withSession<
 
     revalidatePath(`/developer/coworkers/${parsed.data.coworkerId}`);
     revalidatePath("/developer/coworkers");
-    return Ok({ accessId: access.id, status: access.status });
+    return toActionResult(ok({ accessId: access.id, status: access.status }));
   } catch (error) {
     console.error("Failed to revoke developer coworker early access", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/organization/coworker-access-action.ts
+++ b/apps/web/src/lib/actions/organization/coworker-access-action.ts
@@ -1,11 +1,15 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
 
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import { coworkerAccessService } from "@/lib/services/coworker-access.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -26,14 +30,14 @@ type OrganizationAccessMutation = "approve" | "deny" | "revoke";
 function organizationCoworkerAccessAction(method: OrganizationAccessMutation) {
   return withSession<
     CoworkerAccessMutationParameters,
-    Result<{ accessId: string }, ActionError>
+    ActionResultDto<{ accessId: string }, ActionError>
   >(async ({ organizationId, accessId }) => {
     const parsed = coworkerAccessActionSchema.safeParse({
       organizationId,
       accessId,
     });
     if (!parsed.success) {
-      return Err({ code: CommonErrorCode.BAD_INPUT });
+      return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
     }
 
     try {
@@ -41,10 +45,10 @@ function organizationCoworkerAccessAction(method: OrganizationAccessMutation) {
         type: "organization",
         organizationId: parsed.data.organizationId,
       });
-      return Ok({ accessId: access.id });
+      return toActionResult(ok({ accessId: access.id }));
     } catch (error) {
       console.error(`Failed to ${method} organization coworker access`, error);
-      return Err(toCoreApiActionError(error));
+      return toActionResult(err(toCoreApiActionError(error)));
     }
   });
 }

--- a/docs/plans/sok-754-neverthrow-stack.md
+++ b/docs/plans/sok-754-neverthrow-stack.md
@@ -1,0 +1,77 @@
+# SOK-754 — Ban ts-res; neverthrow stack
+
+## Goal
+
+Migrate web Results off `@/lib/ts-res` onto neverthrow + `ActionResultDto` wire shape (SOK-762). Ship as **GitHub stacked PRs** (`gh stack`).
+
+## Locked pattern (SOK-762)
+
+| Layer | Shape |
+|-------|--------|
+| In-process | `import { ok, err, type Result } from "neverthrow"` |
+| Action return | `toActionResult(result)` → `ActionResultDto<T,E>` = `{ ok: true; value: T } \| { ok: false; error: E }` |
+| Clients | `if (!result.ok) …` then `result.value` (never `result.data`) |
+
+## PR Plan
+
+### PR 1: SOK-763 coworker early-access
+
+- **Description:** Migrate coworker early-access actions + UI off ts-res.
+- **Files/components affected:** `workspace-access.action.ts`, `account/coworker-access-action.ts`, `organization/coworker-access-action.ts`, `coworker-access-list.tsx`, `developer-coworker-early-access.tsx`, `coworker-access-notification-actions.tsx`, related tests
+- **Dependencies:** None (SOK-762 merged on main)
+- **Branch:** `sok-763-neverthrow-coworker-early-access`
+
+### PR 2: SOK-764 vendor-grant
+
+- **Description:** Migrate vendor-grant domain actions + UI.
+- **Files/components affected:** `account/vendor-grant-action.ts`, `organization/vendor-grant-action.ts`, `vendor-grants/*`, `tasks-pending-vendor-grant-banner.tsx`, tests
+- **Dependencies:** PR 1
+- **Branch:** `sok-764-neverthrow-vendor-grant`
+
+### PR 3: SOK-765 admin surface
+
+- **Description:** Migrate admin action modules + admin UI callers.
+- **Files/components affected:** `admin-*`, `free-credit-admin`, `invoice-admin`, `vendors/vendor-admin.action.ts`, admin components using `result.data`
+- **Dependencies:** PR 2
+- **Branch:** `sok-765-neverthrow-admin-actions`
+
+### PR 4: SOK-766 auth / onboarding / oauth / subscription
+
+- **Description:** Migrate auth, onboarding, oauth, subscription, seat.
+- **Files/components affected:** `auth/action.ts`, `onboarding/action.ts`, `oauth/action.ts`, `subscription/*`, `organization/seat-action.ts`, related UI
+- **Dependencies:** PR 3
+- **Branch:** `sok-766-neverthrow-auth-onboarding`
+
+### PR 5: SOK-767 remaining
+
+- **Description:** All leftover ts-res production imports (org, credits, hermes, jobs, design-md, coworker display, enterprise, ratings, stragglers).
+- **Files/components affected:** remaining `@/lib/ts-res` importers outside module itself
+- **Dependencies:** PR 4
+- **Branch:** `sok-767-neverthrow-remaining`
+
+### PR 6: SOK-768 delete + enforce
+
+- **Description:** Delete `apps/web/src/lib/ts-res`, zero imports, CI/docs ban.
+- **Files/components affected:** `ts-res/*`, neverthrow rule, biome/CI guard if any
+- **Dependencies:** PR 5
+- **Branch:** `sok-768-delete-ts-res-enforce`
+
+## Stack ops
+
+```bash
+gh stack init \
+  sok-763-neverthrow-coworker-early-access \
+  sok-764-neverthrow-vendor-grant \
+  sok-765-neverthrow-admin-actions \
+  sok-766-neverthrow-auth-onboarding \
+  sok-767-neverthrow-remaining \
+  sok-768-delete-ts-res-enforce
+
+# After each layer is committed on its branch:
+gh stack submit --auto   # drafts by default
+```
+
+## Non-goals
+
+- Core API error shapes
+- Behaviour changes beyond Result envelope rename (`data` → `value`)

--- a/docs/plans/sok-754-neverthrow-stack.md
+++ b/docs/plans/sok-754-neverthrow-stack.md
@@ -17,7 +17,8 @@ Migrate web Results off `@/lib/ts-res` onto neverthrow + `ActionResultDto` wire 
 ### PR 1: SOK-763 coworker early-access
 
 - **Description:** Migrate coworker early-access actions + UI off ts-res.
-- **Files/components affected:** `workspace-access.action.ts`, `account/coworker-access-action.ts`, `organization/coworker-access-action.ts`, `coworker-access-list.tsx`, `developer-coworker-early-access.tsx`, `coworker-access-notification-actions.tsx`, related tests
+- **Files/components affected:** `workspace-access.action.ts`, `account/coworker-access-action.ts`, `organization/coworker-access-action.ts`, `coworker-access-list.tsx`, `developer-coworker-early-access.tsx`, related tests
+- **Call-site rule:** only edit callers that read `result.data` (or type as `ts-res` `Result`). Pure `result.ok` / `result.error` UIs (e.g. `coworker-access-notification-actions.tsx`) need **verify only** — no code change if they never touch the success payload.
 - **Dependencies:** None (SOK-762 merged on main)
 - **Branch:** `sok-763-neverthrow-coworker-early-access`
 


### PR DESCRIPTION
## Summary
Migrate coworker early-access domain off `@/lib/ts-res` onto neverthrow + `ActionResultDto` (`toActionResult`).

**Linear:** [SOK-763](https://linear.app/masumi/issue/SOK-763) · Parent [SOK-754](https://linear.app/masumi/issue/SOK-754)

## Stack
1. **this** → #3738 → #3739 → #3740 → #3741 → #3742

## Pattern
- In-process: `neverthrow` (`ok`/`err`)
- Action return: `toActionResult` → `{ ok, value }` / `{ ok, error }`
- Clients: `result.value` (not `result.data`)

## Test plan
- [x] `workspace-access.action` unit tests
- [x] pre-commit check + typecheck