### PR TITLE
fix(chat): move coworker bot badge to avatar corner

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -182,19 +182,25 @@ describe("ChatMessageRow", () => {
   it("shows coworker bot badge on avatar, not beside name", () => {
     renderRow({ message: coworkerMessage() });
 
-    const badge = screen.getByLabelText("coworkerBadge");
-    expect(badge).toBeInTheDocument();
+    expect(screen.getByTestId("coworker-avatar-badge")).toBeInTheDocument();
+    expect(screen.getByLabelText("coworkerBadge")).toBeInTheDocument();
     expect(screen.getByText("Jamal").closest("span")?.textContent).toBe(
       "Jamal",
     );
     // Containing box must stay avatar-sized (not stretched full row height)
-    expect(badge.closest(".size-8")).toHaveClass("relative", "self-start");
+    const avatarWrap = screen.getByTestId("message-sender-avatar");
+    expect(avatarWrap).toHaveClass("relative", "size-8", "self-start");
+    expect(avatarWrap).toContainElement(
+      screen.getByTestId("coworker-avatar-badge"),
+    );
   });
 
   it("does not show coworker bot badge for human senders", () => {
     renderRow({ message: userMessage() });
 
-    expect(screen.queryByLabelText("coworkerBadge")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("coworker-avatar-badge"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps sender attribution on continuation rows", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -182,10 +182,13 @@ describe("ChatMessageRow", () => {
   it("shows coworker bot badge on avatar, not beside name", () => {
     renderRow({ message: coworkerMessage() });
 
-    expect(screen.getByLabelText("coworkerBadge")).toBeInTheDocument();
+    const badge = screen.getByLabelText("coworkerBadge");
+    expect(badge).toBeInTheDocument();
     expect(screen.getByText("Jamal").closest("span")?.textContent).toBe(
       "Jamal",
     );
+    // Containing box must stay avatar-sized (not stretched full row height)
+    expect(badge.closest(".size-8")).toHaveClass("relative", "self-start");
   });
 
   it("does not show coworker bot badge for human senders", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -179,6 +179,21 @@ function renderContinuation(message: ChatRoomMessage = userMessage()) {
 }
 
 describe("ChatMessageRow", () => {
+  it("shows coworker bot badge on avatar, not beside name", () => {
+    renderRow({ message: coworkerMessage() });
+
+    expect(screen.getByLabelText("coworkerBadge")).toBeInTheDocument();
+    expect(screen.getByText("Jamal").closest("span")?.textContent).toBe(
+      "Jamal",
+    );
+  });
+
+  it("does not show coworker bot badge for human senders", () => {
+    renderRow({ message: userMessage() });
+
+    expect(screen.queryByLabelText("coworkerBadge")).not.toBeInTheDocument();
+  });
+
   it("keeps sender attribution on continuation rows", () => {
     renderRow({ isContinuation: true });
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -182,17 +182,28 @@ describe("ChatMessageRow", () => {
   it("shows coworker bot badge on avatar, not beside name", () => {
     renderRow({ message: coworkerMessage() });
 
-    expect(screen.getByTestId("coworker-avatar-badge")).toBeInTheDocument();
-    expect(screen.getByLabelText("coworkerBadge")).toBeInTheDocument();
-    expect(screen.getByText("Jamal").closest("span")?.textContent).toBe(
-      "Jamal",
+    // File mock returns i18n keys (not English copy); label is coworkerBadge
+    const badge = screen.getByRole("img", { name: "coworkerBadge" });
+    expect(badge).toHaveAttribute("data-testid", "coworker-avatar-badge");
+    // Single labeled chip — catches a residual name-row Bot with the same label
+    expect(screen.getAllByRole("img", { name: "coworkerBadge" })).toHaveLength(
+      1,
     );
-    // Containing box must stay avatar-sized (not stretched full row height)
+
+    const name = screen.getByText("Jamal");
+    expect(name).toHaveTextContent("Jamal");
+    // Badge is under the avatar trigger, not under the name hover trigger
+    expect(name.parentElement).not.toContainElement(badge);
+
+    // HoverCard merges self-start/shrink-0 onto this trigger; size-8 keeps absolute badge on avatar
     const avatarWrap = screen.getByTestId("message-sender-avatar");
-    expect(avatarWrap).toHaveClass("relative", "size-8", "self-start");
-    expect(avatarWrap).toContainElement(
-      screen.getByTestId("coworker-avatar-badge"),
+    expect(avatarWrap).toHaveClass(
+      "relative",
+      "size-8",
+      "shrink-0",
+      "self-start",
     );
+    expect(avatarWrap).toContainElement(badge);
   });
 
   it("does not show coworker bot badge for human senders", () => {
@@ -200,6 +211,9 @@ describe("ChatMessageRow", () => {
 
     expect(
       screen.queryByTestId("coworker-avatar-badge"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "coworkerBadge" }),
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -31,15 +31,21 @@ export function AiCoworkerIcon({ className }: { className?: string }) {
 
 /** Discord-style bot chip for avatar corner (sibling of Avatar, not inside it). */
 export function AiCoworkerAvatarBadge({ className }: { className?: string }) {
+  const t = useTranslations("App.Channels");
+
   return (
     <span
+      role="img"
+      aria-label={t("coworkerBadge")}
+      data-testid="coworker-avatar-badge"
       className={cn(
         // bg-muted + foreground icon so chip reads on dark chat (bg-background was invisible)
         "bg-muted text-foreground absolute -right-0.5 -bottom-0.5 z-10 flex size-3.5 items-center justify-center rounded-full ring-2 ring-background",
         className,
       )}
     >
-      <AiCoworkerIcon className="size-2.5 text-foreground" />
+      {/* Decorative — label lives on the chip so we avoid nested named graphics */}
+      <Bot className="size-2.5 shrink-0" aria-hidden />
     </span>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -34,11 +34,12 @@ export function AiCoworkerAvatarBadge({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "bg-background absolute -right-0.5 -bottom-0.5 flex size-3.5 items-center justify-center rounded-full ring-2 ring-background",
+        // bg-muted + foreground icon so chip reads on dark chat (bg-background was invisible)
+        "bg-muted text-foreground absolute -right-0.5 -bottom-0.5 z-10 flex size-3.5 items-center justify-center rounded-full ring-2 ring-background",
         className,
       )}
     >
-      <AiCoworkerIcon className="size-2.5" />
+      <AiCoworkerIcon className="size-2.5 text-foreground" />
     </span>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -29,6 +29,20 @@ export function AiCoworkerIcon({ className }: { className?: string }) {
   );
 }
 
+/** Discord-style bot chip for avatar corner (sibling of Avatar, not inside it). */
+export function AiCoworkerAvatarBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "bg-background absolute -right-0.5 -bottom-0.5 flex size-3.5 items-center justify-center rounded-full ring-2 ring-background",
+        className,
+      )}
+    >
+      <AiCoworkerIcon className="size-2.5" />
+    </span>
+  );
+}
+
 /** Parity with rooms-client messageLoadFailed empty-state; reload re-fetches RSC props. */
 export function MembersRosterLoadFailed({ className }: { className?: string }) {
   const t = useTranslations("App.Channels");

--- a/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-draft-shared.tsx
@@ -29,8 +29,14 @@ export function AiCoworkerIcon({ className }: { className?: string }) {
   );
 }
 
+interface AiCoworkerAvatarBadgeProps {
+  className?: string;
+}
+
 /** Discord-style bot chip for avatar corner (sibling of Avatar, not inside it). */
-export function AiCoworkerAvatarBadge({ className }: { className?: string }) {
+export function AiCoworkerAvatarBadge({
+  className,
+}: AiCoworkerAvatarBadgeProps) {
   const t = useTranslations("App.Channels");
 
   return (

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1414,6 +1414,7 @@ export function ChatMessageRow({
           profile={hoverProfile}
           side="top"
           align="start"
+          // self-start: article is flex; stretch made this full row height so absolute badge sat at bottom
           className="mt-0.5 shrink-0 self-start"
           currentUserId={currentUserId}
           canOpenHumanDirect={canOpenHumanDirect}
@@ -1421,8 +1422,10 @@ export function ChatMessageRow({
           isOpeningDirect={isOpeningDirect}
           isDirectActionBusy={isDirectActionBusy}
         >
-          {/* self-start: article is flex; stretch made this full row height so absolute badge sat at bottom */}
-          <span className="relative inline-flex size-8 shrink-0 self-start">
+          <span
+            data-testid="message-sender-avatar"
+            className="relative inline-flex size-8 shrink-0"
+          >
             <Avatar className="size-8">
               <AvatarImage src={sender.image ?? undefined} alt="" />
               <AvatarFallback className="text-xs">

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -74,7 +74,7 @@ import { classifyFilePreview } from "@/lib/utils/file-preview";
 import { getInitials } from "@/lib/utils/text";
 import { ChatParticipantHoverCard } from "./chat-participant-hover-card";
 import { participantDirectKey } from "./open-direct-with-participant";
-import { AiCoworkerIcon } from "./room-draft-shared";
+import { AiCoworkerAvatarBadge } from "./room-draft-shared";
 import {
   type ChatParticipantHoverProfile,
   formatMessageTime,
@@ -1421,12 +1421,15 @@ export function ChatMessageRow({
           isOpeningDirect={isOpeningDirect}
           isDirectActionBusy={isDirectActionBusy}
         >
-          <Avatar className="size-8">
-            <AvatarImage src={sender.image ?? undefined} alt="" />
-            <AvatarFallback className="text-xs">
-              {getInitials(sender.name)}
-            </AvatarFallback>
-          </Avatar>
+          <span className="relative inline-flex">
+            <Avatar className="size-8">
+              <AvatarImage src={sender.image ?? undefined} alt="" />
+              <AvatarFallback className="text-xs">
+                {getInitials(sender.name)}
+              </AvatarFallback>
+            </Avatar>
+            {sender.kind === "coworker" ? <AiCoworkerAvatarBadge /> : null}
+          </span>
         </ChatParticipantHoverCard>
       )}
       <div
@@ -1436,7 +1439,7 @@ export function ChatMessageRow({
         )}
       >
         {isContinuation ? null : (
-          <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1">
             <ChatParticipantHoverCard
               profile={hoverProfile}
               side="top"
@@ -1452,7 +1455,6 @@ export function ChatMessageRow({
                 {sender.name}
               </span>
             </ChatParticipantHoverCard>
-            {sender.kind === "coworker" ? <AiCoworkerIcon /> : null}
             <MessageWallClockTime
               value={message.createdAt}
               className="text-muted-foreground text-xs"

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1414,14 +1414,15 @@ export function ChatMessageRow({
           profile={hoverProfile}
           side="top"
           align="start"
-          className="mt-0.5 shrink-0"
+          className="mt-0.5 shrink-0 self-start"
           currentUserId={currentUserId}
           canOpenHumanDirect={canOpenHumanDirect}
           onOpenDirect={onOpenDirectMessage}
           isOpeningDirect={isOpeningDirect}
           isDirectActionBusy={isDirectActionBusy}
         >
-          <span className="relative inline-flex">
+          {/* self-start: article is flex; stretch made this full row height so absolute badge sat at bottom */}
+          <span className="relative inline-flex size-8 shrink-0 self-start">
             <Avatar className="size-8">
               <AvatarImage src={sender.image ?? undefined} alt="" />
               <AvatarFallback className="text-xs">


### PR DESCRIPTION
## Summary
- Move the AI coworker Bot indicator from the message name row onto a Discord-style corner badge on the sender avatar.
- Reuse the same Lucide `Bot` icon via new `AiCoworkerAvatarBadge`.
- Name row is name + time only; badge is sibling of `Avatar` (not inside, so `overflow-hidden` does not clip it).

## Test plan
- [x] `pnpm --filter web test` room-message-row tests (badge on coworker, none on human)
- [ ] Open a chat with a coworker message — bot chip on avatar bottom-right, no icon beside name
- [ ] Human sender — no badge
- [ ] Hover avatar — hover card still works
- [ ] Light + dark mode — badge ring matches background