### PR TITLE
fix(chat): tighten coworker onboarding copy

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1557,8 +1557,8 @@
         "openFab": "Coworker-Chat starten",
         "greeting": "Willkommen!",
         "greetingWithName": "Willkommen {name}!",
-        "intentTitle": "Wofür bist du hier?",
-        "intentDescription": "Wähle eine Richtung — wir schlagen den passenden Coworker und Starter-Prompts vor.",
+        "intentTitle": "Womit möchtest du starten?",
+        "intentDescription": "Wähle einen Schwerpunkt — wir empfehlen den passenden Coworker und Starter-Prompts.",
         "intentChoices": {
           "chat": "Gespräch",
           "tasks": "Aufgaben & Projekte",
@@ -1569,12 +1569,12 @@
           "tasks": "Arbeit aufteilen, Fortschritt verfolgen oder ein Projekt voranbringen.",
           "either": "Wir starten mit Elena und einer Einstiegsidee."
         },
-        "goalTitle": "Starter ausprobieren — oder selbst schreiben",
-        "goalDescription": "Tippe einen Prompt an, um deine erste Nachricht vorzufüllen, oder schreibe unten etwas Eigenes.",
-        "goalLabel": "Dein Ziel",
-        "goalPlaceholder": "z. B. Hilf mir, ein Wochenupdate zu schreiben",
+        "goalTitle": "Starter-Prompt wählen oder selbst formulieren",
+        "goalDescription": "Wähle einen Prompt, um deine erste Nachricht vorzufüllen, oder schreibe unten etwas Eigenes.",
+        "goalLabel": "Deine Nachricht",
+        "goalPlaceholder": "Beispiel: Hilf mir, ein Wochenupdate zu schreiben",
         "tryAsking": {
-          "label": "Versuch’s mal mit",
+          "label": "Vorgeschlagene Prompts",
           "orDivider": "oder",
           "prompts": {
             "chat": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1557,8 +1557,8 @@
         "openFab": "Start coworker chat",
         "greeting": "Welcome!",
         "greetingWithName": "Welcome {name}!",
-        "intentTitle": "What are you here to do?",
-        "intentDescription": "Pick a lane so we can suggest the right coworker and starter prompts.",
+        "intentTitle": "What would you like to focus on?",
+        "intentDescription": "Choose a focus so we can recommend the right coworker and starter prompts.",
         "intentChoices": {
           "chat": "Conversation",
           "tasks": "Tasks & projects",
@@ -1569,12 +1569,12 @@
           "tasks": "Break work down, track progress, or move a project forward.",
           "either": "We'll open with Elena and a starter idea."
         },
-        "goalTitle": "Try a starter — or write your own",
-        "goalDescription": "Tap a prompt to pre-fill your first message, or type something else below.",
-        "goalLabel": "Your goal",
-        "goalPlaceholder": "e.g. Help me draft a weekly update",
+        "goalTitle": "Choose a starter prompt or write your own",
+        "goalDescription": "Select a prompt to prefill your first message, or write your own below.",
+        "goalLabel": "Your message",
+        "goalPlaceholder": "Example: Help me draft a weekly update",
         "tryAsking": {
-          "label": "Try asking",
+          "label": "Suggested prompts",
           "orDivider": "or",
           "prompts": {
             "chat": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1557,8 +1557,8 @@
         "openFab": "Iniciar chat con coworker",
         "greeting": "¡Bienvenido!",
         "greetingWithName": "¡Bienvenido {name}!",
-        "intentTitle": "¿Para qué estás aquí?",
-        "intentDescription": "Elige un camino para sugerirte el coworker y los prompts iniciales adecuados.",
+        "intentTitle": "¿En qué te gustaría centrarte?",
+        "intentDescription": "Elige un enfoque para recomendarte el coworker y los prompts iniciales adecuados.",
         "intentChoices": {
           "chat": "Conversación",
           "tasks": "Tareas y proyectos",
@@ -1569,12 +1569,12 @@
           "tasks": "Dividir el trabajo, seguir el progreso o avanzar un proyecto.",
           "either": "Abrimos con Elena y una idea para empezar."
         },
-        "goalTitle": "Prueba un inicio — o escribe el tuyo",
-        "goalDescription": "Toca un prompt para rellenar tu primer mensaje, o escribe algo abajo.",
-        "goalLabel": "Tu objetivo",
-        "goalPlaceholder": "p. ej. Ayúdame a redactar un resumen semanal",
+        "goalTitle": "Elige un prompt inicial o escribe el tuyo",
+        "goalDescription": "Selecciona un prompt para rellenar tu primer mensaje, o escribe el tuyo abajo.",
+        "goalLabel": "Tu mensaje",
+        "goalPlaceholder": "Ejemplo: Ayúdame a redactar un resumen semanal",
         "tryAsking": {
-          "label": "Prueba a preguntar",
+          "label": "Prompts sugeridos",
           "orDivider": "o",
           "prompts": {
             "chat": {


### PR DESCRIPTION
## Summary

- Make chat coworker onboarding copy more professional on the intent and starter-prompt steps.
- Update English, German, and Spanish message catalogs in parallel.

### Copy changes (EN)

**Step 1 — intent**
- Title: "What are you here to do?" → "What would you like to focus on?"
- Description: "Pick a lane…" → "Choose a focus so we can recommend the right coworker and starter prompts."

**Step 2 — goal / starter prompts**
- Title: "Try a starter — or write your own" → "Choose a starter prompt or write your own"
- Description: "Tap a prompt…" → "Select a prompt to prefill your first message, or write your own below."
- Label: "Your goal" → "Your message"
- Placeholder: "e.g. …" → "Example: …"
- Chip header: "Try asking" → "Suggested prompts"

## Test plan

- [ ] Open coworker chat onboarding as a new user (or reset onboarding state)
- [ ] Confirm step 1 title/description read professionally
- [ ] Continue to step 2; confirm title, description, chip header, field label, and placeholder
- [ ] Spot-check `de` and `es` locales if available
- [ ] `pnpm --filter web messages:parity` (already green locally)