### PR TITLE
feat(web): migrate auth onboarding oauth subscription to neverthrow

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
@@ -119,15 +119,15 @@ describe("OnboardingDialog organization subscription", () => {
     markSubscriptionOnboardingGateSessionSeenMock.mockResolvedValue(undefined);
     window.localStorage.clear();
     completeOnboardingMock.mockResolvedValue({
-      data: { redirectUrl: "/tasks" },
+      value: { redirectUrl: "/tasks" },
       ok: true,
     });
     upgradeOrganizationSubscriptionMock.mockResolvedValue({
-      data: { mode: "complete" },
+      value: { mode: "complete" },
       ok: true,
     });
     upgradePersonalSubscriptionMock.mockResolvedValue({
-      data: { mode: "complete" },
+      value: { mode: "complete" },
       ok: true,
     });
   });
@@ -326,7 +326,7 @@ describe("OnboardingDialog full intro Skip", () => {
     markSubscriptionOnboardingGateSessionSeenMock.mockResolvedValue(undefined);
     window.localStorage.clear();
     completeOnboardingMock.mockResolvedValue({
-      data: { redirectUrl: "/tasks" },
+      value: { redirectUrl: "/tasks" },
       ok: true,
     });
   });

--- a/apps/web/src/app/(app)/components/__tests__/onboarding-subscription-return-handler.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-subscription-return-handler.test.tsx
@@ -44,7 +44,7 @@ describe("OnboardingSubscriptionReturnHandler", () => {
     );
     completeOnboardingMock.mockResolvedValue({
       ok: true,
-      data: { redirectUrl: "/tasks" },
+      value: { redirectUrl: "/tasks" },
     });
 
     render(<OnboardingSubscriptionReturnHandler />);

--- a/apps/web/src/app/(app)/components/onboarding-dialog.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog.tsx
@@ -490,7 +490,7 @@ export function OnboardingDialog({
     try {
       const result = await completeOnboarding();
       if (result.ok) {
-        const redirectUrl = result.data.redirectUrl ?? "/agents";
+        const redirectUrl = result.value.redirectUrl ?? "/agents";
         setOpen(false);
         router.push(redirectUrl);
       } else {
@@ -619,8 +619,8 @@ export function OnboardingDialog({
         return;
       }
 
-      if (result.data.mode === "redirect") {
-        window.location.href = result.data.url;
+      if (result.value.mode === "redirect") {
+        window.location.href = result.value.url;
         return;
       }
 

--- a/apps/web/src/app/(app)/components/onboarding-subscription-return-handler.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-subscription-return-handler.tsx
@@ -45,7 +45,7 @@ export function OnboardingSubscriptionReturnHandler() {
           return;
         }
 
-        router.replace(result.data.redirectUrl ?? "/tasks");
+        router.replace(result.value.redirectUrl ?? "/tasks");
       } catch {
         hasHandledRef.current = false;
         toast.error(tErrors("unexpectedError"));

--- a/apps/web/src/app/(app)/personal-assistant/components/subscription-required-dialog.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/subscription-required-dialog.tsx
@@ -112,8 +112,8 @@ export function SubscriptionRequiredDialog({
         return;
       }
 
-      if (result.data.mode === "redirect") {
-        window.location.href = result.data.url;
+      if (result.value.mode === "redirect") {
+        window.location.href = result.value.url;
         return;
       }
 

--- a/apps/web/src/app/api/billing/portal/__tests__/route.test.ts
+++ b/apps/web/src/app/api/billing/portal/__tests__/route.test.ts
@@ -74,7 +74,7 @@ describe("GET /api/billing/portal", () => {
     getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
     openPersonalBillingPortalServerMock.mockResolvedValue({
       ok: true,
-      data: { url: "https://billing.stripe.com/session/test" },
+      value: { url: "https://billing.stripe.com/session/test" },
     });
 
     const { GET } = await import("../route");
@@ -97,7 +97,7 @@ describe("GET /api/billing/portal", () => {
     getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
     openOrganizationBillingPortalServerMock.mockResolvedValue({
       ok: true,
-      data: { url: "https://billing.stripe.com/session/org" },
+      value: { url: "https://billing.stripe.com/session/org" },
     });
 
     const { GET } = await import("../route");
@@ -207,7 +207,7 @@ describe("GET /api/billing/portal", () => {
     getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
     openPersonalBillingPortalServerMock.mockResolvedValue({
       ok: true,
-      data: { url: "https://evil.com/phish" },
+      value: { url: "https://evil.com/phish" },
     });
 
     const { GET } = await import("../route");

--- a/apps/web/src/app/api/billing/portal/route.ts
+++ b/apps/web/src/app/api/billing/portal/route.ts
@@ -103,10 +103,10 @@ export async function GET(request: NextRequest) {
     return redirectToReturnPathWithError(request, safeReturnPath);
   }
 
-  if (!isAllowedStripeBillingPortalUrl(result.data.url)) {
-    console.error("[billing-portal] rejected redirect url", result.data.url);
+  if (!isAllowedStripeBillingPortalUrl(result.value.url)) {
+    console.error("[billing-portal] rejected redirect url", result.value.url);
     return redirectToReturnPathWithError(request, safeReturnPath);
   }
 
-  return NextResponse.redirect(result.data.url);
+  return NextResponse.redirect(result.value.url);
 }

--- a/apps/web/src/components/billing/__tests__/organization-subscription-section.test.tsx
+++ b/apps/web/src/components/billing/__tests__/organization-subscription-section.test.tsx
@@ -92,11 +92,11 @@ describe("OrganizationSubscriptionSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     updateOrganizationSubscriptionSeatsMock.mockResolvedValue({
-      data: { seats: 3 },
+      value: { seats: 3 },
       ok: true,
     });
     upgradeOrganizationSubscriptionMock.mockResolvedValue({
-      data: { mode: "redirect", url: "https://checkout.stripe.com/test" },
+      value: { mode: "redirect", url: "https://checkout.stripe.com/test" },
       ok: true,
     });
   });
@@ -278,7 +278,7 @@ describe("OrganizationSubscriptionSection", () => {
 
   it("shows success toast and refreshes when upgrade completes without checkout redirect", async () => {
     upgradeOrganizationSubscriptionMock.mockResolvedValue({
-      data: { mode: "complete" },
+      value: { mode: "complete" },
       ok: true,
     });
 

--- a/apps/web/src/components/billing/__tests__/personal-subscription-section.test.tsx
+++ b/apps/web/src/components/billing/__tests__/personal-subscription-section.test.tsx
@@ -80,7 +80,7 @@ describe("PersonalSubscriptionSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     upgradePersonalSubscriptionMock.mockResolvedValue({
-      data: { mode: "redirect", url: "https://checkout.stripe.com/test" },
+      value: { mode: "redirect", url: "https://checkout.stripe.com/test" },
       ok: true,
     });
   });
@@ -163,7 +163,7 @@ describe("PersonalSubscriptionSection", () => {
 
   it("shows success toast and refreshes when upgrade completes without checkout redirect", async () => {
     upgradePersonalSubscriptionMock.mockResolvedValue({
-      data: { mode: "complete" },
+      value: { mode: "complete" },
       ok: true,
     });
 

--- a/apps/web/src/components/billing/organization-subscription-section.tsx
+++ b/apps/web/src/components/billing/organization-subscription-section.tsx
@@ -193,8 +193,8 @@ export function OrganizationSubscriptionSection({
           return;
         }
 
-        if (result.data.mode === "redirect") {
-          window.location.href = result.data.url;
+        if (result.value.mode === "redirect") {
+          window.location.href = result.value.url;
           return;
         }
 

--- a/apps/web/src/components/billing/personal-subscription-section.tsx
+++ b/apps/web/src/components/billing/personal-subscription-section.tsx
@@ -104,8 +104,8 @@ export function PersonalSubscriptionSection({
         return;
       }
 
-      if (result.data.mode === "redirect") {
-        window.location.href = result.data.url;
+      if (result.value.mode === "redirect") {
+        window.location.href = result.value.url;
         return;
       }
 

--- a/apps/web/src/components/members-table/member-actions-modal-context.tsx
+++ b/apps/web/src/components/members-table/member-actions-modal-context.tsx
@@ -59,7 +59,7 @@ export function MemberActionsModalContextProvider({
           };
         }
         notifySeatUnassigned(member.id);
-        return { data: result.data, error: null };
+        return { data: result.value, error: null };
       }
       case MemberAction.CHANGE_TO_OWNER:
         return await authClient.organization.updateMemberRole({

--- a/apps/web/src/lib/actions/auth/action.ts
+++ b/apps/web/src/lib/actions/auth/action.ts
@@ -1,25 +1,32 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { setPasswordViaCore } from "@/lib/auth/core-auth-http.server";
 import { type NewPasswordFormType, newPasswordFormSchema } from "@/lib/schemas";
 import { utmService } from "@/lib/services/utm.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 
 export async function createCredentialAccount(
   data: NewPasswordFormType,
-): Promise<Result<void, ActionError>> {
+): Promise<ActionResultDto<void, ActionError>> {
   const parsedResult = newPasswordFormSchema().safeParse(data);
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+      }),
+    );
   }
   const parsed = parsedResult.data;
 
   try {
     await setPasswordViaCore(parsed.newPassword);
-    return Ok();
+    return toActionResult(ok());
   } catch (error) {
     console.error("Failed to set password", error);
 
@@ -33,15 +40,17 @@ export async function createCredentialAccount(
     // Only surface a message for known (coded) auth errors. Generic infra
     // failures (timeouts, fetch errors) must not leak their raw message.
     if (code) {
-      return Err({
-        code,
-        ...(error instanceof Error && error.message
-          ? { message: error.message }
-          : {}),
-      });
+      return toActionResult(
+        err({
+          code,
+          ...(error instanceof Error && error.message
+            ? { message: error.message }
+            : {}),
+        }),
+      );
     }
 
-    return Err({ code: CommonErrorCode.INTERNAL_SERVER_ERROR });
+    return toActionResult(err({ code: CommonErrorCode.INTERNAL_SERVER_ERROR }));
   }
 }
 

--- a/apps/web/src/lib/actions/oauth/action.ts
+++ b/apps/web/src/lib/actions/oauth/action.ts
@@ -1,9 +1,13 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { type ActionError, CommonErrorCode } from "@/lib/actions";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { getSession } from "@/lib/auth/auth.server";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 
 /**
  * Revokes OAuth client access by deleting consent, revoking refresh tokens, and deleting access tokens.
@@ -15,45 +19,55 @@ import { Err, Ok, type Result } from "@/lib/ts-res";
 export async function revokeOAuthClientAccess(
   consentId: string,
   clientId: string,
-): Promise<Result<void, ActionError>> {
+): Promise<ActionResultDto<void, ActionError>> {
   try {
     // Verify user is authenticated
     const session = await getSession();
     if (!session?.user?.id) {
-      return Err({
-        code: CommonErrorCode.UNAUTHENTICATED,
-        message: "You must be authenticated to revoke OAuth access",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.UNAUTHENTICATED,
+          message: "You must be authenticated to revoke OAuth access",
+        }),
+      );
     }
 
     await coreClient.revokeMyOauthConsent(consentId, clientId);
 
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
     if (error instanceof CoreApiRequestError) {
       switch (error.status) {
         case 400:
-          return Err({
-            code: CommonErrorCode.BAD_INPUT,
-            message: "Client ID does not match the consent",
-          });
+          return toActionResult(
+            err({
+              code: CommonErrorCode.BAD_INPUT,
+              message: "Client ID does not match the consent",
+            }),
+          );
         case 403:
-          return Err({
-            code: CommonErrorCode.UNAUTHORIZED,
-            message: "You can only revoke your own OAuth consents",
-          });
+          return toActionResult(
+            err({
+              code: CommonErrorCode.UNAUTHORIZED,
+              message: "You can only revoke your own OAuth consents",
+            }),
+          );
         case 404:
-          return Err({
-            code: CommonErrorCode.BAD_INPUT,
-            message: "Consent not found",
-          });
+          return toActionResult(
+            err({
+              code: CommonErrorCode.BAD_INPUT,
+              message: "Consent not found",
+            }),
+          );
       }
     }
 
     console.error("Failed to revoke OAuth client access", error);
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-      message: "Failed to revoke OAuth client access",
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+        message: "Failed to revoke OAuth client access",
+      }),
+    );
   }
 }

--- a/apps/web/src/lib/actions/onboarding/action.ts
+++ b/apps/web/src/lib/actions/onboarding/action.ts
@@ -1,14 +1,18 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
 import { getEnvPublicConfig } from "@/config/env.public";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { getSession } from "@/lib/auth/auth.server";
 import { userService } from "@/lib/services";
 import { SUBSCRIPTION_ONBOARDING_GATE_SESSION_COOKIE_NAME } from "@/lib/subscription-onboarding-gate-cookie";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 
 const SUBSCRIPTION_ONBOARDING_GATE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 400;
 
@@ -52,7 +56,7 @@ export async function clearSubscriptionOnboardingGateSessionCookie(): Promise<vo
 }
 
 export async function completeOnboarding(): Promise<
-  Result<{ redirectUrl: string }, ActionError>
+  ActionResultDto<{ redirectUrl: string }, ActionError>
 > {
   try {
     // Mark onboarding as completed without creating anything
@@ -64,13 +68,15 @@ export async function completeOnboarding(): Promise<
     }
 
     revalidatePath("/");
-    return Ok({ redirectUrl: "/tasks" });
+    return toActionResult(ok({ redirectUrl: "/tasks" }));
   } catch (error) {
     console.error("Error completing onboarding:", error);
     const t = await getTranslations("Onboarding.Actions.Errors");
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-      message: error instanceof Error ? error.message : t("failedToComplete"),
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+        message: error instanceof Error ? error.message : t("failedToComplete"),
+      }),
+    );
   }
 }

--- a/apps/web/src/lib/actions/organization/seat-action.ts
+++ b/apps/web/src/lib/actions/organization/seat-action.ts
@@ -1,10 +1,14 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { organizationSeatService } from "@/lib/services/organization-seat.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -48,16 +52,18 @@ interface OrganizationSeatActionParameters extends AuthenticatedRequest {
 
 export const assignOrganizationSeat = withSession<
   OrganizationSeatActionParameters,
-  Result<{ memberId: string; seatAssignedAt: Date }, ActionError>
+  ActionResultDto<{ memberId: string; seatAssignedAt: Date }, ActionError>
 >(async ({ session, memberId, organizationId }) => {
   const parsed = organizationSeatActionSchema.safeParse({
     memberId,
     organizationId,
   });
   if (!parsed.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+      }),
+    );
   }
 
   try {
@@ -67,25 +73,27 @@ export const assignOrganizationSeat = withSession<
       parsed.data.memberId,
     );
 
-    return Ok(result);
+    return toActionResult(ok(result));
   } catch (error) {
     console.error("Failed to assign organization seat", error);
-    return Err(parseSeatActionError(error));
+    return toActionResult(err(parseSeatActionError(error)));
   }
 });
 
 export const unassignOrganizationSeat = withSession<
   OrganizationSeatActionParameters,
-  Result<{ memberId: string }, ActionError>
+  ActionResultDto<{ memberId: string }, ActionError>
 >(async ({ session, memberId, organizationId }) => {
   const parsed = organizationSeatActionSchema.safeParse({
     memberId,
     organizationId,
   });
   if (!parsed.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+      }),
+    );
   }
 
   try {
@@ -95,9 +103,9 @@ export const unassignOrganizationSeat = withSession<
       parsed.data.memberId,
     );
 
-    return Ok(result);
+    return toActionResult(ok(result));
   } catch (error) {
     console.error("Failed to unassign organization seat", error);
-    return Err(parseSeatActionError(error));
+    return toActionResult(err(parseSeatActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/subscription/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/subscription/__tests__/action.test.ts
@@ -87,7 +87,7 @@ describe("subscription actions", () => {
     });
 
     expect(result).toEqual({
-      data: { seats: 9 },
+      value: { seats: 9 },
       ok: true,
     });
     expect(updateOrganizationSubscriptionSeatsMock).toHaveBeenCalledWith(

--- a/apps/web/src/lib/actions/subscription/action.ts
+++ b/apps/web/src/lib/actions/subscription/action.ts
@@ -1,8 +1,13 @@
 "use server";
 
 import type { PaidSubscriptionPlanName } from "@sokosumi/utils";
+import { err, ok } from "neverthrow";
 import * as z from "zod";
 import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { toSubscriptionSeatsActionError } from "@/lib/actions/subscription/map-core-subscription-seats-error";
 import type { SubscriptionChangeResult } from "@/lib/auth/subscription.server";
@@ -11,7 +16,6 @@ import {
   upgradePersonalSubscriptionServer,
 } from "@/lib/auth/subscription.server";
 import { coreClient } from "@/lib/clients/core.client";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -25,7 +29,7 @@ export async function upgradePersonalSubscription({
 }: {
   plan: PaidSubscriptionPlanName;
   returnPath?: string;
-}): Promise<Result<SubscriptionChangeResult, ActionError>> {
+}): Promise<ActionResultDto<SubscriptionChangeResult, ActionError>> {
   return upgradePersonalSubscriptionServer({ plan, returnPath });
 }
 
@@ -39,7 +43,7 @@ export async function upgradeOrganizationSubscription({
   plan: PaidSubscriptionPlanName;
   returnPath: string;
   seats: number;
-}): Promise<Result<SubscriptionChangeResult, ActionError>> {
+}): Promise<ActionResultDto<SubscriptionChangeResult, ActionError>> {
   return upgradeOrganizationSubscriptionServer({
     organizationId,
     plan,
@@ -61,16 +65,18 @@ interface UpdateOrganizationSubscriptionSeatsParameters
 
 export const updateOrganizationSubscriptionSeats = withSession<
   UpdateOrganizationSubscriptionSeatsParameters,
-  Result<{ seats: number }, ActionError>
+  ActionResultDto<{ seats: number }, ActionError>
 >(async ({ organizationId, seats, session }) => {
   const parsed = updateOrganizationSubscriptionSeatsSchema.safeParse({
     organizationId,
     seats,
   });
   if (!parsed.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+      }),
+    );
   }
 
   try {
@@ -84,8 +90,8 @@ export const updateOrganizationSubscriptionSeats = withSession<
       organizationId: parsed.data.organizationId,
     });
 
-    return Ok({ seats: data.seats });
+    return toActionResult(ok({ seats: data.seats }));
   } catch (error) {
-    return Err(toSubscriptionSeatsActionError(error));
+    return toActionResult(err(toSubscriptionSeatsActionError(error)));
   }
 });

--- a/apps/web/src/lib/auth/__tests__/subscription.server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/subscription.server.test.ts
@@ -54,7 +54,7 @@ describe("subscription.server", () => {
     });
 
     expect(result).toEqual({
-      data: {
+      value: {
         mode: "redirect",
         url: "https://checkout.stripe.com/session/test",
       },
@@ -177,7 +177,7 @@ describe("subscription.server", () => {
     });
 
     expect(result).toEqual({
-      data: { url: "https://billing.stripe.com/session/test" },
+      value: { url: "https://billing.stripe.com/session/test" },
       ok: true,
     });
     expect(subscriptionBillingPortalMock).toHaveBeenCalledWith({
@@ -208,7 +208,7 @@ describe("subscription.server", () => {
     });
 
     expect(result).toEqual({
-      data: {
+      value: {
         mode: "redirect",
         url: "https://checkout.stripe.com/session/org-test",
       },
@@ -247,7 +247,7 @@ describe("subscription.server", () => {
     });
 
     expect(result).toEqual({
-      data: { url: "https://billing.stripe.com/session/org-test" },
+      value: { url: "https://billing.stripe.com/session/org-test" },
       ok: true,
     });
     expect(subscriptionBillingPortalMock).toHaveBeenCalledWith({

--- a/apps/web/src/lib/auth/subscription.server.ts
+++ b/apps/web/src/lib/auth/subscription.server.ts
@@ -1,7 +1,12 @@
 import "server-only";
 
 import type { PaidSubscriptionPlanName } from "@sokosumi/utils";
+import { err, ok } from "neverthrow";
 import { headers } from "next/headers";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { OrganizationErrorCode } from "@/lib/actions/errors/error-codes";
 import { clearSubscriptionOnboardingGateSessionCookie } from "@/lib/actions/onboarding";
@@ -11,7 +16,6 @@ import {
 } from "@/lib/auth/auth.server.client";
 import { getAbsoluteRedirectUrlForOrigin } from "@/lib/auth/auth.utils";
 import { buildSubscriptionStatusPath } from "@/lib/stripe/subscription-redirect-urls";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 
 export type SubscriptionChangeResult =
   | { mode: "complete" }
@@ -52,16 +56,16 @@ function mapAuthClientError(error: BetterAuthClientError): ActionError {
 
 function resolveUpgradeResult(
   data: { url?: string | null } | null | undefined,
-): Result<SubscriptionChangeResult, ActionError> {
+): ActionResultDto<SubscriptionChangeResult, ActionError> {
   if (!data?.url) {
-    return Ok({ mode: "complete" });
+    return toActionResult(ok({ mode: "complete" }));
   }
 
-  return Ok({ mode: "redirect", url: data.url });
+  return toActionResult(ok({ mode: "redirect", url: data.url }));
 }
 
 async function resolveSubscriptionRedirectUrls(returnPath: string): Promise<
-  Result<
+  ActionResultDto<
     {
       cancelUrl: string;
       returnUrl: string;
@@ -74,28 +78,32 @@ async function resolveSubscriptionRedirectUrls(returnPath: string): Promise<
   const origin = resolveWebRequestOrigin(requestHeaders);
 
   if (!origin) {
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 
-  return Ok({
-    cancelUrl: getAbsoluteRedirectUrlForOrigin(
-      origin,
-      buildSubscriptionStatusPath(returnPath, "cancel"),
-      SAFE_REDIRECT_FALLBACK,
-    ),
-    returnUrl: getAbsoluteRedirectUrlForOrigin(
-      origin,
-      returnPath,
-      SAFE_REDIRECT_FALLBACK,
-    ),
-    successUrl: getAbsoluteRedirectUrlForOrigin(
-      origin,
-      buildSubscriptionStatusPath(returnPath, "success"),
-      SAFE_REDIRECT_FALLBACK,
-    ),
-  });
+  return toActionResult(
+    ok({
+      cancelUrl: getAbsoluteRedirectUrlForOrigin(
+        origin,
+        buildSubscriptionStatusPath(returnPath, "cancel"),
+        SAFE_REDIRECT_FALLBACK,
+      ),
+      returnUrl: getAbsoluteRedirectUrlForOrigin(
+        origin,
+        returnPath,
+        SAFE_REDIRECT_FALLBACK,
+      ),
+      successUrl: getAbsoluteRedirectUrlForOrigin(
+        origin,
+        buildSubscriptionStatusPath(returnPath, "success"),
+        SAFE_REDIRECT_FALLBACK,
+      ),
+    }),
+  );
 }
 
 export async function upgradePersonalSubscriptionServer({
@@ -104,16 +112,16 @@ export async function upgradePersonalSubscriptionServer({
 }: {
   plan: PaidSubscriptionPlanName;
   returnPath?: string;
-}): Promise<Result<SubscriptionChangeResult, ActionError>> {
+}): Promise<ActionResultDto<SubscriptionChangeResult, ActionError>> {
   const resolvedReturnPath = returnPath ?? "/billing?tab=subscription";
   const redirectUrlsResult =
     await resolveSubscriptionRedirectUrls(resolvedReturnPath);
 
   if (!redirectUrlsResult.ok) {
-    return Err(redirectUrlsResult.error);
+    return toActionResult(err(redirectUrlsResult.error));
   }
 
-  const redirectUrls = redirectUrlsResult.data;
+  const redirectUrls = redirectUrlsResult.value;
 
   const result = await getAuthServerClient().subscription.upgrade({
     plan,
@@ -125,7 +133,7 @@ export async function upgradePersonalSubscriptionServer({
   });
 
   if (result.error) {
-    return Err(mapAuthClientError(result.error));
+    return toActionResult(err(mapAuthClientError(result.error)));
   }
 
   await clearSubscriptionOnboardingGateSessionCookie();
@@ -137,32 +145,34 @@ export async function openPersonalBillingPortalServer({
   returnPath,
 }: {
   returnPath?: string;
-}): Promise<Result<{ url: string }, ActionError>> {
+}): Promise<ActionResultDto<{ url: string }, ActionError>> {
   const resolvedReturnPath = returnPath ?? "/billing?tab=subscription";
   const redirectUrlsResult =
     await resolveSubscriptionRedirectUrls(resolvedReturnPath);
 
   if (!redirectUrlsResult.ok) {
-    return Err(redirectUrlsResult.error);
+    return toActionResult(err(redirectUrlsResult.error));
   }
 
   const result = await getAuthServerClient().subscription.billingPortal({
     customerType: "user",
-    returnUrl: redirectUrlsResult.data.returnUrl,
+    returnUrl: redirectUrlsResult.value.returnUrl,
     disableRedirect: true,
   });
 
   if (result.error) {
-    return Err(mapAuthClientError(result.error));
+    return toActionResult(err(mapAuthClientError(result.error)));
   }
 
   if (!result.data?.url) {
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 
-  return Ok({ url: result.data.url });
+  return toActionResult(ok({ url: result.data.url }));
 }
 
 export async function upgradeOrganizationSubscriptionServer({
@@ -175,14 +185,14 @@ export async function upgradeOrganizationSubscriptionServer({
   plan: PaidSubscriptionPlanName;
   returnPath: string;
   seats: number;
-}): Promise<Result<SubscriptionChangeResult, ActionError>> {
+}): Promise<ActionResultDto<SubscriptionChangeResult, ActionError>> {
   const redirectUrlsResult = await resolveSubscriptionRedirectUrls(returnPath);
 
   if (!redirectUrlsResult.ok) {
-    return Err(redirectUrlsResult.error);
+    return toActionResult(err(redirectUrlsResult.error));
   }
 
-  const redirectUrls = redirectUrlsResult.data;
+  const redirectUrls = redirectUrlsResult.value;
 
   const result = await getAuthServerClient().subscription.upgrade({
     plan,
@@ -196,7 +206,7 @@ export async function upgradeOrganizationSubscriptionServer({
   });
 
   if (result.error) {
-    return Err(mapAuthClientError(result.error));
+    return toActionResult(err(mapAuthClientError(result.error)));
   }
 
   await clearSubscriptionOnboardingGateSessionCookie();
@@ -210,29 +220,31 @@ export async function openOrganizationBillingPortalServer({
 }: {
   organizationId: string;
   returnPath: string;
-}): Promise<Result<{ url: string }, ActionError>> {
+}): Promise<ActionResultDto<{ url: string }, ActionError>> {
   const redirectUrlsResult = await resolveSubscriptionRedirectUrls(returnPath);
 
   if (!redirectUrlsResult.ok) {
-    return Err(redirectUrlsResult.error);
+    return toActionResult(err(redirectUrlsResult.error));
   }
 
   const result = await getAuthServerClient().subscription.billingPortal({
     customerType: "organization",
     referenceId: organizationId,
-    returnUrl: redirectUrlsResult.data.returnUrl,
+    returnUrl: redirectUrlsResult.value.returnUrl,
     disableRedirect: true,
   });
 
   if (result.error) {
-    return Err(mapAuthClientError(result.error));
+    return toActionResult(err(mapAuthClientError(result.error)));
   }
 
   if (!result.data?.url) {
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 
-  return Ok({ url: result.data.url });
+  return toActionResult(ok({ url: result.data.url }));
 }


### PR DESCRIPTION
## Summary
Migrate auth, onboarding, oauth, subscription, seat + billing portal callers.

**Linear:** [SOK-766](https://linear.app/masumi/issue/SOK-766) · Parent [SOK-754](https://linear.app/masumi/issue/SOK-754)

## Stack
#3737 → #3738 → #3739 → **this** → #3741 → #3742