### PR TITLE
refactor(ai-provider): extract conversation commit policy

### DIFF
--- a/packages/ai-provider/src/sokosumi-language-model.ts
+++ b/packages/ai-provider/src/sokosumi-language-model.ts
@@ -10,14 +10,13 @@ import {
   type SharedV4Warning,
 } from "@ai-sdk/provider";
 import { getModelIdentifier } from "@sokosumi/chat";
-import { MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS } from "./coworker-agent-error.js";
 import { parseSokosumiProviderOptions } from "./parse-provider-options.js";
 import {
   buildResponsesApiWarnings,
   lastTurnToResponsesInput,
   promptToResponsesInput,
 } from "./prompt/to-responses-input.js";
-import { createCommitGateStream } from "./stream/commit-gate-stream.js";
+import { withConversationCommitPolicy } from "./stream/conversation-commit-policy.js";
 import {
   createResponsesSseToV4Stream,
   emptyUsage,
@@ -26,7 +25,6 @@ import {
 import type { CreateSokosumiOptions } from "./types.js";
 
 const OPENROUTER_RESPONSES_URL = "https://openrouter.ai/api/v1/responses";
-const COWORKER_CONVERSATION_MAX_RETRIES = 2;
 const SOKOSUMI_SUPPORTED_URL_PATTERNS: Record<string, RegExp[]> = {
   // The Responses API mapping forwards these as image_url/file_url or inline data.
   "*": [/^https?:\/\//i, /^data:/i],
@@ -280,37 +278,18 @@ async function streamCoworkerWithRetry(
   promptWarnings: SharedV4Warning[],
   sokosumiOpts: ReturnType<typeof parseSokosumiProviderOptions>,
   options: LanguageModelV4CallOptions,
-  attempt = 0,
 ): Promise<LanguageModelV4StreamResult> {
   const inConversationMode = Boolean(
     sokosumiOpts.providerConversationId?.trim(),
   );
-  const maxRetries = inConversationMode ? COWORKER_CONVERSATION_MAX_RETRIES : 0;
-  const result = await streamCoworker(promptWarnings, sokosumiOpts, options);
+  const openStream = () =>
+    streamCoworker(promptWarnings, sokosumiOpts, options);
 
-  if (!inConversationMode || attempt >= maxRetries) {
-    return result;
+  if (!inConversationMode) {
+    return openStream();
   }
 
-  return {
-    ...result,
-    stream: createCommitGateStream(result.stream, {
-      minGoodChars: MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS,
-      onRetryNeeded: async () => {
-        const nextAttempt = attempt + 1;
-        if (nextAttempt > maxRetries) {
-          return null;
-        }
-        const retryResult = await streamCoworkerWithRetry(
-          promptWarnings,
-          sokosumiOpts,
-          options,
-          nextAttempt,
-        );
-        return retryResult.stream;
-      },
-    }),
-  };
+  return withConversationCommitPolicy(openStream);
 }
 
 async function streamCoworker(

--- a/packages/ai-provider/src/stream/conversation-commit-policy.test.ts
+++ b/packages/ai-provider/src/stream/conversation-commit-policy.test.ts
@@ -1,0 +1,159 @@
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+} from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+
+import { COWORKER_AGENT_ERROR_SNIPPET } from "../coworker-agent-error.js";
+import {
+  COWORKER_CONVERSATION_MAX_RETRIES,
+  withConversationCommitPolicy,
+} from "./conversation-commit-policy.js";
+
+type TestPart =
+  | { type: "stream-start"; warnings: [] }
+  | { type: "text-delta"; delta: string }
+  | { type: "finish" };
+
+function asPart(part: TestPart): LanguageModelV4StreamPart {
+  return part as LanguageModelV4StreamPart;
+}
+
+function partsStream(
+  parts: TestPart[],
+): ReadableStream<LanguageModelV4StreamPart> {
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) {
+        controller.enqueue(asPart(part));
+      }
+      controller.close();
+    },
+  });
+}
+
+function streamResult(parts: TestPart[]): LanguageModelV4StreamResult {
+  return {
+    stream: partsStream(parts),
+    request: { body: {} },
+    response: { headers: {} },
+  };
+}
+
+function textParts(text: string): TestPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { type: "text-delta", delta: text },
+    { type: "finish" },
+  ];
+}
+
+async function collectText(
+  stream: ReadableStream<LanguageModelV4StreamPart>,
+): Promise<string> {
+  const reader = stream.getReader();
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value.type === "text-delta") {
+        text += value.delta;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return text;
+}
+
+describe("withConversationCommitPolicy", () => {
+  it("exports conversation max retries of 2", () => {
+    expect(COWORKER_CONVERSATION_MAX_RETRIES).toBe(2);
+  });
+
+  it("returns the protocol stream without opening extra attempts on good output", async () => {
+    const openStream = vi.fn(async () =>
+      streamResult(
+        textParts("This is a complete coworker reply with enough text."),
+      ),
+    );
+
+    const result = await withConversationCommitPolicy(openStream);
+
+    expect(openStream).toHaveBeenCalledTimes(1);
+    const text = await collectText(result.stream);
+    expect(text).toBe("This is a complete coworker reply with enough text.");
+  });
+
+  it("retries on agent-error text and emits only the successful attempt text", async () => {
+    let call = 0;
+    const openStream = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return streamResult(
+          textParts(`${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`),
+        );
+      }
+      return streamResult(
+        textParts("This is a complete coworker reply with enough text."),
+      );
+    });
+
+    const result = await withConversationCommitPolicy(openStream);
+    const text = await collectText(result.stream);
+
+    expect(openStream).toHaveBeenCalledTimes(2);
+    expect(text).toBe("This is a complete coworker reply with enough text.");
+  });
+
+  it("retries on short-tail text", async () => {
+    let call = 0;
+    const openStream = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return streamResult(textParts("Done"));
+      }
+      return streamResult(
+        textParts("This is a complete coworker reply with enough text."),
+      );
+    });
+
+    const result = await withConversationCommitPolicy(openStream);
+    const text = await collectText(result.stream);
+
+    expect(openStream).toHaveBeenCalledTimes(2);
+    expect(text).toBe("This is a complete coworker reply with enough text.");
+  });
+
+  it("stops after maxRetries + initial attempt (3 opens max)", async () => {
+    const openStream = vi.fn(async () => streamResult(textParts("Done")));
+
+    const result = await withConversationCommitPolicy(openStream, {
+      maxRetries: COWORKER_CONVERSATION_MAX_RETRIES,
+    });
+    const text = await collectText(result.stream);
+
+    // attempt 0 gated, 1 gated, 2 final ungated → 3 opens
+    expect(openStream).toHaveBeenCalledTimes(3);
+    expect(text).toBe("Done");
+  });
+
+  it("with maxRetries 0 returns the first stream without gating retry", async () => {
+    const openStream = vi.fn(async () =>
+      streamResult(
+        textParts(`${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`),
+      ),
+    );
+
+    const result = await withConversationCommitPolicy(openStream, {
+      maxRetries: 0,
+    });
+    const text = await collectText(result.stream);
+
+    expect(openStream).toHaveBeenCalledTimes(1);
+    expect(text).toContain(COWORKER_AGENT_ERROR_SNIPPET);
+  });
+});

--- a/packages/ai-provider/src/stream/conversation-commit-policy.test.ts
+++ b/packages/ai-provider/src/stream/conversation-commit-policy.test.ts
@@ -172,4 +172,36 @@ describe("withConversationCommitPolicy", () => {
     expect(openStream).toHaveBeenCalledTimes(1);
     expect(text).toContain(COWORKER_AGENT_ERROR_SNIPPET);
   });
+
+  it.each([Number.POSITIVE_INFINITY, Number.NaN] as const)(
+    "treats non-finite maxRetries %s as 0 (no unbounded reopen)",
+    async (maxRetries) => {
+      const openStream = vi.fn(async () =>
+        streamResult(
+          textParts(`${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`),
+        ),
+      );
+
+      const result = await withConversationCommitPolicy(openStream, {
+        maxRetries,
+      });
+      const text = await collectText(result.stream);
+
+      expect(openStream).toHaveBeenCalledTimes(1);
+      expect(text).toContain(COWORKER_AGENT_ERROR_SNIPPET);
+    },
+  );
+
+  it("truncates fractional maxRetries to an integer budget", async () => {
+    const openStream = vi.fn(async () => streamResult(textParts("Done")));
+
+    const result = await withConversationCommitPolicy(openStream, {
+      maxRetries: 1.9,
+    });
+    const text = await collectText(result.stream);
+
+    // trunc(1.9) → 1: attempt 0 gated + attempt 1 final ungated
+    expect(openStream).toHaveBeenCalledTimes(2);
+    expect(text).toBe("Done");
+  });
 });

--- a/packages/ai-provider/src/stream/conversation-commit-policy.test.ts
+++ b/packages/ai-provider/src/stream/conversation-commit-policy.test.ts
@@ -156,4 +156,20 @@ describe("withConversationCommitPolicy", () => {
     expect(openStream).toHaveBeenCalledTimes(1);
     expect(text).toContain(COWORKER_AGENT_ERROR_SNIPPET);
   });
+
+  it("treats negative maxRetries as 0 (single open, no gate retry)", async () => {
+    const openStream = vi.fn(async () =>
+      streamResult(
+        textParts(`${COWORKER_AGENT_ERROR_SNIPPET}. Please try again.`),
+      ),
+    );
+
+    const result = await withConversationCommitPolicy(openStream, {
+      maxRetries: -1,
+    });
+    const text = await collectText(result.stream);
+
+    expect(openStream).toHaveBeenCalledTimes(1);
+    expect(text).toContain(COWORKER_AGENT_ERROR_SNIPPET);
+  });
 });

--- a/packages/ai-provider/src/stream/conversation-commit-policy.ts
+++ b/packages/ai-provider/src/stream/conversation-commit-policy.ts
@@ -1,0 +1,58 @@
+import type { LanguageModelV4StreamResult } from "@ai-sdk/provider";
+
+import { MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS } from "../coworker-agent-error.js";
+import { createCommitGateStream } from "./commit-gate-stream.js";
+
+/** Max retry attempts after the first conversation stream (total opens = max + 1). */
+export const COWORKER_CONVERSATION_MAX_RETRIES = 2;
+
+export interface ConversationCommitPolicyOptions {
+  /**
+   * How many times to re-open the protocol stream after a failed commit-gate
+   * (agent-error or short-tail). Default: {@link COWORKER_CONVERSATION_MAX_RETRIES}.
+   * Pass `0` to skip the gate (single protocol open, no retries).
+   */
+  maxRetries?: number;
+  minGoodChars?: number;
+}
+
+/**
+ * Conversation product policy around a protocol stream factory.
+ *
+ * Protocol (`openStream`) stays mapping/fetch only. This wrapper applies the
+ * commit-gate and re-opens the protocol stream on agent-error / short-tail
+ * until `maxRetries` is exhausted (final attempt is ungated).
+ */
+export async function withConversationCommitPolicy(
+  openStream: () => Promise<LanguageModelV4StreamResult>,
+  options: ConversationCommitPolicyOptions = {},
+  attempt = 0,
+): Promise<LanguageModelV4StreamResult> {
+  const maxRetries = options.maxRetries ?? COWORKER_CONVERSATION_MAX_RETRIES;
+  const minGoodChars =
+    options.minGoodChars ?? MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS;
+  const result = await openStream();
+
+  if (attempt >= maxRetries) {
+    return result;
+  }
+
+  return {
+    ...result,
+    stream: createCommitGateStream(result.stream, {
+      minGoodChars,
+      onRetryNeeded: async () => {
+        const nextAttempt = attempt + 1;
+        if (nextAttempt > maxRetries) {
+          return null;
+        }
+        const retryResult = await withConversationCommitPolicy(
+          openStream,
+          options,
+          nextAttempt,
+        );
+        return retryResult.stream;
+      },
+    }),
+  };
+}

--- a/packages/ai-provider/src/stream/conversation-commit-policy.ts
+++ b/packages/ai-provider/src/stream/conversation-commit-policy.ts
@@ -11,10 +11,23 @@ export interface ConversationCommitPolicyOptions {
    * How many times to re-open the protocol stream after a failed commit-gate
    * (agent-error or short-tail). Default: {@link COWORKER_CONVERSATION_MAX_RETRIES}.
    * Pass `0` to skip the gate (single protocol open, no retries).
-   * Negative values are treated as `0`.
+   * Non-finite (`NaN` / `±Infinity`), negative, and fractional values are
+   * normalized to a non-negative integer (`0` when invalid).
    */
   maxRetries?: number;
   minGoodChars?: number;
+}
+
+/**
+ * Floor non-negative retry budget. Non-finite / negative → 0 so
+ * `attempt >= maxRetries` still terminates.
+ */
+function normalizeMaxRetries(value: number | undefined): number {
+  const raw = value ?? COWORKER_CONVERSATION_MAX_RETRIES;
+  if (!Number.isFinite(raw)) {
+    return 0;
+  }
+  return Math.max(0, Math.trunc(raw));
 }
 
 /**
@@ -36,10 +49,7 @@ async function withConversationCommitPolicyAttempt(
   options: ConversationCommitPolicyOptions,
   attempt: number,
 ): Promise<LanguageModelV4StreamResult> {
-  const maxRetries = Math.max(
-    0,
-    options.maxRetries ?? COWORKER_CONVERSATION_MAX_RETRIES,
-  );
+  const maxRetries = normalizeMaxRetries(options.maxRetries);
   const minGoodChars =
     options.minGoodChars ?? MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS;
   const result = await openStream();

--- a/packages/ai-provider/src/stream/conversation-commit-policy.ts
+++ b/packages/ai-provider/src/stream/conversation-commit-policy.ts
@@ -11,6 +11,7 @@ export interface ConversationCommitPolicyOptions {
    * How many times to re-open the protocol stream after a failed commit-gate
    * (agent-error or short-tail). Default: {@link COWORKER_CONVERSATION_MAX_RETRIES}.
    * Pass `0` to skip the gate (single protocol open, no retries).
+   * Negative values are treated as `0`.
    */
   maxRetries?: number;
   minGoodChars?: number;
@@ -26,13 +27,24 @@ export interface ConversationCommitPolicyOptions {
 export async function withConversationCommitPolicy(
   openStream: () => Promise<LanguageModelV4StreamResult>,
   options: ConversationCommitPolicyOptions = {},
-  attempt = 0,
 ): Promise<LanguageModelV4StreamResult> {
-  const maxRetries = options.maxRetries ?? COWORKER_CONVERSATION_MAX_RETRIES;
+  return withConversationCommitPolicyAttempt(openStream, options, 0);
+}
+
+async function withConversationCommitPolicyAttempt(
+  openStream: () => Promise<LanguageModelV4StreamResult>,
+  options: ConversationCommitPolicyOptions,
+  attempt: number,
+): Promise<LanguageModelV4StreamResult> {
+  const maxRetries = Math.max(
+    0,
+    options.maxRetries ?? COWORKER_CONVERSATION_MAX_RETRIES,
+  );
   const minGoodChars =
     options.minGoodChars ?? MIN_GOOD_COWORKER_OUTPUT_TEXT_CHARS;
   const result = await openStream();
 
+  // Final attempt is ungated (no further onRetryNeeded).
   if (attempt >= maxRetries) {
     return result;
   }
@@ -42,14 +54,10 @@ export async function withConversationCommitPolicy(
     stream: createCommitGateStream(result.stream, {
       minGoodChars,
       onRetryNeeded: async () => {
-        const nextAttempt = attempt + 1;
-        if (nextAttempt > maxRetries) {
-          return null;
-        }
-        const retryResult = await withConversationCommitPolicy(
+        const retryResult = await withConversationCommitPolicyAttempt(
           openStream,
           options,
-          nextAttempt,
+          attempt + 1,
         );
         return retryResult.stream;
       },


### PR DESCRIPTION
## Linear
https://linear.app/masumi/issue/SOK-773/extract-coworker-conversation-commit-policy-from-ai-provider-stream

## Summary
Extract coworker conversation commit-gate + retry orchestration from `SokosumiLanguageModel` into `stream/conversation-commit-policy`. Protocol (SSE→V4 / fetch) stays mapping-only; product policy is explicit. No user-visible behavior change.

## Spec (≤8 lines)
- Conversation mode only still applies gate + up to 2 retries (agent-error / short-tail)
- Progress/lifecycle pass-through unchanged (`commit-gate-stream`)
- Non-conversation / `previousResponseId`-only streams stay ungated
- Invalid-conversation recovery remains protocol-side in `streamCoworker`
- No web/Core/UI changes; no timeout changes

## Verification
- `pnpm --filter @sokosumi/ai-provider check`
- `pnpm --filter @sokosumi/ai-provider test` (86 tests)