### PR TITLE
feat(web): migrate remaining actions and UI off ts-res

### DIFF
--- a/apps/web/src/app/(app)/admin/enterprise-contracts/[id]/edit/page.tsx
+++ b/apps/web/src/app/(app)/admin/enterprise-contracts/[id]/edit/page.tsx
@@ -42,13 +42,13 @@ export default async function EditEnterpriseContractPage({
     );
   }
 
-  if (result.data.status !== "draft") {
+  if (result.value.status !== "draft") {
     redirect(`/admin/enterprise-contracts/${id}`);
   }
 
   const initialOrganization =
     await adminOrganizationService.getOrganizationOptionBySlug(
-      result.data.organizationSlug,
+      result.value.organizationSlug,
     );
 
   return (
@@ -72,12 +72,12 @@ export default async function EditEnterpriseContractPage({
 
         <Card>
           <CardHeader>
-            <CardTitle>{result.data.organizationSlug}</CardTitle>
+            <CardTitle>{result.value.organizationSlug}</CardTitle>
           </CardHeader>
           <CardContent>
             <ContractForm
               mode="edit"
-              contract={result.data}
+              contract={result.value}
               initialOrganization={initialOrganization}
             />
           </CardContent>

--- a/apps/web/src/app/(app)/admin/enterprise-contracts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/enterprise-contracts/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function EnterpriseContractDetailPage({
         <Button variant="outline" asChild>
           <Link href="/admin/enterprise-contracts">Back to list</Link>
         </Button>
-        <ContractDetail contract={result.data} />
+        <ContractDetail contract={result.value} />
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/admin/enterprise-contracts/page.tsx
+++ b/apps/web/src/app/(app)/admin/enterprise-contracts/page.tsx
@@ -62,7 +62,7 @@ async function EnterpriseContractsContent({
 
   return (
     <ContractsTable
-      contracts={result.data}
+      contracts={result.value}
       initialFilterOrganization={initialFilterOrganization}
     />
   );

--- a/apps/web/src/app/(app)/components/__tests__/auto-context-switch.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/auto-context-switch.test.tsx
@@ -45,7 +45,7 @@ describe("AutoContextSwitch", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });
@@ -111,7 +111,7 @@ describe("AutoContextSwitch", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });

--- a/apps/web/src/app/(app)/components/sidebar/components/__tests__/menu-items.test.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/__tests__/menu-items.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/app/components/history-search-dialog-provider", () => ({
 }));
 
 vi.mock("@/lib/actions/hermes", () => ({
-  getHermesUnreadCountAction: vi.fn().mockResolvedValue({ ok: true, data: 0 }),
+  getHermesUnreadCountAction: vi.fn().mockResolvedValue({ ok: true, value: 0 }),
 }));
 
 vi.mock("@/components/ui/sheet", () => ({

--- a/apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/components/personal-assistant-nav.client.tsx
@@ -60,7 +60,7 @@ function useAssistantNavState(enabled: boolean): AssistantNavState {
       }
       const result = await getHermesUnreadCountAction({});
       if (cancelled || !result.ok) return;
-      setState(result.data);
+      setState(result.value);
     };
 
     void tick();

--- a/apps/web/src/app/(app)/components/user-avatar/__tests__/workspace-switcher.test.tsx
+++ b/apps/web/src/app/(app)/components/user-avatar/__tests__/workspace-switcher.test.tsx
@@ -69,7 +69,7 @@ describe("workspace switcher", () => {
       });
       vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
         ok: true,
-        data: {
+        value: {
           organizationId: "org-7",
         },
       });
@@ -91,7 +91,7 @@ describe("workspace switcher", () => {
       });
       vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
         ok: true,
-        data: {
+        value: {
           organizationId: null,
         },
       });
@@ -172,7 +172,7 @@ describe("workspace switcher", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });
@@ -202,7 +202,7 @@ describe("workspace switcher", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });
@@ -232,7 +232,7 @@ describe("workspace switcher", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });
@@ -261,7 +261,7 @@ describe("workspace switcher", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });
@@ -312,7 +312,7 @@ describe("workspace switcher", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });
@@ -364,7 +364,7 @@ describe("workspace switcher", () => {
     );
     vi.mocked(updatePreferredOrganization).mockResolvedValueOnce({
       ok: true,
-      data: {
+      value: {
         organizationId: "org-1",
       },
     });

--- a/apps/web/src/app/(app)/developer/components/tasks/developer-task-list.tsx
+++ b/apps/web/src/app/(app)/developer/components/tasks/developer-task-list.tsx
@@ -48,9 +48,9 @@ export function DeveloperTaskList({ initialPage }: DeveloperTaskListProps) {
         return;
       }
 
-      setTasks((current) => [...current, ...result.data.tasks]);
-      setTotal(result.data.total);
-      setNextCursor(result.data.nextCursor);
+      setTasks((current) => [...current, ...result.value.tasks]);
+      setTotal(result.value.total);
+      setNextCursor(result.value.nextCursor);
     });
   }
 

--- a/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-invite-link-form.tsx
+++ b/apps/web/src/app/(app)/organizations/[organizationSlug]/components/organization-invite-link-form.tsx
@@ -115,7 +115,7 @@ export function OrganizationInviteLinkForm({
       }
 
       toast.success(t("success"));
-      await handleCopyCreatedLink(result.data.url);
+      await handleCopyCreatedLink(result.value.url);
       router.refresh();
     } catch {
       toast.error(t("error"));

--- a/apps/web/src/app/(app)/personal-assistant/components/__tests__/onboarding-progress.test.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/__tests__/onboarding-progress.test.tsx
@@ -43,7 +43,7 @@ vi.mock("../rotating-messages", () => ({
 function progressResult(status: string) {
   return {
     ok: true,
-    data: { status, steps: [], etaSeconds: null },
+    value: { status, steps: [], etaSeconds: null },
   };
 }
 
@@ -110,7 +110,7 @@ describe("OnboardingProgress", () => {
     // must not surface as "Almost done…" during a 1–2 min machine boot.
     getProgressMock.mockResolvedValue({
       ok: true,
-      data: { status: "onboarding", steps: [], etaSeconds: 0 },
+      value: { status: "onboarding", steps: [], etaSeconds: 0 },
     });
 
     render(
@@ -129,7 +129,7 @@ describe("OnboardingProgress", () => {
   it("renders the polled steps verbatim — dynamic subset, orchestrator labels, coarse ETA", async () => {
     getProgressMock.mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         status: "onboarding",
         // A realistic dynamic subset: no integration/sokosumi steps, the
         // inbox step skipped with its alternate label, orchestrator ids
@@ -174,7 +174,7 @@ describe("OnboardingProgress", () => {
     getProgressMock
       .mockResolvedValueOnce({
         ok: true,
-        data: {
+        value: {
           status: "onboarding",
           steps: [
             { id: "memory", label: "Saving your details", status: "running" },
@@ -186,7 +186,7 @@ describe("OnboardingProgress", () => {
       // both the rows AND the last real ETA must survive them.
       .mockResolvedValue({
         ok: true,
-        data: { status: "onboarding", steps: [], etaSeconds: 0 },
+        value: { status: "onboarding", steps: [], etaSeconds: 0 },
       });
 
     render(
@@ -215,7 +215,7 @@ describe("OnboardingProgress", () => {
   it("hands the ETA off to the settling copy when etaSeconds is ≤ 30s", async () => {
     getProgressMock.mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         status: "onboarding",
         steps: [
           {

--- a/apps/web/src/app/(app)/personal-assistant/components/autonomy-panel.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/autonomy-panel.tsx
@@ -103,7 +103,7 @@ export default function AutonomyPanel({
         return;
       }
       toast.success(t("autonomySavedToast"));
-      onAutonomyChanged?.(result.data.autonomyLevel);
+      onAutonomyChanged?.(result.value.autonomyLevel);
       // Sync parent state so the next time the sheet opens it doesn't
       // resync the selector from the stale `autonomyLevel` prop.
       void onRefreshInstance?.();
@@ -131,7 +131,7 @@ export default function AutonomyPanel({
     void listHermesSchedulesAction({}).then((result) => {
       if (cancelled) return;
       setSchedulesLoading(false);
-      if (result.ok) setSchedules(result.data);
+      if (result.ok) setSchedules(result.value);
     });
     return () => {
       cancelled = true;
@@ -283,7 +283,7 @@ function ScheduleRow({
       toast.error(result.error.message ?? t("schedulesToggleFailed"));
       return;
     }
-    onChange(result.data);
+    onChange(result.value);
   };
 
   // Kind label sits inline as muted text. No colored chip — the panel

--- a/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
@@ -364,13 +364,13 @@ export default function HermesExperience({
       }
       // Any successful instance fetch resets the fail-open counter.
       backgroundFailureCountRef.current = 0;
-      if (!instanceResult.data) {
+      if (!instanceResult.value) {
         if (background) return;
         setUiState("idle");
         clearInstanceSnapshot();
         return;
       }
-      const next = uiStateForServerStatus(instanceResult.data.status);
+      const next = uiStateForServerStatus(instanceResult.value.status);
       // Forward-only guard for background refreshes — same shape as the
       // provisioning/onboarding polling loop's `isForwardTransition` check.
       // Without this, a stale orchestrator read could yank the user from
@@ -389,9 +389,9 @@ export default function HermesExperience({
       const messagesResult = await listHermesMessagesAction({});
       if (isCancelled?.()) return;
       if (messagesResult.ok) {
-        setInitialMessages(messagesResult.data);
+        setInitialMessages(messagesResult.value);
       }
-      applyInstanceSnapshot(instanceResult.data);
+      applyInstanceSnapshot(instanceResult.value);
     },
     [t, applyInstanceSnapshot, clearInstanceSnapshot],
   );
@@ -446,8 +446,8 @@ export default function HermesExperience({
         timer = setTimeout(() => void tick(), POLL_INTERVAL_MS);
         return;
       }
-      if (result.data) {
-        const next = uiStateForServerStatus(result.data.status);
+      if (result.value) {
+        const next = uiStateForServerStatus(result.value.status);
         // Ignore stale polls that would walk the state backwards (e.g. a poll
         // racing the orchestrator's status flip right after we POST /onboard).
         if (!isForwardTransition(uiState, next)) {
@@ -463,14 +463,14 @@ export default function HermesExperience({
             // so the chat opens with the welcome already rendered.
             const messagesResult = await listHermesMessagesAction({});
             if (cancelled) return;
-            if (messagesResult.ok) setInitialMessages(messagesResult.data);
+            if (messagesResult.ok) setInitialMessages(messagesResult.value);
           }
           if (cancelled) return;
-          applyInstanceSnapshot(result.data);
+          applyInstanceSnapshot(result.value);
           setUiState(next);
           return;
         }
-        applyInstanceSnapshot(result.data);
+        applyInstanceSnapshot(result.value);
         if (next !== uiState) setUiState(next);
       } else {
         // Provision call succeeded but the instance disappeared — treat as error.
@@ -581,11 +581,11 @@ export default function HermesExperience({
       setErrorMessage(result.error.message ?? t("provisionFailed"));
       return;
     }
-    applyInstanceSnapshot(result.data);
-    const nextUi = uiStateForServerStatus(result.data.status);
+    applyInstanceSnapshot(result.value);
+    const nextUi = uiStateForServerStatus(result.value.status);
     if (nextUi === "running") {
       const messagesResult = await listHermesMessagesAction({});
-      if (messagesResult.ok) setInitialMessages(messagesResult.data);
+      if (messagesResult.ok) setInitialMessages(messagesResult.value);
     }
     // Immediately reflect server-side status — if it already came back as
     // "running" the polling effect will just no-op.

--- a/apps/web/src/app/(app)/personal-assistant/components/onboarding-progress.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/onboarding-progress.tsx
@@ -156,7 +156,7 @@ function useOnboardingProgress(
       consecutiveFailures = 0;
       setState((prev) => ({
         progress: {
-          status: result.data.status as ProgressShape["status"],
+          status: result.value.status as ProgressShape["status"],
           // Keep the last non-empty list: the contract doesn't guarantee
           // steps on every poll (Core maps an absent array to []), and a
           // step-less 200 mid-run — or right at the terminal flip — must
@@ -166,12 +166,12 @@ function useOnboardingProgress(
           // no usable ETA either — adopting that 0 would flash
           // "Almost done…" during the 1–2 min machine boot.
           steps:
-            result.data.steps.length > 0
-              ? result.data.steps
+            result.value.steps.length > 0
+              ? result.value.steps
               : prev.progress.steps,
           etaSeconds:
-            result.data.steps.length > 0
-              ? result.data.etaSeconds
+            result.value.steps.length > 0
+              ? result.value.etaSeconds
               : prev.progress.etaSeconds,
         },
         pollError: false,

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state/confirmation-card.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state/confirmation-card.tsx
@@ -252,11 +252,11 @@ export function ConfirmationCard({
       toast.error(result.error.message ?? t("approveFailed"));
       return;
     }
-    const { status } = result.data;
+    const { status } = result.value;
     const resolutionOrgId = workspaceSelection?.organizationId;
 
     if (status === "errored") {
-      toast.error(result.data.error ?? t("erroredAfterApproval"));
+      toast.error(result.value.error ?? t("erroredAfterApproval"));
       return;
     }
     if (status === "approved") {
@@ -318,10 +318,10 @@ export function ConfirmationCard({
       toast.error(result.error.message ?? t("rejectFailed"));
       return;
     }
-    const { status } = result.data;
+    const { status } = result.value;
 
     if (status === "errored") {
-      toast.error(result.data.error ?? t("rejectFailed"));
+      toast.error(result.value.error ?? t("rejectFailed"));
       return;
     }
     if (status === "rejected") {

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state/stream-chat-turn.ts
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state/stream-chat-turn.ts
@@ -339,7 +339,7 @@ export async function streamChatTurn({
     try {
       const result = await listHermesMessagesAction({});
       if (result.ok) {
-        const next = persistedToMessages(result.data);
+        const next = persistedToMessages(result.value);
         setMessages((prev) => {
           const base =
             abortedPartialId !== null

--- a/apps/web/src/app/(app)/personal-assistant/components/running-state/use-hermes-inbox-sync.ts
+++ b/apps/web/src/app/(app)/personal-assistant/components/running-state/use-hermes-inbox-sync.ts
@@ -31,7 +31,7 @@ export function useHermesInboxSync({
     }
     const result = await listHermesMessagesAction({});
     if (!result.ok || isReplyingRef.current) return;
-    const next = result.data
+    const next = result.value
       .map(persistedToMessage)
       .filter((m): m is Message => m !== null);
     const latest = next[next.length - 1];
@@ -70,7 +70,7 @@ export function useHermesInboxSync({
       // user's just-typed bubble. (Same race fixed in sendMessage by setting
       // isReplyingRef synchronously before any awaits.)
       if (isReplyingRef.current) return;
-      const next = result.data
+      const next = result.value
         .map(persistedToMessage)
         .filter((m): m is Message => m !== null);
 

--- a/apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/skills-marketplace.tsx
@@ -228,7 +228,7 @@ export default function SkillsMarketplace({
         const res = await searchSkillsAction({ q, limit: 24 });
         if (cancelled) return;
         if (res.ok) {
-          setResults(res.data);
+          setResults(res.value);
           setSearchError(null);
         } else {
           const message = res.error.message ?? t("emptyCatalog");
@@ -283,8 +283,8 @@ export default function SkillsMarketplace({
         toast.error(res.error.message ?? t("addFailed"));
         return;
       }
-      markInstalled(item, res.data.status);
-      if (res.data.status === "installing") {
+      markInstalled(item, res.value.status);
+      if (res.value.status === "installing") {
         toast(t("pendingToast", { name: item.name }));
       } else {
         toast.success(t("addedToast", { name: item.name }));
@@ -311,7 +311,7 @@ export default function SkillsMarketplace({
         toast.error(res.error.message ?? t("addFailed"));
         return;
       }
-      const { auditRisk, audits } = res.data;
+      const { auditRisk, audits } = res.value;
       const hasFail = audits.some((a) => a.status === "fail");
       if (auditRisk === "HIGH" || auditRisk === "CRITICAL" || hasFail) {
         toast.error(t("blockedHelp"));

--- a/apps/web/src/app/(app)/personal-assistant/components/use-composio-oauth.ts
+++ b/apps/web/src/app/(app)/personal-assistant/components/use-composio-oauth.ts
@@ -180,7 +180,7 @@ export function useComposioOAuth() {
         };
       }
 
-      const { redirectUrl, connectionId } = initiate.data;
+      const { redirectUrl, connectionId } = initiate.value;
       try {
         popup.location.href = redirectUrl;
       } catch {
@@ -284,9 +284,9 @@ export function useComposioOAuth() {
           addOAuthBreadcrumb("recovery finalize succeeded", {
             provider,
             mode,
-            integrationProvider: recovery.data.provider,
+            integrationProvider: recovery.value.provider,
           });
-          return { ok: true, integration: recovery.data };
+          return { ok: true, integration: recovery.value };
         }
         captureOAuthFailure("popup_closed", {
           provider,
@@ -337,9 +337,9 @@ export function useComposioOAuth() {
       addOAuthBreadcrumb("finalize succeeded", {
         provider,
         mode,
-        integrationProvider: finalize.data.provider,
+        integrationProvider: finalize.value.provider,
       });
-      return { ok: true, integration: finalize.data };
+      return { ok: true, integration: finalize.value };
     },
     [cleanup],
   );

--- a/apps/web/src/app/(app)/tasks/components/__tests__/task-workspace-switch-dialog.test.tsx
+++ b/apps/web/src/app/(app)/tasks/components/__tests__/task-workspace-switch-dialog.test.tsx
@@ -135,7 +135,7 @@ describe("TaskWorkspaceSwitchDialog", () => {
     });
     vi.mocked(updatePreferredOrganization).mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         organizationId: "org_123",
       },
     });

--- a/apps/web/src/app/(flows)/join/[token]/components/join-actions.tsx
+++ b/apps/web/src/app/(flows)/join/[token]/components/join-actions.tsx
@@ -38,7 +38,7 @@ export function JoinActions({
         return;
       }
       try {
-        await activateOrganizationWorkspace(result.data.organizationId);
+        await activateOrganizationWorkspace(result.value.organizationId);
       } catch (error) {
         console.error("Failed to switch organization workspace:", error);
       }

--- a/apps/web/src/components/admin/enterprise-contracts/contract-form.tsx
+++ b/apps/web/src/components/admin/enterprise-contracts/contract-form.tsx
@@ -244,7 +244,7 @@ export function ContractForm({
           return;
         }
         toast.success(t("createSuccess"));
-        router.push(`/admin/enterprise-contracts/${result.data.id}`);
+        router.push(`/admin/enterprise-contracts/${result.value.id}`);
         router.refresh();
         return;
       }

--- a/apps/web/src/components/admin/enterprise-contracts/preview-schedule-panel.tsx
+++ b/apps/web/src/components/admin/enterprise-contracts/preview-schedule-panel.tsx
@@ -50,7 +50,7 @@ export function PreviewSchedulePanel({
         return;
       }
 
-      setPreview(result.data);
+      setPreview(result.value);
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/components/credits/coupon-form.tsx
+++ b/apps/web/src/components/credits/coupon-form.tsx
@@ -99,7 +99,7 @@ export default function CouponForm({
 
             if (result.ok) {
               fireGTMEvent.beginCheckout();
-              window.location.assign(result.data.url);
+              window.location.assign(result.value.url);
               return;
             }
 

--- a/apps/web/src/components/credits/credits-form.tsx
+++ b/apps/web/src/components/credits/credits-form.tsx
@@ -166,7 +166,7 @@ export default function CreditsForm({
 
       if (result.ok) {
         fireGTMEvent.beginCheckout();
-        window.location.href = result.data.url;
+        window.location.href = result.value.url;
       } else {
         switch (result.error.code) {
           case CommonErrorCode.UNAUTHENTICATED:

--- a/apps/web/src/components/design-md/__tests__/design-md-adhoc-dialog.test.tsx
+++ b/apps/web/src/components/design-md/__tests__/design-md-adhoc-dialog.test.tsx
@@ -65,7 +65,7 @@ describe("DesignMdAdHocDialog", () => {
     const user = userEvent.setup();
     startDesignMdGenerationMock.mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         kind: "completed",
         data: { url: "https://blob.example/adhoc.md", extractionId: "1" },
       },
@@ -87,7 +87,7 @@ describe("DesignMdAdHocDialog", () => {
     const onGenerated = vi.fn();
     startDesignMdGenerationMock.mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         kind: "completed",
         data: { url: "https://blob.example/adhoc.md", extractionId: "1" },
       },
@@ -115,15 +115,15 @@ describe("DesignMdAdHocDialog", () => {
     const onGenerated = vi.fn();
     startDesignMdGenerationMock.mockResolvedValue({
       ok: true,
-      data: { kind: "queued", jobId: "job-1", jobToken: "token-1" },
+      value: { kind: "queued", jobId: "job-1", jobToken: "token-1" },
     });
     pollDesignMdGenerationMock.mockResolvedValue({
       ok: true,
-      data: { status: "done", extractionId: 1, designMd: "# Brand" },
+      value: { status: "done", extractionId: 1, designMd: "# Brand" },
     });
     finalizeDesignMdGenerationMock.mockResolvedValue({
       ok: true,
-      data: { url: "https://blob.example/adhoc.md", extractionId: "1" },
+      value: { url: "https://blob.example/adhoc.md", extractionId: "1" },
     });
     renderDialog(onGenerated);
 

--- a/apps/web/src/components/design-md/design-md-upload-trigger.tsx
+++ b/apps/web/src/components/design-md/design-md-upload-trigger.tsx
@@ -66,7 +66,7 @@ export function DesignMdUploadTrigger({
         }
 
         options.onSuccess(file);
-        onSaved?.(result.data);
+        onSaved?.(result.value);
         setFiles([]);
         toast.success(t("uploadSuccess"));
       } catch (error) {

--- a/apps/web/src/components/design-md/use-design-md-generation.ts
+++ b/apps/web/src/components/design-md/use-design-md-generation.ts
@@ -110,16 +110,16 @@ export function useDesignMdGeneration({
             return;
           }
 
-          if (pollResult.data.status === "failed") {
+          if (pollResult.value.status === "failed") {
             failGeneration(
-              pollResult.data.error ??
-                pollResult.data.message ??
+              pollResult.value.error ??
+                pollResult.value.message ??
                 messages.generationFailed,
             );
             return;
           }
 
-          if (isDesignMdJobInProgress(pollResult.data)) {
+          if (isDesignMdJobInProgress(pollResult.value)) {
             pollUntilDone(jobId, jobToken);
             return;
           }
@@ -136,7 +136,7 @@ export function useDesignMdGeneration({
             return;
           }
 
-          completeGeneration(finalizeResult.data);
+          completeGeneration(finalizeResult.value);
         } catch (error) {
           failGeneration(
             getUnknownErrorMessage(error, messages.generationFailed),
@@ -175,13 +175,13 @@ export function useDesignMdGeneration({
           return;
         }
 
-        if (startResult.data.kind === "completed") {
-          completeGeneration(startResult.data.data);
+        if (startResult.value.kind === "completed") {
+          completeGeneration(startResult.value.data);
           return;
         }
 
         safeSetState({ errorMessage: null, status: "polling" });
-        pollUntilDone(startResult.data.jobId, startResult.data.jobToken);
+        pollUntilDone(startResult.value.jobId, startResult.value.jobToken);
       } catch (error) {
         failGeneration(
           getUnknownErrorMessage(error, messages.generationFailed),

--- a/apps/web/src/components/jobs/job-details/refund-request.tsx
+++ b/apps/web/src/components/jobs/job-details/refund-request.tsx
@@ -292,7 +292,7 @@ export default function RequestRefundButton({
         (currentJob) =>
           ({
             ...currentJob,
-            ...result.data.job,
+            ...result.value.job,
           }) as PaidJob,
       );
     } else {

--- a/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
+++ b/apps/web/src/components/organizations/create-organization-wizard/create-organization-wizard.tsx
@@ -277,14 +277,14 @@ export function CreateOrganizationWizard({
           url,
           organizationId: orgId,
         });
-        if (result.ok && result.data.url) {
+        if (result.ok && result.value.url) {
           const previousLogo = logoUrlRef.current;
-          setLogoUrl(result.data.url);
+          setLogoUrl(result.value.url);
           await authClient.organization.update({
             organizationId: orgId,
-            data: { logo: result.data.url },
+            data: { logo: result.value.url },
           });
-          if (previousLogo && previousLogo !== result.data.url) {
+          if (previousLogo && previousLogo !== result.value.url) {
             void cleanupOrganizationLogoBestEffort(orgId, previousLogo);
           }
         }
@@ -381,7 +381,7 @@ export function CreateOrganizationWizard({
 
       const metadata = buildOrganizationMetadataWithUrl(null, url);
       const created = await authClient.organization.create({
-        slug: slugResult.data,
+        slug: slugResult.value,
         name: values.name,
         ...(metadata && { metadata }),
       });
@@ -459,7 +459,7 @@ export function CreateOrganizationWizard({
         organizationId,
       });
       if (result.ok) {
-        setInviteLink(result.data.url);
+        setInviteLink(result.value.url);
       } else {
         setLinkFailed(true);
         toast.error(t("Invite.linkError"));
@@ -543,10 +543,10 @@ export function CreateOrganizationWizard({
         toast.error(result.error.message ?? t("Invite.emailError"));
         return;
       }
-      const sent = result.data.results.filter(
+      const sent = result.value.results.filter(
         (row) => row.status === "sent",
       ).length;
-      const failed = result.data.results.length - sent;
+      const failed = result.value.results.length - sent;
       toast.success(t("Invite.inviteSummary", { sent, failed }));
       setEmails("");
     } catch (error) {

--- a/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
+++ b/apps/web/src/components/organizations/organization-bulk-invite/modal.tsx
@@ -76,7 +76,7 @@ export default function OrganizationBulkInviteModal({
         return;
       }
 
-      const nextResults = result.data.results;
+      const nextResults = result.value.results;
       const sentCount = nextResults.filter(
         (row) => row.status === "sent",
       ).length;

--- a/apps/web/src/components/organizations/organization-information/form.tsx
+++ b/apps/web/src/components/organizations/organization-information/form.tsx
@@ -206,7 +206,7 @@ export default function OrganizationInformationForm({
           return;
         }
 
-        const slug = slugResult.data;
+        const slug = slugResult.value;
         result = await authClient.organization.create({
           slug,
           name: values.name,

--- a/apps/web/src/hooks/__tests__/use-job-submission.test.ts
+++ b/apps/web/src/hooks/__tests__/use-job-submission.test.ts
@@ -71,7 +71,7 @@ describe("useJobSubmission", () => {
     vi.clearAllMocks();
     startJobMock.mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         jobId: "job_123",
       },
     });

--- a/apps/web/src/hooks/__tests__/use-provide-job-input.hook.test.ts
+++ b/apps/web/src/hooks/__tests__/use-provide-job-input.hook.test.ts
@@ -63,7 +63,7 @@ describe("useProvideJobInput", () => {
     });
     provideJobInputMock.mockResolvedValue({
       ok: true,
-      data: {
+      value: {
         jobId: "job_123",
       },
     });

--- a/apps/web/src/hooks/use-job-submission.ts
+++ b/apps/web/src/hooks/use-job-submission.ts
@@ -51,7 +51,7 @@ export function useJobSubmission({
 
       try {
         let result:
-          | { ok: true; data: { jobId: string } }
+          | { ok: true; value: { jobId: string } }
           | { ok: false; error: { code: string } };
         const uploadFiles = async (
           inputData: ReturnType<typeof prepareInputValues>,
@@ -88,10 +88,10 @@ export function useJobSubmission({
           track("Agent hired", {
             agentId: agentId,
             credits: credits,
-            jobId: result.data.jobId,
+            jobId: result.value.jobId,
           });
           onSuccess();
-          router.push(`/agents/${agentId}/jobs/${result.data.jobId}`);
+          router.push(`/agents/${agentId}/jobs/${result.value.jobId}`);
         } else {
           switch (result.error.code) {
             case CommonErrorCode.UNAUTHENTICATED:

--- a/apps/web/src/hooks/use-job-submission.ts
+++ b/apps/web/src/hooks/use-job-submission.ts
@@ -50,9 +50,6 @@ export function useJobSubmission({
       setLoading(true);
 
       try {
-        let result:
-          | { ok: true; value: { jobId: string } }
-          | { ok: false; error: { code: string } };
         const uploadFiles = async (
           inputData: ReturnType<typeof prepareInputValues>,
         ) => {
@@ -72,7 +69,7 @@ export function useJobSubmission({
         const didUploadFiles = await uploadFiles(transformedInputData);
         if (!didUploadFiles) return;
 
-        result = await startJob({
+        const result = await startJob({
           input: {
             agentId: agentId,
             maxAcceptedCents,

--- a/apps/web/src/lib/actions/agent/create-agent-rating.ts
+++ b/apps/web/src/lib/actions/agent/create-agent-rating.ts
@@ -1,10 +1,14 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { getSession } from "@/lib/auth/auth.server";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 
 export interface AgentRatingError {
   code:
@@ -51,31 +55,37 @@ export async function createAgentRating(
   agentId: string,
   rating: number,
   comment?: string,
-): Promise<Result<void, AgentRatingError>> {
+): Promise<ActionResultDto<void, AgentRatingError>> {
   try {
     // Validate session
     const session = await getSession();
     if (!session) {
-      return Err({
-        code: "UNAUTHORIZED",
-        message: "You must be logged in to rate an agent",
-      });
+      return toActionResult(
+        err({
+          code: "UNAUTHORIZED",
+          message: "You must be logged in to rate an agent",
+        }),
+      );
     }
 
     // Validate rating
     if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
-      return Err({
-        code: "INVALID_RATING",
-        message: "Rating must be an integer between 1 and 5",
-      });
+      return toActionResult(
+        err({
+          code: "INVALID_RATING",
+          message: "Rating must be an integer between 1 and 5",
+        }),
+      );
     }
 
     // Validate comment length
     if (comment && comment.length > 1000) {
-      return Err({
-        code: "INVALID_INPUT",
-        message: "Comment must be 1000 characters or less",
-      });
+      return toActionResult(
+        err({
+          code: "INVALID_INPUT",
+          message: "Comment must be 1000 characters or less",
+        }),
+      );
     }
 
     // Core enforces the eligibility gate (a finished job with the agent) and
@@ -89,15 +99,17 @@ export async function createAgentRating(
     revalidatePath(`/agents/${agentId}`, "layout");
     revalidatePath("/agents");
 
-    return Ok(undefined);
+    return toActionResult(ok(undefined));
   } catch (error) {
     if (error instanceof CoreApiRequestError) {
-      return Err(mapCoreErrorToRatingError(error));
+      return toActionResult(err(mapCoreErrorToRatingError(error)));
     }
     console.error("Error creating agent rating:", error);
-    return Err({
-      code: "UNKNOWN",
-      message: "An unexpected error occurred while submitting your rating",
-    });
+    return toActionResult(
+      err({
+        code: "UNKNOWN",
+        message: "An unexpected error occurred while submitting your rating",
+      }),
+    );
   }
 }

--- a/apps/web/src/lib/actions/credits/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/credits/__tests__/action.test.ts
@@ -74,7 +74,7 @@ describe("credits actions", () => {
     });
     expect(result).toEqual({
       ok: true,
-      data: { url: "https://checkout.stripe.com/session/tiered" },
+      value: { url: "https://checkout.stripe.com/session/tiered" },
     });
   });
 
@@ -99,7 +99,7 @@ describe("credits actions", () => {
     });
     expect(result).toEqual({
       ok: true,
-      data: { url: "https://checkout.stripe.com/session/tiered" },
+      value: { url: "https://checkout.stripe.com/session/tiered" },
     });
   });
 
@@ -142,7 +142,7 @@ describe("credits actions", () => {
     });
     expect(result).toEqual({
       ok: true,
-      data: { url: "https://checkout.stripe.com/session/coupon" },
+      value: { url: "https://checkout.stripe.com/session/coupon" },
     });
   });
 

--- a/apps/web/src/lib/actions/credits/action.ts
+++ b/apps/web/src/lib/actions/credits/action.ts
@@ -1,8 +1,12 @@
 "use server";
 
 import { isPositiveIntegerCredits } from "@sokosumi/utils";
-
+import { err, ok } from "neverthrow";
 import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import {
   type ActionError,
   CommonErrorCode,
@@ -11,7 +15,6 @@ import {
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import { CouponError } from "@/lib/errors/coupon-errors";
 import { userService } from "@/lib/services";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -25,22 +28,26 @@ interface PurchaseCreditsParameters extends AuthenticatedRequest {
 
 export const purchaseCredits = withSession<
   PurchaseCreditsParameters,
-  Result<{ url: string }, ActionError>
+  ActionResultDto<{ url: string }, ActionError>
 >(async ({ organizationId, credits, returnPath, session }) => {
   if (!isPositiveIntegerCredits(credits)) {
-    return Err({
-      message: "Invalid credits",
-      code: CreditsErrorCode.INVALID_CREDITS,
-    });
+    return toActionResult(
+      err({
+        message: "Invalid credits",
+        code: CreditsErrorCode.INVALID_CREDITS,
+      }),
+    );
   }
 
   if (organizationId) {
     const member = await userService.getMyMemberInOrganization(organizationId);
     if (!member) {
-      return Err({
-        message: "Unauthorized",
-        code: CommonErrorCode.UNAUTHORIZED,
-      });
+      return toActionResult(
+        err({
+          message: "Unauthorized",
+          code: CommonErrorCode.UNAUTHORIZED,
+        }),
+      );
     }
   }
 
@@ -58,12 +65,14 @@ export const purchaseCredits = withSession<
         organizationId ?? session.session.activeOrganizationId ?? null,
     });
 
-    return Ok({ url: data.url });
+    return toActionResult(ok({ url: data.url }));
   } catch (error) {
     console.error("Failed to purchase credits", error);
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 });
 
@@ -75,15 +84,17 @@ interface ClaimFreeCreditsWithCouponParameters extends AuthenticatedRequest {
 
 export const claimFreeCreditsWithCoupon = withSession<
   ClaimFreeCreditsWithCouponParameters,
-  Result<{ url: string }, ActionError>
+  ActionResultDto<{ url: string }, ActionError>
 >(async ({ organizationId, couponId, returnPath, session }) => {
   if (organizationId) {
     const member = await userService.getMyMemberInOrganization(organizationId);
     if (!member) {
-      return Err({
-        message: "Unauthorized",
-        code: CommonErrorCode.UNAUTHORIZED,
-      });
+      return toActionResult(
+        err({
+          message: "Unauthorized",
+          code: CommonErrorCode.UNAUTHORIZED,
+        }),
+      );
     }
   }
 
@@ -91,10 +102,12 @@ export const claimFreeCreditsWithCoupon = withSession<
     const { data: coupon } = await coreClient.getCouponDetails(couponId);
     const promo = await coreClient.claimCoupon(couponId, { organizationId });
     if (!promo.data.active) {
-      return Err({
-        message: "Invalid coupon",
-        code: CreditsErrorCode.INVALID_COUPON,
-      });
+      return toActionResult(
+        err({
+          message: "Invalid coupon",
+          code: CreditsErrorCode.INVALID_COUPON,
+        }),
+      );
     }
 
     const { data } = await coreClient.createCreditCheckoutSession({
@@ -110,13 +123,15 @@ export const claimFreeCreditsWithCoupon = withSession<
         organizationId ?? session.session.activeOrganizationId ?? null,
     });
 
-    return Ok({ url: data.url });
+    return toActionResult(ok({ url: data.url }));
   } catch (error) {
     console.error("Failed to get free credits with coupon", error);
     if (error instanceof CouponError) {
-      return Err({
-        code: error.code,
-      });
+      return toActionResult(
+        err({
+          code: error.code,
+        }),
+      );
     }
     // Core returns 404 (unknown coupon) or 400 (not a valid credit coupon) when
     // the coupon cannot be validated/claimed; surface the specific
@@ -125,13 +140,17 @@ export const claimFreeCreditsWithCoupon = withSession<
       error instanceof CoreApiRequestError &&
       (error.status === 400 || error.status === 404)
     ) {
-      return Err({
-        message: "Invalid coupon",
-        code: CreditsErrorCode.INVALID_COUPON,
-      });
+      return toActionResult(
+        err({
+          message: "Invalid coupon",
+          code: CreditsErrorCode.INVALID_COUPON,
+        }),
+      );
     }
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 });

--- a/apps/web/src/lib/actions/design-md/action.ts
+++ b/apps/web/src/lib/actions/design-md/action.ts
@@ -1,7 +1,12 @@
 "use server";
 
 import type { DesignMdJobPayload } from "@sokosumi/masumi/tools";
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { coreClient } from "@/lib/clients/core.client";
@@ -24,7 +29,6 @@ import {
   type PersistedDesignMd,
   type StartDesignMdGenerationResult,
 } from "@/lib/services/design-md.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -96,14 +100,16 @@ async function revalidateOwner(owner: DesignMdOwnerSchemaType): Promise<void> {
 
 export const startDesignMdGeneration = withSession<
   StartDesignMdGenerationParameters,
-  Result<StartDesignMdGenerationResult, ActionError>
+  ActionResultDto<StartDesignMdGenerationResult, ActionError>
 >(async (parameters) => {
   const parsedResult = startDesignMdGenerationSchema.safeParse(parameters);
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
@@ -118,50 +124,56 @@ export const startDesignMdGeneration = withSession<
       await revalidateOwner(parsedResult.data.owner);
     }
 
-    return Ok(result);
+    return toActionResult(ok(result));
   } catch (error) {
     console.error("Failed to start DESIGN.md generation", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const pollDesignMdGeneration = withSession<
   PollDesignMdGenerationParameters,
-  Result<DesignMdJobPayload, ActionError>
+  ActionResultDto<DesignMdJobPayload, ActionError>
 >(async (parameters) => {
   const parsedResult = pollDesignMdGenerationSchema.safeParse(parameters);
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
-    return Ok(
-      await designMdService.pollDesignMdJob(
-        parameters.session,
-        parsedResult.data.owner,
-        parsedResult.data.jobId,
-        parsedResult.data.jobToken,
+    return toActionResult(
+      ok(
+        await designMdService.pollDesignMdJob(
+          parameters.session,
+          parsedResult.data.owner,
+          parsedResult.data.jobId,
+          parsedResult.data.jobToken,
+        ),
       ),
     );
   } catch (error) {
     console.error("Failed to poll DESIGN.md generation", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const finalizeDesignMdGeneration = withSession<
   FinalizeDesignMdGenerationParameters,
-  Result<PersistedDesignMd, ActionError>
+  ActionResultDto<PersistedDesignMd, ActionError>
 >(async (parameters) => {
   const parsedResult = finalizeDesignMdGenerationSchema.safeParse(parameters);
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
@@ -173,23 +185,25 @@ export const finalizeDesignMdGeneration = withSession<
     );
 
     await revalidateOwner(parsedResult.data.owner);
-    return Ok(persisted);
+    return toActionResult(ok(persisted));
   } catch (error) {
     console.error("Failed to finalize DESIGN.md generation", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const saveDesignMdUpload = withSession<
   SaveDesignMdUploadParameters,
-  Result<PersistedDesignMd, ActionError>
+  ActionResultDto<PersistedDesignMd, ActionError>
 >(async (parameters) => {
   const parsedResult = saveDesignMdUploadSchema.safeParse(parameters);
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
@@ -199,31 +213,33 @@ export const saveDesignMdUpload = withSession<
     );
 
     await revalidateOwner(parsedResult.data.owner);
-    return Ok(persisted);
+    return toActionResult(ok(persisted));
   } catch (error) {
     console.error("Failed to save DESIGN.md upload", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const removeDesignMd = withSession<
   RemoveDesignMdParameters,
-  Result<{ removed: true }, ActionError>
+  ActionResultDto<{ removed: true }, ActionError>
 >(async (parameters) => {
   const parsedResult = removeDesignMdSchema.safeParse(parameters);
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
     await designMdService.removeDesignMd(parsedResult.data.owner);
     await revalidateOwner(parsedResult.data.owner);
-    return Ok({ removed: true });
+    return toActionResult(ok({ removed: true }));
   } catch (error) {
     console.error("Failed to remove DESIGN.md", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/developer-tasks/action.ts
+++ b/apps/web/src/lib/actions/developer-tasks/action.ts
@@ -1,12 +1,17 @@
 "use server";
 
+import { err, ok } from "neverthrow";
+
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import {
   type DeveloperTaskListPage,
   developerTaskService,
   type ListDeveloperTasksParams,
 } from "@/lib/services/developer-task.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -25,13 +30,13 @@ interface ListDeveloperTasksRequest
 
 export const listDeveloperTasksAction = withSession<
   ListDeveloperTasksRequest,
-  Result<DeveloperTaskListPage, ActionError>
+  ActionResultDto<DeveloperTaskListPage, ActionError>
 >(async ({ cursor, limit, coworkerId }) => {
   try {
-    return Ok(
-      await developerTaskService.listTasks({ cursor, limit, coworkerId }),
+    return toActionResult(
+      ok(await developerTaskService.listTasks({ cursor, limit, coworkerId })),
     );
   } catch (error) {
-    return Err(mapError(error));
+    return toActionResult(err(mapError(error)));
   }
 });

--- a/apps/web/src/lib/actions/enterprise-contract/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/enterprise-contract/__tests__/action.test.ts
@@ -93,7 +93,7 @@ describe("enterprise contract actions", () => {
       throw new Error("Expected success result");
     }
 
-    expect(result.data).toEqual([{ id: "contract-1" }]);
+    expect(result.value).toEqual([{ id: "contract-1" }]);
     expect(listContractsMock).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/lib/actions/enterprise-contract/action.ts
+++ b/apps/web/src/lib/actions/enterprise-contract/action.ts
@@ -1,6 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { assertAdminSession } from "@/lib/auth/admin-access";
@@ -19,7 +24,6 @@ import {
   enterpriseContractAdminService,
   parseEnterpriseContractActivationBlockedError,
 } from "@/lib/services/enterprise-contract-admin.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -55,7 +59,7 @@ interface ListEnterpriseContractsParameters extends AuthenticatedRequest {
 
 export const listEnterpriseContractsAction = withSession<
   ListEnterpriseContractsParameters,
-  Result<EnterpriseContract[], ActionError>
+  ActionResultDto<EnterpriseContract[], ActionError>
 >(async ({ session, organizationSlug, status }) => {
   try {
     assertAdminSession(session);
@@ -63,9 +67,9 @@ export const listEnterpriseContractsAction = withSession<
       organizationSlug: organizationSlug?.trim() || undefined,
       status,
     });
-    return Ok(contracts);
+    return toActionResult(ok(contracts));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -75,15 +79,15 @@ interface CreateEnterpriseContractParameters extends AuthenticatedRequest {
 
 export const createEnterpriseContractAction = withSession<
   CreateEnterpriseContractParameters,
-  Result<EnterpriseContract, ActionError>
+  ActionResultDto<EnterpriseContract, ActionError>
 >(async ({ session, body }) => {
   try {
     assertAdminSession(session);
     const contract = await enterpriseContractAdminService.createContract(body);
     revalidateEnterpriseContractRoutes(contract.id);
-    return Ok(contract);
+    return toActionResult(ok(contract));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -93,14 +97,14 @@ interface GetEnterpriseContractParameters extends AuthenticatedRequest {
 
 export const getEnterpriseContractAction = withSession<
   GetEnterpriseContractParameters,
-  Result<EnterpriseContract, ActionError>
+  ActionResultDto<EnterpriseContract, ActionError>
 >(async ({ session, id }) => {
   try {
     assertAdminSession(session);
     const contract = await enterpriseContractAdminService.getContract(id);
-    return Ok(contract);
+    return toActionResult(ok(contract));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -111,7 +115,7 @@ interface UpdateEnterpriseContractParameters extends AuthenticatedRequest {
 
 export const updateEnterpriseContractAction = withSession<
   UpdateEnterpriseContractParameters,
-  Result<EnterpriseContract, ActionError>
+  ActionResultDto<EnterpriseContract, ActionError>
 >(async ({ session, id, body }) => {
   try {
     assertAdminSession(session);
@@ -120,9 +124,9 @@ export const updateEnterpriseContractAction = withSession<
       body,
     );
     revalidateEnterpriseContractRoutes(id);
-    return Ok(contract);
+    return toActionResult(ok(contract));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -134,26 +138,28 @@ interface PreviewEnterpriseContractPeriodsParameters
 
 export const previewEnterpriseContractPeriodsAction = withSession<
   PreviewEnterpriseContractPeriodsParameters,
-  Result<EnterpriseContractPreview, ActionError>
+  ActionResultDto<EnterpriseContractPreview, ActionError>
 >(async ({ session, id, activatedAt }) => {
   try {
     assertAdminSession(session);
 
     const parsedActivatedAt = new Date(activatedAt);
     if (Number.isNaN(parsedActivatedAt.getTime())) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-        message: "activatedAt must be a valid ISO datetime",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+          message: "activatedAt must be a valid ISO datetime",
+        }),
+      );
     }
 
     const preview = await enterpriseContractAdminService.previewPeriods(
       id,
       parsedActivatedAt,
     );
-    return Ok(preview);
+    return toActionResult(ok(preview));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -164,7 +170,10 @@ interface ActivateEnterpriseContractParameters extends AuthenticatedRequest {
 
 export const activateEnterpriseContractAction = withSession<
   ActivateEnterpriseContractParameters,
-  Result<ActivateEnterpriseContractResponse, EnterpriseContractActionError>
+  ActionResultDto<
+    ActivateEnterpriseContractResponse,
+    EnterpriseContractActionError
+  >
 >(async ({ session, id, paymentReference }) => {
   try {
     assertAdminSession(session);
@@ -175,13 +184,13 @@ export const activateEnterpriseContractAction = withSession<
         : undefined,
     );
     revalidateEnterpriseContractRoutes(id);
-    return Ok(result);
+    return toActionResult(ok(result));
   } catch (error) {
     const blocked = parseEnterpriseContractActivationBlockedError(error);
     if (blocked) {
-      return Err(blocked);
+      return toActionResult(err(blocked));
     }
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });
 
@@ -191,14 +200,14 @@ interface CancelEnterpriseContractParameters extends AuthenticatedRequest {
 
 export const cancelEnterpriseContractAction = withSession<
   CancelEnterpriseContractParameters,
-  Result<EnterpriseContract, ActionError>
+  ActionResultDto<EnterpriseContract, ActionError>
 >(async ({ session, id }) => {
   try {
     assertAdminSession(session);
     const contract = await enterpriseContractAdminService.cancelContract(id);
     revalidateEnterpriseContractRoutes(id);
-    return Ok(contract);
+    return toActionResult(ok(contract));
   } catch (error) {
-    return Err(mapCoreError(error));
+    return toActionResult(err(mapCoreError(error)));
   }
 });

--- a/apps/web/src/lib/actions/hermes/__tests__/unread-count-action.test.ts
+++ b/apps/web/src/lib/actions/hermes/__tests__/unread-count-action.test.ts
@@ -73,7 +73,7 @@ describe("getHermesUnreadCountAction", () => {
 
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         count: 2,
         avatarSeed: "orb-1",
         assistantName: "Ada",

--- a/apps/web/src/lib/actions/hermes/action.ts
+++ b/apps/web/src/lib/actions/hermes/action.ts
@@ -1,8 +1,12 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
-
+import { err, ok } from "neverthrow";
 import type { ActionError } from "@/lib/actions";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { CommonErrorCode } from "@/lib/actions/errors";
 import { getSession } from "@/lib/auth/auth.server";
 import { hasAdminRole } from "@/lib/auth/has-admin-role";
@@ -34,7 +38,6 @@ import type {
   HermesScheduleKind,
   HermesScheduleSource,
 } from "@/lib/hermes/types";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -163,7 +166,7 @@ async function listAllHermesMessages(): Promise<HermesPersistedMessage[]> {
  */
 export const getHermesInstanceAction = withSession<
   Record<string, never>,
-  Result<HermesInstancePublic | null, ActionError>
+  ActionResultDto<HermesInstancePublic | null, ActionError>
 >(async () => {
   try {
     const response = await coreClient.getHermesInstance();
@@ -171,10 +174,10 @@ export const getHermesInstanceAction = withSession<
     // envelope, collapsing HermesGetInstanceEnvelope to `never`. Member types
     // are correct — narrow via the union instead of the envelope.
     const body = response.data as HermesGetInstanceNone | HermesGetInstanceSome;
-    if (!body.hasInstance) return Ok(null);
-    return Ok(mapHermesInstance(body.instance));
+    if (!body.hasInstance) return toActionResult(ok(null));
+    return toActionResult(ok(mapHermesInstance(body.instance)));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -190,19 +193,19 @@ export const getHermesInstanceAction = withSession<
  */
 export const provisionHermesAction = withSession<
   Record<string, never>,
-  Result<HermesInstancePublic, ActionError>
+  ActionResultDto<HermesInstancePublic, ActionError>
 >(async ({ session }) => {
   try {
     // UX-level gate only — Core re-enforces on provision (incl. enterprise).
     // Fail closed when coverage lookups fail.
     const hasCoverage = await hasPaidPlanCoverage();
     if (!hasCoverage && !hasAdminRole(session.user.role)) {
-      return Err({ code: "SUBSCRIPTION_REQUIRED" });
+      return toActionResult(err({ code: "SUBSCRIPTION_REQUIRED" }));
     }
     const response = await coreClient.provisionHermesInstance();
-    return Ok(mapHermesInstance(response.data)!);
+    return toActionResult(ok(mapHermesInstance(response.data)!));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -211,13 +214,13 @@ export const provisionHermesAction = withSession<
  */
 export const destroyHermesAction = withSession<
   Record<string, never>,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async () => {
   try {
     await coreClient.destroyHermesInstance();
-    return Ok();
+    return toActionResult(ok());
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -226,12 +229,12 @@ export const destroyHermesAction = withSession<
  */
 export const listHermesMessagesAction = withSession<
   Record<string, never>,
-  Result<HermesPersistedMessage[], ActionError>
+  ActionResultDto<HermesPersistedMessage[], ActionError>
 >(async () => {
   try {
-    return Ok(await listAllHermesMessages());
+    return toActionResult(ok(await listAllHermesMessages()));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -242,7 +245,7 @@ export const listHermesMessagesAction = withSession<
 export async function getHermesUnreadCountAction(
   _args: Record<string, never> = {},
 ): Promise<
-  Result<
+  ActionResultDto<
     {
       count: number;
       avatarSeed: string | null;
@@ -254,19 +257,21 @@ export async function getHermesUnreadCountAction(
 > {
   const session = await getSession();
   if (!session) {
-    return Err({ code: CommonErrorCode.UNAUTHENTICATED });
+    return toActionResult(err({ code: CommonErrorCode.UNAUTHENTICATED }));
   }
 
   try {
     const response = await coreClient.getHermesUnreadCount();
-    return Ok({
-      count: response.data.count,
-      avatarSeed: response.data.avatarSeed ?? null,
-      assistantName: response.data.assistantName ?? null,
-      hasInstance: response.data.hasInstance ?? false,
-    });
+    return toActionResult(
+      ok({
+        count: response.data.count,
+        avatarSeed: response.data.avatarSeed ?? null,
+        assistantName: response.data.assistantName ?? null,
+        hasInstance: response.data.hasInstance ?? false,
+      }),
+    );
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 }
 
@@ -280,15 +285,15 @@ interface MarkHermesInboxSeenArgs extends AuthenticatedRequest {
  */
 export const markHermesInboxSeenAction = withSession<
   MarkHermesInboxSeenArgs,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ asOfIso }) => {
   try {
     await coreClient.markHermesInboxSeen(
       asOfIso ? { asOfIso: new Date(asOfIso) } : undefined,
     );
-    return Ok();
+    return toActionResult(ok());
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -303,13 +308,13 @@ interface SetHermesSecretArgs extends AuthenticatedRequest {
  */
 export const setHermesSecretAction = withSession<
   SetHermesSecretArgs,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ key, value }) => {
   try {
     await coreClient.setHermesSecret({ key, value });
-    return Ok();
+    return toActionResult(ok());
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -361,7 +366,7 @@ interface StartOnboardingArgs extends AuthenticatedRequest {
  */
 export const startHermesOnboardingAction = withSession<
   StartOnboardingArgs,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(
   async ({
     skipResearch,
@@ -388,9 +393,9 @@ export const startHermesOnboardingAction = withSession<
         autonomyLevel: autonomyLevel ?? undefined,
         personality: personality ?? undefined,
       });
-      return Ok();
+      return toActionResult(ok());
     } catch (error) {
-      return Err(toActionError(error));
+      return toActionResult(err(toActionError(error)));
     }
   },
 );
@@ -415,7 +420,7 @@ interface UpdateHermesInstanceArgs extends AuthenticatedRequest {
  */
 export const updateHermesInstanceAction = withSession<
   UpdateHermesInstanceArgs,
-  Result<HermesInstancePublic, ActionError>
+  ActionResultDto<HermesInstancePublic, ActionError>
 >(
   async ({
     autonomyLevel,
@@ -435,9 +440,9 @@ export const updateHermesInstanceAction = withSession<
         email: email ?? undefined,
         timezone: timezone ?? undefined,
       });
-      return Ok(mapHermesInstance(response.data)!);
+      return toActionResult(ok(mapHermesInstance(response.data)!));
     } catch (error) {
-      return Err(toActionError(error));
+      return toActionResult(err(toActionError(error)));
     }
   },
 );
@@ -459,23 +464,25 @@ export interface HermesOnboardingProgressPayload {
  */
 export const getHermesOnboardingProgressAction = withSession<
   Record<string, never>,
-  Result<HermesOnboardingProgressPayload, ActionError>
+  ActionResultDto<HermesOnboardingProgressPayload, ActionError>
 >(async () => {
   try {
     const response = await coreClient.getHermesOnboardingProgress();
     const data = response.data;
-    return Ok({
-      status: data.status,
-      steps: data.steps.map((step) => ({
-        id: step.id,
-        label: step.label,
-        status: step.status,
-        errorMessage: step.errorMessage ?? null,
-      })),
-      etaSeconds: data.etaSeconds,
-    });
+    return toActionResult(
+      ok({
+        status: data.status,
+        steps: data.steps.map((step) => ({
+          id: step.id,
+          label: step.label,
+          status: step.status,
+          errorMessage: step.errorMessage ?? null,
+        })),
+        etaSeconds: data.etaSeconds,
+      }),
+    );
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -485,13 +492,13 @@ interface DisconnectIntegrationArgs extends AuthenticatedRequest {
 
 export const disconnectHermesIntegrationAction = withSession<
   DisconnectIntegrationArgs,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ provider }) => {
   try {
     await coreClient.disconnectHermesIntegration({ provider });
-    return Ok();
+    return toActionResult(ok());
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -518,20 +525,22 @@ export interface HermesIntegrationOAuthHandoffPayload {
  */
 export const initiateHermesIntegrationAction = withSession<
   InitiateIntegrationArgs,
-  Result<HermesIntegrationOAuthHandoffPayload, ActionError>
+  ActionResultDto<HermesIntegrationOAuthHandoffPayload, ActionError>
 >(async ({ provider, mode }) => {
   try {
     const response = await coreClient.initiateHermesIntegration({
       provider,
       mode: mode ?? "read",
     });
-    return Ok({
-      provider: response.data.provider as HermesIntegrationProvider,
-      redirectUrl: response.data.redirectUrl,
-      connectionId: response.data.connectionId,
-    });
+    return toActionResult(
+      ok({
+        provider: response.data.provider as HermesIntegrationProvider,
+        redirectUrl: response.data.redirectUrl,
+        connectionId: response.data.connectionId,
+      }),
+    );
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -550,7 +559,7 @@ interface FinalizeIntegrationArgs extends AuthenticatedRequest {
  */
 export const finalizeHermesIntegrationAction = withSession<
   FinalizeIntegrationArgs,
-  Result<HermesIntegration, ActionError>
+  ActionResultDto<HermesIntegration, ActionError>
 >(async ({ provider, connectionId, mode }) => {
   try {
     const response = await coreClient.finalizeHermesIntegration({
@@ -558,9 +567,9 @@ export const finalizeHermesIntegrationAction = withSession<
       connectionId,
       mode: mode ?? "read",
     });
-    return Ok(mapHermesIntegration(response.data));
+    return toActionResult(ok(mapHermesIntegration(response.data)));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -610,13 +619,13 @@ function normalizeScheduleKind(kind: string): HermesScheduleKind {
 
 export const listHermesSchedulesAction = withSession<
   Record<string, never>,
-  Result<HermesSchedule[], ActionError>
+  ActionResultDto<HermesSchedule[], ActionError>
 >(async () => {
   try {
     const response = await coreClient.listHermesSchedules();
-    return Ok(response.data.schedules.map(mapHermesSchedule));
+    return toActionResult(ok(response.data.schedules.map(mapHermesSchedule)));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -631,15 +640,15 @@ interface ToggleHermesScheduleArgs extends AuthenticatedRequest {
  */
 export const toggleHermesScheduleAction = withSession<
   ToggleHermesScheduleArgs,
-  Result<HermesSchedule, ActionError>
+  ActionResultDto<HermesSchedule, ActionError>
 >(async ({ scheduleId, enabled }) => {
   try {
     const response = await coreClient.patchHermesSchedule(scheduleId, {
       enabled,
     });
-    return Ok(mapHermesSchedule(response.data));
+    return toActionResult(ok(mapHermesSchedule(response.data)));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -704,7 +713,7 @@ interface ApproveConfirmationArgs extends ResolveConfirmationArgs {
 
 export const approveHermesConfirmationAction = withSession<
   ApproveConfirmationArgs,
-  Result<HermesConfirmationResolveResult, ActionError>
+  ActionResultDto<HermesConfirmationResolveResult, ActionError>
 >(async (args) => {
   try {
     const body: HermesApproveConfirmationRequest = {};
@@ -720,9 +729,9 @@ export const approveHermesConfirmationAction = withSession<
       args.confirmationId,
       Object.keys(body).length > 0 ? body : undefined,
     );
-    return Ok(mapConfirmationResolveResult(response.data));
+    return toActionResult(ok(mapConfirmationResolveResult(response.data)));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -732,7 +741,7 @@ interface RejectConfirmationArgs extends ResolveConfirmationArgs {
 
 export const rejectHermesConfirmationAction = withSession<
   RejectConfirmationArgs,
-  Result<HermesConfirmationResolveResult, ActionError>
+  ActionResultDto<HermesConfirmationResolveResult, ActionError>
 >(async ({ confirmationId, reason, confirmation }) => {
   try {
     const body: HermesRejectConfirmationRequest = {
@@ -745,8 +754,8 @@ export const rejectHermesConfirmationAction = withSession<
       confirmationId,
       body,
     );
-    return Ok(mapConfirmationResolveResult(response.data));
+    return toActionResult(ok(mapConfirmationResolveResult(response.data)));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/hermes/skills.ts
+++ b/apps/web/src/lib/actions/hermes/skills.ts
@@ -1,8 +1,12 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
-
+import { err, ok } from "neverthrow";
 import type { ActionError } from "@/lib/actions";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import {
   CoreApiRequestError,
   coreClientNoRedirect,
@@ -15,7 +19,6 @@ import type {
   SkillCatalogDetail,
   SkillCatalogItem,
 } from "@/lib/clients/generated/core";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -42,7 +45,7 @@ interface BrowseSkillsArgs extends AuthenticatedRequest {
 
 export const getSkillsCatalogAction = withSession<
   BrowseSkillsArgs,
-  Result<SkillCatalogItem[], ActionError>
+  ActionResultDto<SkillCatalogItem[], ActionError>
 >(async ({ view, page, perPage }) => {
   try {
     const response = await coreClientNoRedirect.getSkillsCatalog({
@@ -50,9 +53,9 @@ export const getSkillsCatalogAction = withSession<
       page,
       perPage,
     });
-    return Ok(response.data.skills);
+    return toActionResult(ok(response.data.skills));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -63,28 +66,28 @@ interface SearchSkillsArgs extends AuthenticatedRequest {
 
 export const searchSkillsAction = withSession<
   SearchSkillsArgs,
-  Result<SkillCatalogItem[], ActionError>
+  ActionResultDto<SkillCatalogItem[], ActionError>
 >(async ({ q, limit }) => {
   try {
     const response = await coreClientNoRedirect.searchSkillsCatalog({
       q,
       limit,
     });
-    return Ok(response.data.skills);
+    return toActionResult(ok(response.data.skills));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const getCuratedSkillsAction = withSession<
   AuthenticatedRequest,
-  Result<SkillCatalogItem[], ActionError>
+  ActionResultDto<SkillCatalogItem[], ActionError>
 >(async () => {
   try {
     const response = await coreClientNoRedirect.getCuratedSkills();
-    return Ok(response.data.skills);
+    return toActionResult(ok(response.data.skills));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -95,40 +98,40 @@ interface SkillDetailArgs extends AuthenticatedRequest {
 
 export const getSkillDetailAction = withSession<
   SkillDetailArgs,
-  Result<SkillCatalogDetail, ActionError>
+  ActionResultDto<SkillCatalogDetail, ActionError>
 >(async ({ source, slug }) => {
   try {
     const response = await coreClientNoRedirect.getSkillDetail({
       source,
       slug,
     });
-    return Ok(response.data);
+    return toActionResult(ok(response.data));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const getInstalledSkillsAction = withSession<
   AuthenticatedRequest,
-  Result<InstalledSkill[], ActionError>
+  ActionResultDto<InstalledSkill[], ActionError>
 >(async () => {
   try {
     const response = await coreClientNoRedirect.getInstalledSkills();
-    return Ok(response.data.skills);
+    return toActionResult(ok(response.data.skills));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
 export const getPreinstalledSkillsAction = withSession<
   AuthenticatedRequest,
-  Result<PreinstalledSkill[], ActionError>
+  ActionResultDto<PreinstalledSkill[], ActionError>
 >(async () => {
   try {
     const response = await coreClientNoRedirect.getPreinstalledSkills();
-    return Ok(response.data.skills);
+    return toActionResult(ok(response.data.skills));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -139,13 +142,13 @@ interface InstallSkillArgs extends AuthenticatedRequest {
 
 export const installSkillAction = withSession<
   InstallSkillArgs,
-  Result<InstallSkillResponse, ActionError>
+  ActionResultDto<InstallSkillResponse, ActionError>
 >(async ({ source, slug }) => {
   try {
     const response = await coreClientNoRedirect.installSkill({ source, slug });
-    return Ok(response.data);
+    return toActionResult(ok(response.data));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -155,12 +158,12 @@ interface RemoveSkillArgs extends AuthenticatedRequest {
 
 export const removeSkillAction = withSession<
   RemoveSkillArgs,
-  Result<true, ActionError>
+  ActionResultDto<true, ActionError>
 >(async ({ slug }) => {
   try {
     await coreClientNoRedirect.removeSkill(slug);
-    return Ok(true);
+    return toActionResult(ok(true));
   } catch (error) {
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/job/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/job/__tests__/action.test.ts
@@ -157,7 +157,7 @@ describe("startJob", () => {
     );
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         jobId: "job-1",
       },
     });
@@ -194,7 +194,7 @@ describe("startJob", () => {
     expect(createAgentJobMock.mock.calls[0][1]).not.toHaveProperty("name");
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         jobId: "job-project",
       },
     });
@@ -425,7 +425,7 @@ describe("startJob", () => {
     expect(createAgentJobMock).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         jobId: "job-addon-credits",
       },
     });
@@ -471,7 +471,7 @@ describe("startJob", () => {
     expect(createAgentJobMock).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         jobId: "job-summed-credits",
       },
     });
@@ -710,7 +710,7 @@ describe("requestRefundJob", () => {
     expect(requestJobRefundMock).toHaveBeenCalledWith("job-1");
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         job: {
           id: "job-1",
           jobType: "PAID",
@@ -816,7 +816,7 @@ describe("provideJobInput", () => {
 
   it("submits input through the core client and returns the job id", async () => {
     provideJobInputCoreMock.mockResolvedValue({
-      data: { id: "input-1", input: "{}", inputHash: "h", signature: "s" },
+      value: { id: "input-1", input: "{}", inputHash: "h", signature: "s" },
     });
 
     const { provideJobInput } = await import("../action");

--- a/apps/web/src/lib/actions/job/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/job/__tests__/action.test.ts
@@ -816,7 +816,7 @@ describe("provideJobInput", () => {
 
   it("submits input through the core client and returns the job id", async () => {
     provideJobInputCoreMock.mockResolvedValue({
-      value: { id: "input-1", input: "{}", inputHash: "h", signature: "s" },
+      data: { id: "input-1", input: "{}", inputHash: "h", signature: "s" },
     });
 
     const { provideJobInput } = await import("../action");

--- a/apps/web/src/lib/actions/job/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/job/__tests__/action.test.ts
@@ -583,7 +583,7 @@ describe("updateJobName", () => {
     expect(patchJobMock).toHaveBeenCalledWith("job-1", {
       name: "Renamed Job",
     });
-    expect(result).toEqual({ ok: true, data: undefined });
+    expect(result).toEqual({ ok: true, value: undefined });
   });
 
   it("normalizes an empty name to null before calling core", async () => {
@@ -832,7 +832,7 @@ describe("provideJobInput", () => {
       eventId: "event-1",
       inputData: { answer: "8" },
     });
-    expect(result).toEqual({ ok: true, data: { jobId: "job-1" } });
+    expect(result).toEqual({ ok: true, value: { jobId: "job-1" } });
   });
 
   it("returns BAD_INPUT and skips core for input it cannot narrow", async () => {

--- a/apps/web/src/lib/actions/job/action.ts
+++ b/apps/web/src/lib/actions/job/action.ts
@@ -2,8 +2,13 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { convertCentsToCredits } from "@sokosumi/utils";
+import { err, ok } from "neverthrow";
 import { revalidatePath } from "next/cache";
 import { type ActionError, CommonErrorCode } from "@/lib/actions";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { isJobError, JobErrorCode } from "@/lib/actions/errors/error-codes/job";
 import { toCoreJobInputData } from "@/lib/actions/job/core-job-input";
 import {
@@ -21,7 +26,6 @@ import {
   startJobInputSchema,
 } from "@/lib/schemas";
 import { callAgentHiredWebHook, jobService } from "@/lib/services";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import { normalizeOptionalProjectId } from "@/lib/utils/project";
 import {
   type AuthenticatedRequest,
@@ -168,7 +172,7 @@ interface StartJobParameters extends AuthenticatedRequest {
 
 export const startJob = withSession<
   StartJobParameters,
-  Result<{ jobId: string }, ActionError>
+  ActionResultDto<{ jobId: string }, ActionError>
 >(async ({ input, session }) => {
   return await Sentry.withScope(async (scope) => {
     try {
@@ -220,10 +224,12 @@ export const startJob = withSession<
 
         Sentry.captureMessage("Job start validation failed", "warning");
 
-        return Err({
-          message: "Bad Input",
-          code: CommonErrorCode.BAD_INPUT,
-        });
+        return toActionResult(
+          err({
+            message: "Bad Input",
+            code: CommonErrorCode.BAD_INPUT,
+          }),
+        );
       }
       const parsed = parsedResult.data;
       const coreInputData = toCoreJobInputData(parsed.inputData);
@@ -238,10 +244,12 @@ export const startJob = withSession<
           "warning",
         );
 
-        return Err({
-          message: "Bad Input",
-          code: CommonErrorCode.BAD_INPUT,
-        });
+        return toActionResult(
+          err({
+            message: "Bad Input",
+            code: CommonErrorCode.BAD_INPUT,
+          }),
+        );
       }
 
       const agentRow = await fetchAgentRowForCoreJobStart(parsed.agentId);
@@ -251,17 +259,21 @@ export const startJob = withSession<
 
       if (parsed.maxAcceptedCents === ZERO_ACCEPTED_CENTS) {
         if (agentCredits == null) {
-          return Err({
-            message: "Credit cost is too high",
-            code: JobErrorCode.COST_TOO_HIGH,
-          });
+          return toActionResult(
+            err({
+              message: "Credit cost is too high",
+              code: JobErrorCode.COST_TOO_HIGH,
+            }),
+          );
         }
 
         if (agentCredits > 0) {
-          return Err({
-            message: "Credit cost is too high",
-            code: JobErrorCode.COST_TOO_HIGH,
-          });
+          return toActionResult(
+            err({
+              message: "Credit cost is too high",
+              code: JobErrorCode.COST_TOO_HIGH,
+            }),
+          );
         }
       }
 
@@ -272,17 +284,21 @@ export const startJob = withSession<
         const availableCredits = await resolveAvailableCredits();
 
         if (availableCredits == null) {
-          return Err({
-            message: "Failed to verify credit balance",
-            code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-          });
+          return toActionResult(
+            err({
+              message: "Failed to verify credit balance",
+              code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+            }),
+          );
         }
 
         if (availableCredits < agentCredits) {
-          return Err({
-            message: "Insufficient balance",
-            code: JobErrorCode.INSUFFICIENT_BALANCE,
-          });
+          return toActionResult(
+            err({
+              message: "Insufficient balance",
+              code: JobErrorCode.INSUFFICIENT_BALANCE,
+            }),
+          );
         }
       }
 
@@ -311,7 +327,7 @@ export const startJob = withSession<
       // call after agent hired webhook
       void callAgentHiredWebHook(userId, session.user.email);
       revalidatePath(`/agents/${input.agentId}/jobs/${job.data.id}`, "layout");
-      return Ok({ jobId: job.data.id });
+      return toActionResult(ok({ jobId: job.data.id }));
     } catch (error) {
       scope.setTag("error_type", "job_start_error");
 
@@ -338,7 +354,7 @@ export const startJob = withSession<
             },
           },
         });
-        return Err(actionError);
+        return toActionResult(err(actionError));
       } else if (isJobError(error)) {
         // Type-safe error handling using error.code
         let sentryLevel: "warning" | "error" | "fatal" = "error";
@@ -371,10 +387,12 @@ export const startJob = withSession<
             },
           },
         });
-        return Err({
-          message: error.message,
-          code: error.code,
-        });
+        return toActionResult(
+          err({
+            message: error.message,
+            code: error.code,
+          }),
+        );
       } else {
         // Generic fallback for unexpected errors
         scope.setTag("error_code", CommonErrorCode.INTERNAL_SERVER_ERROR);
@@ -391,10 +409,12 @@ export const startJob = withSession<
             },
           },
         });
-        return Err({
-          message: "Internal server error",
-          code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-        });
+        return toActionResult(
+          err({
+            message: "Internal server error",
+            code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+          }),
+        );
       }
     }
   });
@@ -412,7 +432,7 @@ interface MoveJobToWorkspaceParameters extends AuthenticatedRequest {
 
 export const provideJobInput = withSession<
   ProvideJobInputParameters,
-  Result<{ jobId: string }, ActionError>
+  ActionResultDto<{ jobId: string }, ActionError>
 >(async ({ input, session }) => {
   return await Sentry.withScope(async (scope) => {
     try {
@@ -432,10 +452,12 @@ export const provideJobInput = withSession<
           "warning",
         );
 
-        return Err({
-          message: "Bad Input",
-          code: CommonErrorCode.BAD_INPUT,
-        });
+        return toActionResult(
+          err({
+            message: "Bad Input",
+            code: CommonErrorCode.BAD_INPUT,
+          }),
+        );
       }
 
       // Set user context for Sentry
@@ -467,10 +489,12 @@ export const provideJobInput = withSession<
       // uploaded client-side and replaced with references).
       const coreInputData = toCoreJobInputData(inputData);
       if (!coreInputData) {
-        return Err({
-          message: "Bad Input",
-          code: CommonErrorCode.BAD_INPUT,
-        });
+        return toActionResult(
+          err({
+            message: "Bad Input",
+            code: CommonErrorCode.BAD_INPUT,
+          }),
+        );
       }
 
       // Provide job input through core (ownership + agent call + input write
@@ -491,7 +515,7 @@ export const provideJobInput = withSession<
         },
       });
 
-      return Ok({ jobId });
+      return toActionResult(ok({ jobId }));
     } catch (error) {
       scope.setTag("error_type", "job_input_submission_error");
       scope.setContext("error", {
@@ -509,20 +533,24 @@ export const provideJobInput = withSession<
       });
 
       if (error instanceof CoreApiRequestError) {
-        return Err(toCoreApiActionError(error));
+        return toActionResult(err(toCoreApiActionError(error)));
       }
 
       if (isJobError(error)) {
-        return Err({
-          message: error.message,
-          code: error.code,
-        });
+        return toActionResult(
+          err({
+            message: error.message,
+            code: error.code,
+          }),
+        );
       }
 
-      return Err({
-        message: "Failed to submit job input",
-        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-      });
+      return toActionResult(
+        err({
+          message: "Failed to submit job input",
+          code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+        }),
+      );
     }
   });
 });
@@ -550,14 +578,16 @@ interface UpdateJobNameParameters extends AuthenticatedRequest {
 
 export const updateJobName = withSession<
   UpdateJobNameParameters,
-  Result<void, ActionError>
+  ActionResultDto<void, ActionError>
 >(async ({ jobId, data }) => {
   const parsedResult = jobDetailsNameFormSchema().safeParse(data);
   if (!parsedResult.success) {
-    return Err({
-      message: "Bad Input",
-      code: CommonErrorCode.BAD_INPUT,
-    });
+    return toActionResult(
+      err({
+        message: "Bad Input",
+        code: CommonErrorCode.BAD_INPUT,
+      }),
+    );
   }
   const parsed = parsedResult.data;
 
@@ -566,25 +596,29 @@ export const updateJobName = withSession<
       name: parsed.name === "" ? null : parsed.name,
     });
 
-    return Ok();
+    return toActionResult(ok());
   } catch (error) {
     if (error instanceof CoreApiRequestError) {
       if (error.status === 404) {
-        return Err({
-          message: "Job not found",
-          code: JobErrorCode.JOB_NOT_FOUND,
-        });
+        return toActionResult(
+          err({
+            message: "Job not found",
+            code: JobErrorCode.JOB_NOT_FOUND,
+          }),
+        );
       }
 
       if (error.status === 401 || error.status === 403) {
-        return Err({
-          message: "Unauthorized",
-          code: CommonErrorCode.UNAUTHORIZED,
-        });
+        return toActionResult(
+          err({
+            message: "Unauthorized",
+            code: CommonErrorCode.UNAUTHORIZED,
+          }),
+        );
       }
     }
 
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });
 
@@ -600,41 +634,49 @@ interface RequestRefundJobResponse {
 
 export const requestRefundJob = withSession<
   RequestRefundJobParameters,
-  Result<{ job: RequestRefundJobResponse }, ActionError>
+  ActionResultDto<{ job: RequestRefundJobResponse }, ActionError>
 >(async ({ jobId }) => {
   try {
     const { data: job } = await coreClient.requestJobRefund(jobId);
     if (job.jobType !== "PAID") {
-      return Err({
-        message: "Job not found",
-        code: JobErrorCode.JOB_NOT_FOUND,
-      });
+      return toActionResult(
+        err({
+          message: "Job not found",
+          code: JobErrorCode.JOB_NOT_FOUND,
+        }),
+      );
     }
 
-    return Ok({
-      job: {
-        id: job.id,
-        jobType: job.jobType,
-        status: job.status as Job["status"],
-      },
-    });
+    return toActionResult(
+      ok({
+        job: {
+          id: job.id,
+          jobType: job.jobType,
+          status: job.status as Job["status"],
+        },
+      }),
+    );
   } catch (error) {
     if (error instanceof CoreApiRequestError) {
       if (error.status === 404) {
-        return Err({
-          message: "Job not found",
-          code: JobErrorCode.JOB_NOT_FOUND,
-        });
+        return toActionResult(
+          err({
+            message: "Job not found",
+            code: JobErrorCode.JOB_NOT_FOUND,
+          }),
+        );
       }
 
       if (error.status === 401 || error.status === 403) {
-        return Err({
-          message: "Unauthorized",
-          code: CommonErrorCode.UNAUTHORIZED,
-        });
+        return toActionResult(
+          err({
+            message: "Unauthorized",
+            code: CommonErrorCode.UNAUTHORIZED,
+          }),
+        );
       }
     }
 
-    return Err(toCoreApiActionError(error));
+    return toActionResult(err(toCoreApiActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/organization/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/organization/__tests__/action.test.ts
@@ -99,7 +99,7 @@ describe("organization actions", () => {
 
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         results: [
           { email: "first@example.com", status: "sent" },
           { email: "second@example.com", status: "sent" },
@@ -134,7 +134,7 @@ describe("organization actions", () => {
 
     expect(result).toEqual({
       ok: true,
-      data: {
+      value: {
         results: [
           { email: "ok@example.com", status: "sent" },
           { email: "fail@example.com", status: "failed" },
@@ -281,7 +281,7 @@ describe("updatePreferredOrganization", () => {
 
     expect(result).toEqual({
       ok: true,
-      data: { organizationId: "org-1" },
+      value: { organizationId: "org-1" },
     });
     expect(setMyPreferredOrganizationMock).toHaveBeenCalledWith("org-1");
     expect(invalidatePrivateSidebarChromeMock).toHaveBeenCalledWith({
@@ -304,7 +304,7 @@ describe("updatePreferredOrganization", () => {
 
     expect(result).toEqual({
       ok: true,
-      data: { organizationId: null },
+      value: { organizationId: null },
     });
     expect(setMyPreferredOrganizationMock).toHaveBeenCalledWith(null);
   });

--- a/apps/web/src/lib/actions/organization/action.ts
+++ b/apps/web/src/lib/actions/organization/action.ts
@@ -1,9 +1,14 @@
 "use server";
 
 import { CORE_API_ERROR_KINDS } from "@sokosumi/utils";
+import { err, ok } from "neverthrow";
 import * as z from "zod";
 import { invalidatePrivateSidebarChrome } from "@/app/components/private-sidebar-cache";
 import { getEnvSecrets } from "@/config/env.secrets";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
 import { MemberRole } from "@/lib/clients/generated/core";
@@ -17,7 +22,6 @@ import {
   organizationService,
 } from "@/lib/services/organization.service";
 import { userService } from "@/lib/services/user.service";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -25,25 +29,29 @@ import {
 
 export async function generateOrganizationSlug(
   data: OrganizationInformationFormSchemaType,
-): Promise<Result<string, ActionError>> {
+): Promise<ActionResultDto<string, ActionError>> {
   try {
     const parsedResult = organizationInformationFormSchema().safeParse(data);
     if (!parsedResult.success) {
-      return Err({
-        code: CommonErrorCode.BAD_INPUT,
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.BAD_INPUT,
+        }),
+      );
     }
 
     const slug = await organizationService.generateOrganizationSlugFromName(
       parsedResult.data.name,
     );
 
-    return Ok(slug);
+    return toActionResult(ok(slug));
   } catch (error) {
     console.error("Error generating organization slug", error);
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 }
 
@@ -80,33 +88,39 @@ function parseBulkInviteEmails(rawEmails: string): string[] | null {
 
 export const inviteOrganizationMembersBulk = withSession<
   InviteOrganizationMembersBulkParameters,
-  Result<{ results: BulkInviteResultRow[] }, ActionError>
+  ActionResultDto<{ results: BulkInviteResultRow[] }, ActionError>
 >(async ({ organizationId, rawEmails }) => {
   const parsedResult = bulkInviteEmailsSchema.safeParse({
     organizationId,
     rawEmails,
   });
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   const emails = parseBulkInviteEmails(parsedResult.data.rawEmails);
   if (!emails || emails.length === 0) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: "Enter at least one valid email address",
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: "Enter at least one valid email address",
+      }),
+    );
   }
 
   const invitationLimit = getEnvSecrets().ORG_INVITATION_LIMIT;
   if (emails.length > invitationLimit) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: `You can invite up to ${invitationLimit} members at a time`,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: `You can invite up to ${invitationLimit} members at a time`,
+      }),
+    );
   }
 
   try {
@@ -115,31 +129,39 @@ export const inviteOrganizationMembersBulk = withSession<
     );
 
     if (!member) {
-      return Err({
-        code: CommonErrorCode.UNAUTHORIZED,
-        message: "You are not a member of this organization",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.UNAUTHORIZED,
+          message: "You are not a member of this organization",
+        }),
+      );
     }
 
     if (!isOrganizationOwnerOrAdmin(member.role)) {
-      return Err({
-        code: CommonErrorCode.UNAUTHORIZED,
-        message: "Only organization owners and admins can invite members",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.UNAUTHORIZED,
+          message: "Only organization owners and admins can invite members",
+        }),
+      );
     }
 
-    return Ok(
-      await organizationService.inviteMultipleMembers(
-        parsedResult.data.organizationId,
-        emails,
-        MemberRole.MEMBER,
+    return toActionResult(
+      ok(
+        await organizationService.inviteMultipleMembers(
+          parsedResult.data.organizationId,
+          emails,
+          MemberRole.MEMBER,
+        ),
       ),
     );
   } catch (error) {
     console.error("Failed to bulk invite organization members", error);
-    return Err({
-      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      }),
+    );
   }
 });
 
@@ -153,17 +175,19 @@ interface UpdatePreferredOrganizationParameters extends AuthenticatedRequest {
 
 export const updatePreferredOrganization = withSession<
   UpdatePreferredOrganizationParameters,
-  Result<{ organizationId: string | null }, ActionError>
+  ActionResultDto<{ organizationId: string | null }, ActionError>
 >(async ({ organizationId, session }) => {
   const parsedResult = updatePreferredOrganizationSchema.safeParse({
     organizationId,
   });
 
   if (!parsedResult.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsedResult.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsedResult.error.issues[0]?.message,
+      }),
+    );
   }
 
   const previousOrganizationId = session.session.activeOrganizationId ?? null;
@@ -179,18 +203,22 @@ export const updatePreferredOrganization = withSession<
       previousOrganizationId,
     });
 
-    return Ok({
-      organizationId: data.organizationId,
-    });
+    return toActionResult(
+      ok({
+        organizationId: data.organizationId,
+      }),
+    );
   } catch (error) {
     if (
       error instanceof CoreApiRequestError &&
       error.kind === CORE_API_ERROR_KINDS.ORGANIZATION_MEMBERSHIP_REQUIRED
     ) {
-      return Err({
-        code: CommonErrorCode.UNAUTHORIZED,
-        message: "You are not a member of this organization",
-      });
+      return toActionResult(
+        err({
+          code: CommonErrorCode.UNAUTHORIZED,
+          message: "You are not a member of this organization",
+        }),
+      );
     }
 
     throw error;

--- a/apps/web/src/lib/actions/organization/invite-link-action.ts
+++ b/apps/web/src/lib/actions/organization/invite-link-action.ts
@@ -1,6 +1,11 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
@@ -8,7 +13,6 @@ import type {
   AcceptOrganizationInviteLink,
   OrganizationInviteLink,
 } from "@/lib/clients/generated/core";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -50,7 +54,7 @@ interface CreateOrganizationInviteLinkParameters extends AuthenticatedRequest {
 
 export const createOrganizationInviteLink = withSession<
   CreateOrganizationInviteLinkParameters,
-  Result<OrganizationInviteLink, ActionError>
+  ActionResultDto<OrganizationInviteLink, ActionError>
 >(async ({ organizationId, expiresInDays, maxUses }) => {
   const parsed = createInviteLinkSchema.safeParse({
     organizationId,
@@ -58,10 +62,12 @@ export const createOrganizationInviteLink = withSession<
     maxUses,
   });
   if (!parsed.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsed.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsed.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
@@ -76,10 +82,10 @@ export const createOrganizationInviteLink = withSession<
           : {}),
       },
     );
-    return Ok(data);
+    return toActionResult(ok(data));
   } catch (error) {
     console.error("Failed to create organization invite link", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -90,18 +96,18 @@ interface RevokeOrganizationInviteLinkParameters extends AuthenticatedRequest {
 
 export const revokeOrganizationInviteLink = withSession<
   RevokeOrganizationInviteLinkParameters,
-  Result<null, ActionError>
+  ActionResultDto<null, ActionError>
 >(async ({ organizationId, token }) => {
   if (!organizationId || !token) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
     await coreClient.revokeOrganizationInviteLink(organizationId, token);
-    return Ok(null);
+    return toActionResult(ok(null));
   } catch (error) {
     console.error("Failed to revoke organization invite link", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });
 
@@ -111,17 +117,17 @@ interface AcceptOrganizationInviteLinkParameters extends AuthenticatedRequest {
 
 export const acceptOrganizationInviteLink = withSession<
   AcceptOrganizationInviteLinkParameters,
-  Result<AcceptOrganizationInviteLink, ActionError>
+  ActionResultDto<AcceptOrganizationInviteLink, ActionError>
 >(async ({ token }) => {
   if (!token) {
-    return Err({ code: CommonErrorCode.BAD_INPUT });
+    return toActionResult(err({ code: CommonErrorCode.BAD_INPUT }));
   }
 
   try {
     const { data } = await coreClient.acceptOrganizationInviteLink(token);
-    return Ok(data);
+    return toActionResult(ok(data));
   } catch (error) {
     console.error("Failed to accept organization invite link", error);
-    return Err(toActionError(error));
+    return toActionResult(err(toActionError(error)));
   }
 });

--- a/apps/web/src/lib/actions/organization/site-icon-action.ts
+++ b/apps/web/src/lib/actions/organization/site-icon-action.ts
@@ -1,10 +1,14 @@
 "use server";
 
+import { err, ok } from "neverthrow";
 import * as z from "zod";
+import {
+  type ActionResultDto,
+  toActionResult,
+} from "@/lib/actions/action-result";
 
 import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { CoreApiRequestError, coreClient } from "@/lib/clients/core.client";
-import { Err, Ok, type Result } from "@/lib/ts-res";
 import {
   type AuthenticatedRequest,
   withSession,
@@ -30,14 +34,16 @@ interface ResolveOrganizationSiteIconParameters extends AuthenticatedRequest {
  */
 export const resolveOrganizationSiteIcon = withSession<
   ResolveOrganizationSiteIconParameters,
-  Result<{ url: string | null }, ActionError>
+  ActionResultDto<{ url: string | null }, ActionError>
 >(async ({ url, organizationId }) => {
   const parsed = resolveSiteIconSchema.safeParse({ url, organizationId });
   if (!parsed.success) {
-    return Err({
-      code: CommonErrorCode.BAD_INPUT,
-      message: parsed.error.issues[0]?.message,
-    });
+    return toActionResult(
+      err({
+        code: CommonErrorCode.BAD_INPUT,
+        message: parsed.error.issues[0]?.message,
+      }),
+    );
   }
 
   try {
@@ -45,12 +51,14 @@ export const resolveOrganizationSiteIcon = withSession<
       parsed.data.url,
       parsed.data.organizationId,
     );
-    return Ok({ url: data.url });
+    return toActionResult(ok({ url: data.url }));
   } catch (error) {
     if (error instanceof CoreApiRequestError && error.status === 400) {
-      return Err({ code: CommonErrorCode.BAD_INPUT, message: error.message });
+      return toActionResult(
+        err({ code: CommonErrorCode.BAD_INPUT, message: error.message }),
+      );
     }
     console.error("Failed to resolve organization site icon", error);
-    return Err({ code: CommonErrorCode.INTERNAL_SERVER_ERROR });
+    return toActionResult(err({ code: CommonErrorCode.INTERNAL_SERVER_ERROR }));
   }
 });


### PR DESCRIPTION
## Summary
Migrate remaining web actions/UI (org, credits, hermes, jobs, design-md, enterprise, ratings, developer-tasks). Zero production `@/lib/ts-res` imports after this layer.

**Linear:** [SOK-767](https://linear.app/masumi/issue/SOK-767) · Parent [SOK-754](https://linear.app/masumi/issue/SOK-754)

## Stack
#3737 → #3738 → #3739 → #3740 → **this** → #3742