### PR TITLE
fix(web): restore agents gallery hub px-2 padding

### DIFF
--- a/apps/web/src/app/(app)/agents/__tests__/agents-gallery-padding-contract.test.ts
+++ b/apps/web/src/app/(app)/agents/__tests__/agents-gallery-padding-contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const agentsDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/**
+ * Hub list pages (`/tasks`, `/projects`) use content-shell `px-2` on mobile.
+ * `/agents` must match that gutter — not `px-4` (which stacks on main's `p-4`
+ * and reads wider than sibling hub lists).
+ */
+function galleryShellClass(source: string): string {
+  const match = source.match(/className="(space-y-16[^"]*)"/);
+  if (!match) {
+    throw new Error("No agents gallery shell className found");
+  }
+  return match[1];
+}
+
+describe("agents gallery mobile padding contract", () => {
+  it("page and loading shells use hub-list px-2 (not mobile px-4)", () => {
+    const page = readFileSync(path.join(agentsDir, "page.tsx"), "utf8");
+    const loading = readFileSync(path.join(agentsDir, "loading.tsx"), "utf8");
+
+    const pageShell = galleryShellClass(page);
+    const loadingShell = galleryShellClass(loading);
+
+    expect(pageShell).toBe(loadingShell);
+    expect(pageShell.split(/\s+/)).toContain("px-2");
+    expect(pageShell.split(/\s+/)).not.toContain("px-4");
+    expect(pageShell.split(/\s+/)).not.toContain("md:px-2");
+  });
+});

--- a/apps/web/src/app/(app)/agents/loading.tsx
+++ b/apps/web/src/app/(app)/agents/loading.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function AgentsLoading() {
   return (
     <div className="w-full">
-      <div className="space-y-16 px-4 pb-8 md:space-y-24 md:px-2">
+      <div className="space-y-16 px-2 pb-8 md:space-y-24">
         <section className="space-y-8">
           <div className="space-y-2">
             <Skeleton className="h-7 w-56 md:h-8" />

--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -132,7 +132,7 @@ async function AllAgentsTier() {
 export default function GalleryPage() {
   return (
     <div className="w-full">
-      <div className="space-y-16 px-4 pb-8 md:space-y-24 md:px-2">
+      <div className="space-y-16 px-2 pb-8 md:space-y-24">
         <Suspense fallback={<CoworkersTierFallback />}>
           <CoworkersTier />
         </Suspense>

--- a/apps/web/src/app/(app)/tasks/__tests__/task-detail-padding-parity-contract.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/task-detail-padding-parity-contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function detailShellClass(source: string): string {
+  const match = source.match(/className="(mx-auto max-w-4xl[^"]*)"/);
+  if (!match) {
+    throw new Error("No task detail shell className found");
+  }
+  return match[1];
+}
+
+describe("task detail padding parity contract", () => {
+  it("loading skeleton shell matches loaded TaskDetailView shell", () => {
+    const loading = readFileSync(
+      path.join(appDir, "[taskId]/loading.tsx"),
+      "utf8",
+    );
+    const view = readFileSync(
+      path.join(appDir, "components/task-detail-view.tsx"),
+      "utf8",
+    );
+
+    expect(detailShellClass(loading)).toBe(detailShellClass(view));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up on [SOK-783](https://linear.app/masumi/issue/SOK-783/fix-mobile-agents-gallery-padding-and-agent-detail-chrome) / #3777.

- Restore `/agents` gallery shell to hub-list `px-2` (same as `/tasks` and `/projects`).
- Drop the inverted `px-4 md:px-2` mobile widening — it stacked on `main`’s `p-4` and read wider than sibling hub lists.
- Root cause of the original “too tight” feel was likely the agent fullbleed `:has` leak (already fixed on main via #3786), not page-level `px-2`.
- Add contracts: agents gallery page/loading stay on `px-2`; task detail loading shell stays padding-parity with `TaskDetailView`.

## Task detail skeleton note

Not a bug on this base: loading and loaded already share `px-4`. Parity contract locks that. [SOK-784](https://linear.app/masumi/issue/SOK-784)/#3787 moves both to `px-2 md:px-4` together.

## Test plan

- [x] `pnpm --filter web test` agents + task padding contracts (pass)
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [ ] Mobile `/agents`: content shell padding matches `/tasks` / `/projects` (`px-2`)
- [ ] Soft-nav agent detail → gallery: main padding still present (fullbleed attr cleared)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6003d11d-d07b-4342-865e-ffe5e65e0255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6003d11d-d07b-4342-865e-ffe5e65e0255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

