### PR TITLE
fix(chat): restore room list scroll after progressive shell

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-shell-scroller-overflow.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-shell-scroller-overflow.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { CHAT_MESSAGE_LIST_SCROLLER_CLASS } from "../../chat-message-list-scroller";
+import { ROOM_MESSAGE_LIST_CONTENT_CLASSNAME } from "../room-message-list-skeleton";
+import { ROOM_SHELL_SCROLLER_CLASSNAME } from "../room-shell-layout";
+
+/**
+ * Regression: SOK-778 progressive shell put `flex flex-col` on the message
+ * scroller while content used `min-h-full` + pixel minHeight for justify-end.
+ * That combination clamps scrollHeight to clientHeight — tall rooms cannot
+ * scroll up to older messages.
+ *
+ * Scroller must stay a non-flex overflow box; content owns min-height.
+ */
+describe("room shell scroller overflow contract", () => {
+  it("keeps native overflow scroller without flex column", () => {
+    expect(ROOM_SHELL_SCROLLER_CLASSNAME).toBe(
+      CHAT_MESSAGE_LIST_SCROLLER_CLASS,
+    );
+    expect(ROOM_SHELL_SCROLLER_CLASSNAME).toContain("overflow-y-auto");
+    expect(ROOM_SHELL_SCROLLER_CLASSNAME).toContain("min-h-0");
+    expect(ROOM_SHELL_SCROLLER_CLASSNAME).toContain("flex-1");
+    // flex-1 is width/height grow; display:flex on the scroller itself is the bug.
+    expect(ROOM_SHELL_SCROLLER_CLASSNAME.split(/\s+/)).not.toContain("flex");
+    expect(ROOM_SHELL_SCROLLER_CLASSNAME).not.toContain("flex-col");
+  });
+
+  it("content still uses min-h-full for short-transcript justify-end", () => {
+    expect(ROOM_MESSAGE_LIST_CONTENT_CLASSNAME).toContain("min-h-full");
+    expect(ROOM_MESSAGE_LIST_CONTENT_CLASSNAME).toContain("justify-end");
+    expect(ROOM_MESSAGE_LIST_CONTENT_CLASSNAME).toContain("flex-col");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/room-shell-layout.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-shell-layout.tsx
@@ -28,10 +28,13 @@ export const ROOM_SHELL_DESKTOP_HEADER_CLASSNAME =
 export const ROOM_SHELL_DESKTOP_HEADER_SLOT_CLASSNAME =
   "hidden h-16 shrink-0 border-b md:flex";
 
-export const ROOM_SHELL_SCROLLER_CLASSNAME = cn(
-  CHAT_MESSAGE_LIST_SCROLLER_CLASS,
-  "flex flex-col",
-);
+/**
+ * Native overflow scroller only — do **not** add `flex flex-col` here.
+ * Content uses `min-h-full` / pixel minHeight for short-transcript justify-end.
+ * A flex column scroller + min-height child clamps scrollHeight to clientHeight
+ * so the list cannot scroll up (tall transcripts unreadable).
+ */
+export const ROOM_SHELL_SCROLLER_CLASSNAME = CHAT_MESSAGE_LIST_SCROLLER_CLASS;
 
 interface RoomShellLayoutProps {
   testId?: string;


### PR DESCRIPTION
## Summary

- Room message list could not scroll up after SOK-778 progressive shell (`#3772`): scroller used `flex flex-col` while content used `min-h-full` / pixel minHeight, which clamps `scrollHeight` to `clientHeight`.
- Drop `flex flex-col` from `ROOM_SHELL_SCROLLER_CLASSNAME` so the list stays a native overflow box; content still owns min-height for short-transcript justify-end.
- Add a class-contract regression test so the bad combo cannot return unnoticed.

## Test plan

- [x] Chrome headless layout harness: tall transcript `canScroll` true after fix (false with flex scroller + min-height).
- [x] `pnpm --filter web test` on `room-shell-scroller-overflow`, `rooms-client-ably-island`, `use-stick-to-bottom`.
- [x] Pre-commit `pnpm check` + `pnpm typecheck`.
- [ ] Manually open a long room history and scroll up to older messages / load older.