### PR TITLE
fix(chat): keep early-access coworkers in channel pickers

### DIFF
--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts
@@ -173,13 +173,6 @@ describe("filterCoworkersForComposeKind", () => {
         capabilities: ["chat"],
         canChat: false,
       }),
-      baseCoworker({
-        id: "8",
-        slug: "not-whitelisted",
-        name: "Not whitelisted",
-        capabilities: ["chat"],
-        canChat: false,
-      }),
     ];
 
     expect(
@@ -212,6 +205,11 @@ describe("filterCoworkersForComposeKind", () => {
         capabilities: ["chat"],
       }),
     ).toBe(false);
+  });
+
+  it("keeps early-access (non-whitelisted) runnable chat coworkers pickable", () => {
+    // Core scope=available already filtered whitelist ∪ GRANTED; web must
+    // not re-require isWhitelisted or pilot coworkers (e.g. Noodles) vanish.
     expect(
       coworkerCanChat({
         archivedAt: null,
@@ -219,6 +217,6 @@ describe("filterCoworkersForComposeKind", () => {
         baseURL: "https://responses.example.com/v1",
         capabilities: ["chat"],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/coworker-utils.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-utils.ts
@@ -27,8 +27,14 @@ function hasRunnableChatEndpoint(coworker: CoworkerAvailability): boolean {
   return typeof coworker.baseURL === "string" && coworker.baseURL.trim() !== "";
 }
 
-function isActiveWhitelistedCoworker(coworker: CoworkerAvailability): boolean {
-  return coworker.archivedAt == null && coworker.isWhitelisted !== false;
+/**
+ * Active (not archived) only. Workspace usability (global whitelist ∪
+ * GRANTED early access) is owned by Core `scope=available` /
+ * `validateChatCoworkerIds` — do not re-gate on isWhitelisted here or
+ * pilot coworkers vanish from channel/task pickers.
+ */
+function isActiveCoworker(coworker: CoworkerAvailability): boolean {
+  return coworker.archivedAt == null;
 }
 
 export function coworkerCanChat(coworker: CoworkerAvailability): boolean {
@@ -37,7 +43,7 @@ export function coworkerCanChat(coworker: CoworkerAvailability): boolean {
   }
 
   return (
-    isActiveWhitelistedCoworker(coworker) &&
+    isActiveCoworker(coworker) &&
     coworkerHasCapability(coworker, "chat") &&
     hasRunnableChatEndpoint(coworker)
   );
@@ -46,10 +52,7 @@ export function coworkerCanChat(coworker: CoworkerAvailability): boolean {
 export function coworkerCanHandleTasks(
   coworker: CoworkerAvailability,
 ): boolean {
-  return (
-    isActiveWhitelistedCoworker(coworker) &&
-    coworkerHasCapability(coworker, "tasks")
-  );
+  return isActiveCoworker(coworker) && coworkerHasCapability(coworker, "tasks");
 }
 
 export function filterCoworkersForComposeKind(

--- a/apps/web/src/lib/services/__tests__/coworker.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/coworker.service.test.ts
@@ -110,6 +110,18 @@ describe("coworker.service", () => {
       baseURL: "https://responses.example.com/v1",
       capabilities: ["chat"],
     };
+    // scope=available already encodes whitelist ∪ GRANTED. Early-access
+    // coworkers (isWhitelisted=false, workspace GRANTED) must stay pickable
+    // for channel roster / DMs — matching Core validateChatCoworkerIds.
+    const earlyAccessChatCoworker = {
+      id: "cow-4",
+      slug: "noodles",
+      name: "Noodles",
+      archivedAt: null,
+      isWhitelisted: false,
+      baseURL: "https://responses.example.com/v1",
+      capabilities: ["chat"],
+    };
 
     coreClientMock.getCoworkers.mockResolvedValue({
       data: [
@@ -132,15 +144,7 @@ describe("coworker.service", () => {
           baseURL: "https://responses.example.com/v1",
           capabilities: ["chat"],
         },
-        {
-          id: "cow-4",
-          slug: "not-whitelisted",
-          name: "Not whitelisted",
-          archivedAt: null,
-          isWhitelisted: false,
-          baseURL: "https://responses.example.com/v1",
-          capabilities: ["chat"],
-        },
+        earlyAccessChatCoworker,
       ],
     });
 
@@ -151,6 +155,6 @@ describe("coworker.service", () => {
       scope: "available",
       capability: ["chat"],
     });
-    expect(result).toEqual([runnableChatCoworker]);
+    expect(result).toEqual([runnableChatCoworker, earlyAccessChatCoworker]);
   });
 });


### PR DESCRIPTION
## Summary

- Edit-channel / chat pickers dropped non-globally-whitelisted coworkers that Core already returned via `scope=available` (whitelist ∪ `GRANTED` workspace access).
- Stop re-gating `coworkerCanChat` / `coworkerCanHandleTasks` on `isWhitelisted`; client only checks active + capability (+ chat baseURL). Usability stays Core-owned.
- Regression tests: early-access runnable coworker (Noodles-shaped) remains in `listCoworkers("chat")`.

## Why

User report: new channel could only add whitelisted AI coworkers; early-access coworker Noodles missing from roster UI. Core `validateChatCoworkerIds` already accepts GRANTED peers — bug was pure web filter.

## Test plan

- [x] `pnpm --filter web test src/lib/services/__tests__/coworker.service.test.ts src/app/(app)/chat/utils/__tests__/coworker-utils.test.ts`
- [ ] Manually: workspace with GRANTED (non-whitelisted) chat coworker → Edit channel Members list shows that coworker → save roster succeeds
- [ ] Confirm globally whitelisted coworkers still appear
- [ ] Confirm archived / no-baseURL chat coworkers still filtered out