### PR TITLE
fix(web): clear last chat list row above mobile tab bar

### DIFF
--- a/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
+++ b/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Mobile `/chat/chats` must grow with content so AppMobileChrome's in-flow
+ * tab-bar spacer sits after the last DM in main's scroll. A nested
+ * `min-h-0` + `overflow-y-auto` height-lock left the last row clipped under
+ * the fixed bottom nav (padding on that flex overflow child does not clear).
+ */
+describe("chat/chats page scroll clearance contract", () => {
+  it("does not height-lock the list shell and keeps FAB clearance", () => {
+    const source = readFileSync(join(here, "../page.tsx"), "utf8");
+
+    expect(source).toContain("LIST_MOBILE_CREATE_FAB_CLEARANCE");
+
+    // Drop block comments so docs mentioning the forbidden classes do not
+    // false-positive; still catch real className usage.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(code).not.toMatch(/overflow-y-auto/);
+    expect(code).not.toMatch(/\bmin-h-0\b/);
+  });
+});

--- a/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
+++ b/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
@@ -15,11 +15,13 @@ describe("chat/chats page scroll clearance contract", () => {
   it("does not height-lock the list shell and keeps FAB clearance", () => {
     const source = readFileSync(join(here, "../page.tsx"), "utf8");
 
-    expect(source).toContain("LIST_MOBILE_CREATE_FAB_CLEARANCE");
-
     // Drop block comments so docs mentioning the forbidden classes do not
     // false-positive; still catch real className usage.
     const code = source.replace(/\/\*[\s\S]*?\*\//g, "");
+    // Require clearance on the mobile shell className, not merely imported.
+    expect(code).toMatch(
+      /className=\{cn\([\s\S]*?LIST_MOBILE_CREATE_FAB_CLEARANCE/,
+    );
     expect(code).not.toMatch(/overflow-y-auto/);
     expect(code).not.toMatch(/\bmin-h-0\b/);
   });

--- a/apps/web/src/app/(app)/chat/chats/page.tsx
+++ b/apps/web/src/app/(app)/chat/chats/page.tsx
@@ -48,9 +48,15 @@ export default async function ChatChatsPage() {
 
   return (
     <Sheet open>
+      {/*
+        Grow with content — do not height-lock with min-h-0 + overflow-y-auto.
+        AppMobileChrome's in-flow tab-bar spacer must sit after the last row in
+        main's scroll; padding on a nested overflow flex child does not clear
+        the fixed bottom nav (last DM was clipped).
+      */}
       <div
         className={cn(
-          "md:hidden -m-4 flex min-h-0 flex-1 flex-col overflow-y-auto bg-background",
+          "md:hidden -m-4 flex flex-1 flex-col bg-background",
           LIST_MOBILE_CREATE_FAB_CLEARANCE,
         )}
       >

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { LIST_MOBILE_CREATE_FAB_CLEARANCE } from "@/app/components/mobile-create-fab-geometry";
+
 import { ChatChatsPageSkeleton } from "../chat-chats-loading-view";
 
 describe("ChatChatsPageSkeleton", () => {
@@ -9,6 +11,19 @@ describe("ChatChatsPageSkeleton", () => {
 
     const root = screen.getByTestId("chat-chats-loading");
     expect(root.className).toMatch(/md:hidden/);
+  });
+
+  it("grows with content (no nested overflow height-lock) and pads for FAB", () => {
+    render(<ChatChatsPageSkeleton />);
+
+    const root = screen.getByTestId("chat-chats-loading");
+    // Nested min-h-0 + overflow-y-auto clips the last row under the fixed
+    // tab bar; AppMobileChrome's in-flow spacer needs natural growth.
+    expect(root.className).not.toMatch(/overflow-y-auto/);
+    expect(root.className).not.toMatch(/\bmin-h-0\b/);
+    for (const token of LIST_MOBILE_CREATE_FAB_CLEARANCE.split(/\s+/)) {
+      expect(root.className).toContain(token);
+    }
   });
 
   it("omits Personal Assistant chrome (beta-gated on the real page)", () => {

--- a/apps/web/src/app/(app)/chat/components/chat-chats-loading-view.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-chats-loading-view.tsx
@@ -13,7 +13,9 @@ export function ChatChatsPageSkeleton(): React.ReactElement {
     <div
       data-testid="chat-chats-loading"
       className={cn(
-        "md:hidden -m-4 min-h-0 flex-1 overflow-y-auto p-4",
+        // Match live chats page: grow with content so tab-bar spacer clears
+        // the last row (no nested overflow-y-auto height lock).
+        "md:hidden -m-4 flex flex-1 flex-col bg-background p-4",
         LIST_MOBILE_CREATE_FAB_CLEARANCE,
       )}
     >


### PR DESCRIPTION
## Summary

- Mobile `/chat/chats` no longer height-locks the list with `min-h-0` + `overflow-y-auto`, so `AppMobileChrome`'s in-flow tab-bar spacer sits after the last DM in main scroll.
- Matching Instant loading skeleton; regression contract tests for page + skeleton.

## Why

Nested overflow on a flex shell meant bottom padding could not clear the fixed mobile tab bar, so the last direct message was clipped.

## Test plan

- [x] `pnpm --filter web test` on chats clearance + loading-view tests
- [ ] Mobile `/chat/chats` (~400×563): scroll to end — last DM fully visible above tab bar
- [ ] FAB still clears last rows; desktop sidebar list unchanged