### PR TITLE
fix(chat): polish coworker onboarding copy

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1557,20 +1557,20 @@
         "openFab": "Coworker-Chat starten",
         "greeting": "Willkommen!",
         "greetingWithName": "Willkommen, {name}!",
-        "intentTitle": "Wofür bist du hier?",
-        "intentDescription": "Sag uns, woran du arbeitest — wir matchen dich mit dem richtigen Coworker und Starter-Prompts.",
+        "intentTitle": "Worauf möchtest du dich konzentrieren?",
+        "intentDescription": "Wähle einen Schwerpunkt, damit wir den passenden Coworker und passende Starter-Prompts vorschlagen können.",
         "intentChoices": {
           "chat": "Gespräch",
           "tasks": "Projekte & Aufgaben",
           "either": "Noch unsicher"
         },
         "intentChoiceHints": {
-          "chat": "Recherchieren, brainstormen oder etwas mit einem Coworker durchdenken.",
-          "tasks": "Arbeit aufteilen, einem Coworker zuweisen oder etwas voranbringen.",
-          "either": "Wir starten mit Elena, unserer Standard-KI-Coworkerin, und einer Idee zum Ausprobieren."
+          "chat": "Recherchieren, brainstormen oder ein Problem mit einem Coworker durchdenken.",
+          "tasks": "Arbeit aufteilen, Aufgaben an einen Coworker vergeben oder ein Projekt vorantreiben.",
+          "either": "Wir starten mit Elena, unserer Standard-KI-Coworkerin, und einem vorgeschlagenen Prompt."
         },
         "goalTitle": "Starter-Prompt wählen oder selbst formulieren",
-        "goalDescription": "Wähle einen Prompt, um deine erste Nachricht vorzufüllen, oder schreibe unten etwas Eigenes.",
+        "goalDescription": "Wähle einen Prompt für deine erste Nachricht oder schreibe unten etwas Eigenes.",
         "goalLabel": "Deine Nachricht",
         "goalPlaceholder": "Beispiel: Hilf mir, ein Wochenupdate zu schreiben",
         "tryAsking": {
@@ -1580,25 +1580,25 @@
             "chat": {
               "hannah": "Recherchiere unsere Wettbewerber und vergleiche uns mit ihnen.",
               "alex": "Analysiere die Daten in meinem OneDrive-Ordner.",
-              "elena": "Hilf mir zu klären, wie Sokosumi zu meinem Unternehmen passt und wo ich anfangen sollte."
+              "elena": "Hilf mir zu verstehen, wie Sokosumi zu meinem Unternehmen passt und wo ich anfangen sollte."
             },
             "tasks": {
-              "elena": "Zeig mir den Status aller meiner offenen Tasks und was meine Aufmerksamkeit benötigt.",
-              "alex": "Erstelle mir ein Dashboard für meine Rechercheergebnisse.",
-              "hannah": "Analysiere unsere Zielgruppe: Bedürfnisse, Verhalten, Mediennutzung."
+              "elena": "Zeig mir den Status meiner offenen Tasks und was Aufmerksamkeit braucht.",
+              "alex": "Erstelle ein Dashboard für meine Rechercheergebnisse.",
+              "hannah": "Analysiere unsere Zielgruppe: Bedürfnisse, Verhalten und Mediennutzung."
             },
             "either": {
-              "elena": "Hilf mir zu klären, wie Sokosumi zu meinem Unternehmen passt und wo ich anfangen sollte.",
+              "elena": "Hilf mir zu verstehen, wie Sokosumi zu meinem Unternehmen passt und wo ich anfangen sollte.",
               "hannah": "Recherchiere unsere Wettbewerber und vergleiche uns mit ihnen.",
-              "alex": "Erstelle mir eine Datenvisualisierung für mein Excel-Dokument."
+              "alex": "Erstelle eine Datenvisualisierung aus meinem Excel-Dokument."
             }
           }
         },
         "draftWithGoal": "{goal}",
         "draftWhenSkipped": {
-          "chat": "Ich brauche Hilfe im Gespräch — erzähl mir, wie du mir helfen kannst.",
+          "chat": "Ich möchte ein Gespräch starten — erzähl mir, wie du mir helfen kannst.",
           "tasks": "Ich brauche Hilfe bei Aufgaben und Projekten.",
-          "either": "Erklär mir, wie ich Sokosumi nutze."
+          "either": "Erklär mir, wie ich mit Sokosumi starte."
         },
         "next": "Weiter",
         "back": "Zurück",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1557,20 +1557,20 @@
         "openFab": "Start coworker chat",
         "greeting": "Welcome!",
         "greetingWithName": "Welcome, {name}!",
-        "intentTitle": "What are you here to do?",
-        "intentDescription": "Let us know what you're working on, we'll match you with the right coworker and starter prompts.",
+        "intentTitle": "What would you like to focus on?",
+        "intentDescription": "Choose a focus so we can recommend the right coworker and starter prompts.",
         "intentChoices": {
           "chat": "Conversation",
           "tasks": "Projects & tasks",
           "either": "Not sure yet"
         },
         "intentChoiceHints": {
-          "chat": "Research, brainstorm, or think something through with a coworker.",
-          "tasks": "Break down work, assign it to a coworker, or move something forward.",
-          "either": "We'll start you off with Elena, our default AI coworker, and an idea to try."
+          "chat": "Research, brainstorm, or work through a problem with a coworker.",
+          "tasks": "Break down work, assign tasks to a coworker, or advance a project.",
+          "either": "We'll start with Elena, our default AI coworker, and a suggested prompt."
         },
         "goalTitle": "Choose a starter prompt or write your own",
-        "goalDescription": "Select a prompt to prefill your first message, or write your own below.",
+        "goalDescription": "Select a prompt to fill in your first message, or write your own below.",
         "goalLabel": "Your message",
         "goalPlaceholder": "Example: Help me draft a weekly update",
         "tryAsking": {
@@ -1578,27 +1578,27 @@
           "orDivider": "or",
           "prompts": {
             "chat": {
-              "hannah": "Research our competitors and compare us to them.",
-              "alex": "Analyse the data in my OneDrive folder.",
-              "elena": "Help me figure out how Sokosumi fits my business and where I should start."
+              "hannah": "Research our competitors and compare us with them.",
+              "alex": "Analyze the data in my OneDrive folder.",
+              "elena": "Help me understand how Sokosumi fits my business and where I should start."
             },
             "tasks": {
-              "elena": "Show me the status of all my open tasks and what needs my attention.",
-              "alex": "Build me a Dashboard for my research results.",
-              "hannah": "Analyze our target audience: needs, behaviors, media habits."
+              "elena": "Show me the status of my open tasks and what needs attention.",
+              "alex": "Build a dashboard for my research results.",
+              "hannah": "Analyze our target audience: needs, behaviors, and media habits."
             },
             "either": {
-              "elena": "Help me figure out how Sokosumi fits my business and where I should start.",
-              "hannah": "Research our competitors and compare us to them.",
-              "alex": "Create me Data Visualisation for my Excel Sheet."
+              "elena": "Help me understand how Sokosumi fits my business and where I should start.",
+              "hannah": "Research our competitors and compare us with them.",
+              "alex": "Create a data visualization from my Excel spreadsheet."
             }
           }
         },
         "draftWithGoal": "{goal}",
         "draftWhenSkipped": {
-          "chat": "I'd like help with conversation — tell me how you can help me.",
+          "chat": "I'd like to start a conversation — tell me how you can help.",
           "tasks": "I'd like help with tasks and projects.",
-          "either": "Explain how to use Sokosumi."
+          "either": "Explain how to get started with Sokosumi."
         },
         "next": "Next",
         "back": "Back",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1557,20 +1557,20 @@
         "openFab": "Iniciar chat con coworker",
         "greeting": "¡Bienvenido!",
         "greetingWithName": "¡Bienvenido, {name}!",
-        "intentTitle": "¿Para qué estás aquí?",
-        "intentDescription": "Cuéntanos en qué estás trabajando y te emparejamos con el coworker y los prompts iniciales adecuados.",
+        "intentTitle": "¿En qué te gustaría centrarte?",
+        "intentDescription": "Elige un enfoque para recomendarte el coworker y los prompts iniciales adecuados.",
         "intentChoices": {
           "chat": "Conversación",
           "tasks": "Proyectos y tareas",
           "either": "Aún no estoy seguro"
         },
         "intentChoiceHints": {
-          "chat": "Investiga, idea o piensa algo a fondo con un coworker.",
-          "tasks": "Desglosa el trabajo, asígnalo a un coworker o avanza algo.",
-          "either": "Te empezamos con Elena, nuestra coworker de IA predeterminada, y una idea para probar."
+          "chat": "Investiga, haz una lluvia de ideas o resuelve un problema con un coworker.",
+          "tasks": "Desglosa el trabajo, asigna tareas a un coworker o avanza un proyecto.",
+          "either": "Empezaremos con Elena, nuestra coworker de IA predeterminada, y un prompt sugerido."
         },
         "goalTitle": "Elige un prompt inicial o escribe el tuyo",
-        "goalDescription": "Selecciona un prompt para rellenar tu primer mensaje, o escribe el tuyo abajo.",
+        "goalDescription": "Selecciona un prompt para tu primer mensaje o escribe el tuyo abajo.",
         "goalLabel": "Tu mensaje",
         "goalPlaceholder": "Ejemplo: Ayúdame a redactar un resumen semanal",
         "tryAsking": {
@@ -1580,25 +1580,25 @@
             "chat": {
               "hannah": "Investiga a nuestros competidores y compáranos con ellos.",
               "alex": "Analiza los datos de mi carpeta de OneDrive.",
-              "elena": "Ayúdame a ver cómo encaja Sokosumi en mi negocio y por dónde debería empezar."
+              "elena": "Ayúdame a entender cómo encaja Sokosumi en mi negocio y por dónde debería empezar."
             },
             "tasks": {
-              "elena": "Muéstrame el estado de todos mis Tasks abiertos y qué necesita mi atención.",
-              "alex": "Crea un dashboard para mis resultados de investigación.",
-              "hannah": "Analiza nuestro público objetivo: necesidades, comportamiento, uso de medios."
+              "elena": "Muéstrame el estado de mis Tasks abiertos y qué necesita atención.",
+              "alex": "Crea un panel con mis resultados de investigación.",
+              "hannah": "Analiza nuestro público objetivo: necesidades, comportamiento y uso de medios."
             },
             "either": {
-              "elena": "Ayúdame a ver cómo encaja Sokosumi en mi negocio y por dónde debería empezar.",
+              "elena": "Ayúdame a entender cómo encaja Sokosumi en mi negocio y por dónde debería empezar.",
               "hannah": "Investiga a nuestros competidores y compáranos con ellos.",
-              "alex": "Crea una visualización de datos para mi documento de Excel."
+              "alex": "Crea una visualización de datos a partir de mi hoja de Excel."
             }
           }
         },
         "draftWithGoal": "{goal}",
         "draftWhenSkipped": {
-          "chat": "Me gustaría ayuda con una conversación — cuéntame cómo puedes ayudarme.",
+          "chat": "Me gustaría empezar una conversación — cuéntame cómo puedes ayudar.",
           "tasks": "Me gustaría ayuda con tareas y proyectos.",
-          "either": "Explícame cómo usar Sokosumi."
+          "either": "Explícame cómo empezar con Sokosumi."
         },
         "next": "Siguiente",
         "back": "Atrás",


### PR DESCRIPTION
## Summary

- Polishes chat onboarding intent-step and goal-step copy toward clearer professional English
- Fixes non-native suggested prompts and skip drafts (e.g. “Create me Data Visualisation…”)
- Updates `en` / `de` / `es` in parallel

## Intent step (step 1)

| Before | After |
| --- | --- |
| What are you here to do? | What would you like to focus on? |
| Let us know what you're working on, we'll match… | Choose a focus so we can recommend the right coworker and starter prompts. |
| We'll start you off with Elena… and an idea to try. | We'll start with Elena… and a suggested prompt. |

## Goal step (step 2)

- Description: “prefill” → “fill in”
- Suggested prompts: grammar/capitalization (Build a dashboard…, Create a data visualization…)
- Skip drafts: clearer first messages

## Test plan

- [ ] Open coworker chat onboarding as a user who still sees the flow
- [ ] Step 1: title, description, and three option hints read naturally
- [ ] Step 2: suggested prompts + custom message field copy look correct
- [ ] Switch locale to DE/ES and spot-check the same strings
- [ ] `pnpm --filter web messages:parity` (or full `pnpm web:test` message parity)