### PR TITLE
fix(web): use md:px-2 only on agents gallery shell

### DIFF
--- a/apps/web/src/app/(app)/agents/__tests__/agents-gallery-padding-contract.test.ts
+++ b/apps/web/src/app/(app)/agents/__tests__/agents-gallery-padding-contract.test.ts
@@ -10,9 +10,8 @@ const agentsDir = path.resolve(
 );
 
 /**
- * Hub list pages (`/tasks`, `/projects`) use content-shell `px-2` on mobile.
- * `/agents` must match that gutter — not `px-4` (which stacks on main's `p-4`
- * and reads wider than sibling hub lists).
+ * Gallery shell must not add horizontal padding on mobile — `main` already
+ * has `p-4`. Desktop keeps a light `md:px-2` gutter.
  */
 function galleryShellClass(source: string): string {
   const match = source.match(/className="(space-y-16[^"]*)"/);
@@ -23,16 +22,17 @@ function galleryShellClass(source: string): string {
 }
 
 describe("agents gallery mobile padding contract", () => {
-  it("page and loading shells use hub-list px-2 (not mobile px-4)", () => {
+  it("page and loading shells use md:px-2 only (no mobile px-*)", () => {
     const page = readFileSync(path.join(agentsDir, "page.tsx"), "utf8");
     const loading = readFileSync(path.join(agentsDir, "loading.tsx"), "utf8");
 
     const pageShell = galleryShellClass(page);
     const loadingShell = galleryShellClass(loading);
+    const tokens = pageShell.split(/\s+/);
 
     expect(pageShell).toBe(loadingShell);
-    expect(pageShell.split(/\s+/)).toContain("px-2");
-    expect(pageShell.split(/\s+/)).not.toContain("px-4");
-    expect(pageShell.split(/\s+/)).not.toContain("md:px-2");
+    expect(tokens).toContain("md:px-2");
+    expect(tokens).not.toContain("px-2");
+    expect(tokens).not.toContain("px-4");
   });
 });

--- a/apps/web/src/app/(app)/agents/__tests__/agents-gallery-padding-contract.test.ts
+++ b/apps/web/src/app/(app)/agents/__tests__/agents-gallery-padding-contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const agentsDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/**
+ * Hub list pages (`/tasks`, `/projects`) use content-shell `px-2` on mobile.
+ * `/agents` must match that gutter — not `px-4` (which stacks on main's `p-4`
+ * and reads wider than sibling hub lists).
+ */
+function galleryShellClass(source: string): string {
+  const match = source.match(/className="(space-y-16[^"]*)"/);
+  if (!match) {
+    throw new Error("No agents gallery shell className found");
+  }
+  return match[1];
+}
+
+describe("agents gallery mobile padding contract", () => {
+  it("page and loading shells use hub-list px-2 (not mobile px-4)", () => {
+    const page = readFileSync(path.join(agentsDir, "page.tsx"), "utf8");
+    const loading = readFileSync(path.join(agentsDir, "loading.tsx"), "utf8");
+
+    const pageShell = galleryShellClass(page);
+    const loadingShell = galleryShellClass(loading);
+
+    expect(pageShell).toBe(loadingShell);
+    expect(pageShell.split(/\s+/)).toContain("px-2");
+    expect(pageShell.split(/\s+/)).not.toContain("px-4");
+    expect(pageShell.split(/\s+/)).not.toContain("md:px-2");
+  });
+});

--- a/apps/web/src/app/(app)/agents/loading.tsx
+++ b/apps/web/src/app/(app)/agents/loading.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function AgentsLoading() {
   return (
     <div className="w-full">
-      <div className="space-y-16 px-4 pb-8 md:space-y-24 md:px-2">
+      <div className="space-y-16 px-2 pb-8 md:space-y-24">
         <section className="space-y-8">
           <div className="space-y-2">
             <Skeleton className="h-7 w-56 md:h-8" />

--- a/apps/web/src/app/(app)/agents/loading.tsx
+++ b/apps/web/src/app/(app)/agents/loading.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function AgentsLoading() {
   return (
     <div className="w-full">
-      <div className="space-y-16 px-2 pb-8 md:space-y-24">
+      <div className="space-y-16 pb-8 md:space-y-24 md:px-2">
         <section className="space-y-8">
           <div className="space-y-2">
             <Skeleton className="h-7 w-56 md:h-8" />

--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -132,7 +132,7 @@ async function AllAgentsTier() {
 export default function GalleryPage() {
   return (
     <div className="w-full">
-      <div className="space-y-16 px-2 pb-8 md:space-y-24">
+      <div className="space-y-16 pb-8 md:space-y-24 md:px-2">
         <Suspense fallback={<CoworkersTierFallback />}>
           <CoworkersTier />
         </Suspense>

--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -132,7 +132,7 @@ async function AllAgentsTier() {
 export default function GalleryPage() {
   return (
     <div className="w-full">
-      <div className="space-y-16 px-4 pb-8 md:space-y-24 md:px-2">
+      <div className="space-y-16 px-2 pb-8 md:space-y-24">
         <Suspense fallback={<CoworkersTierFallback />}>
           <CoworkersTier />
         </Suspense>

--- a/apps/web/src/app/(app)/tasks/__tests__/task-detail-padding-parity-contract.test.ts
+++ b/apps/web/src/app/(app)/tasks/__tests__/task-detail-padding-parity-contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function detailShellClass(source: string): string {
+  const match = source.match(/className="(mx-auto max-w-4xl[^"]*)"/);
+  if (!match) {
+    throw new Error("No task detail shell className found");
+  }
+  return match[1];
+}
+
+describe("task detail padding parity contract", () => {
+  it("loading skeleton shell matches loaded TaskDetailView shell", () => {
+    const loading = readFileSync(
+      path.join(appDir, "[taskId]/loading.tsx"),
+      "utf8",
+    );
+    const view = readFileSync(
+      path.join(appDir, "components/task-detail-view.tsx"),
+      "utf8",
+    );
+
+    expect(detailShellClass(loading)).toBe(detailShellClass(view));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up on [SOK-783](https://linear.app/masumi/issue/SOK-783/fix-mobile-agents-gallery-padding-and-agent-detail-chrome) / #3777 (after #3789).

Gallery shell was `space-y-16 px-2 pb-8 md:space-y-24`, which added an extra `px-2` on mobile on top of `main`’s `p-4`. Correct shell:

`space-y-16 pb-8 md:space-y-24 md:px-2`

- Mobile: no page-level horizontal padding (uses `main` `p-4` only)
- `md+`: `md:px-2`
- Loading skeleton matches page
- Contract test locks `md:px-2` without mobile `px-*`

Merged latest `sok-783-…`; conflicts resolved by keeping this PR’s `md:px-2`-only intent over #3789’s hub `px-2`.

## Test plan

- [x] `pnpm --filter web test` agents gallery padding contract
- [x] `pnpm check` + `pnpm typecheck` (pre-commit / merge)
- [ ] Mobile `/agents`: no double gutter; aligns with main padding
- [ ] Desktop `/agents`: `md:px-2` still present
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6003d11d-d07b-4342-865e-ffe5e65e0255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6003d11d-d07b-4342-865e-ffe5e65e0255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

