### PR TITLE
fix(chat): align sidebar room icons in shared leading slot

### DIFF
--- a/apps/web/src/components/chat/__tests__/channel-discoverability-icon.test.tsx
+++ b/apps/web/src/components/chat/__tests__/channel-discoverability-icon.test.tsx
@@ -19,11 +19,11 @@ describe("ChannelDiscoverabilityIcon", () => {
     expect(slots).toHaveLength(3);
 
     for (const slot of slots) {
-      // Outer box matches DM avatars (size-5); glyph left-aligned for optical match.
+      // Outer box matches DM avatars (size-5); glyph stays slightly smaller.
       expect(slot.className).toContain("size-5");
       expect(slot.className).toContain("[&_svg]:size-3.5");
       expect(slot.className).toContain("items-center");
-      expect(slot.className).toContain("justify-start");
+      expect(slot.className).toContain("justify-center");
     }
 
     // Direct child of the menu row must not be an svg, or [&>svg]:size-4 wins.

--- a/apps/web/src/components/chat/__tests__/channel-discoverability-icon.test.tsx
+++ b/apps/web/src/components/chat/__tests__/channel-discoverability-icon.test.tsx
@@ -19,11 +19,11 @@ describe("ChannelDiscoverabilityIcon", () => {
     expect(slots).toHaveLength(3);
 
     for (const slot of slots) {
-      // Outer box matches DM avatars (size-5); glyph stays slightly smaller.
+      // Outer box matches DM avatars (size-5); glyph left-aligned for optical match.
       expect(slot.className).toContain("size-5");
       expect(slot.className).toContain("[&_svg]:size-3.5");
       expect(slot.className).toContain("items-center");
-      expect(slot.className).toContain("justify-center");
+      expect(slot.className).toContain("justify-start");
     }
 
     // Direct child of the menu row must not be an svg, or [&>svg]:size-4 wins.

--- a/apps/web/src/components/chat/__tests__/channel-discoverability-icon.test.tsx
+++ b/apps/web/src/components/chat/__tests__/channel-discoverability-icon.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ChannelDiscoverabilityIcon } from "../channel-discoverability-icon";
 
 describe("ChannelDiscoverabilityIcon", () => {
-  it("keeps public/private/external icons in equal text-sm slots under sidebar svg override", () => {
+  it("keeps public/private/external icons in equal size-5 slots under sidebar svg override", () => {
     const { container } = render(
       <a className="flex items-center gap-2 text-sm [&>svg]:size-4">
         <ChannelDiscoverabilityIcon discoverability="public" />
@@ -19,8 +19,11 @@ describe("ChannelDiscoverabilityIcon", () => {
     expect(slots).toHaveLength(3);
 
     for (const slot of slots) {
-      expect(slot.className).toContain("size-3.5");
+      // Outer box matches DM avatars (size-5); glyph stays slightly smaller.
+      expect(slot.className).toContain("size-5");
       expect(slot.className).toContain("[&_svg]:size-3.5");
+      expect(slot.className).toContain("items-center");
+      expect(slot.className).toContain("justify-center");
     }
 
     // Direct child of the menu row must not be an svg, or [&>svg]:size-4 wins.

--- a/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
@@ -308,6 +308,36 @@ async function openRoomMenu(label = "general") {
   return user;
 }
 
+describe("ChatRoomSidebarRow leading slot", () => {
+  it("wraps any room leading icon in a min-w-5 / h-5 alignment slot", () => {
+    const { container } = render(
+      <ChatRoomSidebarRow
+        room={makeRoom()}
+        href="/chat/rooms/room-1"
+        label="general"
+        isActive={false}
+        leading={<span data-testid="custom-leading">#</span>}
+        onRoomUpdated={vi.fn()}
+      />,
+    );
+
+    const leading = screen.getByTestId("custom-leading");
+    const slot = leading.parentElement;
+    expect(slot).not.toBeNull();
+    expect(slot?.getAttribute("data-slot")).toBe("room-leading");
+    // min-w-5 aligns single icons; width may grow for multi-avatar stacks.
+    expect(slot?.className).toContain("min-w-5");
+    expect(slot?.className).toContain("h-5");
+    expect(slot?.className).toContain("shrink-0");
+    expect(slot?.className).toContain("items-center");
+    expect(slot?.className).toContain("justify-center");
+
+    // Slot is a direct child of the room link so every room type shares the same column.
+    const link = container.querySelector('a[href="/chat/rooms/room-1"]');
+    expect(link?.firstElementChild).toBe(slot);
+  });
+});
+
 describe("ChatRoomSidebarRow leave menu", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
@@ -309,7 +309,7 @@ async function openRoomMenu(label = "general") {
 }
 
 describe("ChatRoomSidebarRow leading slot", () => {
-  it("wraps any room leading icon in a min-w-5 / h-5 alignment slot", () => {
+  it("wraps any room leading icon in a fixed size-5 alignment slot", () => {
     const { container } = render(
       <ChatRoomSidebarRow
         room={makeRoom()}
@@ -325,12 +325,11 @@ describe("ChatRoomSidebarRow leading slot", () => {
     const slot = leading.parentElement;
     expect(slot).not.toBeNull();
     expect(slot?.getAttribute("data-slot")).toBe("room-leading");
-    // min-w-5 aligns single icons; width may grow for multi-avatar stacks.
-    expect(slot?.className).toContain("min-w-5");
-    expect(slot?.className).toContain("h-5");
+    // Fixed size-5 so multi-avatar stacks cannot push labels right.
+    expect(slot?.className).toContain("size-5");
     expect(slot?.className).toContain("shrink-0");
     expect(slot?.className).toContain("items-center");
-    expect(slot?.className).toContain("justify-center");
+    expect(slot?.className).toContain("justify-start");
 
     // Slot is a direct child of the room link so every room type shares the same column.
     const link = container.querySelector('a[href="/chat/rooms/room-1"]');

--- a/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
@@ -309,7 +309,7 @@ async function openRoomMenu(label = "general") {
 }
 
 describe("ChatRoomSidebarRow leading slot", () => {
-  it("wraps any room leading icon in a fixed size-5 alignment slot", () => {
+  it("wraps any room leading icon in a min-w-5 / h-5 alignment slot", () => {
     const { container } = render(
       <ChatRoomSidebarRow
         room={makeRoom()}
@@ -325,11 +325,12 @@ describe("ChatRoomSidebarRow leading slot", () => {
     const slot = leading.parentElement;
     expect(slot).not.toBeNull();
     expect(slot?.getAttribute("data-slot")).toBe("room-leading");
-    // Fixed size-5 so multi-avatar stacks cannot push labels right.
-    expect(slot?.className).toContain("size-5");
+    // min-w-5 aligns single icons; width may grow for multi-avatar stacks.
+    expect(slot?.className).toContain("min-w-5");
+    expect(slot?.className).toContain("h-5");
     expect(slot?.className).toContain("shrink-0");
     expect(slot?.className).toContain("items-center");
-    expect(slot?.className).toContain("justify-start");
+    expect(slot?.className).toContain("justify-center");
 
     // Slot is a direct child of the room link so every room type shares the same column.
     const link = container.querySelector('a[href="/chat/rooms/room-1"]');

--- a/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
+++ b/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
@@ -114,7 +114,7 @@ describe("DirectRoomAvatarStack", () => {
     openDirectMock.mockResolvedValue({ ok: true, roomId: "dm-2" });
   });
 
-  it("fits empty and 1:1 DM leadings in a min-w-5 / h-5 box matching channel icons", () => {
+  it("fits empty, 1:1, and group DM leadings in a fixed size-5 box", () => {
     const { container: emptyContainer, unmount } = render(
       <DirectRoomAvatarStack
         room={makeDirectRoom({ userMembers: [makeUser("me", "Me")] })}
@@ -129,7 +129,7 @@ describe("DirectRoomAvatarStack", () => {
     expect(emptyRoot?.className).toContain("shrink-0");
     unmount();
 
-    const { container } = render(
+    const { container: singleContainer, unmount: unmountSingle } = render(
       <DirectRoomAvatarStack
         room={makeDirectRoom()}
         currentUserId="me"
@@ -138,12 +138,33 @@ describe("DirectRoomAvatarStack", () => {
       />,
     );
 
-    // min-w-5 / h-5 matches channel icon column; multi stacks may grow wider.
-    const stackRoot = container.firstElementChild;
-    expect(stackRoot?.className).toContain("min-w-5");
-    expect(stackRoot?.className).toContain("h-5");
-    expect(stackRoot?.className).toContain("shrink-0");
-    expect(stackRoot?.className).toContain("items-center");
+    const singleRoot = singleContainer.firstElementChild;
+    expect(singleRoot?.className).toContain("size-5");
+    expect(singleRoot?.className).toContain("shrink-0");
+    unmountSingle();
+
+    // Group stacks stay size-5 so the label column does not shift right.
+    const { container: groupContainer } = render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom({
+          userMembers: [
+            makeUser("me", "Me"),
+            makeUser("alice", "Alice"),
+            makeUser("bob", "Bob"),
+          ],
+        })}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId={null}
+      />,
+    );
+
+    const groupRoot = groupContainer.firstElementChild;
+    expect(groupRoot?.className).toContain("size-5");
+    expect(groupRoot?.className).toContain("shrink-0");
+    expect(groupRoot?.className).toContain("relative");
+    expect(screen.getByTestId("dm-sidebar-avatar-alice")).toBeInTheDocument();
+    expect(screen.getByTestId("dm-sidebar-avatar-bob")).toBeInTheDocument();
   });
 
   it("shows participant hover card for a 1:1 human DM avatar", async () => {

--- a/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
+++ b/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
@@ -114,6 +114,38 @@ describe("DirectRoomAvatarStack", () => {
     openDirectMock.mockResolvedValue({ ok: true, roomId: "dm-2" });
   });
 
+  it("fits empty and 1:1 DM leadings in a min-w-5 / h-5 box matching channel icons", () => {
+    const { container: emptyContainer, unmount } = render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom({ userMembers: [makeUser("me", "Me")] })}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId={null}
+      />,
+    );
+
+    const emptyRoot = emptyContainer.firstElementChild;
+    expect(emptyRoot?.className).toContain("size-5");
+    expect(emptyRoot?.className).toContain("shrink-0");
+    unmount();
+
+    const { container } = render(
+      <DirectRoomAvatarStack
+        room={makeDirectRoom()}
+        currentUserId="me"
+        canOpenHumanDirect
+        selectedRoomId={null}
+      />,
+    );
+
+    // min-w-5 / h-5 matches channel icon column; multi stacks may grow wider.
+    const stackRoot = container.firstElementChild;
+    expect(stackRoot?.className).toContain("min-w-5");
+    expect(stackRoot?.className).toContain("h-5");
+    expect(stackRoot?.className).toContain("shrink-0");
+    expect(stackRoot?.className).toContain("items-center");
+  });
+
   it("shows participant hover card for a 1:1 human DM avatar", async () => {
     const user = userEvent.setup();
     render(

--- a/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
+++ b/apps/web/src/components/chat/__tests__/direct-room-avatar-stack.test.tsx
@@ -114,7 +114,7 @@ describe("DirectRoomAvatarStack", () => {
     openDirectMock.mockResolvedValue({ ok: true, roomId: "dm-2" });
   });
 
-  it("fits empty, 1:1, and group DM leadings in a fixed size-5 box", () => {
+  it("fits empty and 1:1 DM leadings in a min-w-5 / h-5 box matching channel icons", () => {
     const { container: emptyContainer, unmount } = render(
       <DirectRoomAvatarStack
         room={makeDirectRoom({ userMembers: [makeUser("me", "Me")] })}
@@ -129,7 +129,7 @@ describe("DirectRoomAvatarStack", () => {
     expect(emptyRoot?.className).toContain("shrink-0");
     unmount();
 
-    const { container: singleContainer, unmount: unmountSingle } = render(
+    const { container } = render(
       <DirectRoomAvatarStack
         room={makeDirectRoom()}
         currentUserId="me"
@@ -138,33 +138,12 @@ describe("DirectRoomAvatarStack", () => {
       />,
     );
 
-    const singleRoot = singleContainer.firstElementChild;
-    expect(singleRoot?.className).toContain("size-5");
-    expect(singleRoot?.className).toContain("shrink-0");
-    unmountSingle();
-
-    // Group stacks stay size-5 so the label column does not shift right.
-    const { container: groupContainer } = render(
-      <DirectRoomAvatarStack
-        room={makeDirectRoom({
-          userMembers: [
-            makeUser("me", "Me"),
-            makeUser("alice", "Alice"),
-            makeUser("bob", "Bob"),
-          ],
-        })}
-        currentUserId="me"
-        canOpenHumanDirect
-        selectedRoomId={null}
-      />,
-    );
-
-    const groupRoot = groupContainer.firstElementChild;
-    expect(groupRoot?.className).toContain("size-5");
-    expect(groupRoot?.className).toContain("shrink-0");
-    expect(groupRoot?.className).toContain("relative");
-    expect(screen.getByTestId("dm-sidebar-avatar-alice")).toBeInTheDocument();
-    expect(screen.getByTestId("dm-sidebar-avatar-bob")).toBeInTheDocument();
+    // min-w-5 / h-5 matches channel icon column; multi stacks may grow wider.
+    const stackRoot = container.firstElementChild;
+    expect(stackRoot?.className).toContain("min-w-5");
+    expect(stackRoot?.className).toContain("h-5");
+    expect(stackRoot?.className).toContain("shrink-0");
+    expect(stackRoot?.className).toContain("items-center");
   });
 
   it("shows participant hover card for a 1:1 human DM avatar", async () => {

--- a/apps/web/src/components/chat/channel-discoverability-icon.tsx
+++ b/apps/web/src/components/chat/channel-discoverability-icon.tsx
@@ -9,7 +9,8 @@ interface ChannelDiscoverabilityIconProps {
 /**
  * Slack-like: `#` for public, lock for private, globe for external.
  * Outer size-5 matches DM avatars so every room row shares one leading column.
- * Glyph stays size-3.5; wrapper blocks sidebar `[&>svg]:size-4` override.
+ * Glyph left-aligned (not centered) so thin icons share the avatar left edge.
+ * Wrapper blocks sidebar `[&>svg]:size-4` override.
  */
 export function ChannelDiscoverabilityIcon({
   discoverability,
@@ -25,7 +26,7 @@ export function ChannelDiscoverabilityIcon({
   return (
     <span
       className={cn(
-        "inline-flex size-5 shrink-0 items-center justify-center [&_svg]:size-3.5",
+        "inline-flex size-5 shrink-0 items-center justify-start [&_svg]:size-3.5",
         className,
       )}
       aria-hidden

--- a/apps/web/src/components/chat/channel-discoverability-icon.tsx
+++ b/apps/web/src/components/chat/channel-discoverability-icon.tsx
@@ -8,7 +8,8 @@ interface ChannelDiscoverabilityIconProps {
 
 /**
  * Slack-like: `#` for public, lock for private, globe for external.
- * Wrapped so sidebar `[&>svg]:size-4` cannot override; size-3.5 matches text-sm.
+ * Outer size-5 matches DM avatars so every room row shares one leading column.
+ * Glyph stays size-3.5; wrapper blocks sidebar `[&>svg]:size-4` override.
  */
 export function ChannelDiscoverabilityIcon({
   discoverability,
@@ -24,7 +25,7 @@ export function ChannelDiscoverabilityIcon({
   return (
     <span
       className={cn(
-        "inline-flex size-3.5 shrink-0 items-center justify-center [&_svg]:size-3.5",
+        "inline-flex size-5 shrink-0 items-center justify-center [&_svg]:size-3.5",
         className,
       )}
       aria-hidden

--- a/apps/web/src/components/chat/channel-discoverability-icon.tsx
+++ b/apps/web/src/components/chat/channel-discoverability-icon.tsx
@@ -9,8 +9,7 @@ interface ChannelDiscoverabilityIconProps {
 /**
  * Slack-like: `#` for public, lock for private, globe for external.
  * Outer size-5 matches DM avatars so every room row shares one leading column.
- * Glyph left-aligned (not centered) so thin icons share the avatar left edge.
- * Wrapper blocks sidebar `[&>svg]:size-4` override.
+ * Glyph stays size-3.5; wrapper blocks sidebar `[&>svg]:size-4` override.
  */
 export function ChannelDiscoverabilityIcon({
   discoverability,
@@ -26,7 +25,7 @@ export function ChannelDiscoverabilityIcon({
   return (
     <span
       className={cn(
-        "inline-flex size-5 shrink-0 items-center justify-start [&_svg]:size-3.5",
+        "inline-flex size-5 shrink-0 items-center justify-center [&_svg]:size-3.5",
         className,
       )}
       aria-hidden

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -167,7 +167,7 @@ export function ChatRoomSidebarRow({
     >
       <span
         data-slot="room-leading"
-        className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center"
+        className="inline-flex size-5 shrink-0 items-center justify-start"
       >
         {leading}
       </span>

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -167,7 +167,7 @@ export function ChatRoomSidebarRow({
     >
       <span
         data-slot="room-leading"
-        className="inline-flex size-5 shrink-0 items-center justify-start"
+        className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center"
       >
         {leading}
       </span>

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -165,7 +165,12 @@ export function ChatRoomSidebarRow({
       )}
       href={href}
     >
-      {leading}
+      <span
+        data-slot="room-leading"
+        className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center"
+      >
+        {leading}
+      </span>
       <span className="min-w-0 flex-1">
         <span
           className={cn(

--- a/apps/web/src/components/chat/direct-room-avatar-stack.tsx
+++ b/apps/web/src/components/chat/direct-room-avatar-stack.tsx
@@ -78,43 +78,55 @@ export function DirectRoomAvatarStack({
     );
   }
 
+  // Fixed size-5 box so group stacks cannot widen the leading column.
+  // Extra faces overlap to the right (absolute) and may paint into the gap.
+  // Position on an outer span — HoverCard trigger forces `relative` and would
+  // fight `absolute` if both lived on the same node.
   return (
-    <span className="inline-flex h-5 min-w-5 shrink-0 items-center">
+    <span className="relative size-5 shrink-0">
       {participants.map((participant, index) => (
-        <ChatParticipantHoverCard
+        <span
           key={`${participant.kind}-${participant.id}`}
-          profile={participant}
-          side="right"
-          align="start"
-          className={cn("relative block", index > 0 && "-ml-2")}
+          className={cn(
+            "absolute top-1/2 -translate-y-1/2",
+            index === 0 && "left-0",
+            index === 1 && "left-1.5",
+            index === 2 && "left-3",
+          )}
           style={{ zIndex: participants.length - index }}
-          currentUserId={currentUserId}
-          canOpenHumanDirect={canOpenHumanDirect}
-          onOpenDirect={handleOpenDirect}
-          isOpeningDirect={
-            openingDirectKey === participantDirectKey(participant)
-          }
-          isDirectActionBusy={openingDirectKey != null}
-          interactive={false}
         >
-          <span
-            className="relative inline-flex"
-            data-testid={`dm-sidebar-avatar-${participant.id}`}
+          <ChatParticipantHoverCard
+            profile={participant}
+            side="right"
+            align="start"
+            currentUserId={currentUserId}
+            canOpenHumanDirect={canOpenHumanDirect}
+            onOpenDirect={handleOpenDirect}
+            isOpeningDirect={
+              openingDirectKey === participantDirectKey(participant)
+            }
+            isDirectActionBusy={openingDirectKey != null}
+            interactive={false}
           >
-            <Avatar className="border-sidebar-background size-5 border">
-              <AvatarImage alt="" src={participant.image ?? undefined} />
-              <AvatarFallback className="text-[0.5625rem] font-medium">
-                {getInitials(participant.name)}
-              </AvatarFallback>
-            </Avatar>
-            <LiveMemberPresenceDot
-              className="-right-0.5 -bottom-0.5 absolute size-2"
-              fallback={participant.presence}
-              isCoworker={participant.kind === "coworker"}
-              userId={participant.id}
-            />
-          </span>
-        </ChatParticipantHoverCard>
+            <span
+              className="relative inline-flex"
+              data-testid={`dm-sidebar-avatar-${participant.id}`}
+            >
+              <Avatar className="border-sidebar-background size-5 border">
+                <AvatarImage alt="" src={participant.image ?? undefined} />
+                <AvatarFallback className="text-[0.5625rem] font-medium">
+                  {getInitials(participant.name)}
+                </AvatarFallback>
+              </Avatar>
+              <LiveMemberPresenceDot
+                className="-right-0.5 -bottom-0.5 absolute size-2"
+                fallback={participant.presence}
+                isCoworker={participant.kind === "coworker"}
+                userId={participant.id}
+              />
+            </span>
+          </ChatParticipantHoverCard>
+        </span>
       ))}
     </span>
   );

--- a/apps/web/src/components/chat/direct-room-avatar-stack.tsx
+++ b/apps/web/src/components/chat/direct-room-avatar-stack.tsx
@@ -79,7 +79,7 @@ export function DirectRoomAvatarStack({
   }
 
   return (
-    <span className="inline-flex h-5 shrink-0 items-center">
+    <span className="inline-flex h-5 min-w-5 shrink-0 items-center">
       {participants.map((participant, index) => (
         <ChatParticipantHoverCard
           key={`${participant.kind}-${participant.id}`}

--- a/apps/web/src/components/chat/direct-room-avatar-stack.tsx
+++ b/apps/web/src/components/chat/direct-room-avatar-stack.tsx
@@ -78,55 +78,43 @@ export function DirectRoomAvatarStack({
     );
   }
 
-  // Fixed size-5 box so group stacks cannot widen the leading column.
-  // Extra faces overlap to the right (absolute) and may paint into the gap.
-  // Position on an outer span — HoverCard trigger forces `relative` and would
-  // fight `absolute` if both lived on the same node.
   return (
-    <span className="relative size-5 shrink-0">
+    <span className="inline-flex h-5 min-w-5 shrink-0 items-center">
       {participants.map((participant, index) => (
-        <span
+        <ChatParticipantHoverCard
           key={`${participant.kind}-${participant.id}`}
-          className={cn(
-            "absolute top-1/2 -translate-y-1/2",
-            index === 0 && "left-0",
-            index === 1 && "left-1.5",
-            index === 2 && "left-3",
-          )}
+          profile={participant}
+          side="right"
+          align="start"
+          className={cn("relative block", index > 0 && "-ml-2")}
           style={{ zIndex: participants.length - index }}
+          currentUserId={currentUserId}
+          canOpenHumanDirect={canOpenHumanDirect}
+          onOpenDirect={handleOpenDirect}
+          isOpeningDirect={
+            openingDirectKey === participantDirectKey(participant)
+          }
+          isDirectActionBusy={openingDirectKey != null}
+          interactive={false}
         >
-          <ChatParticipantHoverCard
-            profile={participant}
-            side="right"
-            align="start"
-            currentUserId={currentUserId}
-            canOpenHumanDirect={canOpenHumanDirect}
-            onOpenDirect={handleOpenDirect}
-            isOpeningDirect={
-              openingDirectKey === participantDirectKey(participant)
-            }
-            isDirectActionBusy={openingDirectKey != null}
-            interactive={false}
+          <span
+            className="relative inline-flex"
+            data-testid={`dm-sidebar-avatar-${participant.id}`}
           >
-            <span
-              className="relative inline-flex"
-              data-testid={`dm-sidebar-avatar-${participant.id}`}
-            >
-              <Avatar className="border-sidebar-background size-5 border">
-                <AvatarImage alt="" src={participant.image ?? undefined} />
-                <AvatarFallback className="text-[0.5625rem] font-medium">
-                  {getInitials(participant.name)}
-                </AvatarFallback>
-              </Avatar>
-              <LiveMemberPresenceDot
-                className="-right-0.5 -bottom-0.5 absolute size-2"
-                fallback={participant.presence}
-                isCoworker={participant.kind === "coworker"}
-                userId={participant.id}
-              />
-            </span>
-          </ChatParticipantHoverCard>
-        </span>
+            <Avatar className="border-sidebar-background size-5 border">
+              <AvatarImage alt="" src={participant.image ?? undefined} />
+              <AvatarFallback className="text-[0.5625rem] font-medium">
+                {getInitials(participant.name)}
+              </AvatarFallback>
+            </Avatar>
+            <LiveMemberPresenceDot
+              className="-right-0.5 -bottom-0.5 absolute size-2"
+              fallback={participant.presence}
+              isCoworker={participant.kind === "coworker"}
+              userId={participant.id}
+            />
+          </span>
+        </ChatParticipantHoverCard>
       ))}
     </span>
   );

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -789,10 +789,7 @@ export function OrganizationChatList({
                   }
                   isActive={activeRoomId === room.id}
                   leading={
-                    <Globe2
-                      className="text-muted-foreground size-3.5 shrink-0"
-                      aria-hidden
-                    />
+                    <ChannelDiscoverabilityIcon discoverability="external" />
                   }
                   onRoomUpdated={handleRoomUpdated}
                   dismissSheetOnNavigate={dismissSheetOnNavigate}


### PR DESCRIPTION
## Summary

- Shared leading slot on every chat sidebar room row (`min-w-5` / `h-5`) so channel, external, and DM icons share one size/position column
- Channel/external discoverability icons use a `size-5` outer box (glyph stays `size-3.5`); external joined rooms reuse `ChannelDiscoverabilityIcon` instead of a bare `Globe2`
- DM avatar stack uses matching `min-w-5` / `h-5` so 1:1 aligns with channels; multi-face stacks may grow wider

## Test plan

- [x] `pnpm --filter web test` on row / channel icon / DM stack tests
- [x] `pnpm check` + workspace typecheck (pre-commit)
- [ ] Visually confirm Channels, External, and Direct Messages icons align in the sidebar
- [ ] Confirm multi-person DM stacks still render without clipping labels