### PR TITLE
fix(ai-provider): pass progress through coworker commit-gate

### DIFF
--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -1,17 +1,37 @@
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import { describe, expect, it, vi } from "vitest";
 
-import { COWORKER_AGENT_ERROR_SNIPPET } from "../coworker-agent-error.js";
+import {
+  COWORKER_AGENT_ERROR_SNIPPET,
+  MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS,
+} from "../coworker-agent-error.js";
 import { createCommitGateStream } from "./commit-gate-stream.js";
 
+type TestPart =
+  | { type: "text-delta"; delta: string }
+  | { type: "reasoning-start"; id: string }
+  | { type: "reasoning-delta"; id: string; delta: string }
+  | { type: "reasoning-end"; id: string }
+  | {
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      input: string;
+    }
+  | { type: "tool-input-delta"; id: string; delta: string }
+  | { type: "finish" };
+
+function asPart(part: TestPart): LanguageModelV4StreamPart {
+  return part as LanguageModelV4StreamPart;
+}
+
 function partsStream(
-  parts: Array<{ type: "text-delta"; delta: string } | { type: "finish" }>,
-): ReadableStream<import("@ai-sdk/provider").LanguageModelV4StreamPart> {
+  parts: TestPart[],
+): ReadableStream<LanguageModelV4StreamPart> {
   return new ReadableStream({
     start(controller) {
       for (const part of parts) {
-        controller.enqueue(
-          part as import("@ai-sdk/provider").LanguageModelV4StreamPart,
-        );
+        controller.enqueue(asPart(part));
       }
       controller.close();
     },
@@ -19,7 +39,7 @@ function partsStream(
 }
 
 async function collectText(
-  stream: ReadableStream<import("@ai-sdk/provider").LanguageModelV4StreamPart>,
+  stream: ReadableStream<LanguageModelV4StreamPart>,
 ): Promise<string> {
   const reader = stream.getReader();
   let text = "";
@@ -33,6 +53,21 @@ async function collectText(
     }
   }
   return text;
+}
+
+async function collectTypes(
+  stream: ReadableStream<LanguageModelV4StreamPart>,
+): Promise<string[]> {
+  const reader = stream.getReader();
+  const types: string[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    types.push(value.type);
+  }
+  return types;
 }
 
 describe("createCommitGateStream", () => {
@@ -116,5 +151,182 @@ describe("createCommitGateStream", () => {
     const text = await collectText(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
     expect(text).toContain(COWORKER_AGENT_ERROR_SNIPPET);
+  });
+
+  it("forwards reasoning progress before answer text commits", async () => {
+    let sourceController!: ReadableStreamDefaultController<LanguageModelV4StreamPart>;
+    const source = new ReadableStream<LanguageModelV4StreamPart>({
+      start(controller) {
+        sourceController = controller;
+      },
+    });
+
+    const onRetryNeeded = vi.fn(async () => null);
+    const gated = createCommitGateStream(source, {
+      onRetryNeeded,
+      minGoodChars: MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS,
+    });
+    const reader = gated.getReader();
+
+    sourceController.enqueue(
+      asPart({ type: "reasoning-start", id: "rs_progress" }),
+    );
+    sourceController.enqueue(
+      asPart({
+        type: "reasoning-delta",
+        id: "rs_progress",
+        delta: "Running tool work…",
+      }),
+    );
+    sourceController.enqueue(
+      asPart({ type: "reasoning-end", id: "rs_progress" }),
+    );
+
+    // Reasoning must leave the gate before any answer text is enqueued.
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "reasoning-start", id: "rs_progress" },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "reasoning-delta",
+        id: "rs_progress",
+        delta: "Running tool work…",
+      },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "reasoning-end", id: "rs_progress" },
+    });
+
+    // Short text stays gated; only commit-threshold text unblocks the buffer.
+    const shortText = "Hi";
+    const commitText = "x".repeat(MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS);
+    sourceController.enqueue(asPart({ type: "text-delta", delta: shortText }));
+    sourceController.enqueue(asPart({ type: "text-delta", delta: commitText }));
+    sourceController.enqueue(asPart({ type: "finish" }));
+    sourceController.close();
+
+    // Buffered short text flushes first, then the committing delta.
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "text-delta", delta: shortText },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "text-delta", delta: commitText },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "finish" },
+    });
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(onRetryNeeded).not.toHaveBeenCalled();
+  });
+
+  it("forwards tool progress before answer text commits", async () => {
+    const onRetryNeeded = vi.fn(async () => null);
+
+    const stream = createCommitGateStream(
+      partsStream([
+        {
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "list_jobs",
+          input: "{}",
+        },
+        { type: "tool-input-delta", id: "call_1", delta: '{"q":' },
+        {
+          type: "text-delta",
+          delta: "This is a complete coworker reply with enough text.",
+        },
+        { type: "finish" },
+      ]),
+      { onRetryNeeded },
+    );
+
+    const types = await collectTypes(stream);
+    expect(types).toEqual([
+      "tool-call",
+      "tool-input-delta",
+      "text-delta",
+      "finish",
+    ]);
+    expect(onRetryNeeded).not.toHaveBeenCalled();
+  });
+
+  it("still retries agent-error after reasoning was already forwarded", async () => {
+    const onRetryNeeded = vi.fn(async () =>
+      partsStream([
+        { type: "text-delta", delta: "This is a complete coworker reply." },
+        { type: "finish" },
+      ]),
+    );
+
+    const stream = createCommitGateStream(
+      partsStream([
+        { type: "reasoning-start", id: "rs_err" },
+        {
+          type: "reasoning-delta",
+          id: "rs_err",
+          delta: "Something went wrong…",
+        },
+        { type: "reasoning-end", id: "rs_err" },
+        {
+          type: "text-delta",
+          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
+        },
+        { type: "finish" },
+      ]),
+      { onRetryNeeded },
+    );
+
+    const types = await collectTypes(stream);
+    expect(onRetryNeeded).toHaveBeenCalledOnce();
+    expect(onRetryNeeded).toHaveBeenCalledWith("agent-error");
+    // Pre-commit reasoning already left the gate; retry supplies the answer.
+    // Buffered agent-error text is discarded on successful retry.
+    expect(types).toEqual([
+      "reasoning-start",
+      "reasoning-delta",
+      "reasoning-end",
+      "text-delta",
+      "finish",
+    ]);
+
+    const textStream = createCommitGateStream(
+      partsStream([
+        { type: "reasoning-start", id: "rs_err" },
+        {
+          type: "reasoning-delta",
+          id: "rs_err",
+          delta: "Something went wrong…",
+        },
+        { type: "reasoning-end", id: "rs_err" },
+        {
+          type: "text-delta",
+          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
+        },
+        { type: "finish" },
+      ]),
+      {
+        onRetryNeeded: async () =>
+          partsStream([
+            {
+              type: "text-delta",
+              delta: "This is a complete coworker reply.",
+            },
+            { type: "finish" },
+          ]),
+      },
+    );
+    expect(await collectText(textStream)).toBe(
+      "This is a complete coworker reply.",
+    );
   });
 });

--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -288,7 +288,7 @@ describe("createCommitGateStream", () => {
     expect(onRetryNeeded).not.toHaveBeenCalled();
   });
 
-  it("forwards stream-start and response-metadata before progress", async () => {
+  it("flushes held stream-start and response-metadata before progress", async () => {
     let sourceController!: ReadableStreamDefaultController<LanguageModelV4StreamPart>;
     const source = new ReadableStream<LanguageModelV4StreamPart>({
       start(controller) {
@@ -305,6 +305,7 @@ describe("createCommitGateStream", () => {
     sourceController.enqueue(
       asPart({ type: "response-metadata", id: "resp_1" }),
     );
+    // Setup is held until progress arrives (not enqueued yet).
     sourceController.enqueue(asPart({ type: "reasoning-start", id: "rs_1" }));
     sourceController.enqueue(
       asPart({
@@ -332,6 +333,93 @@ describe("createCommitGateStream", () => {
     });
 
     sourceController.close();
+  });
+
+  it("retries without re-emitting stream-start when first attempt setup was held", async () => {
+    const onRetryNeeded = vi.fn(async () =>
+      partsStream([
+        { type: "stream-start", warnings: [] },
+        { type: "response-metadata", id: "resp_retry" },
+        {
+          type: "text-delta",
+          delta: "This is a complete coworker reply with enough text.",
+        },
+        { type: "finish" },
+      ]),
+    );
+
+    const stream = createCommitGateStream(
+      partsStream([
+        { type: "stream-start", warnings: [] },
+        { type: "response-metadata", id: "resp_fail" },
+        {
+          type: "text-delta",
+          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
+        },
+        { type: "finish" },
+      ]),
+      { onRetryNeeded },
+    );
+
+    const types = await collectTypes(stream);
+    expect(onRetryNeeded).toHaveBeenCalledOnce();
+    expect(onRetryNeeded).toHaveBeenCalledWith("agent-error");
+    // Failed attempt setup was discarded; only retry stream-start leaves the gate.
+    expect(types).toEqual([
+      "stream-start",
+      "response-metadata",
+      "text-delta",
+      "finish",
+    ]);
+  });
+
+  it("retries after progress without a second stream-start", async () => {
+    const onRetryNeeded = vi.fn(async () =>
+      partsStream([
+        { type: "stream-start", warnings: [] },
+        { type: "response-metadata", id: "resp_retry" },
+        {
+          type: "text-delta",
+          delta: "This is a complete coworker reply with enough text.",
+        },
+        { type: "finish" },
+      ]),
+    );
+
+    const stream = createCommitGateStream(
+      partsStream([
+        { type: "stream-start", warnings: [] },
+        { type: "response-metadata", id: "resp_fail" },
+        { type: "reasoning-start", id: "rs_1" },
+        {
+          type: "reasoning-delta",
+          id: "rs_1",
+          delta: "Still working…",
+        },
+        { type: "reasoning-end", id: "rs_1" },
+        {
+          type: "text-delta",
+          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
+        },
+        { type: "finish" },
+      ]),
+      { onRetryNeeded },
+    );
+
+    const types = await collectTypes(stream);
+    expect(onRetryNeeded).toHaveBeenCalledOnce();
+    // Setup flushed with first progress; retry must not re-emit stream-start.
+    expect(types.filter((t) => t === "stream-start")).toHaveLength(1);
+    expect(types).toEqual([
+      "stream-start",
+      "response-metadata",
+      "reasoning-start",
+      "reasoning-delta",
+      "reasoning-end",
+      "response-metadata",
+      "text-delta",
+      "finish",
+    ]);
   });
 
   it("still retries agent-error after reasoning was already forwarded", async () => {

--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -8,6 +8,8 @@ import {
 import { createCommitGateStream } from "./commit-gate-stream.js";
 
 type TestPart =
+  | { type: "stream-start"; warnings: [] }
+  | { type: "response-metadata"; id: string }
   | { type: "text-delta"; delta: string }
   | { type: "reasoning-start"; id: string }
   | { type: "reasoning-delta"; id: string; delta: string }
@@ -230,34 +232,106 @@ describe("createCommitGateStream", () => {
   });
 
   it("forwards tool progress before answer text commits", async () => {
-    const onRetryNeeded = vi.fn(async () => null);
+    let sourceController!: ReadableStreamDefaultController<LanguageModelV4StreamPart>;
+    const source = new ReadableStream<LanguageModelV4StreamPart>({
+      start(controller) {
+        sourceController = controller;
+      },
+    });
 
-    const stream = createCommitGateStream(
-      partsStream([
-        {
-          type: "tool-call",
-          toolCallId: "call_1",
-          toolName: "list_jobs",
-          input: "{}",
-        },
-        { type: "tool-input-delta", id: "call_1", delta: '{"q":' },
-        {
-          type: "text-delta",
-          delta: "This is a complete coworker reply with enough text.",
-        },
-        { type: "finish" },
-      ]),
-      { onRetryNeeded },
+    const onRetryNeeded = vi.fn(async () => null);
+    const gated = createCommitGateStream(source, { onRetryNeeded });
+    const reader = gated.getReader();
+
+    sourceController.enqueue(
+      asPart({
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "list_jobs",
+        input: "{}",
+      }),
+    );
+    sourceController.enqueue(
+      asPart({ type: "tool-input-delta", id: "call_1", delta: '{"q":' }),
     );
 
-    const types = await collectTypes(stream);
-    expect(types).toEqual([
-      "tool-call",
-      "tool-input-delta",
-      "text-delta",
-      "finish",
-    ]);
+    // Tool parts must leave the gate before any answer text is enqueued.
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "tool-call", toolCallId: "call_1" },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "tool-input-delta", id: "call_1", delta: '{"q":' },
+    });
+
+    sourceController.enqueue(
+      asPart({
+        type: "text-delta",
+        delta: "This is a complete coworker reply with enough text.",
+      }),
+    );
+    sourceController.enqueue(asPart({ type: "finish" }));
+    sourceController.close();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "text-delta",
+        delta: "This is a complete coworker reply with enough text.",
+      },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "finish" },
+    });
     expect(onRetryNeeded).not.toHaveBeenCalled();
+  });
+
+  it("forwards stream-start and response-metadata before progress", async () => {
+    let sourceController!: ReadableStreamDefaultController<LanguageModelV4StreamPart>;
+    const source = new ReadableStream<LanguageModelV4StreamPart>({
+      start(controller) {
+        sourceController = controller;
+      },
+    });
+
+    const gated = createCommitGateStream(source, {
+      onRetryNeeded: async () => null,
+    });
+    const reader = gated.getReader();
+
+    sourceController.enqueue(asPart({ type: "stream-start", warnings: [] }));
+    sourceController.enqueue(
+      asPart({ type: "response-metadata", id: "resp_1" }),
+    );
+    sourceController.enqueue(asPart({ type: "reasoning-start", id: "rs_1" }));
+    sourceController.enqueue(
+      asPart({
+        type: "reasoning-delta",
+        id: "rs_1",
+        delta: "Working…",
+      }),
+    );
+
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "stream-start" },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "response-metadata", id: "resp_1" },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "reasoning-start", id: "rs_1" },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "reasoning-delta", id: "rs_1", delta: "Working…" },
+    });
+
+    sourceController.close();
   });
 
   it("still retries agent-error after reasoning was already forwarded", async () => {

--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -21,7 +21,9 @@ type TestPart =
       toolName: string;
       input: string;
     }
+  | { type: "tool-input-start"; id: string; toolName: string }
   | { type: "tool-input-delta"; id: string; delta: string }
+  | { type: "tool-input-end"; id: string }
   | { type: "finish" };
 
 function asPart(part: TestPart): LanguageModelV4StreamPart {
@@ -61,16 +63,23 @@ async function collectText(
 async function collectTypes(
   stream: ReadableStream<LanguageModelV4StreamPart>,
 ): Promise<string[]> {
+  const parts = await collectParts(stream);
+  return parts.map((part) => part.type);
+}
+
+async function collectParts(
+  stream: ReadableStream<LanguageModelV4StreamPart>,
+): Promise<LanguageModelV4StreamPart[]> {
   const reader = stream.getReader();
-  const types: string[] = [];
+  const parts: LanguageModelV4StreamPart[] = [];
   while (true) {
     const { done, value } = await reader.read();
     if (done) {
       break;
     }
-    types.push(value.type);
+    parts.push(value);
   }
-  return types;
+  return parts;
 }
 
 describe("createCommitGateStream", () => {
@@ -278,8 +287,16 @@ describe("createCommitGateStream", () => {
       }),
     );
     sourceController.enqueue(
+      asPart({
+        type: "tool-input-start",
+        id: "call_1",
+        toolName: "list_jobs",
+      }),
+    );
+    sourceController.enqueue(
       asPart({ type: "tool-input-delta", id: "call_1", delta: '{"q":' }),
     );
+    sourceController.enqueue(asPart({ type: "tool-input-end", id: "call_1" }));
 
     // Tool parts must leave the gate before any answer text is enqueued.
     await expect(reader.read()).resolves.toMatchObject({
@@ -288,7 +305,15 @@ describe("createCommitGateStream", () => {
     });
     await expect(reader.read()).resolves.toMatchObject({
       done: false,
+      value: { type: "tool-input-start", id: "call_1" },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
       value: { type: "tool-input-delta", id: "call_1", delta: '{"q":' },
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "tool-input-end", id: "call_1" },
     });
 
     sourceController.enqueue(
@@ -314,7 +339,7 @@ describe("createCommitGateStream", () => {
     expect(onRetryNeeded).not.toHaveBeenCalled();
   });
 
-  it("flushes held stream-start and response-metadata before progress", async () => {
+  it("holds setup until progress, flushing only stream-start with progress", async () => {
     let sourceController!: ReadableStreamDefaultController<LanguageModelV4StreamPart>;
     const source = new ReadableStream<LanguageModelV4StreamPart>({
       start(controller) {
@@ -331,7 +356,16 @@ describe("createCommitGateStream", () => {
     sourceController.enqueue(
       asPart({ type: "response-metadata", id: "resp_1" }),
     );
-    // Setup is held until progress arrives (not enqueued yet).
+
+    // Setup must stay held until progress arrives.
+    let firstResolved = false;
+    const firstRead = reader.read().then((result) => {
+      firstResolved = true;
+      return result;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(firstResolved).toBe(false);
+
     sourceController.enqueue(asPart({ type: "reasoning-start", id: "rs_1" }));
     sourceController.enqueue(
       asPart({
@@ -341,13 +375,9 @@ describe("createCommitGateStream", () => {
       }),
     );
 
-    await expect(reader.read()).resolves.toMatchObject({
+    await expect(firstRead).resolves.toMatchObject({
       done: false,
       value: { type: "stream-start" },
-    });
-    await expect(reader.read()).resolves.toMatchObject({
-      done: false,
-      value: { type: "response-metadata", id: "resp_1" },
     });
     await expect(reader.read()).resolves.toMatchObject({
       done: false,
@@ -358,7 +388,12 @@ describe("createCommitGateStream", () => {
       value: { type: "reasoning-delta", id: "rs_1", delta: "Working…" },
     });
 
+    // response-metadata is held until commit/end (not flushed with progress).
     sourceController.close();
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: { type: "response-metadata", id: "resp_1" },
+    });
   });
 
   it("retries without re-emitting stream-start when first attempt setup was held", async () => {
@@ -387,19 +422,21 @@ describe("createCommitGateStream", () => {
       { onRetryNeeded },
     );
 
-    const types = await collectTypes(stream);
+    const parts = await collectParts(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
     expect(onRetryNeeded).toHaveBeenCalledWith("agent-error");
-    // Failed attempt setup was discarded; only retry stream-start leaves the gate.
-    expect(types).toEqual([
+    // Failed attempt setup was discarded; only retry setup leaves the gate.
+    expect(parts.map((part) => part.type)).toEqual([
       "stream-start",
       "response-metadata",
       "text-delta",
       "finish",
     ]);
+    const metadata = parts.find((part) => part.type === "response-metadata");
+    expect(metadata).toMatchObject({ id: "resp_retry" });
   });
 
-  it("retries after progress without a second stream-start", async () => {
+  it("retries after progress without a second stream-start or failed response id", async () => {
     const onRetryNeeded = vi.fn(async () =>
       partsStream([
         { type: "stream-start", warnings: [] },
@@ -432,13 +469,15 @@ describe("createCommitGateStream", () => {
       { onRetryNeeded },
     );
 
-    const types = await collectTypes(stream);
+    const parts = await collectParts(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
-    // Setup flushed with first progress; retry must not re-emit stream-start.
-    expect(types.filter((t) => t === "stream-start")).toHaveLength(1);
-    expect(types).toEqual([
+    // stream-start flushed with progress; failed response-metadata discarded;
+    // retry must not re-emit stream-start; only retry response id is visible.
+    expect(parts.filter((part) => part.type === "stream-start")).toHaveLength(
+      1,
+    );
+    expect(parts.map((part) => part.type)).toEqual([
       "stream-start",
-      "response-metadata",
       "reasoning-start",
       "reasoning-delta",
       "reasoning-end",
@@ -446,6 +485,8 @@ describe("createCommitGateStream", () => {
       "text-delta",
       "finish",
     ]);
+    const metadata = parts.find((part) => part.type === "response-metadata");
+    expect(metadata).toMatchObject({ id: "resp_retry" });
   });
 
   it("still retries agent-error after reasoning was already forwarded", async () => {

--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  COWORKER_AGENT_ERROR_MARKER,
   COWORKER_AGENT_ERROR_SNIPPET,
   MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS,
 } from "../coworker-agent-error.js";
@@ -86,6 +87,31 @@ describe("createCommitGateStream", () => {
         {
           type: "text-delta",
           delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
+        },
+        { type: "finish" },
+      ]),
+      { onRetryNeeded },
+    );
+
+    const text = await collectText(stream);
+    expect(onRetryNeeded).toHaveBeenCalledOnce();
+    expect(onRetryNeeded).toHaveBeenCalledWith("agent-error");
+    expect(text).toBe("This is a complete coworker reply.");
+  });
+
+  it("retries on AGENT_ERROR marker the same as full agent-error snippet", async () => {
+    const onRetryNeeded = vi.fn(async () =>
+      partsStream([
+        { type: "text-delta", delta: "This is a complete coworker reply." },
+        { type: "finish" },
+      ]),
+    );
+
+    const stream = createCommitGateStream(
+      partsStream([
+        {
+          type: "text-delta",
+          delta: `Prefix ${COWORKER_AGENT_ERROR_MARKER} suffix`,
         },
         { type: "finish" },
       ]),

--- a/packages/ai-provider/src/stream/commit-gate-stream.test.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.test.ts
@@ -26,6 +26,10 @@ type TestPart =
   | { type: "tool-input-end"; id: string }
   | { type: "finish" };
 
+const COMPLETE_REPLY = "This is a complete coworker reply.";
+const COMPLETE_REPLY_LONG =
+  "This is a complete coworker reply with enough text.";
+
 function asPart(part: TestPart): LanguageModelV4StreamPart {
   return part as LanguageModelV4StreamPart;
 }
@@ -41,6 +45,54 @@ function partsStream(
       controller.close();
     },
   });
+}
+
+function completeReplyParts(text: string = COMPLETE_REPLY): TestPart[] {
+  return [{ type: "text-delta", delta: text }, { type: "finish" }];
+}
+
+function agentErrorTextParts(
+  delta: string = `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
+): TestPart[] {
+  return [{ type: "text-delta", delta }, { type: "finish" }];
+}
+
+function agentErrorWithReasoningSourceParts(): TestPart[] {
+  return [
+    { type: "reasoning-start", id: "rs_err" },
+    {
+      type: "reasoning-delta",
+      id: "rs_err",
+      delta: "Something went wrong…",
+    },
+    { type: "reasoning-end", id: "rs_err" },
+    ...agentErrorTextParts(),
+  ];
+}
+
+function failedAttemptWithSetupParts(extra: TestPart[] = []): TestPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "response-metadata", id: "resp_fail" },
+    ...extra,
+    ...agentErrorTextParts(),
+  ];
+}
+
+function retrySuccessWithSetupStream(
+  text: string = COMPLETE_REPLY_LONG,
+): ReadableStream<LanguageModelV4StreamPart> {
+  return partsStream([
+    { type: "stream-start", warnings: [] },
+    { type: "response-metadata", id: "resp_retry" },
+    ...completeReplyParts(text),
+  ]);
+}
+
+function completeReplyStream(
+  text: string = COMPLETE_REPLY,
+): ReadableStream<LanguageModelV4StreamPart> {
+  return partsStream(completeReplyParts(text));
 }
 
 async function collectText(
@@ -84,62 +136,36 @@ async function collectParts(
 
 describe("createCommitGateStream", () => {
   it("retries on agent-error before commit threshold", async () => {
-    const onRetryNeeded = vi.fn(async () =>
-      partsStream([
-        { type: "text-delta", delta: "This is a complete coworker reply." },
-        { type: "finish" },
-      ]),
-    );
+    const onRetryNeeded = vi.fn(async () => completeReplyStream());
 
-    const stream = createCommitGateStream(
-      partsStream([
-        {
-          type: "text-delta",
-          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
-        },
-        { type: "finish" },
-      ]),
-      { onRetryNeeded },
-    );
+    const stream = createCommitGateStream(partsStream(agentErrorTextParts()), {
+      onRetryNeeded,
+    });
 
     const text = await collectText(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
     expect(onRetryNeeded).toHaveBeenCalledWith("agent-error");
-    expect(text).toBe("This is a complete coworker reply.");
+    expect(text).toBe(COMPLETE_REPLY);
   });
 
   it("retries on AGENT_ERROR marker the same as full agent-error snippet", async () => {
-    const onRetryNeeded = vi.fn(async () =>
-      partsStream([
-        { type: "text-delta", delta: "This is a complete coworker reply." },
-        { type: "finish" },
-      ]),
-    );
+    const onRetryNeeded = vi.fn(async () => completeReplyStream());
 
     const stream = createCommitGateStream(
-      partsStream([
-        {
-          type: "text-delta",
-          delta: `Prefix ${COWORKER_AGENT_ERROR_MARKER} suffix`,
-        },
-        { type: "finish" },
-      ]),
+      partsStream(
+        agentErrorTextParts(`Prefix ${COWORKER_AGENT_ERROR_MARKER} suffix`),
+      ),
       { onRetryNeeded },
     );
 
     const text = await collectText(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
     expect(onRetryNeeded).toHaveBeenCalledWith("agent-error");
-    expect(text).toBe("This is a complete coworker reply.");
+    expect(text).toBe(COMPLETE_REPLY);
   });
 
   it("retries on short-tail before commit threshold", async () => {
-    const onRetryNeeded = vi.fn(async () =>
-      partsStream([
-        { type: "text-delta", delta: "This is a complete coworker reply." },
-        { type: "finish" },
-      ]),
-    );
+    const onRetryNeeded = vi.fn(async () => completeReplyStream());
 
     const stream = createCommitGateStream(
       partsStream([{ type: "text-delta", delta: "Done" }, { type: "finish" }]),
@@ -149,41 +175,28 @@ describe("createCommitGateStream", () => {
     const text = await collectText(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
     expect(onRetryNeeded).toHaveBeenCalledWith("short-tail");
-    expect(text).toBe("This is a complete coworker reply.");
+    expect(text).toBe(COMPLETE_REPLY);
   });
 
   it("commits and streams when output exceeds threshold without retry", async () => {
     const onRetryNeeded = vi.fn(async () => null);
 
     const stream = createCommitGateStream(
-      partsStream([
-        {
-          type: "text-delta",
-          delta: "This is a complete coworker reply with enough text.",
-        },
-        { type: "finish" },
-      ]),
+      partsStream(completeReplyParts(COMPLETE_REPLY_LONG)),
       { onRetryNeeded },
     );
 
     const text = await collectText(stream);
     expect(onRetryNeeded).not.toHaveBeenCalled();
-    expect(text).toBe("This is a complete coworker reply with enough text.");
+    expect(text).toBe(COMPLETE_REPLY_LONG);
   });
 
   it("returns last attempt output when retry is exhausted", async () => {
     const onRetryNeeded = vi.fn(async () => null);
 
-    const stream = createCommitGateStream(
-      partsStream([
-        {
-          type: "text-delta",
-          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
-        },
-        { type: "finish" },
-      ]),
-      { onRetryNeeded },
-    );
+    const stream = createCommitGateStream(partsStream(agentErrorTextParts()), {
+      onRetryNeeded,
+    });
 
     const text = await collectText(stream);
     expect(onRetryNeeded).toHaveBeenCalledOnce();
@@ -317,10 +330,7 @@ describe("createCommitGateStream", () => {
     });
 
     sourceController.enqueue(
-      asPart({
-        type: "text-delta",
-        delta: "This is a complete coworker reply with enough text.",
-      }),
+      asPart({ type: "text-delta", delta: COMPLETE_REPLY_LONG }),
     );
     sourceController.enqueue(asPart({ type: "finish" }));
     sourceController.close();
@@ -329,7 +339,7 @@ describe("createCommitGateStream", () => {
       done: false,
       value: {
         type: "text-delta",
-        delta: "This is a complete coworker reply with enough text.",
+        delta: COMPLETE_REPLY_LONG,
       },
     });
     await expect(reader.read()).resolves.toMatchObject({
@@ -397,28 +407,10 @@ describe("createCommitGateStream", () => {
   });
 
   it("retries without re-emitting stream-start when first attempt setup was held", async () => {
-    const onRetryNeeded = vi.fn(async () =>
-      partsStream([
-        { type: "stream-start", warnings: [] },
-        { type: "response-metadata", id: "resp_retry" },
-        {
-          type: "text-delta",
-          delta: "This is a complete coworker reply with enough text.",
-        },
-        { type: "finish" },
-      ]),
-    );
+    const onRetryNeeded = vi.fn(async () => retrySuccessWithSetupStream());
 
     const stream = createCommitGateStream(
-      partsStream([
-        { type: "stream-start", warnings: [] },
-        { type: "response-metadata", id: "resp_fail" },
-        {
-          type: "text-delta",
-          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
-        },
-        { type: "finish" },
-      ]),
+      partsStream(failedAttemptWithSetupParts()),
       { onRetryNeeded },
     );
 
@@ -437,35 +429,20 @@ describe("createCommitGateStream", () => {
   });
 
   it("retries after progress without a second stream-start or failed response id", async () => {
-    const onRetryNeeded = vi.fn(async () =>
-      partsStream([
-        { type: "stream-start", warnings: [] },
-        { type: "response-metadata", id: "resp_retry" },
-        {
-          type: "text-delta",
-          delta: "This is a complete coworker reply with enough text.",
-        },
-        { type: "finish" },
-      ]),
-    );
+    const onRetryNeeded = vi.fn(async () => retrySuccessWithSetupStream());
 
     const stream = createCommitGateStream(
-      partsStream([
-        { type: "stream-start", warnings: [] },
-        { type: "response-metadata", id: "resp_fail" },
-        { type: "reasoning-start", id: "rs_1" },
-        {
-          type: "reasoning-delta",
-          id: "rs_1",
-          delta: "Still working…",
-        },
-        { type: "reasoning-end", id: "rs_1" },
-        {
-          type: "text-delta",
-          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
-        },
-        { type: "finish" },
-      ]),
+      partsStream(
+        failedAttemptWithSetupParts([
+          { type: "reasoning-start", id: "rs_1" },
+          {
+            type: "reasoning-delta",
+            id: "rs_1",
+            delta: "Still working…",
+          },
+          { type: "reasoning-end", id: "rs_1" },
+        ]),
+      ),
       { onRetryNeeded },
     );
 
@@ -490,28 +467,10 @@ describe("createCommitGateStream", () => {
   });
 
   it("still retries agent-error after reasoning was already forwarded", async () => {
-    const onRetryNeeded = vi.fn(async () =>
-      partsStream([
-        { type: "text-delta", delta: "This is a complete coworker reply." },
-        { type: "finish" },
-      ]),
-    );
+    const onRetryNeeded = vi.fn(async () => completeReplyStream());
 
     const stream = createCommitGateStream(
-      partsStream([
-        { type: "reasoning-start", id: "rs_err" },
-        {
-          type: "reasoning-delta",
-          id: "rs_err",
-          delta: "Something went wrong…",
-        },
-        { type: "reasoning-end", id: "rs_err" },
-        {
-          type: "text-delta",
-          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
-        },
-        { type: "finish" },
-      ]),
+      partsStream(agentErrorWithReasoningSourceParts()),
       { onRetryNeeded },
     );
 
@@ -529,33 +488,11 @@ describe("createCommitGateStream", () => {
     ]);
 
     const textStream = createCommitGateStream(
-      partsStream([
-        { type: "reasoning-start", id: "rs_err" },
-        {
-          type: "reasoning-delta",
-          id: "rs_err",
-          delta: "Something went wrong…",
-        },
-        { type: "reasoning-end", id: "rs_err" },
-        {
-          type: "text-delta",
-          delta: `${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`,
-        },
-        { type: "finish" },
-      ]),
+      partsStream(agentErrorWithReasoningSourceParts()),
       {
-        onRetryNeeded: async () =>
-          partsStream([
-            {
-              type: "text-delta",
-              delta: "This is a complete coworker reply.",
-            },
-            { type: "finish" },
-          ]),
+        onRetryNeeded: async () => completeReplyStream(),
       },
     );
-    expect(await collectText(textStream)).toBe(
-      "This is a complete coworker reply.",
-    );
+    expect(await collectText(textStream)).toBe(COMPLETE_REPLY);
   });
 });

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -54,6 +54,34 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
   return text.length >= minGoodChars;
 }
 
+/**
+ * Progress parts that must leave the gate before answer text commits.
+ *
+ * Room coworker `streamText` uses AI SDK `firstChunkMs` / `chunkMs`. Those
+ * timers only reset on output chunks (non-empty reasoning-delta, tool-call,
+ * tool-input-delta, text-delta). Coworkers may run tools for minutes while
+ * only emitting reasoning heartbeats — if the gate buffers those, Sokosumi
+ * aborts as stalled even though the upstream stream is alive.
+ *
+ * Answer `text-*` (and finish/lifecycle) stay buffered so agent-error and
+ * short-tail retries still hide bad first attempts.
+ */
+function isProgressPassThroughPart(part: LanguageModelV4StreamPart): boolean {
+  switch (part.type) {
+    case "reasoning-start":
+    case "reasoning-delta":
+    case "reasoning-end":
+    case "reasoning-file":
+    case "tool-call":
+    case "tool-input-start":
+    case "tool-input-delta":
+    case "tool-input-end":
+      return true;
+    default:
+      return false;
+  }
+}
+
 export function createCommitGateStream(
   sourceStream: ReadableStream<LanguageModelV4StreamPart>,
   options: CommitGateOptions,
@@ -91,6 +119,8 @@ export function createCommitGateStream(
 
           if (committed) {
             controller.enqueue(value);
+          } else if (isProgressPassThroughPart(value)) {
+            controller.enqueue(value);
           } else {
             buffer.push(value);
           }
@@ -109,6 +139,8 @@ export function createCommitGateStream(
           if (retryReason) {
             const retryStream = await options.onRetryNeeded(retryReason);
             if (retryStream) {
+              // Progress may already have been forwarded; retry only replaces
+              // the buffered answer path (text/finish), not leaked reasoning.
               await pipeStreamToController(retryStream, controller);
               controller.close();
               return;

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -35,6 +35,10 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
 /**
  * Setup lifecycle held until first progress/commit so order is
  * stream-start → progress, without leaking setup on a discarded first attempt.
+ *
+ * `response-metadata` stays held until text **commit** (or end without retry)
+ * so a failed attempt's response id is not flushed with early progress and then
+ * doubled by a successful retry.
  */
 function isHeldSetupLifecyclePart(part: LanguageModelV4StreamPart): boolean {
   return part.type === "stream-start" || part.type === "response-metadata";
@@ -82,7 +86,10 @@ export function createCommitGateStream(
     async start(controller) {
       /** Answer-side parts held until commit (or discarded on successful retry). */
       const answerBuffer: LanguageModelV4StreamPart[] = [];
-      /** `stream-start` / `response-metadata` until first progress or commit. */
+      /**
+       * `stream-start` + `response-metadata` until flushed.
+       * Progress flushes only `stream-start`; commit/end flushes the rest.
+       */
       const setupBuffer: LanguageModelV4StreamPart[] = [];
       let textSoFar = "";
       let committed = false;
@@ -97,6 +104,22 @@ export function createCommitGateStream(
           streamStartEmitted = true;
         }
         controller.enqueue(part);
+      }
+
+      /** AI SDK protocol: stream-start before progress; keep response id until commit. */
+      function flushStreamStartFromSetup(): void {
+        const remaining: LanguageModelV4StreamPart[] = [];
+        for (const part of setupBuffer) {
+          if (part.type === "stream-start") {
+            enqueue(part);
+          } else {
+            remaining.push(part);
+          }
+        }
+        setupBuffer.length = 0;
+        for (const part of remaining) {
+          setupBuffer.push(part);
+        }
       }
 
       function flushSetupBuffer(): void {
@@ -117,15 +140,24 @@ export function createCommitGateStream(
         source: ReadableStream<LanguageModelV4StreamPart>,
       ): Promise<void> {
         const reader = source.getReader();
+        let completed = false;
         try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) {
+              completed = true;
               break;
             }
             enqueue(value);
           }
         } finally {
+          if (!completed) {
+            try {
+              await reader.cancel();
+            } catch {
+              // best-effort cancel of a failed retry pipe
+            }
+          }
           reader.releaseLock();
         }
       }
@@ -154,8 +186,7 @@ export function createCommitGateStream(
           } else if (isHeldSetupLifecyclePart(value)) {
             setupBuffer.push(value);
           } else if (isProgressPassThroughPart(value)) {
-            // Lifecycle must precede progress for AI SDK protocol order.
-            flushSetupBuffer();
+            flushStreamStartFromSetup();
             enqueue(value);
           } else {
             answerBuffer.push(value);
@@ -177,7 +208,8 @@ export function createCommitGateStream(
             if (retryStream) {
               // Discard held setup + answer from the failed attempt. Progress
               // already enqueued may remain. Retry stream is filtered so a
-              // second stream-start is not emitted.
+              // second stream-start is not emitted; held response-metadata from
+              // the failed attempt never left the gate.
               setupBuffer.length = 0;
               answerBuffer.length = 0;
               await pipeRetryStream(retryStream);

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -1,7 +1,7 @@
 import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 
 import {
-  COWORKER_AGENT_ERROR_SNIPPET,
+  coworkerTextLooksLikeAgentError,
   MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS,
 } from "../coworker-agent-error.js";
 
@@ -14,15 +14,11 @@ export interface CommitGateOptions {
   minGoodChars?: number;
 }
 
-function coworkerStreamTextLooksLikeAgentError(text: string): boolean {
-  return text.includes(COWORKER_AGENT_ERROR_SNIPPET);
-}
-
 function coworkerStreamTextLooksSuspiciouslyShort(
   text: string,
   minGoodChars: number,
 ): boolean {
-  if (coworkerStreamTextLooksLikeAgentError(text)) {
+  if (coworkerTextLooksLikeAgentError(text)) {
     return false;
   }
   const trimmed = text.trim();
@@ -30,7 +26,7 @@ function coworkerStreamTextLooksSuspiciouslyShort(
 }
 
 function canCommitStream(text: string, minGoodChars: number): boolean {
-  if (coworkerStreamTextLooksLikeAgentError(text)) {
+  if (coworkerTextLooksLikeAgentError(text)) {
     return false;
   }
   return text.length >= minGoodChars;
@@ -168,7 +164,7 @@ export function createCommitGateStream(
 
         if (!committed) {
           let retryReason: CommitGateRetryReason | null = null;
-          if (coworkerStreamTextLooksLikeAgentError(textSoFar)) {
+          if (coworkerTextLooksLikeAgentError(textSoFar)) {
             retryReason = "agent-error";
           } else if (
             coworkerStreamTextLooksSuspiciouslyShort(textSoFar, minGoodChars)

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -55,7 +55,7 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
 }
 
 /**
- * Progress parts that must leave the gate before answer text commits.
+ * Parts that leave the gate before answer text commits.
  *
  * Room coworker `streamText` uses AI SDK `firstChunkMs` / `chunkMs`. Those
  * timers only reset on output chunks (non-empty reasoning-delta, tool-call,
@@ -63,11 +63,20 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
  * only emitting reasoning heartbeats — if the gate buffers those, Sokosumi
  * aborts as stalled even though the upstream stream is alive.
  *
- * Answer `text-*` (and finish/lifecycle) stay buffered so agent-error and
- * short-tail retries still hide bad first attempts.
+ * Also pass through stream lifecycle that must precede progress (`stream-start`,
+ * `response-metadata`) so AI SDK protocol order stays intact, and `error` so
+ * mid-stream failures are not held until a late text commit.
+ *
+ * Answer `text-*` and `finish` stay buffered so agent-error / short-tail
+ * retries still hide bad first attempts. Structural start/end parts that are
+ * not themselves keepalive chunks (e.g. reasoning-start) still pass through so
+ * block integrity is preserved when deltas stream early.
  */
-function isProgressPassThroughPart(part: LanguageModelV4StreamPart): boolean {
+function isPreCommitPassThroughPart(part: LanguageModelV4StreamPart): boolean {
   switch (part.type) {
+    case "stream-start":
+    case "response-metadata":
+    case "error":
     case "reasoning-start":
     case "reasoning-delta":
     case "reasoning-end":
@@ -119,7 +128,7 @@ export function createCommitGateStream(
 
           if (committed) {
             controller.enqueue(value);
-          } else if (isProgressPassThroughPart(value)) {
+          } else if (isPreCommitPassThroughPart(value)) {
             controller.enqueue(value);
           } else {
             buffer.push(value);

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -29,24 +29,6 @@ function coworkerStreamTextLooksSuspiciouslyShort(
   return trimmed.length > 0 && trimmed.length < minGoodChars;
 }
 
-async function pipeStreamToController(
-  source: ReadableStream<LanguageModelV4StreamPart>,
-  controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
-): Promise<void> {
-  const reader = source.getReader();
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      controller.enqueue(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
-
 function canCommitStream(text: string, minGoodChars: number): boolean {
   if (coworkerStreamTextLooksLikeAgentError(text)) {
     return false;
@@ -55,7 +37,15 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
 }
 
 /**
- * Parts that leave the gate before answer text commits.
+ * Setup lifecycle held until first progress/commit so order is
+ * stream-start → progress, without leaking setup on a discarded first attempt.
+ */
+function isHeldSetupLifecyclePart(part: LanguageModelV4StreamPart): boolean {
+  return part.type === "stream-start" || part.type === "response-metadata";
+}
+
+/**
+ * Progress parts that leave the gate before answer text commits.
  *
  * Room coworker `streamText` uses AI SDK `firstChunkMs` / `chunkMs`. Those
  * timers only reset on output chunks (non-empty reasoning-delta, tool-call,
@@ -63,19 +53,12 @@ function canCommitStream(text: string, minGoodChars: number): boolean {
  * only emitting reasoning heartbeats — if the gate buffers those, Sokosumi
  * aborts as stalled even though the upstream stream is alive.
  *
- * Also pass through stream lifecycle that must precede progress (`stream-start`,
- * `response-metadata`) so AI SDK protocol order stays intact, and `error` so
- * mid-stream failures are not held until a late text commit.
- *
- * Answer `text-*` and `finish` stay buffered so agent-error / short-tail
- * retries still hide bad first attempts. Structural start/end parts that are
- * not themselves keepalive chunks (e.g. reasoning-start) still pass through so
- * block integrity is preserved when deltas stream early.
+ * `error` also leaves early so mid-stream failures are not held until a late
+ * text commit. Answer `text-*` and `finish` stay buffered for agent-error /
+ * short-tail retries.
  */
-function isPreCommitPassThroughPart(part: LanguageModelV4StreamPart): boolean {
+function isProgressPassThroughPart(part: LanguageModelV4StreamPart): boolean {
   switch (part.type) {
-    case "stream-start":
-    case "response-metadata":
     case "error":
     case "reasoning-start":
     case "reasoning-delta":
@@ -101,9 +84,55 @@ export function createCommitGateStream(
 
   return new ReadableStream<LanguageModelV4StreamPart>({
     async start(controller) {
-      const buffer: LanguageModelV4StreamPart[] = [];
+      /** Answer-side parts held until commit (or discarded on successful retry). */
+      const answerBuffer: LanguageModelV4StreamPart[] = [];
+      /** `stream-start` / `response-metadata` until first progress or commit. */
+      const setupBuffer: LanguageModelV4StreamPart[] = [];
       let textSoFar = "";
       let committed = false;
+      /** At most one `stream-start` leaves the gate (retries must not re-emit). */
+      let streamStartEmitted = false;
+
+      function enqueue(part: LanguageModelV4StreamPart): void {
+        if (part.type === "stream-start") {
+          if (streamStartEmitted) {
+            return;
+          }
+          streamStartEmitted = true;
+        }
+        controller.enqueue(part);
+      }
+
+      function flushSetupBuffer(): void {
+        for (const part of setupBuffer) {
+          enqueue(part);
+        }
+        setupBuffer.length = 0;
+      }
+
+      function flushAnswerBuffer(): void {
+        for (const part of answerBuffer) {
+          enqueue(part);
+        }
+        answerBuffer.length = 0;
+      }
+
+      async function pipeRetryStream(
+        source: ReadableStream<LanguageModelV4StreamPart>,
+      ): Promise<void> {
+        const reader = source.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            enqueue(value);
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      }
 
       try {
         while (true) {
@@ -118,20 +147,22 @@ export function createCommitGateStream(
 
           if (!committed && canCommitStream(textSoFar, minGoodChars)) {
             committed = true;
-            for (const bufferedPart of buffer) {
-              controller.enqueue(bufferedPart);
-            }
-            buffer.length = 0;
-            controller.enqueue(value);
+            flushSetupBuffer();
+            flushAnswerBuffer();
+            enqueue(value);
             continue;
           }
 
           if (committed) {
-            controller.enqueue(value);
-          } else if (isPreCommitPassThroughPart(value)) {
-            controller.enqueue(value);
+            enqueue(value);
+          } else if (isHeldSetupLifecyclePart(value)) {
+            setupBuffer.push(value);
+          } else if (isProgressPassThroughPart(value)) {
+            // Lifecycle must precede progress for AI SDK protocol order.
+            flushSetupBuffer();
+            enqueue(value);
           } else {
-            buffer.push(value);
+            answerBuffer.push(value);
           }
         }
 
@@ -148,17 +179,19 @@ export function createCommitGateStream(
           if (retryReason) {
             const retryStream = await options.onRetryNeeded(retryReason);
             if (retryStream) {
-              // Progress may already have been forwarded; retry only replaces
-              // the buffered answer path (text/finish), not leaked reasoning.
-              await pipeStreamToController(retryStream, controller);
+              // Discard held setup + answer from the failed attempt. Progress
+              // already enqueued may remain. Retry stream is filtered so a
+              // second stream-start is not emitted.
+              setupBuffer.length = 0;
+              answerBuffer.length = 0;
+              await pipeRetryStream(retryStream);
               controller.close();
               return;
             }
           }
 
-          for (const bufferedPart of buffer) {
-            controller.enqueue(bufferedPart);
-          }
+          flushSetupBuffer();
+          flushAnswerBuffer();
         }
 
         controller.close();


### PR DESCRIPTION
## Summary

Conversation-mode coworker streams use AI SDK idle timeouts (`firstChunkMs` / `chunkMs` = 90s on room mention dispatch). The commit-gate buffered **every** stream part until answer text was “good enough,” so upstream progress never reached the timeout layer. Long Eve/model/tool work then aborted as stalled even while the Responses stream was alive.

This PR keeps product behavior (hide short/agent-error answer text, retry) and:

1. Forwards **progress** before answer text commits (reasoning / tool parts, plus `error`)
2. **Holds** `stream-start` / `response-metadata` until first progress or text commit, then flushes them first (AI SDK order)
3. On successful retry, **discards** held setup + answer from the failed attempt and **dedupes** `stream-start` so retries do not emit a second setup
4. Aligns agent-error detection with shared `coworkerTextLooksLikeAgentError` (full Elena snippet **or** `AGENT_ERROR` marker)

### What changed

- Pre-commit progress pass-through: `reasoning-*`, `tool-call`, `tool-input-*`, `error`
- Setup lifecycle lazy-flush: `stream-start`, `response-metadata`
- Answer `text-*` / `finish` still buffered until min-good text (and not agent-error)
- Retry: drop failed setup/answer; at most one consumer `stream-start`
- Agent-error gate uses package helper (snippet + marker), not snippet-only
- Unit tests: progressive reasoning/tool delivery, lifecycle-before-progress, single `stream-start` on retry, marker-only agent-error retry

### Not in this PR

- Coworker-side heartbeat deployment (required ops — see below)
- Empty reasoning deltas / SSE `: keepalive` as timer resets (AI SDK does **not** count them)
- Extracting commit-gate into a separate policy wrap — [SOK-773](https://linear.app/masumi/issue/SOK-773/extract-coworker-conversation-commit-policy-from-ai-provider-stream)

## Coworker requirements (required to avoid the stall)

Sokosumi only **forwards** content it receives. Coworkers that spend **>90s** before the first answer character must emit **content-bearing** Responses events on a cadence **well under 90s** (e.g. every 15–30s).

### Do

1. While tools / model / Eve work runs, emit standards-shaped **reasoning progress** (OpenAI Responses):
   - `response.output_item.added` with `item.type = "reasoning"`
   - `response.reasoning_summary_text.delta` with **non-empty** `delta` (empty deltas do **not** reset timers)
   - close the reasoning item cleanly before final answer text
2. Use short progress labels only (“running tool X…”, “fetching data…”) — do not put keepalives in answer text.
3. When the answer is ready, stream normal output text and complete the response as today.

Optional: real tool stream events also count as content; today Sokosumi’s production SSE path mainly maps **reasoning** (and text). Prefer reasoning heartbeats unless you already emit tool V4-shaped content.

### Do not

| Anti-pattern | Why it fails |
| --- | --- |
| SSE comments only (`: keepalive`) | Transport noise; AI SDK does **not** count it |
| Setup-only frames (`response.created`, empty protocol) | Not content-bearing |
| Empty `reasoning_summary_text.delta` | Does not reset `firstChunkMs` / `chunkMs` |
| Dummy **answer** text as a heartbeat | Pollutes the user-visible reply |
| ≥90s silence before first content, or between content chunks | Core aborts on idle budgets |

### End-to-end path

| Layer | Behavior |
| --- | --- |
| Coworker | Non-empty `response.reasoning_summary_text.delta` (or text/tool content) on a &lt;90s cadence |
| `@sokosumi/ai-provider` SSE map | → `reasoning-delta` (etc.) |
| Commit-gate (this PR) | Forwards progress **before** answer text commits; setup ordered and not double-emitted on retry |
| AI SDK `streamText` | Non-empty `reasoning-delta` / `text-delta` / `tool-call` / `tool-input-delta` reset `firstChunkMs` / `chunkMs` |

Without coworker content heartbeats, room mention dispatch still dies at `ROOM_COWORKER_FIRST_CHUNK_MS` / `ROOM_COWORKER_CHUNK_MS` (90s).

## Test plan

- [x] `pnpm --filter @sokosumi/ai-provider test` (commit-gate suite + package suite green)
- [x] Progressive pass-through (reasoning, tools)
- [x] Setup lifecycle flushes before progress; single `stream-start` on retry
- [x] Agent-error retry after progress already forwarded
- [x] `AGENT_ERROR` marker retries same as full snippet
- [ ] After a coworker deploys heartbeats: room `@mention` with tool work &gt;90s before first answer char completes without stall abort