### PR TITLE
fix(web): dedupe membership-visible rooms on chats cold load

### DIFF
--- a/apps/web/src/app/(app)/chat/chats/page.tsx
+++ b/apps/web/src/app/(app)/chat/chats/page.tsx
@@ -1,5 +1,6 @@
 import { connection } from "next/server";
 import { LIST_MOBILE_CREATE_FAB_CLEARANCE } from "@/app/components/mobile-create-fab-geometry";
+import { getPrivateCachedChatListChrome } from "@/app/components/private-sidebar-cache";
 import PersonalAssistantNav from "@/app/components/sidebar/components/personal-assistant-nav.client";
 import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
 import { Sheet } from "@/components/ui/sheet";
@@ -7,17 +8,7 @@ import { SidebarSeparator } from "@/components/ui/sidebar";
 import { getSession } from "@/lib/auth/auth.server";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
-import {
-  type ChatRoomsPage,
-  chatRoomService,
-  userService,
-} from "@/lib/services";
 import { cn } from "@/lib/utils";
-
-const EMPTY_ROOMS_PAGE: ChatRoomsPage = {
-  rooms: [],
-  nextCursor: null,
-};
 
 /**
  * Mobile Chats tab: Personal Assistant (beta-gated) above Channels + DMs
@@ -26,31 +17,23 @@ const EMPTY_ROOMS_PAGE: ChatRoomsPage = {
  *
  * Instant Nav uses `chats/loading.tsx` while this page streams after
  * `connection()`.
+ *
+ * Membership-visible rooms come from the same private-cache slice as the app
+ * sidebar (`getPrivateCachedChatListChrome`) so cold load does not double-hit
+ * Core (SOK-779). Cache key must match sidebar: session user id + active org.
  */
 export default async function ChatChatsPage() {
   await connection();
 
-  const [activeOrganization, session] = await Promise.all([
-    userService.getActiveOrganization(),
-    getSession(),
-  ]);
+  const session = await getSession();
+  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
+  const currentUserId = session?.user.id ?? "";
 
-  const activeOrganizationId = activeOrganization?.id ?? null;
-  const chatRoomsPromise = chatRoomService
-    .listRooms()
-    .catch(() => EMPTY_ROOMS_PAGE);
-  const archivedChatRoomsPromise = activeOrganizationId
-    ? chatRoomService.listArchivedRooms().catch(() => EMPTY_ROOMS_PAGE)
-    : Promise.resolve(EMPTY_ROOMS_PAGE);
-  const membersPromise = userService
-    .getMyMembersWithOrganizations()
-    .catch(() => []);
-
-  const [chatRoomsPage, archivedChatRoomsPage, members] = await Promise.all([
-    chatRoomsPromise,
-    archivedChatRoomsPromise,
-    membersPromise,
-  ]);
+  const { chatRoomsPage, archivedChatRoomsPage, members } =
+    await getPrivateCachedChatListChrome({
+      userId: currentUserId,
+      activeOrganizationId,
+    });
 
   const canDeleteArchivedRooms = Boolean(
     activeOrganizationId &&
@@ -79,7 +62,7 @@ export default async function ChatChatsPage() {
           roomsNextCursor={chatRoomsPage.nextCursor}
           archivedRooms={archivedChatRoomsPage.rooms}
           archivedRoomsNextCursor={archivedChatRoomsPage.nextCursor}
-          currentUserId={session?.user.id ?? ""}
+          currentUserId={currentUserId}
           organizationId={activeOrganizationId}
           canDeleteArchivedRooms={canDeleteArchivedRooms}
           dismissSheetOnNavigate={false}

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -35,7 +35,10 @@ describe("loadChatListChromeData", () => {
     ]);
   });
 
-  it("loads membership-visible rooms, archived, and members once per call", async () => {
+  it("issues one rooms + archived + members fetch per loadChatListChromeData call", async () => {
+    // Proves the shared body is a single fan-out, not N service calls per field.
+    // In-request SSR dedupe of sidebar+page is Next private-cache runtime (not
+    // exercisable here); dual call-site wiring is locked by the contract tests.
     const { loadChatListChromeData } = await import("../private-sidebar-cache");
 
     const result = await loadChatListChromeData("org-1");

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listRoomsMock = vi.fn();
+const listArchivedRoomsMock = vi.fn();
+const getMyMembersWithOrganizationsMock = vi.fn();
+
+vi.mock("@/lib/services", () => ({
+  chatRoomService: {
+    listRooms: (...args: unknown[]) => listRoomsMock(...args),
+    listArchivedRooms: (...args: unknown[]) => listArchivedRoomsMock(...args),
+  },
+  userService: {
+    getMyMembersWithOrganizations: (...args: unknown[]) =>
+      getMyMembersWithOrganizationsMock(...args),
+  },
+}));
+
+const EMPTY_PAGE = { rooms: [], nextCursor: null };
+
+describe("loadChatListChromeData", () => {
+  beforeEach(() => {
+    listRoomsMock.mockReset();
+    listArchivedRoomsMock.mockReset();
+    getMyMembersWithOrganizationsMock.mockReset();
+    listRoomsMock.mockResolvedValue({
+      rooms: [{ id: "room-1" }],
+      nextCursor: "next",
+    });
+    listArchivedRoomsMock.mockResolvedValue({
+      rooms: [{ id: "archived-1" }],
+      nextCursor: null,
+    });
+    getMyMembersWithOrganizationsMock.mockResolvedValue([
+      { organizationId: "org-1", role: "owner" },
+    ]);
+  });
+
+  it("loads membership-visible rooms, archived, and members once per call", async () => {
+    const { loadChatListChromeData } = await import("../private-sidebar-cache");
+
+    const result = await loadChatListChromeData("org-1");
+
+    expect(listRoomsMock).toHaveBeenCalledTimes(1);
+    expect(listRoomsMock).toHaveBeenCalledWith();
+    expect(listArchivedRoomsMock).toHaveBeenCalledTimes(1);
+    expect(getMyMembersWithOrganizationsMock).toHaveBeenCalledTimes(1);
+    expect(result.chatRoomsPage.rooms).toEqual([{ id: "room-1" }]);
+    expect(result.archivedChatRoomsPage.rooms).toEqual([{ id: "archived-1" }]);
+    expect(result.members).toEqual([
+      { organizationId: "org-1", role: "owner" },
+    ]);
+  });
+
+  it("skips archived rooms Core fetch when no active organization", async () => {
+    const { loadChatListChromeData } = await import("../private-sidebar-cache");
+
+    const result = await loadChatListChromeData(null);
+
+    expect(listRoomsMock).toHaveBeenCalledTimes(1);
+    expect(listArchivedRoomsMock).not.toHaveBeenCalled();
+    expect(getMyMembersWithOrganizationsMock).toHaveBeenCalledTimes(1);
+    expect(result.archivedChatRoomsPage).toEqual(EMPTY_PAGE);
+  });
+
+  it("returns empty pages when room fetches fail", async () => {
+    listRoomsMock.mockRejectedValueOnce(new Error("rooms down"));
+    listArchivedRoomsMock.mockRejectedValueOnce(new Error("archived down"));
+    getMyMembersWithOrganizationsMock.mockRejectedValueOnce(
+      new Error("members down"),
+    );
+    const { loadChatListChromeData } = await import("../private-sidebar-cache");
+
+    const result = await loadChatListChromeData("org-1");
+
+    expect(result.chatRoomsPage).toEqual(EMPTY_PAGE);
+    expect(result.archivedChatRoomsPage).toEqual(EMPTY_PAGE);
+    expect(result.members).toEqual([]);
+  });
+});
+
+describe("chat list chrome single-source composition contract", () => {
+  it("sidebar and chats page both call getPrivateCachedChatListChrome", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const sidebar = readFileSync(
+      join(dir, "../private-cached-app-sidebar.tsx"),
+      "utf8",
+    );
+    const chatsPage = readFileSync(
+      join(dir, "../../chat/chats/page.tsx"),
+      "utf8",
+    );
+
+    expect(sidebar).toMatch(/getPrivateCachedChatListChrome/);
+    expect(chatsPage).toMatch(/getPrivateCachedChatListChrome/);
+    // Page must not re-issue raw listRooms / listArchived / members after the
+    // shared private-cache slice owns that cold composition work.
+    expect(chatsPage).not.toMatch(/chatRoomService\s*\.\s*listRooms\s*\(/);
+    expect(chatsPage).not.toMatch(
+      /chatRoomService\s*\.\s*listArchivedRooms\s*\(/,
+    );
+    expect(chatsPage).not.toMatch(
+      /userService\s*\.\s*getMyMembersWithOrganizations\s*\(/,
+    );
+  });
+
+  it("private cache loader tags user/org like sidebar chrome", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+
+    const source = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../private-sidebar-cache.ts",
+      ),
+      "utf8",
+    );
+
+    expect(source).toMatch(/"use cache: private"/);
+    expect(source).toMatch(/privateSidebarUserTag/);
+    expect(source).toMatch(/privateSidebarOrgTag/);
+    expect(source).toMatch(/function getPrivateCachedChatListChrome/);
+  });
+});

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -39,7 +39,9 @@ describe("loadChatListChromeData", () => {
     // Proves the shared body is a single fan-out, not N service calls per field.
     // In-request SSR dedupe of sidebar+page is Next private-cache runtime (not
     // exercisable here); dual call-site wiring is locked by the contract tests.
-    const { loadChatListChromeData } = await import("../private-sidebar-cache");
+    const { loadChatListChromeData } = await import(
+      "@/app/components/private-sidebar-cache"
+    );
 
     const result = await loadChatListChromeData("org-1");
 
@@ -55,7 +57,9 @@ describe("loadChatListChromeData", () => {
   });
 
   it("skips archived rooms Core fetch when no active organization", async () => {
-    const { loadChatListChromeData } = await import("../private-sidebar-cache");
+    const { loadChatListChromeData } = await import(
+      "@/app/components/private-sidebar-cache"
+    );
 
     const result = await loadChatListChromeData(null);
 
@@ -71,7 +75,9 @@ describe("loadChatListChromeData", () => {
     getMyMembersWithOrganizationsMock.mockRejectedValueOnce(
       new Error("members down"),
     );
-    const { loadChatListChromeData } = await import("../private-sidebar-cache");
+    const { loadChatListChromeData } = await import(
+      "@/app/components/private-sidebar-cache"
+    );
 
     const result = await loadChatListChromeData("org-1");
 

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -9,15 +9,12 @@ import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-ven
 import { getEnvPublicConfig } from "@/config/env.public";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
-import {
-  type ChatRoomsPage,
-  chatRoomService,
-  userService,
-} from "@/lib/services";
+import { chatRoomService } from "@/lib/services";
 import { resolvePlanName } from "@/lib/utils/plan-label";
 
 import {
   getCachedMyCredits,
+  getPrivateCachedChatListChrome,
   privateSidebarOrgTag,
   privateSidebarUserTag,
 } from "./private-sidebar-cache";
@@ -29,11 +26,6 @@ interface PrivateCachedAppSidebarProps {
   activeOrganizationId: string | null;
   adminMenuEnabled: boolean;
 }
-
-const EMPTY_ROOMS_PAGE: ChatRoomsPage = {
-  rooms: [],
-  nextCursor: null,
-};
 
 /**
  * Session-aware sidebar chrome for Instant Navigations.
@@ -58,19 +50,15 @@ export default async function PrivateCachedAppSidebar({
   const lowCreditsThreshold =
     getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
 
-  const membersPromise = userService
-    .getMyMembersWithOrganizations()
-    .catch(() => []);
+  // Membership-visible rooms + archived + members: shared private-cache slice
+  // with `/chat/chats` so cold composition does not double-hit Core (SOK-779).
   // Personal coworker directs exist with no active org; Core returns those when
-  // organization context is null. Named channels still need an org (empty list then).
-  // Guest rooms (any host org) are mixed into listRooms; pending invites are
-  // separate (invitee-facing) for the External sidebar section.
-  const chatRoomsPromise = chatRoomService
-    .listRooms()
-    .catch(() => EMPTY_ROOMS_PAGE);
-  const archivedChatRoomsPromise = activeOrganizationId
-    ? chatRoomService.listArchivedRooms().catch(() => EMPTY_ROOMS_PAGE)
-    : Promise.resolve(EMPTY_ROOMS_PAGE);
+  // organization context is null. Guest rooms (any host org) are mixed into the
+  // list. Pending invites stay sidebar-only (invitee External section).
+  const chatListChromePromise = getPrivateCachedChatListChrome({
+    userId: sessionUser.id,
+    activeOrganizationId,
+  });
   const pendingInvitationsPromise = chatRoomService
     .listPendingInvitations()
     .catch(() => []);
@@ -78,26 +66,24 @@ export default async function PrivateCachedAppSidebar({
 
   const [
     tPlan,
-    members,
-    chatRoomsPage,
-    archivedChatRoomsPage,
+    chatListChrome,
     pendingChatRoomInvitations,
     { showVendors: showDeveloperVendors },
     creditsResult,
   ] = await Promise.all([
     tPlanPromise,
-    membersPromise,
-    chatRoomsPromise,
-    archivedChatRoomsPromise,
+    chatListChromePromise,
     pendingInvitationsPromise,
     getDeveloperVendorAdminAccess(),
     creditsPromise,
   ]);
 
-  const chatRooms = chatRoomsPage.rooms;
-  const chatRoomsNextCursor = chatRoomsPage.nextCursor;
-  const archivedChatRooms = archivedChatRoomsPage.rooms;
-  const archivedChatRoomsNextCursor = archivedChatRoomsPage.nextCursor;
+  const { members } = chatListChrome;
+  const chatRooms = chatListChrome.chatRoomsPage.rooms;
+  const chatRoomsNextCursor = chatListChrome.chatRoomsPage.nextCursor;
+  const archivedChatRooms = chatListChrome.archivedChatRoomsPage.rooms;
+  const archivedChatRoomsNextCursor =
+    chatListChrome.archivedChatRoomsPage.nextCursor;
 
   const creditsData = creditsResult?.data.credits ?? null;
   const currentPlan = creditsData?.subscription?.plan ?? "free";

--- a/apps/web/src/app/(app)/components/private-sidebar-cache.ts
+++ b/apps/web/src/app/(app)/components/private-sidebar-cache.ts
@@ -36,6 +36,11 @@ export interface PrivateCachedChatListChrome {
  * Testable body for membership-visible rooms + archived + members.
  * Prefer {@link getPrivateCachedChatListChrome} from RSC so sidebar and chats
  * list share one private-cache slice (React.cache does not cross use-cache).
+ *
+ * Fail-soft: service errors become empty pages/arrays (same as pre-SOK-779
+ * sidebar/page). When used under private cache those empties are shared until
+ * revalidate or `invalidatePrivateSidebarChrome` — intentional chrome tradeoff,
+ * not a hard fail that would blank the whole layout.
  */
 export async function loadChatListChromeData(
   activeOrganizationId: string | null,

--- a/apps/web/src/app/(app)/components/private-sidebar-cache.ts
+++ b/apps/web/src/app/(app)/components/private-sidebar-cache.ts
@@ -1,9 +1,17 @@
 import "server-only";
 
-import { updateTag } from "next/cache";
+import { cacheLife, cacheTag, updateTag } from "next/cache";
 import { cache } from "react";
 import { coreClient } from "@/lib/clients/core.client";
-import type { GetUsersByIdCreditsResponse } from "@/lib/clients/generated/core";
+import type {
+  GetUsersByIdCreditsResponse,
+  MemberWithOrganization,
+} from "@/lib/clients/generated/core";
+import {
+  type ChatRoomsPage,
+  chatRoomService,
+  userService,
+} from "@/lib/services";
 
 export function privateSidebarUserTag(userId: string): string {
   return `app-sidebar-user-${userId}`;
@@ -11,6 +19,62 @@ export function privateSidebarUserTag(userId: string): string {
 
 export function privateSidebarOrgTag(organizationId: string): string {
   return `app-sidebar-org-${organizationId}`;
+}
+
+const EMPTY_ROOMS_PAGE: ChatRoomsPage = {
+  rooms: [],
+  nextCursor: null,
+};
+
+export interface PrivateCachedChatListChrome {
+  chatRoomsPage: ChatRoomsPage;
+  archivedChatRoomsPage: ChatRoomsPage;
+  members: MemberWithOrganization[];
+}
+
+/**
+ * Testable body for membership-visible rooms + archived + members.
+ * Prefer {@link getPrivateCachedChatListChrome} from RSC so sidebar and chats
+ * list share one private-cache slice (React.cache does not cross use-cache).
+ */
+export async function loadChatListChromeData(
+  activeOrganizationId: string | null,
+): Promise<PrivateCachedChatListChrome> {
+  const chatRoomsPromise = chatRoomService
+    .listRooms()
+    .catch(() => EMPTY_ROOMS_PAGE);
+  const archivedChatRoomsPromise = activeOrganizationId
+    ? chatRoomService.listArchivedRooms().catch(() => EMPTY_ROOMS_PAGE)
+    : Promise.resolve(EMPTY_ROOMS_PAGE);
+  const membersPromise = userService
+    .getMyMembersWithOrganizations()
+    .catch(() => []);
+
+  const [chatRoomsPage, archivedChatRoomsPage, members] = await Promise.all([
+    chatRoomsPromise,
+    archivedChatRoomsPromise,
+    membersPromise,
+  ]);
+
+  return { chatRoomsPage, archivedChatRoomsPage, members };
+}
+
+/**
+ * Membership-visible rooms chrome shared by private sidebar + `/chat/chats`.
+ * Same private tags/life as sidebar so cold composition hits Core once.
+ */
+export async function getPrivateCachedChatListChrome(args: {
+  userId: string;
+  activeOrganizationId: string | null;
+}): Promise<PrivateCachedChatListChrome> {
+  "use cache: private";
+  cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
+  cacheTag(privateSidebarUserTag(args.userId));
+  if (args.activeOrganizationId) {
+    cacheTag(privateSidebarOrgTag(args.activeOrganizationId));
+  }
+
+  return loadChatListChromeData(args.activeOrganizationId);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Share one `"use cache: private"` slice (`getPrivateCachedChatListChrome`) for membership-visible rooms, archived rooms, and members between the app sidebar and `/chat/chats`.
- Stops cold composition from double-hitting Core (React `cache()` does not cross the sidebar private-cache boundary).
- Call-count + single-source contract tests under mocked services.

Closes linear issue [SOK-779](https://linear.app/masumi/issue/SOK-779/fixweb-dedupe-membership-visible-rooms-on-chats-cold-load) (parent [SOK-776](https://linear.app/masumi/issue/SOK-776/spec-web-speed-insights-performance-tracer-stack)).

## Spec summary

- Cold chats list + sidebar: one fetch of membership-visible rooms
- Related archived rooms / members also deduped at existing private-sidebar cache seam
- No new global store; reuse private tags/life already used by sidebar chrome
- Invalidate path unchanged (`invalidatePrivateSidebarChrome`)

## Test plan

- [x] `pnpm --filter web test` for `chat-list-chrome-cache`, `private-sidebar-cache`, sidebar contract, chat Instant contracts
- [x] `pnpm check` + full typecheck (pre-commit)
- [ ] Manual: cold load `/chat/chats` — list + sidebar show same membership-visible rooms; revoke membership still drops room (existing soft-remove + tag invalidation)
- [ ] After ~7d prod: glance Speed Insights `/chat/chats` LCP (informational only)