### PR TITLE
fix(chat): keep blank lines visible after send

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-blank-lines.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-blank-lines.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Regression: extra blank line in a typed message must still show after send.
+ *
+ * Composer stores blank lines as `\n\n` → two adjacent `<p>` nodes. Room styles
+ * zero paragraph margins for density; without an inter-paragraph gap that blank
+ * line looks swallowed after send.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Markdown from "@/components/markdown";
+import { htmlToMarkdown } from "@/lib/utils/composer-markdown-dom";
+
+import {
+  buildRoomComposerMessageContent,
+  ROOM_MESSAGE_MARKDOWN_CLASSNAME,
+} from "../room-helpers";
+
+function fromHtml(html: string): string {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  return htmlToMarkdown(root);
+}
+
+/** True if DOM still shows a blank line between "line one" and "line two". */
+function hasVisibleBlankBetween(container: HTMLElement): boolean {
+  const paragraphs = Array.from(container.querySelectorAll("p"));
+  const brCount = container.querySelectorAll("br").length;
+  const hasEmptyP = paragraphs.some((p) => (p.textContent ?? "").trim() === "");
+  const rootClass =
+    (container.firstElementChild as HTMLElement | null)?.className ?? "";
+  const marginsZeroed = rootClass.includes("prose-p:my-0");
+  // Explicit gap between consecutive paragraphs (room density fix).
+  const hasInterParagraphGap = rootClass.includes("p+p]:mt-");
+
+  if (hasEmptyP) return true;
+  if (brCount >= 2) return true;
+  if (hasInterParagraphGap && paragraphs.length >= 2) return true;
+  if (!marginsZeroed && paragraphs.length >= 2) return true;
+  return false;
+}
+
+function renderRoom(content: string) {
+  return render(
+    <Markdown className={ROOM_MESSAGE_MARKDOWN_CLASSNAME}>{content}</Markdown>,
+  );
+}
+
+describe("room message blank lines after send", () => {
+  it("send path keeps internal blank line in payload", () => {
+    const md = fromHtml("line one<br><br>line two");
+    const payload = buildRoomComposerMessageContent(md, [], () => "");
+    expect(payload).toMatch(/line one\n\n+line two/);
+  });
+
+  it("send path keeps single soft newline in payload", () => {
+    const md = fromHtml("line one<br>line two");
+    const payload = buildRoomComposerMessageContent(md, [], () => "");
+    expect(payload).toMatch(/line one\nline two/);
+  });
+
+  it("contenteditable blank div survives to payload", () => {
+    const md = fromHtml(
+      "<div>line one</div><div><br></div><div>line two</div>",
+    );
+    const payload = buildRoomComposerMessageContent(md, [], () => "");
+    expect(payload).toMatch(/line one\n\n+line two/);
+  });
+
+  it("AFTER SEND: blank line still visible in room message body", () => {
+    const md = fromHtml("line one<br><br>line two");
+    const payload = buildRoomComposerMessageContent(md, [], () => "");
+    const { container } = renderRoom(payload);
+    expect(hasVisibleBlankBetween(container)).toBe(true);
+    expect(ROOM_MESSAGE_MARKDOWN_CLASSNAME).toContain("p+p]:mt-");
+  });
+
+  it("AFTER SEND: soft single newline still visible (line break kept)", () => {
+    const md = fromHtml("line one<br>line two");
+    const payload = buildRoomComposerMessageContent(md, [], () => "");
+    const { container } = renderRoom(payload);
+    expect(container.querySelectorAll("br").length).toBeGreaterThan(0);
+    expect(container.textContent).toContain("line one");
+    expect(container.textContent).toContain("line two");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-blank-lines.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-blank-lines.test.tsx
@@ -16,28 +16,14 @@ import {
   ROOM_MESSAGE_MARKDOWN_CLASSNAME,
 } from "../room-helpers";
 
+/** Tokens that encode the room blank-line spacing contract. */
+const DENSITY_CLASS = "prose-p:my-0";
+const INTER_PARAGRAPH_GAP_CLASS = "[&_p+p]:mt-3";
+
 function fromHtml(html: string): string {
   const root = document.createElement("div");
   root.innerHTML = html;
   return htmlToMarkdown(root);
-}
-
-/** True if DOM still shows a blank line between "line one" and "line two". */
-function hasVisibleBlankBetween(container: HTMLElement): boolean {
-  const paragraphs = Array.from(container.querySelectorAll("p"));
-  const brCount = container.querySelectorAll("br").length;
-  const hasEmptyP = paragraphs.some((p) => (p.textContent ?? "").trim() === "");
-  const rootClass =
-    (container.firstElementChild as HTMLElement | null)?.className ?? "";
-  const marginsZeroed = rootClass.includes("prose-p:my-0");
-  // Explicit gap between consecutive paragraphs (room density fix).
-  const hasInterParagraphGap = rootClass.includes("p+p]:mt-");
-
-  if (hasEmptyP) return true;
-  if (brCount >= 2) return true;
-  if (hasInterParagraphGap && paragraphs.length >= 2) return true;
-  if (!marginsZeroed && paragraphs.length >= 2) return true;
-  return false;
 }
 
 function renderRoom(content: string) {
@@ -46,7 +32,34 @@ function renderRoom(content: string) {
   );
 }
 
+function roomRootClass(container: HTMLElement): string {
+  return (container.firstElementChild as HTMLElement | null)?.className ?? "";
+}
+
+/**
+ * Blank-line contract: adjacent content paragraphs under density + gap classes.
+ * Does not accept empty `<p>`, multi-`<br>`, or non-zeroed margins as substitutes.
+ */
+function assertsBlankLineSpacingContract(container: HTMLElement): void {
+  const paragraphs = Array.from(container.querySelectorAll("p"));
+  const rootClass = roomRootClass(container);
+
+  expect(paragraphs.length).toBeGreaterThanOrEqual(2);
+  expect(paragraphs.every((p) => (p.textContent ?? "").trim().length > 0)).toBe(
+    true,
+  );
+  expect(rootClass).toContain(DENSITY_CLASS);
+  expect(rootClass).toContain(INTER_PARAGRAPH_GAP_CLASS);
+}
+
 describe("room message blank lines after send", () => {
+  it("ROOM_MESSAGE_MARKDOWN_CLASSNAME carries density + inter-paragraph gap", () => {
+    expect(ROOM_MESSAGE_MARKDOWN_CLASSNAME).toContain(DENSITY_CLASS);
+    expect(ROOM_MESSAGE_MARKDOWN_CLASSNAME).toContain(
+      INTER_PARAGRAPH_GAP_CLASS,
+    );
+  });
+
   it("send path keeps internal blank line in payload", () => {
     const md = fromHtml("line one<br><br>line two");
     const payload = buildRoomComposerMessageContent(md, [], () => "");
@@ -67,12 +80,21 @@ describe("room message blank lines after send", () => {
     expect(payload).toMatch(/line one\n\n+line two/);
   });
 
-  it("AFTER SEND: blank line still visible in room message body", () => {
+  it("AFTER SEND: blank line uses adjacent paragraphs with density + gap classes", () => {
     const md = fromHtml("line one<br><br>line two");
     const payload = buildRoomComposerMessageContent(md, [], () => "");
     const { container } = renderRoom(payload);
-    expect(hasVisibleBlankBetween(container)).toBe(true);
-    expect(ROOM_MESSAGE_MARKDOWN_CLASSNAME).toContain("p+p]:mt-");
+    assertsBlankLineSpacingContract(container);
+  });
+
+  it("AFTER SEND: single-paragraph message keeps density without multi-p requirement", () => {
+    const { container } = renderRoom("just one paragraph");
+    const paragraphs = container.querySelectorAll("p");
+    const rootClass = roomRootClass(container);
+
+    expect(paragraphs.length).toBe(1);
+    expect(rootClass).toContain(DENSITY_CLASS);
+    expect(rootClass).toContain(INTER_PARAGRAPH_GAP_CLASS);
   });
 
   it("AFTER SEND: soft single newline still visible (line break kept)", () => {

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -67,6 +67,7 @@ import {
   formatRoomMarkdownMentions,
   type PendingRoomQuote,
   partitionRoomMentionSuggestions,
+  ROOM_QUOTE_MARKDOWN_CLASSNAME,
   type RoomMentionParticipant,
 } from "./room-helpers";
 
@@ -195,7 +196,7 @@ function PendingQuotePreview({
           ) : null}
           {quote.snippet.trim() ? (
             <div className="text-muted-foreground line-clamp-4 min-w-0 flex-1 text-xs leading-5">
-              <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
+              <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
                 {formatRoomMarkdownMentions({
                   content: quote.snippet,
                   coworkersById,

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -15,6 +15,17 @@ import type {
 } from "@/lib/clients/generated/core";
 import { parseMentions } from "@/lib/utils/mention-parser";
 
+/**
+ * Room markdown density: zero default paragraph margin so single-block
+ * messages stay tight, but restore vertical gap between consecutive `<p>`
+ * nodes so blank lines (`\n\n` after send) stay visible.
+ */
+export const ROOM_MESSAGE_MARKDOWN_CLASSNAME =
+  "text-base! md:text-sm! prose-p:my-0 [&_p+p]:mt-3 prose-p:leading-6 prose-ul:my-1 prose-ol:my-1 prose-pre:my-2";
+
+export const ROOM_QUOTE_MARKDOWN_CLASSNAME =
+  "prose-p:my-0 [&_p+p]:mt-2 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0";
+
 export interface DirectParticipantPreview {
   id: string;
   name: string;

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -80,6 +80,8 @@ import {
   formatMessageTime,
   formatRoomMarkdownMentions,
   messageSender,
+  ROOM_MESSAGE_MARKDOWN_CLASSNAME,
+  ROOM_QUOTE_MARKDOWN_CLASSNAME,
   scrollToRoomMessageElement,
 } from "./room-helpers";
 
@@ -267,7 +269,7 @@ function MessageQuoteBlock({
               expanded ? null : "line-clamp-4",
             )}
           >
-            <Markdown className="prose-p:my-0 prose-p:leading-5 prose-ul:my-0 prose-ol:my-0 prose-pre:my-0">
+            <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
               {formatRoomMarkdownMentions({
                 content: quote.snippet,
                 coworkersById,
@@ -393,7 +395,7 @@ function ChannelMarkdownSegment({
   }
 
   return (
-    <Markdown className="text-base! md:text-sm! prose-p:my-0 prose-p:leading-6 prose-ul:my-1 prose-ol:my-1 prose-pre:my-2">
+    <Markdown className={ROOM_MESSAGE_MARKDOWN_CLASSNAME}>
       {formatRoomMarkdownMentions({
         content,
         coworkersById,


### PR DESCRIPTION
## Summary

- Blank lines in chat messages looked removed after send even though the payload kept `\n\n`.
- Cause: room Markdown used `prose-p:my-0`, so paragraph spacing (the blank-line encoding) collapsed.
- Fix: keep dense single-paragraph bubbles, restore gap between consecutive `<p>` via `[&_p+p]:mt-*` on message body and quotes.
- Regression tests cover composer → send payload → room render for blank and soft newlines.

## Test plan

- [x] `pnpm --filter web exec vitest run src/app/(app)/chat/components/__tests__/room-message-blank-lines.test.tsx`
- [x] `pnpm --filter web exec vitest run src/app/(app)/chat/components/__tests__/room-message-row.test.tsx`
- [ ] Manually: type two lines with a blank line between (Shift+Enter twice), send, confirm blank line still shows in the bubble
- [ ] Manually: single soft line break still wraps correctly; single-paragraph messages stay tight