### PR TITLE
feat(web): migrate vendor-grant domain to neverthrow

### DIFF
--- a/apps/web/src/app/(app)/components/header/__tests__/notification-item.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/notification-item.test.tsx
@@ -87,7 +87,10 @@ describe("NotificationItem vendor-grant Accept", () => {
     approveMyVendorGrantMock.mockReset();
     approveOrganizationVendorGrantMock.mockReset();
     removeNotificationMock.mockReset();
-    approveMyVendorGrantMock.mockResolvedValue({ ok: true, data: {} });
+    approveMyVendorGrantMock.mockResolvedValue({
+      ok: true,
+      value: { grantId: "grant-1" },
+    });
   });
 
   it("does not fire row navigation onClick when Accept is clicked", async () => {

--- a/apps/web/src/app/(app)/tasks/components/tasks-pending-vendor-grant-banner.tsx
+++ b/apps/web/src/app/(app)/tasks/components/tasks-pending-vendor-grant-banner.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { err, ok } from "neverthrow";
 import { useTranslations } from "next-intl";
-
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { VendorGrantApprovalActions } from "@/components/vendor-grants/vendor-grant-approval-actions";
 import { createMyVendorGrant } from "@/lib/actions/account/vendor-grant-action";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
 import { createOrganizationVendorGrant } from "@/lib/actions/organization/vendor-grant-action";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 
 interface TasksPendingVendorGrantBannerProps {
   canApprove: boolean;
@@ -46,7 +49,7 @@ export function TasksPendingVendorGrantBanner({
 
   async function grantVendorAccess(
     vendorId: string,
-  ): Promise<Result<{ grantId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ grantId: string }, ActionError>> {
     if (organizationId) {
       return createOrganizationVendorGrant({
         organizationId,
@@ -57,7 +60,7 @@ export function TasksPendingVendorGrantBanner({
   }
 
   async function approveAllPendingGrants(): Promise<
-    Result<unknown, ActionError>
+    ActionResultDto<unknown, ActionError>
   > {
     let approved = 0;
 
@@ -65,13 +68,15 @@ export function TasksPendingVendorGrantBanner({
       const result = await grantVendorAccess(vendorId);
       if (!result.ok) {
         if (approved > 0) {
-          return Err({
-            code: "vendor_grant_partial_approve",
-            message: t("approvePartialError", {
-              approved,
-              total: pendingVendorIds.length,
+          return toActionResult(
+            err({
+              code: "vendor_grant_partial_approve",
+              message: t("approvePartialError", {
+                approved,
+                total: pendingVendorIds.length,
+              }),
             }),
-          });
+          );
         }
 
         return result;
@@ -80,7 +85,7 @@ export function TasksPendingVendorGrantBanner({
       approved += 1;
     }
 
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   }
 
   return (

--- a/apps/web/src/components/vendor-grants/vendor-grant-approval-actions.tsx
+++ b/apps/web/src/components/vendor-grants/vendor-grant-approval-actions.tsx
@@ -8,8 +8,8 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { useNotifications } from "@/contexts/notification-provider";
+import type { ActionResultDto } from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
-import type { Result } from "@/lib/ts-res";
 
 interface VendorGrantApprovalActionsLabels {
   approve: string;
@@ -26,8 +26,8 @@ interface VendorGrantApprovalActionsProps {
   reviewHref?: string | null;
   refreshAfterApproveAttempt?: boolean;
   labels: VendorGrantApprovalActionsLabels;
-  onApprove: () => Promise<Result<unknown, ActionError>>;
-  onDeny?: () => Promise<Result<unknown, ActionError>>;
+  onApprove: () => Promise<ActionResultDto<unknown, ActionError>>;
+  onDeny?: () => Promise<ActionResultDto<unknown, ActionError>>;
 }
 
 export function VendorGrantApprovalActions({
@@ -46,7 +46,7 @@ export function VendorGrantApprovalActions({
 
   async function runAction(
     action: "approve" | "deny",
-    mutation: () => Promise<Result<unknown, ActionError>>,
+    mutation: () => Promise<ActionResultDto<unknown, ActionError>>,
   ) {
     setLoadingAction(action);
     let shouldRefresh = false;

--- a/apps/web/src/components/vendor-grants/vendor-grant-create-form.tsx
+++ b/apps/web/src/components/vendor-grants/vendor-grant-create-form.tsx
@@ -14,8 +14,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import type { ActionResultDto } from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
-import type { Result } from "@/lib/ts-res";
 
 type VendorGrantFormNamespace =
   | "App.Account.VendorGrants"
@@ -27,7 +27,7 @@ interface VendorGrantCreateFormProps {
   namespace: VendorGrantFormNamespace;
   onCreate: (params: {
     vendorId: string;
-  }) => Promise<Result<{ grantId: string }, ActionError>>;
+  }) => Promise<ActionResultDto<{ grantId: string }, ActionError>>;
 }
 
 function firstEnabledVendorId(

--- a/apps/web/src/components/vendor-grants/vendor-grant-vendor-list.tsx
+++ b/apps/web/src/components/vendor-grants/vendor-grant-vendor-list.tsx
@@ -16,6 +16,7 @@ import {
   denyMyVendorGrant,
   revokeMyVendorGrant,
 } from "@/lib/actions/account/vendor-grant-action";
+import type { ActionResultDto } from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
 import {
   approveOrganizationVendorGrant,
@@ -23,7 +24,6 @@ import {
   denyOrganizationVendorGrant,
   revokeOrganizationVendorGrant,
 } from "@/lib/actions/organization";
-import type { Result } from "@/lib/ts-res";
 import {
   isGrantDeniedOrRevoked,
   isGrantGranted,
@@ -169,7 +169,7 @@ function VendorCardActions({
 
   async function approveGrant(
     grantId: string,
-  ): Promise<Result<{ grantId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ grantId: string }, ActionError>> {
     if (mode === "organization") {
       const id = requireOrganizationId();
       if (!id) {
@@ -185,7 +185,7 @@ function VendorCardActions({
 
   async function denyGrant(
     grantId: string,
-  ): Promise<Result<{ grantId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ grantId: string }, ActionError>> {
     if (mode === "organization") {
       const id = requireOrganizationId();
       if (!id) {
@@ -201,7 +201,7 @@ function VendorCardActions({
 
   async function revokeGrant(
     grantId: string,
-  ): Promise<Result<{ grantId: string }, ActionError>> {
+  ): Promise<ActionResultDto<{ grantId: string }, ActionError>> {
     if (mode === "organization") {
       const id = requireOrganizationId();
       if (!id) {
@@ -216,7 +216,7 @@ function VendorCardActions({
   }
 
   async function createGrant(): Promise<
-    Result<{ grantId: string }, ActionError>
+    ActionResultDto<{ grantId: string }, ActionError>
   > {
     if (mode === "organization") {
       const id = requireOrganizationId();
@@ -233,7 +233,7 @@ function VendorCardActions({
 
   async function runAction(
     action: VendorCardAction,
-    step: () => Promise<Result<unknown, ActionError>>,
+    step: () => Promise<ActionResultDto<unknown, ActionError>>,
     successKey:
       | "approveSuccess"
       | "denySuccess"

--- a/apps/web/src/lib/actions/account/vendor-grant-action.ts
+++ b/apps/web/src/lib/actions/account/vendor-grant-action.ts
@@ -1,11 +1,14 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
-
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import { vendorGrantService } from "@/lib/services/vendor-grant.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -29,80 +32,80 @@ interface CreateVendorGrantParameters extends AuthenticatedRequest {
 
 export const approveMyVendorGrant = withSession<
   VendorGrantMutationParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ grantId }) => {
   const parsed = vendorGrantActionSchema.safeParse({ grantId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
     const grant = await vendorGrantService.approveMyVendorGrant(
       parsed.data.grantId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to approve personal vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
 export const denyMyVendorGrant = withSession<
   VendorGrantMutationParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ grantId }) => {
   const parsed = vendorGrantActionSchema.safeParse({ grantId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
     const grant = await vendorGrantService.denyMyVendorGrant(
       parsed.data.grantId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to deny personal vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
 export const revokeMyVendorGrant = withSession<
   VendorGrantMutationParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ grantId }) => {
   const parsed = vendorGrantActionSchema.safeParse({ grantId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
     const grant = await vendorGrantService.revokeMyVendorGrant(
       parsed.data.grantId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to revoke personal vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
 export const createMyVendorGrant = withSession<
   CreateVendorGrantParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ vendorId }) => {
   const parsed = createVendorGrantActionSchema.safeParse({ vendorId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
     const grant = await vendorGrantService.createMyVendorGrant(
       parsed.data.vendorId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to create personal vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/organization/vendor-grant-action.ts
+++ b/apps/web/src/lib/actions/organization/vendor-grant-action.ts
@@ -1,11 +1,14 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
-
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import { vendorGrantService } from "@/lib/services/vendor-grant.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -33,11 +36,11 @@ interface CreateVendorGrantParameters extends AuthenticatedRequest {
 
 export const approveOrganizationVendorGrant = withSession<
   VendorGrantMutationParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ organizationId, grantId }) => {
   const parsed = vendorGrantActionSchema.safeParse({ organizationId, grantId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -45,20 +48,20 @@ export const approveOrganizationVendorGrant = withSession<
       parsed.data.organizationId,
       parsed.data.grantId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to approve vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
 export const denyOrganizationVendorGrant = withSession<
   VendorGrantMutationParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ organizationId, grantId }) => {
   const parsed = vendorGrantActionSchema.safeParse({ organizationId, grantId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -66,20 +69,20 @@ export const denyOrganizationVendorGrant = withSession<
       parsed.data.organizationId,
       parsed.data.grantId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to deny vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
 export const revokeOrganizationVendorGrant = withSession<
   VendorGrantMutationParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ organizationId, grantId }) => {
   const parsed = vendorGrantActionSchema.safeParse({ organizationId, grantId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -87,23 +90,23 @@ export const revokeOrganizationVendorGrant = withSession<
       parsed.data.organizationId,
       parsed.data.grantId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to revoke vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
 export const createOrganizationVendorGrant = withSession<
   CreateVendorGrantParameters,
-  Result<{ grantId: string }, ActionError>
+  ActionResultDto<{ grantId: string }, ActionError>
 >(async ({ organizationId, vendorId }) => {
   const parsed = createVendorGrantActionSchema.safeParse({
     organizationId,
     vendorId,
   });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -111,9 +114,9 @@ export const createOrganizationVendorGrant = withSession<
       parsed.data.organizationId,
       parsed.data.vendorId,
     );
-    return Ok({ grantId: grant.id });
+    return toActionResult(ok({ grantId: grant.id }));
   } catch (error) {
     console.error("Failed to create vendor grant", error);
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });


### PR DESCRIPTION
## Summary
Migrate vendor-grant domain to neverthrow + ActionResultDto.

**Linear:** [SOK-764](https://linear.app/masumi/issue/SOK-764) · Parent [SOK-754](https://linear.app/masumi/issue/SOK-754)

## Stack
#3737 → **this** → #3739 → #3740 → #3741 → #3742