### PR TITLE
fix(chat): shrink coworker thinking chrome to meta scale

### DIFF
--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -171,14 +171,14 @@ export function CoworkerLoadingState({
   const elapsedMs = useLiveElapsedMs(startedAtMs);
   return (
     <div
-      className={cn("flex w-fit max-w-full items-center gap-2.5", className)}
+      className={cn("flex w-fit max-w-full items-center gap-1.5", className)}
       role="status"
       aria-live="polite"
       data-testid="coworker-loading-state"
     >
       <DrivePixelGrid />
       <span
-        className="bui-shimmer-text truncate text-sm font-medium"
+        className="bui-shimmer-text truncate text-xs font-medium"
         data-testid="coworker-loading-label"
       >
         {label}
@@ -272,7 +272,7 @@ export function CoworkerThoughtTrace({
           }
         }}
         className={cn(
-          "-mx-1.5 flex w-fit max-w-full items-center gap-2 rounded-md px-1.5 py-1 text-left",
+          "-mx-1 flex w-fit max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-left",
           "transition-colors duration-100",
           hasBody &&
             "hover:bg-muted/60 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
@@ -280,11 +280,11 @@ export function CoworkerThoughtTrace({
         )}
       >
         <svg
-          width="16"
-          height="16"
+          width="12"
+          height="12"
           viewBox="0 0 24 24"
           aria-hidden
-          className="shrink-0"
+          className="size-3 shrink-0"
           fill={
             working
               ? "var(--muted-foreground)"
@@ -294,18 +294,18 @@ export function CoworkerThoughtTrace({
           <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z" />
         </svg>
         {working ? (
-          <span className="bui-shimmer-text truncate text-sm font-medium whitespace-nowrap">
+          <span className="bui-shimmer-text truncate text-xs font-medium whitespace-nowrap">
             {headerLabel}
           </span>
         ) : (
-          <span className="text-muted-foreground truncate text-sm font-medium whitespace-nowrap">
+          <span className="text-muted-foreground truncate text-xs font-medium whitespace-nowrap">
             {headerLabel}
           </span>
         )}
         {hasBody ? (
           <svg
-            width="14"
-            height="14"
+            width="12"
+            height="12"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -313,7 +313,7 @@ export function CoworkerThoughtTrace({
             strokeLinecap="round"
             strokeLinejoin="round"
             aria-hidden
-            className="text-muted-foreground shrink-0 transition-transform duration-300"
+            className="text-muted-foreground size-3 shrink-0 transition-transform duration-300"
             style={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)" }}
           >
             <path d="M6 9l6 6 6-6" />
@@ -334,17 +334,17 @@ export function CoworkerThoughtTrace({
           aria-hidden={!expanded}
         >
           <div className="overflow-hidden">
-            <div className="relative mt-1 ml-[5px] pl-4">
+            <div className="relative mt-0.5 ml-1 pl-3">
               <span
                 aria-hidden
-                className="bg-border absolute left-[3px] w-px"
+                className="bg-border absolute left-px w-px"
                 style={{
-                  top: -8,
+                  top: -6,
                   height: lineHeight ? lineHeight - 2 : 0,
                   transition: "height 500ms cubic-bezier(0.23,1,0.32,1)",
                 }}
               />
-              <div ref={traceRef} className="flex flex-col gap-1 py-1">
+              <div ref={traceRef} className="flex flex-col gap-0.5 py-0.5">
                 <p
                   className={cn(
                     "text-muted-foreground text-xs leading-relaxed whitespace-pre-wrap",
@@ -394,7 +394,7 @@ export function CoworkerLiveThought({
       />
       <span
         aria-hidden
-        className="text-muted-foreground ml-[26px] font-mono text-xs tabular-nums"
+        className="text-muted-foreground ml-5 font-mono text-xs tabular-nums"
         data-testid="live-stream-elapsed"
       >
         <LiveElapsed startedAtMs={startedAtMs} />

--- a/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
+++ b/apps/web/src/app/(app)/chat/components/coworker-thought-ui.tsx
@@ -272,7 +272,8 @@ export function CoworkerThoughtTrace({
           }
         }}
         className={cn(
-          "-mx-1 flex w-fit max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-left",
+          // min-h-6 keeps ~24px touch target at default root while type stays text-xs.
+          "-mx-1 flex min-h-6 w-fit max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-left",
           "transition-colors duration-100",
           hasBody &&
             "hover:bg-muted/60 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
@@ -280,8 +281,6 @@ export function CoworkerThoughtTrace({
         )}
       >
         <svg
-          width="12"
-          height="12"
           viewBox="0 0 24 24"
           aria-hidden
           className="size-3 shrink-0"
@@ -304,8 +303,6 @@ export function CoworkerThoughtTrace({
         )}
         {hasBody ? (
           <svg
-            width="12"
-            height="12"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -337,10 +334,10 @@ export function CoworkerThoughtTrace({
             <div className="relative mt-0.5 ml-1 pl-3">
               <span
                 aria-hidden
-                className="bg-border absolute left-px w-px"
+                className="bg-border absolute -top-1.5 left-px w-px"
                 style={{
-                  top: -6,
-                  height: lineHeight ? lineHeight - 2 : 0,
+                  // Dynamic body height from layout; 2px short so rail ends in the text block.
+                  height: lineHeight ? Math.max(0, lineHeight - 2) : 0,
                   transition: "height 500ms cubic-bezier(0.23,1,0.32,1)",
                 }}
               />

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1545,7 +1545,7 @@ export function ChatMessageRow({
               ) : (
                 <>
                   {thoughtView?.disclosure ? (
-                    <div className="mb-1.5">
+                    <div className="mb-1">
                       <CoworkerThoughtTrace
                         working={false}
                         headerLabel={

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -722,15 +722,16 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
  */
 .bui-pixel-grid {
   display: grid;
-  grid-template-columns: repeat(3, 4px);
-  gap: 1.5px;
+  /* Meta-scale loader: sit with chat chrome (text-xs), not body type. */
+  grid-template-columns: repeat(3, 0.1875rem);
+  gap: 0.0625rem;
   flex-shrink: 0;
 }
 
 .bui-pixel-cell {
-  width: 4px;
-  height: 4px;
-  border-radius: 1px;
+  width: 0.1875rem;
+  height: 0.1875rem;
+  border-radius: 0.0625rem;
   background-color: var(--foreground);
   opacity: 0.15;
   will-change: opacity;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -722,15 +722,15 @@ main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
  */
 .bui-pixel-grid {
   display: grid;
-  /* Meta-scale loader: sit with chat chrome (text-xs), not body type. */
-  grid-template-columns: repeat(3, 0.1875rem);
+  /* Meta-scale Drive: rem so it tracks root/Dynamic Type; 0.25rem keeps wave legible. */
+  grid-template-columns: repeat(3, 0.25rem);
   gap: 0.0625rem;
   flex-shrink: 0;
 }
 
 .bui-pixel-cell {
-  width: 0.1875rem;
-  height: 0.1875rem;
+  width: 0.25rem;
+  height: 0.25rem;
   border-radius: 0.0625rem;
   background-color: var(--foreground);
   opacity: 0.15;


### PR DESCRIPTION
## Summary
- Scale coworker “is thinking” loader and “Thought for Xs” disclosure to chat meta size (`text-xs`, tighter gaps, smaller Drive grid + icons).
- Keeps shimmer, live timer, and expand/collapse behavior; only visual hierarchy changes.

## Test plan
- [x] `pnpm --filter web test` room-message-row + coworker-thought-ui + coworker-thought utils (87 pass)
- [ ] In a channel, @mention a coworker — loading row should sit with reactions/meta, not dominate the message
- [ ] Stream overlay empty thinking + live Thought beat still readable
- [ ] After reply, collapsed “Thought for Ns” is quieter above the answer; expand still works