### PR TITLE
fix(chat): polish coworker mention failed status chip

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4928,7 +4928,6 @@
       "MentionStatus": {
         "pending": "Rufe {name}",
         "sent": "{name} denkt nach",
-        "responded": "{name} hat geantwortet",
         "failed": "{name} konnte nicht antworten",
         "nameFallback": "Coworker"
       },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4929,7 +4929,7 @@
         "pending": "Rufe {name}",
         "sent": "{name} denkt nach",
         "responded": "{name} hat geantwortet",
-        "failed": "{name} fehlgeschlagen",
+        "failed": "{name} konnte nicht antworten",
         "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4929,7 +4929,7 @@
         "pending": "Calling {name}",
         "sent": "{name} is thinking",
         "responded": "{name} replied",
-        "failed": "{name} failed",
+        "failed": "{name} couldn't reply",
         "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4928,7 +4928,6 @@
       "MentionStatus": {
         "pending": "Calling {name}",
         "sent": "{name} is thinking",
-        "responded": "{name} replied",
         "failed": "{name} couldn't reply",
         "nameFallback": "Coworker"
       },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4928,7 +4928,6 @@
       "MentionStatus": {
         "pending": "Llamando a {name}",
         "sent": "{name} está pensando",
-        "responded": "{name} respondió",
         "failed": "{name} no pudo responder",
         "nameFallback": "Coworker"
       },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4929,7 +4929,7 @@
         "pending": "Llamando a {name}",
         "sent": "{name} está pensando",
         "responded": "{name} respondió",
-        "failed": "{name} falló",
+        "failed": "{name} no pudo responder",
         "nameFallback": "Coworker"
       },
       "composerPlaceholderWithChannel": "Message #{channel}",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1683,10 +1683,12 @@ describe("ChatMessageRow coworker Thought", () => {
         onToggleReaction={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("coworker-mention-terminal")).toHaveAttribute(
-      "data-variant",
-      "failed",
-    );
+    const terminal = screen.getByTestId("coworker-mention-terminal");
+    expect(terminal).toHaveAttribute("data-variant", "failed");
+    expect(terminal).toHaveAttribute("role", "status");
+    expect(terminal).toHaveTextContent("MentionStatus.failed");
+    // Soft chip, not a frozen pixel-grid loader.
+    expect(screen.queryByTestId("bui-static-grid")).not.toBeInTheDocument();
   });
 
   it("shows Beautiful UI loading state on empty stream overlay", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1684,10 +1684,13 @@ describe("ChatMessageRow coworker Thought", () => {
       />,
     );
     const terminal = screen.getByTestId("coworker-mention-terminal");
-    expect(terminal).toHaveAttribute("data-variant", "failed");
     expect(terminal).toHaveAttribute("role", "status");
     expect(terminal).toHaveTextContent("MentionStatus.failed");
-    // Soft chip, not a frozen pixel-grid loader.
+    expect(terminal).toHaveClass("bg-destructive/10", "border-destructive/20");
+    expect(
+      screen.getByTestId("coworker-mention-failed-icon"),
+    ).toBeInTheDocument();
+    // Soft chip replaces the frozen pixel-grid loader.
     expect(screen.queryByTestId("bui-static-grid")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -194,48 +194,35 @@ export function CoworkerLoadingState({
   );
 }
 
+interface CoworkerMentionFailedStatusProps {
+  label: string;
+  className?: string;
+}
+
 /**
- * Terminal mention status after the live thinking row.
- * Failed: soft alert chip (icon + label) — not a frozen loading grid.
- * Responded: muted label only (usually hidden; success is the reply itself).
+ * Failed mention terminal status after the live thinking row.
+ * Soft alert chip (icon + label) — success is the coworker reply itself (no chrome).
  */
 export function CoworkerMentionTerminalStatus({
   label,
-  variant,
   className,
-}: {
-  label: string;
-  variant: "responded" | "failed";
-  className?: string;
-}) {
-  if (variant === "failed") {
-    return (
-      <div
-        className={cn(
-          "border-destructive/20 bg-destructive/10 text-destructive",
-          "inline-flex w-fit max-w-full items-center gap-1.5 rounded-md border px-2 py-1",
-          className,
-        )}
-        role="status"
-        data-testid="coworker-mention-terminal"
-        data-variant="failed"
-      >
-        <CircleAlert className="size-3.5 shrink-0" aria-hidden />
-        <span className="truncate text-xs font-medium">{label}</span>
-      </div>
-    );
-  }
-
+}: CoworkerMentionFailedStatusProps) {
   return (
     <div
       className={cn(
-        "text-muted-foreground flex w-fit max-w-full items-center gap-1.5",
+        "border-destructive/20 bg-destructive/10 text-destructive",
+        "inline-flex w-fit max-w-full items-center gap-1.5 rounded-md border px-2 py-1",
         className,
       )}
+      role="status"
       data-testid="coworker-mention-terminal"
-      data-variant="responded"
     >
-      <span className="truncate text-sm font-medium">{label}</span>
+      <CircleAlert
+        className="size-3.5 shrink-0"
+        aria-hidden
+        data-testid="coworker-mention-failed-icon"
+      />
+      <span className="truncate text-xs font-medium">{label}</span>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -6,6 +6,7 @@
  * Tokens remapped to Sokosumi semantic colors.
  */
 
+import { CircleAlert } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -193,25 +194,10 @@ export function CoworkerLoadingState({
   );
 }
 
-/** Static dim Drive grid — same footprint as loading, no motion. */
-function StaticPixelGrid() {
-  return (
-    <span aria-hidden className="bui-pixel-grid" data-testid="bui-static-grid">
-      {DRIVE_PIXEL_DELAYS_MS.map((_, i) => (
-        <span
-          key={i}
-          className="bui-pixel-cell"
-          style={{ opacity: 0.15 }}
-          data-testid="bui-static-pixel"
-        />
-      ))}
-    </span>
-  );
-}
-
 /**
- * Terminal mention status in the same layout as loading (static grid + label).
- * `responded` / `failed` after the live thinking row.
+ * Terminal mention status after the live thinking row.
+ * Failed: soft alert chip (icon + label) — not a frozen loading grid.
+ * Responded: muted label only (usually hidden; success is the reply itself).
  */
 export function CoworkerMentionTerminalStatus({
   label,
@@ -222,21 +208,34 @@ export function CoworkerMentionTerminalStatus({
   variant: "responded" | "failed";
   className?: string;
 }) {
+  if (variant === "failed") {
+    return (
+      <div
+        className={cn(
+          "border-destructive/20 bg-destructive/10 text-destructive",
+          "inline-flex w-fit max-w-full items-center gap-1.5 rounded-md border px-2 py-1",
+          className,
+        )}
+        role="status"
+        data-testid="coworker-mention-terminal"
+        data-variant="failed"
+      >
+        <CircleAlert className="size-3.5 shrink-0" aria-hidden />
+        <span className="truncate text-xs font-medium">{label}</span>
+      </div>
+    );
+  }
+
   return (
     <div
-      className={cn("flex w-fit max-w-full items-center gap-2.5", className)}
+      className={cn(
+        "text-muted-foreground flex w-fit max-w-full items-center gap-1.5",
+        className,
+      )}
       data-testid="coworker-mention-terminal"
-      data-variant={variant}
+      data-variant="responded"
     >
-      <StaticPixelGrid />
-      <span
-        className={cn(
-          "truncate text-sm font-medium",
-          variant === "failed" ? "text-destructive" : "text-muted-foreground",
-        )}
-      >
-        {label}
-      </span>
+      <span className="truncate text-sm font-medium">{label}</span>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1297,11 +1297,7 @@ function MessageMetaFooter({
               );
             }
             return (
-              <CoworkerMentionTerminalStatus
-                key={mention.id}
-                label={label}
-                variant="failed"
-              />
+              <CoworkerMentionTerminalStatus key={mention.id} label={label} />
             );
           })}
         </div>


### PR DESCRIPTION
## Summary
- Failed channel @mention status no longer reuses a frozen Drive pixel grid with bare red text (looked broken).
- Soft destructive chip with `CircleAlert` + softer label copy: “couldn't reply” (en/de/es).
- Test asserts soft chip path (no static grid, `role="status"`).

## Test plan
- [x] `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx -t "hides mention status"`
- [ ] Manually fail a channel @mention and confirm chip looks intentional (soft red pill + icon + “couldn't reply”)
- [ ] Confirm thinking/loading state still uses animated pixel grid + shimmer
- [ ] Confirm successful reply still shows no terminal status chip