### PR TITLE
feat(web): migrate admin action surface to neverthrow

### DIFF
--- a/apps/web/src/app/(app)/admin/invoices/[invoiceId]/page.tsx
+++ b/apps/web/src/app/(app)/admin/invoices/[invoiceId]/page.tsx
@@ -58,7 +58,7 @@ export default async function InvoiceDetailPage({
 
         <Card>
           <CardContent>
-            <InvoiceDetail invoice={result.data} />
+            <InvoiceDetail invoice={result.value} />
           </CardContent>
         </Card>
       </div>

--- a/apps/web/src/app/(app)/developer/components/vendors/vendor-admin-detail.tsx
+++ b/apps/web/src/app/(app)/developer/components/vendors/vendor-admin-detail.tsx
@@ -48,9 +48,9 @@ export function VendorAdminDetail({ vendor }: VendorAdminDetailProps) {
         toast.success(t("profile.saveSuccess"));
         setCurrentVendor((previous) => ({
           ...previous,
-          name: result.data.name,
-          logos: result.data.logos,
-          updatedAt: result.data.updatedAt,
+          name: result.value.name,
+          logos: result.value.logos,
+          updatedAt: result.value.updatedAt,
         }));
         return true;
       } finally {

--- a/apps/web/src/components/admin/agents/agent-list.tsx
+++ b/apps/web/src/components/admin/agents/agent-list.tsx
@@ -117,10 +117,10 @@ export function AgentList({ initialPage }: AgentListProps) {
       }
 
       setAgents((current) =>
-        cursor ? [...current, ...result.data.agents] : result.data.agents,
+        cursor ? [...current, ...result.value.agents] : result.value.agents,
       );
-      setTotal(result.data.total);
-      setNextCursor(result.data.nextCursor);
+      setTotal(result.value.total);
+      setNextCursor(result.value.nextCursor);
     });
   }
 

--- a/apps/web/src/components/admin/agents/agent-metadata-form.tsx
+++ b/apps/web/src/components/admin/agents/agent-metadata-form.tsx
@@ -176,9 +176,9 @@ export function AgentMetadataForm({ agentId, detail }: AgentMetadataFormProps) {
         toast.error(result.error.message ?? t("saveError"));
         return;
       }
-      setForm(toFormState(result.data));
-      setResolved(result.data.resolved);
-      setHasOverride(result.data.override !== null);
+      setForm(toFormState(result.value));
+      setResolved(result.value.resolved);
+      setHasOverride(result.value.override !== null);
       toast.success(t("saveSuccess"));
       router.refresh();
     });
@@ -191,9 +191,9 @@ export function AgentMetadataForm({ agentId, detail }: AgentMetadataFormProps) {
         toast.error(result.error.message ?? t("clearError"));
         return;
       }
-      setForm(toFormState(result.data));
+      setForm(toFormState(result.value));
       setHasOverride(false);
-      setResolved(result.data.resolved);
+      setResolved(result.value.resolved);
       toast.success(t("clearSuccess"));
       router.refresh();
     });

--- a/apps/web/src/components/admin/coworkers/coworker-form.tsx
+++ b/apps/web/src/components/admin/coworkers/coworker-form.tsx
@@ -166,7 +166,7 @@ export function CoworkerForm({ coworker, accessRows = [] }: CoworkerFormProps) {
         return;
       }
 
-      applySavedCoworker(result.data.coworker);
+      applySavedCoworker(result.value.coworker);
       toast.success(t("success.whitelistSaved"));
       router.refresh();
     } finally {
@@ -192,7 +192,7 @@ export function CoworkerForm({ coworker, accessRows = [] }: CoworkerFormProps) {
         return;
       }
 
-      applySavedCoworker(result.data.coworker);
+      applySavedCoworker(result.value.coworker);
       toast.success(t("success.archived"));
       router.refresh();
     } finally {
@@ -218,7 +218,7 @@ export function CoworkerForm({ coworker, accessRows = [] }: CoworkerFormProps) {
         return;
       }
 
-      applySavedCoworker(result.data.coworker);
+      applySavedCoworker(result.value.coworker);
       toast.success(t("success.unarchived"));
       router.refresh();
     } finally {
@@ -265,7 +265,7 @@ export function CoworkerForm({ coworker, accessRows = [] }: CoworkerFormProps) {
         return;
       }
 
-      applySavedCoworker(result.data.coworker);
+      applySavedCoworker(result.value.coworker);
       toast.success(t("success.controlsSaved"));
       router.refresh();
     } finally {

--- a/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
+++ b/apps/web/src/components/admin/invoices/__tests__/invoice-form.test.tsx
@@ -230,7 +230,7 @@ describe("InvoiceForm billing preview", () => {
     vi.clearAllMocks();
     getBillingMock.mockResolvedValue({
       ok: true,
-      data: completeBillingDetails,
+      value: completeBillingDetails,
     });
   });
 
@@ -254,7 +254,7 @@ describe("InvoiceForm billing preview", () => {
   it("disables submit when billing address has no country", async () => {
     getBillingMock.mockResolvedValue({
       ok: true,
-      data: incompleteBillingDetails,
+      value: incompleteBillingDetails,
     });
     const user = userEvent.setup();
     render(<InvoiceForm prices={prices} />);
@@ -313,11 +313,11 @@ describe("InvoiceForm billing preview", () => {
   it("ignores stale billing responses when the recipient changes quickly", async () => {
     const firstLoad = createDeferred<{
       ok: true;
-      data: StripeCustomerBillingDetails;
+      value: StripeCustomerBillingDetails;
     }>();
     const secondLoad = createDeferred<{
       ok: true;
-      data: StripeCustomerBillingDetails;
+      value: StripeCustomerBillingDetails;
     }>();
 
     getBillingMock
@@ -332,7 +332,7 @@ describe("InvoiceForm billing preview", () => {
 
     secondLoad.resolve({
       ok: true,
-      data: {
+      value: {
         ...completeBillingDetails,
         address: {
           line1: "Beta Street 2",
@@ -349,7 +349,7 @@ describe("InvoiceForm billing preview", () => {
 
     firstLoad.resolve({
       ok: true,
-      data: {
+      value: {
         ...completeBillingDetails,
         address: {
           line1: "Stale Acme Street 1",
@@ -372,11 +372,11 @@ describe("InvoiceForm billing preview", () => {
     getBillingMock
       .mockResolvedValueOnce({
         ok: true,
-        data: incompleteBillingDetails,
+        value: incompleteBillingDetails,
       })
       .mockResolvedValueOnce({
         ok: true,
-        data: completeBillingDetails,
+        value: completeBillingDetails,
       });
 
     const user = userEvent.setup();

--- a/apps/web/src/components/admin/invoices/invoice-detail.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-detail.tsx
@@ -34,7 +34,7 @@ export function InvoiceDetail({ invoice: initialInvoice }: InvoiceDetailProps) {
         toast.error(result.error.message ?? t("Result.paidError"));
         return;
       }
-      setInvoice(result.data);
+      setInvoice(result.value);
       toast.success(t("Result.paidSuccess"));
     } finally {
       setIsMarkingPaid(false);

--- a/apps/web/src/components/admin/invoices/invoice-form.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-form.tsx
@@ -138,7 +138,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
         setBillingLoadError(result.error.message ?? t("Form.billingLoadError"));
         return;
       }
-      setBillingDetails(result.data);
+      setBillingDetails(result.value);
     } finally {
       if (loadId === billingLoadIdRef.current) {
         setIsBillingLoading(false);
@@ -231,7 +231,7 @@ export function InvoiceForm({ prices }: InvoiceFormProps) {
         return;
       }
       toast.success(t("Form.createSuccess"));
-      router.push(`/admin/invoices/${result.data.invoiceId}`);
+      router.push(`/admin/invoices/${result.value.invoiceId}`);
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/components/admin/invoices/invoice-list.tsx
+++ b/apps/web/src/components/admin/invoices/invoice-list.tsx
@@ -128,7 +128,7 @@ export function InvoiceList({ initialInvoices }: InvoiceListProps) {
         toast.error(result.error.message ?? t("loadError"));
         return;
       }
-      setInvoices(result.data);
+      setInvoices(result.value);
     });
   }
 

--- a/apps/web/src/components/admin/organizations/organization-detail-panel.tsx
+++ b/apps/web/src/components/admin/organizations/organization-detail-panel.tsx
@@ -33,6 +33,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import type { ActionResultDto } from "@/lib/actions/action-result";
 import { listAdminOrganizationMembersAction } from "@/lib/actions/admin-organizations/action";
 import {
   addAdminOrganizationMemberAction,
@@ -50,7 +51,6 @@ import type {
   AdminOrganizationOverviewDetail,
 } from "@/lib/services/admin-organization.service";
 import type { AdminUserOption } from "@/lib/services/admin-user.service";
-import type { Result } from "@/lib/ts-res";
 import { formatCreditsForDisplay } from "@/lib/utils/credits";
 
 interface OrganizationDetailPanelProps {
@@ -96,10 +96,10 @@ export function OrganizationDetailPanel({
         return;
       }
       setMembers((current) =>
-        cursor ? [...current, ...result.data.members] : result.data.members,
+        cursor ? [...current, ...result.value.members] : result.value.members,
       );
-      setMemberTotal(result.data.total);
-      setNextCursor(result.data.nextCursor);
+      setMemberTotal(result.value.total);
+      setNextCursor(result.value.nextCursor);
     });
   }
 
@@ -116,7 +116,7 @@ export function OrganizationDetailPanel({
   }
 
   function runMemberAction(
-    action: () => Promise<Result<void, ActionError>>,
+    action: () => Promise<ActionResultDto<void, ActionError>>,
     successMessage: string,
   ) {
     startTransition(async () => {

--- a/apps/web/src/components/admin/organizations/organization-list.tsx
+++ b/apps/web/src/components/admin/organizations/organization-list.tsx
@@ -61,11 +61,11 @@ export function OrganizationList({ initialPage }: OrganizationListProps) {
       }
       setOrganizations((current) =>
         cursor
-          ? [...current, ...result.data.organizations]
-          : result.data.organizations,
+          ? [...current, ...result.value.organizations]
+          : result.value.organizations,
       );
-      setTotal(result.data.total);
-      setNextCursor(result.data.nextCursor);
+      setTotal(result.value.total);
+      setNextCursor(result.value.nextCursor);
     });
   }
 

--- a/apps/web/src/components/admin/tasks/task-list.tsx
+++ b/apps/web/src/components/admin/tasks/task-list.tsx
@@ -74,10 +74,10 @@ export function TaskList({ initialPage }: TaskListProps) {
         return;
       }
       setTasks((current) =>
-        cursor ? [...current, ...result.data.tasks] : result.data.tasks,
+        cursor ? [...current, ...result.value.tasks] : result.value.tasks,
       );
-      setTotal(result.data.total);
-      setNextCursor(result.data.nextCursor);
+      setTotal(result.value.total);
+      setNextCursor(result.value.nextCursor);
     });
   }
 

--- a/apps/web/src/components/admin/users/user-list.tsx
+++ b/apps/web/src/components/admin/users/user-list.tsx
@@ -74,10 +74,10 @@ export function UserList({ initialPage }: UserListProps) {
         return;
       }
       setUsers((current) =>
-        cursor ? [...current, ...result.data.users] : result.data.users,
+        cursor ? [...current, ...result.value.users] : result.value.users,
       );
-      setTotal(result.data.total);
-      setNextCursor(result.data.nextCursor);
+      setTotal(result.value.total);
+      setNextCursor(result.value.nextCursor);
     });
   }
 

--- a/apps/web/src/components/admin/vendors/vendor-form.tsx
+++ b/apps/web/src/components/admin/vendors/vendor-form.tsx
@@ -270,7 +270,7 @@ export function VendorForm(props: VendorFormProps) {
           return;
         }
 
-        const vendorId = result.data.id;
+        const vendorId = result.value.id;
         let lightUrl = logosForCreate.light;
         let darkUrl = logosForCreate.dark;
 
@@ -309,8 +309,8 @@ export function VendorForm(props: VendorFormProps) {
                 name: values.name,
                 logos: { light: lightUrl, dark: darkUrl },
                 current: {
-                  name: result.data.name,
-                  logos: result.data.logos,
+                  name: result.value.name,
+                  logos: result.value.logos,
                 },
               },
             });
@@ -366,17 +366,17 @@ export function VendorForm(props: VendorFormProps) {
         void cleanupVendorLogoBestEffort(baseline.id, previous.dark);
       }
       logosAtOpenRef.current = {
-        light: result.data.logos.light,
-        dark: result.data.logos.dark,
+        light: result.value.logos.light,
+        dark: result.value.logos.dark,
       };
 
-      setBaseline(result.data);
+      setBaseline(result.value);
       form.reset({
-        name: result.data.name,
-        slug: result.data.slug,
+        name: result.value.name,
+        slug: result.value.slug,
         logos: {
-          light: result.data.logos.light,
-          dark: result.data.logos.dark,
+          light: result.value.logos.light,
+          dark: result.value.logos.dark,
         },
       });
       toast.success(t("saveSuccess"));

--- a/apps/web/src/components/coworkers/__tests__/coworker-display-form.test.tsx
+++ b/apps/web/src/components/coworkers/__tests__/coworker-display-form.test.tsx
@@ -78,7 +78,7 @@ describe("CoworkerDisplayForm", () => {
     const user = userEvent.setup();
     const updateAction = vi.fn().mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         coworker: mockCoreCoworker({ name: "Ops Agent Updated" }),
         imageError: "blob down",
       },
@@ -135,7 +135,7 @@ describe("CoworkerDisplayForm", () => {
 
     resolveAction?.({
       ok: true,
-      data: {
+      value: {
         coworker: mockCoreCoworker({ name: "Ops Agent Renamed" }),
       },
     });

--- a/apps/web/src/components/coworkers/coworker-display-form.tsx
+++ b/apps/web/src/components/coworkers/coworker-display-form.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import type { ActionResultDto } from "@/lib/actions/action-result";
 import type { ActionError } from "@/lib/actions/errors";
 import { CommonErrorCode } from "@/lib/actions/errors";
 import type { Coworker } from "@/lib/clients/generated/core/types.gen";
@@ -34,7 +35,6 @@ import type {
   CoworkerImageIntent,
   UpdateCoworkerDisplayResult,
 } from "@/lib/services/coworker-display.service";
-import type { Result } from "@/lib/ts-res";
 
 import {
   buildCoworkerDisplayPatchBody,
@@ -51,7 +51,7 @@ export type UpdateCoworkerDisplayAction = (input: {
   };
   imageIntent?: CoworkerImageIntent;
   imageFile?: File;
-}) => Promise<Result<UpdateCoworkerDisplayResult, ActionError>>;
+}) => Promise<ActionResultDto<UpdateCoworkerDisplayResult, ActionError>>;
 
 interface CoworkerDisplayFormProps {
   coworker: Coworker;
@@ -109,7 +109,7 @@ export function CoworkerDisplayForm({
     setImageValue(toImageDisplayValue(saved.image));
   }
 
-  function handleActionError(result: Result<unknown, ActionError>) {
+  function handleActionError(result: ActionResultDto<unknown, ActionError>) {
     if (result.ok) {
       return false;
     }
@@ -154,8 +154,8 @@ export function CoworkerDisplayForm({
           return;
         }
 
-        applySavedCoworker(result.data.coworker);
-        if (result.data.imageError) {
+        applySavedCoworker(result.value.coworker);
+        if (result.value.imageError) {
           toast.error(t("errors.imageSaveFailed"));
         } else {
           toast.success(t("success.imageSaved"));
@@ -188,8 +188,8 @@ export function CoworkerDisplayForm({
           return;
         }
 
-        applySavedCoworker(result.data.coworker);
-        if (result.data.imageError) {
+        applySavedCoworker(result.value.coworker);
+        if (result.value.imageError) {
           toast.error(t("errors.imageSaveFailed"));
         } else {
           toast.success(t("success.imageRemoved"));
@@ -253,8 +253,8 @@ export function CoworkerDisplayForm({
           return;
         }
 
-        applySavedCoworker(result.data.coworker);
-        if (result.data.imageError) {
+        applySavedCoworker(result.value.coworker);
+        if (result.value.imageError) {
           toast.success(t("success.saved"));
           toast.error(t("errors.imageSaveFailed"));
         } else {

--- a/apps/web/src/lib/actions/admin-agents/action.ts
+++ b/apps/web/src/lib/actions/admin-agents/action.ts
@@ -1,6 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { updateTag } from "next/cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import {
@@ -15,7 +20,6 @@ import {
   adminAgentService,
   type ListAdminAgentsParams,
 } from "@/lib/services/admin-agent.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -42,22 +46,24 @@ interface ListAdminAgentsRequest
 
 export const listAdminAgentsAction = withSession<
   ListAdminAgentsRequest,
-  Result<AdminAgentListPage, ActionError>
+  ActionResultDto<AdminAgentListPage, ActionError>
 >(async ({ session, q, cursor, limit, status, sortBy, sortOrder }) => {
   try {
     assertAdminSession(session);
-    return Ok(
-      await adminAgentService.listAgents({
-        q,
-        cursor,
-        limit,
-        status,
-        sortBy,
-        sortOrder,
-      }),
+    return toActionResult(
+      ok(
+        await adminAgentService.listAgents({
+          q,
+          cursor,
+          limit,
+          status,
+          sortBy,
+          sortOrder,
+        }),
+      ),
     );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -68,7 +74,7 @@ interface PatchAdminAgentMetadataOverrideRequest extends AuthenticatedRequest {
 
 export const patchAdminAgentMetadataOverrideAction = withSession<
   PatchAdminAgentMetadataOverrideRequest,
-  Result<
+  ActionResultDto<
     Awaited<ReturnType<typeof adminAgentService.patchMetadataOverride>>,
     ActionError
   >
@@ -78,9 +84,9 @@ export const patchAdminAgentMetadataOverrideAction = withSession<
     const detail = await adminAgentService.patchMetadataOverride(agentId, body);
     updateTag(AGENTS_CACHE_TAG);
     updateTag(CATEGORIES_CACHE_TAG);
-    return Ok(detail);
+    return toActionResult(ok(detail));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -90,7 +96,7 @@ interface DeleteAdminAgentMetadataOverrideRequest extends AuthenticatedRequest {
 
 export const deleteAdminAgentMetadataOverrideAction = withSession<
   DeleteAdminAgentMetadataOverrideRequest,
-  Result<
+  ActionResultDto<
     Awaited<ReturnType<typeof adminAgentService.deleteMetadataOverride>>,
     ActionError
   >
@@ -100,8 +106,8 @@ export const deleteAdminAgentMetadataOverrideAction = withSession<
     const detail = await adminAgentService.deleteMetadataOverride(agentId);
     updateTag(AGENTS_CACHE_TAG);
     updateTag(CATEGORIES_CACHE_TAG);
-    return Ok(detail);
+    return toActionResult(ok(detail));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/admin-coworkers/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-coworkers/__tests__/action.test.ts
@@ -234,7 +234,7 @@ describe("admin coworker actions", () => {
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       { organizationId: "org_123" },
     );
-    expect(result.data).toEqual({
+    expect(result.value).toEqual({
       accessId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
       status: "GRANTED",
     });

--- a/apps/web/src/lib/actions/admin-coworkers/action.ts
+++ b/apps/web/src/lib/actions/admin-coworkers/action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { err, ok } from "neverthrow";
+import { err, ok, type Result } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import * as z from "zod";
 import {
@@ -87,12 +87,16 @@ interface UpdateAdminCoworkerControlsParameters extends AuthenticatedRequest {
   priority?: number;
 }
 
+/**
+ * In-process validation only — returns neverthrow Result.
+ * Map to ActionResultDto at the server-action boundary via toActionResult.
+ */
 function sanitizeControlsPatchBody(
   input: Pick<
     UpdateAdminCoworkerControlsParameters,
     "capabilities" | "priority"
   >,
-): ActionResultDto<AdminCoworkerControlsPatchBody, ActionError> {
+): Result<AdminCoworkerControlsPatchBody, ActionError> {
   const patchBody: AdminCoworkerControlsPatchBody = {};
 
   if (input.capabilities !== undefined) {
@@ -101,38 +105,32 @@ function sanitizeControlsPatchBody(
       (capability) => !ADMIN_COWORKER_CAPABILITIES.includes(capability),
     );
     if (invalidCapability) {
-      return toActionResult(
-        err({
-          code: CommonErrorCode.BAD_INPUT,
-          message: `Invalid capability: ${invalidCapability}`,
-        }),
-      );
+      return err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: `Invalid capability: ${invalidCapability}`,
+      });
     }
     patchBody.capabilities = capabilities;
   }
 
   if (input.priority !== undefined) {
     if (!Number.isInteger(input.priority)) {
-      return toActionResult(
-        err({
-          code: CommonErrorCode.BAD_INPUT,
-          message: "Priority must be an integer",
-        }),
-      );
+      return err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: "Priority must be an integer",
+      });
     }
     patchBody.priority = input.priority;
   }
 
   if (Object.keys(patchBody).length === 0) {
-    return toActionResult(
-      err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "No coworker control changes to save",
-      }),
-    );
+    return err({
+      code: CommonErrorCode.BAD_INPUT,
+      message: "No coworker control changes to save",
+    });
   }
 
-  return toActionResult(ok(patchBody));
+  return ok(patchBody);
 }
 
 export const updateAdminCoworkerControlsAction = withSession<
@@ -151,8 +149,8 @@ export const updateAdminCoworkerControlsAction = withSession<
       capabilities,
       priority,
     });
-    if (!sanitizeResult.ok) {
-      return sanitizeResult;
+    if (sanitizeResult.isErr()) {
+      return toActionResult(err(sanitizeResult.error));
     }
 
     const coworker = await adminCoworkerService.updateControls(

--- a/apps/web/src/lib/actions/admin-coworkers/action.ts
+++ b/apps/web/src/lib/actions/admin-coworkers/action.ts
@@ -1,7 +1,12 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import * as z from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { validateCoworkerDisplayActionInput } from "@/lib/actions/coworkers/apply-display-action-input";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
@@ -18,7 +23,6 @@ import {
 } from "@/lib/services/admin-coworker.service";
 import { coworkerAccessService } from "@/lib/services/coworker-access.service";
 import { type UpdateCoworkerDisplayResult } from "@/lib/services/coworker-display.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -51,7 +55,7 @@ interface UpdateAdminCoworkerDisplayParameters extends AuthenticatedRequest {
 
 export const updateAdminCoworkerDisplayAction = withSession<
   UpdateAdminCoworkerDisplayParameters,
-  Result<UpdateCoworkerDisplayResult, ActionError>
+  ActionResultDto<UpdateCoworkerDisplayResult, ActionError>
 >(async ({ session, id, patchBody, imageIntent, imageFile }) => {
   try {
     assertAdminSession(session);
@@ -63,7 +67,7 @@ export const updateAdminCoworkerDisplayAction = withSession<
       imageFile,
     });
     if (validatedInput.isErr()) {
-      return Err(validatedInput.error);
+      return toActionResult(err(validatedInput.error));
     }
 
     const result = await adminCoworkerService.updateDisplay(
@@ -71,9 +75,9 @@ export const updateAdminCoworkerDisplayAction = withSession<
     );
 
     revalidateAdminCoworkerRoutes(validatedInput.value.id);
-    return Ok(result);
+    return toActionResult(ok(result));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -88,7 +92,7 @@ function sanitizeControlsPatchBody(
     UpdateAdminCoworkerControlsParameters,
     "capabilities" | "priority"
   >,
-): Result<AdminCoworkerControlsPatchBody, ActionError> {
+): ActionResultDto<AdminCoworkerControlsPatchBody, ActionError> {
   const patchBody: AdminCoworkerControlsPatchBody = {};
 
   if (input.capabilities !== undefined) {
@@ -97,37 +101,43 @@ function sanitizeControlsPatchBody(
       (capability) => !ADMIN_COWORKER_CAPABILITIES.includes(capability),
     );
     if (invalidCapability) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: `Invalid capability: ${invalidCapability}`,
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: `Invalid capability: ${invalidCapability}`,
+        }),
+      );
     }
     patchBody.capabilities = capabilities;
   }
 
   if (input.priority !== undefined) {
     if (!Number.isInteger(input.priority)) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "Priority must be an integer",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: "Priority must be an integer",
+        }),
+      );
     }
     patchBody.priority = input.priority;
   }
 
   if (Object.keys(patchBody).length === 0) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: "No coworker control changes to save",
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: "No coworker control changes to save",
+      }),
+    );
   }
 
-  return Ok(patchBody);
+  return toActionResult(ok(patchBody));
 }
 
 export const updateAdminCoworkerControlsAction = withSession<
   UpdateAdminCoworkerControlsParameters,
-  Result<
+  ActionResultDto<
     {
       coworker: Awaited<ReturnType<typeof adminCoworkerService.updateControls>>;
     },
@@ -147,13 +157,13 @@ export const updateAdminCoworkerControlsAction = withSession<
 
     const coworker = await adminCoworkerService.updateControls(
       id,
-      sanitizeResult.data,
+      sanitizeResult.value,
     );
 
     revalidateAdminCoworkerRoutes(id);
-    return Ok({ coworker });
+    return toActionResult(ok({ coworker }));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -164,7 +174,7 @@ interface UpdateAdminCoworkerWhitelistParameters extends AuthenticatedRequest {
 
 export const updateAdminCoworkerWhitelistAction = withSession<
   UpdateAdminCoworkerWhitelistParameters,
-  Result<
+  ActionResultDto<
     {
       coworker: Awaited<
         ReturnType<typeof adminCoworkerService.updateWhitelist>
@@ -182,9 +192,9 @@ export const updateAdminCoworkerWhitelistAction = withSession<
     );
 
     revalidateAdminCoworkerRoutes(id);
-    return Ok({ coworker });
+    return toActionResult(ok({ coworker }));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -194,7 +204,7 @@ interface ArchiveAdminCoworkerParameters extends AuthenticatedRequest {
 
 export const archiveAdminCoworkerAction = withSession<
   ArchiveAdminCoworkerParameters,
-  Result<
+  ActionResultDto<
     {
       coworker: Awaited<
         ReturnType<typeof adminCoworkerService.archiveCoworker>
@@ -209,9 +219,9 @@ export const archiveAdminCoworkerAction = withSession<
     const coworker = await adminCoworkerService.archiveCoworker(id);
 
     revalidateAdminCoworkerRoutes(id);
-    return Ok({ coworker });
+    return toActionResult(ok({ coworker }));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -221,7 +231,7 @@ interface UnarchiveAdminCoworkerParameters extends AuthenticatedRequest {
 
 export const unarchiveAdminCoworkerAction = withSession<
   UnarchiveAdminCoworkerParameters,
-  Result<
+  ActionResultDto<
     {
       coworker: Awaited<
         ReturnType<typeof adminCoworkerService.unarchiveCoworker>
@@ -236,9 +246,9 @@ export const unarchiveAdminCoworkerAction = withSession<
     const coworker = await adminCoworkerService.unarchiveCoworker(id);
 
     revalidateAdminCoworkerRoutes(id);
-    return Ok({ coworker });
+    return toActionResult(ok({ coworker }));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -277,7 +287,7 @@ function toAccessTargetBody(parsed: {
 
 export const grantAdminCoworkerEarlyAccessAction = withSession<
   GrantAdminCoworkerEarlyAccessParameters,
-  Result<{ accessId: string; status: string }, ActionError>
+  ActionResultDto<{ accessId: string; status: string }, ActionError>
 >(async ({ session, coworkerId, targetType, targetId }) => {
   try {
     assertAdminSession(session);
@@ -288,7 +298,7 @@ export const grantAdminCoworkerEarlyAccessAction = withSession<
       targetId,
     });
     if (!parsed.success) {
-      return Err({ code: CommonErrorCode.BAD_INPUT });
+      return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
     }
 
     const access = await coworkerAccessService.createForCoworker(
@@ -297,16 +307,16 @@ export const grantAdminCoworkerEarlyAccessAction = withSession<
     );
 
     revalidateAdminCoworkerRoutes(parsed.data.coworkerId);
-    return Ok({ accessId: access.id, status: access.status });
+    return toActionResult(ok({ accessId: access.id, status: access.status }));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
 /** Revoke GRANTED access for a list row (by workspace id). */
 export const revokeAdminCoworkerEarlyAccessAction = withSession<
   RevokeAdminCoworkerEarlyAccessParameters,
-  Result<{ accessId: string; status: string }, ActionError>
+  ActionResultDto<{ accessId: string; status: string }, ActionError>
 >(async ({ session, coworkerId, workspaceId }) => {
   try {
     assertAdminSession(session);
@@ -316,7 +326,7 @@ export const revokeAdminCoworkerEarlyAccessAction = withSession<
       workspaceId,
     });
     if (!parsed.success) {
-      return Err({ code: CommonErrorCode.BAD_INPUT });
+      return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
     }
 
     const access = await coworkerAccessService.forceRevokeForCoworker(
@@ -325,8 +335,8 @@ export const revokeAdminCoworkerEarlyAccessAction = withSession<
     );
 
     revalidateAdminCoworkerRoutes(parsed.data.coworkerId);
-    return Ok({ accessId: access.id, status: access.status });
+    return toActionResult(ok({ accessId: access.id, status: access.status }));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });

--- a/apps/web/src/lib/actions/admin-organizations/action.ts
+++ b/apps/web/src/lib/actions/admin-organizations/action.ts
@@ -1,5 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
@@ -10,7 +16,6 @@ import {
   type ListAdminOrganizationMembersParams,
   type ListAdminOrganizationsParams,
 } from "@/lib/services/admin-organization.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -37,19 +42,21 @@ interface ListAdminOrganizationsRequest
 
 export const listAdminOrganizationsAction = withSession<
   ListAdminOrganizationsRequest,
-  Result<AdminOrganizationOverviewPage, ActionError>
+  ActionResultDto<AdminOrganizationOverviewPage, ActionError>
 >(async ({ session, query, cursor, limit }) => {
   try {
     assertAdminSession(session);
-    return Ok(
-      await adminOrganizationService.listOrganizations({
-        query,
-        cursor,
-        limit,
-      }),
+    return toActionResult(
+      ok(
+        await adminOrganizationService.listOrganizations({
+          query,
+          cursor,
+          limit,
+        }),
+      ),
     );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -61,17 +68,19 @@ interface ListAdminOrganizationMembersRequest
 
 export const listAdminOrganizationMembersAction = withSession<
   ListAdminOrganizationMembersRequest,
-  Result<AdminOrganizationMemberOverviewPage, ActionError>
+  ActionResultDto<AdminOrganizationMemberOverviewPage, ActionError>
 >(async ({ session, slug, cursor, limit }) => {
   try {
     assertAdminSession(session);
-    return Ok(
-      await adminOrganizationService.listOrganizationMembers(slug, {
-        cursor,
-        limit,
-      }),
+    return toActionResult(
+      ok(
+        await adminOrganizationService.listOrganizationMembers(slug, {
+          cursor,
+          limit,
+        }),
+      ),
     );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/admin-organizations/member-actions.ts
+++ b/apps/web/src/lib/actions/admin-organizations/member-actions.ts
@@ -1,12 +1,16 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -60,11 +64,11 @@ interface AddAdminOrganizationMemberRequest extends AuthenticatedRequest {
 
 export const addAdminOrganizationMemberAction = withSession<
   AddAdminOrganizationMemberRequest,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ session, slug, userId, role }) => {
   const parsed = addMemberSchema.safeParse({ slug, userId, role });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -73,9 +77,11 @@ export const addAdminOrganizationMemberAction = withSession<
       userId: parsed.data.userId,
       role: parsed.data.role,
     });
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return Err(mapMemberActionError(error, "Failed to add member"));
+    return toActionResult(
+      err(mapMemberActionError(error, "Failed to add member")),
+    );
   }
 });
 
@@ -86,11 +92,11 @@ interface AdminOrganizationMemberRequest extends AuthenticatedRequest {
 
 export const removeAdminOrganizationMemberAction = withSession<
   AdminOrganizationMemberRequest,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ session, slug, memberId }) => {
   const parsed = memberMutationSchema.safeParse({ slug, memberId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -99,9 +105,11 @@ export const removeAdminOrganizationMemberAction = withSession<
       parsed.data.slug,
       parsed.data.memberId,
     );
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return Err(mapMemberActionError(error, "Failed to remove member"));
+    return toActionResult(
+      err(mapMemberActionError(error, "Failed to remove member")),
+    );
   }
 });
 
@@ -112,11 +120,11 @@ interface UpdateAdminOrganizationMemberRoleRequest
 
 export const updateAdminOrganizationMemberRoleAction = withSession<
   UpdateAdminOrganizationMemberRoleRequest,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ session, slug, memberId, role }) => {
   const parsed = updateRoleSchema.safeParse({ slug, memberId, role });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -126,19 +134,21 @@ export const updateAdminOrganizationMemberRoleAction = withSession<
       parsed.data.memberId,
       { role: parsed.data.role },
     );
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return Err(mapMemberActionError(error, "Failed to update member role"));
+    return toActionResult(
+      err(mapMemberActionError(error, "Failed to update member role")),
+    );
   }
 });
 
 export const assignAdminOrganizationMemberSeatAction = withSession<
   AdminOrganizationMemberRequest,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ session, slug, memberId }) => {
   const parsed = memberMutationSchema.safeParse({ slug, memberId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -147,19 +157,21 @@ export const assignAdminOrganizationMemberSeatAction = withSession<
       parsed.data.slug,
       parsed.data.memberId,
     );
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return Err(mapMemberActionError(error, "Failed to assign seat"));
+    return toActionResult(
+      err(mapMemberActionError(error, "Failed to assign seat")),
+    );
   }
 });
 
 export const unassignAdminOrganizationMemberSeatAction = withSession<
   AdminOrganizationMemberRequest,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ session, slug, memberId }) => {
   const parsed = memberMutationSchema.safeParse({ slug, memberId });
   if (!parsed.success) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
@@ -168,8 +180,10 @@ export const unassignAdminOrganizationMemberSeatAction = withSession<
       parsed.data.slug,
       parsed.data.memberId,
     );
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return Err(mapMemberActionError(error, "Failed to unassign seat"));
+    return toActionResult(
+      err(mapMemberActionError(error, "Failed to unassign seat")),
+    );
   }
 });

--- a/apps/web/src/lib/actions/admin-search/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-search/__tests__/action.test.ts
@@ -51,7 +51,7 @@ describe("admin search actions", () => {
     expect(searchUsersServiceMock).toHaveBeenCalledWith("ada");
     expect(result).toEqual({
       ok: true,
-      data: [{ id: "u1", name: "Ada", email: "ada@example.com" }],
+      value: [{ id: "u1", name: "Ada", email: "ada@example.com" }],
     });
   });
 
@@ -65,7 +65,7 @@ describe("admin search actions", () => {
     expect(searchOrganizationsServiceMock).toHaveBeenCalledWith("acme");
     expect(result).toEqual({
       ok: true,
-      data: [{ id: "o1", name: "Acme", slug: "acme" }],
+      value: [{ id: "o1", name: "Acme", slug: "acme" }],
     });
   });
 

--- a/apps/web/src/lib/actions/admin-search/action.ts
+++ b/apps/web/src/lib/actions/admin-search/action.ts
@@ -1,5 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
@@ -11,7 +17,6 @@ import {
   type AdminUserOption,
   adminUserService,
 } from "@/lib/services/admin-user.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -37,24 +42,26 @@ interface SearchParameters extends AuthenticatedRequest {
 
 export const searchUsersAction = withSession<
   SearchParameters,
-  Result<AdminUserOption[], ActionError>
+  ActionResultDto<AdminUserOption[], ActionError>
 >(async ({ session, query }) => {
   try {
     assertAdminSession(session);
-    return Ok(await adminUserService.searchUsers(query));
+    return toActionResult(ok(await adminUserService.searchUsers(query)));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
 export const searchOrganizationsAction = withSession<
   SearchParameters,
-  Result<AdminOrganizationOption[], ActionError>
+  ActionResultDto<AdminOrganizationOption[], ActionError>
 >(async ({ session, query }) => {
   try {
     assertAdminSession(session);
-    return Ok(await adminOrganizationService.searchOrganizations(query));
+    return toActionResult(
+      ok(await adminOrganizationService.searchOrganizations(query)),
+    );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/admin-search/client.ts
+++ b/apps/web/src/lib/actions/admin-search/client.ts
@@ -15,7 +15,7 @@ export async function searchOrganizationsClient(
   if (!result.ok) {
     throw new Error(result.error.message ?? "Failed to search organizations");
   }
-  return result.data;
+  return result.value;
 }
 
 export async function searchUsersClient(
@@ -25,5 +25,5 @@ export async function searchUsersClient(
   if (!result.ok) {
     throw new Error(result.error.message ?? "Failed to search users");
   }
-  return result.data;
+  return result.value;
 }

--- a/apps/web/src/lib/actions/admin-tasks/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-tasks/__tests__/action.test.ts
@@ -61,7 +61,7 @@ describe("listAdminTasksAction", () => {
       cursor: undefined,
       limit: 20,
     });
-    expect(result).toEqual({ ok: true, data: page });
+    expect(result).toEqual({ ok: true, value: page });
   });
 
   it("rejects a non-admin session with UNAUTHORIZED", async () => {

--- a/apps/web/src/lib/actions/admin-tasks/action.ts
+++ b/apps/web/src/lib/actions/admin-tasks/action.ts
@@ -1,5 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
@@ -8,7 +14,6 @@ import {
   adminTaskService,
   type ListAdminTasksParams,
 } from "@/lib/services/admin-task.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -34,12 +39,14 @@ interface ListAdminTasksRequest
 
 export const listAdminTasksAction = withSession<
   ListAdminTasksRequest,
-  Result<AdminTaskListPage, ActionError>
+  ActionResultDto<AdminTaskListPage, ActionError>
 >(async ({ session, query, cursor, limit }) => {
   try {
     assertAdminSession(session);
-    return Ok(await adminTaskService.listTasks({ query, cursor, limit }));
+    return toActionResult(
+      ok(await adminTaskService.listTasks({ query, cursor, limit })),
+    );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/admin-users/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/admin-users/__tests__/action.test.ts
@@ -59,7 +59,7 @@ describe("listAdminUsersAction", () => {
       cursor: undefined,
       limit: 20,
     });
-    expect(result).toEqual({ ok: true, data: page });
+    expect(result).toEqual({ ok: true, value: page });
   });
 
   it("rejects a non-admin session with UNAUTHORIZED", async () => {

--- a/apps/web/src/lib/actions/admin-users/action.ts
+++ b/apps/web/src/lib/actions/admin-users/action.ts
@@ -1,5 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
 import { isAdminAccessRequiredError } from "@/lib/auth/errors";
@@ -8,7 +14,6 @@ import {
   adminUserService,
   type ListAdminUsersParams,
 } from "@/lib/services/admin-user.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -34,12 +39,14 @@ interface ListAdminUsersRequest
 
 export const listAdminUsersAction = withSession<
   ListAdminUsersRequest,
-  Result<AdminUserOverviewPage, ActionError>
+  ActionResultDto<AdminUserOverviewPage, ActionError>
 >(async ({ session, query, cursor, limit }) => {
   try {
     assertAdminSession(session);
-    return Ok(await adminUserService.listUsers({ query, cursor, limit }));
+    return toActionResult(
+      ok(await adminUserService.listUsers({ query, cursor, limit })),
+    );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/admin-vendors/action.ts
+++ b/apps/web/src/lib/actions/admin-vendors/action.ts
@@ -1,7 +1,12 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
@@ -9,7 +14,6 @@ import { isAdminAccessRequiredError } from "@/lib/auth/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import type { Vendor } from "@/lib/clients/generated/core";
 import { adminVendorService } from "@/lib/services/admin-vendor.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -74,23 +78,25 @@ interface CreateAdminVendorParameters extends AuthenticatedRequest {
 
 export const createAdminVendorAction = withSession<
   CreateAdminVendorParameters,
-  Result<Vendor, ActionError>
+  ActionResultDto<Vendor, ActionError>
 >(async ({ input, session }) => {
   try {
     assertAdminSession(session);
     const parsed = createVendorSchema.safeParse(input);
     if (!parsed.success) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "Invalid vendor input",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: "Invalid vendor input",
+        }),
+      );
     }
 
     const vendor = await adminVendorService.createVendor(parsed.data);
     revalidateAdminVendorRoutes(vendor.id);
-    return Ok(vendor);
+    return toActionResult(ok(vendor));
   } catch (error) {
-    return Err(toAdminActionError(error));
+    return toActionResult(err(toAdminActionError(error)));
   }
 });
 
@@ -100,26 +106,30 @@ interface PatchAdminVendorParameters extends AuthenticatedRequest {
 
 export const patchAdminVendorAction = withSession<
   PatchAdminVendorParameters,
-  Result<Vendor, ActionError>
+  ActionResultDto<Vendor, ActionError>
 >(async ({ input, session }) => {
   try {
     assertAdminSession(session);
     const parsed = patchVendorSchema.safeParse(input);
     if (!parsed.success) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "Invalid vendor profile input",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: "Invalid vendor profile input",
+        }),
+      );
     }
 
     const existing = await adminVendorService.getVendorById(
       parsed.data.vendorId,
     );
     if (!existing) {
-      return Err({
-        code: CommonErrorCode.NOT_FOUND,
-        message: "Vendor not found",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.NOT_FOUND,
+          message: "Vendor not found",
+        }),
+      );
     }
 
     const vendor = await adminVendorService.patchVendor(
@@ -136,8 +146,8 @@ export const patchAdminVendorAction = withSession<
     );
 
     revalidateAdminVendorRoutes(vendor.id);
-    return Ok(vendor);
+    return toActionResult(ok(vendor));
   } catch (error) {
-    return Err(toAdminActionError(error));
+    return toActionResult(err(toAdminActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/coworkers/update-display.action.ts
+++ b/apps/web/src/lib/actions/coworkers/update-display.action.ts
@@ -1,7 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
-
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { validateCoworkerDisplayActionInput } from "@/lib/actions/coworkers/apply-display-action-input";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
@@ -10,7 +14,6 @@ import {
   type UpdateCoworkerDisplayResult,
 } from "@/lib/services/coworker-display.service";
 import { developerCoworkerService } from "@/lib/services/developer-coworker.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -33,7 +36,7 @@ interface UpdateDeveloperCoworkerDisplayParameters
 
 export const updateDeveloperCoworkerDisplayAction = withSession<
   UpdateDeveloperCoworkerDisplayParameters,
-  Result<UpdateCoworkerDisplayResult, ActionError>
+  ActionResultDto<UpdateCoworkerDisplayResult, ActionError>
 >(async ({ session: _session, id, patchBody, imageIntent, imageFile }) => {
   try {
     const validatedInput = validateCoworkerDisplayActionInput({
@@ -43,17 +46,19 @@ export const updateDeveloperCoworkerDisplayAction = withSession<
       imageFile,
     });
     if (validatedInput.isErr()) {
-      return Err(validatedInput.error);
+      return toActionResult(err(validatedInput.error));
     }
 
     const ownedCoworker = await developerCoworkerService.getOwnedCoworkerById(
       validatedInput.value.id,
     );
     if (!ownedCoworker) {
-      return Err({
-        code: CommonErrorCode.NOT_FOUND,
-        message: "Coworker not found",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.NOT_FOUND,
+          message: "Coworker not found",
+        }),
+      );
     }
 
     const result = await coworkerDisplayService.updateDisplay(
@@ -61,8 +66,8 @@ export const updateDeveloperCoworkerDisplayAction = withSession<
     );
 
     revalidateDeveloperCoworkerRoutes(validatedInput.value.id);
-    return Ok(result);
+    return toActionResult(ok(result));
   } catch (error) {
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/free-credit-admin/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/free-credit-admin/__tests__/action.test.ts
@@ -83,7 +83,7 @@ describe("grantFreeCreditsAction", () => {
     if (!result.ok) {
       throw new Error("Expected success result");
     }
-    expect(result.data).toEqual(GRANT);
+    expect(result.value).toEqual(GRANT);
     expect(grantFreeCreditsMock).toHaveBeenCalledWith({
       target: { targetType: "user", targetId: "user_1" },
       credits: 500,

--- a/apps/web/src/lib/actions/free-credit-admin/action.ts
+++ b/apps/web/src/lib/actions/free-credit-admin/action.ts
@@ -1,6 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
@@ -11,7 +16,6 @@ import {
   FreeCreditValidationError,
   freeCreditAdminService,
 } from "@/lib/services/free-credit-admin.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -49,7 +53,7 @@ interface GrantFreeCreditsParameters extends AuthenticatedRequest {
 
 export const grantFreeCreditsAction = withSession<
   GrantFreeCreditsParameters,
-  Result<FreeCreditGrant, ActionError>
+  ActionResultDto<FreeCreditGrant, ActionError>
 >(
   async ({
     session,
@@ -71,9 +75,9 @@ export const grantFreeCreditsAction = withSession<
       revalidatePath("/admin/users");
       revalidatePath("/admin/organizations", "layout");
       revalidatePath("/admin/tasks");
-      return Ok(grant);
+      return toActionResult(ok(grant));
     } catch (error) {
-      return Err(mapError(error));
+      return toActionResult(err(mapError(error)));
     }
   },
 );

--- a/apps/web/src/lib/actions/invoice-admin/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/invoice-admin/__tests__/action.test.ts
@@ -87,7 +87,7 @@ describe("markAdminInvoicePaidAction", () => {
     if (!result.ok) {
       throw new Error("Expected success result");
     }
-    expect(result.data).toEqual(SUMMARY);
+    expect(result.value).toEqual(SUMMARY);
     expect(markInvoicePaidMock).toHaveBeenCalledWith("in_1");
     expect(revalidatePathMock).toHaveBeenCalledWith("/admin/invoices");
   });

--- a/apps/web/src/lib/actions/invoice-admin/action.ts
+++ b/apps/web/src/lib/actions/invoice-admin/action.ts
@@ -1,7 +1,12 @@
 "use server";
 
 import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
@@ -16,7 +21,6 @@ import {
   InvoiceValidationError,
   invoiceAdminService,
 } from "@/lib/services/invoice-admin.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -67,7 +71,7 @@ interface CreateAdminInvoiceParameters extends AuthenticatedRequest {
 
 export const createAdminInvoiceAction = withSession<
   CreateAdminInvoiceParameters,
-  Result<InvoiceSummary, ActionError>
+  ActionResultDto<InvoiceSummary, ActionError>
 >(async ({ session, targetType, targetId, credits, ttlDays, priceId }) => {
   try {
     assertAdminSession(session);
@@ -78,9 +82,9 @@ export const createAdminInvoiceAction = withSession<
       priceId,
     });
     revalidatePath("/admin/invoices");
-    return Ok(summary);
+    return toActionResult(ok(summary));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -91,7 +95,7 @@ interface ListAdminInvoicesParameters extends AuthenticatedRequest {
 
 export const listAdminInvoicesAction = withSession<
   ListAdminInvoicesParameters,
-  Result<InvoiceListItem[], ActionError>
+  ActionResultDto<InvoiceListItem[], ActionError>
 >(async ({ session, status, recipient }) => {
   try {
     assertAdminSession(session);
@@ -99,9 +103,9 @@ export const listAdminInvoicesAction = withSession<
       status,
       recipient,
     });
-    return Ok(invoices);
+    return toActionResult(ok(invoices));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -111,20 +115,22 @@ interface GetAdminInvoiceParameters extends AuthenticatedRequest {
 
 export const getAdminInvoiceAction = withSession<
   GetAdminInvoiceParameters,
-  Result<InvoiceSummary, ActionError>
+  ActionResultDto<InvoiceSummary, ActionError>
 >(async ({ session, invoiceId }) => {
   try {
     assertAdminSession(session);
     const summary = await invoiceAdminService.getInvoice(invoiceId);
     if (!summary) {
-      return Err({
-        code: CommonErrorCode.NOT_FOUND,
-        message: "Admin invoice not found",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.NOT_FOUND,
+          message: "Admin invoice not found",
+        }),
+      );
     }
-    return Ok(summary);
+    return toActionResult(ok(summary));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -134,15 +140,15 @@ interface MarkAdminInvoicePaidParameters extends AuthenticatedRequest {
 
 export const markAdminInvoicePaidAction = withSession<
   MarkAdminInvoicePaidParameters,
-  Result<InvoiceSummary, ActionError>
+  ActionResultDto<InvoiceSummary, ActionError>
 >(async ({ session, invoiceId }) => {
   try {
     assertAdminSession(session);
     const summary = await invoiceAdminService.markInvoicePaid(invoiceId);
     revalidatePath("/admin/invoices");
-    return Ok(summary);
+    return toActionResult(ok(summary));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -152,15 +158,15 @@ interface DeleteAdminInvoiceParameters extends AuthenticatedRequest {
 
 export const deleteAdminInvoiceAction = withSession<
   DeleteAdminInvoiceParameters,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ session, invoiceId }) => {
   try {
     assertAdminSession(session);
     await invoiceAdminService.deleteInvoice(invoiceId);
     revalidatePath("/admin/invoices");
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });
 
@@ -172,15 +178,15 @@ interface GetAdminRecipientBillingDetailsParameters
 
 export const getAdminRecipientBillingDetailsAction = withSession<
   GetAdminRecipientBillingDetailsParameters,
-  Result<StripeCustomerBillingDetails, ActionError>
+  ActionResultDto<StripeCustomerBillingDetails, ActionError>
 >(async ({ session, targetType, targetId }) => {
   try {
     assertAdminSession(session);
     const billingDetails = await invoiceAdminService.getRecipientBillingDetails(
       { targetType, targetId },
     );
-    return Ok(billingDetails);
+    return toActionResult(ok(billingDetails));
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/vendors/vendor-admin.action.ts
+++ b/apps/web/src/lib/actions/vendors/vendor-admin.action.ts
@@ -1,13 +1,17 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toCoreApiActionError } from "@/lib/clients/core.client";
 import type { Vendor } from "@/lib/clients/generated/core";
 import { vendorService } from "@/lib/services/vendor.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -46,25 +50,29 @@ interface PatchVendorProfileParameters extends AuthenticatedRequest {
 
 export const patchVendorProfileAction = withSession<
   PatchVendorProfileParameters,
-  Result<Vendor, ActionError>
+  ActionResultDto<Vendor, ActionError>
 >(async ({ input }) => {
   try {
     const parsed = patchVendorProfileSchema.safeParse(input);
     if (!parsed.success) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "Invalid vendor profile input",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: "Invalid vendor profile input",
+        }),
+      );
     }
 
     const panelData = await vendorService.getVendorAdminPanelData(
       parsed.data.vendorId,
     );
     if (!panelData) {
-      return Err({
-        code: CommonErrorCode.UNAUTHORIZED,
-        message: "Vendor admin access required",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.UNAUTHORIZED,
+          message: "Vendor admin access required",
+        }),
+      );
     }
 
     const vendor = await vendorService.patchVendorProfile(
@@ -84,8 +92,8 @@ export const patchVendorProfileAction = withSession<
     );
 
     revalidateDeveloperVendorRoutes(parsed.data.vendorId);
-    return Ok(vendor);
+    return toActionResult(ok(vendor));
   } catch (error) {
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });


### PR DESCRIPTION
## Summary
Migrate admin action surface (admin-*, free-credit, invoice, vendor-admin) + shared coworker display path for form typing.

**Linear:** [SOK-765](https://linear.app/masumi/issue/SOK-765) · Parent [SOK-754](https://linear.app/masumi/issue/SOK-754)

## Stack
#3737 → #3738 → **this** → #3740 → #3741 → #3742