### PR TITLE
feat(chat): show coworker Thought in room streams

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,3 +37,17 @@ _Avoid_: Sidebar rooms, room list (when meaning who is in the room)
 **Membership revoke**:
 The event that the current user is no longer a member of a room — by remote removal (kick / roster remove) or by voluntary leave. After revoke they must not remain in membership-visible rooms for that room.
 _Avoid_: Access revoke (when meaning coworker workspace pilot access, not room membership)
+
+### Chat coworker thought
+
+**Mention status**:
+The lifecycle of a coworker @mention on a user message (calling → thinking → replied or failed). It is not the coworker’s reply body and not Thought.
+_Avoid_: Reply status, thinking badge (as the name of the concept)
+
+**Thought**:
+The coworker’s reasoning text for a turn (provider reasoning / summary parts), distinct from the answer body. Shown live as the current beat while the turn is open, and after the answer as a Thought disclosure.
+_Avoid_: Chain-of-thought (unless product means hidden provider CoT never sent to the client), internal monologue
+
+**Thought disclosure**:
+The collapsed control on a coworker assistant message that reveals Thought (and duration when known) after the answer is available or when reloading a message that already stored Thought.
+_Avoid_: Reasoning accordion, steps panel (Hermes-specific layout names)

--- a/apps/core/src/helpers/persist-assistant-to-chat-room.ts
+++ b/apps/core/src/helpers/persist-assistant-to-chat-room.ts
@@ -3,7 +3,7 @@ import { isPrismaUniqueViolation } from "@/helpers/prisma";
 import prisma from "@/lib/db/prisma";
 import type { PersistedChatUiPart } from "./message-content";
 
-function reasoningPartsToMetadata(
+export function reasoningPartsToMetadata(
   reasoning: unknown,
 ): Array<{ type: string; text: string }> | undefined {
   if (!Array.isArray(reasoning) || reasoning.length === 0) {
@@ -24,13 +24,13 @@ function reasoningPartsToMetadata(
   return out.length > 0 ? out : undefined;
 }
 
-function buildAssistantMessageMetadata(
-  reasoningSteps: Array<{ type: string; text: string }> | undefined,
-  thoughtTiming: { startedAtMs: number; endedAtMs: number } | undefined,
-  uiParts: PersistedChatUiPart[] | undefined,
-  responsesApiResponseId: string | null | undefined,
-): Record<string, unknown> | undefined {
+/** Thought fields only (`reasoning` + `thought_timing_ms`) for room message metadata. */
+export function thoughtMetadataFields(
+  reasoning: unknown,
+  thoughtTiming?: { startedAtMs: number; endedAtMs: number },
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
+  const reasoningSteps = reasoningPartsToMetadata(reasoning);
   if (reasoningSteps && reasoningSteps.length > 0) {
     out.reasoning = reasoningSteps;
   }
@@ -44,6 +44,18 @@ function buildAssistantMessageMetadata(
       end: thoughtTiming.endedAtMs,
     };
   }
+  return out;
+}
+
+function buildAssistantMessageMetadata(
+  reasoningSteps: Array<{ type: string; text: string }> | undefined,
+  thoughtTiming: { startedAtMs: number; endedAtMs: number } | undefined,
+  uiParts: PersistedChatUiPart[] | undefined,
+  responsesApiResponseId: string | null | undefined,
+): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {
+    ...thoughtMetadataFields(reasoningSteps, thoughtTiming),
+  };
   if (uiParts && uiParts.length > 0) {
     out.ui_message_v1 = {
       parts: uiParts,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.test.ts
@@ -643,16 +643,11 @@ describe("POST /chats/rooms/{id}/stream", () => {
     expect(response.status).toBe(200);
 
     const streamCall = streamTextMock.mock.calls[0]![0] as {
-      onChunk: (args: { chunk: { type: string } }) => void;
       onFinish: (finishEvent: {
         text: string;
         reasoning?: unknown[];
       }) => Promise<void>;
     };
-
-    streamCall.onChunk({ chunk: { type: "reasoning-start" } });
-    streamCall.onChunk({ chunk: { type: "reasoning-delta" } });
-    streamCall.onChunk({ chunk: { type: "reasoning-end" } });
 
     await streamCall.onFinish({
       text: "Assistant reply",

--- a/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/stream/post.ts
@@ -411,11 +411,8 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         current: null,
       };
 
-      const thoughtPhaseMs = {
-        start: null as number | null,
-        end: null as number | null,
-        sawReasoningChunk: false,
-      };
+      // Full generation wall-clock for product "Thought for …" (not reasoning-token span only).
+      const generationStartedAtMs = Date.now();
 
       const onInvalidProviderConversationId = async () => {
         if (parentMessageId) {
@@ -477,26 +474,6 @@ export default function mount(app: OpenAPIHonoWithAuth) {
         providerOptions: {
           sokosumi: sokosumiProviderOptions,
         } as unknown as Parameters<typeof streamText>[0]["providerOptions"],
-        onChunk: ({ chunk }) => {
-          const chunkType = chunk.type as string;
-          if (
-            chunkType === "reasoning-start" ||
-            chunkType === "reasoning-delta"
-          ) {
-            thoughtPhaseMs.sawReasoningChunk = true;
-            thoughtPhaseMs.start = thoughtPhaseMs.start ?? Date.now();
-          }
-          if (chunkType === "reasoning-end") {
-            thoughtPhaseMs.end = Date.now();
-          }
-          if (
-            chunk.type === "text-delta" &&
-            thoughtPhaseMs.sawReasoningChunk &&
-            thoughtPhaseMs.end == null
-          ) {
-            thoughtPhaseMs.end = Date.now();
-          }
-        },
         onFinish: async (finishEvent) => {
           const text = finishEvent.text?.trim() ?? "";
           if (!text) {
@@ -505,20 +482,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           const hasReasoning =
             Array.isArray(finishEvent.reasoning) &&
             finishEvent.reasoning.length > 0;
-          if (
-            hasReasoning &&
-            thoughtPhaseMs.start != null &&
-            thoughtPhaseMs.end == null
-          ) {
-            thoughtPhaseMs.end = Date.now();
-          }
-          const thoughtTiming =
-            hasReasoning && thoughtPhaseMs.start != null
-              ? {
-                  startedAtMs: thoughtPhaseMs.start,
-                  endedAtMs: thoughtPhaseMs.end ?? Date.now(),
-                }
-              : undefined;
+          const thoughtTiming = hasReasoning
+            ? {
+                startedAtMs: generationStartedAtMs,
+                endedAtMs: Date.now(),
+              }
+            : undefined;
           const persistArgs = {
             roomId: room.id,
             senderCoworkerId: coworker.id,

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -157,6 +157,7 @@ beforeEach(() => {
   findManyMock.mockResolvedValue([]);
   streamTextMock.mockReturnValue({
     text: Promise.resolve("Hello back"),
+    reasoning: Promise.resolve([]),
   });
   createMock.mockResolvedValue({ id: "reply_1" });
   deleteMock.mockResolvedValue({ id: "reply_1" });
@@ -306,6 +307,33 @@ describe("dispatchChatRoomMention claim", () => {
       }),
     });
     expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("persists Thought metadata on the reply when provider returns reasoning", async () => {
+    findUniqueMock.mockResolvedValue(pendingMention());
+    updateManyMock.mockResolvedValue({ count: 1 });
+    streamTextMock.mockReturnValue({
+      text: Promise.resolve("Hello back"),
+      reasoning: Promise.resolve([
+        { type: "reasoning", text: "Looked up the room context." },
+      ]),
+    });
+
+    await dispatchChatRoomMention(MENTION_ID);
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: "Hello back",
+          metadata: expect.objectContaining({
+            mention_id: MENTION_ID,
+            reasoning: [
+              { type: "reasoning", text: "Looked up the room context." },
+            ],
+          }),
+        }),
+      }),
+    );
   });
 
   it("discards the reply when finalize loses the claim race", async () => {

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -330,10 +330,19 @@ describe("dispatchChatRoomMention claim", () => {
             reasoning: [
               { type: "reasoning", text: "Looked up the room context." },
             ],
+            thought_timing_ms: expect.objectContaining({
+              start: expect.any(Number),
+              end: expect.any(Number),
+            }),
           }),
         }),
       }),
     );
+    const createArg = createMock.mock.calls[0]?.[0] as {
+      data: { metadata: { thought_timing_ms: { start: number; end: number } } };
+    };
+    const timing = createArg.data.metadata.thought_timing_ms;
+    expect(timing.end).toBeGreaterThanOrEqual(timing.start);
   });
 
   it("discards the reply when finalize loses the claim race", async () => {

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -4,6 +4,7 @@ import { streamText } from "ai";
 
 import { findUsableCoworkerByCapabilityInWorkspace } from "@/helpers/access-control";
 import { publishChatRoomMessageRealtimeById } from "@/helpers/chat-room-message-realtime";
+import { thoughtMetadataFields } from "@/helpers/persist-assistant-to-chat-room";
 import prisma from "@/lib/db/prisma";
 import { getSokosumiProvider } from "@/lib/sokosumi-ai-provider";
 import { resolveWorkspaceIdForChatRoom } from "@/routes/v1/chats/rooms/helpers";
@@ -370,6 +371,11 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
   });
 
   // Idle chunk timeouts abort stalls; totalMs is the hard ceiling.
+  const thoughtPhaseMs: {
+    start: number | null;
+    end: number | null;
+    sawReasoningChunk: boolean;
+  } = { start: null, end: null, sawReasoningChunk: false };
   const result = streamText({
     model: getSokosumiProvider()(null),
     messages: [{ role: "user", content: prompt }],
@@ -378,6 +384,23 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
     providerOptions: {
       sokosumi: providerOptions,
     } as unknown as Parameters<typeof streamText>[0]["providerOptions"],
+    onChunk: ({ chunk }) => {
+      const chunkType = chunk.type as string;
+      if (chunkType === "reasoning-start" || chunkType === "reasoning-delta") {
+        thoughtPhaseMs.sawReasoningChunk = true;
+        thoughtPhaseMs.start = thoughtPhaseMs.start ?? Date.now();
+      }
+      if (chunkType === "reasoning-end") {
+        thoughtPhaseMs.end = Date.now();
+      }
+      if (
+        chunk.type === "text-delta" &&
+        thoughtPhaseMs.sawReasoningChunk &&
+        thoughtPhaseMs.end == null
+      ) {
+        thoughtPhaseMs.end = Date.now();
+      }
+    },
   });
   const responseText = (await result.text).trim();
   if (!responseText || coworkerTextLooksLikeAgentError(responseText)) {
@@ -387,6 +410,25 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
     );
     return;
   }
+
+  const reasoningParts = await result.reasoning;
+  const hasReasoning =
+    Array.isArray(reasoningParts) && reasoningParts.length > 0;
+  if (
+    hasReasoning &&
+    thoughtPhaseMs.start != null &&
+    thoughtPhaseMs.end == null
+  ) {
+    thoughtPhaseMs.end = Date.now();
+  }
+  const thoughtTiming =
+    hasReasoning && thoughtPhaseMs.start != null
+      ? {
+          startedAtMs: thoughtPhaseMs.start,
+          endedAtMs: thoughtPhaseMs.end ?? Date.now(),
+        }
+      : undefined;
+  const thoughtMeta = thoughtMetadataFields(reasoningParts, thoughtTiming);
 
   const publishedMessageIds = await prisma.$transaction(async (tx) => {
     // Re-check membership after the provider call: eviction during streamText
@@ -446,6 +488,7 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
         metadata: {
           in_reply_to_message_id: mention.message.id,
           mention_id: mention.id,
+          ...thoughtMeta,
         },
       },
     });

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -371,11 +371,9 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
   });
 
   // Idle chunk timeouts abort stalls; totalMs is the hard ceiling.
-  const thoughtPhaseMs: {
-    start: number | null;
-    end: number | null;
-    sawReasoningChunk: boolean;
-  } = { start: null, end: null, sawReasoningChunk: false };
+  // Wall-clock generation time (not reasoning-token phase only) — product
+  // "Thought for …" matches the live "is thinking" timer the user saw.
+  const generationStartedAtMs = Date.now();
   const result = streamText({
     model: getSokosumiProvider()(null),
     messages: [{ role: "user", content: prompt }],
@@ -384,25 +382,9 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
     providerOptions: {
       sokosumi: providerOptions,
     } as unknown as Parameters<typeof streamText>[0]["providerOptions"],
-    onChunk: ({ chunk }) => {
-      const chunkType = chunk.type as string;
-      if (chunkType === "reasoning-start" || chunkType === "reasoning-delta") {
-        thoughtPhaseMs.sawReasoningChunk = true;
-        thoughtPhaseMs.start = thoughtPhaseMs.start ?? Date.now();
-      }
-      if (chunkType === "reasoning-end") {
-        thoughtPhaseMs.end = Date.now();
-      }
-      if (
-        chunk.type === "text-delta" &&
-        thoughtPhaseMs.sawReasoningChunk &&
-        thoughtPhaseMs.end == null
-      ) {
-        thoughtPhaseMs.end = Date.now();
-      }
-    },
   });
   const responseText = (await result.text).trim();
+  const generationEndedAtMs = Date.now();
   if (!responseText || coworkerTextLooksLikeAgentError(responseText)) {
     await markMentionFailed(
       mentionId,
@@ -414,20 +396,12 @@ async function runChatRoomMentionDispatch(mentionId: string): Promise<void> {
   const reasoningParts = await result.reasoning;
   const hasReasoning =
     Array.isArray(reasoningParts) && reasoningParts.length > 0;
-  if (
-    hasReasoning &&
-    thoughtPhaseMs.start != null &&
-    thoughtPhaseMs.end == null
-  ) {
-    thoughtPhaseMs.end = Date.now();
-  }
-  const thoughtTiming =
-    hasReasoning && thoughtPhaseMs.start != null
-      ? {
-          startedAtMs: thoughtPhaseMs.start,
-          endedAtMs: thoughtPhaseMs.end ?? Date.now(),
-        }
-      : undefined;
+  const thoughtTiming = hasReasoning
+    ? {
+        startedAtMs: generationStartedAtMs,
+        endedAtMs: generationEndedAtMs,
+      }
+    : undefined;
   const thoughtMeta = thoughtMetadataFields(reasoningParts, thoughtTiming);
 
   const publishedMessageIds = await prisma.$transaction(async (tx) => {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1532,6 +1532,7 @@
           "searchingFiles": "Dateien werden durchsucht...",
           "callingTools": "Tools werden aufgerufen...",
           "thoughtForSeconds": "Gedacht für {seconds}s",
+          "thoughtForDuration": "Gedacht für {duration}",
           "expandSteps": "Überlegungsschritte anzeigen",
           "collapseSteps": "Überlegungsschritte ausblenden"
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1533,8 +1533,8 @@
           "callingTools": "Tools werden aufgerufen...",
           "thoughtForSeconds": "Gedacht für {seconds}s",
           "thoughtForDuration": "Gedacht für {duration}",
-          "expandSteps": "Überlegungsschritte anzeigen",
-          "collapseSteps": "Überlegungsschritte ausblenden"
+          "expandSteps": "Überlegung anzeigen",
+          "collapseSteps": "Überlegung ausblenden"
         },
         "chatErrorTitle": "Chat-Fehler",
         "errorFallbackDescription": "Bei der Chat-Oberfläche ist ein Problem aufgetreten. Bitte lade die Seite neu oder kontaktiere den Support, falls das Problem weiterhin besteht.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1531,10 +1531,8 @@
           "thinking": "Denkt nach...",
           "searchingFiles": "Dateien werden durchsucht...",
           "callingTools": "Tools werden aufgerufen...",
-          "thoughtForSeconds": "Gedacht für {seconds}s",
           "thoughtForDuration": "Gedacht für {duration}",
-          "expandSteps": "Überlegung anzeigen",
-          "collapseSteps": "Überlegung ausblenden"
+          "expandSteps": "Überlegung anzeigen"
         },
         "chatErrorTitle": "Chat-Fehler",
         "errorFallbackDescription": "Bei der Chat-Oberfläche ist ein Problem aufgetreten. Bitte lade die Seite neu oder kontaktiere den Support, falls das Problem weiterhin besteht.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1542,8 +1542,8 @@
           "callingTools": "Calling tools...",
           "thoughtForSeconds": "Thought for {seconds}s",
           "thoughtForDuration": "Thought for {duration}",
-          "expandSteps": "Show reasoning steps",
-          "collapseSteps": "Hide reasoning steps"
+          "expandSteps": "Show thought",
+          "collapseSteps": "Hide thought"
         },
         "chatErrorTitle": "Chat Error",
         "errorFallbackDescription": "Something went wrong with the chat interface. Please try refreshing or contact support if the issue persists.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1541,6 +1541,7 @@
           "searchingFiles": "Searching files...",
           "callingTools": "Calling tools...",
           "thoughtForSeconds": "Thought for {seconds}s",
+          "thoughtForDuration": "Thought for {duration}",
           "expandSteps": "Show reasoning steps",
           "collapseSteps": "Hide reasoning steps"
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1540,10 +1540,8 @@
           "thinking": "Thinking...",
           "searchingFiles": "Searching files...",
           "callingTools": "Calling tools...",
-          "thoughtForSeconds": "Thought for {seconds}s",
           "thoughtForDuration": "Thought for {duration}",
-          "expandSteps": "Show thought",
-          "collapseSteps": "Hide thought"
+          "expandSteps": "Show thought"
         },
         "chatErrorTitle": "Chat Error",
         "errorFallbackDescription": "Something went wrong with the chat interface. Please try refreshing or contact support if the issue persists.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1531,10 +1531,8 @@
           "thinking": "Pensando...",
           "searchingFiles": "Buscando archivos...",
           "callingTools": "Usando herramientas...",
-          "thoughtForSeconds": "Pensado durante {seconds}s",
           "thoughtForDuration": "Pensado durante {duration}",
-          "expandSteps": "Mostrar pensamiento",
-          "collapseSteps": "Ocultar pensamiento"
+          "expandSteps": "Mostrar pensamiento"
         },
         "chatErrorTitle": "Error en el chat",
         "errorFallbackDescription": "Hubo un problema con la interfaz del chat. Por favor, recarga la página o contacta con soporte si el problema persiste.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1533,8 +1533,8 @@
           "callingTools": "Usando herramientas...",
           "thoughtForSeconds": "Pensado durante {seconds}s",
           "thoughtForDuration": "Pensado durante {duration}",
-          "expandSteps": "Mostrar pasos de razonamiento",
-          "collapseSteps": "Ocultar pasos de razonamiento"
+          "expandSteps": "Mostrar pensamiento",
+          "collapseSteps": "Ocultar pensamiento"
         },
         "chatErrorTitle": "Error en el chat",
         "errorFallbackDescription": "Hubo un problema con la interfaz del chat. Por favor, recarga la página o contacta con soporte si el problema persiste.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1532,6 +1532,7 @@
           "searchingFiles": "Buscando archivos...",
           "callingTools": "Usando herramientas...",
           "thoughtForSeconds": "Pensado durante {seconds}s",
+          "thoughtForDuration": "Pensado durante {duration}",
           "expandSteps": "Mostrar pasos de razonamiento",
           "collapseSteps": "Ocultar pasos de razonamiento"
         },

--- a/apps/web/src/app/(app)/chat/components/__tests__/coworker-thought-ui.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/coworker-thought-ui.test.ts
@@ -3,7 +3,21 @@ import { describe, expect, it } from "vitest";
 import {
   drivePixelOpacity,
   drivePixelOpacityAtPhase,
+  formatBeautifulElapsed,
 } from "../coworker-thought-ui";
+
+describe("formatBeautifulElapsed", () => {
+  it("matches Beautiful UI tenths under a minute", () => {
+    expect(formatBeautifulElapsed(0)).toBe("0.0s");
+    expect(formatBeautifulElapsed(10_400)).toBe("10.4s");
+    expect(formatBeautifulElapsed(59_900)).toBe("59.9s");
+  });
+
+  it("formats a minute and above as m s.s", () => {
+    expect(formatBeautifulElapsed(60_000)).toBe("1m 0.0s");
+    expect(formatBeautifulElapsed(75_500)).toBe("1m 15.5s");
+  });
+});
 
 describe("drivePixelOpacityAtPhase", () => {
   it("is dim at start and end of cycle", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/coworker-thought-ui.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/coworker-thought-ui.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  drivePixelOpacity,
+  drivePixelOpacityAtPhase,
+} from "../coworker-thought-ui";
+
+describe("drivePixelOpacityAtPhase", () => {
+  it("is dim at start and end of cycle", () => {
+    expect(drivePixelOpacityAtPhase(0)).toBeCloseTo(0.15, 2);
+    expect(drivePixelOpacityAtPhase(0.8)).toBeCloseTo(0.15, 2);
+  });
+
+  it("is bright mid-peak", () => {
+    expect(drivePixelOpacityAtPhase(0.3)).toBeCloseTo(1, 2);
+  });
+});
+
+describe("drivePixelOpacity", () => {
+  it("offsets cells so the wave moves left to right", () => {
+    // At t=200ms with 140ms step, col0 is ahead of col2 on the first row.
+    const left = drivePixelOpacity(200, 0, 1000);
+    const right = drivePixelOpacity(200, 280, 1000);
+    expect(left).toBeGreaterThan(right);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1683,9 +1683,9 @@ describe("ChatMessageRow coworker Thought", () => {
     const trace = screen.getByTestId("coworker-thought-trace");
     expect(trace).toHaveAttribute("data-working", "true");
     expect(trace).toHaveTextContent("reasoning.thinking");
-    expect(screen.getByTestId("coworker-thought-body")).toHaveTextContent(
-      "Counting registrations in last 30 days",
-    );
+    const body = screen.getByTestId("coworker-thought-body");
+    expect(body).toHaveTextContent("Counting registrations in last 30 days");
+    expect(body.className).toMatch(/line-clamp-3/);
     expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1546,3 +1546,94 @@ describe("ChatMessageRow", () => {
     );
   });
 });
+
+describe("ChatMessageRow coworker Thought", () => {
+  it("shows Thinking fallback on empty stream overlay without Thought", () => {
+    renderRow({
+      message: coworkerMessage({
+        id: "stream:asst-1",
+        content: "",
+        metadata: { streaming: true },
+      }),
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("reasoning.thinking");
+  });
+
+  it("shows live Thought beat on stream overlay instead of Thinking", () => {
+    renderRow({
+      message: coworkerMessage({
+        id: "stream:asst-2",
+        content: "",
+        metadata: {
+          streaming: true,
+          reasoning: [
+            {
+              type: "reasoning",
+              text: "Counting registrations in last 30 days",
+            },
+          ],
+        },
+      }),
+    });
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("Counting registrations in last 30 days");
+    expect(status).not.toHaveTextContent("reasoning.thinking");
+  });
+
+  it("shows collapsed Thought disclosure with duration when metadata has Thought", async () => {
+    const user = userEvent.setup();
+    renderRow({
+      message: coworkerMessage({
+        content: "There were 142 new registrations.",
+        metadata: {
+          reasoning: [{ type: "reasoning", text: "Queried user table." }],
+          thought_timing_ms: { start: 1_000, end: 13_000 },
+        },
+      }),
+    });
+
+    expect(
+      screen.getByText("There were 142 new registrations."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Queried user table.")).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole("button", {
+      name: "reasoning.thoughtForSeconds",
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Queried user table.")).toBeInTheDocument();
+  });
+
+  it("uses expand label when Thought exists without valid timing", () => {
+    renderRow({
+      message: coworkerMessage({
+        content: "Answer body",
+        metadata: {
+          reasoning: [{ type: "reasoning", text: "Some thought" }],
+        },
+      }),
+    });
+
+    expect(
+      screen.getByRole("button", { name: "reasoning.expandSteps" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits Thought disclosure when there is no reasoning metadata", () => {
+    renderRow({
+      message: coworkerMessage({ content: "Plain answer" }),
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "reasoning.expandSteps" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "reasoning.thoughtForSeconds" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1558,6 +1558,7 @@ describe("ChatMessageRow coworker Thought", () => {
     });
 
     expect(screen.getByRole("status")).toHaveTextContent("reasoning.thinking");
+    expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 
   it("shows live Thought beat on stream overlay instead of Thinking", () => {
@@ -1580,6 +1581,27 @@ describe("ChatMessageRow coworker Thought", () => {
     const status = screen.getByRole("status");
     expect(status).toHaveTextContent("Counting registrations in last 30 days");
     expect(status).not.toHaveTextContent("reasoning.thinking");
+    expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
+  });
+
+  it("shows elapsed seconds on the live Thinking row", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-10T12:00:10.000Z"));
+    try {
+      renderRow({
+        message: coworkerMessage({
+          id: "stream:asst-elapsed",
+          content: "",
+          createdAt: new Date("2026-08-10T12:00:00.000Z"),
+          metadata: { streaming: true },
+        }),
+      });
+      expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
+        "10s",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shows collapsed Thought disclosure with duration when metadata has Thought", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -36,6 +36,9 @@ vi.mock("next-intl", () => ({
       if (key === "imageAlt" && values) {
         return `Preview image for ${values.title}`;
       }
+      if (key === "reasoning.thoughtForDuration" && values?.duration != null) {
+        return `Thought for ${String(values.duration)}`;
+      }
       return key;
     };
   },
@@ -1725,9 +1728,8 @@ describe("ChatMessageRow coworker Thought", () => {
       screen.getByText("There were 142 new registrations."),
     ).toBeInTheDocument();
 
-    // Mock next-intl returns key; duration is formatted as 1m 3s in the values.
     const toggle = screen.getByRole("button", {
-      name: /reasoning.thoughtForDuration/i,
+      name: "Thought for 1m 3s",
     });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.getByTestId("coworker-thought-body")).not.toBeVisible();

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1587,6 +1587,66 @@ describe("ChatMessageRow coworker Thought", () => {
     expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 
+  it("shows static terminal status for replied and failed mentions", () => {
+    const coworkersById = new Map([
+      [
+        "cow-1",
+        {
+          id: "cow-1",
+          name: "Noodles",
+          slug: "noodles",
+          caption: null,
+          image: null,
+          presence: "online" as const,
+        },
+      ],
+    ]);
+    const { rerender } = render(
+      <ChatMessageRow
+        message={userMessage({
+          mentions: [
+            {
+              id: "m1",
+              coworkerId: "cow-1",
+              status: "responded",
+              responseMessageId: "r1",
+            },
+          ],
+        })}
+        coworkersById={coworkersById}
+        coworkersBySlug={new Map()}
+        onToggleReaction={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("coworker-mention-terminal")).toHaveAttribute(
+      "data-variant",
+      "responded",
+    );
+    expect(screen.getByTestId("bui-static-grid")).toBeInTheDocument();
+
+    rerender(
+      <ChatMessageRow
+        message={userMessage({
+          mentions: [
+            {
+              id: "m1",
+              coworkerId: "cow-1",
+              status: "failed",
+              responseMessageId: null,
+            },
+          ],
+        })}
+        coworkersById={coworkersById}
+        coworkersBySlug={new Map()}
+        onToggleReaction={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("coworker-mention-terminal")).toHaveAttribute(
+      "data-variant",
+      "failed",
+    );
+  });
+
   it("shows Beautiful UI loading state on empty stream overlay", () => {
     renderRow({
       message: coworkerMessage({
@@ -1655,7 +1715,7 @@ describe("ChatMessageRow coworker Thought", () => {
         content: "There were 142 new registrations.",
         metadata: {
           reasoning: [{ type: "reasoning", text: "Queried user table." }],
-          thought_timing_ms: { start: 1_000, end: 13_000 },
+          thought_timing_ms: { start: 1_000, end: 64_000 },
         },
       }),
     });
@@ -1664,8 +1724,9 @@ describe("ChatMessageRow coworker Thought", () => {
       screen.getByText("There were 142 new registrations."),
     ).toBeInTheDocument();
 
+    // Mock next-intl returns key; duration is formatted as 1m 3s in the values.
     const toggle = screen.getByRole("button", {
-      name: /reasoning.thoughtForSeconds/i,
+      name: /reasoning.thoughtForDuration/i,
     });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.getByTestId("coworker-thought-body")).not.toBeVisible();

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1587,7 +1587,7 @@ describe("ChatMessageRow coworker Thought", () => {
     expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 
-  it("shows static terminal status for replied and failed mentions", () => {
+  it("hides mention status when coworker replied; shows failed terminal only", () => {
     const coworkersById = new Map([
       [
         "cow-1",
@@ -1618,11 +1618,12 @@ describe("ChatMessageRow coworker Thought", () => {
         onToggleReaction={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("coworker-mention-terminal")).toHaveAttribute(
-      "data-variant",
-      "responded",
-    );
-    expect(screen.getByTestId("bui-static-grid")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("coworker-mention-terminal"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("coworker-loading-state"),
+    ).not.toBeInTheDocument();
 
     rerender(
       <ChatMessageRow

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1548,7 +1548,7 @@ describe("ChatMessageRow", () => {
 });
 
 describe("ChatMessageRow coworker Thought", () => {
-  it("shows Thinking fallback on empty stream overlay without Thought", () => {
+  it("shows Beautiful UI loading state on empty stream overlay", () => {
     renderRow({
       message: coworkerMessage({
         id: "stream:asst-1",
@@ -1557,11 +1557,13 @@ describe("ChatMessageRow coworker Thought", () => {
       }),
     });
 
-    expect(screen.getByRole("status")).toHaveTextContent("reasoning.thinking");
+    expect(screen.getByTestId("coworker-loading-state")).toHaveTextContent(
+      "reasoning.thinking",
+    );
     expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 
-  it("shows live Thought beat on stream overlay instead of Thinking", () => {
+  it("shows working Thought trace with live beat on stream overlay", () => {
     renderRow({
       message: coworkerMessage({
         id: "stream:asst-2",
@@ -1578,13 +1580,16 @@ describe("ChatMessageRow coworker Thought", () => {
       }),
     });
 
-    const status = screen.getByRole("status");
-    expect(status).toHaveTextContent("Counting registrations in last 30 days");
-    expect(status).not.toHaveTextContent("reasoning.thinking");
+    const trace = screen.getByTestId("coworker-thought-trace");
+    expect(trace).toHaveAttribute("data-working", "true");
+    expect(trace).toHaveTextContent("reasoning.thinking");
+    expect(screen.getByTestId("coworker-thought-body")).toHaveTextContent(
+      "Counting registrations in last 30 days",
+    );
     expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 
-  it("shows elapsed seconds on the live Thinking row", () => {
+  it("shows tenths elapsed on the live Loading row", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-10T12:00:10.000Z"));
     try {
@@ -1597,7 +1602,7 @@ describe("ChatMessageRow coworker Thought", () => {
         }),
       });
       expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
-        "10s",
+        "10.0s",
       );
     } finally {
       vi.useRealTimers();
@@ -1619,16 +1624,19 @@ describe("ChatMessageRow coworker Thought", () => {
     expect(
       screen.getByText("There were 142 new registrations."),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Queried user table.")).not.toBeInTheDocument();
 
     const toggle = screen.getByRole("button", {
-      name: "reasoning.thoughtForSeconds",
+      name: /reasoning.thoughtForSeconds/i,
     });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("coworker-thought-body")).not.toBeVisible();
 
     await user.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("Queried user table.")).toBeInTheDocument();
+    expect(screen.getByTestId("coworker-thought-body")).toBeVisible();
+    expect(screen.getByTestId("coworker-thought-body")).toHaveTextContent(
+      "Queried user table.",
+    );
   });
 
   it("uses expand label when Thought exists without valid timing", () => {
@@ -1642,7 +1650,7 @@ describe("ChatMessageRow coworker Thought", () => {
     });
 
     expect(
-      screen.getByRole("button", { name: "reasoning.expandSteps" }),
+      screen.getByRole("button", { name: /reasoning.expandSteps/i }),
     ).toBeInTheDocument();
   });
 
@@ -1652,10 +1660,7 @@ describe("ChatMessageRow coworker Thought", () => {
     });
 
     expect(
-      screen.queryByRole("button", { name: "reasoning.expandSteps" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "reasoning.thoughtForSeconds" }),
+      screen.queryByTestId("coworker-thought-trace"),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -3,7 +3,10 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+import type {
+  ChatRoomCoworkerParticipant,
+  ChatRoomMessage,
+} from "@/lib/clients/generated/core";
 
 import { ChatMessageRow } from "../room-message-row";
 
@@ -137,6 +140,7 @@ function renderRow({
   onCancelEdit,
   onSaveEdit,
   isSavingEdit = false,
+  coworkersById = new Map(),
 }: {
   message?: ChatRoomMessage;
   isContinuation?: boolean;
@@ -151,11 +155,12 @@ function renderRow({
   onCancelEdit?: () => void;
   onSaveEdit?: (content?: string) => void;
   isSavingEdit?: boolean;
+  coworkersById?: Map<string, ChatRoomCoworkerParticipant>;
 } = {}) {
   render(
     <ChatMessageRow
       message={message}
-      coworkersById={new Map()}
+      coworkersById={coworkersById}
       coworkersBySlug={new Map()}
       currentUserId={currentUserId}
       onToggleReaction={vi.fn()}
@@ -1548,6 +1553,40 @@ describe("ChatMessageRow", () => {
 });
 
 describe("ChatMessageRow coworker Thought", () => {
+  it("shows Beautiful UI loading on mention status while coworker is thinking", () => {
+    renderRow({
+      message: userMessage({
+        content: "@Noodles which org has the most members?",
+        createdAt: new Date("2026-08-10T12:00:00.000Z"),
+        mentions: [
+          {
+            id: "mention-1",
+            coworkerId: "cow-1",
+            status: "sent",
+            responseMessageId: null,
+          },
+        ],
+      }),
+      coworkersById: new Map([
+        [
+          "cow-1",
+          {
+            id: "cow-1",
+            name: "Noodles",
+            slug: "noodles",
+            caption: null,
+            image: null,
+            presence: "online",
+          },
+        ],
+      ]),
+    });
+
+    const loading = screen.getByTestId("coworker-loading-state");
+    expect(loading).toHaveTextContent("MentionStatus.sent");
+    expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
+  });
+
   it("shows Beautiful UI loading state on empty stream overlay", () => {
     renderRow({
       message: coworkerMessage({

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+/**
+ * Loading + Thinking primitives adapted from Beautiful UI
+ * (https://beautiful-ui-five.vercel.app/ — Loading State / Thinking · Reasoning).
+ * Tokens remapped to Sokosumi semantic colors.
+ */
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Beautiful UI loading timer: tenths under 60s, then `m s.s`. */
+export function formatBeautifulElapsed(elapsedMs: number): string {
+  const total = Math.max(0, elapsedMs) / 1000;
+  if (total < 60) {
+    return `${total.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(total / 60);
+  const rem = total % 60;
+  return `${minutes}m ${rem.toFixed(1)}s`;
+}
+
+const CHEVRON_DELAYS = Array.from({ length: 9 }, (_, i) => {
+  const r = Math.floor(i / 3);
+  const c = i % 3;
+  return (c + Math.abs(r - 1)) * 90;
+});
+
+function useLiveElapsedMs(startedAtMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(id);
+  }, []);
+  return Math.max(0, now - startedAtMs);
+}
+
+/**
+ * Pixel-grid loader + shimmer label + live elapsed (Beautiful UI Loading State).
+ * Used while the coworker stream has no answer yet.
+ */
+export function CoworkerLoadingState({
+  label,
+  startedAtMs,
+  className,
+}: {
+  label: string;
+  startedAtMs: number;
+  className?: string;
+}) {
+  const elapsedMs = useLiveElapsedMs(startedAtMs);
+  return (
+    <div
+      className={cn("flex w-fit max-w-full items-center gap-2.5", className)}
+      role="status"
+      aria-live="polite"
+      data-testid="coworker-loading-state"
+    >
+      <span
+        aria-hidden
+        className="grid shrink-0 grid-cols-[repeat(3,4px)] gap-[1.5px]"
+      >
+        {CHEVRON_DELAYS.map((delay, i) => (
+          <span
+            key={i}
+            className="bg-foreground size-1 rounded-[1px] motion-reduce:animate-none"
+            style={{
+              opacity: 0.15,
+              animation: `bui-pixel-on 650ms ease-in-out ${delay}ms infinite`,
+            }}
+          />
+        ))}
+      </span>
+      <span
+        className="bui-shimmer-text truncate text-[13px] font-medium"
+        data-testid="coworker-loading-label"
+      >
+        {label}
+      </span>
+      <span
+        className="text-muted-foreground shrink-0 font-mono text-xs tabular-nums"
+        data-testid="live-stream-elapsed"
+      >
+        {formatBeautifulElapsed(elapsedMs)}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Expandable Thought header + optional prose body (Beautiful UI Thinking · Reasoning).
+ * - Live: working shimmer "Thinking" + optional live beat in expanded body
+ * - Done: "Thought for Ns" settled label + full Thought text
+ */
+export function CoworkerThoughtTrace({
+  working,
+  headerLabel,
+  bodyText,
+  defaultExpanded = false,
+  className,
+}: {
+  working: boolean;
+  headerLabel: string;
+  bodyText?: string | null;
+  defaultExpanded?: boolean;
+  className?: string;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const traceRef = useRef<HTMLDivElement>(null);
+  const [lineHeight, setLineHeight] = useState(0);
+  const hasBody = Boolean(bodyText?.trim());
+
+  useLayoutEffect(() => {
+    if (traceRef.current) {
+      setLineHeight(traceRef.current.offsetHeight);
+    }
+  }, [expanded, bodyText, working]);
+
+  return (
+    <div
+      className={cn("flex w-full min-w-0 flex-col", className)}
+      data-testid="coworker-thought-trace"
+      data-working={working ? "true" : "false"}
+    >
+      <button
+        type="button"
+        aria-expanded={hasBody ? expanded : undefined}
+        disabled={!hasBody}
+        onClick={() => {
+          if (hasBody) {
+            setExpanded((value) => !value);
+          }
+        }}
+        className={cn(
+          "-mx-1.5 flex w-fit max-w-full items-center gap-2 rounded-md px-1.5 py-1 text-left",
+          "transition-colors duration-100",
+          hasBody &&
+            "hover:bg-muted/60 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+          !hasBody && "cursor-default",
+        )}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          aria-hidden
+          className="shrink-0"
+          fill={
+            working
+              ? "var(--muted-foreground)"
+              : "color-mix(in oklab, var(--muted-foreground) 70%, transparent)"
+          }
+        >
+          <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z" />
+        </svg>
+        {working ? (
+          <span className="bui-shimmer-text truncate text-[13px] font-medium whitespace-nowrap">
+            {headerLabel}
+          </span>
+        ) : (
+          <span className="text-muted-foreground truncate text-[13px] font-medium whitespace-nowrap">
+            {headerLabel}
+          </span>
+        )}
+        {hasBody ? (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+            className="text-muted-foreground shrink-0 transition-transform duration-300"
+            style={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)" }}
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+        ) : null}
+      </button>
+
+      {hasBody ? (
+        <div
+          className="grid transition-[grid-template-rows,opacity] duration-400"
+          style={{
+            gridTemplateRows: expanded ? "1fr" : "0fr",
+            opacity: expanded ? 1 : 0,
+            transitionTimingFunction: "cubic-bezier(0.23, 1, 0.32, 1)",
+          }}
+          // Keep body out of a11y tree when collapsed (still animates open/closed).
+          inert={!expanded ? true : undefined}
+          aria-hidden={!expanded}
+        >
+          <div className="overflow-hidden">
+            <div className="relative mt-1 ml-[5px] pl-4">
+              <span
+                aria-hidden
+                className="bg-border absolute left-[3px] w-px"
+                style={{
+                  top: -8,
+                  height: lineHeight ? lineHeight - 2 : 0,
+                  transition: "height 500ms cubic-bezier(0.23,1,0.32,1)",
+                }}
+              />
+              <div ref={traceRef} className="flex flex-col gap-1 py-1">
+                <p
+                  className="text-muted-foreground text-[12.5px] leading-relaxed whitespace-pre-wrap"
+                  data-testid="coworker-thought-body"
+                >
+                  {bodyText}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Live stream: loading grid when no beat yet; otherwise working Thought
+ * header with live beat as expandable body (default open).
+ */
+export function CoworkerLiveThought({
+  label,
+  liveBeat,
+  startedAtMs,
+}: {
+  label: string;
+  liveBeat: string | null;
+  startedAtMs: number;
+}) {
+  if (!liveBeat) {
+    return <CoworkerLoadingState label={label} startedAtMs={startedAtMs} />;
+  }
+  return (
+    <div
+      className="flex min-w-0 flex-col gap-1"
+      role="status"
+      aria-live="polite"
+    >
+      <CoworkerThoughtTrace
+        working
+        headerLabel={label}
+        bodyText={liveBeat}
+        defaultExpanded
+      />
+      <span
+        className="text-muted-foreground ml-[26px] font-mono text-xs tabular-nums"
+        data-testid="live-stream-elapsed"
+      >
+        <LiveElapsed startedAtMs={startedAtMs} />
+      </span>
+    </div>
+  );
+}
+
+function LiveElapsed({ startedAtMs }: { startedAtMs: number }) {
+  const elapsedMs = useLiveElapsedMs(startedAtMs);
+  return <>{formatBeautifulElapsed(elapsedMs)}</>;
+}

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -316,7 +316,11 @@ export function CoworkerThoughtTrace({
               />
               <div ref={traceRef} className="flex flex-col gap-1 py-1">
                 <p
-                  className="text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap"
+                  className={cn(
+                    "text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap",
+                    // Spec: clamp live beat so multi-reader rooms do not flood.
+                    working && "line-clamp-3",
+                  )}
                   data-testid="coworker-thought-body"
                 >
                   {bodyText}

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -21,10 +21,15 @@ export function formatBeautifulElapsed(elapsedMs: number): string {
   return `${minutes}m ${rem.toFixed(1)}s`;
 }
 
-const CHEVRON_DELAYS = Array.from({ length: 9 }, (_, i) => {
-  const r = Math.floor(i / 3);
-  const c = i % 3;
-  return (c + Math.abs(r - 1)) * 90;
+/**
+ * Beautiful UI Drive (chevron wavefront left → right).
+ * Delay step 140ms (demo uses 90ms) with a 1000ms cycle so the wave is
+ * slower and easier to read in chat.
+ */
+const DRIVE_PIXEL_DELAYS_MS = Array.from({ length: 9 }, (_, i) => {
+  const row = Math.floor(i / 3);
+  const col = i % 3;
+  return (col + Math.abs(row - 1)) * 140;
 });
 
 function useLiveElapsedMs(startedAtMs: number): number {
@@ -57,18 +62,12 @@ export function CoworkerLoadingState({
       aria-live="polite"
       data-testid="coworker-loading-state"
     >
-      <span
-        aria-hidden
-        className="grid shrink-0 grid-cols-[repeat(3,4px)] gap-[1.5px]"
-      >
-        {CHEVRON_DELAYS.map((delay, i) => (
+      <span aria-hidden className="bui-pixel-grid">
+        {DRIVE_PIXEL_DELAYS_MS.map((delayMs, i) => (
           <span
             key={i}
-            className="bg-foreground size-1 rounded-[1px] motion-reduce:animate-none"
-            style={{
-              opacity: 0.15,
-              animation: `bui-pixel-on 650ms ease-in-out ${delay}ms infinite`,
-            }}
+            className="bui-pixel-cell"
+            style={{ animationDelay: `${delayMs}ms` }}
           />
         ))}
       </span>

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -63,28 +63,6 @@ export function drivePixelOpacity(
   return drivePixelOpacityAtPhase(t / cycleMs);
 }
 
-function useAnimationClockMs(): number {
-  const [elapsedMs, setElapsedMs] = useState(0);
-  useEffect(() => {
-    // Respect reduced motion: freeze grid at dim (no wave).
-    const reduce =
-      typeof window !== "undefined" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduce) {
-      return;
-    }
-    const start = performance.now();
-    let frame = 0;
-    const tick = (now: number) => {
-      setElapsedMs(now - start);
-      frame = requestAnimationFrame(tick);
-    };
-    frame = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frame);
-  }, []);
-  return elapsedMs;
-}
-
 function useLiveElapsedMs(startedAtMs: number): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -94,16 +72,47 @@ function useLiveElapsedMs(startedAtMs: number): number {
   return Math.max(0, now - startedAtMs);
 }
 
-/** 3×3 Drive wave — JS-driven so it does not depend on CSS keyframes. */
+/**
+ * 3×3 Drive wave — rAF updates pixel opacity via refs (no React setState per frame).
+ */
 function DrivePixelGrid() {
-  const elapsedMs = useAnimationClockMs();
+  const cellRefs = useRef<(HTMLSpanElement | null)[]>([]);
+  useEffect(() => {
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) {
+      return;
+    }
+    const start = performance.now();
+    let frame = 0;
+    const tick = (now: number) => {
+      const elapsedMs = now - start;
+      const cells = cellRefs.current;
+      for (let i = 0; i < DRIVE_PIXEL_DELAYS_MS.length; i += 1) {
+        const el = cells[i];
+        if (el) {
+          el.style.opacity = String(
+            drivePixelOpacity(elapsedMs, DRIVE_PIXEL_DELAYS_MS[i]!),
+          );
+        }
+      }
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
   return (
     <span aria-hidden className="bui-pixel-grid" data-testid="bui-drive-grid">
       {DRIVE_PIXEL_DELAYS_MS.map((delayMs, i) => (
         <span
           key={i}
+          ref={(el) => {
+            cellRefs.current[i] = el;
+          }}
           className="bui-pixel-cell"
-          style={{ opacity: drivePixelOpacity(elapsedMs, delayMs) }}
+          style={{ opacity: drivePixelOpacity(0, delayMs) }}
           data-testid="bui-drive-pixel"
         />
       ))}

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -63,12 +63,17 @@ export function drivePixelOpacity(
   return drivePixelOpacityAtPhase(t / cycleMs);
 }
 
+/**
+ * Deterministic first paint (SSR/client match), then live clock after mount.
+ * Seeding with `startedAtMs` yields 0.0s until the effect runs.
+ */
 function useLiveElapsedMs(startedAtMs: number): number {
-  const [now, setNow] = useState(() => Date.now());
+  const [now, setNow] = useState(startedAtMs);
   useEffect(() => {
+    setNow(Date.now());
     const id = setInterval(() => setNow(Date.now()), 100);
     return () => clearInterval(id);
-  }, []);
+  }, [startedAtMs]);
   return Math.max(0, now - startedAtMs);
 }
 
@@ -78,29 +83,58 @@ function useLiveElapsedMs(startedAtMs: number): number {
 function DrivePixelGrid() {
   const cellRefs = useRef<(HTMLSpanElement | null)[]>([]);
   useEffect(() => {
-    const reduce =
-      typeof window !== "undefined" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduce) {
-      return;
-    }
-    const start = performance.now();
+    const media =
+      typeof window !== "undefined"
+        ? window.matchMedia("(prefers-reduced-motion: reduce)")
+        : null;
     let frame = 0;
-    const tick = (now: number) => {
-      const elapsedMs = now - start;
-      const cells = cellRefs.current;
-      for (let i = 0; i < DRIVE_PIXEL_DELAYS_MS.length; i += 1) {
-        const el = cells[i];
+    let start = performance.now();
+
+    const stop = () => {
+      if (frame !== 0) {
+        cancelAnimationFrame(frame);
+        frame = 0;
+      }
+      for (const el of cellRefs.current) {
         if (el) {
-          el.style.opacity = String(
-            drivePixelOpacity(elapsedMs, DRIVE_PIXEL_DELAYS_MS[i]!),
-          );
+          el.style.opacity = "0.15";
         }
       }
+    };
+
+    const startWave = () => {
+      stop();
+      start = performance.now();
+      const tick = (now: number) => {
+        const elapsedMs = now - start;
+        const cells = cellRefs.current;
+        for (let i = 0; i < DRIVE_PIXEL_DELAYS_MS.length; i += 1) {
+          const el = cells[i];
+          if (el) {
+            el.style.opacity = String(
+              drivePixelOpacity(elapsedMs, DRIVE_PIXEL_DELAYS_MS[i]!),
+            );
+          }
+        }
+        frame = requestAnimationFrame(tick);
+      };
       frame = requestAnimationFrame(tick);
     };
-    frame = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frame);
+
+    const onMotionPreferenceChange = () => {
+      if (media?.matches) {
+        stop();
+      } else {
+        startWave();
+      }
+    };
+
+    onMotionPreferenceChange();
+    media?.addEventListener("change", onMotionPreferenceChange);
+    return () => {
+      media?.removeEventListener("change", onMotionPreferenceChange);
+      stop();
+    };
   }, []);
 
   return (
@@ -149,6 +183,7 @@ export function CoworkerLoadingState({
         {label}
       </span>
       <span
+        aria-hidden
         className="text-muted-foreground shrink-0 font-mono text-xs tabular-nums"
         data-testid="live-stream-elapsed"
       >
@@ -372,6 +407,7 @@ export function CoworkerLiveThought({
         defaultExpanded
       />
       <span
+        aria-hidden
         className="text-muted-foreground ml-[26px] font-mono text-xs tabular-nums"
         data-testid="live-stream-elapsed"
       >

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -149,6 +149,54 @@ export function CoworkerLoadingState({
   );
 }
 
+/** Static dim Drive grid — same footprint as loading, no motion. */
+function StaticPixelGrid() {
+  return (
+    <span aria-hidden className="bui-pixel-grid" data-testid="bui-static-grid">
+      {DRIVE_PIXEL_DELAYS_MS.map((_, i) => (
+        <span
+          key={i}
+          className="bui-pixel-cell"
+          style={{ opacity: 0.15 }}
+          data-testid="bui-static-pixel"
+        />
+      ))}
+    </span>
+  );
+}
+
+/**
+ * Terminal mention status in the same layout as loading (static grid + label).
+ * `responded` / `failed` after the live thinking row.
+ */
+export function CoworkerMentionTerminalStatus({
+  label,
+  variant,
+  className,
+}: {
+  label: string;
+  variant: "responded" | "failed";
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("flex w-fit max-w-full items-center gap-2.5", className)}
+      data-testid="coworker-mention-terminal"
+      data-variant={variant}
+    >
+      <StaticPixelGrid />
+      <span
+        className={cn(
+          "truncate text-sm font-medium",
+          variant === "failed" ? "text-destructive" : "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
 /**
  * Expandable Thought header + optional prose body (Beautiful UI Thinking · Reasoning).
  * - Live: working shimmer "Thinking" + optional live beat in expanded body

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -73,7 +73,7 @@ export function CoworkerLoadingState({
         ))}
       </span>
       <span
-        className="bui-shimmer-text truncate text-[13px] font-medium"
+        className="bui-shimmer-text truncate text-sm font-medium"
         data-testid="coworker-loading-label"
       >
         {label}
@@ -155,11 +155,11 @@ export function CoworkerThoughtTrace({
           <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z" />
         </svg>
         {working ? (
-          <span className="bui-shimmer-text truncate text-[13px] font-medium whitespace-nowrap">
+          <span className="bui-shimmer-text truncate text-sm font-medium whitespace-nowrap">
             {headerLabel}
           </span>
         ) : (
-          <span className="text-muted-foreground truncate text-[13px] font-medium whitespace-nowrap">
+          <span className="text-muted-foreground truncate text-sm font-medium whitespace-nowrap">
             {headerLabel}
           </span>
         )}
@@ -207,7 +207,7 @@ export function CoworkerThoughtTrace({
               />
               <div ref={traceRef} className="flex flex-col gap-1 py-1">
                 <p
-                  className="text-muted-foreground text-[12.5px] leading-relaxed whitespace-pre-wrap"
+                  className="text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap"
                   data-testid="coworker-thought-body"
                 >
                   {bodyText}

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -23,14 +23,67 @@ export function formatBeautifulElapsed(elapsedMs: number): string {
 
 /**
  * Beautiful UI Drive (chevron wavefront left → right).
- * Delay step 140ms (demo uses 90ms) with a 1000ms cycle so the wave is
- * slower and easier to read in chat.
+ * Demo uses 90ms step / 650ms cycle; we use slower timings for chat.
  */
+const DRIVE_CYCLE_MS = 1000;
+const DRIVE_DELAY_STEP_MS = 140;
 const DRIVE_PIXEL_DELAYS_MS = Array.from({ length: 9 }, (_, i) => {
   const row = Math.floor(i / 3);
   const col = i % 3;
-  return (col + Math.abs(row - 1)) * 140;
+  return (col + Math.abs(row - 1)) * DRIVE_DELAY_STEP_MS;
 });
+
+/**
+ * Sample Beautiful UI `pixel-on` opacity curve at phase [0, 1).
+ * 0–18% rise, 18–42% hold bright, 42–62% fall, 62–100% dim.
+ */
+export function drivePixelOpacityAtPhase(phase01: number): number {
+  const p = ((phase01 % 1) + 1) % 1;
+  const dim = 0.15;
+  const bright = 1;
+  if (p < 0.18) {
+    return dim + (bright - dim) * (p / 0.18);
+  }
+  if (p < 0.42) {
+    return bright;
+  }
+  if (p < 0.62) {
+    return bright + (dim - bright) * ((p - 0.42) / 0.2);
+  }
+  return dim;
+}
+
+/** Opacity for one Drive cell given elapsed animation time and cell delay. */
+export function drivePixelOpacity(
+  elapsedMs: number,
+  delayMs: number,
+  cycleMs = DRIVE_CYCLE_MS,
+): number {
+  const t = (((elapsedMs - delayMs) % cycleMs) + cycleMs) % cycleMs;
+  return drivePixelOpacityAtPhase(t / cycleMs);
+}
+
+function useAnimationClockMs(): number {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    // Respect reduced motion: freeze grid at dim (no wave).
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) {
+      return;
+    }
+    const start = performance.now();
+    let frame = 0;
+    const tick = (now: number) => {
+      setElapsedMs(now - start);
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+  return elapsedMs;
+}
 
 function useLiveElapsedMs(startedAtMs: number): number {
   const [now, setNow] = useState(() => Date.now());
@@ -41,9 +94,26 @@ function useLiveElapsedMs(startedAtMs: number): number {
   return Math.max(0, now - startedAtMs);
 }
 
+/** 3×3 Drive wave — JS-driven so it does not depend on CSS keyframes. */
+function DrivePixelGrid() {
+  const elapsedMs = useAnimationClockMs();
+  return (
+    <span aria-hidden className="bui-pixel-grid" data-testid="bui-drive-grid">
+      {DRIVE_PIXEL_DELAYS_MS.map((delayMs, i) => (
+        <span
+          key={i}
+          className="bui-pixel-cell"
+          style={{ opacity: drivePixelOpacity(elapsedMs, delayMs) }}
+          data-testid="bui-drive-pixel"
+        />
+      ))}
+    </span>
+  );
+}
+
 /**
  * Pixel-grid loader + shimmer label + live elapsed (Beautiful UI Loading State).
- * Used while the coworker stream has no answer yet.
+ * Used for mention thinking + stream overlay waiting states.
  */
 export function CoworkerLoadingState({
   label,
@@ -62,15 +132,7 @@ export function CoworkerLoadingState({
       aria-live="polite"
       data-testid="coworker-loading-state"
     >
-      <span aria-hidden className="bui-pixel-grid">
-        {DRIVE_PIXEL_DELAYS_MS.map((delayMs, i) => (
-          <span
-            key={i}
-            className="bui-pixel-cell"
-            style={{ animationDelay: `${delayMs}ms` }}
-          />
-        ))}
-      </span>
+      <DrivePixelGrid />
       <span
         className="bui-shimmer-text truncate text-sm font-medium"
         data-testid="coworker-loading-label"

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -3,7 +3,6 @@
 import { getExtensionFromUrl } from "@sokosumi/utils";
 import {
   CheckCircle2,
-  Loader2,
   MessageCircle,
   Pencil,
   Quote,
@@ -24,6 +23,7 @@ import {
 } from "react";
 import {
   CoworkerLiveThought,
+  CoworkerLoadingState,
   CoworkerThoughtTrace,
 } from "@/app/chat/components/coworker-thought-ui";
 import { useClientLocalCalendarReady } from "@/app/chat/hooks/use-client-local-calendar-ready";
@@ -1262,11 +1262,23 @@ function MessageMetaFooter({
         </button>
       ) : null}
       {!isDeleted && message.mentions.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5 pt-1.5">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 pt-1.5">
           {message.mentions.map((mention) => {
             const name =
               coworkersById.get(mention.coworkerId)?.name ??
               t("MentionStatus.nameFallback");
+            const label = t(`MentionStatus.${mention.status}`, { name });
+            // Channel @mentions have no client stream overlay — show Beautiful UI
+            // loading here (pending/sent) so "Noodles is thinking" is not a dead badge.
+            if (mention.status === "pending" || mention.status === "sent") {
+              return (
+                <CoworkerLoadingState
+                  key={mention.id}
+                  label={label}
+                  startedAtMs={new Date(message.createdAt).getTime()}
+                />
+              );
+            }
             return (
               <Badge
                 key={mention.id}
@@ -1276,10 +1288,8 @@ function MessageMetaFooter({
               >
                 {mention.status === "responded" ? (
                   <CheckCircle2 className="size-3" />
-                ) : mention.status === "failed" ? null : (
-                  <Loader2 className="size-3 animate-spin" />
-                )}
-                {t(`MentionStatus.${mention.status}`, { name })}
+                ) : null}
+                {label}
               </Badge>
             );
           })}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -3,7 +3,6 @@
 import { getExtensionFromUrl } from "@sokosumi/utils";
 import {
   CheckCircle2,
-  ChevronRight,
   Loader2,
   MessageCircle,
   Pencil,
@@ -23,12 +22,12 @@ import {
   useRef,
   useState,
 } from "react";
-import { useClientLocalCalendarReady } from "@/app/chat/hooks/use-client-local-calendar-ready";
 import {
-  type CoworkerThoughtDisclosure,
-  formatLiveElapsedLabel,
-  resolveCoworkerThoughtViewModel,
-} from "@/app/chat/utils/coworker-thought";
+  CoworkerLiveThought,
+  CoworkerThoughtTrace,
+} from "@/app/chat/components/coworker-thought-ui";
+import { useClientLocalCalendarReady } from "@/app/chat/hooks/use-client-local-calendar-ready";
+import { resolveCoworkerThoughtViewModel } from "@/app/chat/utils/coworker-thought";
 import {
   getJumboEmojiCount,
   jumboEmojiClassName,
@@ -1290,67 +1289,6 @@ function MessageMetaFooter({
   );
 }
 
-/** Live wait counter on the stream overlay (Thinking… / Thought beat). */
-function LiveStreamElapsed({ startedAtMs }: { startedAtMs: number }) {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, []);
-  const elapsedSeconds = Math.max(0, Math.floor((now - startedAtMs) / 1000));
-  return (
-    <span
-      className="text-muted-foreground/70 shrink-0 text-xs tabular-nums"
-      data-testid="live-stream-elapsed"
-    >
-      {formatLiveElapsedLabel(elapsedSeconds)}
-    </span>
-  );
-}
-
-/** Collapsed-by-default Thought disclosure on coworker assistant messages. */
-function CoworkerThoughtDisclosureControl({
-  disclosure,
-  thoughtForSecondsLabel,
-  expandLabel,
-  collapseLabel,
-}: {
-  disclosure: CoworkerThoughtDisclosure;
-  thoughtForSecondsLabel: (seconds: number) => string;
-  expandLabel: string;
-  collapseLabel: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const summary =
-    disclosure.durationSeconds != null
-      ? thoughtForSecondsLabel(disclosure.durationSeconds)
-      : expandLabel;
-  return (
-    <div className="mb-1.5">
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        className="text-muted-foreground hover:text-foreground focus-visible:ring-primary/40 inline-flex max-w-full items-center gap-1 rounded text-xs font-medium transition-colors outline-none focus-visible:ring-2"
-      >
-        <ChevronRight
-          aria-hidden
-          className={cn(
-            "size-3 shrink-0 transition-transform",
-            open && "rotate-90",
-          )}
-        />
-        <span className="truncate">{open ? collapseLabel : summary}</span>
-      </button>
-      {open ? (
-        <p className="text-muted-foreground border-border/60 mt-1.5 border-l pl-3 text-xs leading-5 whitespace-pre-wrap italic">
-          {disclosure.text}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
 export function ChatMessageRow({
   message,
   coworkersById,
@@ -1574,43 +1512,30 @@ export function ChatMessageRow({
                   onCancel={onCancelEdit}
                   isSaving={isSavingEdit}
                 />
-              ) : thoughtView?.showThinkingFallback ? (
-                <div
-                  className="flex min-w-0 items-baseline gap-2"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <span className="reasoning-text-shine text-base leading-5 md:text-sm">
-                    {tChat("reasoning.thinking")}
-                  </span>
-                  <LiveStreamElapsed
-                    startedAtMs={new Date(message.createdAt).getTime()}
-                  />
-                </div>
-              ) : thoughtView?.liveBeat ? (
-                <div
-                  className="flex min-w-0 items-baseline gap-2"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <p className="reasoning-text-shine text-muted-foreground line-clamp-3 min-w-0 flex-1 text-base leading-5 italic md:text-sm">
-                    {thoughtView.liveBeat}
-                  </p>
-                  <LiveStreamElapsed
-                    startedAtMs={new Date(message.createdAt).getTime()}
-                  />
-                </div>
+              ) : thoughtView?.showThinkingFallback ||
+                thoughtView?.liveBeat != null ? (
+                <CoworkerLiveThought
+                  label={tChat("reasoning.thinking")}
+                  liveBeat={thoughtView.liveBeat}
+                  startedAtMs={new Date(message.createdAt).getTime()}
+                />
               ) : (
                 <>
                   {thoughtView?.disclosure ? (
-                    <CoworkerThoughtDisclosureControl
-                      disclosure={thoughtView.disclosure}
-                      thoughtForSecondsLabel={(seconds) =>
-                        tChat("reasoning.thoughtForSeconds", { seconds })
-                      }
-                      expandLabel={tChat("reasoning.expandSteps")}
-                      collapseLabel={tChat("reasoning.collapseSteps")}
-                    />
+                    <div className="mb-1.5">
+                      <CoworkerThoughtTrace
+                        working={false}
+                        headerLabel={
+                          thoughtView.disclosure.durationSeconds != null
+                            ? tChat("reasoning.thoughtForSeconds", {
+                                seconds: thoughtView.disclosure.durationSeconds,
+                              })
+                            : tChat("reasoning.expandSteps")
+                        }
+                        bodyText={thoughtView.disclosure.text}
+                        defaultExpanded={false}
+                      />
+                    </div>
                   ) : null}
                   <ChannelMessageBody
                     messageId={message.id}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1210,6 +1210,12 @@ function MessageMetaFooter({
   isDeleted: boolean;
 }) {
   const t = useTranslations("App.Channels");
+  /**
+   * First time this client mounts a pending/sent mention chip — wall clock for
+   * the loading elapsed timer. Avoids using user-message createdAt (reload of a
+   * stuck mention would show multi-minute age).
+   */
+  const mentionThinkStartMsByIdRef = useRef(new Map<string, number>());
 
   return (
     <>
@@ -1272,11 +1278,21 @@ function MessageMetaFooter({
             // Channel @mentions have no client stream overlay — show Beautiful UI
             // loading here (pending/sent) so "Noodles is thinking" is not a dead badge.
             if (mention.status === "pending" || mention.status === "sent") {
+              let thinkStartMs = mentionThinkStartMsByIdRef.current.get(
+                mention.id,
+              );
+              if (thinkStartMs == null) {
+                thinkStartMs = Date.now();
+                mentionThinkStartMsByIdRef.current.set(
+                  mention.id,
+                  thinkStartMs,
+                );
+              }
               return (
                 <CoworkerLoadingState
                   key={mention.id}
                   label={label}
-                  startedAtMs={new Date(message.createdAt).getTime()}
+                  startedAtMs={thinkStartMs}
                 />
               );
             }

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -26,6 +26,7 @@ import {
 import { useClientLocalCalendarReady } from "@/app/chat/hooks/use-client-local-calendar-ready";
 import {
   type CoworkerThoughtDisclosure,
+  formatLiveElapsedLabel,
   resolveCoworkerThoughtViewModel,
 } from "@/app/chat/utils/coworker-thought";
 import {
@@ -1289,6 +1290,24 @@ function MessageMetaFooter({
   );
 }
 
+/** Live wait counter on the stream overlay (Thinking… / Thought beat). */
+function LiveStreamElapsed({ startedAtMs }: { startedAtMs: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const elapsedSeconds = Math.max(0, Math.floor((now - startedAtMs) / 1000));
+  return (
+    <span
+      className="text-muted-foreground/70 shrink-0 text-xs tabular-nums"
+      data-testid="live-stream-elapsed"
+    >
+      {formatLiveElapsedLabel(elapsedSeconds)}
+    </span>
+  );
+}
+
 /** Collapsed-by-default Thought disclosure on coworker assistant messages. */
 function CoworkerThoughtDisclosureControl({
   disclosure,
@@ -1556,21 +1575,31 @@ export function ChatMessageRow({
                   isSaving={isSavingEdit}
                 />
               ) : thoughtView?.showThinkingFallback ? (
-                <span
-                  className="reasoning-text-shine text-base leading-5 md:text-sm"
+                <div
+                  className="flex min-w-0 items-baseline gap-2"
                   role="status"
                   aria-live="polite"
                 >
-                  {tChat("reasoning.thinking")}
-                </span>
+                  <span className="reasoning-text-shine text-base leading-5 md:text-sm">
+                    {tChat("reasoning.thinking")}
+                  </span>
+                  <LiveStreamElapsed
+                    startedAtMs={new Date(message.createdAt).getTime()}
+                  />
+                </div>
               ) : thoughtView?.liveBeat ? (
-                <p
-                  className="reasoning-text-shine text-muted-foreground line-clamp-3 text-base leading-5 italic md:text-sm"
+                <div
+                  className="flex min-w-0 items-baseline gap-2"
                   role="status"
                   aria-live="polite"
                 >
-                  {thoughtView.liveBeat}
-                </p>
+                  <p className="reasoning-text-shine text-muted-foreground line-clamp-3 min-w-0 flex-1 text-base leading-5 italic md:text-sm">
+                    {thoughtView.liveBeat}
+                  </p>
+                  <LiveStreamElapsed
+                    startedAtMs={new Date(message.createdAt).getTime()}
+                  />
+                </div>
               ) : (
                 <>
                   {thoughtView?.disclosure ? (

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1258,9 +1258,13 @@ function MessageMetaFooter({
           {t("Thread.replyCount", { count: message.threadReplyCount })}
         </button>
       ) : null}
-      {!isDeleted && message.mentions.length > 0 ? (
+      {!isDeleted && message.mentions.some((m) => m.status !== "responded") ? (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 pt-1.5">
           {message.mentions.map((mention) => {
+            // Success = coworker reply in the transcript; no "replied" chrome.
+            if (mention.status === "responded") {
+              return null;
+            }
             const name =
               coworkersById.get(mention.coworkerId)?.name ??
               t("MentionStatus.nameFallback");
@@ -1280,7 +1284,7 @@ function MessageMetaFooter({
               <CoworkerMentionTerminalStatus
                 key={mention.id}
                 label={label}
-                variant={mention.status === "failed" ? "failed" : "responded"}
+                variant="failed"
               />
             );
           })}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { getExtensionFromUrl } from "@sokosumi/utils";
-import {
-  CheckCircle2,
-  MessageCircle,
-  Pencil,
-  Quote,
-  Trash2,
-} from "lucide-react";
+import { MessageCircle, Pencil, Quote, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
@@ -24,10 +18,14 @@ import {
 import {
   CoworkerLiveThought,
   CoworkerLoadingState,
+  CoworkerMentionTerminalStatus,
   CoworkerThoughtTrace,
 } from "@/app/chat/components/coworker-thought-ui";
 import { useClientLocalCalendarReady } from "@/app/chat/hooks/use-client-local-calendar-ready";
-import { resolveCoworkerThoughtViewModel } from "@/app/chat/utils/coworker-thought";
+import {
+  formatThoughtDurationLabel,
+  resolveCoworkerThoughtViewModel,
+} from "@/app/chat/utils/coworker-thought";
 import {
   getJumboEmojiCount,
   jumboEmojiClassName,
@@ -49,7 +47,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { FileChipMiniPreviewFrame } from "@/components/ui/file-chip-mini-preview";
 import { FileTypeIcon } from "@/components/ui/file-icon";
@@ -1280,17 +1277,11 @@ function MessageMetaFooter({
               );
             }
             return (
-              <Badge
+              <CoworkerMentionTerminalStatus
                 key={mention.id}
-                variant={
-                  mention.status === "failed" ? "destructive" : "outline"
-                }
-              >
-                {mention.status === "responded" ? (
-                  <CheckCircle2 className="size-3" />
-                ) : null}
-                {label}
-              </Badge>
+                label={label}
+                variant={mention.status === "failed" ? "failed" : "responded"}
+              />
             );
           })}
         </div>
@@ -1537,8 +1528,10 @@ export function ChatMessageRow({
                         working={false}
                         headerLabel={
                           thoughtView.disclosure.durationSeconds != null
-                            ? tChat("reasoning.thoughtForSeconds", {
-                                seconds: thoughtView.disclosure.durationSeconds,
+                            ? tChat("reasoning.thoughtForDuration", {
+                                duration: formatThoughtDurationLabel(
+                                  thoughtView.disclosure.durationSeconds,
+                                ),
                               })
                             : tChat("reasoning.expandSteps")
                         }

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -3,6 +3,7 @@
 import { getExtensionFromUrl } from "@sokosumi/utils";
 import {
   CheckCircle2,
+  ChevronRight,
   Loader2,
   MessageCircle,
   Pencil,
@@ -18,10 +19,15 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import { useClientLocalCalendarReady } from "@/app/chat/hooks/use-client-local-calendar-ready";
+import {
+  type CoworkerThoughtDisclosure,
+  resolveCoworkerThoughtViewModel,
+} from "@/app/chat/utils/coworker-thought";
 import {
   getJumboEmojiCount,
   jumboEmojiClassName,
@@ -1283,6 +1289,49 @@ function MessageMetaFooter({
   );
 }
 
+/** Collapsed-by-default Thought disclosure on coworker assistant messages. */
+function CoworkerThoughtDisclosureControl({
+  disclosure,
+  thoughtForSecondsLabel,
+  expandLabel,
+  collapseLabel,
+}: {
+  disclosure: CoworkerThoughtDisclosure;
+  thoughtForSecondsLabel: (seconds: number) => string;
+  expandLabel: string;
+  collapseLabel: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const summary =
+    disclosure.durationSeconds != null
+      ? thoughtForSecondsLabel(disclosure.durationSeconds)
+      : expandLabel;
+  return (
+    <div className="mb-1.5">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="text-muted-foreground hover:text-foreground focus-visible:ring-primary/40 inline-flex max-w-full items-center gap-1 rounded text-xs font-medium transition-colors outline-none focus-visible:ring-2"
+      >
+        <ChevronRight
+          aria-hidden
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
+        />
+        <span className="truncate">{open ? collapseLabel : summary}</span>
+      </button>
+      {open ? (
+        <p className="text-muted-foreground border-border/60 mt-1.5 border-l pl-3 text-xs leading-5 whitespace-pre-wrap italic">
+          {disclosure.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export function ChatMessageRow({
   message,
   coworkersById,
@@ -1347,10 +1396,27 @@ export function ChatMessageRow({
   const isDirectActionBusy = openingDirectParticipantKey != null;
   const isStreamOverlay = message.id.startsWith("stream:");
   const isDeleted = message.deletedAt != null;
+  const thoughtView = useMemo(() => {
+    if (message.sender.type !== "coworker" || isDeleted) {
+      return null;
+    }
+    return resolveCoworkerThoughtViewModel({
+      content: message.content,
+      isStreamOverlay,
+      metadata: message.metadata,
+    });
+  }, [
+    isDeleted,
+    isStreamOverlay,
+    message.content,
+    message.metadata,
+    message.sender.type,
+  ]);
   const isThinking =
-    isStreamOverlay &&
-    message.sender.type === "coworker" &&
-    message.content.trim().length === 0;
+    thoughtView?.showThinkingFallback === true ||
+    (thoughtView != null &&
+      thoughtView.liveBeat != null &&
+      message.content.trim().length === 0);
   const canQuote =
     showQuoteButton && Boolean(onQuote) && !isStreamOverlay && !isDeleted;
   const canEdit =
@@ -1489,7 +1555,7 @@ export function ChatMessageRow({
                   onCancel={onCancelEdit}
                   isSaving={isSavingEdit}
                 />
-              ) : isThinking ? (
+              ) : thoughtView?.showThinkingFallback ? (
                 <span
                   className="reasoning-text-shine text-base leading-5 md:text-sm"
                   role="status"
@@ -1497,8 +1563,26 @@ export function ChatMessageRow({
                 >
                   {tChat("reasoning.thinking")}
                 </span>
+              ) : thoughtView?.liveBeat ? (
+                <p
+                  className="reasoning-text-shine text-muted-foreground line-clamp-3 text-base leading-5 italic md:text-sm"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {thoughtView.liveBeat}
+                </p>
               ) : (
                 <>
+                  {thoughtView?.disclosure ? (
+                    <CoworkerThoughtDisclosureControl
+                      disclosure={thoughtView.disclosure}
+                      thoughtForSecondsLabel={(seconds) =>
+                        tChat("reasoning.thoughtForSeconds", { seconds })
+                      }
+                      expandLabel={tChat("reasoning.expandSteps")}
+                      collapseLabel={tChat("reasoning.collapseSteps")}
+                    />
+                  ) : null}
                   <ChannelMessageBody
                     messageId={message.id}
                     content={message.content}

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-coworker-direct-room-stream.test.ts
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-coworker-direct-room-stream.test.ts
@@ -4,6 +4,7 @@ import { mergeMessagesWithStreamOverlay } from "@/app/chat/utils/merge-room-mess
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 
 import {
+  assignStableOverlayCreatedAtMs,
   buildCoworkerStreamSendMessageOptions,
   createResumePendingCoworkerShell,
   RESUME_PENDING_STREAM_MESSAGE_ID,
@@ -50,6 +51,23 @@ function persistedUser(content: string): ChatRoomMessage {
     deletedAt: null,
   };
 }
+
+describe("assignStableOverlayCreatedAtMs", () => {
+  it("reuses the first-seen timestamp for the same message id", () => {
+    const map = new Map<string, number>();
+    const first = assignStableOverlayCreatedAtMs(map, "msg-a", 0, 1_000);
+    const second = assignStableOverlayCreatedAtMs(map, "msg-a", 0, 5_000);
+    expect(first).toBe(1_000);
+    expect(second).toBe(1_000);
+  });
+
+  it("keeps later message ids strictly after earlier ones when assigned in order", () => {
+    const map = new Map<string, number>();
+    const user = assignStableOverlayCreatedAtMs(map, "user", 0, 1_000);
+    const assistant = assignStableOverlayCreatedAtMs(map, "asst", 1, 1_000);
+    expect(assistant).toBeGreaterThan(user);
+  });
+});
 
 describe("buildCoworkerStreamSendMessageOptions", () => {
   it("returns undefined when neither parent nor quote is set", () => {

--- a/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
@@ -5,6 +5,7 @@ import { DefaultChatTransport, type UIMessage } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CHAT_API_PATH } from "@/app/chat/utils/chat-route-base";
+import { reasoningStepsForMetadata } from "@/app/chat/utils/coworker-thought";
 import { extractMessageContent } from "@/app/chat/utils/message-utils";
 import { clearPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
 import type {
@@ -121,6 +122,14 @@ function uiMessageToTransientRoomMessage({
   parentMessageId: string | null;
 }): ChatRoomMessage {
   const content = extractMessageContent(message);
+  const reasoningSteps =
+    message.role === "assistant"
+      ? reasoningStepsForMetadata(message.parts)
+      : undefined;
+  const assistantMetadata: Record<string, unknown> = {
+    streaming: true,
+    ...(reasoningSteps ? { reasoning: reasoningSteps } : {}),
+  };
 
   if (message.role === "user") {
     return {
@@ -157,7 +166,7 @@ function uiMessageToTransientRoomMessage({
     reactions: [],
     threadReplyCount: 0,
     threadLastReplyAt: null,
-    metadata: { streaming: true },
+    metadata: assistantMetadata,
     quote: null,
     membership: null,
     unfurls: null,

--- a/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-coworker-direct-room-stream.ts
@@ -23,6 +23,31 @@ const autoStreamStartedRoomIds = new Set<string>();
 /** Empty coworker shell shown while resume SSE is active but messages empty. */
 export const RESUME_PENDING_STREAM_MESSAGE_ID = "stream:resume-pending";
 
+/**
+ * First-seen wall clock for a stream overlay message id. Reuses the stored
+ * value so elapsed timers do not reset when the overlay useMemo reruns on
+ * each stream chunk.
+ */
+export function assignStableOverlayCreatedAtMs(
+  map: Map<string, number>,
+  key: string,
+  indexHint: number,
+  nowMs: number = Date.now(),
+): number {
+  const existing = map.get(key);
+  if (existing != null) {
+    return existing;
+  }
+  let ms = nowMs + indexHint;
+  for (const value of map.values()) {
+    if (value >= ms) {
+      ms = value + 1;
+    }
+  }
+  map.set(key, ms);
+  return ms;
+}
+
 function streamParentStorageKey(roomId: string): string {
   return `sokosumi:room-stream-parent:${roomId}`;
 }
@@ -248,15 +273,27 @@ export function useCoworkerDirectRoomStream({
   const [streamParentMessageId, setStreamParentMessageId] = useState<
     string | null
   >(null);
+  /**
+   * First-seen wall clock per useChat message id so overlay `createdAt` (and
+   * thus live elapsed timers) do not reset on every stream chunk recompute.
+   */
+  const overlayCreatedAtByMessageIdRef = useRef(new Map<string, number>());
 
   // Restore thread parent for mid-stream resume (sessionStorage survives remount).
   useEffect(() => {
     if (!roomId) {
       setStreamParentMessageId(null);
+      overlayCreatedAtByMessageIdRef.current.clear();
       return;
     }
     setStreamParentMessageId(readStoredStreamParentMessageId(roomId));
   }, [roomId]);
+
+  useEffect(() => {
+    if (!enabled) {
+      overlayCreatedAtByMessageIdRef.current.clear();
+    }
+  }, [enabled]);
 
   const transport = useMemo(
     () =>
@@ -364,7 +401,13 @@ export function useCoworkerDirectRoomStream({
     if (!enabled || !roomId) {
       return [];
     }
-    const baseMs = Date.now();
+    const createdAtById = overlayCreatedAtByMessageIdRef.current;
+    function stableCreatedAt(key: string, indexHint: number): Date {
+      return new Date(
+        assignStableOverlayCreatedAtMs(createdAtById, key, indexHint),
+      );
+    }
+
     // Resume gap: only `streaming` (active SSE) before first chunk — not
     // `submitted` (idle enter / 204 would flash Thinking…).
     if (messages.length === 0) {
@@ -380,14 +423,33 @@ export function useCoworkerDirectRoomStream({
           createResumePendingCoworkerShell({
             roomId,
             coworker,
-            createdAt: new Date(baseMs),
+            createdAt: stableCreatedAt(RESUME_PENDING_STREAM_MESSAGE_ID, 0),
             parentMessageId: streamParentMessageId,
           }),
         ];
       }
       return [];
     }
-    // Index-offset createdAt keeps useChat order when clocks share a ms.
+
+    // Drop keys for messages no longer in the live stream (turn finished / replaced).
+    const liveIds = new Set(
+      messages
+        .filter((m) => m.role === "user" || m.role === "assistant")
+        .map((m) => m.id),
+    );
+    for (const key of [...createdAtById.keys()]) {
+      if (key === RESUME_PENDING_STREAM_MESSAGE_ID) {
+        if (liveIds.size > 0) {
+          createdAtById.delete(key);
+        }
+        continue;
+      }
+      if (!liveIds.has(key)) {
+        createdAtById.delete(key);
+      }
+    }
+
+    // Stable createdAt keeps elapsed timers from resetting on each chunk.
     // Keep empty assistant shells so the coworker avatar/name show while tokens
     // arrive (merge appends overlay in array order — user stays first).
     return messages
@@ -400,7 +462,7 @@ export function useCoworkerDirectRoomStream({
           roomId,
           currentUser,
           coworker,
-          createdAt: new Date(baseMs + index),
+          createdAt: stableCreatedAt(message.id, index),
           parentMessageId: streamParentMessageId,
         }),
       );

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
@@ -6,8 +6,22 @@ import {
   extractThoughtTextFromMessageParts,
   extractThoughtTextFromMetadata,
   formatLiveElapsedLabel,
+  formatThoughtDurationLabel,
   resolveCoworkerThoughtViewModel,
 } from "../coworker-thought";
+
+describe("formatThoughtDurationLabel", () => {
+  it("formats under a minute as seconds", () => {
+    expect(formatThoughtDurationLabel(3)).toBe("3s");
+    expect(formatThoughtDurationLabel(59)).toBe("59s");
+  });
+
+  it("formats a minute and above as m and optional s", () => {
+    expect(formatThoughtDurationLabel(60)).toBe("1m");
+    expect(formatThoughtDurationLabel(63)).toBe("1m 3s");
+    expect(formatThoughtDurationLabel(125)).toBe("2m 5s");
+  });
+});
 
 describe("formatLiveElapsedLabel", () => {
   it("formats under a minute as seconds", () => {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { formatBeautifulElapsed } from "../../components/coworker-thought-ui";
 import {
   extractThoughtDurationSeconds,
   extractThoughtTextFromMessageParts,
@@ -19,6 +20,19 @@ describe("formatLiveElapsedLabel", () => {
     expect(formatLiveElapsedLabel(60)).toBe("1:00");
     expect(formatLiveElapsedLabel(75)).toBe("1:15");
     expect(formatLiveElapsedLabel(125)).toBe("2:05");
+  });
+});
+
+describe("formatBeautifulElapsed", () => {
+  it("matches Beautiful UI tenths under a minute", () => {
+    expect(formatBeautifulElapsed(0)).toBe("0.0s");
+    expect(formatBeautifulElapsed(10_400)).toBe("10.4s");
+    expect(formatBeautifulElapsed(59_900)).toBe("59.9s");
+  });
+
+  it("formats a minute and above as m s.s", () => {
+    expect(formatBeautifulElapsed(60_000)).toBe("1m 0.0s");
+    expect(formatBeautifulElapsed(75_500)).toBe("1m 15.5s");
   });
 });
 

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { formatBeautifulElapsed } from "../../components/coworker-thought-ui";
 import {
   extractThoughtDurationSeconds,
   extractThoughtTextFromMessageParts,
@@ -19,19 +18,6 @@ describe("formatThoughtDurationLabel", () => {
     expect(formatThoughtDurationLabel(60)).toBe("1m");
     expect(formatThoughtDurationLabel(63)).toBe("1m 3s");
     expect(formatThoughtDurationLabel(125)).toBe("2m 5s");
-  });
-});
-
-describe("formatBeautifulElapsed", () => {
-  it("matches Beautiful UI tenths under a minute", () => {
-    expect(formatBeautifulElapsed(0)).toBe("0.0s");
-    expect(formatBeautifulElapsed(10_400)).toBe("10.4s");
-    expect(formatBeautifulElapsed(59_900)).toBe("59.9s");
-  });
-
-  it("formats a minute and above as m s.s", () => {
-    expect(formatBeautifulElapsed(60_000)).toBe("1m 0.0s");
-    expect(formatBeautifulElapsed(75_500)).toBe("1m 15.5s");
   });
 });
 

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
@@ -5,7 +5,6 @@ import {
   extractThoughtDurationSeconds,
   extractThoughtTextFromMessageParts,
   extractThoughtTextFromMetadata,
-  formatLiveElapsedLabel,
   formatThoughtDurationLabel,
   resolveCoworkerThoughtViewModel,
 } from "../coworker-thought";
@@ -20,20 +19,6 @@ describe("formatThoughtDurationLabel", () => {
     expect(formatThoughtDurationLabel(60)).toBe("1m");
     expect(formatThoughtDurationLabel(63)).toBe("1m 3s");
     expect(formatThoughtDurationLabel(125)).toBe("2m 5s");
-  });
-});
-
-describe("formatLiveElapsedLabel", () => {
-  it("formats under a minute as seconds", () => {
-    expect(formatLiveElapsedLabel(0)).toBe("0s");
-    expect(formatLiveElapsedLabel(12.9)).toBe("12s");
-    expect(formatLiveElapsedLabel(59)).toBe("59s");
-  });
-
-  it("formats a minute and above as m:ss", () => {
-    expect(formatLiveElapsedLabel(60)).toBe("1:00");
-    expect(formatLiveElapsedLabel(75)).toBe("1:15");
-    expect(formatLiveElapsedLabel(125)).toBe("2:05");
   });
 });
 
@@ -106,6 +91,14 @@ describe("extractThoughtDurationSeconds", () => {
         thought_timing_ms: { start: 1000, end: 4500 },
       }),
     ).toBe(4);
+  });
+
+  it("accepts numeric strings for start/end", () => {
+    expect(
+      extractThoughtDurationSeconds({
+        thought_timing_ms: { start: "1000", end: "64000" },
+      }),
+    ).toBe(63);
   });
 
   it("returns null when timing missing or invalid", () => {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
@@ -4,8 +4,23 @@ import {
   extractThoughtDurationSeconds,
   extractThoughtTextFromMessageParts,
   extractThoughtTextFromMetadata,
+  formatLiveElapsedLabel,
   resolveCoworkerThoughtViewModel,
 } from "../coworker-thought";
+
+describe("formatLiveElapsedLabel", () => {
+  it("formats under a minute as seconds", () => {
+    expect(formatLiveElapsedLabel(0)).toBe("0s");
+    expect(formatLiveElapsedLabel(12.9)).toBe("12s");
+    expect(formatLiveElapsedLabel(59)).toBe("59s");
+  });
+
+  it("formats a minute and above as m:ss", () => {
+    expect(formatLiveElapsedLabel(60)).toBe("1:00");
+    expect(formatLiveElapsedLabel(75)).toBe("1:15");
+    expect(formatLiveElapsedLabel(125)).toBe("2:05");
+  });
+});
 
 describe("extractThoughtTextFromMessageParts", () => {
   it("joins non-empty reasoning parts in order", () => {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/coworker-thought.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractThoughtDurationSeconds,
+  extractThoughtTextFromMessageParts,
+  extractThoughtTextFromMetadata,
+  resolveCoworkerThoughtViewModel,
+} from "../coworker-thought";
+
+describe("extractThoughtTextFromMessageParts", () => {
+  it("joins non-empty reasoning parts in order", () => {
+    expect(
+      extractThoughtTextFromMessageParts([
+        { type: "reasoning", text: "First beat." },
+        { type: "text", text: "Answer" },
+        { type: "reasoning", text: "Second beat." },
+      ]),
+    ).toBe("First beat.\n\nSecond beat.");
+  });
+
+  it("treats redacted_reasoning as Thought", () => {
+    expect(
+      extractThoughtTextFromMessageParts([
+        { type: "redacted_reasoning", text: "[hidden summary]" },
+      ]),
+    ).toBe("[hidden summary]");
+  });
+
+  it("ignores empty reasoning and non-reasoning types", () => {
+    expect(
+      extractThoughtTextFromMessageParts([
+        { type: "reasoning", text: "  " },
+        { type: "text", text: "Hello" },
+        { type: "file", url: "https://x", mediaType: "image/png" },
+      ]),
+    ).toBe("");
+  });
+});
+
+describe("extractThoughtTextFromMetadata", () => {
+  it("reads metadata.reasoning steps", () => {
+    expect(
+      extractThoughtTextFromMetadata({
+        reasoning: [
+          { type: "reasoning", text: "Looked up users." },
+          { type: "reasoning", text: "Counted 142." },
+        ],
+      }),
+    ).toBe("Looked up users.\n\nCounted 142.");
+  });
+
+  it("returns empty when reasoning missing or empty", () => {
+    expect(extractThoughtTextFromMetadata(null)).toBe("");
+    expect(extractThoughtTextFromMetadata({})).toBe("");
+    expect(extractThoughtTextFromMetadata({ reasoning: [] })).toBe("");
+  });
+});
+
+describe("extractThoughtDurationSeconds", () => {
+  it("returns whole seconds from thought_timing_ms when valid", () => {
+    expect(
+      extractThoughtDurationSeconds({
+        thought_timing_ms: { start: 1000, end: 4500 },
+      }),
+    ).toBe(4);
+  });
+
+  it("returns null when timing missing or invalid", () => {
+    expect(extractThoughtDurationSeconds(null)).toBeNull();
+    expect(
+      extractThoughtDurationSeconds({
+        thought_timing_ms: { start: 0, end: 10 },
+      }),
+    ).toBeNull();
+    expect(
+      extractThoughtDurationSeconds({
+        thought_timing_ms: { start: 5000, end: 1000 },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveCoworkerThoughtViewModel", () => {
+  it("shows live beat while stream overlay has Thought but no answer", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "",
+      isStreamOverlay: true,
+      metadata: {
+        streaming: true,
+        reasoning: [{ type: "reasoning", text: "Counting registrations…" }],
+      },
+    });
+    expect(vm).toEqual({
+      liveBeat: "Counting registrations…",
+      disclosure: null,
+      showThinkingFallback: false,
+    });
+  });
+
+  it("uses only the latest Thought step for the live beat", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "",
+      isStreamOverlay: true,
+      metadata: {
+        streaming: true,
+        reasoning: [
+          { type: "reasoning", text: "First beat." },
+          { type: "reasoning", text: "Latest beat." },
+        ],
+      },
+    });
+    expect(vm.liveBeat).toBe("Latest beat.");
+    expect(vm.disclosure).toBeNull();
+  });
+
+  it("joins all Thought steps in disclosure text", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "Answer",
+      isStreamOverlay: false,
+      metadata: {
+        reasoning: [
+          { type: "reasoning", text: "First." },
+          { type: "reasoning", text: "Second." },
+        ],
+      },
+    });
+    expect(vm.disclosure?.text).toBe("First.\n\nSecond.");
+  });
+
+  it("falls back to Thinking when stream overlay empty of answer and Thought", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "   ",
+      isStreamOverlay: true,
+      metadata: { streaming: true },
+    });
+    expect(vm).toEqual({
+      liveBeat: null,
+      disclosure: null,
+      showThinkingFallback: true,
+    });
+  });
+
+  it("uses parts when metadata has no reasoning yet", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "",
+      isStreamOverlay: true,
+      metadata: { streaming: true },
+      parts: [{ type: "reasoning", text: "From parts" }],
+    });
+    expect(vm.liveBeat).toBe("From parts");
+    expect(vm.showThinkingFallback).toBe(false);
+  });
+
+  it("shows collapsed disclosure when answer and Thought present", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "There were 142 registrations.",
+      isStreamOverlay: false,
+      metadata: {
+        reasoning: [{ type: "reasoning", text: "Queried users table." }],
+        thought_timing_ms: { start: 0, end: 12_000 },
+      },
+    });
+    // start 0 is invalid for duration
+    expect(vm.liveBeat).toBeNull();
+    expect(vm.showThinkingFallback).toBe(false);
+    expect(vm.disclosure).toEqual({
+      text: "Queried users table.",
+      durationSeconds: null,
+    });
+  });
+
+  it("includes durationSeconds when timing valid", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "Done.",
+      isStreamOverlay: false,
+      metadata: {
+        reasoning: [{ type: "reasoning", text: "Step one." }],
+        thought_timing_ms: { start: 1000, end: 19_500 },
+      },
+    });
+    expect(vm.disclosure).toEqual({
+      text: "Step one.",
+      durationSeconds: 19,
+    });
+  });
+
+  it("has no disclosure when Thought empty even with answer", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "Hello",
+      isStreamOverlay: false,
+      metadata: null,
+    });
+    expect(vm.disclosure).toBeNull();
+    expect(vm.showThinkingFallback).toBe(false);
+  });
+
+  it("prefers disclosure over live beat once answer text exists on stream overlay", () => {
+    const vm = resolveCoworkerThoughtViewModel({
+      content: "Partial answer",
+      isStreamOverlay: true,
+      metadata: {
+        streaming: true,
+        reasoning: [{ type: "reasoning", text: "Still thinking notes" }],
+      },
+    });
+    expect(vm.liveBeat).toBeNull();
+    expect(vm.disclosure?.text).toBe("Still thinking notes");
+    expect(vm.showThinkingFallback).toBe(false);
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
@@ -108,6 +108,17 @@ export function extractThoughtDurationSeconds(
   return Math.max(0, Math.round((end - start) / 1000));
 }
 
+/** Product label fragment: `3s`, `1m 3s`, `2m` (no "Thought for" prefix). */
+export function formatThoughtDurationLabel(totalSeconds: number): string {
+  const secs = Math.max(0, Math.round(totalSeconds));
+  if (secs < 60) {
+    return `${secs}s`;
+  }
+  const minutes = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return rem === 0 ? `${minutes}m` : `${minutes}m ${rem}s`;
+}
+
 export function resolveCoworkerThoughtViewModel(input: {
   content: string;
   isStreamOverlay: boolean;

--- a/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
@@ -157,6 +157,20 @@ export function resolveCoworkerThoughtViewModel(input: {
   };
 }
 
+/**
+ * Live wait label for the stream overlay (`0s` … `59s`, then `m:ss`).
+ * Pure so tests do not need a ticking clock.
+ */
+export function formatLiveElapsedLabel(elapsedSeconds: number): string {
+  const secs = Math.max(0, Math.floor(elapsedSeconds));
+  if (secs < 60) {
+    return `${secs}s`;
+  }
+  const minutes = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${minutes}:${String(rem).padStart(2, "0")}`;
+}
+
 /** Shape stored under room message metadata for reasoning steps. */
 export function reasoningStepsForMetadata(
   parts: unknown,

--- a/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
@@ -97,15 +97,27 @@ export function extractThoughtDurationSeconds(
     return null;
   }
   const rec = timing as Record<string, unknown>;
-  const start = typeof rec.start === "number" ? rec.start : Number.NaN;
-  const end = typeof rec.end === "number" ? rec.end : Number.NaN;
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+  const start = parseThoughtTimingNumber(rec.start);
+  const end = parseThoughtTimingNumber(rec.end);
+  if (start == null || end == null) {
     return null;
   }
   if (start <= 0 || end < start) {
     return null;
   }
   return Math.max(0, Math.round((end - start) / 1000));
+}
+
+/** Accept number or numeric string (align with Core metadata parsers). */
+function parseThoughtTimingNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
 }
 
 /** Product label fragment: `3s`, `1m 3s`, `2m` (no "Thought for" prefix). */
@@ -166,20 +178,6 @@ export function resolveCoworkerThoughtViewModel(input: {
     },
     showThinkingFallback: false,
   };
-}
-
-/**
- * Live wait label for the stream overlay (`0s` … `59s`, then `m:ss`).
- * Pure so tests do not need a ticking clock.
- */
-export function formatLiveElapsedLabel(elapsedSeconds: number): string {
-  const secs = Math.max(0, Math.floor(elapsedSeconds));
-  if (secs < 60) {
-    return `${secs}s`;
-  }
-  const minutes = Math.floor(secs / 60);
-  const rem = secs % 60;
-  return `${minutes}:${String(rem).padStart(2, "0")}`;
 }
 
 /** Shape stored under room message metadata for reasoning steps. */

--- a/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
+++ b/apps/web/src/app/(app)/chat/utils/coworker-thought.ts
@@ -1,0 +1,187 @@
+import { isChatUiProviderReasoningPartType } from "@sokosumi/utils";
+
+export interface CoworkerThoughtDisclosure {
+  text: string;
+  /** Whole seconds; null when timing unknown or invalid. */
+  durationSeconds: number | null;
+}
+
+export interface CoworkerThoughtViewModel {
+  /** Latest Thought text for the live stream overlay (no answer yet). */
+  liveBeat: string | null;
+  /** Post-answer / durable disclosure; null when no Thought. */
+  disclosure: CoworkerThoughtDisclosure | null;
+  /** Stream overlay with no answer and no Thought yet → static Thinking... */
+  showThinkingFallback: boolean;
+}
+
+function readPartText(part: Record<string, unknown>): string {
+  if ("text" in part && part.text != null) {
+    return String(part.text).trim();
+  }
+  if ("content" in part && part.content != null) {
+    return String(part.content).trim();
+  }
+  return "";
+}
+
+function collectReasoningTexts(parts: unknown): string[] {
+  if (!Array.isArray(parts)) {
+    return [];
+  }
+  const chunks: string[] = [];
+  for (const part of parts) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const record = part as Record<string, unknown>;
+    if (!isChatUiProviderReasoningPartType(record.type)) {
+      continue;
+    }
+    const text = readPartText(record);
+    if (text) {
+      chunks.push(text);
+    }
+  }
+  return chunks;
+}
+
+/** Join non-empty provider reasoning parts from a UIMessage-style parts array. */
+export function extractThoughtTextFromMessageParts(parts: unknown): string {
+  return collectReasoningTexts(parts).join("\n\n");
+}
+
+/** Latest non-empty reasoning part only (live stream beat). */
+export function extractLatestThoughtBeatFromMessageParts(
+  parts: unknown,
+): string {
+  const chunks = collectReasoningTexts(parts);
+  return chunks.length > 0 ? chunks[chunks.length - 1]! : "";
+}
+
+function reasoningStepsFromMetadata(metadata: unknown): unknown[] {
+  if (!metadata || typeof metadata !== "object") {
+    return [];
+  }
+  const reasoning = (metadata as Record<string, unknown>).reasoning;
+  return Array.isArray(reasoning) ? reasoning : [];
+}
+
+/** Join Thought from Core-persisted `metadata.reasoning` steps. */
+export function extractThoughtTextFromMetadata(metadata: unknown): string {
+  return collectReasoningTexts(reasoningStepsFromMetadata(metadata)).join(
+    "\n\n",
+  );
+}
+
+/** Latest non-empty step from `metadata.reasoning` (live stream beat). */
+export function extractLatestThoughtBeatFromMetadata(
+  metadata: unknown,
+): string {
+  const chunks = collectReasoningTexts(reasoningStepsFromMetadata(metadata));
+  return chunks.length > 0 ? chunks[chunks.length - 1]! : "";
+}
+
+/**
+ * Duration from `metadata.thought_timing_ms` (`start` / `end` epoch ms).
+ * Null when missing, start ≤ 0, or end < start.
+ */
+export function extractThoughtDurationSeconds(
+  metadata: unknown,
+): number | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+  const timing = (metadata as Record<string, unknown>).thought_timing_ms;
+  if (!timing || typeof timing !== "object") {
+    return null;
+  }
+  const rec = timing as Record<string, unknown>;
+  const start = typeof rec.start === "number" ? rec.start : Number.NaN;
+  const end = typeof rec.end === "number" ? rec.end : Number.NaN;
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return null;
+  }
+  if (start <= 0 || end < start) {
+    return null;
+  }
+  return Math.max(0, Math.round((end - start) / 1000));
+}
+
+export function resolveCoworkerThoughtViewModel(input: {
+  content: string;
+  isStreamOverlay: boolean;
+  metadata?: unknown;
+  /** Optional live UIMessage parts when metadata not yet filled. */
+  parts?: unknown;
+}): CoworkerThoughtViewModel {
+  const answer = input.content.trim();
+  const thoughtTextFull =
+    extractThoughtTextFromMetadata(input.metadata) ||
+    extractThoughtTextFromMessageParts(input.parts ?? null);
+  const liveBeatText =
+    extractLatestThoughtBeatFromMetadata(input.metadata) ||
+    extractLatestThoughtBeatFromMessageParts(input.parts ?? null);
+  const durationSeconds = extractThoughtDurationSeconds(input.metadata);
+
+  if (input.isStreamOverlay && answer.length === 0) {
+    if (liveBeatText.length > 0) {
+      return {
+        liveBeat: liveBeatText,
+        disclosure: null,
+        showThinkingFallback: false,
+      };
+    }
+    return {
+      liveBeat: null,
+      disclosure: null,
+      showThinkingFallback: true,
+    };
+  }
+
+  if (thoughtTextFull.length === 0) {
+    return {
+      liveBeat: null,
+      disclosure: null,
+      showThinkingFallback: false,
+    };
+  }
+
+  return {
+    liveBeat: null,
+    disclosure: {
+      text: thoughtTextFull,
+      durationSeconds,
+    },
+    showThinkingFallback: false,
+  };
+}
+
+/** Shape stored under room message metadata for reasoning steps. */
+export function reasoningStepsForMetadata(
+  parts: unknown,
+): Array<{ type: string; text: string }> | undefined {
+  if (!Array.isArray(parts)) {
+    return undefined;
+  }
+  const out: Array<{ type: string; text: string }> = [];
+  for (const part of parts) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const record = part as Record<string, unknown>;
+    if (!isChatUiProviderReasoningPartType(record.type)) {
+      continue;
+    }
+    const text = readPartText(record);
+    if (!text) {
+      continue;
+    }
+    const type =
+      typeof record.type === "string" && record.type.trim()
+        ? record.type.trim()
+        : "reasoning";
+    out.push({ type, text });
+  }
+  return out.length > 0 ? out : undefined;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -132,6 +132,17 @@
   --color-agent-verified-foreground: hsla(142, 72%, 29%, 1);
 
   --animate-reasoning-text-shine: reasoning-text-shine 2.5s ease-in-out infinite;
+  /* Beautiful UI shimmer — register like reasoning-text-shine so Tailwind emits it. */
+  --animate-bui-shimmer-text: bui-shimmer-text 1.8s linear infinite;
+
+  @keyframes bui-shimmer-text {
+    0% {
+      background-position: 150% 0;
+    }
+    100% {
+      background-position: -50% 0;
+    }
+  }
 
   @keyframes accordion-down {
     from {
@@ -705,34 +716,10 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
 }
 
 /*
- * Beautiful UI Loading Drive wave
- * (https://beautiful-ui-five.vercel.app/#loading-state)
- * Keyframes must be top-level so inline animation-name can resolve them.
- * Cycle is slightly slower than the demo (650ms → 1000ms) for chat density.
+ * Beautiful UI Loading grid layout.
+ * Drive wave opacity is JS-driven (see coworker-thought-ui DrivePixelGrid) —
+ * CSS keyframes were not reliably applied in the chat surface.
  */
-@keyframes bui-pixel-on {
-  0%,
-  100% {
-    opacity: 0.15;
-  }
-  18%,
-  42% {
-    opacity: 1;
-  }
-  62% {
-    opacity: 0.15;
-  }
-}
-
-@keyframes bui-shimmer-text {
-  0% {
-    background-position: 150% 0;
-  }
-  100% {
-    background-position: -50% 0;
-  }
-}
-
 .bui-pixel-grid {
   display: grid;
   grid-template-columns: repeat(3, 4px);
@@ -746,10 +733,7 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
   border-radius: 1px;
   background-color: var(--foreground);
   opacity: 0.15;
-  animation-name: bui-pixel-on;
-  animation-duration: 1000ms;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
+  will-change: opacity;
 }
 
 /* Shimmer label from Beautiful UI Loading / Thinking */
@@ -764,7 +748,7 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  animation: bui-shimmer-text 1.8s linear infinite;
+  animation: var(--animate-bui-shimmer-text);
 }
 
 @utility reasoning-step-in {
@@ -905,10 +889,5 @@ body[data-hermes-fullscreen="true"] [data-app-main] {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     color: var(--foreground);
-  }
-
-  .bui-pixel-cell {
-    animation: none !important;
-    opacity: 0.35;
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -197,6 +197,30 @@
     }
   }
 
+  /* Beautiful UI loading / thinking (https://beautiful-ui-five.vercel.app/) */
+  @keyframes bui-pixel-on {
+    0%,
+    100% {
+      opacity: 0.15;
+    }
+    18%,
+    42% {
+      opacity: 1;
+    }
+    62% {
+      opacity: 0.15;
+    }
+  }
+
+  @keyframes bui-shimmer-text {
+    0% {
+      background-position: 150% 0;
+    }
+    100% {
+      background-position: -50% 0;
+    }
+  }
+
   @keyframes reasoning-step-in {
     from {
       opacity: 0;
@@ -704,6 +728,21 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
   animation: var(--animate-reasoning-text-shine);
 }
 
+/* Shimmer label from Beautiful UI Loading / Thinking */
+@utility bui-shimmer-text {
+  background-image: linear-gradient(
+    90deg,
+    var(--muted-foreground) 35%,
+    var(--foreground) 50%,
+    var(--muted-foreground) 65%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: bui-shimmer-text 1.4s linear infinite;
+}
+
 @utility reasoning-step-in {
   animation: var(--animate-reasoning-step-in);
 }
@@ -834,5 +873,17 @@ body[data-hermes-fullscreen="true"] [data-app-main] {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     color: var(--foreground);
+  }
+
+  .bui-shimmer-text {
+    animation: none;
+    background: none;
+    -webkit-background-clip: border-box;
+    background-clip: border-box;
+    color: var(--foreground);
+  }
+
+  [data-testid="coworker-loading-state"] span[aria-hidden] span {
+    animation: none !important;
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -197,30 +197,6 @@
     }
   }
 
-  /* Beautiful UI loading / thinking (https://beautiful-ui-five.vercel.app/) */
-  @keyframes bui-pixel-on {
-    0%,
-    100% {
-      opacity: 0.15;
-    }
-    18%,
-    42% {
-      opacity: 1;
-    }
-    62% {
-      opacity: 0.15;
-    }
-  }
-
-  @keyframes bui-shimmer-text {
-    0% {
-      background-position: 150% 0;
-    }
-    100% {
-      background-position: -50% 0;
-    }
-  }
-
   @keyframes reasoning-step-in {
     from {
       opacity: 0;
@@ -728,6 +704,54 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
   animation: var(--animate-reasoning-text-shine);
 }
 
+/*
+ * Beautiful UI Loading Drive wave
+ * (https://beautiful-ui-five.vercel.app/#loading-state)
+ * Keyframes must be top-level so inline animation-name can resolve them.
+ * Cycle is slightly slower than the demo (650ms → 1000ms) for chat density.
+ */
+@keyframes bui-pixel-on {
+  0%,
+  100% {
+    opacity: 0.15;
+  }
+  18%,
+  42% {
+    opacity: 1;
+  }
+  62% {
+    opacity: 0.15;
+  }
+}
+
+@keyframes bui-shimmer-text {
+  0% {
+    background-position: 150% 0;
+  }
+  100% {
+    background-position: -50% 0;
+  }
+}
+
+.bui-pixel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 4px);
+  gap: 1.5px;
+  flex-shrink: 0;
+}
+
+.bui-pixel-cell {
+  width: 4px;
+  height: 4px;
+  border-radius: 1px;
+  background-color: var(--foreground);
+  opacity: 0.15;
+  animation-name: bui-pixel-on;
+  animation-duration: 1000ms;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
 /* Shimmer label from Beautiful UI Loading / Thinking */
 @utility bui-shimmer-text {
   background-image: linear-gradient(
@@ -740,7 +764,7 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  animation: bui-shimmer-text 1.4s linear infinite;
+  animation: bui-shimmer-text 1.8s linear infinite;
 }
 
 @utility reasoning-step-in {
@@ -883,7 +907,8 @@ body[data-hermes-fullscreen="true"] [data-app-main] {
     color: var(--foreground);
   }
 
-  [data-testid="coworker-loading-state"] span[aria-hidden] span {
+  .bui-pixel-cell {
     animation: none !important;
+    opacity: 0.35;
   }
 }

--- a/docs/adr/0002-room-coworker-thought-shared-collapsed.md
+++ b/docs/adr/0002-room-coworker-thought-shared-collapsed.md
@@ -1,0 +1,18 @@
+# ADR 0002: Room coworker Thought is shared transcript content, collapsed by default
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Decision
+
+In chat **rooms**, a coworker **Thought** (provider reasoning text for a turn) is part of the shared assistant message: every member who can see the message can see the same live beat and the same **Thought disclosure**. The disclosure is **collapsed by default**. **Mention status** on the parent user message stays lifecycle-only (calling / thinking / replied / failed) and must not carry Thought text.
+
+## Why
+
+Rooms are multi-reader transcripts. Hiding Thought to only the mentioner needs a second ACL and fights transparency. Putting Thought in the mention badge overloads a compact multi-mention chip and mixes lifecycle with content. Always-expanded Thought floods channels. Collapsed shared disclosure gives liveness during the wait and opt-in audit after, without private-to-mentioner complexity.
+
+## Consequences
+
+- Persist Thought with the assistant message (existing metadata path); reload shows the same disclosure.
+- No mentioner-only or admin-only Thought UI for rooms without reopening this ADR.
+- Tool steps inside the disclosure and Hermes/PA component unification are out of scope of this decision.

--- a/docs/superpowers/specs/2026-08-10-room-coworker-thought-design.md
+++ b/docs/superpowers/specs/2026-08-10-room-coworker-thought-design.md
@@ -130,4 +130,3 @@ Good tests assert **external behavior** (what the user/view model exposes), not 
 - Commit-gate / stall-timer work that pass-throughs reasoning is complementary; this spec is about **showing** Thought, not inventing heartbeats.
 - Optional follow-ups (not v1): tool steps in disclosure; soft DM default peek; badge elapsed timer only.
 - Domain language: use **Mention status**, **Thought**, **Thought disclosure** from `CONTEXT.md`.
-)

--- a/docs/superpowers/specs/2026-08-10-room-coworker-thought-design.md
+++ b/docs/superpowers/specs/2026-08-10-room-coworker-thought-design.md
@@ -1,0 +1,133 @@
+# Spec: Room coworker Thought (live + Thought disclosure)
+
+**Date:** 2026-08-10  
+**Status:** Ready for agent  
+**ADR:** [0002-room-coworker-thought-shared-collapsed](../../adr/0002-room-coworker-thought-shared-collapsed.md)  
+**Glossary:** `CONTEXT.md` — Mention status, Thought, Thought disclosure  
+
+## Problem Statement
+
+When a user @mentions a coworker (for example Noodles) in a chat room, they wait a long time with only coarse **Mention status** (“Noodles is thinking” → “Noodles replied”) and a static “Thinking...” placeholder on the stream overlay. Real provider reasoning may already stream and may already be stored on the assistant message, but the room UI does not show **Thought** live or as a post-answer **Thought disclosure**. That feels stuck during the wait and offers no way to audit why the answer landed after it arrives.
+
+## Solution
+
+For all room coworker streams (channel mentions, coworker DMs, multi-party rooms with a stream):
+
+1. **Live:** On the coworker stream bubble, while there is no answer body yet, show the latest non-empty Thought beat (line-clamped). If no Thought has arrived yet, keep the existing “Thinking...” fallback. Do not put Thought text in the mention badge.
+2. **After answer:** On the coworker assistant message, show a **collapsed-by-default Thought disclosure** (“Thought for {n}s” when timing is known; otherwise an expand label without inventing a duration). Expanding reveals the full stored Thought text.
+3. **Durable:** Same disclosure after reload / late join when message metadata already has Thought (and timing when present).
+4. **Shared:** Every room member who can see the message sees the same live beat and the same disclosure (Thought is transcript content, not private to the mentioner).
+
+Ship in three slices: live → in-session collapse → durable reload.
+
+## User Stories
+
+1. As a room member who @mentioned a coworker, I want to see the latest Thought beat while they work, so that I know the system is not stuck.
+2. As a room member, I want a “Thinking...” fallback when Thought has not started yet, so that empty streams still feel alive.
+3. As a room member, I want Thought to update as new beats arrive (latest beat wins, not a growing wall of text), so that the channel stays scannable.
+4. As a room member, I want long Thought clipped to a few lines while live, so that multi-reader channels are not flooded.
+5. As a room member, I want the answer body to never include Thought mixed into the markdown reply, so that the answer stays clean.
+6. As a room member, I want a collapsed Thought disclosure after the reply lands, so that I can open reasoning only when I care.
+7. As a room member, I want “Thought for {n}s” when timing is known, so that wait length is legible after the fact.
+8. As a room member, I want an expand label without a fake duration when Thought exists but timing is missing, so that we never invent numbers.
+9. As a room member, I want no Thought disclosure when the provider sent no Thought, so that we do not show empty chrome.
+10. As a room member who reloads the room, I want the same collapsed Thought disclosure when metadata stored Thought, so that transparency survives refresh.
+11. As a late joiner, I want to see the same disclosure as others, so that the transcript is shared truth.
+12. As a room member, I want Mention status on the parent user message to stay lifecycle-only (calling / thinking / replied / failed), so that multi-mention badges stay compact.
+13. As a room member, I do not want Thought text inside the Mention status badge, so that lifecycle and content stay separate.
+14. As a coworker DM participant, I want the same Thought behavior as channel streams, so that all room coworker streams feel consistent.
+15. As a channel member who did not write the mention, I still want to see Thought on the assistant message, so that room transparency matches the shared transcript model.
+16. As a user of i18n, I want existing reasoning copy keys reused where possible (`thoughtForSeconds`, expand/collapse, thinking), so that locales stay consistent.
+17. As an implementer, I want pure helpers mapping stream parts + metadata → view model, so that UI tests stay thin.
+18. As an implementer, I want Core persist of reasoning + thought timing to remain the source of durable Thought, so that we avoid a new API for v1.
+19. As a product owner, I want tools out of the v1 disclosure, so that reasoning ships without waiting on tool-step UI.
+20. As a product owner, I want Hermes/PA unification out of v1, so that room work is not blocked on a cross-surface refactor.
+21. As a room member, I want expand/collapse of Thought disclosure to be keyboard-accessible, so that the control is usable without a pointer.
+22. As a room member on mobile, I want line-clamped live Thought and collapsed disclosure defaults, so that small screens stay usable.
+23. As a tester, I want unit tests on the view-model helpers and presentation tests on the message row, so that regressions are caught without flaky live Noodles E2E.
+24. As a platform maintainer, I want ADR 0002 respected (shared, collapsed, badge lifecycle-only), so that future “private Thought” or “Thought in badge” ideas reopen the decision explicitly.
+
+## Implementation Decisions
+
+### Product / domain (locked in grill + ADR 0002)
+
+- Job: live liveness **and** post-hoc transparency.
+- Scope v1: all **room coworker streams**.
+- After answer: Thought disclosure always **collapsed** by default.
+- Content: full provider Thought as sent/stored (not inventing CoT the provider never sent).
+- Live: latest beat only, line-clamp ~2–3; fallback “Thinking...”.
+- Badge: Mention status lifecycle only.
+- Audience: all members who can see the message.
+- Tools: out of v1 (component shape may leave room for later).
+- Empty Thought: no disclosure row.
+- Copy: “Thought for {n}s” when timing known; else expand without fake duration.
+- Ship slices: (1) live, (2) in-session collapse, (3) durable reload.
+
+### Architecture
+
+- Prefer a **pure message view-model helper** (web chat utils) that, given stream/UI parts and/or room message metadata, returns:
+  - answer text (existing extract rules — text only, no reasoning),
+  - optional live Thought beat string,
+  - optional disclosure payload `{ text, durationSeconds? }`.
+- Room message row (or a small presentational child) renders:
+  - live beat / Thinking... on stream overlay when answer empty,
+  - Thought disclosure above/near answer when disclosure payload present and not in pure-thinking empty state.
+- Stream overlay mapping must pass through reasoning parts into the view-model (today `extractMessageContent` strips them for body — keep that for answer; add separate Thought extraction).
+- Durable path: read assistant message metadata fields already written by Core (`reasoning` steps + `thought_timing_ms` when present). If client DTO drops metadata needed for Thought, fix mapping so metadata reaches the row — no new endpoint required for v1 if metadata already on the message.
+- Mention status UI remains unchanged except not hosting Thought.
+
+### Non-schema preference
+
+- No new Prisma columns required if metadata already holds reasoning + timing.
+- No mention lifecycle state machine changes.
+
+### i18n
+
+- Prefer existing `App.Chat.Chat.reasoning.*` keys (`thinking`, `thoughtForSeconds`, expand/collapse steps) over new parallel namespaces; add only if copy gaps appear.
+
+### Accessibility
+
+- Live Thought: `role="status"` / polite live region as appropriate (existing thinking placeholder pattern).
+- Thought disclosure: button with `aria-expanded`, visible focus ring.
+
+## Testing Decisions
+
+Good tests assert **external behavior** (what the user/view model exposes), not private React state machine internals.
+
+### Seams (approved)
+
+1. **Room message row (UI)** — props → render: live beat vs Thinking...; collapsed disclosure labels; no disclosure without Thought; answer free of Thought; Mention status unchanged.
+2. **Message view-model helpers** — pure functions: parts/metadata → answer + live beat + disclosure; duration only when timing valid; extract answer still excludes reasoning.
+3. **Core persist (regression only)** — reasoning + thought timing still stored when provider sends them; only touch if wiring breaks.
+
+### Prior art
+
+- Web: `message-utils` tests (answer strips reasoning).
+- Web: `room-message-row` component tests.
+- Core: `persist-assistant-to-chat-room` tests for reasoning + `thought_timing_ms`.
+- Pattern only (not a hard dependency): Hermes `ReasoningLine` / `MessageSteps`.
+
+### Out of test scope for v1
+
+- Full browser E2E against live Noodles.
+- Hermes/PA suite as required gate.
+- Multi-tab Ably as a separate product surface.
+
+## Out of Scope
+
+1. Hermes / personal-assistant redesign or mandatory shared component extraction.
+2. Tool steps / chips inside Thought disclosure.
+3. Thought text inside Mention status badge.
+4. Per-user ACL (only mentioner / only admins see Thought).
+5. Always-expanded Thought in rooms.
+6. Inventing CoT the provider never sent.
+7. Changing mention lifecycle states (`pending` / `sent` / `responded` / `failed`).
+8. New Core public API solely for Thought if metadata already ships on the message.
+
+## Further Notes
+
+- Provider may only emit **reasoning summaries**; UI shows what is received — that is still Thought in product language.
+- Commit-gate / stall-timer work that pass-throughs reasoning is complementary; this spec is about **showing** Thought, not inventing heartbeats.
+- Optional follow-ups (not v1): tool steps in disclosure; soft DM default peek; badge elapsed timer only.
+- Domain language: use **Mention status**, **Thought**, **Thought disclosure** from `CONTEXT.md`.
+)


### PR DESCRIPTION
## Summary

Shows coworker **Thought** in room chat (SOK-774): live beat while streaming, collapsed Thought disclosure after the answer, and durable disclosure from message metadata after reload.

- Live stream overlay: latest Thought beat (line-clamp) or “Thinking...” fallback
- After answer: collapsed “Thought for {n}s” / expand steps disclosure
- Stream overlay maps reasoning into `metadata.reasoning`
- Core mention dispatch persists Thought + timing so channel replies keep disclosure on reload
- ADR + design spec + glossary terms

## Linear

- SOK-774

## Test plan

- [x] `pnpm --filter web test` (full suite)
- [x] Core dispatch + persist tests
- [x] Pre-commit check + typecheck
- [ ] Manual: coworker DM stream shows live Thought beat when provider emits reasoning
- [ ] Manual: after answer, disclosure expands/collapses and shows duration when timing present
- [ ] Manual: reload room and confirm disclosure still present on persisted assistant message
- [ ] Manual: channel @mention still uses Mention status badge only (no live stream); reply has disclosure when reasoning was stored

## Notes

Channel @mentions do not stream mid-turn to the client (server awaits full text). Live Thought is on the coworker DM stream path; mention path gets durable Thought after reply when the provider returns reasoning.