### PR TITLE
fix(web): PA first paint without billing block

### DIFF
--- a/apps/web/src/app/(app)/personal-assistant/README.md
+++ b/apps/web/src/app/(app)/personal-assistant/README.md
@@ -68,6 +68,15 @@ the `ProgressPips` macro indicator (`Setup → Personalize → Ready`).
 The wrapper `HermesExperience` polls the instance, normalizes states, and
 unmounts the polling effect when the route leaves the foreground.
 
+### First paint (billing deferred)
+
+`page.tsx` does **not** await paid-plan coverage or the subscription catalog
+before streaming UI. It loads session, returns `<Suspense fallback={<LoadingState />}>`,
+and defers memberships + coverage + catalog to `HermesExperienceWithAccess`.
+Gate stays fail-closed once resolved; Core still re-checks on provision/chat.
+Soft-nav Instant stays off (`export const instant = false` on the layout).
+`RunningState` (and settings/skills) is dynamic-imported off the experience entry.
+
 ### Full-bleed chat under the shared header
 
 The shared `AppLayout` renders a breadcrumb `Header` (`h-16` / 4rem; 64px at
@@ -293,9 +302,12 @@ For a hard local-only reset, drop those rows directly.
 apps/web/src/app/(app)/personal-assistant/
 ├── README.md                            ← you are here
 ├── layout.tsx                           ← beta whitelist gate + FullscreenEffect
-├── page.tsx                             ← session pass-through, renders HermesExperience
+├── loading.tsx                          ← route-transition LoadingState shell
+├── page.tsx                             ← session + Suspense shell; billing deferred (see First paint)
+├── hermes-page-subscription.ts          ← fail-closed paid gate + wall plan mapping
 └── components/
-    ├── hermes-experience.tsx            ← state machine + polling
+    ├── hermes-experience.tsx            ← state machine + polling; RunningState dynamic-import
+
     ├── empty-state.tsx                  ← shell: /personal-assistant when no instance
     ├── empty-state/                     ← hero + journey + features + examples + disclaimer modules
     ├── provisioning-state.tsx           ← honest "Setting up your agent…" view

--- a/apps/web/src/app/(app)/personal-assistant/__tests__/hermes-page-subscription.test.ts
+++ b/apps/web/src/app/(app)/personal-assistant/__tests__/hermes-page-subscription.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSubscriptionWallPlans,
+  resolveHermesHasActiveSubscription,
+} from "@/app/personal-assistant/hermes-page-subscription";
+import type { GetSubscriptionCatalogResponse } from "@/lib/clients/generated/core";
+
+describe("resolveHermesHasActiveSubscription", () => {
+  it("is false when no coverage and not admin (fail-closed)", () => {
+    expect(resolveHermesHasActiveSubscription(false, "user")).toBe(false);
+    expect(resolveHermesHasActiveSubscription(false, null)).toBe(false);
+    expect(resolveHermesHasActiveSubscription(false, undefined)).toBe(false);
+  });
+
+  it("is true when coverage is true", () => {
+    expect(resolveHermesHasActiveSubscription(true, "user")).toBe(true);
+  });
+
+  it("is true for platform admin even without coverage", () => {
+    expect(resolveHermesHasActiveSubscription(false, "admin")).toBe(true);
+    expect(resolveHermesHasActiveSubscription(false, "user,admin")).toBe(true);
+  });
+});
+
+describe("buildSubscriptionWallPlans", () => {
+  it("returns empty when catalog is missing", () => {
+    expect(buildSubscriptionWallPlans(null)).toEqual([]);
+    expect(buildSubscriptionWallPlans(undefined)).toEqual([]);
+  });
+
+  it("maps starter/standard/pro in product order", () => {
+    const catalog = {
+      data: {
+        free: { credits: 250, currency: "eur", monthlyAmount: 0 },
+        starter: { credits: 1_750, currency: "eur", monthlyAmount: 2_500 },
+        standard: { credits: 5_250, currency: "eur", monthlyAmount: 7_500 },
+        pro: { credits: 14_000, currency: "eur", monthlyAmount: 20_000 },
+      },
+    } as GetSubscriptionCatalogResponse;
+
+    expect(buildSubscriptionWallPlans(catalog)).toEqual([
+      {
+        name: "starter",
+        monthlyAmount: 2_500,
+        currency: "eur",
+        credits: 1_750,
+      },
+      {
+        name: "standard",
+        monthlyAmount: 7_500,
+        currency: "eur",
+        credits: 5_250,
+      },
+      {
+        name: "pro",
+        monthlyAmount: 20_000,
+        currency: "eur",
+        credits: 14_000,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/app/(app)/personal-assistant/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/__tests__/page.test.tsx
@@ -114,28 +114,14 @@ describe("HermesPage first paint + billing gate", () => {
   });
 
   it("returns Suspense shell without awaiting coverage or catalog", async () => {
-    let resolveCoverage!: (value: boolean) => void;
-    hasPaidPlanCoverageMock.mockReturnValue(
-      new Promise<boolean>((resolve) => {
-        resolveCoverage = resolve;
-      }),
-    );
-    getSubscriptionCatalogMock.mockReturnValue(
-      new Promise(() => {
-        /* intentionally never resolves during this assertion */
-      }),
-    );
-
+    // Assertion is "not called" — keep resolved mocks (no open-handle stubs).
     const { default: HermesPage } = await import("../page");
     const tree = await HermesPage();
 
-    // Shell returned while billing promises are still pending.
     expect(hasPaidPlanCoverageMock).not.toHaveBeenCalled();
     expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(getMyMembersWithOrganizationsMock).not.toHaveBeenCalled();
     expect(isValidElement(tree)).toBe(true);
-
-    // Cleanup pending promise so Vitest does not hang on open handles.
-    resolveCoverage(false);
   });
 
   it("passes fail-closed hasActiveSubscription when coverage is false", async () => {
@@ -221,6 +207,57 @@ describe("HermesPage first paint + billing gate", () => {
     expect(element.props).toEqual(
       expect.objectContaining({
         hasActiveSubscription: true,
+      }),
+    );
+  });
+
+  it("empty wall plans when catalog fetch fails", async () => {
+    getSubscriptionCatalogMock.mockRejectedValue(new Error("catalog down"));
+    hasPaidPlanCoverageMock.mockResolvedValue(false);
+    const { HermesExperienceWithAccess } = await import("../page");
+
+    const element = await HermesExperienceWithAccess({
+      userId: "user-1",
+      userName: "Ada",
+      userEmail: "ada@example.com",
+      userImageUrl: null,
+      activeOrganizationId: "org-1",
+      userRole: "user",
+    });
+
+    expect(isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        hasActiveSubscription: false,
+        subscriptionWallPlans: [],
+      }),
+    );
+  });
+
+  it("memberships failure still probes coverage with empty org ids", async () => {
+    getMyMembersWithOrganizationsMock.mockRejectedValue(
+      new Error("memberships down"),
+    );
+    hasPaidPlanCoverageMock.mockResolvedValue(true);
+    const { HermesExperienceWithAccess } = await import("../page");
+
+    const element = await HermesExperienceWithAccess({
+      userId: "user-1",
+      userName: "Ada",
+      userEmail: "ada@example.com",
+      userImageUrl: null,
+      activeOrganizationId: null,
+      userRole: "user",
+    });
+
+    expect(hasPaidPlanCoverageMock).toHaveBeenCalledWith({
+      organizationIds: [],
+    });
+    expect(isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        hasActiveSubscription: true,
+        organizations: [],
       }),
     );
   });

--- a/apps/web/src/app/(app)/personal-assistant/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/__tests__/page.test.tsx
@@ -1,0 +1,234 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const getMyMembersWithOrganizationsMock = vi.fn();
+const hasPaidPlanCoverageMock = vi.fn();
+const getSubscriptionCatalogMock = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: async () => (key: string) => key,
+}));
+
+vi.mock("@/lib/auth/auth.server", () => ({
+  getSession: (...args: unknown[]) => getSessionMock(...args),
+}));
+
+vi.mock("@/lib/clients/core.client", () => ({
+  coreClient: {
+    getSubscriptionCatalog: (...args: unknown[]) =>
+      getSubscriptionCatalogMock(...args),
+  },
+}));
+
+vi.mock("@/lib/hermes/paid-plan-coverage", () => ({
+  hasPaidPlanCoverage: (...args: unknown[]) => hasPaidPlanCoverageMock(...args),
+}));
+
+vi.mock("@/lib/services/user.service", () => ({
+  userService: {
+    getMyMembersWithOrganizations: (...args: unknown[]) =>
+      getMyMembersWithOrganizationsMock(...args),
+  },
+}));
+
+vi.mock("@/app/personal-assistant/components/hermes-experience", () => ({
+  default: function HermesExperienceMock() {
+    return <div data-testid="hermes-experience" />;
+  },
+}));
+
+vi.mock("@/app/personal-assistant/components/loading-state", () => ({
+  default: function LoadingStateMock() {
+    return <div data-testid="loading-state" />;
+  },
+}));
+
+function createSession(overrides?: {
+  role?: string;
+  userId?: string;
+  email?: string;
+}) {
+  return {
+    user: {
+      id: overrides?.userId ?? "user-1",
+      name: "Ada",
+      email: overrides?.email ?? "ada@example.com",
+      image: null,
+      role: overrides?.role ?? "user",
+    },
+    session: {
+      activeOrganizationId: "org-1",
+    },
+  };
+}
+
+function findHermesExperienceElement(
+  node: ReactNode,
+): ReactElement | undefined {
+  if (!isValidElement(node)) return undefined;
+  if (typeof node.type === "function") {
+    const name =
+      (node.type as { name?: string }).name ??
+      (node.type as { displayName?: string }).displayName;
+    if (name === "HermesExperienceWithAccess") {
+      return node as ReactElement;
+    }
+  }
+  const props = node.props as { children?: ReactNode };
+  if (props?.children == null) return undefined;
+  if (Array.isArray(props.children)) {
+    for (const child of props.children) {
+      const found = findHermesExperienceElement(child);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  return findHermesExperienceElement(props.children);
+}
+
+describe("HermesPage first paint + billing gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue(createSession());
+    getMyMembersWithOrganizationsMock.mockResolvedValue([
+      {
+        organization: {
+          id: "org-1",
+          name: "Acme",
+          slug: "acme",
+        },
+      },
+    ]);
+    hasPaidPlanCoverageMock.mockResolvedValue(false);
+    getSubscriptionCatalogMock.mockResolvedValue({
+      data: {
+        free: { credits: 250, currency: "eur", monthlyAmount: 0 },
+        starter: { credits: 1_750, currency: "eur", monthlyAmount: 2_500 },
+        standard: { credits: 5_250, currency: "eur", monthlyAmount: 7_500 },
+        pro: { credits: 14_000, currency: "eur", monthlyAmount: 20_000 },
+      },
+    });
+  });
+
+  it("returns Suspense shell without awaiting coverage or catalog", async () => {
+    let resolveCoverage!: (value: boolean) => void;
+    hasPaidPlanCoverageMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveCoverage = resolve;
+      }),
+    );
+    getSubscriptionCatalogMock.mockReturnValue(
+      new Promise(() => {
+        /* intentionally never resolves during this assertion */
+      }),
+    );
+
+    const { default: HermesPage } = await import("../page");
+    const tree = await HermesPage();
+
+    // Shell returned while billing promises are still pending.
+    expect(hasPaidPlanCoverageMock).not.toHaveBeenCalled();
+    expect(getSubscriptionCatalogMock).not.toHaveBeenCalled();
+    expect(isValidElement(tree)).toBe(true);
+
+    // Cleanup pending promise so Vitest does not hang on open handles.
+    resolveCoverage(false);
+  });
+
+  it("passes fail-closed hasActiveSubscription when coverage is false", async () => {
+    hasPaidPlanCoverageMock.mockResolvedValue(false);
+    const { HermesExperienceWithAccess } = await import("../page");
+
+    const element = await HermesExperienceWithAccess({
+      userId: "user-1",
+      userName: "Ada",
+      userEmail: "ada@example.com",
+      userImageUrl: null,
+      activeOrganizationId: "org-1",
+      userRole: "user",
+    });
+
+    expect(hasPaidPlanCoverageMock).toHaveBeenCalledWith({
+      organizationIds: ["org-1"],
+    });
+    expect(isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        hasActiveSubscription: false,
+        subscriptionWallPlans: [
+          {
+            name: "starter",
+            monthlyAmount: 2_500,
+            currency: "eur",
+            credits: 1_750,
+          },
+          {
+            name: "standard",
+            monthlyAmount: 7_500,
+            currency: "eur",
+            credits: 5_250,
+          },
+          {
+            name: "pro",
+            monthlyAmount: 20_000,
+            currency: "eur",
+            credits: 14_000,
+          },
+        ],
+        organizations: [{ id: "org-1", name: "Acme", slug: "acme" }],
+      }),
+    );
+  });
+
+  it("passes hasActiveSubscription true when coverage resolves paid", async () => {
+    hasPaidPlanCoverageMock.mockResolvedValue(true);
+    const { HermesExperienceWithAccess } = await import("../page");
+
+    const element = await HermesExperienceWithAccess({
+      userId: "user-1",
+      userName: "Ada",
+      userEmail: "ada@example.com",
+      userImageUrl: null,
+      activeOrganizationId: null,
+      userRole: "user",
+    });
+
+    expect(isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        hasActiveSubscription: true,
+      }),
+    );
+  });
+
+  it("admin bypasses wall when coverage is false", async () => {
+    hasPaidPlanCoverageMock.mockResolvedValue(false);
+    const { HermesExperienceWithAccess } = await import("../page");
+
+    const element = await HermesExperienceWithAccess({
+      userId: "admin-1",
+      userName: "Admin",
+      userEmail: "admin@example.com",
+      userImageUrl: null,
+      activeOrganizationId: null,
+      userRole: "admin",
+    });
+
+    expect(isValidElement(element)).toBe(true);
+    expect(element.props).toEqual(
+      expect.objectContaining({
+        hasActiveSubscription: true,
+      }),
+    );
+  });
+
+  it("default page places HermesExperienceWithAccess under Suspense", async () => {
+    const { default: HermesPage } = await import("../page");
+    const tree = await HermesPage();
+    const child = findHermesExperienceElement(tree);
+    expect(child).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(app)/personal-assistant/__tests__/personal-assistant-first-paint-contract.test.ts
+++ b/apps/web/src/app/(app)/personal-assistant/__tests__/personal-assistant-first-paint-contract.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const paDir = join(here, "..");
+
+function readPa(rel: string): string {
+  return readFileSync(join(paDir, rel), "utf8");
+}
+
+/** Drop comments so doc strings do not false-positive scans. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+describe("personal-assistant first-paint contract (SOK-780)", () => {
+  it("keeps Instant soft-nav opt-out", () => {
+    const layout = stripComments(readPa("layout.tsx"));
+    expect(layout).toMatch(/export\s+const\s+instant\s*=\s*false/);
+  });
+
+  it("page streams Suspense shell before billing work", () => {
+    const page = stripComments(readPa("page.tsx"));
+    // Outer page must wrap experience in Suspense with LoadingState fallback.
+    expect(page).toMatch(/<Suspense[\s\S]*fallback=\{<\s*LoadingState/);
+    // Billing probes must live in the deferred child, not the default page body.
+    expect(page).toMatch(/hasPaidPlanCoverage/);
+    expect(page).toMatch(/getSubscriptionCatalog/);
+    // Default export should return Suspense without awaiting coverage first:
+    // coverage call must appear after the default function's return of Suspense,
+    // i.e. only inside a separate async component in the same file.
+    const defaultMatch = page.match(
+      /export\s+default\s+async\s+function\s+\w+[\s\S]*?^}/m,
+    );
+    expect(defaultMatch).toBeTruthy();
+    const defaultBody = defaultMatch?.[0] ?? "";
+    expect(defaultBody).toMatch(/return\s*\(\s*<Suspense/);
+    expect(defaultBody).not.toMatch(/hasPaidPlanCoverage\s*\(/);
+    expect(defaultBody).not.toMatch(/getSubscriptionCatalog\s*\(/);
+  });
+
+  it("loading shell uses static orb (no animated LCP candidate)", () => {
+    const loading = stripComments(readPa("components/loading-state.tsx"));
+    // Must not enable animate={true}; default/static is required for LCP.
+    expect(loading).not.toMatch(/animate\s*=\s*\{?\s*true/);
+    // Explicit static is preferred when AuroraOrb is present.
+    if (loading.includes("AuroraOrb")) {
+      expect(loading).toMatch(/animate\s*=\s*\{?\s*false/);
+    }
+  });
+
+  it("defers RunningState (settings/skills) off the experience entry", () => {
+    const experience = stripComments(
+      readPa("components/hermes-experience.tsx"),
+    );
+    // No static import of running-state module.
+    expect(experience).not.toMatch(
+      /import\s+RunningState\s+from\s+["'][^"']*running-state["']/,
+    );
+    // Dynamic import keeps heavy client surface off first paint chunk.
+    expect(experience).toMatch(
+      /dynamic\s*\(\s*\(\s*\)\s*=>\s*import\s*\(\s*["'][^"']*running-state["']/,
+    );
+  });
+});

--- a/apps/web/src/app/(app)/personal-assistant/__tests__/personal-assistant-first-paint-contract.test.ts
+++ b/apps/web/src/app/(app)/personal-assistant/__tests__/personal-assistant-first-paint-contract.test.ts
@@ -80,5 +80,13 @@ describe("personal-assistant first-paint contract (SOK-780)", () => {
     expect(experience).toMatch(
       /dynamic\s*\(\s*\(\s*\)\s*=>\s*import\s*\(\s*["'][^"']*running-state["']/,
     );
+    // Seed-aware Suspense fallback while the chunk is pending (not default
+    // "personal-assistant" seed on next/dynamic loading option).
+    expect(experience).not.toMatch(
+      /dynamic\s*\([\s\S]*?loading\s*:\s*\(\s*\)\s*=>\s*<\s*LoadingState/,
+    );
+    expect(experience).toMatch(
+      /fallback=\{<\s*LoadingState\s+seed=\{effectiveOrbSeed\}/,
+    );
   });
 });

--- a/apps/web/src/app/(app)/personal-assistant/__tests__/personal-assistant-first-paint-contract.test.ts
+++ b/apps/web/src/app/(app)/personal-assistant/__tests__/personal-assistant-first-paint-contract.test.ts
@@ -15,6 +15,27 @@ function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
 }
 
+/**
+ * Brace-depth slice of `export default async function … { … }`.
+ * More stable than non-greedy `^}` (nested top-level-looking closes).
+ */
+function extractDefaultAsyncFunction(source: string): string | null {
+  const header = source.match(
+    /export\s+default\s+async\s+function\s+\w+\s*\([^)]*\)\s*\{/,
+  );
+  if (!header || header.index === undefined) return null;
+  let depth = 1;
+  let i = header.index + header[0].length;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    i += 1;
+  }
+  if (depth !== 0) return null;
+  return source.slice(header.index, i);
+}
+
 describe("personal-assistant first-paint contract (SOK-780)", () => {
   it("keeps Instant soft-nav opt-out", () => {
     const layout = stripComments(readPa("layout.tsx"));
@@ -29,13 +50,9 @@ describe("personal-assistant first-paint contract (SOK-780)", () => {
     expect(page).toMatch(/hasPaidPlanCoverage/);
     expect(page).toMatch(/getSubscriptionCatalog/);
     // Default export should return Suspense without awaiting coverage first:
-    // coverage call must appear after the default function's return of Suspense,
-    // i.e. only inside a separate async component in the same file.
-    const defaultMatch = page.match(
-      /export\s+default\s+async\s+function\s+\w+[\s\S]*?^}/m,
-    );
-    expect(defaultMatch).toBeTruthy();
-    const defaultBody = defaultMatch?.[0] ?? "";
+    // coverage call must appear only inside a separate async component.
+    const defaultBody = extractDefaultAsyncFunction(page);
+    expect(defaultBody).toBeTruthy();
     expect(defaultBody).toMatch(/return\s*\(\s*<Suspense/);
     expect(defaultBody).not.toMatch(/hasPaidPlanCoverage\s*\(/);
     expect(defaultBody).not.toMatch(/getSubscriptionCatalog\s*\(/);

--- a/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
@@ -3,7 +3,14 @@
 import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 
 import EmptyState from "@/app/personal-assistant/components/empty-state";
@@ -43,10 +50,13 @@ import type {
   HermesPersonality,
 } from "@/lib/hermes/types";
 
-/** Running chat + settings/skills panels — heavy; keep off first-paint entry. */
+/**
+ * Running chat + settings/skills panels — heavy; keep off first-paint entry.
+ * No `loading` option here: seed-aware fallback is the parent Suspense so the
+ * orb does not flash the default "personal-assistant" seed during chunk load.
+ */
 const RunningState = dynamic(
   () => import("@/app/personal-assistant/components/running-state"),
-  { loading: () => <LoadingState /> },
 );
 
 export type { HermesOrganizationOption };
@@ -778,21 +788,23 @@ export default function HermesExperience({
   }
   return (
     <>
-      <RunningState
-        userName={userName ?? null}
-        userImageUrl={userImageUrl ?? null}
-        avatarSeed={effectiveOrbSeed}
-        orbBaseSeed={orbBaseSeed}
-        instance={instance}
-        previewMode={previewMode}
-        initialMessages={initialMessages}
-        organizations={effectiveOrganizations}
-        activeOrganizationId={effectiveActiveOrgId}
-        hasActiveSubscription={hasActiveSubscription}
-        onRequireSubscription={() => setSubscriptionWallOpen(true)}
-        onDestroy={handleDestroy}
-        onRefresh={() => refetchHermes({ background: true })}
-      />
+      <Suspense fallback={<LoadingState seed={effectiveOrbSeed} />}>
+        <RunningState
+          userName={userName ?? null}
+          userImageUrl={userImageUrl ?? null}
+          avatarSeed={effectiveOrbSeed}
+          orbBaseSeed={orbBaseSeed}
+          instance={instance}
+          previewMode={previewMode}
+          initialMessages={initialMessages}
+          organizations={effectiveOrganizations}
+          activeOrganizationId={effectiveActiveOrgId}
+          hasActiveSubscription={hasActiveSubscription}
+          onRequireSubscription={() => setSubscriptionWallOpen(true)}
+          onDestroy={handleDestroy}
+          onRefresh={() => refetchHermes({ background: true })}
+        />
+      </Suspense>
       {subscriptionWall}
     </>
   );

--- a/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/hermes-experience.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -20,7 +21,6 @@ import LoadingState from "@/app/personal-assistant/components/loading-state";
 import OnboardingProgress from "@/app/personal-assistant/components/onboarding-progress";
 import OnboardingScreen from "@/app/personal-assistant/components/onboarding-screen";
 import ProvisioningState from "@/app/personal-assistant/components/provisioning-state";
-import RunningState from "@/app/personal-assistant/components/running-state";
 import {
   SubscriptionRequiredDialog,
   type SubscriptionWallPlan,
@@ -42,6 +42,12 @@ import type {
   HermesPersistedMessage,
   HermesPersonality,
 } from "@/lib/hermes/types";
+
+/** Running chat + settings/skills panels — heavy; keep off first-paint entry. */
+const RunningState = dynamic(
+  () => import("@/app/personal-assistant/components/running-state"),
+  { loading: () => <LoadingState /> },
+);
 
 export type { HermesOrganizationOption };
 

--- a/apps/web/src/app/(app)/personal-assistant/components/loading-state.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/components/loading-state.tsx
@@ -34,7 +34,7 @@ export default function LoadingState({
         <AuroraOrb
           seed={seed}
           size={96}
-          animate
+          animate={false}
           className="size-20 md:size-24"
           alt={tCommon("hermesAvatarAlt")}
         />

--- a/apps/web/src/app/(app)/personal-assistant/hermes-page-subscription.ts
+++ b/apps/web/src/app/(app)/personal-assistant/hermes-page-subscription.ts
@@ -1,0 +1,41 @@
+import type { SelfServeSubscriptionPlanName } from "@sokosumi/utils";
+
+import type { SubscriptionWallPlan } from "@/app/personal-assistant/components/subscription-required-dialog";
+import { hasAdminRole } from "@/lib/auth/has-admin-role";
+import type { GetSubscriptionCatalogResponse } from "@/lib/clients/generated/core";
+
+const PAID_PLAN_ORDER = [
+  "starter",
+  "standard",
+  "pro",
+] as const satisfies SelfServeSubscriptionPlanName[];
+
+/**
+ * UX gate for PA activate/use. Fail-closed: only coverage or platform
+ * admin unlocks; everyone else can still view landing/history.
+ */
+export function resolveHermesHasActiveSubscription(
+  hasCoverage: boolean,
+  userRole: string | null | undefined,
+): boolean {
+  return hasCoverage || hasAdminRole(userRole);
+}
+
+/**
+ * Map Core catalog → subscription wall plan chips. Empty when catalog
+ * missing (wall still works without links).
+ */
+export function buildSubscriptionWallPlans(
+  catalog: GetSubscriptionCatalogResponse | null | undefined,
+): SubscriptionWallPlan[] {
+  if (!catalog) return [];
+  return PAID_PLAN_ORDER.map((name) => {
+    const plan = catalog.data[name];
+    return {
+      name,
+      monthlyAmount: plan.monthlyAmount,
+      currency: plan.currency,
+      credits: plan.credits,
+    };
+  });
+}

--- a/apps/web/src/app/(app)/personal-assistant/page.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/page.tsx
@@ -9,6 +9,7 @@ import {
   buildSubscriptionWallPlans,
   resolveHermesHasActiveSubscription,
 } from "@/app/personal-assistant/hermes-page-subscription";
+import { defaultOrbSeed } from "@/lib/aurora-orb";
 import { getSession } from "@/lib/auth/auth.server";
 import { coreClient } from "@/lib/clients/core.client";
 import type { GetSubscriptionCatalogResponse } from "@/lib/clients/generated/core";
@@ -116,6 +117,7 @@ export async function HermesExperienceWithAccess({
  */
 export default async function HermesPage() {
   const session = await getSession();
+  const userId = session?.user.id ?? null;
   const userName = session?.user.name ?? null;
   const userEmail = session?.user.email ?? null;
   const userImageUrl = session?.user.image
@@ -124,11 +126,15 @@ export default async function HermesPage() {
       ? gravatarUrl(session.user.email, { size: 80, default: "404" })
       : null;
   const activeOrganizationId = session?.session.activeOrganizationId ?? null;
+  // Match HermesExperience's pre-instance loading seed so Suspense → client
+  // loading does not flash a different orb. loading.tsx stays seedless
+  // (no session without an extra await that would delay route shell paint).
+  const shellOrbSeed = userId ? defaultOrbSeed(userId) : undefined;
 
   return (
-    <Suspense fallback={<LoadingState />}>
+    <Suspense fallback={<LoadingState seed={shellOrbSeed} />}>
       <HermesExperienceWithAccess
-        userId={session?.user.id ?? null}
+        userId={userId}
         userName={userName}
         userEmail={userEmail}
         userImageUrl={userImageUrl}

--- a/apps/web/src/app/(app)/personal-assistant/page.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/page.tsx
@@ -1,4 +1,3 @@
-import type { SelfServeSubscriptionPlanName } from "@sokosumi/utils";
 import gravatarUrl from "gravatar-url";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
@@ -6,19 +5,15 @@ import { Suspense } from "react";
 
 import HermesExperience from "@/app/personal-assistant/components/hermes-experience";
 import LoadingState from "@/app/personal-assistant/components/loading-state";
-import type { SubscriptionWallPlan } from "@/app/personal-assistant/components/subscription-required-dialog";
+import {
+  buildSubscriptionWallPlans,
+  resolveHermesHasActiveSubscription,
+} from "@/app/personal-assistant/hermes-page-subscription";
 import { getSession } from "@/lib/auth/auth.server";
-import { hasAdminRole } from "@/lib/auth/has-admin-role";
 import { coreClient } from "@/lib/clients/core.client";
 import type { GetSubscriptionCatalogResponse } from "@/lib/clients/generated/core";
 import { hasPaidPlanCoverage } from "@/lib/hermes/paid-plan-coverage";
 import { userService } from "@/lib/services/user.service";
-
-const PAID_PLAN_ORDER = [
-  "starter",
-  "standard",
-  "pro",
-] as const satisfies SelfServeSubscriptionPlanName[];
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("App.Hermes.Metadata");
@@ -28,21 +23,32 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function HermesPage() {
-  const session = await getSession();
-  const userName = session?.user.name ?? null;
-  const userEmail = session?.user.email ?? null;
-  const userImageUrl = session?.user.image
-    ? session.user.image
-    : session?.user.email
-      ? gravatarUrl(session.user.email, { size: 80, default: "404" })
-      : null;
+interface HermesExperienceWithAccessProps {
+  userId: string | null;
+  userName: string | null;
+  userEmail: string | null;
+  userImageUrl: string | null;
+  activeOrganizationId: string | null;
+  userRole: string | null | undefined;
+}
 
+/**
+ * Deferred billing + membership work. Suspends under the page Suspense
+ * so LoadingState paints before paid-plan coverage / catalog finish
+ * (SOK-780). Fail-closed gate once resolved.
+ */
+export async function HermesExperienceWithAccess({
+  userId,
+  userName,
+  userEmail,
+  userImageUrl,
+  activeOrganizationId,
+  userRole,
+}: HermesExperienceWithAccessProps) {
   // Org context for the confirmation-card dropdown (lets the user reroute
   // sokosumi_create_task / sokosumi_create_job into the right workspace
   // before approving). Empty list when not signed in or no memberships.
-  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
-  const memberships = session
+  const memberships = userId
     ? await userService
         .getMyMembersWithOrganizations()
         .catch(
@@ -69,43 +75,64 @@ export default async function HermesPage() {
   // Coverage = personal Stripe plan OR any member org's billing plan
   // (enterprise contract or paid self-serve) — same rule as Core.
   const [hasCoverage, catalogResultRaw] = await Promise.all([
-    session
+    userId
       ? hasPaidPlanCoverage({
           organizationIds: memberships.map((m) => m.organization.id),
         })
       : Promise.resolve(false),
-    session ? coreClient.getSubscriptionCatalog().catch(() => null) : null,
+    userId ? coreClient.getSubscriptionCatalog().catch(() => null) : null,
   ]);
-  const hasActiveSubscription = hasCoverage || hasAdminRole(session?.user.role);
+  const hasActiveSubscription = resolveHermesHasActiveSubscription(
+    hasCoverage,
+    userRole,
+  );
 
   // The 3 paid plans — gives the subscription wall real, clickable plan
   // links instead of a vague "upgrade to unlock". Best-effort: the wall
   // still works (minus the plan links) if the catalog fetch fails.
   const catalogResult =
     catalogResultRaw as GetSubscriptionCatalogResponse | null;
-  const subscriptionWallPlans: SubscriptionWallPlan[] = catalogResult
-    ? PAID_PLAN_ORDER.map((name) => {
-        const plan = catalogResult.data[name];
-        return {
-          name,
-          monthlyAmount: plan.monthlyAmount,
-          currency: plan.currency,
-          credits: plan.credits,
-        };
-      })
-    : [];
+  const subscriptionWallPlans = buildSubscriptionWallPlans(catalogResult);
+
+  return (
+    <HermesExperience
+      userId={userId}
+      userName={userName}
+      userEmail={userEmail}
+      userImageUrl={userImageUrl}
+      organizations={organizations}
+      activeOrganizationId={activeOrganizationId}
+      hasActiveSubscription={hasActiveSubscription}
+      subscriptionWallPlans={subscriptionWallPlans}
+    />
+  );
+}
+
+/**
+ * Session-only fast path. Memberships, paid-plan coverage, and the
+ * subscription catalog stream behind Suspense so first paint is the
+ * loading shell (also used by loading.tsx for route transitions).
+ */
+export default async function HermesPage() {
+  const session = await getSession();
+  const userName = session?.user.name ?? null;
+  const userEmail = session?.user.email ?? null;
+  const userImageUrl = session?.user.image
+    ? session.user.image
+    : session?.user.email
+      ? gravatarUrl(session.user.email, { size: 80, default: "404" })
+      : null;
+  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
 
   return (
     <Suspense fallback={<LoadingState />}>
-      <HermesExperience
+      <HermesExperienceWithAccess
         userId={session?.user.id ?? null}
         userName={userName}
         userEmail={userEmail}
         userImageUrl={userImageUrl}
-        organizations={organizations}
         activeOrganizationId={activeOrganizationId}
-        hasActiveSubscription={hasActiveSubscription}
-        subscriptionWallPlans={subscriptionWallPlans}
+        userRole={session?.user.role}
       />
     </Suspense>
   );

--- a/apps/web/src/app/(app)/personal-assistant/page.tsx
+++ b/apps/web/src/app/(app)/personal-assistant/page.tsx
@@ -37,6 +37,10 @@ interface HermesExperienceWithAccessProps {
  * so LoadingState paints before paid-plan coverage / catalog finish
  * (SOK-780). Fail-closed gate once resolved.
  */
+type MembershipList = Awaited<
+  ReturnType<typeof userService.getMyMembersWithOrganizations>
+>;
+
 export async function HermesExperienceWithAccess({
   userId,
   userName,
@@ -45,21 +49,20 @@ export async function HermesExperienceWithAccess({
   activeOrganizationId,
   userRole,
 }: HermesExperienceWithAccessProps) {
+  // Catalog does not need org IDs — start it with memberships so multi-org
+  // membership latency does not serialize catalog TTI after the shell.
+  const catalogPromise: Promise<GetSubscriptionCatalogResponse | null> = userId
+    ? coreClient.getSubscriptionCatalog().catch(() => null)
+    : Promise.resolve(null);
+
   // Org context for the confirmation-card dropdown (lets the user reroute
   // sokosumi_create_task / sokosumi_create_job into the right workspace
   // before approving). Empty list when not signed in or no memberships.
-  const memberships = userId
+  const memberships: MembershipList = userId
     ? await userService
         .getMyMembersWithOrganizations()
-        .catch(
-          () =>
-            [] as Awaited<
-              ReturnType<typeof userService.getMyMembersWithOrganizations>
-            >,
-        )
-    : ([] as Awaited<
-        ReturnType<typeof userService.getMyMembersWithOrganizations>
-      >);
+        .catch((): MembershipList => [])
+    : [];
   const organizations = memberships.map((m) => ({
     id: m.organization.id,
     name: m.organization.name,
@@ -74,13 +77,13 @@ export async function HermesExperienceWithAccess({
   // entirely so the team can set up and test instances without billing.
   // Coverage = personal Stripe plan OR any member org's billing plan
   // (enterprise contract or paid self-serve) — same rule as Core.
-  const [hasCoverage, catalogResultRaw] = await Promise.all([
+  const [hasCoverage, catalogResult] = await Promise.all([
     userId
       ? hasPaidPlanCoverage({
           organizationIds: memberships.map((m) => m.organization.id),
         })
       : Promise.resolve(false),
-    userId ? coreClient.getSubscriptionCatalog().catch(() => null) : null,
+    catalogPromise,
   ]);
   const hasActiveSubscription = resolveHermesHasActiveSubscription(
     hasCoverage,
@@ -90,8 +93,6 @@ export async function HermesExperienceWithAccess({
   // The 3 paid plans — gives the subscription wall real, clickable plan
   // links instead of a vague "upgrade to unlock". Best-effort: the wall
   // still works (minus the plan links) if the catalog fetch fails.
-  const catalogResult =
-    catalogResultRaw as GetSubscriptionCatalogResponse | null;
   const subscriptionWallPlans = buildSubscriptionWallPlans(catalogResult);
 
   return (


### PR DESCRIPTION
## Linear

[SOK-780](https://linear.app/masumi/issue/SOK-780/fixweb-personal-assistant-first-paint-without-billing-block) (parent [SOK-776](https://linear.app/masumi/issue/SOK-776))

## Summary

- Stream PA `LoadingState` under Suspense before memberships / paid-plan coverage / subscription catalog resolve
- Keep fail-closed `hasActiveSubscription` + admin bypass after billing resolves
- Static AuroraOrb on loading shell (LCP); dynamic-import `RunningState` (settings/skills) off experience entry
- `instant = false` unchanged; web-only (no Core batch billing API)

## Verification

- `pnpm web:check` / `pnpm web:test` (incl. PA first-paint contract + page gate tests)
- Manual (post-ship, ~7d): glance Speed Insights `/personal-assistant` LCP (informational)