### PR TITLE
fix(web): stop agent fullbleed :has leak under Activity

### DIFF
--- a/apps/web/src/app/(app)/agents/[agentId]/components/__tests__/agent-fullbleed-effect.test.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/components/__tests__/agent-fullbleed-effect.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import AgentFullbleedEffect from "../agent-fullbleed-effect";
+
+describe("AgentFullbleedEffect", () => {
+  afterEach(() => {
+    delete document.body.dataset.agentFullbleed;
+  });
+
+  it("sets body data-agent-fullbleed on mount and clears on unmount", () => {
+    expect(document.body.dataset.agentFullbleed).toBeUndefined();
+
+    const { unmount } = render(<AgentFullbleedEffect />);
+
+    expect(document.body.dataset.agentFullbleed).toBe("true");
+    expect(document.body.getAttribute("data-agent-fullbleed")).toBe("true");
+
+    unmount();
+
+    expect(document.body.dataset.agentFullbleed).toBeUndefined();
+    expect(document.body.hasAttribute("data-agent-fullbleed")).toBe(false);
+  });
+});

--- a/apps/web/src/app/(app)/agents/[agentId]/components/agent-fullbleed-effect.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/components/agent-fullbleed-effect.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Toggles `data-agent-fullbleed="true"` on `<body>` while the agent detail
+ * segment is mounted. Global CSS keys off the body attribute (not `:has`) so
+ * Next.js Activity / Instant Navigations cannot leave a hidden marker in the
+ * tree that would keep gallery `main` padding at 0 after soft nav away.
+ */
+export default function AgentFullbleedEffect() {
+  useEffect(() => {
+    document.body.dataset.agentFullbleed = "true";
+    return () => {
+      delete document.body.dataset.agentFullbleed;
+    };
+  }, []);
+  return null;
+}

--- a/apps/web/src/app/(app)/agents/[agentId]/layout.tsx
+++ b/apps/web/src/app/(app)/agents/[agentId]/layout.tsx
@@ -7,6 +7,8 @@ import {
 import { getCoreAgentById } from "@/lib/agents/core-loaders";
 import { cn } from "@/lib/utils";
 
+import AgentFullbleedEffect from "./components/agent-fullbleed-effect";
+
 export async function generateMetadata({
   params,
 }: {
@@ -36,6 +38,7 @@ export default function AgentDetailLayout({
         "md:pt-0",
       )}
     >
+      <AgentFullbleedEffect />
       {children}
     </div>
   );

--- a/apps/web/src/app/__tests__/agent-fullbleed-globals-contract.test.ts
+++ b/apps/web/src/app/__tests__/agent-fullbleed-globals-contract.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const GLOBALS_CSS = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../globals.css",
+);
+
+/** Drop block + line comments so explanatory prose cannot false-fail. */
+function cssWithoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+describe("agent fullbleed globals.css contract", () => {
+  it("keys shell padding/overflow off body attr, not :has", () => {
+    const css = readFileSync(GLOBALS_CSS, "utf8");
+    const rules = cssWithoutComments(css);
+
+    expect(rules).toContain('body[data-agent-fullbleed="true"]');
+    expect(rules).not.toMatch(/:has\(\[data-agent-fullbleed\]\)/);
+  });
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -504,24 +504,27 @@
 /*
  * Agents full-bleed layout
  *
- * We scope these overrides to `/agents/[agentId]/*` via the
- * `data-agent-fullbleed` marker in that segment layout.
+ * Keyed off `body[data-agent-fullbleed="true"]` (toggled by
+ * AgentFullbleedEffect), not `:has([data-agent-fullbleed])`. Under Next.js
+ * Activity / Instant Navigations the segment layout can stay mounted but
+ * hidden; `:has` would still match and leave gallery `main` padding at 0.
+ * Effect cleanup clears the body attribute when the segment hides/unmounts.
  *
- * This avoids nested scroll containers and allows `position: sticky` to work by
- * disabling overflow clipping/hidden wrappers for that subtree.
+ * Layout still keeps a `data-agent-fullbleed` marker for clarity; CSS does
+ * not key off it. Overflow visible avoids nested scroll so sticky works.
  */
-[data-app-shell]:has([data-agent-fullbleed]),
-[data-app-content]:has([data-agent-fullbleed]),
-[data-app-content-inner]:has([data-agent-fullbleed]) {
+body[data-agent-fullbleed="true"] [data-app-shell],
+body[data-agent-fullbleed="true"] [data-app-content],
+body[data-agent-fullbleed="true"] [data-app-content-inner] {
   overflow: visible !important;
 }
 
-main[data-app-main]:has([data-agent-fullbleed]) {
+body[data-agent-fullbleed="true"] main[data-app-main] {
   padding: 0 !important;
   overflow: visible !important;
 }
 
-main[data-app-main]:has([data-agent-fullbleed]) [data-app-main-inner] {
+body[data-agent-fullbleed="true"] main[data-app-main] [data-app-main-inner] {
   overflow: visible !important;
 }
 

--- a/apps/web/src/components/agents/agent-detail/agent-detail.tsx
+++ b/apps/web/src/components/agents/agent-detail/agent-detail.tsx
@@ -55,7 +55,7 @@ export function AgentDetail({
   return (
     <div
       className={cn(
-        "mt-4 flex w-full flex-col space-y-8 px-4 pb-8 md:px-0",
+        "mt-0 flex w-full flex-col space-y-8 px-4 pb-8 md:mt-4 md:px-0",
         className,
       )}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up for [SOK-783](https://linear.app/masumi/issue/SOK-783/fix-mobile-agents-gallery-padding-and-agent-detail-chrome) / #3777.

- **Root cause:** Instant Navigations (React Activity) keep a hidden `data-agent-fullbleed` node, so CSS `:has()` kept zeroing `main` padding after leaving agent detail — gallery gutters looked intermittent.
- **Fix:** toggle `body[data-agent-fullbleed]` via `AgentFullbleedEffect` (Hermes fullscreen pattern); CSS keys off the body attribute so Activity hide runs effect cleanup and restores gallery `p-4`.
- **Agent detail:** drop mobile-only extra margin from the removed sticky sub-header (`mt-0 md:mt-4`). Layout still supplies `APP_MAIN_MOBILE_PT_CLASS` (80px / 5rem) for the app header.

## Test plan

- [x] `pnpm web:check` (exit 0)
- [x] `pnpm web:test` (exit 0; 3210 passed)
- [x] Soft-nav `/agents/[id]` → `/agents`: `body` attr cleared; `main` paddingLeft/Right `16px`
- [x] Agent detail mobile: `body` attr set; `main` padding `0`; layout `paddingTop` `80px`; AgentDetail `marginTop` `0`
- [x] CI green at `headSha` `369b56b91fcb5bc145f582af536a89452a6f88a1`

## UI proof

[Gallery after soft-nav from detail (gutters restored)](https://cursor.com/agents/bc-243f4122-1cc0-40a4-9fd9-781b8b3a2593/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-783-followup%2Fagents-gallery-after-soft-nav.png)
[Agent detail mobile (no extra sub-header margin)](https://cursor.com/agents/bc-243f4122-1cc0-40a4-9fd9-781b8b3a2593/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsok-783-followup%2Fagent-detail-seeded.png)

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Maintainability | `agent-fullbleed-effect.tsx` + layout marker | Body and layout both use `data-agent-fullbleed`; CSS correctly keys on `body[…="true"]`, but `querySelector("[data-agent-fullbleed]")` hits `body` first. Harmless; rename layout marker later if desired. |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-243f4122-1cc0-40a4-9fd9-781b8b3a2593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-243f4122-1cc0-40a4-9fd9-781b8b3a2593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

