### PR TITLE
chore(verify): fall back to coworker vault

### DIFF
--- a/.cursor/skills/verify-sokosumi/SKILL.md
+++ b/.cursor/skills/verify-sokosumi/SKILL.md
@@ -69,7 +69,7 @@ For Cursor background shells, kill those shell PIDs (or stop the terminal jobs) 
 
 Require `doctor ok`. If `owned_by_verify=no`, do **read-only** checks only — never mutate a foreign instance. If ports already answer before `launch`, the helper refuses (no double-drive).
 
-Doctor also prints `fixture_auth=ok|fail` (Core `POST /auth/sign-in/email` for `alice@sokosumi.test`) and whether `agent-browser` is on `PATH`. Fixture failure is a **warn** (local DB may lack seeds) — not a doctor fail. On cloud-agent Neon branches, expect `fixture_auth=ok` before driving.
+Doctor also prints `fixture_auth=ok|fail` (Core `POST /auth/sign-in/email` for `alice@sokosumi.test`), `vault_profile=…` when `agent-browser auth list` has the coworker profile, and whether `agent-browser` is on `PATH`. Fixture failure is a **warn** (local/shared DB may lack seeds) — not a doctor fail. On cloud-agent Neon branches, expect `fixture_auth=ok` before driving. On a coworker machine or shared Neon, expect `fixture_auth=fail` and use the vault — do **not** seed Alice onto that database.
 
 Optional Core-only smoke:
 
@@ -77,20 +77,25 @@ Optional Core-only smoke:
 .cursor/skills/verify-sokosumi/bin/verify-sokosumi core-smoke
 ```
 
-## Sign-in (cloud agents: use the harness)
+## Sign-in (use the harness)
 
-Prefer the helper over hand-rolled browser clicks. It probes fixtures, drives UI Enter-submit, and falls back to Core cookie bootstrap (parses `Set-Cookie` from `POST /auth/sign-in/email`, then `agent-browser cookies set` with `HttpOnly` + `SameSite=Lax` on `localhost` — raw `cookies set --curl` often hits CDP “Invalid cookie fields” on Better Auth cookies):
+Prefer the helper over hand-rolled browser clicks. `auto` (default):
+
+1. Probe Core email sign-in for the fixture (`alice@sokosumi.test` unless overridden).
+2. If the fixture works: UI Enter-submit, then Core cookie bootstrap.
+3. If the fixture fails: coworker vault `agent-browser auth login sokosumi` with `[data-testid="auth-field-email"]` / `[data-testid="auth-field-currentPassword"]`. Persist check is `/agents` — do not wait `networkidle` on `/chat` (Ably hangs that wait).
 
 ```bash
 export AGENT_BROWSER_SESSION_NAME=sokosumi
-.cursor/skills/verify-sokosumi/bin/verify-sokosumi doctor   # require doctor ok + fixture_auth=ok on agent DBs
-.cursor/skills/verify-sokosumi/bin/verify-sokosumi sign-in  # alice@sokosumi.test / Password123!
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi doctor   # require doctor ok; fixture_auth=ok only on agent DBs
+.cursor/skills/verify-sokosumi/bin/verify-sokosumi sign-in  # fixtures, else vault
 # or: … sign-in --admin
-# or: … sign-in --method cookie   # skip flaky UI; unlock rest of map
-# or: … sign-in --method ui       # UI-only (no cookie fallback)
+# or: … sign-in --method vault    # skip fixtures; coworker profile
+# or: … sign-in --method cookie   # fixture cookie bootstrap only
+# or: … sign-in --method ui       # fixture UI only (signin-submit proof)
 ```
 
-Artifacts land under `.cursor/verify-sokosumi-artifacts/sign-in/` (`after-login.snapshot.txt`, `account.txt`, `method.txt`). Cookie-only unlocks later features — for `signin-submit` proof, require `--method ui` (or `auto` that succeeded with `method=ui`).
+Artifacts land under `.cursor/verify-sokosumi-artifacts/sign-in/` (`after-login.snapshot.txt`, `account.txt`, `method.txt` = `ui` | `cookie` | `vault`). Cookie-only unlocks later features — for `signin-submit` proof, require `method=ui`. Vault unlocks the map on coworker/shared Neon; it is not fixture `signin-submit` proof.
 
 ## Drive
 
@@ -106,9 +111,9 @@ export AGENT_BROWSER_SESSION_NAME=sokosumi
 
 Stable auth selectors: `[data-testid="auth-field-email"]`, `[data-testid="auth-field-currentPassword"]`, `[data-testid="auth-submit"]`.
 
-**Login rule (manual drive):** fill email/password fields only, then **press Enter** — do not click submit, Google, Microsoft, Passkey, or Magic Link. react-hook-form can race a programmatic click; social/passkey controls sit **above** the password form and steal automation focus.
+**Login rule (manual drive):** fill email/password fields only, then **press Enter** — do not click submit, Google, Microsoft, Passkey, or Magic Link. react-hook-form can race a programmatic click; social/passkey controls sit **above** the password form and steal automation focus. After login, open `/agents` to prove the session. Do not `wait --load networkidle` on `/chat`.
 
-If UI login leaves you on `/signin` or bounces back after a “success” (classic `BETTER_AUTH_COOKIE_DOMAIN` trap, or passkey/OAuth interference), fix env first, then `verify-sokosumi sign-in --method cookie` (see [sign-in.md](./features/sign-in.md)). API bootstrap alone is not UI proof — reopen a protected page in the browser after injecting cookies.
+If UI login leaves you on `/signin` or bounces back after a “success” (classic `BETTER_AUTH_COOKIE_DOMAIN` trap, or passkey/OAuth interference), fix env first, then `verify-sokosumi sign-in --method cookie` when fixtures work, or `--method vault` on a coworker machine (see [sign-in.md](./features/sign-in.md)). API bootstrap alone is not UI proof — reopen a protected page in the browser after injecting cookies.
 
 Credentials (pick one):
 
@@ -117,8 +122,8 @@ Credentials (pick one):
 | Cloud-agent fixtures | `alice@sokosumi.test` | `Password123!` | Neon `cloud-agent-*` branches after migrate/seed (owns org `alice-fixture`) |
 | Cloud-agent admin | `admin@sokosumi.test` | `Password123!` | Admin UI `/admin` (owns org `admin-fixture`) |
 | Cloud-agent bob | `bob@sokosumi.test` | `Password123!` | Second user (owns org `bob-fixture`) |
-| Local signup | unique `*@sokosumi.test` via `/signup` | choose once | Empty/local DB without fixtures |
-| Coworker vault | `agent-browser auth save sokosumi …` | machine-local | Personal accounts — never commit |
+| Coworker vault | `agent-browser auth save sokosumi …` | machine-local | Shared/preprod Neon or local DB — never seed Alice here |
+| Local signup | unique `*@sokosumi.test` via `/signup` | choose once | No fixtures and no vault |
 
 OAuth, magic-link, and passkey do **not** work with placeholder credentials. Skip those paths.
 
@@ -162,7 +167,7 @@ Executable: `.cursor/skills/verify-sokosumi/bin/verify-sokosumi`
 .cursor/skills/verify-sokosumi/bin/verify-sokosumi cleanup
 ```
 
-Env overrides: `VERIFY_SOKOSUMI_WEB_URL`, `VERIFY_SOKOSUMI_CORE_URL`, `VERIFY_SOKOSUMI_STATE_DIR`, `VERIFY_SOKOSUMI_ARTIFACT_ROOT`, `VERIFY_SOKOSUMI_EMAIL`, `VERIFY_SOKOSUMI_PASSWORD`.
+Env overrides: `VERIFY_SOKOSUMI_WEB_URL`, `VERIFY_SOKOSUMI_CORE_URL`, `VERIFY_SOKOSUMI_STATE_DIR`, `VERIFY_SOKOSUMI_ARTIFACT_ROOT`, `VERIFY_SOKOSUMI_EMAIL`, `VERIFY_SOKOSUMI_PASSWORD`, `VERIFY_SOKOSUMI_VAULT_PROFILE`.
 
 ## Isolate
 
@@ -177,6 +182,7 @@ Default ports **3000** (web) and **8787** (core) are shared. Second concurrent v
 - `COMPOSIO_API_KEY` set without an `ak_` prefix → Core refuses to start (optional key; omit or use `ak_…`)
 - Empty local catalog: `/agents` soft-empty (“No agents available”) or Core 500 until `credit_cost` rows exist
 - Ably placeholders break realtime chat UI
-- Fixtures exist only on agent Neon branches, not production/`main`
+- Fixtures exist only on agent Neon branches, not production/`main`. `fixture_auth=fail` on a coworker/shared Neon → vault or signup; never seed Alice onto that DB
+- After login, prove the session on `/agents`. `wait --load networkidle` on `/chat` hangs (Ably)
 - Node **24.x** required
 - `/signin` shows Google / Microsoft / Passkey / Magic Link **above** the password form — automation must target `[data-testid="auth-field-*"]` only

--- a/.cursor/skills/verify-sokosumi/bin/verify-sokosumi
+++ b/.cursor/skills/verify-sokosumi/bin/verify-sokosumi
@@ -18,6 +18,8 @@ mkdir -p "$STATE_DIR" "$LOG_DIR" "$ARTIFACT_ROOT"
 
 DEFAULT_FIXTURE_EMAIL="${VERIFY_SOKOSUMI_EMAIL:-alice@sokosumi.test}"
 DEFAULT_FIXTURE_PASSWORD="${VERIFY_SOKOSUMI_PASSWORD:-Password123!}"
+AUTH_EMAIL_SELECTOR='[data-testid="auth-field-email"]'
+AUTH_PASSWORD_SELECTOR='[data-testid="auth-field-currentPassword"]'
 
 function usage() {
   cat <<'EOF'
@@ -27,15 +29,16 @@ Commands:
   launch     Start Core (:8787) and Web (:3000) for this verification run.
              Uses with-db.mjs when .cursor/cloud-agent-db.env exists.
   doctor     Read-only health check (ports, OpenAPI, sign-in page, fixture probe).
-  sign-in    Authenticate demo fixtures into agent-browser (UI, then cookie fallback).
+  sign-in    Authenticate into agent-browser (fixtures, then coworker vault).
   cleanup    Stop processes started by launch (keeps proof artifacts).
   core-smoke GET Core OpenAPI JSON; exit 0 if HTTP 200.
 
 sign-in options:
   --email <email>       default alice@sokosumi.test (or VERIFY_SOKOSUMI_EMAIL)
   --password <pass>     default Password123! (or VERIFY_SOKOSUMI_PASSWORD)
-  --method ui|cookie|auto   default auto (UI first, cookie bootstrap on failure)
+  --method ui|cookie|auto|vault   default auto
   --admin               shorthand for admin@sokosumi.test
+  --vault               shorthand for --method vault
 
 Env overrides:
   VERIFY_SOKOSUMI_WEB_URL   default http://localhost:3000
@@ -43,6 +46,7 @@ Env overrides:
   VERIFY_SOKOSUMI_STATE_DIR state/pids/logs directory
   VERIFY_SOKOSUMI_ARTIFACT_ROOT proof artifact root
   VERIFY_SOKOSUMI_EMAIL / VERIFY_SOKOSUMI_PASSWORD  fixture credentials for sign-in
+  VERIFY_SOKOSUMI_VAULT_PROFILE  default sokosumi (agent-browser auth profile)
   AGENT_BROWSER_SESSION_NAME  preferred: sokosumi (session cookie reuse)
 EOF
 }
@@ -209,9 +213,13 @@ function fixture_probe() {
   fi
   echo "fixture_auth=fail email=$email (Core POST /auth/sign-in/email → HTTP $http_status)"
   echo "warn: demo fixtures missing or Core auth rejected credentials."
-  echo "warn: on Neon cloud-agent-* branches run: node scripts/cloud-agent-db/provision.mjs"
-  echo "warn: or seed: node scripts/cloud-agent-db/with-db.mjs -- pnpm cloud-agent-db:seed-auth"
-  echo "warn: otherwise use features/sign-up.md for a disposable account"
+  if cloud_agent_db; then
+    echo "warn: cloud-agent DB: node scripts/cloud-agent-db/provision.mjs"
+    echo "warn: or seed: node scripts/cloud-agent-db/with-db.mjs -- pnpm cloud-agent-db:seed-auth"
+  else
+    echo "warn: coworker / shared Neon: verify-sokosumi sign-in --method vault, or features/sign-up.md"
+    echo "warn: do not seed alice@sokosumi.test onto a shared or preprod Neon"
+  fi
   if [[ -f "$tmp/body.json" ]]; then
     head -c 400 "$tmp/body.json" | tr '\n' ' ' >&2 || true
     echo >&2
@@ -228,6 +236,48 @@ function require_agent_browser() {
     return 1
   fi
   return 0
+}
+
+function cloud_agent_db() {
+  [[ -f "$REPO_ROOT/.cursor/cloud-agent-db.env" ]]
+}
+
+function vault_profile() {
+  echo "${VERIFY_SOKOSUMI_VAULT_PROFILE:-sokosumi}"
+}
+
+function vault_profile_exists() {
+  local name="$1"
+  command -v agent-browser >/dev/null 2>&1 || return 1
+  agent-browser auth list 2>/dev/null | grep -Eq "(^|[[:space:]])${name}([[:space:]]|$)"
+}
+
+function vault_profile_email() {
+  local name="$1"
+  local line
+  line="$(agent-browser auth show "$name" 2>/dev/null | grep -E '^Username:' || true)"
+  line="${line#Username:}"
+  echo "${line#"${line%%[![:space:]]*}"}"
+}
+
+function wait_authed_agents() {
+  # Persist check. Do not wait --load networkidle on /chat — Ably keeps the
+  # network busy and that wait hangs. Prove the session on /agents instead.
+  # Prefer a short sleep over `wait --url` here — that wait has a long default
+  # timeout and can sit for minutes after a successful navigation.
+  agent-browser open "$WEB_URL/agents" >/dev/null
+  sleep 2
+}
+
+function record_sign_in() {
+  local email="$1"
+  local method="$2"
+  local art_dir="$ARTIFACT_ROOT/sign-in"
+  mkdir -p "$art_dir"
+  agent-browser snapshot -i >"$art_dir/after-login.snapshot.txt" || true
+  agent-browser screenshot >/dev/null || true
+  printf '%s\n' "$email" >"$art_dir/account.txt"
+  printf 'method=%s\n' "$method" >"$art_dir/method.txt"
 }
 
 function web_host() {
@@ -340,8 +390,7 @@ function sign_in_cookie() {
     return 1
   fi
 
-  agent-browser open "$WEB_URL/agents" >/dev/null
-  agent-browser wait --load networkidle >/dev/null || agent-browser wait 2000 >/dev/null || true
+  wait_authed_agents
   local url
   url="$(agent-browser get url 2>/dev/null || true)"
   echo "sign-in cookie: landed $url"
@@ -351,10 +400,7 @@ function sign_in_cookie() {
     return 1
   fi
 
-  agent-browser snapshot -i >"$art_dir/after-login.snapshot.txt" || true
-  agent-browser screenshot >/dev/null || true
-  echo "$email" >"$art_dir/account.txt"
-  echo "method=cookie" >"$art_dir/method.txt"
+  record_sign_in "$email" "cookie"
   echo "sign-in cookie ok (session in AGENT_BROWSER_SESSION_NAME=${AGENT_BROWSER_SESSION_NAME})"
   echo "note: cookie bootstrap unlocks the map; record UI path separately if proving signin-submit."
   return 0
@@ -378,16 +424,16 @@ function sign_in_ui() {
   agent-browser wait --load networkidle >/dev/null || agent-browser wait 1500 >/dev/null || true
 
   # Fill only password-form testids — never click Google/Microsoft/Passkey/Magic Link.
-  if ! agent-browser fill '[data-testid="auth-field-email"]' "$email"; then
+  if ! agent-browser fill "$AUTH_EMAIL_SELECTOR" "$email"; then
     echo "error: could not fill auth-field-email (passkey/OAuth may have stolen focus — retry once)." >&2
     agent-browser wait 500 >/dev/null || true
-    agent-browser fill '[data-testid="auth-field-email"]' "$email"
+    agent-browser fill "$AUTH_EMAIL_SELECTOR" "$email"
   fi
-  agent-browser fill '[data-testid="auth-field-currentPassword"]' "$password"
+  agent-browser fill "$AUTH_PASSWORD_SELECTOR" "$password"
   # react-hook-form: wait for controlled state, then Enter (not click auth-submit).
   agent-browser wait 400 >/dev/null || sleep 0.4
   agent-browser press Enter
-  agent-browser wait --load networkidle >/dev/null || agent-browser wait 3000 >/dev/null || true
+  # Do not wait --load networkidle here: post-login often lands on /chat and Ably hangs that wait.
   agent-browser wait 1000 >/dev/null || sleep 1
 
   url="$(agent-browser get url 2>/dev/null || true)"
@@ -398,8 +444,7 @@ function sign_in_ui() {
     return 1
   fi
 
-  agent-browser open "$WEB_URL/agents" >/dev/null
-  agent-browser wait --load networkidle >/dev/null || agent-browser wait 2000 >/dev/null || true
+  wait_authed_agents
   url="$(agent-browser get url 2>/dev/null || true)"
   echo "sign-in ui: persist check → $url"
   if ! assert_authed_url "$url"; then
@@ -408,11 +453,70 @@ function sign_in_ui() {
     return 1
   fi
 
-  agent-browser snapshot -i >"$art_dir/after-login.snapshot.txt" || true
-  agent-browser screenshot >/dev/null || true
-  echo "$email" >"$art_dir/account.txt"
-  echo "method=ui" >"$art_dir/method.txt"
+  record_sign_in "$email" "ui"
   echo "sign-in ui ok (session in AGENT_BROWSER_SESSION_NAME=${AGENT_BROWSER_SESSION_NAME})"
+  return 0
+}
+
+function sign_in_vault() {
+  local profile art_dir url email
+  profile="$(vault_profile)"
+  art_dir="$ARTIFACT_ROOT/sign-in"
+  mkdir -p "$art_dir"
+  require_agent_browser
+  export AGENT_BROWSER_SESSION_NAME="${AGENT_BROWSER_SESSION_NAME:-sokosumi}"
+
+  if ! vault_profile_exists "$profile"; then
+    echo "error: no agent-browser auth profile '$profile'." >&2
+    echo "error: one-time save (password via stdin, never commit):" >&2
+    echo "  agent-browser auth save $profile \\" >&2
+    echo "    --url $WEB_URL/signin \\" >&2
+    echo "    --username you@example.com --password-stdin \\" >&2
+    echo "    --username-selector '$AUTH_EMAIL_SELECTOR' \\" >&2
+    echo "    --password-selector '$AUTH_PASSWORD_SELECTOR'" >&2
+    return 1
+  fi
+
+  email="$(vault_profile_email "$profile")"
+  echo "sign-in vault: open $WEB_URL/signin via profile $profile (${email:-unknown})"
+  agent-browser open "$WEB_URL/signin" >/dev/null
+  agent-browser cookies clear >/dev/null || true
+  agent-browser open "$WEB_URL/signin" >/dev/null
+  agent-browser wait 1500 >/dev/null || sleep 1.5
+
+  if ! agent-browser auth login "$profile" \
+    --username-selector "$AUTH_EMAIL_SELECTOR" \
+    --password-selector "$AUTH_PASSWORD_SELECTOR"; then
+    echo "error: agent-browser auth login $profile failed." >&2
+    return 1
+  fi
+
+  url="$(agent-browser get url 2>/dev/null || true)"
+  if ! assert_authed_url "$url"; then
+    echo "sign-in vault: still on auth page after login — Enter submit"
+    agent-browser wait 400 >/dev/null || sleep 0.4
+    agent-browser press Enter
+    agent-browser wait 1000 >/dev/null || sleep 1
+    url="$(agent-browser get url 2>/dev/null || true)"
+  fi
+
+  if ! assert_authed_url "$url"; then
+    echo "error: vault sign-in stayed on auth page ($url)." >&2
+    agent-browser snapshot -i >"$art_dir/ui-fail.snapshot.txt" || true
+    return 1
+  fi
+
+  wait_authed_agents
+  url="$(agent-browser get url 2>/dev/null || true)"
+  echo "sign-in vault: persist check → $url"
+  if ! assert_authed_url "$url"; then
+    echo "error: session did not persist on /agents (bounced to $url)." >&2
+    echo "error: classic cause: BETTER_AUTH_COOKIE_DOMAIN set — comment out in apps/core/.env and restart Core." >&2
+    return 1
+  fi
+
+  record_sign_in "${email:-vault:$profile}" "vault"
+  echo "sign-in vault ok (profile=$profile session=${AGENT_BROWSER_SESSION_NAME})"
   return 0
 }
 
@@ -439,6 +543,10 @@ function sign_in() {
         email="admin@sokosumi.test"
         shift
         ;;
+      --vault)
+        method="vault"
+        shift
+        ;;
       -h | --help)
         usage
         return 0
@@ -451,7 +559,7 @@ function sign_in() {
     esac
   done
 
-  if [[ -z "$email" || -z "$password" ]]; then
+  if [[ "$method" != "vault" && ( -z "$email" || -z "$password" ) ]]; then
     echo "error: email and password required" >&2
     return 1
   fi
@@ -474,30 +582,55 @@ function sign_in() {
     return 1
   fi
 
-  # Probe fixtures early so UI failures are explained.
-  if ! fixture_probe "$email" "$password"; then
-    if [[ "$method" == "ui" || "$method" == "auto" ]]; then
-      echo "error: refusing UI/cookie sign-in — Core rejected fixture credentials." >&2
-      return 1
-    fi
+  local fixtures_ok=0
+  if [[ "$method" == "vault" ]]; then
+    echo "sign-in: --method vault (skip fixture probe)"
+  elif fixture_probe "$email" "$password"; then
+    fixtures_ok=1
   fi
 
   case "$method" in
+    vault)
+      sign_in_vault
+      ;;
     ui)
+      if [[ "$fixtures_ok" -ne 1 ]]; then
+        echo "error: refusing --method ui — Core rejected credentials." >&2
+        echo "error: coworker/shared Neon: sign-in --method vault, or features/sign-up.md" >&2
+        return 1
+      fi
       sign_in_ui "$email" "$password"
       ;;
     cookie)
+      if [[ "$fixtures_ok" -ne 1 ]]; then
+        echo "error: refusing --method cookie — Core rejected credentials." >&2
+        return 1
+      fi
       sign_in_cookie "$email" "$password"
       ;;
     auto)
-      if sign_in_ui "$email" "$password"; then
+      if [[ "$fixtures_ok" -eq 1 ]]; then
+        if sign_in_ui "$email" "$password"; then
+          return 0
+        fi
+        echo "sign-in auto: UI path failed — falling back to Core cookie bootstrap"
+        sign_in_cookie "$email" "$password"
+        return
+      fi
+      echo "sign-in auto: fixtures rejected — falling back to coworker vault"
+      if sign_in_vault; then
         return 0
       fi
-      echo "sign-in auto: UI path failed — falling back to Core cookie bootstrap"
-      sign_in_cookie "$email" "$password"
+      echo "error: vault fallback failed. Create a disposable user (features/sign-up.md)." >&2
+      if cloud_agent_db; then
+        echo "error: cloud-agent DB: provision/seed fixtures, then retry." >&2
+      else
+        echo "error: do not seed alice@sokosumi.test onto a shared or preprod Neon." >&2
+      fi
+      return 1
       ;;
     *)
-      echo "error: --method must be ui|cookie|auto (got $method)" >&2
+      echo "error: --method must be ui|cookie|auto|vault (got $method)" >&2
       return 1
       ;;
   esac
@@ -552,6 +685,14 @@ function doctor() {
 
   if command -v agent-browser >/dev/null 2>&1; then
     echo "agent_browser=$(command -v agent-browser)"
+    local vp ve
+    vp="$(vault_profile)"
+    if vault_profile_exists "$vp"; then
+      ve="$(vault_profile_email "$vp")"
+      echo "vault_profile=$vp email=${ve:-unknown}"
+    else
+      echo "vault_profile=missing name=$vp"
+    fi
   else
     echo "agent_browser=missing"
     echo "warn: install agent-browser for UI drive (npm i -g agent-browser && agent-browser install)"

--- a/.cursor/skills/verify-sokosumi/features/README.md
+++ b/.cursor/skills/verify-sokosumi/features/README.md
@@ -7,10 +7,10 @@ Maintained source for verifying user-facing Sokosumi behavior. Read this index b
 - Launch Core (`http://localhost:8787`) and Web (`http://localhost:3000`) for this run (Cursor background shells or `verify-sokosumi launch` in a durable terminal). Record pids in `.cursor/verify-sokosumi-artifacts/state/dev.pids`.
 - Run `.cursor/skills/verify-sokosumi/bin/verify-sokosumi doctor` and require `doctor ok` with `owned_by_verify=yes`.
 - Export `AGENT_BROWSER_SESSION_NAME=sokosumi`.
-- Prefer fixture `alice@sokosumi.test` / `Password123!` on cloud-agent Neon branches; otherwise create a disposable user (see [Sign up](./sign-up.md)).
+- Prefer fixture `alice@sokosumi.test` / `Password123!` on cloud-agent Neon branches. On a coworker machine or shared Neon, use the `sokosumi` vault (`sign-in --method vault`) or a disposable user (see [Sign up](./sign-up.md)). Do **not** seed Alice onto a shared/preprod database.
 - Use **`localhost`**, not `127.0.0.1`, for browser URLs (Better Auth origin/cookies).
 - Confirm `BETTER_AUTH_COOKIE_DOMAIN` is unset in `apps/core/.env` before login; `doctor` fails when it is set.
-- After doctor, authenticate with `.cursor/skills/verify-sokosumi/bin/verify-sokosumi sign-in` (UI then cookie fallback). Expect `fixture_auth=ok` on agent Neon branches.
+- After doctor, authenticate with `.cursor/skills/verify-sokosumi/bin/verify-sokosumi sign-in` (fixtures, then vault). Expect `fixture_auth=ok` only on agent Neon branches.
 - Never drive an instance that was not started by this verification run.
 - Put proof under `.cursor/verify-sokosumi-artifacts/<feature-id>/` (gitignored). Cleanup must keep those files.
 

--- a/.cursor/skills/verify-sokosumi/features/chat-landing.md
+++ b/.cursor/skills/verify-sokosumi/features/chat-landing.md
@@ -21,7 +21,7 @@ Preconditions:
 - Signed in (see [Sign in](./sign-in.md)).
 - `verify-sokosumi doctor` ok.
 
-- **Open landing.** Run `agent-browser open http://localhost:3000/chat` then `agent-browser wait --load networkidle`.
+- **Open landing.** Run `agent-browser open http://localhost:3000/chat` then `agent-browser wait --url "**/chat"`. Do not `wait --load networkidle` on `/chat` — Ably keeps the network busy and that wait hangs.
 - **Confirm URL.** Run `agent-browser get url`. URL contains `/chat` and is not `/signin`.
 - **Auth `/` redirect.** Run `agent-browser open http://localhost:3000/` then wait; URL ends on `/chat` (covers `chat-default-landing` via the authenticated root hop).
 - **Confirm shell.** Run `agent-browser snapshot -i`. Prefer welcome heading and/or `[data-testid="multimodal-input"]` / message composer plus app nav (`data-app-shell` / sidebar), not a room transcript.

--- a/.cursor/skills/verify-sokosumi/features/sign-in.md
+++ b/.cursor/skills/verify-sokosumi/features/sign-in.md
@@ -19,29 +19,31 @@ Sign in lets a user authenticate with email and password, reach the authenticate
 Preconditions:
 
 - `verify-sokosumi doctor` reports `doctor ok` and `owned_by_verify=yes`.
-- On cloud-agent Neon branches, doctor should also show `fixture_auth=ok` for `alice@sokosumi.test`. If `fixture_auth=fail`, re-run `node scripts/cloud-agent-db/provision.mjs` (or seed auth fixtures) before UI login.
-- Credentials available: fixture `alice@sokosumi.test` / `Password123!`, or a coworker vault `agent-browser auth login sokosumi`, or a user created via [Sign up](./sign-up.md).
+- Cloud-agent Neon: doctor should show `fixture_auth=ok` for `alice@sokosumi.test`. If it fails, re-run `node scripts/cloud-agent-db/provision.mjs` (or seed auth fixtures) — only on `cloud-agent-*` branches.
+- Coworker / shared Neon: doctor will show `fixture_auth=fail`. Use the vault (`sign-in --method vault` or `auto` fallback). Do **not** seed Alice onto that database. If there is no vault profile, create a disposable user via [Sign up](./sign-up.md).
+- Credentials available: fixture `alice@sokosumi.test` / `Password123!`, coworker vault `agent-browser auth login sokosumi`, or a user created via [Sign up](./sign-up.md).
 - `AGENT_BROWSER_SESSION_NAME=sokosumi` is set.
 - `agent-browser` on `PATH` (`npm i -g agent-browser && agent-browser install`).
 
-### Preferred: harness (cloud agents)
+### Preferred: harness
 
 ```bash
 export AGENT_BROWSER_SESSION_NAME=sokosumi
 .cursor/skills/verify-sokosumi/bin/verify-sokosumi sign-in
 # admin UI: … sign-in --admin
-# skip flaky UI: … sign-in --method cookie
-# UI-only proof of signin-submit: … sign-in --method ui
+# coworker / shared Neon: … sign-in --method vault
+# skip flaky UI (fixtures only): … sign-in --method cookie
+# UI-only proof of signin-submit (fixtures only): … sign-in --method ui
 ```
 
-`auto` (default) tries UI Enter-submit first, then Core cookie bootstrap via `agent-browser cookies set --curl`. Writes `.cursor/verify-sokosumi-artifacts/sign-in/` (`after-login.snapshot.txt`, `account.txt`, `method.txt`). For feature proof of `signin-submit`, require `method=ui` in that dir (cookie-only unlocks the rest of the map).
+`auto` (default) probes the fixture. If Core accepts it: UI Enter-submit, then cookie bootstrap. If Core rejects it: coworker vault `agent-browser auth login` with the email/password testids, then persist on `/agents`. Writes `.cursor/verify-sokosumi-artifacts/sign-in/` (`after-login.snapshot.txt`, `account.txt`, `method.txt` = `ui` | `cookie` | `vault`). For feature proof of `signin-submit`, require `method=ui` in that dir (cookie/vault unlock the rest of the map).
 
 ### Manual UI recipe
 
 - **Open form.** Run `agent-browser open http://localhost:3000/signin` then `agent-browser snapshot -i`. The page exposes `[data-testid="auth-field-email"]` and `[data-testid="auth-field-currentPassword"]` (locale may label fields `E-Mail` / `Passwort`). Google / Microsoft / Passkey / Magic Link sit **above** the password form — ignore them.
-- **Fill credentials.** Either `agent-browser auth login sokosumi` (vault) or `agent-browser fill '[data-testid="auth-field-email"]' "<email>"` and `agent-browser fill '[data-testid="auth-field-currentPassword"]' "<password>"`. Prefer CSS testids over snapshot refs so OAuth buttons are not selected by accident.
-- **Submit.** Wait briefly after fill (~400ms), then `agent-browser press Enter` and `agent-browser wait --load networkidle`. URL leaves `/signin` (client often hits `/` then lands on `/chat`). Snapshot shows authenticated chrome (e.g. welcome heading, nav links).
-- **Persist.** Run `agent-browser open http://localhost:3000/agents` then `agent-browser wait --load networkidle`. URL stays on `/agents` (not bounced to `/signin`).
+- **Fill credentials.** Either `agent-browser auth login sokosumi --username-selector '[data-testid="auth-field-email"]' --password-selector '[data-testid="auth-field-currentPassword"]'` (vault) or `agent-browser fill` those same testids. Prefer CSS testids over snapshot refs so OAuth buttons are not selected by accident.
+- **Submit.** Wait briefly after fill (~400ms), then `agent-browser press Enter` if still on `/signin`. Do **not** `wait --load networkidle` here — post-login often lands on `/chat` and Ably hangs that wait.
+- **Persist.** Run `agent-browser open http://localhost:3000/agents` then `agent-browser wait --url "**/agents"`. URL stays on `/agents` (not bounced to `/signin`). Snapshot authenticated chrome there.
 - **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/sign-in`, save `snapshot -i` to `after-login.snapshot.txt`, run `agent-browser screenshot`, copy newest `~/.agent-browser/tmp/screenshots/*.png` to `after-login.png`. Artifacts show authenticated UI, not the sign-in form.
 
 ### Cookie bootstrap when UI login fails
@@ -84,8 +86,8 @@ Computer-use notes (live-proved with `alice@sokosumi.test`):
 - Prefer `verify-sokosumi sign-in` over ad-hoc clicks — most cloud-agent failures are OAuth/passkey focus steal, submit-click races, missing fixtures, or cookie-domain traps.
 - Clicking `[data-testid="auth-submit"]` after vault fill can no-op; always submit with Enter after a short wait.
 - OAuth, magic-link, and passkey are not valid verification paths with placeholder credentials. Passkey also runs conditional mediation (`autoFill`) when the browser supports it — that can steal focus from the email field (`autoComplete="username webauthn"`).
-- Wrong password / missing fixtures leave the user on `/signin` (Core returns non-2xx). Doctor `fixture_auth=fail` means seed first — do not keep retrying the form.
-- Fixtures exist only on cloud-agent Neon branches — otherwise use [Sign up](./sign-up.md) first.
+- Wrong password / missing fixtures leave the user on `/signin` (Core returns non-2xx). Doctor `fixture_auth=fail` on a **cloud-agent** branch means provision/seed first. On a **coworker / shared Neon** it means use the vault or [Sign up](./sign-up.md) — do not seed Alice onto that database, and do not keep retrying the Alice form.
+- Fixtures exist only on cloud-agent Neon branches.
 - `127.0.0.1` can break auth cookies/origin; stick to `localhost`.
 - `BETTER_AUTH_COOKIE_DOMAIN` set to a production host (default in Core `.env.example`) breaks localhost sessions — comment it out before driving. Doctor fails when this trap is present.
 - Browser auth client posts to Core (`http://localhost:8787/auth`); session cookies are host-scoped on `localhost` (shared across ports). Cookie inject must target domain `localhost`, not `127.0.0.1`.

--- a/.cursor/skills/verify-sokosumi/features/sign-up.md
+++ b/.cursor/skills/verify-sokosumi/features/sign-up.md
@@ -1,6 +1,6 @@
 # Sign up
 
-Sign up creates a disposable email/password account when cloud-agent fixtures are unavailable (typical empty local DB). Use this only to unlock other features — not as a substitute for fixture login on agent branches.
+Sign up creates a disposable email/password account when cloud-agent fixtures are unavailable and there is no coworker vault (`agent-browser auth list` has no `sokosumi` profile). Use this only to unlock other features — not as a substitute for fixture login on agent branches or vault login on a shared Neon.
 
 ## Sub-features
 
@@ -18,14 +18,14 @@ Sign up creates a disposable email/password account when cloud-agent fixtures ar
 Preconditions:
 
 - `verify-sokosumi doctor` ok and `owned_by_verify=yes`.
-- Fixtures unavailable or intentionally unused.
+- Fixtures unavailable or intentionally unused. Prefer `verify-sokosumi sign-in --method vault` when a `sokosumi` profile exists.
 - Choose a unique email, e.g. `verify-$(date +%s)@sokosumi.test`, and a password meeting app rules (fixture-style `Password123!` is fine).
 
 - **Open form.** Run `agent-browser open http://localhost:3000/signup`, wait until the snapshot shows Name / Email / Password textboxes (a too-early snapshot can be empty or `about:blank` right after `close`). Google / Microsoft / Magic Link sit **above** the email form — ignore them (same trap as sign-in).
 - **Fill required fields.** Prefer refs from that **fresh** snapshot (`textbox "Name"` / `"Email"` / `"Password"`). CSS `[data-testid="auth-field-name|email|password"]` works once the form is interactive; they fail if you fill before the fields appear. Optional marketing checkbox can stay unchecked.
 - **Accept terms.** Prefer `agent-browser check` on the terms checkbox (accessible name about Terms / Nutzungsbedingungen, or `#termsAccepted`). Submit stays **disabled** until terms are accepted.
 - **Submit.** When `Register` / `Registrieren` is enabled, **click** the snapshot ref (`@eN`, not bare `@N` — agent-browser needs the `e` prefix). Prefer click over Enter — Enter can leave the form unchanged. Wait for navigation away from `/signup` (often `/` then `/chat`). Signup has **no** `data-testid="auth-submit"` (that testid is sign-in only).
-- **Confirm session.** Open `/agents` or `/chat`; must not bounce to `/signin`.
+- **Confirm session.** Open `/agents` and `wait --url "**/agents"`; must not bounce to `/signin`. Do not wait `networkidle` on `/chat`.
 - **Proof.** `mkdir -p .cursor/verify-sokosumi-artifacts/sign-up` then screenshot + snapshot of the post-signup authenticated view. Record the email in `account.txt` (no password).
 
 ### Bootstrap when UI checkbox will not toggle
@@ -47,6 +47,6 @@ Require HTTP 200 and a `user.email` in the body. Do **not** count API signup alo
 - Email verification is off in local/core config — do not wait for a verification email. A “confirm email” banner after login is OK.
 - OAuth and magic-link signup paths are invalid with placeholder credentials.
 - Do not reuse an email that already exists; pick a fresh address per run.
-- On cloud-agent branches, prefer fixtures over signup unless testing signup itself.
+- On cloud-agent branches, prefer fixtures over signup unless testing signup itself. On a coworker / shared Neon, prefer the vault over creating another disposable user.
 - Origin must be `http://localhost:3000` for Core auth API calls (`INVALID_ORIGIN` otherwise).
 - Submit button stays disabled until terms are accepted.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -435,17 +435,24 @@ Each coworker stores their **own** credentials (nothing shared/committed):
 # one-time, per machine — password read from stdin, never echoed
 agent-browser auth save sokosumi \
   --url http://localhost:3000/signin \
-  --username you@nmkr.io --password-stdin
+  --username you@example.com --password-stdin \
+  --username-selector '[data-testid="auth-field-email"]' \
+  --password-selector '[data-testid="auth-field-currentPassword"]'
 ```
 
-Reliable login recipe (fill via vault, submit via Enter — not the vault click):
+Prefer `verify-sokosumi sign-in` (fixtures, then this vault). Manual recipe:
 
 ```bash
 agent-browser open http://localhost:3000/signin
-agent-browser auth login sokosumi      # fills email + password
-agent-browser press Enter              # submits the form
-agent-browser wait --load networkidle
+agent-browser auth login sokosumi \
+  --username-selector '[data-testid="auth-field-email"]' \
+  --password-selector '[data-testid="auth-field-currentPassword"]'
+# if still on /signin: press Enter (vault click can race react-hook-form)
+agent-browser open http://localhost:3000/agents
+agent-browser wait --url "**/agents"
 ```
+
+Do not `wait --load networkidle` on `/chat` after login — Ably hangs that wait. Prove the session on `/agents`.
 
 Stable selectors exist for deterministic targeting if you fill fields yourself:
 `[data-testid="auth-field-email"]`, `[data-testid="auth-field-currentPassword"]`,


### PR DESCRIPTION
On coworker machines and shared/preprod Neon, `alice@sokosumi.test` does not exist. `verify-sokosumi sign-in` used to probe Alice, get 401, and refuse — so the documented helper could not log in.

`auto` now:
1. Probe the fixture.
2. If Core accepts it → UI Enter-submit, then cookie bootstrap.
3. If Core rejects it → local `agent-browser` vault `sokosumi` with `[data-testid="auth-field-email"]` / `[data-testid="auth-field-currentPassword"]`.
4. Prove the session on `/agents`. Do not `wait --load networkidle` on `/chat` (Ably hangs that wait).

Also:
- `--method vault` / `--vault`
- doctor prints `vault_profile=…` and tells you not to seed Alice onto a shared Neon
- vault `auth save` example uses `you@example.com` plus the testid selectors (each person saves their own account locally)

## Verification
- `bash -n` on the helper
- `pnpm check && pnpm typecheck` (pre-commit)
- live `doctor` + `sign-in --method vault` against local web/core
- `sign-in --method ui` refuses without fixtures and points at the vault