### PR TITLE
feat(database): add task x402 payment records

### DIFF
--- a/apps/core/src/helpers/deletion-evaluate.test.ts
+++ b/apps/core/src/helpers/deletion-evaluate.test.ts
@@ -1,3 +1,4 @@
+import { TaskX402PaymentStatus } from "@sokosumi/database";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -9,11 +10,13 @@ import {
 
 const {
   taskPaymentClaimFindFirstMock,
+  taskX402PaymentFindFirstMock,
   getMembersByOrganizationIdMock,
   isLastWorkspaceMock,
   captureMessageMock,
 } = vi.hoisted(() => ({
   taskPaymentClaimFindFirstMock: vi.fn(),
+  taskX402PaymentFindFirstMock: vi.fn(),
   getMembersByOrganizationIdMock: vi.fn(),
   isLastWorkspaceMock: vi.fn(),
   captureMessageMock: vi.fn(),
@@ -45,6 +48,9 @@ function createPrisma() {
     taskPaymentClaim: {
       findFirst: taskPaymentClaimFindFirstMock,
     },
+    taskX402Payment: {
+      findFirst: taskX402PaymentFindFirstMock,
+    },
   };
 }
 
@@ -71,6 +77,7 @@ describe("evaluateUserDeletion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     taskPaymentClaimFindFirstMock.mockResolvedValue(null);
+    taskX402PaymentFindFirstMock.mockResolvedValue(null);
   });
 
   it("returns empty when no payment-claim blockers apply", async () => {
@@ -135,6 +142,43 @@ describe("evaluateUserDeletion", () => {
       },
     });
   });
+
+  it("returns TASK_X402_PAYMENT_PENDING when a pending x402 payment exists", async () => {
+    mockClaimLookups({ reviewRequired: null, pending: null });
+    taskX402PaymentFindFirstMock.mockResolvedValue({ id: "x402_pending" });
+
+    await expect(
+      evaluateUserDeletion("user_delete", createPrisma() as never),
+    ).resolves.toEqual({
+      blockers: ["TASK_X402_PAYMENT_PENDING"],
+      reviewRequiredClaim: null,
+    });
+    expect(taskX402PaymentFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        status: TaskX402PaymentStatus.PENDING,
+        OR: [
+          { transaction: { userId: "user_delete" } },
+          { task: { ownerId: "user_delete" } },
+        ],
+      },
+      select: { id: true },
+    });
+  });
+
+  it("lists claim blockers before x402 pending when both apply", async () => {
+    mockClaimLookups({
+      reviewRequired: null,
+      pending: { id: "claim_pending" },
+    });
+    taskX402PaymentFindFirstMock.mockResolvedValue({ id: "x402_pending" });
+
+    await expect(
+      evaluateUserDeletion("user_delete", createPrisma() as never),
+    ).resolves.toEqual({
+      blockers: ["TASK_PAYMENT_CLAIM_PENDING", "TASK_X402_PAYMENT_PENDING"],
+      reviewRequiredClaim: null,
+    });
+  });
 });
 
 describe("throwIfUserDeletionBlocked", () => {
@@ -195,6 +239,23 @@ describe("throwIfUserDeletionBlocked", () => {
         status: "BAD_REQUEST",
         body: expect.objectContaining({
           code: "TASK_PAYMENT_CLAIM_PENDING",
+        }),
+      }),
+    );
+    expect(captureMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("throws TASK_X402_PAYMENT_PENDING without paging Sentry", () => {
+    expect(() =>
+      throwIfUserDeletionBlocked("user_delete", {
+        blockers: ["TASK_X402_PAYMENT_PENDING"],
+        reviewRequiredClaim: null,
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        status: "BAD_REQUEST",
+        body: expect.objectContaining({
+          code: "TASK_X402_PAYMENT_PENDING",
         }),
       }),
     );

--- a/apps/core/src/helpers/deletion-evaluate.test.ts
+++ b/apps/core/src/helpers/deletion-evaluate.test.ts
@@ -158,6 +158,7 @@ describe("evaluateUserDeletion", () => {
         status: TaskX402PaymentStatus.PENDING,
         OR: [
           { transaction: { userId: "user_delete" } },
+          { refundTransaction: { userId: "user_delete" } },
           { task: { ownerId: "user_delete" } },
         ],
       },

--- a/apps/core/src/helpers/deletion-evaluate.ts
+++ b/apps/core/src/helpers/deletion-evaluate.ts
@@ -1,5 +1,8 @@
 import * as Sentry from "@sentry/node";
-import { TaskPaymentClaimStatus } from "@sokosumi/database";
+import {
+  TaskPaymentClaimStatus,
+  TaskX402PaymentStatus,
+} from "@sokosumi/database";
 import type { createPrismaClient } from "@sokosumi/database/client";
 import { memberRepository } from "@sokosumi/database/repositories";
 import { APIError } from "better-auth/api";
@@ -11,6 +14,7 @@ type PrismaClient = ReturnType<typeof createPrismaClient>;
 export const USER_DELETION_BLOCKER_CODES = [
   "TASK_PAYMENT_CLAIM_REVIEW_REQUIRED",
   "TASK_PAYMENT_CLAIM_PENDING",
+  "TASK_X402_PAYMENT_PENDING",
 ] as const;
 
 export type UserDeletionBlocker = (typeof USER_DELETION_BLOCKER_CODES)[number];
@@ -36,6 +40,8 @@ const USER_DELETION_MESSAGES: Record<UserDeletionBlocker, string> = {
   TASK_PAYMENT_CLAIM_REVIEW_REQUIRED:
     "A task payment needs administrator review before your account can be deleted. Please contact support.",
   TASK_PAYMENT_CLAIM_PENDING:
+    "Wait for pending task payments to settle before deleting your account.",
+  TASK_X402_PAYMENT_PENDING:
     "Wait for pending task payments to settle before deleting your account.",
 };
 
@@ -87,6 +93,20 @@ export async function evaluateUserDeletion(
   });
   if (pendingPaymentClaim) {
     blockers.push("TASK_PAYMENT_CLAIM_PENDING");
+  }
+
+  // Same throw-priority as the claim guards above: evaluate reports this so
+  // GET /deletion can show it, and beforeDelete throws before the wipe. The
+  // task-owner branch matters because taskId is RESTRICT.
+  const pendingX402Payment = await prisma.taskX402Payment.findFirst({
+    where: {
+      status: TaskX402PaymentStatus.PENDING,
+      OR: [{ transaction: { userId } }, { task: { ownerId: userId } }],
+    },
+    select: { id: true },
+  });
+  if (pendingX402Payment) {
+    blockers.push("TASK_X402_PAYMENT_PENDING");
   }
 
   return { blockers, reviewRequiredClaim: reviewRequired };

--- a/apps/core/src/helpers/deletion-evaluate.ts
+++ b/apps/core/src/helpers/deletion-evaluate.ts
@@ -101,7 +101,15 @@ export async function evaluateUserDeletion(
   const pendingX402Payment = await prisma.taskX402Payment.findFirst({
     where: {
       status: TaskX402PaymentStatus.PENDING,
-      OR: [{ transaction: { userId } }, { task: { ownerId: userId } }],
+      // refundTransaction should be impossible on a PENDING row (the refund
+      // is written when status flips), but nothing DB-level forbids it and
+      // the FK is RESTRICT — without this branch such a row would fail the
+      // user cascade with a raw FK 500 instead of this clean 400.
+      OR: [
+        { transaction: { userId } },
+        { refundTransaction: { userId } },
+        { task: { ownerId: userId } },
+      ],
     },
     select: { id: true },
   });

--- a/apps/core/src/helpers/user-deletion-tasks.test.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.test.ts
@@ -163,8 +163,12 @@ describe("prepareTasksForUserDeletion", () => {
     expect(taskX402PaymentFindFirstMock).toHaveBeenCalledWith({
       where: {
         status: TaskX402PaymentStatus.PENDING,
+        // All three RESTRICT branches, including refundTransaction — a
+        // PENDING row carrying one should be impossible, but the FK would
+        // 500 the user cascade if it existed, so the guard checks it.
         OR: [
           { transaction: { userId: "user_delete" } },
+          { refundTransaction: { userId: "user_delete" } },
           { task: { ownerId: "user_delete" } },
         ],
       },
@@ -204,7 +208,13 @@ describe("prepareTasksForUserDeletion", () => {
         ],
       },
     });
-    expect(taskDeleteManyMock).toHaveBeenCalled();
+    // ORDER is the invariant, not just both-called: taskId is RESTRICT, so
+    // sweeping x402 payments after the task delete fails the owned-task
+    // delete on task_x402_payment_taskId_fkey and account deletion 500s.
+    const x402SweepCallOrder =
+      taskX402PaymentDeleteManyMock.mock.invocationCallOrder[0];
+    const taskDeleteCallOrder = taskDeleteManyMock.mock.invocationCallOrder[0];
+    expect(x402SweepCallOrder).toBeLessThan(taskDeleteCallOrder);
   });
 
   it("clears coworker-creator RESTRICT refs for foreign-owned tasks", async () => {

--- a/apps/core/src/helpers/user-deletion-tasks.test.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.test.ts
@@ -236,6 +236,143 @@ describe("prepareTasksForUserDeletion", () => {
     expect(sweepArgs.where.status).not.toHaveProperty("in");
   });
 
+  /**
+   * The x402 `findFirst` is called twice with different predicates: the
+   * PENDING blocker guard, then the foreign-charge detector that runs over the
+   * rows the sweep is about to delete. Discriminate on `status` the way the
+   * real query would.
+   */
+  function mockX402Lookups(options: {
+    pending?: { id: string } | null;
+    foreignCharge?: {
+      id: string;
+      taskId: string;
+      transaction: { userId: string };
+    } | null;
+  }) {
+    taskX402PaymentFindFirstMock.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) => {
+        if (where.status === TaskX402PaymentStatus.PENDING) {
+          return options.pending ?? null;
+        }
+        return options.foreignCharge ?? null;
+      },
+    );
+  }
+
+  it("pages when the sweep would remove a payment charged to another user", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+    mockX402Lookups({
+      foreignCharge: {
+        id: "x402_foreign",
+        taskId: "tsk_owned",
+        transaction: { userId: "user_charged" },
+      },
+    });
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    // The detector must look at exactly the rows the sweep deletes whose
+    // charge is someone else's: reachable only through the refund or
+    // task-owner branch, never the charge branch.
+    expect(taskX402PaymentFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        status: { not: TaskX402PaymentStatus.PENDING },
+        transaction: { userId: { not: "user_delete" } },
+        OR: [
+          { refundTransaction: { userId: "user_delete" } },
+          { task: { ownerId: "user_delete" } },
+        ],
+      },
+      select: {
+        id: true,
+        taskId: true,
+        transaction: { select: { userId: true } },
+      },
+    });
+    // Task.ownerId is documented as always the billing owner, so this should
+    // be unreachable. If it ever fires, a live third party's payment record is
+    // being destroyed by someone else's account deletion — silent today.
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      "Account deletion is removing a task x402 payment charged to another user",
+      expect.objectContaining({
+        level: "error",
+        tags: expect.objectContaining({
+          error_type: "user_deletion_x402_payment_foreign_charge",
+        }),
+        extra: expect.objectContaining({
+          userId: "user_delete",
+          taskX402PaymentId: "x402_foreign",
+          taskId: "tsk_owned",
+          chargedUserId: "user_charged",
+        }),
+      }),
+    );
+  });
+
+  it("still sweeps the foreign-charge row it paged about", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+    mockX402Lookups({
+      foreignCharge: {
+        id: "x402_foreign",
+        taskId: "tsk_owned",
+        transaction: { userId: "user_charged" },
+      },
+    });
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    // Narrowing the OR to hide the row is not the fix: the task-owner branch
+    // is load-bearing for the RESTRICT on taskId, so dropping it would fail
+    // the owned-task delete with a raw FK 500. Make it visible, not silent.
+    expect(taskX402PaymentDeleteManyMock).toHaveBeenCalledWith({
+      where: {
+        status: { not: TaskX402PaymentStatus.PENDING },
+        OR: [
+          { transaction: { userId: "user_delete" } },
+          { refundTransaction: { userId: "user_delete" } },
+          { task: { ownerId: "user_delete" } },
+        ],
+      },
+    });
+    expect(taskDeleteManyMock).toHaveBeenCalled();
+
+    // Two lookups: the PENDING blocker guard, then the foreign-charge
+    // detector. The detector reads rows the sweep deletes, so it is only
+    // meaningful before it.
+    expect(taskX402PaymentFindFirstMock).toHaveBeenCalledTimes(2);
+    const detectCallOrder =
+      taskX402PaymentFindFirstMock.mock.invocationCallOrder[1];
+    const sweepCallOrder =
+      taskX402PaymentDeleteManyMock.mock.invocationCallOrder[0];
+    expect(detectCallOrder).toBeLessThan(sweepCallOrder);
+  });
+
+  it("does not page when every swept payment is charged to the deleted user", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+    mockX402Lookups({ foreignCharge: null });
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    // The detector still has to run — silence must come from finding nothing,
+    // not from skipping the check.
+    expect(taskX402PaymentFindFirstMock).toHaveBeenCalledTimes(2);
+    expect(taskX402PaymentDeleteManyMock).toHaveBeenCalled();
+    expect(captureMessageMock).not.toHaveBeenCalled();
+  });
+
   it("clears coworker-creator RESTRICT refs for foreign-owned tasks", async () => {
     coworkerAssignmentFindManyMock.mockResolvedValue([{ coworkerId: "cow_1" }]);
     taskFindManyMock.mockResolvedValue([

--- a/apps/core/src/helpers/user-deletion-tasks.test.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.test.ts
@@ -194,13 +194,7 @@ describe("prepareTasksForUserDeletion", () => {
     // the owned-task delete / user cascade fails on the FK.
     expect(taskX402PaymentDeleteManyMock).toHaveBeenCalledWith({
       where: {
-        status: {
-          in: [
-            TaskX402PaymentStatus.VERIFIED,
-            TaskX402PaymentStatus.FAILED,
-            TaskX402PaymentStatus.REFUNDED,
-          ],
-        },
+        status: { not: TaskX402PaymentStatus.PENDING },
         OR: [
           { transaction: { userId: "user_delete" } },
           { refundTransaction: { userId: "user_delete" } },
@@ -215,6 +209,31 @@ describe("prepareTasksForUserDeletion", () => {
       taskX402PaymentDeleteManyMock.mock.invocationCallOrder[0];
     const taskDeleteCallOrder = taskDeleteManyMock.mock.invocationCallOrder[0];
     expect(x402SweepCallOrder).toBeLessThan(taskDeleteCallOrder);
+  });
+
+  it("sweeps every non-pending x402 status instead of enumerating them", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    // Asserting the predicate shape, not a fixture row: the enum has no
+    // fifth member today, so a future status (e.g. EXPIRED_UNUSED) cannot be
+    // exercised here. An enumerated `in: [...]` would match neither this
+    // sweep nor the PENDING guard above it, leaving the row behind — and
+    // taskId is RESTRICT, so the task.deleteMany below would then fail with
+    // a raw FK error and 500 the account deletion. Negating PENDING keeps
+    // the sweep exhaustive by construction as the enum grows.
+    const [sweepArgs] = taskX402PaymentDeleteManyMock.mock.calls[0] as [
+      { where: { status: unknown } },
+    ];
+    expect(sweepArgs.where.status).toEqual({
+      not: TaskX402PaymentStatus.PENDING,
+    });
+    expect(sweepArgs.where.status).not.toHaveProperty("in");
   });
 
   it("clears coworker-creator RESTRICT refs for foreign-owned tasks", async () => {

--- a/apps/core/src/helpers/user-deletion-tasks.test.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.test.ts
@@ -1,4 +1,7 @@
-import { TaskPaymentClaimStatus } from "@sokosumi/database";
+import {
+  TaskPaymentClaimStatus,
+  TaskX402PaymentStatus,
+} from "@sokosumi/database";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { prepareTasksForUserDeletion } from "./user-deletion-tasks";
@@ -10,11 +13,14 @@ const {
   taskUpdateMock,
   taskDeleteManyMock,
   taskPaymentClaimDeleteManyMock,
+  taskX402PaymentFindFirstMock,
+  taskX402PaymentDeleteManyMock,
   chatRoomFindManyMock,
   chatRoomUpdateMock,
   chatRoomDeleteMock,
   transactionMock,
   deleteTaskFileIfOwnedMock,
+  captureMessageMock,
 } = vi.hoisted(() => ({
   coworkerAssignmentFindManyMock: vi.fn(),
   taskFindManyMock: vi.fn(),
@@ -22,15 +28,22 @@ const {
   taskUpdateMock: vi.fn(),
   taskDeleteManyMock: vi.fn(),
   taskPaymentClaimDeleteManyMock: vi.fn(),
+  taskX402PaymentFindFirstMock: vi.fn(),
+  taskX402PaymentDeleteManyMock: vi.fn(),
   chatRoomFindManyMock: vi.fn(),
   chatRoomUpdateMock: vi.fn(),
   chatRoomDeleteMock: vi.fn(),
   transactionMock: vi.fn(),
   deleteTaskFileIfOwnedMock: vi.fn(),
+  captureMessageMock: vi.fn(),
 }));
 
 vi.mock("@/lib/blob", () => ({
   deleteTaskFileIfOwned: deleteTaskFileIfOwnedMock,
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureMessage: captureMessageMock,
 }));
 
 describe("prepareTasksForUserDeletion", () => {
@@ -38,6 +51,8 @@ describe("prepareTasksForUserDeletion", () => {
     vi.clearAllMocks();
     taskFileFindManyMock.mockResolvedValue([]);
     taskPaymentClaimDeleteManyMock.mockResolvedValue({ count: 0 });
+    taskX402PaymentFindFirstMock.mockResolvedValue(null);
+    taskX402PaymentDeleteManyMock.mockResolvedValue({ count: 0 });
     chatRoomFindManyMock.mockResolvedValue([]);
     chatRoomUpdateMock.mockResolvedValue({});
     chatRoomDeleteMock.mockResolvedValue({});
@@ -57,6 +72,10 @@ describe("prepareTasksForUserDeletion", () => {
         },
         taskPaymentClaim: {
           deleteMany: taskPaymentClaimDeleteManyMock,
+        },
+        taskX402Payment: {
+          findFirst: taskX402PaymentFindFirstMock,
+          deleteMany: taskX402PaymentDeleteManyMock,
         },
         chatRoom: {
           findMany: chatRoomFindManyMock,
@@ -124,6 +143,64 @@ describe("prepareTasksForUserDeletion", () => {
         OR: [
           { transaction: { userId: "user_delete" } },
           { refundTransaction: { userId: "user_delete" } },
+        ],
+      },
+    });
+    expect(taskDeleteManyMock).toHaveBeenCalled();
+  });
+
+  it("blocks deletion while a task x402 payment is pending", async () => {
+    taskX402PaymentFindFirstMock.mockResolvedValue({ id: "x402_pending" });
+
+    const promise = prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    await expect(promise).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      body: expect.objectContaining({ code: "TASK_X402_PAYMENT_PENDING" }),
+    });
+    expect(taskX402PaymentFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        status: TaskX402PaymentStatus.PENDING,
+        OR: [
+          { transaction: { userId: "user_delete" } },
+          { task: { ownerId: "user_delete" } },
+        ],
+      },
+      select: { id: true },
+    });
+    expect(taskX402PaymentDeleteManyMock).not.toHaveBeenCalled();
+    expect(taskDeleteManyMock).not.toHaveBeenCalled();
+    // A pending x402 payment clears itself (coworker retry or reconciler
+    // auto-refund), so unlike a review-required claim it must not page.
+    expect(captureMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("removes terminal x402 payments before the task and transaction cascades", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    // Every RESTRICT branch (charge, refund, task owner) must be swept, or
+    // the owned-task delete / user cascade fails on the FK.
+    expect(taskX402PaymentDeleteManyMock).toHaveBeenCalledWith({
+      where: {
+        status: {
+          in: [
+            TaskX402PaymentStatus.VERIFIED,
+            TaskX402PaymentStatus.FAILED,
+            TaskX402PaymentStatus.REFUNDED,
+          ],
+        },
+        OR: [
+          { transaction: { userId: "user_delete" } },
+          { refundTransaction: { userId: "user_delete" } },
+          { task: { ownerId: "user_delete" } },
         ],
       },
     });

--- a/apps/core/src/helpers/user-deletion-tasks.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.ts
@@ -56,7 +56,15 @@ export async function prepareTasksForUserDeletion(
     const pendingX402Payment = await tx.taskX402Payment.findFirst({
       where: {
         status: TaskX402PaymentStatus.PENDING,
-        OR: [{ transaction: { userId } }, { task: { ownerId: userId } }],
+        // refundTransaction should be impossible on a PENDING row (the refund
+        // is written when status flips), but nothing DB-level forbids it and
+        // the FK is RESTRICT — without this branch such a row would fail the
+        // user cascade with a raw FK 500 instead of this clean 400.
+        OR: [
+          { transaction: { userId } },
+          { refundTransaction: { userId } },
+          { task: { ownerId: userId } },
+        ],
       },
       select: { id: true },
     });

--- a/apps/core/src/helpers/user-deletion-tasks.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import {
   TaskPaymentClaimStatus,
   TaskX402PaymentStatus,
@@ -24,7 +25,9 @@ type PrismaClient = ReturnType<typeof createPrismaClient>;
  *   them within a bounded window, so no operator page) and are also reported
  *   by `evaluateUserDeletion`. Every non-PENDING x402 payment is removed
  *   because its RESTRICT task and transaction relations would otherwise
- *   block both the owned-task delete and the user cascade.
+ *   block both the owned-task delete and the user cascade. A swept payment
+ *   whose charge belongs to another user pages Sentry — it means Task.ownerId
+ *   was not the billing owner.
  * - Chat rooms this user created re-point `createdByUserId` to another remaining
  *   human member. Rooms with no other human member are deleted so Restrict does
  *   not 500 an allowed wipe.
@@ -74,6 +77,45 @@ export async function prepareTasksForUserDeletion(
         message:
           "Wait for pending task payments to settle before deleting your account.",
       });
+    }
+
+    // The sweep below deletes on `task.ownerId` regardless of who was
+    // charged. Task.ownerId is documented as always the billing owner, so a
+    // row swept through the task-owner (or refund) branch whose charge belongs
+    // to someone else should be unreachable — but nothing enforces that. If it
+    // ever happens, one user's account deletion silently destroys a different,
+    // live user's payment record: the charge Transaction survives, while the
+    // chain leg, nonce, agent and network are lost. Narrowing the sweep is not
+    // the fix (the task-owner branch is load-bearing for the RESTRICT on
+    // taskId), so make the invariant break visible instead.
+    const foreignChargePayment = await tx.taskX402Payment.findFirst({
+      where: {
+        status: { not: TaskX402PaymentStatus.PENDING },
+        transaction: { userId: { not: userId } },
+        // Only the non-charge branches can reach a foreign charge; the
+        // `transaction: { userId }` branch is this user's own by definition.
+        OR: [{ refundTransaction: { userId } }, { task: { ownerId: userId } }],
+      },
+      select: {
+        id: true,
+        taskId: true,
+        transaction: { select: { userId: true } },
+      },
+    });
+    if (foreignChargePayment) {
+      Sentry.captureMessage(
+        "Account deletion is removing a task x402 payment charged to another user",
+        {
+          level: "error",
+          tags: { error_type: "user_deletion_x402_payment_foreign_charge" },
+          extra: {
+            userId,
+            taskX402PaymentId: foreignChargePayment.id,
+            taskId: foreignChargePayment.taskId,
+            chargedUserId: foreignChargePayment.transaction.userId,
+          },
+        },
+      );
     }
 
     // Non-pending x402 payments hold RESTRICT relations on the task, the

--- a/apps/core/src/helpers/user-deletion-tasks.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.ts
@@ -22,9 +22,9 @@ type PrismaClient = ReturnType<typeof createPrismaClient>;
  *   transaction relations do not block user cascade.
  * - Pending x402 payments block deletion the same way (the reconciler clears
  *   them within a bounded window, so no operator page) and are also reported
- *   by `evaluateUserDeletion`. Terminal x402 payments are removed because
- *   their RESTRICT task and transaction relations would otherwise block both
- *   the owned-task delete and the user cascade.
+ *   by `evaluateUserDeletion`. Every non-PENDING x402 payment is removed
+ *   because its RESTRICT task and transaction relations would otherwise
+ *   block both the owned-task delete and the user cascade.
  * - Chat rooms this user created re-point `createdByUserId` to another remaining
  *   human member. Rooms with no other human member are deleted so Restrict does
  *   not 500 an allowed wipe.
@@ -76,19 +76,21 @@ export async function prepareTasksForUserDeletion(
       });
     }
 
-    // Terminal x402 payments hold RESTRICT relations on the task, the charge
-    // transaction, and any refund transaction; every branch must be swept or
-    // the owned-task delete / user cascade fails. Operator attribution
-    // survives in the FK-free task_x402_payment_action rows.
+    // Non-pending x402 payments hold RESTRICT relations on the task, the
+    // charge transaction, and any refund transaction; every branch must be
+    // swept or the owned-task delete / user cascade fails. Operator
+    // attribution survives in the FK-free task_x402_payment_action rows.
+    //
+    // Negating PENDING rather than listing the terminal statuses is
+    // deliberate: the guard above already rejects PENDING, so everything
+    // reaching here must be swept, and this predicate stays exhaustive as
+    // the enum grows. An enumeration would silently miss a new status (the
+    // planned EXPIRED_UNUSED, say) — it would match neither branch, survive
+    // the sweep, and then fail the RESTRICT taskId FK on the task delete
+    // below with a raw 500 instead of a clean deletion.
     await tx.taskX402Payment.deleteMany({
       where: {
-        status: {
-          in: [
-            TaskX402PaymentStatus.VERIFIED,
-            TaskX402PaymentStatus.FAILED,
-            TaskX402PaymentStatus.REFUNDED,
-          ],
-        },
+        status: { not: TaskX402PaymentStatus.PENDING },
         OR: [
           { transaction: { userId } },
           { refundTransaction: { userId } },

--- a/apps/core/src/helpers/user-deletion-tasks.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.ts
@@ -1,5 +1,9 @@
-import { TaskPaymentClaimStatus } from "@sokosumi/database";
+import {
+  TaskPaymentClaimStatus,
+  TaskX402PaymentStatus,
+} from "@sokosumi/database";
 import type { createPrismaClient } from "@sokosumi/database/client";
+import { APIError } from "better-auth/api";
 
 import { deleteTaskFileIfOwned } from "@/lib/blob";
 
@@ -16,6 +20,11 @@ type PrismaClient = ReturnType<typeof createPrismaClient>;
  * - Payment-claim blockers live in `evaluateUserDeletion`. This prep runs only
  *   after that list is empty. Terminal claims are removed so their RESTRICT
  *   transaction relations do not block user cascade.
+ * - Pending x402 payments block deletion the same way (the reconciler clears
+ *   them within a bounded window, so no operator page) and are also reported
+ *   by `evaluateUserDeletion`. Terminal x402 payments are removed because
+ *   their RESTRICT task and transaction relations would otherwise block both
+ *   the owned-task delete and the user cascade.
  * - Chat rooms this user created re-point `createdByUserId` to another remaining
  *   human member. Rooms with no other human member are deleted so Restrict does
  *   not 500 an allowed wipe.
@@ -36,6 +45,47 @@ export async function prepareTasksForUserDeletion(
           ],
         },
         OR: [{ transaction: { userId } }, { refundTransaction: { userId } }],
+      },
+    });
+
+    // A PENDING x402 payment either re-runs its sign on coworker retry or is
+    // auto-refunded by the reconciler — bounded, self-clearing, so unlike a
+    // review-required claim it never pages Sentry. The task-owner branch
+    // matters because taskId is RESTRICT: a pending payment on an owned task
+    // blocks the owned-task delete below regardless of who was charged.
+    const pendingX402Payment = await tx.taskX402Payment.findFirst({
+      where: {
+        status: TaskX402PaymentStatus.PENDING,
+        OR: [{ transaction: { userId } }, { task: { ownerId: userId } }],
+      },
+      select: { id: true },
+    });
+    if (pendingX402Payment) {
+      throw new APIError("BAD_REQUEST", {
+        code: "TASK_X402_PAYMENT_PENDING",
+        message:
+          "Wait for pending task payments to settle before deleting your account.",
+      });
+    }
+
+    // Terminal x402 payments hold RESTRICT relations on the task, the charge
+    // transaction, and any refund transaction; every branch must be swept or
+    // the owned-task delete / user cascade fails. Operator attribution
+    // survives in the FK-free task_x402_payment_action rows.
+    await tx.taskX402Payment.deleteMany({
+      where: {
+        status: {
+          in: [
+            TaskX402PaymentStatus.VERIFIED,
+            TaskX402PaymentStatus.FAILED,
+            TaskX402PaymentStatus.REFUNDED,
+          ],
+        },
+        OR: [
+          { transaction: { userId } },
+          { refundTransaction: { userId } },
+          { task: { ownerId: userId } },
+        ],
       },
     });
 

--- a/docs/wayfinder/x402-evm/build-log.md
+++ b/docs/wayfinder/x402-evm/build-log.md
@@ -71,3 +71,81 @@ deployed x402 surface. Only `spec/SPEC_SOURCES.md` changed (provenance note).
   `PENDING|VERIFIED|FAILED|REFUNDED`, `@@index([agentId, status])` for the
   per-endpoint refund aggregation, plus the FK-free append-only
   `TaskX402PaymentAction` sibling.
+
+## Sub-component 2 — TaskX402Payment schema + migration (`x402-2-model`) — 2026-08-11
+
+**Branch:** `x402-2-model`, cut from `x402-1-spec-refresh` (`eafc3a89d`). Two
+commits: the schema + migration, and the user-deletion guard + tests.
+
+### Schema decisions
+
+- `TaskX402PaymentStatus` (`PENDING|VERIFIED|FAILED|REFUNDED`) with a doc
+  comment pinning why VERIFIED is terminal for the automated flow: the node
+  signs locally, Soko cannot observe settlement until the phased-settlement
+  reconciler (ticket 011 Q3) ships; REFUNDED is reachable only from
+  PENDING/FAILED auto-refunds or an operator goodwill refund.
+- `TaskX402Payment` per PR1-SPEC §4 verbatim, plus the relations the spec
+  implies: `taskId → Task` **Restrict** (a money record must never vanish
+  with its task — the same reasoning as the claim's Restrict on its
+  transactions; the claim itself has no task FK, only `taskEventId SetNull`),
+  `agentId → Agent` Restrict (aggregation key; no production code path
+  hard-deletes Agent rows, so Restrict costs nothing today),
+  `taskEventId → TaskEvent` SetNull `@unique`, `transactionId` /
+  `refundTransactionId → Transaction` Restrict `@unique` — mirroring the
+  claim exactly.
+- Indexes: the `@@unique([taskId, idempotencyKey])` dedupe ships in the same
+  migration as the table (the node has no idempotency of its own),
+  `@@index([agentId, status])` for §5 aggregation, and
+  `@@index([status, validBefore])` for the future reconciler's expiry scan.
+- `TaskX402PaymentAction` mirrors `TaskPaymentClaimAction`: append-only,
+  FK-free (account deletion hard-deletes terminal payments and can remove the
+  operator's User row; cascade would erase the audit trail, restrict would
+  block deletion).
+- Back-relations added on `Task`, `Agent`, `TaskEvent` (`x402Payment?`), and
+  `Transaction` (two named relations, claim-style).
+
+### Migration
+
+`20260811130000_task_x402_payment` — timestamped after
+`20260811120000_external_channels`. Fully idempotent (enum via
+`duplicate_object` guard, `CREATE TABLE/INDEX IF NOT EXISTS`, FK adds in
+`DO $$` guards), matching the payment-v2 branch style. Validated on scratch
+local Postgres: full `prisma migrate deploy` from zero, a second direct
+`psql` re-apply of the new file (no-op, NOTICEs only), and
+`prisma migrate diff` from the applied DB to the schema shows **no x402
+drift** (the only reported diffs are pre-existing SQL-only partial unique
+indexes Prisma cannot model, e.g. `chat_room_guest_invitation`'s
+pending-status unique).
+
+### User-deletion guard (apps/core)
+
+`prepareTasksForUserDeletion` now mirrors the claim guard for x402 payments:
+PENDING blocks with `TASK_X402_PAYMENT_PENDING` (no Sentry page — unlike a
+review-required claim it self-clears via coworker retry or reconciler
+auto-refund), then terminal payments are swept across **all three** RESTRICT
+branches (`transaction`, `refundTransaction`, `task.ownerId`) before
+`task.deleteMany`. The task-owner branch is the one the claim guard does not
+have: `taskId` is Restrict, so a payment row on an owned task would fail the
+owned-task delete regardless of who was charged.
+
+### Verification
+
+- Scratch-DB migration validation as above (local Postgres was available).
+- `pnpm --filter @sokosumi/database test` — 36 files passed, 245 tests.
+- `pnpm --filter core test src/helpers/user-deletion-tasks.test.ts` — 11
+  passed (5 existing + 6 new/extended).
+- `pnpm typecheck` — all workspaces clean.
+- `pnpm check` — 3118 files, no fixes.
+- `prisma format` fixed pre-existing alignment drift from the
+  external-channels commit; formatting-only churn in `schema.prisma`.
+
+### What sub-component 3 needs to know
+
+- Core resolves `@sokosumi/database` through its built `dist` — after any
+  schema change run `pnpm --filter @sokosumi/database build` (not just
+  `prisma:generate`) or core tests see `undefined` enums.
+- `TaskX402PaymentAction.action` doc comment reserves `"refund" | "resolve"`;
+  the admin surface (§5) should stick to those strings.
+- No status transition guard exists at the DB layer — terminal-at-VERIFIED is
+  enforced by application code; the pay-route service must not add post-
+  VERIFIED transitions until the phased-settlement reconciler ships.

--- a/docs/wayfinder/x402-evm/build-log.md
+++ b/docs/wayfinder/x402-evm/build-log.md
@@ -149,3 +149,14 @@ owned-task delete regardless of who was charged.
 - No status transition guard exists at the DB layer — terminal-at-VERIFIED is
   enforced by application code; the pay-route service must not add post-
   VERIFIED transitions until the phased-settlement reconciler ships.
+
+### Step-2 review follow-ups (for sub-component 3+)
+
+- **`idempotencyKey` MUST be `.max()`-bounded in the pay route's Zod** —
+  it sits inside the `[taskId, idempotencyKey]` btree unique, and an
+  unbounded coworker-supplied key can exceed the btree row limit at INSERT
+  time: a runtime 500 (charge rolls back, no money lost) where a 400 belongs.
+  Mirror identifierFromPurchaser's bounds (something like max 200).
+- Review fixes applied on x402-2-model: order assertion on the terminal
+  sweep (RESTRICT means sweep-before-task-delete is load-bearing), and a
+  third `refundTransaction` OR branch on the PENDING guard.

--- a/docs/wayfinder/x402-evm/build-log.md
+++ b/docs/wayfinder/x402-evm/build-log.md
@@ -132,8 +132,8 @@ owned-task delete regardless of who was charged.
 
 - Scratch-DB migration validation as above (local Postgres was available).
 - `pnpm --filter @sokosumi/database test` — 36 files passed, 245 tests.
-- `pnpm --filter core test src/helpers/user-deletion-tasks.test.ts` — 11
-  passed (5 existing + 6 new/extended).
+- `pnpm --filter core test src/helpers/user-deletion-tasks.test.ts` — 15
+  passed (8 pre-existing + 7 new x402 cases).
 - `pnpm typecheck` — all workspaces clean.
 - `pnpm check` — 3118 files, no fixes.
 - `prisma format` fixed pre-existing alignment drift from the
@@ -160,3 +160,62 @@ owned-task delete regardless of who was charged.
 - Review fixes applied on x402-2-model: order assertion on the terminal
   sweep (RESTRICT means sweep-before-task-delete is load-bearing), and a
   third `refundTransaction` OR branch on the PENDING guard.
+
+### Confirmation-review fixes (migration convergence)
+
+Two latent migration defects, both reproduced against local Postgres 18.4
+before fixing and re-probed after:
+
+- **Nonce-replay unique had a NULL hole.** `payerAddress` is nullable and a
+  btree unique treats NULLs as distinct, while the partial predicate gates
+  only on `payloadNonce IS NOT NULL` — two rows with the same nonce and a NULL
+  payer inserted cleanly, which is the exact double-debit the index claims to
+  prevent. Closed with a CHECK making the pair all-or-nothing
+  (`task_x402_payment_nonce_payer_together_chk`), declared inline on the
+  CREATE and restated in a `DO $$` guard for the converge path. Prisma cannot
+  model CHECK constraints, so it is hand-written and documented on the
+  `@@unique` in `schema.prisma`. `NULLS NOT DISTINCT` was rejected: it fights
+  the `partialIndexes` generator and would show as permanent `migrate diff`
+  drift.
+- **The enum was the one object that did not restate its shape.** The
+  `DO $$ CREATE TYPE … EXCEPTION WHEN duplicate_object` guard swallows the
+  whole type on re-apply, so an amended member set never reaches a database
+  that applied an earlier shape of the file. Appended
+  `ALTER TYPE … ADD VALUE IF NOT EXISTS` for all four members. Verified by A/B
+  on a converged database: with the restatements a simulated
+  `EXPIRED_UNUSED` amendment lands (5 members), without them the database
+  silently stays on 4.
+
+`ALTER TYPE … ADD VALUE` is transaction-safe on PostgreSQL 12+ **only so long
+as the member being added is not used in the same transaction**, so these
+statements are safe whether or not the runner wraps the file in one. The
+proviso holds here because no statement in this file uses a member it adds — the sole
+enum literal is `DEFAULT 'PENDING'` in the CREATE TABLE, and on the fresh path
+the type is created in the same transaction (which makes all its members
+usable) while on every converge path 'PENDING' already exists. A future
+amendment must add a member here and use it in a *later* migration; using it
+in the same file raises `unsafe use of new value of enum type`. Confirmed
+empirically on Postgres 18.4, both the working case and the failing one.
+
+Validated on scratch local Postgres: `prisma migrate deploy` from zero; a hand
+re-apply of the amended file; and deploy-then-hand-apply from **all four**
+historical shapes of this file (`da9e9030f`, `d3a5ffee4`, `22bf84681`,
+`0cb68cdd2`) — all five resulting `pg_dump -s` outputs byte-identical.
+`prisma migrate diff` reports no x402 drift (only the pre-existing `chat_room`
+partial-unique artifacts). Constraint probes on the real migrated table: a
+nonce without a payer and a payer without a nonce are both rejected, two
+all-NULL PENDING rows still coexist, and a repeated `(network, asset, payer,
+nonce)` tuple still trips `task_x402_payment_nonce_replay_uidx`.
+
+Guarded by `packages/database/src/types/__tests__/x402-migration-convergence.test.ts`,
+which derives its expectations from `schema.prisma` — adding a fifth enum
+member or another nullable column to the replay tuple fails the suite until
+the migration converges on it.
+
+Verification for this step:
+
+- `pnpm --filter @sokosumi/database test` — 248 passed, 2 skipped (38 files).
+- `pnpm --filter core test` — 3211 passed, 6 skipped (355 files).
+- `pnpm typecheck` — all workspaces clean.
+- `pnpm check` — 3119 files, no fixes.
+- `prisma format` / `prisma validate` — no churn beyond the added comment.

--- a/docs/wayfinder/x402-evm/build-log.md
+++ b/docs/wayfinder/x402-evm/build-log.md
@@ -106,8 +106,9 @@ commits: the schema + migration, and the user-deletion guard + tests.
 
 ### Migration
 
-`20260811130000_task_x402_payment` — timestamped after
-`20260811120000_external_channels`. Fully idempotent (enum via
+`20260819130000_task_x402_payment` — formerly `20260811130000_task_x402_payment`,
+re-timestamped after `20260818120000_better_auth_1_7_account_identity` so the
+stack applies after the current main tip. Fully idempotent (enum via
 `duplicate_object` guard, `CREATE TABLE/INDEX IF NOT EXISTS`, FK adds in
 `DO $$` guards), matching the payment-v2 branch style. Validated on scratch
 local Postgres: full `prisma migrate deploy` from zero, a second direct

--- a/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
+++ b/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
@@ -114,6 +114,13 @@ END $$;
 -- CASCADE would let that erase the financial audit trail, and a RESTRICT would
 -- make account deletion fail — so the ids are stored as plain values that
 -- outlive both, which is the normal shape for an audit log.
+--
+-- The denormalized columns are not decoration: paymentId points at a row that
+-- account deletion hard-deletes, so without them the surviving action row is
+-- an unresolvable pointer to a dead uuid. Plain columns, never foreign keys —
+-- an FK to task/Agent/User/payment would either cascade the audit row away or
+-- block account deletion, which is the whole thing this table avoids.
+-- Nullable so the append-only table tolerates rows written before this change.
 CREATE TABLE IF NOT EXISTS "task_x402_payment_action" (
     "id" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -121,9 +128,28 @@ CREATE TABLE IF NOT EXISTS "task_x402_payment_action" (
     "action" TEXT NOT NULL,
     "operatorId" TEXT NOT NULL,
     "reason" TEXT NOT NULL,
+    "cents" BIGINT,
+    "amount" TEXT,
+    "asset" TEXT,
+    "caip2Network" TEXT,
+    "taskId" TEXT,
+    "agentId" TEXT,
+    "chargedUserId" TEXT,
 
     CONSTRAINT "task_x402_payment_action_pkey" PRIMARY KEY ("id")
 );
+
+-- AlterTable
+-- A database that already applied the pre-denormalization version of the
+-- CREATE TABLE above skips it entirely (IF NOT EXISTS), so add the columns
+-- separately too. Both paths converge on the same shape.
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "cents" BIGINT;
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "amount" TEXT;
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "asset" TEXT;
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "caip2Network" TEXT;
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "taskId" TEXT;
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "agentId" TEXT;
+ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "chargedUserId" TEXT;
 
 -- CreateIndex
 CREATE INDEX IF NOT EXISTS "task_x402_payment_action_paymentId_createdAt_idx" ON "task_x402_payment_action"("paymentId", "createdAt");

--- a/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
+++ b/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS "task_x402_payment" (
     "id" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-    "idempotencyKey" TEXT NOT NULL,
+    "idempotencyKey" VARCHAR(200) NOT NULL,
     "status" "TaskX402PaymentStatus" NOT NULL DEFAULT 'PENDING',
     "caip2Network" TEXT NOT NULL,
     "asset" TEXT NOT NULL,

--- a/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
+++ b/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
@@ -15,6 +15,30 @@ EXCEPTION
   WHEN duplicate_object THEN null;
 END $$;
 
+-- AlterEnum
+-- The guard above swallows the whole type on re-apply, so a database that
+-- applied an earlier shape of this file keeps that shape's member set forever
+-- — the one object here that did not restate itself. Every member is therefore
+-- restated, matching the converge discipline the columns and constraints below
+-- already follow. Re-running is a no-op once the members match.
+--
+-- ALTER TYPE … ADD VALUE is transaction-safe on PostgreSQL 12+ so long as the
+-- member being added is not USED in the same transaction, so these are safe
+-- whether or not the runner wraps this file in one. That proviso holds here,
+-- and only here, because no statement in this file uses a member this file
+-- adds: the sole enum literal below is the `DEFAULT 'PENDING'` in the CREATE
+-- TABLE, and on the fresh path the type itself is created in the same
+-- transaction (which makes all of its members usable), while on every converge
+-- path 'PENDING' already exists and the ADD VALUE is a no-op.
+--
+-- A future amendment that adds a member MUST NOT also use it in this file —
+-- Postgres rejects that with `unsafe use of new value of enum type`. Add the
+-- member here, and use it in a later migration.
+ALTER TYPE "TaskX402PaymentStatus" ADD VALUE IF NOT EXISTS 'PENDING';
+ALTER TYPE "TaskX402PaymentStatus" ADD VALUE IF NOT EXISTS 'VERIFIED';
+ALTER TYPE "TaskX402PaymentStatus" ADD VALUE IF NOT EXISTS 'FAILED';
+ALTER TYPE "TaskX402PaymentStatus" ADD VALUE IF NOT EXISTS 'REFUNDED';
+
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "task_x402_payment" (
     "id" TEXT NOT NULL,
@@ -38,7 +62,11 @@ CREATE TABLE IF NOT EXISTS "task_x402_payment" (
     "transactionId" TEXT NOT NULL,
     "refundTransactionId" TEXT,
 
-    CONSTRAINT "task_x402_payment_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "task_x402_payment_pkey" PRIMARY KEY ("id"),
+    -- See the AlterTable below for why this constraint exists; declared here
+    -- too so the fresh-create path gets it without a second statement.
+    CONSTRAINT "task_x402_payment_nonce_payer_together_chk"
+      CHECK (("payerAddress" IS NULL) = ("payloadNonce" IS NULL))
 );
 
 -- AlterTable
@@ -75,6 +103,32 @@ CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_taskId_idempotencyKey_key" 
 CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_nonce_replay_uidx"
   ON "task_x402_payment" ("caip2Network", "asset", "payerAddress", "payloadNonce")
   WHERE "payloadNonce" IS NOT NULL;
+
+-- AlterTable
+-- Closes the NULL hole in the index above. A btree unique treats NULLs as
+-- distinct while the partial predicate gates only on `payloadNonce IS NOT
+-- NULL`, so two rows with the same nonce and a NULL "payerAddress" insert
+-- cleanly and the index stays silent — two credit debits behind one EIP-3009
+-- authorization, precisely what it claims to prevent. That is reachable
+-- without a bug in this table: the VERIFIED transition writes both fields from
+-- the node's response, and a response that omits `payer` (or an upstream
+-- rename) leaves one of them undefined. Making the tuple all-or-nothing means
+-- the index never sees a half-populated key, and a half-populated write fails
+-- the transition and leaves the row PENDING — which is refundable, the same
+-- outcome the index's own violation path produces.
+--
+-- Prisma cannot model CHECK constraints, so this joins the hand-written
+-- statements; it is restated here (and inline on the CREATE above) because a
+-- database that already applied an earlier shape of this file skips the CREATE
+-- entirely. Safe unconditionally: nothing writes this table yet on any
+-- database that can reach this migration, so no existing row can violate it.
+DO $$ BEGIN
+  ALTER TABLE "task_x402_payment"
+    ADD CONSTRAINT "task_x402_payment_nonce_payer_together_chk"
+    CHECK (("payerAddress" IS NULL) = ("payloadNonce" IS NULL));
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
 
 -- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_taskEventId_key" ON "task_x402_payment"("taskEventId");

--- a/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
+++ b/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
@@ -1,0 +1,132 @@
+-- x402/Bazaar payment record (PR1-SPEC §4). Sibling of task_payment_claim, not
+-- a reuse — the escrow claim's state machine (processing lease, retry ladder,
+-- blockchainIdentifier) is meaningless here; this record is terminal at sign
+-- time. Statements are idempotent so a preview database that partially applied
+-- an earlier run can re-apply without failing.
+
+-- CreateEnum
+-- VERIFIED is terminal for the automated flow: the node signs the X-PAYMENT
+-- header locally and Soko cannot observe settlement until the phased-settlement
+-- reconciler (ticket 011 Q3) ships. REFUNDED is reached from PENDING/FAILED
+-- auto-refunds or an operator goodwill refund only.
+DO $$ BEGIN
+  CREATE TYPE "TaskX402PaymentStatus" AS ENUM ('PENDING', 'VERIFIED', 'FAILED', 'REFUNDED');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "task_x402_payment" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "status" "TaskX402PaymentStatus" NOT NULL DEFAULT 'PENDING',
+    "caip2Network" TEXT NOT NULL,
+    "asset" TEXT NOT NULL,
+    "amount" TEXT NOT NULL,
+    "payTo" TEXT NOT NULL,
+    "attemptId" TEXT,
+    "failureReason" TEXT,
+    "payerAddress" TEXT,
+    "payloadNonce" TEXT,
+    "paymentPayloadHash" TEXT,
+    "validBefore" TIMESTAMP(3),
+    "taskId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "taskEventId" TEXT,
+    "transactionId" TEXT NOT NULL,
+    "refundTransactionId" TEXT,
+
+    CONSTRAINT "task_x402_payment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+-- The dedupe unique (ticket 003): the node has no idempotency of its own, so
+-- this unique must ship in the same change as the table.
+CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_taskId_idempotencyKey_key" ON "task_x402_payment"("taskId", "idempotencyKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_taskEventId_key" ON "task_x402_payment"("taskEventId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_transactionId_key" ON "task_x402_payment"("transactionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_refundTransactionId_key" ON "task_x402_payment"("refundTransactionId");
+
+-- CreateIndex
+-- Per-endpoint refund aggregation (PR1-SPEC §5).
+CREATE INDEX IF NOT EXISTS "task_x402_payment_agentId_status_idx" ON "task_x402_payment"("agentId", "status");
+
+-- CreateIndex
+-- Phased-settlement reconciler expiry scan (ticket 011 Q3).
+CREATE INDEX IF NOT EXISTS "task_x402_payment_status_validBefore_idx" ON "task_x402_payment"("status", "validBefore");
+
+-- AddForeignKey
+-- RESTRICT: a money record must never vanish with its task; account deletion
+-- resolves payments first (prepareTasksForUserDeletion).
+DO $$ BEGIN
+  ALTER TABLE "task_x402_payment" ADD CONSTRAINT "task_x402_payment_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "task"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- AddForeignKey
+-- RESTRICT: agentId is the per-endpoint aggregation key; agent rows must not
+-- be hard-deleted while payment history exists.
+DO $$ BEGIN
+  ALTER TABLE "task_x402_payment" ADD CONSTRAINT "task_x402_payment_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- AddForeignKey
+DO $$ BEGIN
+  ALTER TABLE "task_x402_payment" ADD CONSTRAINT "task_x402_payment_taskEventId_fkey" FOREIGN KEY ("taskEventId") REFERENCES "taskEvent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- AddForeignKey
+-- RESTRICT: the credit debit stays available for refund/compensation for the
+-- record's lifetime.
+DO $$ BEGIN
+  ALTER TABLE "task_x402_payment" ADD CONSTRAINT "task_x402_payment_transactionId_fkey" FOREIGN KEY ("transactionId") REFERENCES "Transaction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- AddForeignKey
+DO $$ BEGIN
+  ALTER TABLE "task_x402_payment" ADD CONSTRAINT "task_x402_payment_refundTransactionId_fkey" FOREIGN KEY ("refundTransactionId") REFERENCES "Transaction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- Append-only audit trail for operator decisions on task x402 payments.
+-- Refund moves money, so operator attribution cannot live in a mutable column
+-- on the payment itself.
+--
+-- Deliberately FK-free. Both referents are erased by ordinary lifecycle work:
+-- account deletion hard-deletes terminal payments (see
+-- prepareTasksForUserDeletion) and can remove the operator's own User row. A
+-- CASCADE would let that erase the financial audit trail, and a RESTRICT would
+-- make account deletion fail — so the ids are stored as plain values that
+-- outlive both, which is the normal shape for an audit log.
+CREATE TABLE IF NOT EXISTS "task_x402_payment_action" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "paymentId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "operatorId" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+
+    CONSTRAINT "task_x402_payment_action_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "task_x402_payment_action_paymentId_createdAt_idx" ON "task_x402_payment_action"("paymentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "task_x402_payment_action_operatorId_createdAt_idx" ON "task_x402_payment_action"("operatorId", "createdAt");

--- a/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
+++ b/packages/database/prisma/migrations/20260811130000_task_x402_payment/migration.sql
@@ -22,14 +22,14 @@ CREATE TABLE IF NOT EXISTS "task_x402_payment" (
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "idempotencyKey" VARCHAR(200) NOT NULL,
     "status" "TaskX402PaymentStatus" NOT NULL DEFAULT 'PENDING',
-    "caip2Network" TEXT NOT NULL,
-    "asset" TEXT NOT NULL,
+    "caip2Network" VARCHAR(64) NOT NULL,
+    "asset" VARCHAR(128) NOT NULL,
     "amount" TEXT NOT NULL,
     "payTo" TEXT NOT NULL,
     "attemptId" TEXT,
     "failureReason" TEXT,
-    "payerAddress" TEXT,
-    "payloadNonce" TEXT,
+    "payerAddress" VARCHAR(42),
+    "payloadNonce" VARCHAR(66),
     "paymentPayloadHash" TEXT,
     "validBefore" TIMESTAMP(3),
     "taskId" TEXT NOT NULL,
@@ -41,10 +41,40 @@ CREATE TABLE IF NOT EXISTS "task_x402_payment" (
     CONSTRAINT "task_x402_payment_pkey" PRIMARY KEY ("id")
 );
 
+-- AlterTable
+-- A database that already applied an earlier version of the CREATE TABLE
+-- above skips it entirely (IF NOT EXISTS), so every column bound has to be
+-- restated here or it never reaches that database. Widening idempotencyKey to
+-- VARCHAR(200) inside the CREATE alone left such a database on unbounded TEXT
+-- — exactly the btree 2704-byte overflow the bound exists to prevent, since
+-- the column sits inside the (taskId, idempotencyKey) unique. Re-running these
+-- is a no-op once the types already match; both paths converge on one shape.
+ALTER TABLE "task_x402_payment" ALTER COLUMN "idempotencyKey" TYPE VARCHAR(200);
+ALTER TABLE "task_x402_payment" ALTER COLUMN "caip2Network" TYPE VARCHAR(64);
+ALTER TABLE "task_x402_payment" ALTER COLUMN "asset" TYPE VARCHAR(128);
+ALTER TABLE "task_x402_payment" ALTER COLUMN "payerAddress" TYPE VARCHAR(42);
+ALTER TABLE "task_x402_payment" ALTER COLUMN "payloadNonce" TYPE VARCHAR(66);
+
 -- CreateIndex
 -- The dedupe unique (ticket 003): the node has no idempotency of its own, so
 -- this unique must ship in the same change as the table.
 CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_taskId_idempotencyKey_key" ON "task_x402_payment"("taskId", "idempotencyKey");
+
+-- CreateIndex
+-- EIP-3009 replay protection, mirrored into the database. payloadNonce +
+-- payerAddress are that protocol's replay primitive: the token contract's
+-- authorizationState mapping guarantees a given (payer, nonce) authorization
+-- can be consumed at most once, so two payment rows carrying the same one mean
+-- two credit debits behind a single settleable transfer — the second can never
+-- land on-chain, and without this nothing notices. Scoped by network+asset
+-- because authorizationState is per-token-contract. Partial because a PENDING
+-- row has no nonce yet (it is written on the transition to VERIFIED) and many
+-- such rows must coexist; a violation therefore fails that transition, leaves
+-- the row PENDING, and PENDING is refundable — the right outcome for a
+-- provably unsettleable authorization.
+CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_nonce_replay_uidx"
+  ON "task_x402_payment" ("caip2Network", "asset", "payerAddress", "payloadNonce")
+  WHERE "payloadNonce" IS NOT NULL;
 
 -- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "task_x402_payment_taskEventId_key" ON "task_x402_payment"("taskEventId");
@@ -120,21 +150,33 @@ END $$;
 -- an unresolvable pointer to a dead uuid. Plain columns, never foreign keys —
 -- an FK to task/Agent/User/payment would either cascade the audit row away or
 -- block account deletion, which is the whole thing this table avoids.
--- Nullable so the append-only table tolerates rows written before this change.
+--
+-- The denormalized columns are NOT NULL. "Writers MUST populate them" was a
+-- doc comment nothing enforced, and a writer omitting one would silently
+-- produce an audit row naming an operator who moved real money without saying
+-- whose — found only in a dispute. Every one is derivable at write time from a
+-- non-nullable source (the payment's own columns, and its mandatory charge
+-- Transaction), so the constraint can never reject a legitimate write.
+--
+-- `reason` is bounded because this table is append-only and deliberately never
+-- swept by prepareTasksForUserDeletion: whatever an operator writes here
+-- outlives the erasure of every account it mentions. It must stay a short
+-- coded rationale, not narrative that could carry third-party personal data
+-- past a GDPR Art. 17 request.
 CREATE TABLE IF NOT EXISTS "task_x402_payment_action" (
     "id" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "paymentId" TEXT NOT NULL,
     "action" TEXT NOT NULL,
     "operatorId" TEXT NOT NULL,
-    "reason" TEXT NOT NULL,
-    "cents" BIGINT,
-    "amount" TEXT,
-    "asset" TEXT,
-    "caip2Network" TEXT,
-    "taskId" TEXT,
-    "agentId" TEXT,
-    "chargedUserId" TEXT,
+    "reason" VARCHAR(500) NOT NULL,
+    "cents" BIGINT NOT NULL,
+    "amount" TEXT NOT NULL,
+    "asset" VARCHAR(128) NOT NULL,
+    "caip2Network" VARCHAR(64) NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "chargedUserId" TEXT NOT NULL,
 
     CONSTRAINT "task_x402_payment_action_pkey" PRIMARY KEY ("id")
 );
@@ -142,7 +184,8 @@ CREATE TABLE IF NOT EXISTS "task_x402_payment_action" (
 -- AlterTable
 -- A database that already applied the pre-denormalization version of the
 -- CREATE TABLE above skips it entirely (IF NOT EXISTS), so add the columns
--- separately too. Both paths converge on the same shape.
+-- separately too. Added nullable first so the statement is valid whether or
+-- not the column already exists; the NOT NULL follows below.
 ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "cents" BIGINT;
 ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "amount" TEXT;
 ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "asset" TEXT;
@@ -150,6 +193,23 @@ ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "caip2Network" T
 ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "taskId" TEXT;
 ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "agentId" TEXT;
 ALTER TABLE "task_x402_payment_action" ADD COLUMN IF NOT EXISTS "chargedUserId" TEXT;
+
+-- AlterTable
+-- Same converge discipline for the bounds and the NOT NULLs: restated here so
+-- they also reach a database that skipped the CREATE. Safe unconditionally —
+-- nothing writes this table yet on any database that can reach this migration,
+-- so there is no row to violate a constraint or overflow a bound. Re-running
+-- is a no-op once the shape matches.
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "reason" TYPE VARCHAR(500);
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "asset" TYPE VARCHAR(128);
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "caip2Network" TYPE VARCHAR(64);
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "cents" SET NOT NULL;
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "amount" SET NOT NULL;
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "asset" SET NOT NULL;
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "caip2Network" SET NOT NULL;
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "taskId" SET NOT NULL;
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "agentId" SET NOT NULL;
+ALTER TABLE "task_x402_payment_action" ALTER COLUMN "chargedUserId" SET NOT NULL;
 
 -- CreateIndex
 CREATE INDEX IF NOT EXISTS "task_x402_payment_action_paymentId_createdAt_idx" ON "task_x402_payment_action"("paymentId", "createdAt");

--- a/packages/database/prisma/migrations/20260819130000_task_x402_payment/migration.sql
+++ b/packages/database/prisma/migrations/20260819130000_task_x402_payment/migration.sql
@@ -1,8 +1,12 @@
+-- Formerly 20260811130000_task_x402_payment. Re-timestamped after
+-- main's 20260818120000_better_auth_1_7_account_identity so x402 migrations
+-- apply after the current main tip. Statements are idempotent so a preview
+-- database that already applied the older name can re-apply this without failing.
+--
 -- x402/Bazaar payment record (PR1-SPEC §4). Sibling of task_payment_claim, not
 -- a reuse — the escrow claim's state machine (processing lease, retry ladder,
 -- blockchainIdentifier) is meaningless here; this record is terminal at sign
--- time. Statements are idempotent so a preview database that partially applied
--- an earlier run can re-apply without failing.
+-- time.
 
 -- CreateEnum
 -- VERIFIED is terminal for the automated flow: the node signs the X-PAYMENT

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -789,6 +789,7 @@ model Agent {
 
   userAgentRating UserAgentRating[]
   jobs            Job[]
+  x402Payments    TaskX402Payment[]
 
   tags       Tag[]      @relation("AgentTag")
   categories Category[] @relation("AgentCategory")
@@ -926,6 +927,8 @@ model Transaction {
   taskEvents               TaskEvent[]        @relation("TransactionTaskEvent")
   taskPaymentClaim         TaskPaymentClaim?  @relation("TransactionTaskPaymentClaim")
   refundedTaskPaymentClaim TaskPaymentClaim?  @relation("RefundedTransactionTaskPaymentClaim")
+  taskX402Payment          TaskX402Payment?   @relation("TransactionTaskX402Payment")
+  refundedTaskX402Payment  TaskX402Payment?   @relation("RefundedTransactionTaskX402Payment")
   coworkerUsage            CoworkerUsage?     @relation("TransactionCoworkerUsage")
   orchestratorUsage        OrchestratorUsage? @relation("TransactionOrchestratorUsage")
 
@@ -1665,9 +1668,10 @@ model Task {
 
   share PublicShare?
 
-  events TaskEvent[]
-  jobs   Job[]
-  files  TaskFile[]
+  events       TaskEvent[]
+  jobs         Job[]
+  files        TaskFile[]
+  x402Payments TaskX402Payment[]
 
   linksFrom TaskLink[] @relation("TaskLinkFrom")
   linksTo   TaskLink[] @relation("TaskLinkTo")
@@ -1795,6 +1799,19 @@ enum TaskPaymentClaimStatus {
   REFUNDED
 }
 
+/// VERIFIED is terminal for the automated flow (PR1-SPEC §4): the node signs
+/// the X-PAYMENT header locally and Soko cannot observe settlement, so nothing
+/// may auto-progress a VERIFIED record until the phased-settlement reconciler
+/// (ticket 011 Q3) ships. REFUNDED is reached from PENDING (stale-sign
+/// auto-refund), FAILED (synchronous provably-unpaid refund), or an operator
+/// goodwill refund — never by automated post-VERIFIED reconciliation.
+enum TaskX402PaymentStatus {
+  PENDING
+  VERIFIED
+  FAILED
+  REFUNDED
+}
+
 model TaskEvent {
   id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
@@ -1823,6 +1840,7 @@ model TaskEvent {
   transaction   Transaction? @relation("TransactionTaskEvent", fields: [transactionId], references: [id], onDelete: SetNull)
 
   paymentClaim TaskPaymentClaim?
+  x402Payment  TaskX402Payment?
 
   @@index([transactionId])
   @@index([orchestratorId])
@@ -1890,6 +1908,97 @@ model TaskPaymentClaimAction {
   @@index([claimId, createdAt])
   @@index([operatorId, createdAt])
   @@map("task_payment_claim_action")
+}
+
+/// x402/Bazaar payment record (PR1-SPEC §4). Sibling of TaskPaymentClaim, not
+/// a reuse — the escrow claim's state machine (processing lease, retry ladder,
+/// blockchainIdentifier) is meaningless here; this record is terminal at sign
+/// time.
+model TaskX402Payment {
+  id        String   @id @default(uuid(7))
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  /// Coworker-supplied; the node has no idempotency of its own (ticket 011),
+  /// so [taskId, idempotencyKey] is the sole dedupe.
+  idempotencyKey String
+  status         TaskX402PaymentStatus @default(PENDING)
+
+  // What was requested / signed
+  caip2Network  String
+  asset         String
+  amount        String // base units, chain-native
+  payTo         String
+  attemptId     String? // node attempt id, present once signed
+  failureReason String?
+
+  // Phased settlement observation (ticket 011 Q3): stored now, consumed by a
+  // later reconciler that checks EIP-3009 authorizationState after expiry —
+  // consumed → settled-observed; unused → EXPIRED_UNUSED → post-hoc
+  // auto-refund (provably unpaid). Terminal-at-VERIFIED until that ships.
+  payerAddress       String? // EIP-3009 `from`
+  payloadNonce       String?
+  paymentPayloadHash String?
+  validBefore        DateTime? // authorization expiry
+
+  // Links: task identity, the charged agent (per-endpoint aggregation),
+  // the credit debit, and its compensating refund.
+
+  /// Restrict, not Cascade: a money record must never vanish with its task.
+  /// Account deletion resolves payments first (prepareTasksForUserDeletion) —
+  /// same reasoning as the claim's Restrict on its transactions.
+  taskId String
+  task   Task   @relation(fields: [taskId], references: [id], onDelete: Restrict)
+
+  /// Restrict: agentId is the per-endpoint aggregation key (PR1-SPEC §5);
+  /// agent rows are never hard-deleted while payment history exists.
+  agentId String
+  agent   Agent  @relation(fields: [agentId], references: [id], onDelete: Restrict)
+
+  taskEventId String?    @unique
+  taskEvent   TaskEvent? @relation(fields: [taskEventId], references: [id], onDelete: SetNull)
+
+  /// The credit charge. Restrict so the debit stays available for
+  /// refund/compensation for the record's lifetime.
+  transactionId String      @unique
+  transaction   Transaction @relation("TransactionTaskX402Payment", fields: [transactionId], references: [id], onDelete: Restrict)
+
+  refundTransactionId String?      @unique
+  refundTransaction   Transaction? @relation("RefundedTransactionTaskX402Payment", fields: [refundTransactionId], references: [id], onDelete: Restrict)
+
+  @@unique([taskId, idempotencyKey]) // the dedupe unique (ticket 003)
+  @@index([agentId, status]) // per-endpoint refund aggregation (PR1-SPEC §5)
+  @@index([status, validBefore]) // phased-settlement reconciler expiry scan
+  @@map("task_x402_payment")
+}
+
+/// Append-only audit trail for operator decisions on a task x402 payment.
+/// These actions move money (goodwill refund) or resolve a record, so
+/// attribution must live in rows that are never updated or deleted.
+///
+/// Deliberately FK-free: account deletion hard-deletes terminal payments and
+/// can remove the operator's User row, so a cascade would erase the financial
+/// audit trail while a restrict would block account deletion. Storing plain
+/// ids lets the record outlive both, which is the normal shape for an audit
+/// log.
+model TaskX402PaymentAction {
+  id        String   @id @default(uuid(7))
+  createdAt DateTime @default(now())
+
+  /// TaskX402Payment.id — intentionally not a relation (see above).
+  paymentId String
+
+  /// "refund" | "resolve"
+  action String
+
+  /// User.id of the acting administrator — intentionally not a relation.
+  operatorId String
+
+  reason String
+
+  @@index([paymentId, createdAt])
+  @@index([operatorId, createdAt])
+  @@map("task_x402_payment_action")
 }
 
 model CoworkerUsage {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1990,6 +1990,13 @@ model TaskX402Payment {
   /// a single settleable transfer. Scoped by network+asset because the
   /// authorizationState mapping is per-token-contract, and partial because a
   /// PENDING row has no nonce yet and many such rows must coexist.
+  ///
+  /// A btree unique treats NULLs as distinct, so on its own this index lets
+  /// two rows share a nonce whenever `payerAddress` is NULL. The migration
+  /// therefore also carries a CHECK
+  /// (`task_x402_payment_nonce_payer_together_chk`) making the pair
+  /// all-or-nothing, which Prisma cannot express here. Writers must set both
+  /// fields together or neither.
   @@unique([caip2Network, asset, payerAddress, payloadNonce], map: "task_x402_payment_nonce_replay_uidx", where: { payloadNonce: { not: null } })
   @@index([agentId, status]) // per-endpoint refund aggregation (PR1-SPEC §5)
   @@index([status, validBefore]) // phased-settlement reconciler expiry scan

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1920,8 +1920,11 @@ model TaskX402Payment {
   updatedAt DateTime @updatedAt
 
   /// Coworker-supplied; the node has no idempotency of its own (ticket 011),
-  /// so [taskId, idempotencyKey] is the sole dedupe.
-  idempotencyKey String
+  /// so [taskId, idempotencyKey] is the sole dedupe. Bounded at the DB level
+  /// (the route Zod also caps it at 200): it sits inside the composite btree
+  /// unique, and an unbounded value could exceed the 2704-byte index-row
+  /// limit — a length error the DB rejects cleanly beats an opaque overflow.
+  idempotencyKey String                @db.VarChar(200)
   status         TaskX402PaymentStatus @default(PENDING)
 
   // What was requested / signed

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1984,6 +1984,14 @@ model TaskX402Payment {
 /// audit trail while a restrict would block account deletion. Storing plain
 /// ids lets the record outlive both, which is the normal shape for an audit
 /// log.
+///
+/// Because `paymentId` can point at a hard-deleted row, writers MUST populate
+/// the denormalized facts below at write time. Without them the surviving
+/// action row is an unresolvable pointer — no amount, no asset, no network, no
+/// task, no subject user — which is worthless as evidence for exactly the case
+/// (an operator refunding real on-chain money) the log exists to record. They
+/// are nullable only so the append-only table tolerates the rows written
+/// before this change; new writes must fill every one they know.
 model TaskX402PaymentAction {
   id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
@@ -1998,6 +2006,30 @@ model TaskX402PaymentAction {
   operatorId String
 
   reason String
+
+  // Denormalized snapshot of the payment at action time. Plain columns, never
+  // relations: an FK here would defeat the point, either cascading the audit
+  // row away with the payment/task/agent/user or blocking account deletion.
+
+  /// Credit magnitude of the payment's debit, in cents — the money the
+  /// operator moved. Copied from the charge Transaction, whose sign convention
+  /// (negative = spend) does not survive here: store the magnitude.
+  cents BigInt?
+
+  /// On-chain leg, copied verbatim from TaskX402Payment: base-unit amount,
+  /// asset, and CAIP-2 network. Same types as the source columns.
+  amount       String?
+  asset        String?
+  caip2Network String?
+
+  /// Correlation keys, copied from TaskX402Payment — Task.id and Agent.id as
+  /// plain values, not relations.
+  taskId  String?
+  agentId String?
+
+  /// User.id charged by the payment (the charge Transaction's userId) — the
+  /// subject of the refund, which the operator is not.
+  chargedUserId String?
 
   @@index([paymentId, createdAt])
   @@index([operatorId, createdAt])

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1927,9 +1927,15 @@ model TaskX402Payment {
   idempotencyKey String                @db.VarChar(200)
   status         TaskX402PaymentStatus @default(PENDING)
 
-  // What was requested / signed
-  caip2Network  String
-  asset         String
+  // What was requested / signed.
+  //
+  // caip2Network and asset are bounded because they sit inside the nonce
+  // replay unique below — same 2704-byte btree reasoning as idempotencyKey.
+  // The lengths are generous against their real shapes (CAIP-2 `eip155:<id>`
+  // and a 42-char ERC-20 address); the app already validates both, so this is
+  // a backstop, not the primary check.
+  caip2Network  String  @db.VarChar(64)
+  asset         String  @db.VarChar(128)
   amount        String // base units, chain-native
   payTo         String
   attemptId     String? // node attempt id, present once signed
@@ -1939,8 +1945,16 @@ model TaskX402Payment {
   // later reconciler that checks EIP-3009 authorizationState after expiry —
   // consumed → settled-observed; unused → EXPIRED_UNUSED → post-hoc
   // auto-refund (provably unpaid). Terminal-at-VERIFIED until that ships.
-  payerAddress       String? // EIP-3009 `from`
-  payloadNonce       String?
+  //
+  // payerAddress and payloadNonce are bounded to their exact on-chain shapes
+  // (a 42-char `0x`-prefixed EVM address, a 66-char `0x`-prefixed bytes32
+  // nonce). They come straight off the node's response, which is an unbounded
+  // string upstream, so this is both the btree bound and the only shape check
+  // they get. A non-conforming value fails the VERIFIED update and leaves the
+  // row PENDING — refundable, which is the correct outcome for a payment
+  // whose authorization tuple Soko cannot record.
+  payerAddress       String?   @db.VarChar(42) // EIP-3009 `from`
+  payloadNonce       String?   @db.VarChar(66)
   paymentPayloadHash String?
   validBefore        DateTime? // authorization expiry
 
@@ -1970,6 +1984,13 @@ model TaskX402Payment {
   refundTransaction   Transaction? @relation("RefundedTransactionTaskX402Payment", fields: [refundTransactionId], references: [id], onDelete: Restrict)
 
   @@unique([taskId, idempotencyKey]) // the dedupe unique (ticket 003)
+  /// EIP-3009 replay protection, mirrored into the database. The chain
+  /// guarantees a given (payer, nonce) authorization can be consumed exactly
+  /// once, so two records carrying the same one mean two credit debits behind
+  /// a single settleable transfer. Scoped by network+asset because the
+  /// authorizationState mapping is per-token-contract, and partial because a
+  /// PENDING row has no nonce yet and many such rows must coexist.
+  @@unique([caip2Network, asset, payerAddress, payloadNonce], map: "task_x402_payment_nonce_replay_uidx", where: { payloadNonce: { not: null } })
   @@index([agentId, status]) // per-endpoint refund aggregation (PR1-SPEC §5)
   @@index([status, validBefore]) // phased-settlement reconciler expiry scan
   @@map("task_x402_payment")
@@ -1985,13 +2006,18 @@ model TaskX402Payment {
 /// ids lets the record outlive both, which is the normal shape for an audit
 /// log.
 ///
-/// Because `paymentId` can point at a hard-deleted row, writers MUST populate
-/// the denormalized facts below at write time. Without them the surviving
-/// action row is an unresolvable pointer — no amount, no asset, no network, no
-/// task, no subject user — which is worthless as evidence for exactly the case
-/// (an operator refunding real on-chain money) the log exists to record. They
-/// are nullable only so the append-only table tolerates the rows written
-/// before this change; new writes must fill every one they know.
+/// Because `paymentId` can point at a hard-deleted row, the denormalized
+/// facts below are NOT NULL. Without them the surviving action row is an
+/// unresolvable pointer — no amount, no asset, no network, no task, no subject
+/// user — which is worthless as evidence for exactly the case (an operator
+/// refunding real on-chain money) the log exists to record. "Writers MUST
+/// populate them" was a comment nothing enforced: a writer that omitted one
+/// produced, silently, a row naming an operator who moved real money without
+/// saying whose. The constraint is at the database so that omission is a write
+/// error, not a discovery made during a dispute. Every one is derivable at
+/// write time from non-nullable sources (TaskX402Payment's own columns, and
+/// its mandatory charge Transaction), so none of them can legitimately be
+/// absent.
 model TaskX402PaymentAction {
   id        String   @id @default(uuid(7))
   createdAt DateTime @default(now())
@@ -2005,7 +2031,14 @@ model TaskX402PaymentAction {
   /// User.id of the acting administrator — intentionally not a relation.
   operatorId String
 
-  reason String
+  /// Short coded rationale for the action ("duplicate_charge",
+  /// "node_unreachable", …) — never narrative. This table is append-only and
+  /// is deliberately never swept by prepareTasksForUserDeletion, so anything
+  /// written here outlives the erasure of every account it mentions. Free-text
+  /// prose about a third party would therefore survive a GDPR Art. 17 request
+  /// against that person, which no downstream deletion can undo. Bounded so
+  /// the column cannot quietly become a narrative field.
+  reason String @db.VarChar(500)
 
   // Denormalized snapshot of the payment at action time. Plain columns, never
   // relations: an FK here would defeat the point, either cascading the audit
@@ -2014,22 +2047,26 @@ model TaskX402PaymentAction {
   /// Credit magnitude of the payment's debit, in cents — the money the
   /// operator moved. Copied from the charge Transaction, whose sign convention
   /// (negative = spend) does not survive here: store the magnitude.
-  cents BigInt?
+  /// Always available: TaskX402Payment.transactionId is non-nullable and
+  /// Transaction.amount is non-nullable.
+  cents BigInt
 
   /// On-chain leg, copied verbatim from TaskX402Payment: base-unit amount,
-  /// asset, and CAIP-2 network. Same types as the source columns.
-  amount       String?
-  asset        String?
-  caip2Network String?
+  /// asset, and CAIP-2 network. Same types as the source columns, all three of
+  /// which are non-nullable there.
+  amount       String
+  asset        String @db.VarChar(128)
+  caip2Network String @db.VarChar(64)
 
   /// Correlation keys, copied from TaskX402Payment — Task.id and Agent.id as
-  /// plain values, not relations.
-  taskId  String?
-  agentId String?
+  /// plain values, not relations. Non-nullable at the source.
+  taskId  String
+  agentId String
 
   /// User.id charged by the payment (the charge Transaction's userId) — the
-  /// subject of the refund, which the operator is not.
-  chargedUserId String?
+  /// subject of the refund, which the operator is not. Always available:
+  /// Transaction.userId is non-nullable.
+  chargedUserId String
 
   @@index([paymentId, createdAt])
   @@index([operatorId, createdAt])

--- a/packages/database/src/types/__tests__/x402-migration-convergence.test.ts
+++ b/packages/database/src/types/__tests__/x402-migration-convergence.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Convergence guards for the x402 payment migration.
+ *
+ * `20260811130000_task_x402_payment` is deliberately re-appliable: preview and
+ * dev databases may already hold an earlier shape of the same file, so every
+ * object it declares is restated idempotently and both paths (fresh CREATE and
+ * already-created) must land on one shape.
+ *
+ * These tests derive their expectations from `schema.prisma` rather than
+ * restating the SQL, so they fail when the model gains something the migration
+ * does not converge on — the actual regression this file exists to catch.
+ *
+ * Runtime behaviour of the constraints themselves is only observable inside
+ * Postgres and is validated by SQL probes against a real server, not here.
+ */
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const schemaPath = join(packageRoot, "prisma/schema.prisma");
+const x402MigrationPath = join(
+  packageRoot,
+  "prisma/migrations/20260811130000_task_x402_payment/migration.sql",
+);
+
+const NONCE_REPLAY_INDEX = "task_x402_payment_nonce_replay_uidx";
+const NONCE_PAYER_CHECK = "task_x402_payment_nonce_payer_together_chk";
+
+function readSchema(): string {
+  return readFileSync(schemaPath, "utf8");
+}
+
+function readX402Migration(): string {
+  return readFileSync(x402MigrationPath, "utf8");
+}
+
+function enumMembers(schema: string, enumName: string): string[] {
+  const match = schema.match(new RegExp(`enum ${enumName}\\s*\\{([^}]*)\\}`));
+  expect(match, `enum ${enumName} in schema.prisma`).toBeTruthy();
+
+  return (match?.[1] ?? "")
+    .split("\n")
+    .map((line) => line.replace(/\/\/.*$/, "").trim())
+    .filter((line) => /^[A-Z][A-Z0-9_]*$/.test(line));
+}
+
+function modelBlock(schema: string, modelName: string): string {
+  const match = schema.match(
+    new RegExp(`model ${modelName}\\s*\\{([\\s\\S]*?)\\n\\}`),
+  );
+  expect(match, `model ${modelName} in schema.prisma`).toBeTruthy();
+  return match?.[1] ?? "";
+}
+
+/** Columns listed in the `@@unique` carrying `map: "<indexName>"`. */
+function mappedUniqueColumns(model: string, indexName: string): string[] {
+  const match = model.match(
+    new RegExp(`@@unique\\(\\[([^\\]]*)\\][^\\n]*map:\\s*"${indexName}"`),
+  );
+  expect(match, `@@unique mapped to ${indexName}`).toBeTruthy();
+
+  return (match?.[1] ?? "").split(",").map((column) => column.trim());
+}
+
+/** Optional (`Type?`) scalar fields declared on a model block. */
+function optionalScalarFields(model: string): Set<string> {
+  const optional = new Set<string>();
+
+  for (const line of model.split("\n")) {
+    const match = line.trim().match(/^(\w+)\s+(\w+)\?/);
+    if (match?.[1]) {
+      optional.add(match[1]);
+    }
+  }
+
+  return optional;
+}
+
+/** The body of the `CREATE TABLE … ("…")` statement for a table. */
+function createTableBody(sql: string, tableName: string): string {
+  const start = sql.indexOf(`CREATE TABLE IF NOT EXISTS "${tableName}" (`);
+  expect(start, `CREATE TABLE for ${tableName}`).toBeGreaterThan(-1);
+
+  const end = sql.indexOf("\n);", start);
+  expect(end, `end of CREATE TABLE for ${tableName}`).toBeGreaterThan(start);
+
+  return sql.slice(start, end);
+}
+
+describe("x402 migration convergence", () => {
+  it("restates every TaskX402PaymentStatus member as an idempotent ALTER TYPE", () => {
+    // The `DO $$ CREATE TYPE … EXCEPTION WHEN duplicate_object` guard swallows
+    // the whole type when it already exists, so a database that applied an
+    // earlier shape of this file keeps the old member set forever. Every other
+    // object here converges via a restated statement; the enum must too, or
+    // the next amendment strands preview/dev on a stale type and the app hits
+    // `invalid input value for enum "TaskX402PaymentStatus"`.
+    const members = enumMembers(readSchema(), "TaskX402PaymentStatus");
+    const sql = readX402Migration();
+
+    expect(members.length).toBeGreaterThan(0);
+
+    for (const member of members) {
+      expect(
+        sql,
+        `ALTER TYPE restatement for TaskX402PaymentStatus.${member}`,
+      ).toContain(
+        `ALTER TYPE "TaskX402PaymentStatus" ADD VALUE IF NOT EXISTS '${member}';`,
+      );
+    }
+  });
+
+  it("ties every nullable column of the nonce-replay unique together with a CHECK", () => {
+    // Postgres btree uniques treat NULLs as distinct, and the partial
+    // predicate only gates on `payloadNonce IS NOT NULL`. Two rows with a NULL
+    // `payerAddress` and the same nonce therefore insert cleanly — two credit
+    // debits behind one EIP-3009 authorization, exactly what the index claims
+    // to prevent. The CHECK makes the tuple all-or-nothing so the index can
+    // never see a half-populated key.
+    const schema = readSchema();
+    const model = modelBlock(schema, "TaskX402Payment");
+    const optional = optionalScalarFields(model);
+
+    const nullableReplayColumns = mappedUniqueColumns(
+      model,
+      NONCE_REPLAY_INDEX,
+    ).filter((column) => optional.has(column));
+
+    expect(nullableReplayColumns.length).toBeGreaterThan(1);
+
+    const sql = readX402Migration();
+    const checkStatements = sql
+      .split("\n")
+      .filter((line) => line.includes(NONCE_PAYER_CHECK));
+
+    expect(
+      checkStatements.length,
+      `${NONCE_PAYER_CHECK} declared on both the CREATE and the converge path`,
+    ).toBeGreaterThanOrEqual(2);
+
+    for (const column of nullableReplayColumns) {
+      expect(sql, `${NONCE_PAYER_CHECK} covers "${column}"`).toContain(
+        `"${column}" IS NULL`,
+      );
+    }
+  });
+
+  it("declares the nonce/payer CHECK on both the fresh and the converge path", () => {
+    // A database that already applied an earlier shape of this file skips the
+    // CREATE TABLE entirely (IF NOT EXISTS), so a constraint declared only
+    // inline never reaches it — the same discipline every FK here follows.
+    const sql = readX402Migration();
+
+    expect(
+      createTableBody(sql, "task_x402_payment"),
+      "inline CHECK on the fresh CREATE TABLE path",
+    ).toContain(`CONSTRAINT "${NONCE_PAYER_CHECK}"`);
+
+    expect(sql, "idempotent ADD CONSTRAINT on the converge path").toMatch(
+      new RegExp(
+        `ALTER TABLE "task_x402_payment"\\s*\\n?\\s*ADD CONSTRAINT "${NONCE_PAYER_CHECK}"`,
+      ),
+    );
+  });
+});

--- a/packages/database/src/types/__tests__/x402-migration-convergence.test.ts
+++ b/packages/database/src/types/__tests__/x402-migration-convergence.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 /**
  * Convergence guards for the x402 payment migration.
  *
- * `20260811130000_task_x402_payment` is deliberately re-appliable: preview and
+ * `20260819130000_task_x402_payment` is deliberately re-appliable: preview and
  * dev databases may already hold an earlier shape of the same file, so every
  * object it declares is restated idempotently and both paths (fresh CREATE and
  * already-created) must land on one shape.
@@ -23,7 +23,7 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 const schemaPath = join(packageRoot, "prisma/schema.prisma");
 const x402MigrationPath = join(
   packageRoot,
-  "prisma/migrations/20260811130000_task_x402_payment/migration.sql",
+  "prisma/migrations/20260819130000_task_x402_payment/migration.sql",
 );
 
 const NONCE_REPLAY_INDEX = "task_x402_payment_nonce_replay_uidx";

--- a/packages/database/src/types/__tests__/x402-migration-convergence.test.ts
+++ b/packages/database/src/types/__tests__/x402-migration-convergence.test.ts
@@ -28,6 +28,14 @@ const x402MigrationPath = join(
 
 const NONCE_REPLAY_INDEX = "task_x402_payment_nonce_replay_uidx";
 const NONCE_PAYER_CHECK = "task_x402_payment_nonce_payer_together_chk";
+/**
+ * The exact predicate, not just the columns it mentions. Both spellings of the
+ * hole this closes — payer without nonce, and nonce without payer — are only
+ * refused by the equality; an `OR`-shaped predicate naming the same columns
+ * passes a substring check while permitting both.
+ */
+const NONCE_PAYER_PREDICATE =
+  'CHECK (("payerAddress" IS NULL) = ("payloadNonce" IS NULL))';
 
 function readSchema(): string {
   return readFileSync(schemaPath, "utf8");
@@ -146,6 +154,19 @@ describe("x402 migration convergence", () => {
         `"${column}" IS NULL`,
       );
     }
+
+    // Asserting the two column names appear is NOT enough: a predicate like
+    // `(("payerAddress" IS NULL) OR ("payloadNonce" IS NULL) OR TRUE)` contains
+    // both substrings, satisfies every check above, and is vacuously true —
+    // reopening the NULL-payer nonce-replay hole this constraint exists to
+    // close. Pin the whole equality, and pin it on BOTH paths.
+    expect(
+      checkStatements.length,
+      `${NONCE_PAYER_PREDICATE} declared on both paths`,
+    ).toBe(
+      sql.split("\n").filter((line) => line.includes(NONCE_PAYER_PREDICATE))
+        .length,
+    );
   });
 
   it("declares the nonce/payer CHECK on both the fresh and the converge path", () => {


### PR DESCRIPTION
Stack 2/6 of the x402/EVM build — the data model. No user-facing behaviour yet; this PR only makes the records possible and keeps account deletion correct once they exist.

- `TaskX402PaymentStatus` (`PENDING | VERIFIED | FAILED | REFUNDED`, terminal at VERIFIED) and `TaskX402Payment`, with the dedupe unique `[taskId, idempotencyKey]`, the aggregation index `[agentId, status]`, and the phased-settlement fields plus `[status, validBefore]`
- `TaskX402PaymentAction` — the operator audit table. Deliberately **FK-free and append-only** so a record of an operator moving real on-chain money survives the hard-deletion of the payment row during account deletion
- `prepareTasksForUserDeletion` extended: a PENDING payment blocks deletion with a clean 400 across all three RESTRICT branches, and everything else is swept before the task cascade

## Migration

`20260819130000_task_x402_payment` (formerly `20260811130000`), fully idempotent, timestamped after main's `20260818120000_better_auth_1_7_account_identity`. It has been **amended in place** several times during this stack rather than followed by new migrations — safe because it has never been applied to production. A preview database that already ran the older name should be reset.

Validated against real Postgres: `migrate deploy` from zero, a hand re-apply proving idempotency, convergence from all four earlier shapes of the file (each produces a byte-identical `pg_dump -s`), and `migrate diff` showing no x402 drift.

## What the security review changed

- **The audit row was an unresolvable pointer.** It stored only `paymentId`, `action`, `operatorId`, `reason` — so once account deletion removed the payment, the surviving record of an operator refunding real money named no amount, asset, chain, or subject. Seven denormalized money-fact columns added, all NOT NULL, all plain non-FK (an FK would cascade or block and defeat the point).
- **The nonce-replay unique had a NULL hole.** `payerAddress` is nullable and Postgres treats NULLs as distinct, while the partial predicate gated only on `payloadNonce`, so two rows sharing a nonce inserted cleanly — proven against the real index. Now fenced by `CHECK (("payerAddress" IS NULL) = ("payloadNonce" IS NULL))`.
- **The terminal sweep enumerated statuses.** Adding the planned `EXPIRED_UNUSED` would have matched neither the sweep nor the PENDING guard, leaving a row whose RESTRICT `taskId` 500s the entire account deletion. Inverted to `status: { not: PENDING }`.
- **The enum swallowed itself on re-apply**, unlike every other object in the migration, which would have left dev databases on a stale enum after the next amendment. Now restated with `ALTER TYPE … ADD VALUE IF NOT EXISTS`, with a proviso in the file: this is transaction-safe only while no statement uses a newly added member.
- `reason` bounded to `VarChar(500)`, and a Sentry page when the sweep removes a payment charged to a different user than the one being deleted.

## Verification

`pnpm --filter @sokosumi/database test` (248), `pnpm --filter core test` (3588 at the top of the stack), `pnpm typecheck`, `pnpm check` — all clean. Migration validated against local Postgres as described above.

Stacked on #3773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

