### PR TITLE
fix(chat): stop #301 on omitted pending invites

### DIFF
--- a/apps/web/src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
@@ -1,0 +1,196 @@
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatRoom } from "@/lib/clients/generated/core";
+
+import { OrganizationChatList } from "../organization-chat-list.client";
+
+/**
+ * Production: mobile `/chat/chats` mounts OrganizationChatList without
+ * `pendingInvitations`. Default `= []` creates a new array every render;
+ * render-time `pendingInvitations !== prevPendingInvitations` sync then
+ * never converges → React #301 → Chat Error boundary.
+ */
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/chat/chats",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/contexts/lazy-ably-provider", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/ably/use-chat-membership-revoked-control", () => ({
+  useChatMembershipRevokedControl: () => {},
+}));
+
+vi.mock("@/hooks/use-chat-unread-document-title", () => ({
+  useChatUnreadDocumentTitle: () => {},
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  acceptChatRoomInvitationAction: vi.fn(),
+  declineChatRoomInvitationAction: vi.fn(),
+  deleteRoomAction: vi.fn(),
+  listPendingChatRoomInvitationsAction: vi.fn(async () => ({
+    ok: true,
+    value: [],
+  })),
+  restoreRoomAction: vi.fn(),
+}));
+
+vi.mock("@/app/chat/components/browse-channels-dialog", () => ({
+  BrowseChannelsDialog: () => null,
+}));
+
+vi.mock("@/app/chat/components/room-helpers", () => ({
+  getRoomDisplayName: () => "room",
+}));
+
+vi.mock("../chat-room-sidebar-row", () => ({
+  ChatRoomSidebarRow: () => null,
+}));
+
+vi.mock("../direct-room-avatar-stack", () => ({
+  DirectRoomAvatarStack: () => null,
+}));
+
+vi.mock("../organization-chat-list.actions", () => ({
+  listOrganizationChatRoomsAction: vi.fn(async () => ({
+    ok: true,
+    value: { rooms: [], nextCursor: null },
+  })),
+  listOrganizationArchivedChatRoomsAction: vi.fn(async () => ({
+    ok: true,
+    value: { rooms: [], nextCursor: null },
+  })),
+  loadMoreOrganizationArchivedChatRoomsAction: vi.fn(),
+  loadMoreOrganizationChatRoomsAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarMenu: ({ children }: { children: ReactNode }) => <ul>{children}</ul>,
+  SidebarMenuItem: ({ children }: { children: ReactNode }) => (
+    <li>{children}</li>
+  ),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AlertDialogAction: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CollapsibleTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const emptyRooms: ChatRoom[] = [];
+
+function renderChatsTabList() {
+  return (
+    <OrganizationChatList
+      rooms={emptyRooms}
+      roomsNextCursor={null}
+      archivedRooms={emptyRooms}
+      archivedRoomsNextCursor={null}
+      currentUserId="user-1"
+      organizationId="org-1"
+      canDeleteArchivedRooms={false}
+      dismissSheetOnNavigate={false}
+    />
+  );
+}
+
+describe("OrganizationChatList pendingInvitations default (Chat Error / #301)", () => {
+  it("survives re-render when pendingInvitations prop is omitted", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const { rerender } = render(renderChatsTabList());
+      expect(() => {
+        rerender(renderChatsTabList());
+      }).not.toThrow();
+      expect(
+        consoleError.mock.calls.some((call) =>
+          call.some((arg) =>
+            typeof arg === "string"
+              ? arg.includes("Too many re-renders")
+              : arg instanceof Error &&
+                arg.message.includes("Too many re-renders"),
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -89,6 +89,10 @@ import {
 
 const ORGANIZATION_CHAT_POLL_MS = 15_000;
 
+/** Stable empty default — inline `= []` is a new array every render and
+ *  infinite-loops the render-time pendingInvitations sync (React #301). */
+const EMPTY_PENDING_INVITATIONS: ChatRoomInvitation[] = [];
+
 /** Upsert first-page rooms; keep older rows previously appended via load-more. */
 function upsertFirstPageRooms(
   firstPage: ChatRoom[],
@@ -231,7 +235,7 @@ export function OrganizationChatList({
   roomsNextCursor,
   archivedRooms,
   archivedRoomsNextCursor,
-  pendingInvitations = [],
+  pendingInvitations = EMPTY_PENDING_INVITATIONS,
   currentUserId,
   organizationId,
   canDeleteArchivedRooms = false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mobile **Chats** (`/chat/chats`) mounts `OrganizationChatList` without `pendingInvitations`. The prop defaulted to inline `= []`, so every render got a **new** empty array. Render-time sync (`pendingInvitations !== prevPendingInvitations`) never converged → React **#301** (too many re-renders) → **Chat Error** boundary.

Fix: module-level `EMPTY_PENDING_INVITATIONS` stable default.

## Hypothesis (diagnosing-bugs)

Correct cause: default-arg identity trap + render-time prop sync on the `/chat/chats` call site (sidebar already passes a real array).

Console **#418** (hydration text) and Sentry tunnel **404** (`/4yv3iq04…`) look separate/noise; this PR targets the Chat Error / #301 path.

## Verification

```bash
pnpm --filter web test src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
```

- Red without fix (`Too many re-renders`)
- Green with stable empty default

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f946ef00-65df-41f7-ad86-b3500d3ff438?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f946ef00-65df-41f7-ad86-b3500d3ff438&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

