### PR TITLE
fix(web): gate org presence map on Ably token capability

### DIFF
--- a/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authorizeMock, getMock, channelsByName, ablyClient } = vi.hoisted(
+  () => {
+    const authorize = vi.fn();
+    const get = vi.fn();
+    return {
+      authorizeMock: authorize,
+      getMock: get,
+      channelsByName: new Map<
+        string,
+        {
+          name: string;
+          presence: {
+            subscribe: ReturnType<typeof vi.fn>;
+            unsubscribe: ReturnType<typeof vi.fn>;
+            get: ReturnType<typeof vi.fn>;
+          };
+        }
+      >(),
+      ablyClient: {
+        auth: { authorize },
+        channels: { get },
+        connection: {
+          on: vi.fn(),
+          off: vi.fn(),
+        },
+      },
+    };
+  },
+);
+
+vi.mock("ably/react", () => ({
+  useAbly: () => ablyClient,
+}));
+
+import { useOrgPresenceMap } from "../use-org-presence-map";
+
+function channelFor(name: string) {
+  let channel = channelsByName.get(name);
+  if (!channel) {
+    channel = {
+      name,
+      presence: {
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        get: vi.fn().mockResolvedValue([]),
+      },
+    };
+    channelsByName.set(name, channel);
+  }
+  return channel;
+}
+
+function tokenWithOrgs(...organizationIds: string[]) {
+  const capability: Record<string, string[]> = {
+    "tasks:all:user_1": ["subscribe"],
+  };
+  for (const organizationId of organizationIds) {
+    capability[`presence:org_${organizationId}`] = ["presence", "subscribe"];
+  }
+  return { capability: JSON.stringify(capability) };
+}
+
+describe("useOrgPresenceMap", () => {
+  beforeEach(() => {
+    authorizeMock.mockReset();
+    getMock.mockReset();
+    channelsByName.clear();
+    ablyClient.connection.on.mockReset();
+    ablyClient.connection.off.mockReset();
+    getMock.mockImplementation((name: string) => channelFor(name));
+  });
+
+  /**
+   * SOKOSUMI-R0: attaching `presence:org_*` without that channel on the token
+   * yields Ably "Channel denied access based on given capability" as an
+   * unhandledrejection. Map must gate on token capability (same as publisher).
+   */
+  it("does not attach when active org is missing from token capability", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("other_org"));
+
+    renderHook(() => useOrgPresenceMap("active_org"));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Bug signal (red before fix): map attached active org without a grant.
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_active_org");
+    expect(
+      channelsByName.get("presence:org_active_org")?.presence.subscribe,
+    ).toBeUndefined();
+  });
+
+  it("subscribes after authorize when token grants the active org", async () => {
+    authorizeMock.mockResolvedValue(tokenWithOrgs("active_org"));
+
+    renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalled();
+      expect(getMock).toHaveBeenCalledWith("presence:org_active_org");
+      expect(
+        channelFor("presence:org_active_org").presence.subscribe,
+      ).toHaveBeenCalled();
+      expect(
+        channelFor("presence:org_active_org").presence.get,
+      ).toHaveBeenCalled();
+    });
+  });
+
+  it("does not attach when authorize fails", async () => {
+    authorizeMock.mockRejectedValue(new Error("token refresh failed"));
+
+    renderHook(() => useOrgPresenceMap("active_org"));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
@@ -185,4 +185,80 @@ describe("useOrgPresenceMap", () => {
       expect(getMock).toHaveBeenCalledWith("presence:org_active_org");
     });
   });
+
+  it("clears prior roster and unsubscribes when organization switches", async () => {
+    let resolveOrgBAuth: ((value: unknown) => void) | undefined;
+    authorizeMock
+      .mockResolvedValueOnce(tokenWithOrgs("org_a"))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOrgBAuth = resolve;
+          }),
+      );
+
+    channelFor("presence:org_org_a").presence.get.mockResolvedValue([
+      {
+        // instance id must pass isValidAblyClientInstanceId (≥8 chars pattern)
+        clientId: "user_1:instanceA1",
+        data: { lastActiveAt: Date.now(), visible: true },
+      },
+    ]);
+
+    const { result, rerender } = renderHook(
+      ({ organizationId }: { organizationId: string }) =>
+        useOrgPresenceMap(organizationId),
+      { initialProps: { organizationId: "org_a" } },
+    );
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith("presence:org_org_a");
+      expect(result.current.size).toBeGreaterThan(0);
+    });
+
+    const orgAUnsubscribe =
+      channelFor("presence:org_org_a").presence.unsubscribe;
+
+    rerender({ organizationId: "org_b" });
+
+    // Effect entry clears roster before the deferred org_b authorize settles.
+    await waitFor(() => {
+      expect(result.current.size).toBe(0);
+      expect(orgAUnsubscribe).toHaveBeenCalled();
+    });
+    expect(getMock).not.toHaveBeenCalledWith("presence:org_org_b");
+
+    resolveOrgBAuth?.(tokenWithOrgs("org_b"));
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith("presence:org_org_b");
+      expect(
+        channelFor("presence:org_org_b").presence.subscribe,
+      ).toHaveBeenCalled();
+    });
+  });
+
+  it("tears down an attached channel when reconnect authorize fails", async () => {
+    authorizeMock
+      .mockResolvedValueOnce(tokenWithOrgs("active_org"))
+      .mockRejectedValueOnce(new Error("token refresh failed"));
+
+    const { result } = renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith("presence:org_active_org");
+      expect(
+        channelFor("presence:org_active_org").presence.subscribe,
+      ).toHaveBeenCalled();
+    });
+
+    const channel = channelFor("presence:org_active_org");
+    connectedHandler()?.();
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalledTimes(2);
+      expect(channel.presence.unsubscribe).toHaveBeenCalled();
+      expect(result.current.size).toBe(0);
+    });
+  });
 });

--- a/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
+++ b/apps/web/src/lib/ably/__tests__/use-org-presence-map.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { authorizeMock, getMock, channelsByName, ablyClient } = vi.hoisted(
@@ -63,6 +63,13 @@ function tokenWithOrgs(...organizationIds: string[]) {
   return { capability: JSON.stringify(capability) };
 }
 
+function connectedHandler(): (() => void) | undefined {
+  const call = ablyClient.connection.on.mock.calls.find(
+    (args) => args[0] === "connected",
+  );
+  return call?.[1] as (() => void) | undefined;
+}
+
 describe("useOrgPresenceMap", () => {
   beforeEach(() => {
     authorizeMock.mockReset();
@@ -83,15 +90,26 @@ describe("useOrgPresenceMap", () => {
 
     renderHook(() => useOrgPresenceMap("active_org"));
 
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalled();
     });
 
-    // Bug signal (red before fix): map attached active org without a grant.
     expect(getMock).not.toHaveBeenCalledWith("presence:org_active_org");
     expect(
       channelsByName.get("presence:org_active_org")?.presence.subscribe,
     ).toBeUndefined();
+  });
+
+  it("does not attach when token capability is unparseable", async () => {
+    authorizeMock.mockResolvedValue({ capability: "not-json" });
+
+    renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalled();
+    });
+
+    expect(getMock).not.toHaveBeenCalled();
   });
 
   it("subscribes after authorize when token grants the active org", async () => {
@@ -116,10 +134,55 @@ describe("useOrgPresenceMap", () => {
 
     renderHook(() => useOrgPresenceMap("active_org"));
 
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalled();
     });
 
     expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it("re-syncs on connected after a denied grant becomes available", async () => {
+    authorizeMock
+      .mockResolvedValueOnce(tokenWithOrgs("other_org"))
+      .mockResolvedValueOnce(tokenWithOrgs("active_org"));
+
+    renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getMock).not.toHaveBeenCalled();
+
+    const onConnected = connectedHandler();
+    expect(onConnected).toBeTypeOf("function");
+    onConnected?.();
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalledTimes(2);
+      expect(getMock).toHaveBeenCalledWith("presence:org_active_org");
+      expect(
+        channelFor("presence:org_active_org").presence.subscribe,
+      ).toHaveBeenCalled();
+    });
+  });
+
+  it("re-syncs on connected after authorize fails then succeeds", async () => {
+    authorizeMock
+      .mockRejectedValueOnce(new Error("token refresh failed"))
+      .mockResolvedValueOnce(tokenWithOrgs("active_org"));
+
+    renderHook(() => useOrgPresenceMap("active_org"));
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getMock).not.toHaveBeenCalled();
+
+    connectedHandler()?.();
+
+    await waitFor(() => {
+      expect(authorizeMock).toHaveBeenCalledTimes(2);
+      expect(getMock).toHaveBeenCalledWith("presence:org_active_org");
+    });
   });
 });

--- a/apps/web/src/lib/ably/use-org-presence-map.ts
+++ b/apps/web/src/lib/ably/use-org-presence-map.ts
@@ -10,6 +10,8 @@ import type * as Ably from "ably";
 import { useAbly } from "ably/react";
 import { useEffect, useState } from "react";
 
+import { organizationIdsFromAblyCapability } from "./organization-ids-from-ably-capability";
+
 const RECLASSIFY_TICK_MS = 30_000;
 
 function samePresenceMap(
@@ -39,6 +41,10 @@ function membersToInputs(
 /**
  * Live org presence map: userId → online | afk.
  * Users absent from the map are offline (caller uses fallback).
+ *
+ * Gates attach on token capability (same as publisher). Attaching
+ * `presence:org_*` without a grant yields Ably capability-denied failures
+ * (SOKOSUMI-R0) as unhandled rejections.
  */
 export function useOrgPresenceMap(
   organizationId: string | null | undefined,
@@ -54,10 +60,14 @@ export function useOrgPresenceMap(
       return;
     }
 
+    // Narrow for async start() — TS does not carry control-flow into closures.
+    const activeOrganizationId = organizationId;
+
     let cancelled = false;
-    const channelName = makeOrgPresenceChannelName(organizationId);
-    const channel = ably.channels.get(channelName);
+    let channel: Ably.RealtimeChannel | null = null;
     let members = new Map<string, Ably.PresenceMessage>();
+    let intervalId: number | undefined;
+    let onConnected: (() => void) | undefined;
 
     function recompute() {
       if (cancelled) {
@@ -89,6 +99,9 @@ export function useOrgPresenceMap(
     }
 
     async function hydrate() {
+      if (!channel) {
+        return;
+      }
       try {
         const current = await channel.presence.get();
         if (cancelled) {
@@ -105,32 +118,69 @@ export function useOrgPresenceMap(
       }
     }
 
-    channel.presence.subscribe("enter", upsertMember);
-    channel.presence.subscribe("update", upsertMember);
-    channel.presence.subscribe("present", upsertMember);
-    channel.presence.subscribe("leave", removeMember);
-    channel.presence.subscribe("absent", removeMember);
+    async function start() {
+      let tokenDetails: Ably.TokenDetails | null = null;
+      try {
+        tokenDetails = await ably.auth.authorize();
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Ably authorize for presence map failed:", error);
+        }
+        return;
+      }
+      if (cancelled) {
+        return;
+      }
 
-    void hydrate();
+      // Missing/unparseable capability → no attach (never fall back to bare
+      // organizationId; that is SOKOSUMI-R0). Empty grant list same.
+      const grantedIds =
+        organizationIdsFromAblyCapability(tokenDetails?.capability) ?? [];
+      if (!grantedIds.includes(activeOrganizationId)) {
+        if (!cancelled) {
+          setPresenceByUserId(new Map());
+        }
+        return;
+      }
 
-    // Non-resumable reconnects can leave local members stale (ghost Online/AFK).
-    // Replace from presence.get() whenever Ably reconnects.
-    const onConnected = () => {
+      const channelName = makeOrgPresenceChannelName(activeOrganizationId);
+      channel = ably.channels.get(channelName);
+
+      channel.presence.subscribe("enter", upsertMember);
+      channel.presence.subscribe("update", upsertMember);
+      channel.presence.subscribe("present", upsertMember);
+      channel.presence.subscribe("leave", removeMember);
+      channel.presence.subscribe("absent", removeMember);
+
       void hydrate();
-    };
-    ably.connection.on("connected", onConnected);
 
-    const intervalId = window.setInterval(recompute, RECLASSIFY_TICK_MS);
+      // Non-resumable reconnects can leave local members stale (ghost Online/AFK).
+      // Replace from presence.get() whenever Ably reconnects.
+      onConnected = () => {
+        void hydrate();
+      };
+      ably.connection.on("connected", onConnected);
+
+      intervalId = window.setInterval(recompute, RECLASSIFY_TICK_MS);
+    }
+
+    void start();
 
     return () => {
       cancelled = true;
-      window.clearInterval(intervalId);
-      ably.connection.off("connected", onConnected);
-      channel.presence.unsubscribe("enter", upsertMember);
-      channel.presence.unsubscribe("update", upsertMember);
-      channel.presence.unsubscribe("present", upsertMember);
-      channel.presence.unsubscribe("leave", removeMember);
-      channel.presence.unsubscribe("absent", removeMember);
+      if (intervalId != null) {
+        window.clearInterval(intervalId);
+      }
+      if (onConnected) {
+        ably.connection.off("connected", onConnected);
+      }
+      if (channel) {
+        channel.presence.unsubscribe("enter", upsertMember);
+        channel.presence.unsubscribe("update", upsertMember);
+        channel.presence.unsubscribe("present", upsertMember);
+        channel.presence.unsubscribe("leave", removeMember);
+        channel.presence.unsubscribe("absent", removeMember);
+      }
       // Do not detach: publisher owns channel lifecycle on shared RealtimeChannel
       // instances. Detach here would leave this client from org presence.
     };

--- a/apps/web/src/lib/ably/use-org-presence-map.ts
+++ b/apps/web/src/lib/ably/use-org-presence-map.ts
@@ -61,7 +61,7 @@ export function useOrgPresenceMap(
       return;
     }
 
-    // Narrow for async start() — TS does not carry control-flow into closures.
+    // Narrow for async runSyncOnce() — TS does not carry control-flow into closures.
     const activeOrganizationId = organizationId;
     // Drop prior org roster immediately so UI does not flash stale members
     // while authorize runs for the new workspace.

--- a/apps/web/src/lib/ably/use-org-presence-map.ts
+++ b/apps/web/src/lib/ably/use-org-presence-map.ts
@@ -155,6 +155,9 @@ export function useOrgPresenceMap(
       } catch (error) {
         if (!cancelled) {
           console.error("Ably authorize for presence map failed:", error);
+          // Prior successful attach must not keep handlers/interval/roster after
+          // a reconnect auth failure (REST fallback needs empty map).
+          tearDownSubscription();
         }
         return;
       }

--- a/apps/web/src/lib/ably/use-org-presence-map.ts
+++ b/apps/web/src/lib/ably/use-org-presence-map.ts
@@ -44,7 +44,8 @@ function membersToInputs(
  *
  * Gates attach on token capability (same as publisher). Attaching
  * `presence:org_*` without a grant yields Ably capability-denied failures
- * (SOKOSUMI-R0) as unhandled rejections.
+ * (SOKOSUMI-R0) as unhandled rejections. Re-syncs on `connected` so a
+ * transient auth/grant miss can recover without remounting.
  */
 export function useOrgPresenceMap(
   organizationId: string | null | undefined,
@@ -62,12 +63,17 @@ export function useOrgPresenceMap(
 
     // Narrow for async start() — TS does not carry control-flow into closures.
     const activeOrganizationId = organizationId;
+    // Drop prior org roster immediately so UI does not flash stale members
+    // while authorize runs for the new workspace.
+    setPresenceByUserId(new Map());
 
     let cancelled = false;
     let channel: Ably.RealtimeChannel | null = null;
     let members = new Map<string, Ably.PresenceMessage>();
     let intervalId: number | undefined;
-    let onConnected: (() => void) | undefined;
+    /** Coalesce mount + connected so authorize never overlaps. */
+    let syncInFlight = false;
+    let syncQueued = false;
 
     function recompute() {
       if (cancelled) {
@@ -98,6 +104,30 @@ export function useOrgPresenceMap(
       recompute();
     }
 
+    function unsubscribePresence() {
+      if (!channel) {
+        return;
+      }
+      channel.presence.unsubscribe("enter", upsertMember);
+      channel.presence.unsubscribe("update", upsertMember);
+      channel.presence.unsubscribe("present", upsertMember);
+      channel.presence.unsubscribe("leave", removeMember);
+      channel.presence.unsubscribe("absent", removeMember);
+    }
+
+    function tearDownSubscription() {
+      unsubscribePresence();
+      channel = null;
+      members = new Map();
+      if (intervalId != null) {
+        window.clearInterval(intervalId);
+        intervalId = undefined;
+      }
+      if (!cancelled) {
+        setPresenceByUserId(new Map());
+      }
+    }
+
     async function hydrate() {
       if (!channel) {
         return;
@@ -118,7 +148,7 @@ export function useOrgPresenceMap(
       }
     }
 
-    async function start() {
+    async function runSyncOnce() {
       let tokenDetails: Ably.TokenDetails | null = null;
       try {
         tokenDetails = await ably.auth.authorize();
@@ -137,50 +167,60 @@ export function useOrgPresenceMap(
       const grantedIds =
         organizationIdsFromAblyCapability(tokenDetails?.capability) ?? [];
       if (!grantedIds.includes(activeOrganizationId)) {
-        if (!cancelled) {
-          setPresenceByUserId(new Map());
-        }
+        tearDownSubscription();
         return;
       }
 
-      const channelName = makeOrgPresenceChannelName(activeOrganizationId);
-      channel = ably.channels.get(channelName);
+      if (!channel) {
+        const channelName = makeOrgPresenceChannelName(activeOrganizationId);
+        channel = ably.channels.get(channelName);
 
-      channel.presence.subscribe("enter", upsertMember);
-      channel.presence.subscribe("update", upsertMember);
-      channel.presence.subscribe("present", upsertMember);
-      channel.presence.subscribe("leave", removeMember);
-      channel.presence.subscribe("absent", removeMember);
+        channel.presence.subscribe("enter", upsertMember);
+        channel.presence.subscribe("update", upsertMember);
+        channel.presence.subscribe("present", upsertMember);
+        channel.presence.subscribe("leave", removeMember);
+        channel.presence.subscribe("absent", removeMember);
 
-      void hydrate();
+        intervalId = window.setInterval(recompute, RECLASSIFY_TICK_MS);
+      }
 
       // Non-resumable reconnects can leave local members stale (ghost Online/AFK).
-      // Replace from presence.get() whenever Ably reconnects.
-      onConnected = () => {
-        void hydrate();
-      };
-      ably.connection.on("connected", onConnected);
-
-      intervalId = window.setInterval(recompute, RECLASSIFY_TICK_MS);
+      // Replace from presence.get() whenever Ably reconnects / re-syncs.
+      await hydrate();
     }
 
-    void start();
+    async function syncChannels() {
+      if (syncInFlight) {
+        syncQueued = true;
+        return;
+      }
+      syncInFlight = true;
+      try {
+        do {
+          syncQueued = false;
+          await runSyncOnce();
+        } while (syncQueued && !cancelled);
+      } finally {
+        syncInFlight = false;
+      }
+    }
+
+    // Always listen — including after deny/auth fail — so a later reconnect
+    // can pick up a grant (publisher re-authorizes on connected the same way).
+    const onConnected = () => {
+      void syncChannels();
+    };
+    ably.connection.on("connected", onConnected);
+    void syncChannels();
 
     return () => {
       cancelled = true;
+      syncQueued = false;
+      ably.connection.off("connected", onConnected);
       if (intervalId != null) {
         window.clearInterval(intervalId);
       }
-      if (onConnected) {
-        ably.connection.off("connected", onConnected);
-      }
-      if (channel) {
-        channel.presence.unsubscribe("enter", upsertMember);
-        channel.presence.unsubscribe("update", upsertMember);
-        channel.presence.unsubscribe("present", upsertMember);
-        channel.presence.unsubscribe("leave", removeMember);
-        channel.presence.unsubscribe("absent", removeMember);
-      }
+      unsubscribePresence();
       // Do not detach: publisher owns channel lifecycle on shared RealtimeChannel
       // instances. Detach here would leave this client from org presence.
     };


### PR DESCRIPTION
## Summary

- **Bug (SOKOSUMI-R0):** `useOrgPresenceMap` attached `presence:org_{activeOrg}` from the UI without checking Ably token capability. When the token lacked that channel, Ably failed attach with `Channel denied access based on given capability` as an unhandled rejection on `/tasks` and other app-shell routes.
- **Fix:** Authorize first, parse granted org IDs from token capability (same helper as the presence publisher), and only subscribe/`presence.get` when the active org is granted. No grant or auth failure → empty map (REST fallback), no attach.
- **Tests:** Regression coverage for missing capability, granted org, and authorize failure.

## TLDR

**Issue:** Presence roster map joined Ably channels the token did not allow.  
**Fix:** Only attach after `authorize()` and capability check, like the publisher.

## Test plan

- [x] `pnpm --filter web exec vitest run src/lib/ably/__tests__/use-org-presence-map.test.tsx`
- [x] `pnpm --filter web exec vitest run src/lib/ably/__tests__/ src/contexts/__tests__/org-presence-provider.test.tsx` (63 tests)
- [ ] After deploy: confirm SOKOSUMI-R0 stops escalating; presence dots still work when token grants the active org
- [ ] If presence stays empty in prod, verify Mainnet Ably subscribe-key includes `presence:*` (wildcard `presence:org_*` does not match `presence:org_{uuid}`)

Fixes SOKOSUMI-R0