### PR TITLE
fix(web): native mobile chrome for projects list

### DIFF
--- a/apps/web/src/app/(app)/projects/components/projects-loading-view.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-loading-view.tsx
@@ -21,7 +21,7 @@ export function ProjectsLoadingView({ labels }: ProjectsLoadingViewProps) {
         </Button>
       </div>
 
-      <div className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border">
+      <div className="bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border">
         <div className="divide-border/50 divide-y px-2">
           {Array.from({ length: 4 }, (_, index) => (
             <ProjectListItemSkeleton key={index} />

--- a/apps/web/src/app/(app)/projects/components/projects-view.tsx
+++ b/apps/web/src/app/(app)/projects/components/projects-view.tsx
@@ -99,7 +99,7 @@ export function ProjectsView({
         </div>
 
         {hasLoadedProjects ? (
-          <div className="bg-muted/30 border-border/50 overflow-hidden rounded-xl border">
+          <div className="bg-muted/30 border-border/50 -mx-6 overflow-hidden rounded-none border-0 md:mx-0 md:rounded-xl md:border">
             <div className="divide-border/50 divide-y px-2">
               {items.map((project) => (
                 <ProjectListItem


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the `/projects` list feel native on mobile by matching History and Tasks edge-to-edge list chrome (SOK-740 / SOK-748). Desktop card chrome is unchanged.

Closes [SOK-769](https://linear.app/masumi/issue/SOK-769/make-projects-list-feel-native-on-mobile)

## Spec summary

- Mobile list shell: `-mx-6`, `rounded-none`, `border-0`
- From `md:` up: restore `md:mx-0 md:rounded-xl md:border`
- Keep inner `px-2` on list content
- Loading skeleton shell matches the loaded list
- Empty state, detail pages, modals, and row content stay out of scope

## Verification

- `pnpm web:check`
- `pnpm web:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8084ab37-10ab-4e54-a0b2-3f336c53415e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8084ab37-10ab-4e54-a0b2-3f336c53415e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

