### PR TITLE
feat(chat): show participant hover card on DM sidebar avatars

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -192,15 +192,17 @@ describe("ChatParticipantHoverCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps a non-button trigger when interactive is false (nested in links)", () => {
+  it("keeps a non-button unlabeled trigger when interactive is false (nested in links)", () => {
     render(
       <ChatParticipantHoverCard profile={humanProfile} interactive={false}>
-        <span data-testid="passive-trigger">avatar</span>
+        <span data-testid="passive-trigger" aria-label="should-be-cleared">
+          avatar
+        </span>
       </ChatParticipantHoverCard>,
     );
 
     const trigger = screen.getByTestId("passive-trigger");
-    expect(trigger).toHaveAttribute("aria-label", "Ada Lovelace");
+    expect(trigger).not.toHaveAttribute("aria-label");
     expect(trigger).not.toHaveAttribute("role", "button");
     expect(
       screen.queryByRole("button", { name: "Ada Lovelace" }),

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -192,10 +192,15 @@ describe("ChatParticipantHoverCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps a non-button unlabeled trigger when interactive is false (nested in links)", () => {
+  it("strips inherited focus semantics when interactive is false (nested in links)", () => {
     render(
       <ChatParticipantHoverCard profile={humanProfile} interactive={false}>
-        <span data-testid="passive-trigger" aria-label="should-be-cleared">
+        <span
+          data-testid="passive-trigger"
+          role="button"
+          tabIndex={0}
+          aria-label="should-be-cleared"
+        >
           avatar
         </span>
       </ChatParticipantHoverCard>,
@@ -203,7 +208,8 @@ describe("ChatParticipantHoverCard", () => {
 
     const trigger = screen.getByTestId("passive-trigger");
     expect(trigger).not.toHaveAttribute("aria-label");
-    expect(trigger).not.toHaveAttribute("role", "button");
+    expect(trigger).not.toHaveAttribute("role");
+    expect(trigger).not.toHaveAttribute("tabindex");
     expect(
       screen.queryByRole("button", { name: "Ada Lovelace" }),
     ).not.toBeInTheDocument();

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx
@@ -192,6 +192,21 @@ describe("ChatParticipantHoverCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps a non-button trigger when interactive is false (nested in links)", () => {
+    render(
+      <ChatParticipantHoverCard profile={humanProfile} interactive={false}>
+        <span data-testid="passive-trigger">avatar</span>
+      </ChatParticipantHoverCard>,
+    );
+
+    const trigger = screen.getByTestId("passive-trigger");
+    expect(trigger).toHaveAttribute("aria-label", "Ada Lovelace");
+    expect(trigger).not.toHaveAttribute("role", "button");
+    expect(
+      screen.queryByRole("button", { name: "Ada Lovelace" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("uses the child control itself as the hover trigger hit target", () => {
     render(
       <div className="flex" style={{ display: "flex", height: 400 }}>

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -85,9 +85,13 @@ function renderHoverTrigger({
         ? {
             role: singleChild.props.role ?? "button",
             tabIndex: singleChild.props.tabIndex ?? 0,
+            // Named for keyboard focus; skip when nested in a link (row owns name).
+            "aria-label": singleChild.props["aria-label"] ?? profileName,
           }
-        : {}),
-      "aria-label": singleChild.props["aria-label"] ?? profileName,
+        : {
+            // Drop any child label so SRs don't double-speak the row link name.
+            "aria-label": undefined,
+          }),
       "aria-hidden": undefined,
       style: { ...singleChild.props.style, ...style },
       className: cn(
@@ -102,7 +106,6 @@ function renderHoverTrigger({
   if (!interactive) {
     return (
       <span
-        aria-label={profileName}
         style={style}
         className={cn(
           "relative inline-flex w-fit max-w-full cursor-pointer self-start p-0 leading-none",

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -89,6 +89,9 @@ function renderHoverTrigger({
             "aria-label": singleChild.props["aria-label"] ?? profileName,
           }
         : {
+            // Strip focus semantics if the child brought them (e.g. nested in a link).
+            role: undefined,
+            tabIndex: undefined,
             // Drop any child label so SRs don't double-speak the row link name.
             "aria-label": undefined,
           }),

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -39,6 +39,11 @@ interface ChatParticipantHoverCardProps {
   isOpeningDirect?: boolean;
   /** True while any hover-card DM open is in flight (disables Message). */
   isDirectActionBusy?: boolean;
+  /**
+   * When false, the trigger is not a keyboard button (use when nested inside
+   * a link/row that already owns activation). Still hoverable.
+   */
+  interactive?: boolean;
 }
 
 interface TriggerChildProps {
@@ -55,11 +60,13 @@ function renderHoverTrigger({
   children,
   className,
   style,
+  interactive,
 }: {
   profileName: string;
   children: ReactNode;
   className?: string;
   style?: CSSProperties;
+  interactive: boolean;
 }) {
   const childItems = Children.toArray(children).filter((child) => {
     if (typeof child === "string" || typeof child === "number") {
@@ -74,17 +81,37 @@ function renderHoverTrigger({
 
   if (singleChild) {
     return cloneElement(singleChild, {
-      role: singleChild.props.role ?? "button",
-      tabIndex: singleChild.props.tabIndex ?? 0,
+      ...(interactive
+        ? {
+            role: singleChild.props.role ?? "button",
+            tabIndex: singleChild.props.tabIndex ?? 0,
+          }
+        : {}),
       "aria-label": singleChild.props["aria-label"] ?? profileName,
       "aria-hidden": undefined,
       style: { ...singleChild.props.style, ...style },
       className: cn(
-        "cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "cursor-pointer outline-none",
+        interactive && "focus-visible:ring-2 focus-visible:ring-ring",
         singleChild.props.className,
         className,
       ),
     });
+  }
+
+  if (!interactive) {
+    return (
+      <span
+        aria-label={profileName}
+        style={style}
+        className={cn(
+          "relative inline-flex w-fit max-w-full cursor-pointer self-start p-0 leading-none",
+          className,
+        )}
+      >
+        {children}
+      </span>
+    );
   }
 
   return (
@@ -115,6 +142,7 @@ export function ChatParticipantHoverCard({
   onOpenDirect,
   isOpeningDirect = false,
   isDirectActionBusy = false,
+  interactive = true,
 }: ChatParticipantHoverCardProps) {
   const t = useTranslations("App.Channels");
 
@@ -143,6 +171,7 @@ export function ChatParticipantHoverCard({
           children,
           className,
           style,
+          interactive,
         })}
       </HoverCardTrigger>
       <HoverCardContent

--- a/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
+++ b/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatRoom } from "@/lib/clients/generated/core";
+
+const { openDirectMock, pushMock } = vi.hoisted(() => ({
+  openDirectMock: vi.fn(),
+  pushMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const labels: Record<string, string> = {
+      coworkerBadge: "AI coworker",
+      humanBadge: "Human",
+      openDirectMessage: "Message",
+    };
+    return labels[key] ?? key;
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    "data-testid"?: string;
+  }) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/chat/live-member-presence-dot", () => ({
+  LiveMemberPresenceDot: () => <span data-testid="presence-dot" />,
+}));
+
+vi.mock("@/app/chat/components/open-direct-with-participant", () => ({
+  participantDirectKey: (profile: { kind: string; id: string }) =>
+    `${profile.kind}:${profile.id}`,
+  canShowOpenDirect: ({
+    profile,
+    currentUserId,
+    canOpenHumanDirect,
+    onOpenDirect,
+  }: {
+    profile: { kind: string; id: string };
+    currentUserId?: string;
+    canOpenHumanDirect: boolean;
+    onOpenDirect?: unknown;
+  }) => {
+    if (!onOpenDirect) return false;
+    if (profile.kind === "human") {
+      if (!canOpenHumanDirect) return false;
+      if (currentUserId && profile.id === currentUserId) return false;
+    }
+    return true;
+  },
+  openDirectWithParticipant: (...args: unknown[]) => openDirectMock(...args),
+}));
+
+import { DirectRoomAvatarStack } from "../direct-room-avatar-stack";
+
+function makeUser(id: string, name?: string) {
+  return {
+    id,
+    name: name ?? `User ${id}`,
+    email: `${id}@example.com`,
+    image: null as string | null,
+    presence: "online" as const,
+  };
+}
+
+function makeCoworker(id: string, name: string, slug: string) {
+  return {
+    id,
+    name,
+    slug,
+    caption: `${name} caption`,
+    image: null as string | null,
+    presence: "online" as const,
+  };
+}
+
+function makeDirectRoom(overrides: Partial<ChatRoom> = {}): ChatRoom {
+  return {
+    id: "dm-1",
+    organizationId: "org-1",
+    name: "dm",
+    slug: "dm",
+    kind: "direct",
+    directKey: "key",
+    topic: null,
+    discoverability: "private",
+    createdByUserId: "me",
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    pinnedAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    userMembers: [makeUser("me", "Me"), makeUser("patrick", "Patrick Tobler")],
+    coworkerMembers: [],
+    ...overrides,
+  };
+}
+
+describe("DirectRoomAvatarStack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openDirectMock.mockResolvedValue({ ok: true, roomId: "dm-2" });
+  });
+
+  it("shows participant hover card for a 1:1 human DM avatar", async () => {
+    const user = userEvent.setup();
+    render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom()}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId={null}
+      />,
+    );
+
+    await user.hover(screen.getByLabelText("Patrick Tobler"));
+
+    const card = screen.getByTestId("chat-participant-hover-card");
+    expect(card).toHaveTextContent("Patrick Tobler");
+    expect(card).toHaveTextContent("Human");
+    expect(card).toHaveTextContent("patrick@example.com");
+  });
+
+  it("shows a hover card per stacked participant in a group DM", () => {
+    render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom({
+          userMembers: [
+            makeUser("me", "Me"),
+            makeUser("alice", "Alice"),
+            makeUser("bob", "Bob"),
+          ],
+        })}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId={null}
+      />,
+    );
+
+    // HoverCard is mocked open so each stacked avatar mounts its card.
+    const cards = screen.getAllByTestId("chat-participant-hover-card");
+    expect(cards).toHaveLength(2);
+    expect(cards.map((card) => card.textContent).join(" ")).toContain("Alice");
+    expect(cards.map((card) => card.textContent).join(" ")).toContain("Bob");
+    expect(screen.getByLabelText("Alice")).toBeInTheDocument();
+    expect(screen.getByLabelText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows coworker hover card with caption and Message action", async () => {
+    const user = userEvent.setup();
+    render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom({
+          userMembers: [makeUser("me", "Me")],
+          coworkerMembers: [makeCoworker("cw-1", "Matt", "matt")],
+        })}
+        currentUserId="me"
+        canOpenHumanDirect={false}
+        selectedRoomId={null}
+      />,
+    );
+
+    await user.hover(screen.getByLabelText("Matt"));
+
+    const card = screen.getByTestId("chat-participant-hover-card");
+    expect(card).toHaveTextContent("Matt");
+    expect(card).toHaveTextContent("AI coworker");
+    expect(card).toHaveTextContent("Matt caption");
+    expect(
+      screen.getByRole("button", { name: /Message/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens a direct when Message is clicked from the hover card", async () => {
+    const user = userEvent.setup();
+    render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom()}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId="dm-1"
+      />,
+    );
+
+    await user.hover(screen.getByLabelText("Patrick Tobler"));
+    await user.click(screen.getByRole("button", { name: /Message/i }));
+
+    expect(openDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: expect.objectContaining({
+          kind: "human",
+          id: "patrick",
+          name: "Patrick Tobler",
+        }),
+        selectedRoomId: "dm-1",
+      }),
+    );
+  });
+
+  it("renders a non-interactive fallback when the DM has no other participants", () => {
+    render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom({
+          userMembers: [makeUser("me", "Me")],
+          coworkerMembers: [],
+        })}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId={null}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("chat-participant-hover-card"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Me")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
+++ b/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
@@ -44,29 +44,20 @@ vi.mock("@/components/chat/live-member-presence-dot", () => ({
   LiveMemberPresenceDot: () => <span data-testid="presence-dot" />,
 }));
 
-vi.mock("@/app/chat/components/open-direct-with-participant", () => ({
-  participantDirectKey: (profile: { kind: string; id: string }) =>
-    `${profile.kind}:${profile.id}`,
-  canShowOpenDirect: ({
-    profile,
-    currentUserId,
-    canOpenHumanDirect,
-    onOpenDirect,
-  }: {
-    profile: { kind: string; id: string };
-    currentUserId?: string;
-    canOpenHumanDirect: boolean;
-    onOpenDirect?: unknown;
-  }) => {
-    if (!onOpenDirect) return false;
-    if (profile.kind === "human") {
-      if (!canOpenHumanDirect) return false;
-      if (currentUserId && profile.id === currentUserId) return false;
-    }
-    return true;
+vi.mock(
+  "@/app/chat/components/open-direct-with-participant",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/app/chat/components/open-direct-with-participant")
+      >();
+    return {
+      ...actual,
+      openDirectWithParticipant: (...args: unknown[]) =>
+        openDirectMock(...args),
+    };
   },
-  openDirectWithParticipant: (...args: unknown[]) => openDirectMock(...args),
-}));
+);
 
 import { DirectRoomAvatarStack } from "../direct-room-avatar-stack";
 
@@ -132,7 +123,10 @@ describe("DirectRoomAvatarStack", () => {
       />,
     );
 
-    await user.hover(screen.getByLabelText("Patrick Tobler"));
+    const avatar = screen.getByTestId("dm-sidebar-avatar-patrick");
+    expect(avatar).not.toHaveAttribute("role", "button");
+    expect(avatar).not.toHaveAttribute("aria-label");
+    await user.hover(avatar);
 
     const card = screen.getByTestId("chat-participant-hover-card");
     expect(card).toHaveTextContent("Patrick Tobler");
@@ -161,8 +155,14 @@ describe("DirectRoomAvatarStack", () => {
     expect(cards).toHaveLength(2);
     expect(cards.map((card) => card.textContent).join(" ")).toContain("Alice");
     expect(cards.map((card) => card.textContent).join(" ")).toContain("Bob");
-    expect(screen.getByLabelText("Alice")).toBeInTheDocument();
-    expect(screen.getByLabelText("Bob")).toBeInTheDocument();
+    expect(screen.getByTestId("dm-sidebar-avatar-alice")).toBeInTheDocument();
+    expect(screen.getByTestId("dm-sidebar-avatar-bob")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Alice" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Bob" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows coworker hover card with caption and Message action", async () => {
@@ -179,7 +179,7 @@ describe("DirectRoomAvatarStack", () => {
       />,
     );
 
-    await user.hover(screen.getByLabelText("Matt"));
+    await user.hover(screen.getByTestId("dm-sidebar-avatar-cw-1"));
 
     const card = screen.getByTestId("chat-participant-hover-card");
     expect(card).toHaveTextContent("Matt");
@@ -201,7 +201,7 @@ describe("DirectRoomAvatarStack", () => {
       />,
     );
 
-    await user.hover(screen.getByLabelText("Patrick Tobler"));
+    await user.hover(screen.getByTestId("dm-sidebar-avatar-patrick"));
     await user.click(screen.getByRole("button", { name: /Message/i }));
 
     expect(openDirectMock).toHaveBeenCalledWith(
@@ -232,6 +232,8 @@ describe("DirectRoomAvatarStack", () => {
     expect(
       screen.queryByTestId("chat-participant-hover-card"),
     ).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Me")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("dm-sidebar-avatar-me"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/chat/direct-room-avatar-stack.tsx
+++ b/apps/web/src/components/chat/direct-room-avatar-stack.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { ChatParticipantHoverCard } from "@/app/chat/components/chat-participant-hover-card";
+import {
+  openDirectWithParticipant,
+  participantDirectKey,
+} from "@/app/chat/components/open-direct-with-participant";
+import {
+  type ChatParticipantHoverProfile,
+  getRoomParticipantPreviews,
+} from "@/app/chat/components/room-helpers";
+import { LiveMemberPresenceDot } from "@/components/chat/live-member-presence-dot";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { ChatRoom } from "@/lib/clients/generated/core";
+import { cn } from "@/lib/utils";
+import { getInitials } from "@/lib/utils/text";
+
+interface DirectRoomAvatarStackProps {
+  room: ChatRoom;
+  currentUserId: string;
+  canOpenHumanDirect: boolean;
+  selectedRoomId: string | null;
+}
+
+/** Other humans + all coworkers in a direct room (excludes current user). */
+function getDirectHoverProfiles(
+  room: ChatRoom,
+  currentUserId: string,
+): ChatParticipantHoverProfile[] {
+  return getRoomParticipantPreviews(room)
+    .filter(
+      (participant) =>
+        participant.kind === "coworker" || participant.id !== currentUserId,
+    )
+    .slice(0, 3);
+}
+
+/**
+ * Avatar stack for sidebar DM rows. Each face opens the shared participant
+ * hover card (profile + Message). Trigger stays non-button because the row
+ * link already owns keyboard/click navigation.
+ */
+export function DirectRoomAvatarStack({
+  room,
+  currentUserId,
+  canOpenHumanDirect,
+  selectedRoomId,
+}: DirectRoomAvatarStackProps) {
+  const router = useRouter();
+  const [openingDirectKey, setOpeningDirectKey] = useState<string | null>(null);
+  const participants = getDirectHoverProfiles(room, currentUserId);
+
+  async function handleOpenDirect(profile: ChatParticipantHoverProfile) {
+    if (openingDirectKey) return;
+    setOpeningDirectKey(participantDirectKey(profile));
+    try {
+      await openDirectWithParticipant({
+        profile,
+        selectedRoomId,
+        router,
+        onError: toast.error,
+      });
+    } finally {
+      setOpeningDirectKey(null);
+    }
+  }
+
+  if (participants.length === 0) {
+    return (
+      <span className="bg-muted text-muted-foreground flex size-5 shrink-0 items-center justify-center rounded-full text-[0.625rem] font-medium">
+        <MessageCircle className="size-3" aria-hidden />
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex h-5 shrink-0 items-center">
+      {participants.map((participant, index) => (
+        <ChatParticipantHoverCard
+          key={`${participant.kind}-${participant.id}`}
+          profile={participant}
+          side="right"
+          align="start"
+          className={cn("relative block", index > 0 && "-ml-2")}
+          style={{ zIndex: participants.length - index }}
+          currentUserId={currentUserId}
+          canOpenHumanDirect={canOpenHumanDirect}
+          onOpenDirect={handleOpenDirect}
+          isOpeningDirect={
+            openingDirectKey === participantDirectKey(participant)
+          }
+          isDirectActionBusy={openingDirectKey != null}
+          interactive={false}
+        >
+          <span className="relative inline-flex" aria-label={participant.name}>
+            <Avatar className="border-sidebar-background size-5 border">
+              <AvatarImage alt="" src={participant.image ?? undefined} />
+              <AvatarFallback className="text-[0.5625rem] font-medium">
+                {getInitials(participant.name)}
+              </AvatarFallback>
+            </Avatar>
+            <LiveMemberPresenceDot
+              className="-right-0.5 -bottom-0.5 absolute size-2"
+              fallback={participant.presence}
+              isCoworker={participant.kind === "coworker"}
+              userId={participant.id}
+            />
+          </span>
+        </ChatParticipantHoverCard>
+      ))}
+    </span>
+  );
+}

--- a/apps/web/src/components/chat/direct-room-avatar-stack.tsx
+++ b/apps/web/src/components/chat/direct-room-avatar-stack.tsx
@@ -97,7 +97,10 @@ export function DirectRoomAvatarStack({
           isDirectActionBusy={openingDirectKey != null}
           interactive={false}
         >
-          <span className="relative inline-flex" aria-label={participant.name}>
+          <span
+            className="relative inline-flex"
+            data-testid={`dm-sidebar-avatar-${participant.id}`}
+          >
             <Avatar className="border-sidebar-background size-5 border">
               <AvatarImage alt="" src={participant.image ?? undefined} />
               <AvatarFallback className="text-[0.5625rem] font-medium">

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  ChevronDown,
-  Ellipsis,
-  MessageCircle,
-  Plus,
-  RotateCcw,
-  Trash2,
-} from "lucide-react";
+import { ChevronDown, Ellipsis, Plus, RotateCcw, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -22,11 +15,7 @@ import {
 import { toast } from "sonner";
 import { deleteRoomAction, restoreRoomAction } from "@/app/chat/actions";
 import { BrowseChannelsDialog } from "@/app/chat/components/browse-channels-dialog";
-import {
-  getDirectRoomParticipants,
-  getRoomDisplayName,
-} from "@/app/chat/components/room-helpers";
-import { LiveMemberPresenceDot } from "@/components/chat/live-member-presence-dot";
+import { getRoomDisplayName } from "@/app/chat/components/room-helpers";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,7 +26,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -62,11 +50,11 @@ import { useChatUnreadDocumentTitle } from "@/hooks/use-chat-unread-document-tit
 import { useChatMembershipRevokedControl } from "@/lib/ably/use-chat-membership-revoked-control";
 import type { ChatRoom } from "@/lib/clients/generated/core";
 import { cn } from "@/lib/utils";
-import { getInitials } from "@/lib/utils/text";
 import { ChannelDiscoverabilityIcon } from "./channel-discoverability-icon";
 import { compareChatRoomsByRecentActivity } from "./chat-room-activity-sort";
 import { ChatRoomSidebarRow } from "./chat-room-sidebar-row";
 import { countChatRoomsWithUnreadAttention } from "./chat-unread-document-title";
+import { DirectRoomAvatarStack } from "./direct-room-avatar-stack";
 import {
   notifyOrganizationChatRoomsChanged,
   ORGANIZATION_CHAT_ROOMS_CHANGED_EVENT,
@@ -121,55 +109,6 @@ interface OrganizationChatListProps {
    * Set false when the list is page-mounted outside a Sheet.
    */
   dismissSheetOnNavigate?: boolean;
-}
-
-function DirectAvatarStack({
-  room,
-  currentUserId,
-}: {
-  room: ChatRoom;
-  currentUserId: string;
-}) {
-  const participants = getDirectRoomParticipants(room, currentUserId).slice(
-    0,
-    3,
-  );
-
-  if (participants.length === 0) {
-    return (
-      <span className="bg-muted text-muted-foreground flex size-5 shrink-0 items-center justify-center rounded-full text-[0.625rem] font-medium">
-        <MessageCircle className="size-3" aria-hidden />
-      </span>
-    );
-  }
-
-  return (
-    <span className="inline-flex h-5 shrink-0 items-center">
-      {participants.map((participant, index) => (
-        <span
-          className={cn("relative block", index > 0 && "-ml-2")}
-          key={participant.id}
-          title={participant.name}
-        >
-          <Avatar className="border-sidebar-background size-5 border">
-            <AvatarImage
-              alt={participant.name}
-              src={participant.image ?? undefined}
-            />
-            <AvatarFallback className="text-[0.5625rem] font-medium">
-              {getInitials(participant.name)}
-            </AvatarFallback>
-          </Avatar>
-          <LiveMemberPresenceDot
-            className="-right-0.5 -bottom-0.5 absolute size-2"
-            fallback={participant.presence}
-            isCoworker={participant.kind === "coworker"}
-            userId={participant.id}
-          />
-        </span>
-      ))}
-    </span>
-  );
 }
 
 function SectionHeader({
@@ -888,9 +827,11 @@ export function OrganizationChatList({
                   label={getRoomDisplayName(room, currentUserId)}
                   isActive={activeRoomId === room.id}
                   leading={
-                    <DirectAvatarStack
+                    <DirectRoomAvatarStack
                       room={room}
                       currentUserId={currentUserId}
+                      canOpenHumanDirect={hasOrganization}
+                      selectedRoomId={activeRoomId}
                     />
                   }
                   onRoomUpdated={handleRoomUpdated}


### PR DESCRIPTION
## Summary

- Show the same participant hover card when hovering Direct Messages sidebar avatars (human or coworker).
- Group DMs: each stacked face gets its own card; Message CTA opens/ensures a DM.
- Passive hover trigger (`interactive={false}`) avoids nested buttons inside the row link.

## Test plan

- [ ] Open chat with several DMs in the sidebar
- [ ] Hover a 1:1 human avatar → card shows name, Human badge, email, Message
- [ ] Hover a coworker avatar → card shows name, AI coworker badge, caption, Message
- [ ] Hover each face in a group DM stack → card updates per person
- [ ] Click Message from the card → opens/navigates to that DM
- [ ] Click the avatar/row (not Message) → still navigates to that room
- [ ] Collapsed sidebar icon mode → hover still works on small avatars
- [ ] `pnpm --filter web test src/components/chat/__tests__/direct-room-avatar-stack.test.tsx src/app/(app)/chat/components/__tests__/chat-participant-hover-card.test.tsx`