### PR TITLE
perf(web): stream app chrome on cold load

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: Notification (for this cue), banner (unless referring to a specific lay
 
 ### Header identity
 
+**App chrome**:
+The persistent sidebar and header on authenticated pages: nav, membership-visible rooms, Workspace switcher, and Notification Center.
+_Avoid_: Topbar, shell (unless meaning the loading frame)
+
 **Workspace switcher**:
 The header control that shows the active personal or organization workspace and lets the user switch between them. This is the identity/context control, not the Notification Center entry point.
 _Avoid_: Profile menu (unless a separate account menu is introduced), notification avatar

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -116,6 +116,37 @@ describe("chat list chrome single-source composition contract", () => {
     );
   });
 
+  it("header workspace switcher reads members from getPrivateCachedChatListChrome", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+
+    const headerProfile = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../header/header-profile-section.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(headerProfile).toMatch(/getPrivateCachedChatListChrome/);
+    expect(headerProfile).not.toMatch(
+      /userService\s*\.\s*getMyMembersWithOrganizations\s*\(/,
+    );
+
+    const deferredAccount = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../sidebar-deferred-account.tsx",
+      ),
+      "utf8",
+    );
+    expect(deferredAccount).toMatch(/getPrivateCachedChatListChrome/);
+    expect(deferredAccount).not.toMatch(
+      /userService\s*\.\s*getMyMembersWithOrganizations\s*\(/,
+    );
+  });
+
   it("private cache loader tags user/org like sidebar chrome", async () => {
     const { readFileSync } = await import("node:fs");
     const { dirname, join } = await import("node:path");

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -147,6 +147,32 @@ describe("chat list chrome single-source composition contract", () => {
     );
   });
 
+  it("header Notification Center sits outside the members Suspense", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+
+    const headerProfile = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../header/header-profile-section.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(headerProfile).toMatch(/HeaderNotificationBell/);
+    expect(headerProfile).toMatch(
+      /<Suspense[\s\S]*HeaderProfileSectionInner[\s\S]*<\/Suspense>\s*<HeaderNotificationBell/,
+    );
+
+    const fallback = headerProfile.slice(
+      headerProfile.indexOf("function HeaderProfileSectionSkeleton"),
+      headerProfile.indexOf("export default function HeaderProfileSection"),
+    );
+    expect(fallback).toMatch(/size-4/);
+    expect(fallback).not.toMatch(/size-8/);
+  });
+
   it("private cache loader tags user/org like sidebar chrome", async () => {
     const { readFileSync } = await import("node:fs");
     const { dirname, join } = await import("node:path");

--- a/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
@@ -28,4 +28,10 @@ describe("PrivateCachedAppSidebar session contract", () => {
     expect(source).not.toMatch(/getDeveloperVendorAdminAccess/);
     expect(source).not.toMatch(/resolvePlanName/);
   });
+
+  it("does not own private-cache directives; the shared loader does", () => {
+    expect(source).not.toMatch(/"use cache: private"/);
+    expect(source).not.toMatch(/\bcacheLife\b/);
+    expect(source).not.toMatch(/\bcacheTag\b/);
+  });
 });

--- a/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/private-cached-app-sidebar-contract.test.ts
@@ -20,4 +20,12 @@ describe("PrivateCachedAppSidebar session contract", () => {
   it("takes sessionUser from the authenticated frame instead", () => {
     expect(source).toMatch(/sessionUser:\s*SessionUser/);
   });
+
+  it("does not block rooms chrome on pending invites, credits, or vendor-admin", () => {
+    expect(source).toMatch(/getPrivateCachedChatListChrome/);
+    expect(source).not.toMatch(/listPendingInvitations/);
+    expect(source).not.toMatch(/getCachedMyCredits/);
+    expect(source).not.toMatch(/getDeveloperVendorAdminAccess/);
+    expect(source).not.toMatch(/resolvePlanName/);
+  });
 });

--- a/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
+++ b/apps/web/src/app/(app)/components/authenticated-app-frame.tsx
@@ -19,7 +19,6 @@ import {
   APP_SHELL_BELOW_HEADER_MD_MAX_HEIGHT_CLASS,
   APP_SHELL_BELOW_HEADER_MD_MIN_HEIGHT_CLASS,
 } from "./app-shell-safe-area";
-import { AppSidebarFallback } from "./app-sidebar-fallback";
 import Header from "./header";
 import { LoginAccountNoticeToast } from "./login-account-notice-toast.client";
 import { NoticeDialogProvider } from "./notice-dialog-context";
@@ -58,13 +57,11 @@ export default async function AuthenticatedAppFrame({
                 activeOrganizationId={activeOrganizationId}
               >
                 <BreadcrumbOverrideProvider>
-                  <Suspense fallback={<AppSidebarFallback />}>
-                    <PrivateCachedAppSidebar
-                      sessionUser={session.user}
-                      activeOrganizationId={activeOrganizationId}
-                      adminMenuEnabled={adminMenuEnabled}
-                    />
-                  </Suspense>
+                  <PrivateCachedAppSidebar
+                    sessionUser={session.user}
+                    activeOrganizationId={activeOrganizationId}
+                    adminMenuEnabled={adminMenuEnabled}
+                  />
                   <Suspense fallback={null}>
                     <AppShellOverlays session={session} />
                   </Suspense>

--- a/apps/web/src/app/(app)/components/header/__tests__/header-profile-section.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-profile-section.client.test.tsx
@@ -28,10 +28,6 @@ vi.mock("@/app/components/header/header-workspace-switch.client", () => ({
   },
 }));
 
-vi.mock("@/app/components/header/header-notification-bell.client", () => ({
-  HeaderNotificationBell: () => null,
-}));
-
 vi.mock("@/app/components/header/header-account-control.client", () => ({
   HeaderAccountControl: (props: unknown) => {
     headerAccountControlMock(props);

--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
@@ -64,6 +64,9 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     expect(
       screen.getByTestId("workspace-switcher-skeleton"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "switchWorkspace" }),
+    ).toBeInTheDocument();
   });
 
   it("shows personal workspace from session when no org is active", () => {

--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
@@ -1,0 +1,102 @@
+import type { SessionUser } from "@sokosumi/utils";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { MemberWithOrganization } from "@/lib/clients/generated/core";
+
+import HeaderWorkspaceSwitch from "../header-workspace-switch.client";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/hooks/use-modal", () => ({
+  default: () => ({
+    Component: null,
+    showModal: vi.fn(),
+  }),
+}));
+
+const sessionUser: SessionUser = {
+  id: "user-1",
+  name: "Test User",
+  email: "test@example.com",
+  emailVerified: true,
+  image: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  termsAccepted: true,
+  marketingOptIn: false,
+  onboardingCompleted: true,
+};
+
+const orgMember: MemberWithOrganization = {
+  id: "member-1",
+  organizationId: "org-a",
+  userId: "user-1",
+  role: "member",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  seatAssignedAt: null,
+  organization: {
+    id: "org-a",
+    name: "Org A",
+    slug: "org-a",
+    logo: null,
+    metadata: null,
+    stripeCustomerId: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  },
+};
+
+describe("HeaderWorkspaceSwitch last-known members", () => {
+  it("skeletons the chip when active org is missing from cached members", () => {
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[]}
+        activeOrganizationId="org-a"
+        isPending={false}
+        onSelectWorkspace={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Test User")).not.toBeInTheDocument();
+    expect(screen.queryByText("Org A")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("workspace-switcher-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows personal workspace from session when no org is active", () => {
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[]}
+        activeOrganizationId={null}
+        isPending={false}
+        onSelectWorkspace={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("workspace-switcher-skeleton"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the matching last-known org when members include it", () => {
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[orgMember]}
+        activeOrganizationId="org-a"
+        isPending={false}
+        onSelectWorkspace={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Org A")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("workspace-switcher-skeleton"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(app)/components/header/header-profile-section.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.client.tsx
@@ -9,7 +9,6 @@ import type { CreditUsage } from "@/lib/types/credit";
 import { cn } from "@/lib/utils";
 
 import { HeaderAccountControl } from "./header-account-control.client";
-import { HeaderNotificationBell } from "./header-notification-bell.client";
 import HeaderWorkspaceSwitch from "./header-workspace-switch.client";
 
 export interface HeaderAccountSummary {
@@ -117,7 +116,6 @@ export default function HeaderProfileSectionClient({
         isPending={isPending}
         onSelectWorkspace={handleSelectWorkspace}
       />
-      <HeaderNotificationBell />
       <Suspense fallback={<HeaderAccountControlSkeleton />}>
         <HeaderAccountControlSlot
           sessionUser={sessionUser}

--- a/apps/web/src/app/(app)/components/header/header-profile-section.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.tsx
@@ -2,14 +2,16 @@ import type { Session } from "@sokosumi/utils";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { resolveLowCreditsBillingPath } from "@/app/components/account-notice-state";
-import { getCachedMyCredits } from "@/app/components/private-sidebar-cache";
+import {
+  getCachedMyCredits,
+  getPrivateCachedChatListChrome,
+} from "@/app/components/private-sidebar-cache";
 import { resolveCreditUsage } from "@/app/components/sidebar";
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
 import { getEnvPublicConfig } from "@/config/env.public";
-import type { MemberWithOrganization } from "@/lib/clients/generated/core";
-import { userService } from "@/lib/services";
 import { resolvePlanName } from "@/lib/utils/plan-label";
 
+import { HeaderNotificationBell } from "./header-notification-bell.client";
 import HeaderProfileSectionClient, {
   type HeaderAccountSummary,
 } from "./header-profile-section.client";
@@ -36,12 +38,15 @@ export default function HeaderProfileSection({
   adminMenuEnabled,
 }: HeaderProfileSectionProps) {
   return (
-    <Suspense fallback={<HeaderProfileSectionSkeleton />}>
-      <HeaderProfileSectionInner
-        session={session}
-        adminMenuEnabled={adminMenuEnabled}
-      />
-    </Suspense>
+    <div className="flex h-8 items-center gap-1.5 md:h-auto">
+      <Suspense fallback={<HeaderProfileSectionSkeleton />}>
+        <HeaderProfileSectionInner
+          session={session}
+          adminMenuEnabled={adminMenuEnabled}
+        />
+      </Suspense>
+      <HeaderNotificationBell />
+    </div>
   );
 }
 
@@ -92,12 +97,14 @@ async function HeaderProfileSectionInner({
 }: HeaderProfileSectionProps) {
   const activeOrganizationId = session.session.activeOrganizationId ?? null;
 
-  // Start account-summary work immediately, but only await members here so
-  // desktop workspace switch + notification bell are not blocked by credits.
+  // Start account-summary work immediately, but only await last-known members
+  // here so desktop workspace switch + notification bell are not blocked by
+  // credits. Shared private-cache slice with sidebar / chats (SOK-779).
   const accountSummaryPromise = loadHeaderAccountSummary(adminMenuEnabled);
-  const members = await userService
-    .getMyMembersWithOrganizations()
-    .catch(() => [] as MemberWithOrganization[]);
+  const { members } = await getPrivateCachedChatListChrome({
+    userId: session.user.id,
+    activeOrganizationId,
+  });
 
   return (
     <HeaderProfileSectionClient

--- a/apps/web/src/app/(app)/components/header/header-profile-section.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.tsx
@@ -1,12 +1,11 @@
 import type { Session } from "@sokosumi/utils";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
-import { resolveLowCreditsBillingPath } from "@/app/components/account-notice-state";
 import {
   getCachedMyCredits,
   getPrivateCachedChatListChrome,
 } from "@/app/components/private-sidebar-cache";
-import { resolveCreditUsage } from "@/app/components/sidebar";
+import { mapAccountCreditsChrome } from "@/app/components/sidebar";
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
 import { getEnvPublicConfig } from "@/config/env.public";
 import { resolvePlanName } from "@/lib/utils/plan-label";
@@ -61,29 +60,19 @@ async function loadHeaderAccountSummary(
       getCachedMyCredits(),
     ]);
 
-  const creditsData = creditsResult?.data.credits ?? null;
-  const currentPlan = creditsData?.subscription?.plan ?? "free";
-  const planForLabel = creditsData === null ? null : currentPlan;
-  const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
-  const currentTimestampMs = creditsResult?.meta?.timestamp
-    ? new Date(creditsResult.meta.timestamp).getTime()
-    : 0;
-  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
-  const subscriptionPeriodEndMs = subscriptionPeriodEnd
-    ? new Date(subscriptionPeriodEnd).getTime()
-    : null;
-  const planName = await resolvePlanName(planForLabel);
+  const credits = mapAccountCreditsChrome(creditsResult);
+  const planName = await resolvePlanName(credits.planForLabel);
 
   return {
     planName,
-    totalCredits: creditsData?.total ?? null,
-    extraCredits: creditsData?.buffer ?? null,
-    creditUsage: resolveCreditUsage(creditsData),
-    subscriptionPeriodEndMs,
-    currentTimestampMs,
+    totalCredits: credits.totalCredits,
+    extraCredits: credits.extraCredits,
+    creditUsage: credits.creditUsage,
+    subscriptionPeriodEndMs: credits.subscriptionPeriodEndMs,
+    currentTimestampMs: credits.currentTimestampMs,
     lowCreditsThreshold,
     buyCreditsLabel: tPlan("getMoreCredits"),
-    buyCreditsPath,
+    buyCreditsPath: credits.buyCreditsPath,
     adminMenuEnabled,
     showDeveloperVendors,
   };

--- a/apps/web/src/app/(app)/components/header/header-profile-section.tsx
+++ b/apps/web/src/app/(app)/components/header/header-profile-section.tsx
@@ -23,12 +23,10 @@ interface HeaderProfileSectionProps {
 
 function HeaderProfileSectionSkeleton() {
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex flex-col items-end gap-1">
-        <div className="bg-muted h-4 w-28 animate-pulse rounded-md" />
-        <div className="bg-muted h-3 w-36 animate-pulse rounded-md" />
-      </div>
-      <div className="bg-muted size-8 animate-pulse rounded-full" />
+    <div className="flex h-8 items-center gap-1.5" aria-hidden>
+      <div className="bg-muted h-3 w-20 animate-pulse rounded-md" />
+      <div className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
+      <div className="bg-muted size-4 shrink-0 animate-pulse rounded-sm" />
     </div>
   );
 }
@@ -97,9 +95,10 @@ async function HeaderProfileSectionInner({
 }: HeaderProfileSectionProps) {
   const activeOrganizationId = session.session.activeOrganizationId ?? null;
 
-  // Start account-summary work immediately, but only await last-known members
-  // here so desktop workspace switch + notification bell are not blocked by
-  // credits. Shared private-cache slice with sidebar / chats (SOK-779).
+  // Start account-summary work immediately. Await the shared private-cache
+  // chrome slice (rooms + archived + members) so the switcher uses last-known
+  // members. Notification Center is a sibling of this Suspense and does not
+  // wait. Credits stay on accountSummaryPromise.
   const accountSummaryPromise = loadHeaderAccountSummary(adminMenuEnabled);
   const { members } = await getPrivateCachedChatListChrome({
     userId: session.user.id,

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -147,7 +147,7 @@ export default function HeaderWorkspaceSwitch({
       ? personalWorkspace
       : (organizationWorkspaces.find(
           (workspace) => workspace.id === activeOrganizationId,
-        ) ?? personalWorkspace);
+        ) ?? null);
 
   const handleWorkspaceSelect = (workspaceId: string | null) => {
     setIsDropdownOpen(false);
@@ -170,16 +170,29 @@ export default function HeaderWorkspaceSwitch({
             disabled={isPending}
           >
             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-1.5">
-              <span className="max-w-24 truncate text-right leading-none font-medium md:max-w-none md:leading-tight">
-                {activeWorkspace?.name}
-              </span>
-              <HeaderWorkspaceAvatar
-                sessionUser={sessionUser}
-                organization={activeWorkspace?.organization ?? null}
-                className="size-4 shrink-0"
-                logoSize={12}
-                decorative
-              />
+              {activeWorkspace ? (
+                <>
+                  <span className="max-w-24 truncate text-right leading-none font-medium md:max-w-none md:leading-tight">
+                    {activeWorkspace.name}
+                  </span>
+                  <HeaderWorkspaceAvatar
+                    sessionUser={sessionUser}
+                    organization={activeWorkspace.organization ?? null}
+                    className="size-4 shrink-0"
+                    logoSize={12}
+                    decorative
+                  />
+                </>
+              ) : (
+                <span
+                  data-testid="workspace-switcher-skeleton"
+                  className="col-span-2 flex items-center justify-end gap-1.5"
+                  aria-hidden
+                >
+                  <span className="bg-muted h-3 w-20 animate-pulse rounded-md" />
+                  <span className="bg-muted size-4 shrink-0 animate-pulse rounded-full" />
+                </span>
+              )}
               <ChevronsUpDown className="text-muted-foreground size-4 shrink-0 self-center md:row-span-2 md:size-4.5" />
               <span className="text-muted-foreground col-span-2 col-start-1 max-md:hidden max-w-full truncate text-right text-xs leading-tight">
                 {sessionUser.email}

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -168,6 +168,12 @@ export default function HeaderWorkspaceSwitch({
             type="button"
             className="text-foreground hover:opacity-80 flex h-8 min-w-0 items-center text-sm transition-opacity md:h-auto"
             disabled={isPending}
+            aria-busy={!activeWorkspace}
+            aria-label={
+              activeWorkspace
+                ? undefined
+                : tOrganizationSwitcher("switchWorkspace")
+            }
           >
             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-1.5">
               {activeWorkspace ? (

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -1,14 +1,9 @@
 import type { SessionUser } from "@sokosumi/utils";
-import { cacheLife, cacheTag } from "next/cache";
 import { Suspense } from "react";
 import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
-import {
-  getPrivateCachedChatListChrome,
-  privateSidebarOrgTag,
-  privateSidebarUserTag,
-} from "./private-sidebar-cache";
+import { getPrivateCachedChatListChrome } from "./private-sidebar-cache";
 import Sidebar from "./sidebar";
 import SidebarDeferredAccount, {
   SidebarAccountChipFallback,
@@ -77,13 +72,6 @@ async function PrivateCachedSidebarRooms({
   userId,
   activeOrganizationId,
 }: PrivateCachedSidebarRoomsProps) {
-  "use cache: private";
-  cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
-  cacheTag(privateSidebarUserTag(userId));
-  if (activeOrganizationId) {
-    cacheTag(privateSidebarOrgTag(activeOrganizationId));
-  }
-
   // Shared private-cache slice with `/chat/chats` (SOK-779). Personal coworker
   // directs exist with no active org; Core returns those when organization
   // context is null. Guest rooms (any host org) are mixed into the list.

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -1,25 +1,18 @@
 import type { SessionUser } from "@sokosumi/utils";
 import { cacheLife, cacheTag } from "next/cache";
-import { getTranslations } from "next-intl/server";
-import {
-  resolveAccountNotice,
-  resolveLowCreditsBillingPath,
-} from "@/app/components/account-notice-state";
-import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
-import { getEnvPublicConfig } from "@/config/env.public";
+import { Suspense } from "react";
+import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
-import { chatRoomService } from "@/lib/services";
-import { resolvePlanName } from "@/lib/utils/plan-label";
-
 import {
-  getCachedMyCredits,
   getPrivateCachedChatListChrome,
   privateSidebarOrgTag,
   privateSidebarUserTag,
 } from "./private-sidebar-cache";
-import { AccountNoticeHydrator } from "./shell-hydrators.client";
-import Sidebar, { resolveCreditUsage } from "./sidebar";
+import Sidebar from "./sidebar";
+import SidebarDeferredAccount, {
+  SidebarAccountChipFallback,
+} from "./sidebar-deferred-account";
 
 interface PrivateCachedAppSidebarProps {
   sessionUser: SessionUser;
@@ -28,55 +21,76 @@ interface PrivateCachedAppSidebarProps {
 }
 
 /**
- * Session-aware sidebar chrome for Instant Navigations.
- * Private-cache slice loads all sidebar data inside this boundary so soft
- * navigations can fill the Suspense hole from browser memory without uncached
- * async SC children under the cached tree.
+ * Sync sidebar frame so cold load paints nav immediately after session.
+ * Membership-visible rooms stay in a private-cache slice (shared with
+ * `/chat/chats`). Credits / vendor-admin / account notice stream. Pending
+ * invites are filled by OrganizationChatList's client refresh.
  */
-export default async function PrivateCachedAppSidebar({
+export default function PrivateCachedAppSidebar({
   sessionUser,
   activeOrganizationId,
   adminMenuEnabled,
 }: PrivateCachedAppSidebarProps) {
+  const hermesMenuEnabled = isHermesBetaAccessEmail(sessionUser.email);
+
+  return (
+    <Sidebar
+      hermesMenuEnabled={hermesMenuEnabled}
+      chatList={
+        <Suspense fallback={<SidebarChatListFallback />}>
+          <PrivateCachedSidebarRooms
+            userId={sessionUser.id}
+            activeOrganizationId={activeOrganizationId}
+          />
+        </Suspense>
+      }
+      accountFooter={
+        <Suspense fallback={<SidebarAccountChipFallback />}>
+          <SidebarDeferredAccount
+            sessionUser={sessionUser}
+            activeOrganizationId={activeOrganizationId}
+            adminMenuEnabled={adminMenuEnabled}
+          />
+        </Suspense>
+      }
+    />
+  );
+}
+
+function SidebarChatListFallback() {
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2" aria-hidden>
+      <div className="bg-muted h-4 w-20 animate-pulse rounded-md" />
+      <div className="bg-muted h-8 w-full animate-pulse rounded-md" />
+      <div className="bg-muted h-8 w-full animate-pulse rounded-md" />
+      <div className="bg-muted h-8 w-5/6 animate-pulse rounded-md" />
+    </div>
+  );
+}
+
+interface PrivateCachedSidebarRoomsProps {
+  userId: string;
+  activeOrganizationId: string | null;
+}
+
+async function PrivateCachedSidebarRooms({
+  userId,
+  activeOrganizationId,
+}: PrivateCachedSidebarRoomsProps) {
   "use cache: private";
   cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
-  cacheTag(privateSidebarUserTag(sessionUser.id));
+  cacheTag(privateSidebarUserTag(userId));
   if (activeOrganizationId) {
     cacheTag(privateSidebarOrgTag(activeOrganizationId));
   }
 
-  const tPlanPromise = getTranslations("App.Header.Plan");
-  const hermesMenuEnabled = isHermesBetaAccessEmail(sessionUser.email);
-  const lowCreditsThreshold =
-    getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
-
-  // Membership-visible rooms + archived + members: shared private-cache slice
-  // with `/chat/chats` so cold composition does not double-hit Core (SOK-779).
-  // Personal coworker directs exist with no active org; Core returns those when
-  // organization context is null. Guest rooms (any host org) are mixed into the
-  // list. Pending invites stay sidebar-only (invitee External section).
-  const chatListChromePromise = getPrivateCachedChatListChrome({
-    userId: sessionUser.id,
+  // Shared private-cache slice with `/chat/chats` (SOK-779). Personal coworker
+  // directs exist with no active org; Core returns those when organization
+  // context is null. Guest rooms (any host org) are mixed into the list.
+  const chatListChrome = await getPrivateCachedChatListChrome({
+    userId,
     activeOrganizationId,
   });
-  const pendingInvitationsPromise = chatRoomService
-    .listPendingInvitations()
-    .catch(() => []);
-  const creditsPromise = getCachedMyCredits();
-
-  const [
-    tPlan,
-    chatListChrome,
-    pendingChatRoomInvitations,
-    { showVendors: showDeveloperVendors },
-    creditsResult,
-  ] = await Promise.all([
-    tPlanPromise,
-    chatListChromePromise,
-    pendingInvitationsPromise,
-    getDeveloperVendorAdminAccess(),
-    creditsPromise,
-  ]);
 
   const { members } = chatListChrome;
   const chatRooms = chatListChrome.chatRoomsPage.rooms;
@@ -84,20 +98,6 @@ export default async function PrivateCachedAppSidebar({
   const archivedChatRooms = chatListChrome.archivedChatRoomsPage.rooms;
   const archivedChatRoomsNextCursor =
     chatListChrome.archivedChatRoomsPage.nextCursor;
-
-  const creditsData = creditsResult?.data.credits ?? null;
-  const currentPlan = creditsData?.subscription?.plan ?? "free";
-  const planForLabel = creditsData === null ? null : currentPlan;
-  const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
-  const currentTimestampMs = creditsResult?.meta?.timestamp
-    ? new Date(creditsResult.meta.timestamp).getTime()
-    : 0;
-  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
-  const subscriptionPeriodEndMs = subscriptionPeriodEnd
-    ? new Date(subscriptionPeriodEnd).getTime()
-    : null;
-
-  const planName = await resolvePlanName(planForLabel);
 
   const canDeleteArchivedRooms = Boolean(
     activeOrganizationId &&
@@ -108,40 +108,16 @@ export default async function PrivateCachedAppSidebar({
       ),
   );
 
-  const accountNotice = resolveAccountNotice({
-    credits: creditsData?.total ?? null,
-    currentPlan: creditsData === null ? null : currentPlan,
-    email: sessionUser.email,
-    emailVerified: sessionUser.emailVerified,
-    threshold: lowCreditsThreshold,
-  });
-
   return (
-    <>
-      <AccountNoticeHydrator accountNotice={accountNotice} />
-      <Sidebar
-        activeOrganizationId={activeOrganizationId}
-        adminMenuEnabled={adminMenuEnabled}
-        archivedChatRooms={archivedChatRooms}
-        archivedChatRoomsNextCursor={archivedChatRoomsNextCursor}
-        buyCreditsLabel={tPlan("getMoreCredits")}
-        buyCreditsPath={buyCreditsPath}
-        canDeleteArchivedRooms={canDeleteArchivedRooms}
-        chatRooms={chatRooms}
-        chatRoomsNextCursor={chatRoomsNextCursor}
-        pendingChatRoomInvitations={pendingChatRoomInvitations}
-        creditsData={creditsData}
-        creditUsage={resolveCreditUsage(creditsData)}
-        currentTimestampMs={currentTimestampMs}
-        currentUserId={sessionUser.id}
-        hermesMenuEnabled={hermesMenuEnabled}
-        lowCreditsThreshold={lowCreditsThreshold}
-        members={members}
-        planName={planName}
-        sessionUser={sessionUser}
-        showDeveloperVendors={showDeveloperVendors}
-        subscriptionPeriodEndMs={subscriptionPeriodEndMs}
-      />
-    </>
+    <OrganizationChatList
+      key={activeOrganizationId ?? "personal"}
+      rooms={chatRooms}
+      roomsNextCursor={chatRoomsNextCursor}
+      archivedRooms={archivedChatRooms}
+      archivedRoomsNextCursor={archivedChatRoomsNextCursor}
+      currentUserId={userId}
+      organizationId={activeOrganizationId}
+      canDeleteArchivedRooms={canDeleteArchivedRooms}
+    />
   );
 }

--- a/apps/web/src/app/(app)/components/private-sidebar-cache.ts
+++ b/apps/web/src/app/(app)/components/private-sidebar-cache.ts
@@ -40,7 +40,8 @@ export interface PrivateCachedChatListChrome {
  * Fail-soft: service errors become empty pages/arrays (same as pre-SOK-779
  * sidebar/page). When used under private cache those empties are shared until
  * revalidate or `invalidatePrivateSidebarChrome` — intentional chrome tradeoff,
- * not a hard fail that would blank the whole layout.
+ * not a hard fail that would blank the whole layout. Empty members with an
+ * active org also skeletons the Workspace switcher until that cache goes stale.
  */
 export async function loadChatListChromeData(
   activeOrganizationId: string | null,

--- a/apps/web/src/app/(app)/components/sidebar-deferred-account.tsx
+++ b/apps/web/src/app/(app)/components/sidebar-deferred-account.tsx
@@ -1,10 +1,7 @@
 import type { SessionUser } from "@sokosumi/utils";
 import { getTranslations } from "next-intl/server";
-import {
-  resolveAccountNotice,
-  resolveLowCreditsBillingPath,
-} from "@/app/components/account-notice-state";
-import { resolveCreditUsage } from "@/app/components/sidebar";
+import { resolveAccountNotice } from "@/app/components/account-notice-state";
+import { mapAccountCreditsChrome } from "@/app/components/sidebar";
 import { SidebarAccountChip } from "@/app/components/sidebar/components/sidebar-account-chip.client";
 import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
 import { getEnvPublicConfig } from "@/config/env.public";
@@ -45,21 +42,11 @@ export default async function SidebarDeferredAccount({
       getDeveloperVendorAdminAccess(),
     ]);
 
-  const creditsData = creditsResult?.data.credits ?? null;
-  const currentPlan = creditsData?.subscription?.plan ?? "free";
-  const planForLabel = creditsData === null ? null : currentPlan;
-  const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
-  const currentTimestampMs = creditsResult?.meta?.timestamp
-    ? new Date(creditsResult.meta.timestamp).getTime()
-    : 0;
-  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
-  const subscriptionPeriodEndMs = subscriptionPeriodEnd
-    ? new Date(subscriptionPeriodEnd).getTime()
-    : null;
-  const planName = await resolvePlanName(planForLabel);
+  const credits = mapAccountCreditsChrome(creditsResult);
+  const planName = await resolvePlanName(credits.planForLabel);
   const accountNotice = resolveAccountNotice({
-    credits: creditsData?.total ?? null,
-    currentPlan: creditsData === null ? null : currentPlan,
+    credits: credits.totalCredits,
+    currentPlan: credits.creditsData === null ? null : credits.currentPlan,
     email: sessionUser.email,
     emailVerified: sessionUser.emailVerified,
     threshold: lowCreditsThreshold,
@@ -71,14 +58,14 @@ export default async function SidebarDeferredAccount({
       <SidebarAccountChip
         sessionUser={sessionUser}
         planName={planName}
-        totalCredits={creditsData?.total ?? null}
-        extraCredits={creditsData?.buffer ?? null}
-        creditUsage={resolveCreditUsage(creditsData)}
-        subscriptionPeriodEndMs={subscriptionPeriodEndMs}
-        currentTimestampMs={currentTimestampMs}
+        totalCredits={credits.totalCredits}
+        extraCredits={credits.extraCredits}
+        creditUsage={credits.creditUsage}
+        subscriptionPeriodEndMs={credits.subscriptionPeriodEndMs}
+        currentTimestampMs={credits.currentTimestampMs}
         lowCreditsThreshold={lowCreditsThreshold}
         buyCreditsLabel={tPlan("getMoreCredits")}
-        buyCreditsPath={buyCreditsPath}
+        buyCreditsPath={credits.buyCreditsPath}
         adminSettingsChrome={{
           adminMenuEnabled,
           members: chatListChrome.members,

--- a/apps/web/src/app/(app)/components/sidebar-deferred-account.tsx
+++ b/apps/web/src/app/(app)/components/sidebar-deferred-account.tsx
@@ -1,0 +1,106 @@
+import type { SessionUser } from "@sokosumi/utils";
+import { getTranslations } from "next-intl/server";
+import {
+  resolveAccountNotice,
+  resolveLowCreditsBillingPath,
+} from "@/app/components/account-notice-state";
+import { resolveCreditUsage } from "@/app/components/sidebar";
+import { SidebarAccountChip } from "@/app/components/sidebar/components/sidebar-account-chip.client";
+import { getDeveloperVendorAdminAccess } from "@/app/developer/get-developer-vendor-admin-access";
+import { getEnvPublicConfig } from "@/config/env.public";
+import { resolvePlanName } from "@/lib/utils/plan-label";
+
+import {
+  getCachedMyCredits,
+  getPrivateCachedChatListChrome,
+} from "./private-sidebar-cache";
+import { AccountNoticeHydrator } from "./shell-hydrators.client";
+
+interface SidebarDeferredAccountProps {
+  sessionUser: SessionUser;
+  activeOrganizationId: string | null;
+  adminMenuEnabled: boolean;
+}
+
+/**
+ * Credits, plan, vendor-admin, and account notice. Streamed behind Suspense
+ * so they do not gate nav + membership-visible rooms.
+ */
+export default async function SidebarDeferredAccount({
+  sessionUser,
+  activeOrganizationId,
+  adminMenuEnabled,
+}: SidebarDeferredAccountProps) {
+  const lowCreditsThreshold =
+    getEnvPublicConfig().NEXT_PUBLIC_CREDITS_BUY_BUTTON_THRESHOLD;
+
+  const [tPlan, chatListChrome, creditsResult, { showVendors }] =
+    await Promise.all([
+      getTranslations("App.Header.Plan"),
+      getPrivateCachedChatListChrome({
+        userId: sessionUser.id,
+        activeOrganizationId,
+      }),
+      getCachedMyCredits(),
+      getDeveloperVendorAdminAccess(),
+    ]);
+
+  const creditsData = creditsResult?.data.credits ?? null;
+  const currentPlan = creditsData?.subscription?.plan ?? "free";
+  const planForLabel = creditsData === null ? null : currentPlan;
+  const buyCreditsPath = resolveLowCreditsBillingPath(currentPlan);
+  const currentTimestampMs = creditsResult?.meta?.timestamp
+    ? new Date(creditsResult.meta.timestamp).getTime()
+    : 0;
+  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
+  const subscriptionPeriodEndMs = subscriptionPeriodEnd
+    ? new Date(subscriptionPeriodEnd).getTime()
+    : null;
+  const planName = await resolvePlanName(planForLabel);
+  const accountNotice = resolveAccountNotice({
+    credits: creditsData?.total ?? null,
+    currentPlan: creditsData === null ? null : currentPlan,
+    email: sessionUser.email,
+    emailVerified: sessionUser.emailVerified,
+    threshold: lowCreditsThreshold,
+  });
+
+  return (
+    <>
+      <AccountNoticeHydrator accountNotice={accountNotice} />
+      <SidebarAccountChip
+        sessionUser={sessionUser}
+        planName={planName}
+        totalCredits={creditsData?.total ?? null}
+        extraCredits={creditsData?.buffer ?? null}
+        creditUsage={resolveCreditUsage(creditsData)}
+        subscriptionPeriodEndMs={subscriptionPeriodEndMs}
+        currentTimestampMs={currentTimestampMs}
+        lowCreditsThreshold={lowCreditsThreshold}
+        buyCreditsLabel={tPlan("getMoreCredits")}
+        buyCreditsPath={buyCreditsPath}
+        adminSettingsChrome={{
+          adminMenuEnabled,
+          members: chatListChrome.members,
+          activeOrganizationId,
+          showDeveloperVendors: showVendors,
+        }}
+      />
+    </>
+  );
+}
+
+export function SidebarAccountChipFallback() {
+  return (
+    <div
+      className="flex w-full items-center gap-2.5 p-2 group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-0"
+      aria-hidden
+    >
+      <div className="bg-muted size-8 shrink-0 animate-pulse rounded-full" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1 group-data-[collapsible=icon]:hidden">
+        <div className="bg-muted h-3 w-24 animate-pulse rounded-md" />
+        <div className="bg-muted h-3 w-16 animate-pulse rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/components/sidebar/__tests__/resolve-credit-usage.test.ts
+++ b/apps/web/src/app/(app)/components/sidebar/__tests__/resolve-credit-usage.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { StripeSubscriptionStatus } from "@/lib/clients/generated/core";
 
 import type { SidebarCreditsData } from "../index";
-import { resolveCreditUsage } from "../index";
+import { mapAccountCreditsChrome, resolveCreditUsage } from "../index";
 
 function buildCreditsData(
   subscriptionCredits: NonNullable<
@@ -47,6 +47,68 @@ describe("resolveCreditUsage", () => {
       remaining: 75,
       total: 100,
       used: 25,
+    });
+  });
+});
+
+describe("mapAccountCreditsChrome", () => {
+  it("maps a missing credits fetch to free-plan chrome with no plan label", () => {
+    expect(mapAccountCreditsChrome(null)).toEqual({
+      creditsData: null,
+      currentPlan: "free",
+      planForLabel: null,
+      buyCreditsPath: "/billing?tab=subscription",
+      currentTimestampMs: 0,
+      subscriptionPeriodEndMs: null,
+      totalCredits: null,
+      extraCredits: null,
+      creditUsage: null,
+    });
+  });
+
+  it("maps a credits payload into chip fields and timestamps", () => {
+    const periodEnd = new Date("2026-09-01T00:00:00.000Z");
+    const timestamp = new Date("2026-08-13T12:00:00.000Z");
+    const creditsData = {
+      ...buildCreditsData(),
+      buffer: 10,
+      subscription: {
+        ...buildCreditsData().subscription!,
+        periodEnd,
+      },
+    };
+
+    expect(
+      mapAccountCreditsChrome({
+        data: {
+          subscription: creditsData.subscription,
+          extra: {
+            credits: { total: 10, remaining: 10, used: 0 },
+            buckets: [],
+            enterprise: null,
+          },
+          credits: creditsData,
+        },
+        meta: {
+          timestamp,
+          requestId: "req-1",
+        },
+      }),
+    ).toEqual({
+      creditsData,
+      currentPlan: "pro",
+      planForLabel: "pro",
+      buyCreditsPath: "/billing?tab=credits",
+      currentTimestampMs: timestamp.getTime(),
+      subscriptionPeriodEndMs: periodEnd.getTime(),
+      totalCredits: 100,
+      extraCredits: 10,
+      creditUsage: {
+        percentageUsed: 25,
+        remaining: 75,
+        total: 100,
+        used: 25,
+      },
     });
   });
 });

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -1,5 +1,4 @@
-import type { SessionUser } from "@sokosumi/utils";
-import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
+import type { ReactNode } from "react";
 import {
   Sidebar as ShadcnSidebar,
   SidebarContent,
@@ -7,19 +6,13 @@ import {
   SidebarHeader,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
-import type {
-  ChatRoom,
-  ChatRoomInvitation,
-  GetUsersByIdCreditsResponse,
-  MemberWithOrganization,
-} from "@/lib/clients/generated/core";
+import type { GetUsersByIdCreditsResponse } from "@/lib/clients/generated/core";
 import type { CreditUsage } from "@/lib/types/credit";
 
 import AnnouncementCards from "./components/announcement-cards";
 import CustomTrigger from "./components/custom-trigger";
 import MenuItems from "./components/menu-items";
 import PersonalAssistantNav from "./components/personal-assistant-nav.client";
-import { SidebarAccountChip } from "./components/sidebar-account-chip.client";
 import SidebarLogo from "./components/sidebar-logo.client";
 
 export type SidebarCreditsData = GetUsersByIdCreditsResponse["data"]["credits"];
@@ -48,51 +41,15 @@ export function resolveCreditUsage(
 }
 
 interface SidebarProps {
-  activeOrganizationId: string | null;
-  adminMenuEnabled: boolean;
-  archivedChatRooms: ChatRoom[];
-  archivedChatRoomsNextCursor: string | null;
-  buyCreditsLabel: string;
-  buyCreditsPath: string;
-  canDeleteArchivedRooms: boolean;
-  chatRooms: ChatRoom[];
-  chatRoomsNextCursor: string | null;
-  pendingChatRoomInvitations: ChatRoomInvitation[];
-  creditsData: SidebarCreditsData | null;
-  creditUsage: CreditUsage | null;
-  currentTimestampMs: number;
-  currentUserId: string;
+  accountFooter: ReactNode;
+  chatList: ReactNode;
   hermesMenuEnabled: boolean;
-  lowCreditsThreshold: number;
-  members: MemberWithOrganization[];
-  planName: string | null;
-  sessionUser: SessionUser;
-  showDeveloperVendors: boolean;
-  subscriptionPeriodEndMs: number | null;
 }
 
 export default function Sidebar({
-  activeOrganizationId,
-  adminMenuEnabled,
-  archivedChatRooms,
-  archivedChatRoomsNextCursor,
-  buyCreditsLabel,
-  buyCreditsPath,
-  canDeleteArchivedRooms,
-  chatRooms,
-  chatRoomsNextCursor,
-  pendingChatRoomInvitations,
-  creditsData,
-  creditUsage,
-  currentTimestampMs,
-  currentUserId,
+  accountFooter,
+  chatList,
   hermesMenuEnabled,
-  lowCreditsThreshold,
-  members,
-  planName,
-  sessionUser,
-  showDeveloperVendors,
-  subscriptionPeriodEndMs,
 }: SidebarProps) {
   return (
     <ShadcnSidebar collapsible="icon">
@@ -113,17 +70,7 @@ export default function Sidebar({
           {hermesMenuEnabled ? <SidebarSeparator className="-mt-px" /> : null}
           <MenuItems />
           <SidebarSeparator />
-          <OrganizationChatList
-            key={activeOrganizationId ?? "personal"}
-            rooms={chatRooms}
-            roomsNextCursor={chatRoomsNextCursor}
-            archivedRooms={archivedChatRooms}
-            archivedRoomsNextCursor={archivedChatRoomsNextCursor}
-            pendingInvitations={pendingChatRoomInvitations}
-            currentUserId={currentUserId}
-            organizationId={activeOrganizationId}
-            canDeleteArchivedRooms={canDeleteArchivedRooms}
-          />
+          {chatList}
         </div>
       </SidebarContent>
       <SidebarFooter className="mt-auto shrink-0 px-0">
@@ -132,24 +79,7 @@ export default function Sidebar({
             8px there, matching the 8px this adds on the sides. The inset only
             grows on phones, where the home indicator sits in that 8px. */}
         <div className="p-2 pt-0 pb-[env(safe-area-inset-bottom)] group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
-          <SidebarAccountChip
-            sessionUser={sessionUser}
-            planName={planName}
-            totalCredits={creditsData?.total ?? null}
-            extraCredits={creditsData?.buffer ?? null}
-            creditUsage={creditUsage}
-            subscriptionPeriodEndMs={subscriptionPeriodEndMs}
-            currentTimestampMs={currentTimestampMs}
-            lowCreditsThreshold={lowCreditsThreshold}
-            buyCreditsLabel={buyCreditsLabel}
-            buyCreditsPath={buyCreditsPath}
-            adminSettingsChrome={{
-              adminMenuEnabled,
-              members,
-              activeOrganizationId,
-              showDeveloperVendors,
-            }}
-          />
+          {accountFooter}
         </div>
       </SidebarFooter>
     </ShadcnSidebar>

--- a/apps/web/src/app/(app)/components/sidebar/index.tsx
+++ b/apps/web/src/app/(app)/components/sidebar/index.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { resolveLowCreditsBillingPath } from "@/app/components/account-notice-state";
 import {
   Sidebar as ShadcnSidebar,
   SidebarContent,
@@ -37,6 +38,44 @@ export function resolveCreditUsage(
     remaining: Math.max(subscriptionCredits.remaining, 0),
     total,
     used,
+  };
+}
+
+export interface AccountCreditsChrome {
+  creditsData: SidebarCreditsData | null;
+  currentPlan: string;
+  planForLabel: string | null;
+  buyCreditsPath: string;
+  currentTimestampMs: number;
+  subscriptionPeriodEndMs: number | null;
+  totalCredits: number | null;
+  extraCredits: number | null;
+  creditUsage: CreditUsage | null;
+}
+
+/** Shared header/sidebar mapping from a credits Core payload. */
+export function mapAccountCreditsChrome(
+  creditsResult: GetUsersByIdCreditsResponse | null,
+): AccountCreditsChrome {
+  const creditsData = creditsResult?.data.credits ?? null;
+  const currentPlan = creditsData?.subscription?.plan ?? "free";
+  const planForLabel = creditsData === null ? null : currentPlan;
+  const subscriptionPeriodEnd = creditsData?.subscription?.periodEnd ?? null;
+
+  return {
+    creditsData,
+    currentPlan,
+    planForLabel,
+    buyCreditsPath: resolveLowCreditsBillingPath(currentPlan),
+    currentTimestampMs: creditsResult?.meta?.timestamp
+      ? new Date(creditsResult.meta.timestamp).getTime()
+      : 0,
+    subscriptionPeriodEndMs: subscriptionPeriodEnd
+      ? new Date(subscriptionPeriodEnd).getTime()
+      : null,
+    totalCredits: creditsData?.total ?? null,
+    extraCredits: creditsData?.buffer ?? null,
+    creditUsage: resolveCreditUsage(creditsData),
   };
 }
 


### PR DESCRIPTION
## Summary

Cold load of authenticated **app chrome** (sidebar + header) no longer waits on credits, vendor-admin, or a live members fetch before the frame paints.

- Header Workspace switcher reads last-known members from `getPrivateCachedChatListChrome` (same private-cache slice as sidebar / chats).
- Sidebar frame is sync after session: nav paints immediately; membership-visible rooms stay in the existing private cache; credits / vendor-admin / account notice stream behind Suspense.
- If `activeOrganizationId` is set but missing from cached members, the chip skeletons instead of flashing personal identity.
- Notification Center no longer waits on the members/rooms cache fill.
- Pending invites still fill via `OrganizationChatList` client refresh (rooms do not wait).

Cache life unchanged (`stale` 300s / `revalidate` 60s / `expire` 1h). Breadcrumbs still use their own Suspense + live members fetch.

## Verification

- `pnpm --filter web exec vitest run` on chrome/header contract and workspace-switch tests
- `pnpm --filter web typecheck`
- Pre-commit: `biome check` + repo typecheck

Browser cold-load feel not measured in this change. Hard-refresh `/chat` or `/agents` after sign-in to confirm frame-first paint.