### PR TITLE
perf(web): defer room roster so chrome paints from getRoom

### DIFF
--- a/apps/web/src/app/(app)/chat/__tests__/load-room-shell-roster.test.ts
+++ b/apps/web/src/app/(app)/chat/__tests__/load-room-shell-roster.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const loadOrganizationMembersMock = vi.fn();
+const listCoworkersMock = vi.fn();
+
+vi.mock("../load-organization-members", () => ({
+  loadOrganizationMembers: (...args: unknown[]) =>
+    loadOrganizationMembersMock(...args),
+}));
+
+vi.mock("@/lib/services/coworker.service", () => ({
+  coworkerService: {
+    listCoworkers: (...args: unknown[]) => listCoworkersMock(...args),
+  },
+}));
+
+import { loadRoomShellRoster } from "../load-room-shell-roster";
+
+describe("loadRoomShellRoster", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads members and coworkers in parallel", async () => {
+    const members = [{ id: "member_1" }];
+    const coworkers = [{ id: "coworker_1" }];
+    loadOrganizationMembersMock.mockResolvedValue({
+      members,
+      failed: false,
+    });
+    listCoworkersMock.mockResolvedValue(coworkers);
+
+    await expect(loadRoomShellRoster("org_1")).resolves.toEqual({
+      organizationMembers: members,
+      membersLoadFailed: false,
+      coworkers,
+    });
+    expect(loadOrganizationMembersMock).toHaveBeenCalledWith("org_1");
+    expect(listCoworkersMock).toHaveBeenCalledWith("chat");
+  });
+
+  it("propagates members soft-fail", async () => {
+    loadOrganizationMembersMock.mockResolvedValue({
+      members: [],
+      failed: true,
+    });
+    listCoworkersMock.mockResolvedValue([]);
+
+    await expect(loadRoomShellRoster("org_1")).resolves.toEqual({
+      organizationMembers: [],
+      membersLoadFailed: true,
+      coworkers: [],
+    });
+  });
+
+  it("passes null organizationId through for personal workspace", async () => {
+    loadOrganizationMembersMock.mockResolvedValue({
+      members: [],
+      failed: false,
+    });
+    listCoworkersMock.mockResolvedValue([{ id: "c1" }]);
+
+    await expect(loadRoomShellRoster(null)).resolves.toEqual({
+      organizationMembers: [],
+      membersLoadFailed: false,
+      coworkers: [{ id: "c1" }],
+    });
+    expect(loadOrganizationMembersMock).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-open-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-open-loading-view.test.tsx
@@ -1,36 +1,42 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("@/hooks/use-keyboard-open", () => ({
-  useKeyboardOpen: () => false,
-}));
-
-vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
-}));
-
-vi.mock("@/app/chat/utils/format-toolbar-preference-storage", () => ({
-  getFormatToolbarOpenPreference: () => null,
-  resolveFormatToolbarOpenOnMount: () => true,
-}));
+import { describe, expect, it } from "vitest";
 
 import { RoomOpenLoadingView } from "../room-open-loading-view";
 
+const here = dirname(fileURLToPath(import.meta.url));
+const roomsDir = join(here, "../../rooms/[roomId]");
+
 describe("RoomOpenLoadingView", () => {
-  it("uses shared room shell tree with left-aligned skeleton and composer", () => {
-    const { container, getByTestId } = render(<RoomOpenLoadingView />);
+  it("is composer-less (list skeleton only) so missing rooms never flash send UI", () => {
+    const { container, getByTestId, queryByTestId } = render(
+      <RoomOpenLoadingView />,
+    );
 
     expect(getByTestId("chat-room-loading")).toBeTruthy();
-    expect(container.querySelector("main")).toBeTruthy();
-    expect(container.querySelector("section")).toBeTruthy();
     expect(getByTestId("room-message-list-skeleton")).toBeTruthy();
-    expect(container.querySelector(".flex-row-reverse")).toBeNull();
+    expect(queryByTestId("room-session-composer")).toBeNull();
     expect(
       container.querySelector("[data-room-composer-mention-anchor]"),
-    ).toBeTruthy();
-    expect(container.querySelector("[data-placeholder]")).toBeTruthy();
-    expect(container.querySelector('[role="toolbar"]')).toBeTruthy();
-    expect(container.querySelectorAll("button").length).toBeGreaterThan(5);
-    expect(container.querySelector(".animate-spin")).toBeNull();
+    ).toBeNull();
+    expect(container.querySelector("[data-placeholder]")).toBeNull();
+    expect(container.querySelector('[role="toolbar"]')).toBeNull();
+  });
+});
+
+describe("chat room Instant / Suspense fallback contract", () => {
+  it("loading.tsx uses composer-less RoomOpenLoadingView", () => {
+    const source = readFileSync(join(roomsDir, "loading.tsx"), "utf8");
+    expect(source).toMatch(/RoomOpenLoadingView/);
+    expect(source).not.toMatch(/RoomMessageComposer|room-session-composer/);
+  });
+
+  it("page Suspense fallback is composer-less RoomOpenLoadingView", () => {
+    const source = readFileSync(join(roomsDir, "page.tsx"), "utf8");
+    expect(source).toMatch(
+      /Suspense\s+fallback=\{\s*<RoomOpenLoadingView\s*\/>\s*\}/,
+    );
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -160,7 +160,22 @@ vi.mock("../draft-direct-message", () => ({
 }));
 
 vi.mock("../edit-channel-dialog", () => ({
-  EditChannelDialog: () => null,
+  EditChannelDialog: ({
+    membersLoadFailed,
+    members,
+    coworkers,
+  }: {
+    membersLoadFailed?: boolean;
+    members?: unknown[];
+    coworkers?: unknown[];
+  }) => (
+    <div
+      data-testid="edit-channel-dialog-probe"
+      data-members-load-failed={String(Boolean(membersLoadFailed))}
+      data-members-count={String(members?.length ?? 0)}
+      data-coworkers-count={String(coworkers?.length ?? 0)}
+    />
+  ),
 }));
 
 vi.mock("../chat-participant-hover-card", () => ({
@@ -558,5 +573,107 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
       "data-focus-on-mount",
       "true",
     );
+  });
+});
+
+describe("RoomsClient progressive roster (header + composer without members)", () => {
+  it("paints room title and composer while rosterPromise is pending", () => {
+    const messagesPromise = new Promise<{
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }>(() => undefined);
+    const rosterPromise = new Promise<{
+      organizationMembers: [];
+      membersLoadFailed: boolean;
+      coworkers: [];
+    }>(() => undefined);
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        messagesPromise={messagesPromise}
+        rosterPromise={rosterPromise}
+      />,
+    );
+
+    expect(screen.getByText("general")).toBeTruthy();
+    expect(screen.getByTestId("room-session-composer")).toBeTruthy();
+    expect(screen.getByTestId("room-message-list-skeleton")).toBeTruthy();
+    const probe = screen.getByTestId("edit-channel-dialog-probe");
+    expect(probe).toHaveAttribute("data-members-load-failed", "false");
+    expect(probe).toHaveAttribute("data-members-count", "0");
+    expect(probe).toHaveAttribute("data-coworkers-count", "0");
+  });
+
+  it("hydrates roster into the same instance without remounting composer", async () => {
+    let resolveRoster!: (page: {
+      organizationMembers: {
+        id: string;
+        role: string;
+        user: { id: string; name: string; email: string; image: null };
+      }[];
+      membersLoadFailed: boolean;
+      coworkers: { id: string; name: string }[];
+    }) => void;
+    const rosterPromise = new Promise<{
+      organizationMembers: {
+        id: string;
+        role: string;
+        user: { id: string; name: string; email: string; image: null };
+      }[];
+      membersLoadFailed: boolean;
+      coworkers: { id: string; name: string }[];
+    }>((resolve) => {
+      resolveRoster = resolve;
+    });
+    const messagesPromise = new Promise<{
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }>(() => undefined);
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        messagesPromise={messagesPromise}
+        rosterPromise={rosterPromise as never}
+      />,
+    );
+
+    const composer = screen.getByTestId("room-session-composer");
+    expect(screen.getByText("general")).toBeTruthy();
+
+    await act(async () => {
+      resolveRoster({
+        organizationMembers: [
+          {
+            id: "member-1",
+            role: "member",
+            user: {
+              id: "user-2",
+              name: "Bob",
+              email: "bob@example.com",
+              image: null,
+            },
+          },
+        ],
+        membersLoadFailed: true,
+        coworkers: [{ id: "coworker-1", name: "Agent" }],
+      });
+      await rosterPromise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("edit-channel-dialog-probe")).toHaveAttribute(
+        "data-members-load-failed",
+        "true",
+      );
+    });
+    const probe = screen.getByTestId("edit-channel-dialog-probe");
+    expect(probe).toHaveAttribute("data-members-count", "1");
+    expect(probe).toHaveAttribute("data-coworkers-count", "1");
+    expect(screen.getByTestId("room-session-composer")).toBe(composer);
+    expect(screen.getByText("general")).toBeTruthy();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -639,9 +639,47 @@ describe("RoomsClient progressive roster (header + composer without members)", (
       />,
     );
 
-    // Title must not wait on isMobile===true portal or roster hydrate.
-    expect(screen.getByText("general")).toBeTruthy();
+    // Title must not wait on isMobile===true portal, roster, or avatars.
+    expect(screen.getByTestId("room-open-title")).toHaveTextContent("general");
     expect(screen.getByTestId("room-session-composer")).toBeTruthy();
+  });
+
+  it("shows getRoom title with composer when portal host exists (never blank header)", async () => {
+    mockIsMobileMedia.mockReturnValue(true);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    mockHeaderRoomSlotHost.mockReturnValue(host);
+
+    const messagesPromise = new Promise<{
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }>(() => undefined);
+    const rosterPromise = new Promise<{
+      organizationMembers: [];
+      membersLoadFailed: boolean;
+      coworkers: [];
+    }>(() => undefined);
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        messagesPromise={messagesPromise}
+        rosterPromise={rosterPromise}
+      />,
+    );
+
+    // Portal flips in useEffect; title must still be present with composer
+    // (in-column first, then portaled) — never back-chevron-only blank header.
+    expect(screen.getByTestId("room-open-title")).toHaveTextContent("general");
+    expect(screen.getByTestId("room-session-composer")).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        host.querySelector("[data-testid='room-open-title']"),
+      ).toHaveTextContent("general");
+    });
+
+    document.body.removeChild(host);
   });
 
   it("hydrates roster into the same instance without remounting composer", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -1,13 +1,15 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { type ReactNode, type Ref, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
+import type { RoomShellRosterPage } from "@/app/chat/load-room-shell-roster";
 import type {
   ChatRoom,
   ChatRoomMessage,
+  Coworker,
+  Member,
   Organization,
 } from "@/lib/clients/generated/core";
-
+import { MemberRole } from "@/lib/clients/generated/core";
 import type { RoomComposerHandle } from "../room-composer";
 import { RoomsClient } from "../rooms-client";
 
@@ -683,24 +685,45 @@ describe("RoomsClient progressive roster (header + composer without members)", (
   });
 
   it("hydrates roster into the same instance without remounting composer", async () => {
-    let resolveRoster!: (page: {
-      organizationMembers: {
-        id: string;
-        role: string;
-        user: { id: string; name: string; email: string; image: null };
-      }[];
-      membersLoadFailed: boolean;
-      coworkers: { id: string; name: string }[];
-    }) => void;
-    const rosterPromise = new Promise<{
-      organizationMembers: {
-        id: string;
-        role: string;
-        user: { id: string; name: string; email: string; image: null };
-      }[];
-      membersLoadFailed: boolean;
-      coworkers: { id: string; name: string }[];
-    }>((resolve) => {
+    const hydratedMember: Member = {
+      id: "member-1",
+      organizationId: "org-1",
+      role: MemberRole.MEMBER,
+      seatAssignedAt: null,
+      createdAt: new Date("2026-07-01T12:00:00.000Z"),
+      user: {
+        id: "user-2",
+        name: "Bob",
+        email: "bob@example.com",
+        image: null,
+      },
+      lastSeenAt: null,
+    };
+    const hydratedCoworker: Coworker = {
+      id: "coworker-1",
+      createdAt: new Date("2026-07-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+      archivedAt: null,
+      isWhitelisted: true,
+      priority: 0,
+      slug: "agent",
+      name: "Agent",
+      vendor: {
+        id: "vendor-1",
+        createdAt: new Date("2026-07-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+        name: "Vendor",
+        slug: "vendor",
+        logos: { light: null, dark: null },
+      },
+      baseURL: null,
+      capabilities: ["chat"],
+      image: null,
+      metadata: null,
+    };
+
+    let resolveRoster!: (page: RoomShellRosterPage) => void;
+    const rosterPromise = new Promise<RoomShellRosterPage>((resolve) => {
       resolveRoster = resolve;
     });
     const messagesPromise = new Promise<{
@@ -713,7 +736,7 @@ describe("RoomsClient progressive roster (header + composer without members)", (
       <RoomsClient
         {...baseProps}
         messagesPromise={messagesPromise}
-        rosterPromise={rosterPromise as never}
+        rosterPromise={rosterPromise}
       />,
     );
 
@@ -722,20 +745,9 @@ describe("RoomsClient progressive roster (header + composer without members)", (
 
     await act(async () => {
       resolveRoster({
-        organizationMembers: [
-          {
-            id: "member-1",
-            role: "member",
-            user: {
-              id: "user-2",
-              name: "Bob",
-              email: "bob@example.com",
-              image: null,
-            },
-          },
-        ],
+        organizationMembers: [hydratedMember],
         membersLoadFailed: true,
-        coworkers: [{ id: "coworker-1", name: "Agent" }],
+        coworkers: [hydratedCoworker],
       });
       await rosterPromise;
     });

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { type ReactNode, type Ref, useImperativeHandle } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   ChatRoom,
@@ -10,6 +10,11 @@ import type {
 
 import type { RoomComposerHandle } from "../room-composer";
 import { RoomsClient } from "../rooms-client";
+
+const { mockIsMobileMedia, mockHeaderRoomSlotHost } = vi.hoisted(() => ({
+  mockIsMobileMedia: vi.fn((): boolean | undefined => false),
+  mockHeaderRoomSlotHost: vi.fn((): HTMLElement | null => null),
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -43,11 +48,11 @@ vi.mock("@/hooks/use-is-apple-platform", () => ({
 }));
 
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobileMedia: () => false,
+  useIsMobileMedia: () => mockIsMobileMedia(),
 }));
 
 vi.mock("@/app/components/header/use-header-room-slot-host", () => ({
-  useHeaderRoomSlotHost: () => null,
+  useHeaderRoomSlotHost: () => mockHeaderRoomSlotHost(),
 }));
 
 vi.mock("@/contexts/breadcrumb-override-context", () => ({
@@ -577,6 +582,11 @@ describe("RoomsClient progressive history (real composer + list skeleton)", () =
 });
 
 describe("RoomsClient progressive roster (header + composer without members)", () => {
+  beforeEach(() => {
+    mockIsMobileMedia.mockReturnValue(false);
+    mockHeaderRoomSlotHost.mockReturnValue(null);
+  });
+
   it("paints room title and composer while rosterPromise is pending", () => {
     const messagesPromise = new Promise<{
       messages: ChatRoomMessage[];
@@ -604,6 +614,34 @@ describe("RoomsClient progressive roster (header + composer without members)", (
     expect(probe).toHaveAttribute("data-members-load-failed", "false");
     expect(probe).toHaveAttribute("data-members-count", "0");
     expect(probe).toHaveAttribute("data-coworkers-count", "0");
+  });
+
+  it("paints getRoom title with composer before mobile portal/media is ready", () => {
+    mockIsMobileMedia.mockReturnValue(undefined);
+    mockHeaderRoomSlotHost.mockReturnValue(null);
+
+    const messagesPromise = new Promise<{
+      messages: ChatRoomMessage[];
+      nextCursor: string | null;
+      failed: boolean;
+    }>(() => undefined);
+    const rosterPromise = new Promise<{
+      organizationMembers: [];
+      membersLoadFailed: boolean;
+      coworkers: [];
+    }>(() => undefined);
+
+    render(
+      <RoomsClient
+        {...baseProps}
+        messagesPromise={messagesPromise}
+        rosterPromise={rosterPromise}
+      />,
+    );
+
+    // Title must not wait on isMobile===true portal or roster hydrate.
+    expect(screen.getByText("general")).toBeTruthy();
+    expect(screen.getByTestId("room-session-composer")).toBeTruthy();
   });
 
   it("hydrates roster into the same instance without remounting composer", async () => {

--- a/apps/web/src/app/(app)/chat/components/room-open-loading-view.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-open-loading-view.tsx
@@ -1,41 +1,15 @@
-"use client";
-
-import { ALargeSmall, AtSign, Paperclip, SmilePlus } from "lucide-react";
-import { useLayoutEffect, useState } from "react";
-
 import { RoomMessageListSkeleton } from "@/app/chat/components/room-message-list-skeleton";
 import { RoomShellLayout } from "@/app/chat/components/room-shell-layout";
-import {
-  getFormatToolbarOpenPreference,
-  resolveFormatToolbarOpenOnMount,
-} from "@/app/chat/utils/format-toolbar-preference-storage";
-import { ComposerFormatToolbar } from "@/components/chat/composer-format-toolbar";
-import {
-  ROOM_COMPOSER_EDITOR_PLACEHOLDER_CLASSNAME,
-  ROOM_COMPOSER_TEXTAREA_CLASSNAME,
-  ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME,
-  RoomMessageComposer,
-} from "@/components/chat/room-message-composer";
-import { Button } from "@/components/ui/button";
-import { MOBILE_BREAKPOINT } from "@/hooks/use-mobile";
-import { cn } from "@/lib/utils";
 
 /**
- * Instant / Suspense fallback: same shell tree as progressive RoomsClient +
- * real composer chrome + left-aligned message-list skeleton.
+ * Instant / Suspense fallback for `/chat/rooms/[roomId]`.
+ *
+ * Composer-less on purpose: missing/invalid rooms redirect after this shell.
+ * Mounting a fake composer here flashes send UI for nonexistent rooms and lets
+ * an `empty:before` bone win mobile LCP before real chrome. Real title +
+ * composer arrive together from RoomsClient after `getRoom`.
  */
 export function RoomOpenLoadingView(): React.ReactElement {
-  const [formatToolbarOpen, setFormatToolbarOpen] = useState(false);
-  useLayoutEffect(() => {
-    setFormatToolbarOpen(
-      resolveFormatToolbarOpenOnMount({
-        stored: getFormatToolbarOpenPreference(),
-        viewportWidth: window.innerWidth,
-        mobileBreakpoint: MOBILE_BREAKPOINT,
-      }),
-    );
-  }, []);
-
   return (
     <RoomShellLayout
       testId="chat-room-loading"
@@ -43,100 +17,7 @@ export function RoomOpenLoadingView(): React.ReactElement {
       reserveDesktopHeader
       desktopHeader={null}
       listContent={<RoomMessageListSkeleton />}
-      composer={
-        <div className="pointer-events-none" aria-hidden>
-          <RoomMessageComposer
-            onSubmit={(event) => {
-              event.preventDefault();
-            }}
-            attachments={[]}
-            onRemoveAttachment={() => {
-              /* no-op */
-            }}
-            removeAttachmentLabel={() => ""}
-            isSending={false}
-            sendDisabled
-            sendAriaLabel="Send"
-            withOuterPadding={false}
-            withSafeAreaPadding
-            className="px-3 pt-2 md:px-5 md:pt-3"
-            aboveEditor={
-              formatToolbarOpen ? (
-                <ComposerFormatToolbar
-                  onFormat={() => {
-                    /* no-op */
-                  }}
-                  onLink={() => {
-                    /* no-op */
-                  }}
-                />
-              ) : null
-            }
-            toolbarStart={
-              <>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-                  disabled
-                  tabIndex={-1}
-                >
-                  <Paperclip className="size-4" aria-hidden />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={cn(
-                    ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME,
-                    formatToolbarOpen && "bg-muted text-foreground",
-                  )}
-                  disabled
-                  tabIndex={-1}
-                  aria-pressed={formatToolbarOpen}
-                >
-                  <ALargeSmall className="size-4" aria-hidden />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-                  disabled
-                  tabIndex={-1}
-                >
-                  <SmilePlus className="size-4" aria-hidden />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME}
-                  disabled
-                  tabIndex={-1}
-                >
-                  <AtSign className="size-4" aria-hidden />
-                </Button>
-              </>
-            }
-          >
-            {/*
-              Structural twin of ComposerWysiwygEditor empty host: same min-h
-              + empty:before placeholder geometry (no contenteditable / i18n
-              room name — generic bone only).
-            */}
-            <div
-              className={cn(
-                ROOM_COMPOSER_TEXTAREA_CLASSNAME,
-                ROOM_COMPOSER_EDITOR_PLACEHOLDER_CLASSNAME,
-                "pointer-events-none",
-              )}
-              data-placeholder=" "
-            />
-          </RoomMessageComposer>
-        </div>
-      }
+      composer={null}
     />
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-shell-roster-hydrator.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-shell-roster-hydrator.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import type { RoomShellRosterPage } from "@/app/chat/load-room-shell-roster";
+
+/**
+ * Resolves deferred org members + coworkers into the parent RoomsClient.
+ * Parent (header + composer) stays mounted; roster-dependent UI updates later.
+ */
+export function RoomShellRosterHydrator({
+  promise,
+  onResolved,
+}: {
+  promise: Promise<RoomShellRosterPage>;
+  onResolved: (page: RoomShellRosterPage) => void;
+}) {
+  const onResolvedRef = useRef(onResolved);
+  onResolvedRef.current = onResolved;
+  const deliveredPromiseRef = useRef<Promise<RoomShellRosterPage> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void promise.then(
+      (page) => {
+        if (cancelled) {
+          return;
+        }
+        if (deliveredPromiseRef.current === promise) {
+          return;
+        }
+        deliveredPromiseRef.current = promise;
+        onResolvedRef.current(page);
+      },
+      () => {
+        // Unexpected reject (members soft-fail inside loader; coworkers may
+        // still reject). Never leave parent pending forever.
+        if (cancelled) {
+          return;
+        }
+        if (deliveredPromiseRef.current === promise) {
+          return;
+        }
+        deliveredPromiseRef.current = promise;
+        onResolvedRef.current({
+          organizationMembers: [],
+          membersLoadFailed: true,
+          coworkers: [],
+        });
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [promise]);
+
+  return null;
+}

--- a/apps/web/src/app/(app)/chat/components/room-shell-roster-hydrator.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-shell-roster-hydrator.tsx
@@ -4,6 +4,11 @@ import { useEffect, useRef } from "react";
 
 import type { RoomShellRosterPage } from "@/app/chat/load-room-shell-roster";
 
+interface RoomShellRosterHydratorProps {
+  promise: Promise<RoomShellRosterPage>;
+  onResolved: (page: RoomShellRosterPage) => void;
+}
+
 /**
  * Resolves deferred org members + coworkers into the parent RoomsClient.
  * Parent (header + composer) stays mounted; roster-dependent UI updates later.
@@ -11,10 +16,7 @@ import type { RoomShellRosterPage } from "@/app/chat/load-room-shell-roster";
 export function RoomShellRosterHydrator({
   promise,
   onResolved,
-}: {
-  promise: Promise<RoomShellRosterPage>;
-  onResolved: (page: RoomShellRosterPage) => void;
-}) {
+}: RoomShellRosterHydratorProps) {
   const onResolvedRef = useRef(onResolved);
   onResolvedRef.current = onResolved;
   const deliveredPromiseRef = useRef<Promise<RoomShellRosterPage> | null>(null);

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -339,6 +339,8 @@ interface RoomHeaderChromeProps {
   canLeave: boolean;
   canInviteGuests: boolean;
   membersLoadFailed: boolean;
+  /** When false, skip avatar stack so title can paint without it. */
+  showParticipants: boolean;
 }
 
 function RoomHeaderChrome({
@@ -361,6 +363,7 @@ function RoomHeaderChrome({
   canLeave,
   canInviteGuests,
   membersLoadFailed,
+  showParticipants,
 }: RoomHeaderChromeProps) {
   const t = useTranslations("App.Channels");
 
@@ -375,7 +378,12 @@ function RoomHeaderChrome({
             discoverability={room.discoverability}
           />
         )}
-        <p className="text-muted-foreground truncate text-sm">{displayName}</p>
+        <p
+          className="text-muted-foreground truncate text-sm"
+          data-testid="room-open-title"
+        >
+          {displayName}
+        </p>
       </div>
       <div className="flex shrink-0 items-center gap-1.5 md:gap-2">
         <RoomSearchPanel
@@ -412,13 +420,15 @@ function RoomHeaderChrome({
               t("UnreadThreads.unreadReplies", { count }),
           }}
         />
-        <RoomParticipantStack
-          room={room}
-          currentUserId={currentUserId}
-          canOpenHumanDirect={canOpenHumanDirect}
-          onOpenDirect={onOpenDirect}
-          openingDirectKey={openingDirectKey}
-        />
+        {showParticipants ? (
+          <RoomParticipantStack
+            room={room}
+            currentUserId={currentUserId}
+            canOpenHumanDirect={canOpenHumanDirect}
+            onOpenDirect={onOpenDirect}
+            openingDirectKey={openingDirectKey}
+          />
+        ) : null}
         {isDirectRoom ? null : (
           <EditChannelDialog
             channel={room}
@@ -461,6 +471,19 @@ export function RoomsClient({
   const isApple = useIsApplePlatform();
   const isMobile = useIsMobileMedia();
   const headerRoomSlotHost = useHeaderRoomSlotHost();
+  // Defer portal until after first paint so getRoom title lands in-column with
+  // the composer (useLayoutEffect host + isMobile would portal before paint and
+  // leave the app header blank on the first real chrome frame).
+  const [mobileHeaderPortaled, setMobileHeaderPortaled] = useState(false);
+  useEffect(() => {
+    setMobileHeaderPortaled(isMobile === true && headerRoomSlotHost != null);
+  }, [isMobile, headerRoomSlotHost]);
+  // Defer participant avatars one frame so the title string is not gated on
+  // the avatar stack committing in the same first paint.
+  const [showHeaderParticipants, setShowHeaderParticipants] = useState(false);
+  useEffect(() => {
+    setShowHeaderParticipants(true);
+  }, []);
   // Defer local day separators / continuation until after hydrate (SOKOSUMI-A).
   const localCalendarReady = useClientLocalCalendarReady();
   const [openingDirectKey, setOpeningDirectKey] = useState<string | null>(null);
@@ -2217,6 +2240,7 @@ export function RoomsClient({
         canLeave={canLeaveSelectedRoom}
         canInviteGuests={canInviteGuestsToSelectedRoom}
         membersLoadFailed={membersLoadFailed}
+        showParticipants={showHeaderParticipants}
       />
     ) : null;
 
@@ -2365,7 +2389,7 @@ export function RoomsClient({
 
     return (
       <>
-        {isMobile === true && headerRoomSlotHost && roomHeaderChrome
+        {mobileHeaderPortaled && headerRoomSlotHost && roomHeaderChrome
           ? createPortal(roomHeaderChrome, headerRoomSlotHost)
           : null}
         <RoomShellLayout
@@ -2384,13 +2408,10 @@ export function RoomsClient({
             ) : null
           }
           reserveDesktopHeader
-          // Until mobile portal host is ready (`isMobile` starts undefined), keep
-          // title in-column with the composer so getRoom name paints immediately
-          // and does not wait on roster hydrate / media-query effect.
+          // Keep title in-column until after first paint (portal flips in
+          // useEffect). First real chrome frame = title + composer together.
           desktopHeader={
-            !(isMobile === true && headerRoomSlotHost) && roomHeaderChrome
-              ? roomHeaderChrome
-              : null
+            !mobileHeaderPortaled && roomHeaderChrome ? roomHeaderChrome : null
           }
           wrapColumn={(columnBody) => (
             <RoomFileDropZone

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2384,8 +2384,13 @@ export function RoomsClient({
             ) : null
           }
           reserveDesktopHeader
+          // Until mobile portal host is ready (`isMobile` starts undefined), keep
+          // title in-column with the composer so getRoom name paints immediately
+          // and does not wait on roster hydrate / media-query effect.
           desktopHeader={
-            isMobile === false && roomHeaderChrome ? roomHeaderChrome : null
+            !(isMobile === true && headerRoomSlotHost) && roomHeaderChrome
+              ? roomHeaderChrome
+              : null
           }
           wrapColumn={(columnBody) => (
             <RoomFileDropZone

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -35,6 +35,7 @@ import {
   useCoworkerDirectRoomStream,
 } from "@/app/chat/hooks/use-coworker-direct-room-stream";
 import { useStickToBottom } from "@/app/chat/hooks/use-stick-to-bottom";
+import type { RoomShellRosterPage } from "@/app/chat/load-room-shell-roster";
 import {
   filterTopLevelChatRoomMessages,
   isReplyUnderThreadParent,
@@ -150,6 +151,7 @@ import {
   ROOM_SHELL_ROOT_CLASSNAME,
   RoomShellLayout,
 } from "./room-shell-layout";
+import { RoomShellRosterHydrator } from "./room-shell-roster-hydrator";
 import { ThreadPanel } from "./thread-panel";
 
 interface RoomsClientProps {
@@ -173,6 +175,11 @@ interface RoomsClientProps {
    * instance so real header + composer stay mounted while the list skeletons.
    */
   messagesPromise?: Promise<RoomMessagePage>;
+  /**
+   * Deferred org members + coworkers. Room chrome paints from `rooms` alone;
+   * roster streams in for pickers / mentions / admin gates.
+   */
+  rosterPromise?: Promise<RoomShellRosterPage>;
 }
 
 const COWORKER_RESPONSE_POLL_MS = 2500;
@@ -433,17 +440,18 @@ function RoomHeaderChrome({
 export function RoomsClient({
   activeOrganization,
   rooms,
-  organizationMembers,
+  organizationMembers: organizationMembersProp,
   currentUserId,
-  coworkers,
+  coworkers: coworkersProp,
   selectedRoomId,
   isCreateChannelRequested,
   isNewDirectMessage,
   messageLoadFailed,
-  membersLoadFailed,
+  membersLoadFailed: membersLoadFailedProp,
   messages,
   messagesNextCursor,
   messagesPromise,
+  rosterPromise,
 }: RoomsClientProps) {
   const t = useTranslations("App.Channels");
   const tBreadcrumb = useTranslations("Components.Breadcrumb");
@@ -471,6 +479,9 @@ export function RoomsClient({
     useState(messageLoadFailed);
   const [syncedMessagesPromise, setSyncedMessagesPromise] =
     useState(messagesPromise);
+  const [deferredRoster, setDeferredRoster] =
+    useState<RoomShellRosterPage | null>(null);
+  const [syncedRosterPromise, setSyncedRosterPromise] = useState(rosterPromise);
   const [syncedHistoryRoomId, setSyncedHistoryRoomId] =
     useState(selectedRoomId);
   // RoomsClient stays mounted across /chat/rooms/[id] navigations. Progressive
@@ -484,6 +495,9 @@ export function RoomsClient({
       setMessageLoadFailedState(false);
       setDeferredHistoryPending(true);
     }
+    if (rosterPromise != null) {
+      setDeferredRoster(null);
+    }
   }
   if (messagesPromise !== syncedMessagesPromise) {
     setSyncedMessagesPromise(messagesPromise);
@@ -495,6 +509,24 @@ export function RoomsClient({
       setMessageLoadFailedState(messageLoadFailed);
     }
   }
+  if (rosterPromise !== syncedRosterPromise) {
+    setSyncedRosterPromise(rosterPromise);
+    if (rosterPromise == null) {
+      setDeferredRoster(null);
+    }
+  }
+  const organizationMembers =
+    rosterPromise != null
+      ? (deferredRoster?.organizationMembers ?? organizationMembersProp)
+      : organizationMembersProp;
+  const coworkers =
+    rosterPromise != null
+      ? (deferredRoster?.coworkers ?? coworkersProp)
+      : coworkersProp;
+  const membersLoadFailed =
+    rosterPromise != null
+      ? (deferredRoster?.membersLoadFailed ?? membersLoadFailedProp)
+      : membersLoadFailedProp;
   const messagesPending = deferredHistoryPending;
   const effectiveMessageLoadFailed = messagesPending
     ? false
@@ -506,6 +538,13 @@ export function RoomsClient({
     setMessageLoadFailedState(page.failed);
     setDeferredHistoryPending(false);
   }, []);
+
+  const handleDeferredRosterResolved = useCallback(
+    (page: RoomShellRosterPage) => {
+      setDeferredRoster(page);
+    },
+    [],
+  );
 
   const [threadParentMessage, setThreadParentMessage] =
     useState<ChatRoomMessage | null>(null);
@@ -2185,6 +2224,12 @@ export function RoomsClient({
     const showListSkeleton = messagesPending && displayMessages.length === 0;
     const openRoomListBody = (
       <>
+        {rosterPromise ? (
+          <RoomShellRosterHydrator
+            promise={rosterPromise}
+            onResolved={handleDeferredRosterResolved}
+          />
+        ) : null}
         {messagesPromise ? (
           <RoomMessagesHydrator
             promise={messagesPromise}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -480,6 +480,8 @@ export function RoomsClient({
   }, [isMobile, headerRoomSlotHost]);
   // Defer participant avatars one frame so the title string is not gated on
   // the avatar stack committing in the same first paint.
+  // Approved LCP exception: mount-only Effect keeps title-with-composer paint
+  // order; do not replace with render-time/portal-only avatar mounting.
   const [showHeaderParticipants, setShowHeaderParticipants] = useState(false);
   useEffect(() => {
     setShowHeaderParticipants(true);

--- a/apps/web/src/app/(app)/chat/load-room-shell-roster.ts
+++ b/apps/web/src/app/(app)/chat/load-room-shell-roster.ts
@@ -1,0 +1,31 @@
+import type { Coworker, Member } from "@/lib/clients/generated/core";
+import { coworkerService } from "@/lib/services/coworker.service";
+
+import { loadOrganizationMembers } from "./load-organization-members";
+
+/** Org roster + chat coworkers for room chrome enrichment (pickers, mentions). */
+export interface RoomShellRosterPage {
+  organizationMembers: Member[];
+  membersLoadFailed: boolean;
+  coworkers: Coworker[];
+}
+
+/**
+ * Secondary to room open: header/composer need getRoom only. Soft-fail members
+ * via {@link loadOrganizationMembers}; coworkers still throw on unexpected
+ * errors (same as prior await).
+ */
+export async function loadRoomShellRoster(
+  organizationId: string | null | undefined,
+): Promise<RoomShellRosterPage> {
+  const [membersPage, coworkers] = await Promise.all([
+    loadOrganizationMembers(organizationId),
+    coworkerService.listCoworkers("chat"),
+  ]);
+
+  return {
+    organizationMembers: membersPage.members,
+    membersLoadFailed: membersPage.failed,
+    coworkers,
+  };
+}

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -6,8 +6,7 @@ vi.mock("server-only", () => ({}));
 const getSessionMock = vi.fn();
 const getActiveOrganizationMock = vi.fn();
 const getRoomMock = vi.fn();
-const listCoworkersMock = vi.fn();
-const loadOrganizationMembersMock = vi.fn();
+const loadRoomShellRosterMock = vi.fn();
 const loadRoomMessagesMock = vi.fn();
 const redirectMock = vi.fn((url: string) => {
   throw new Error(`REDIRECT:${url}`);
@@ -41,15 +40,8 @@ vi.mock("@/lib/services", () => ({
   },
 }));
 
-vi.mock("@/lib/services/coworker.service", () => ({
-  coworkerService: {
-    listCoworkers: (...args: unknown[]) => listCoworkersMock(...args),
-  },
-}));
-
-vi.mock("@/app/chat/load-organization-members", () => ({
-  loadOrganizationMembers: (...args: unknown[]) =>
-    loadOrganizationMembersMock(...args),
+vi.mock("@/app/chat/load-room-shell-roster", () => ({
+  loadRoomShellRoster: (...args: unknown[]) => loadRoomShellRosterMock(...args),
 }));
 
 vi.mock("@/app/chat/load-room-messages", () => ({
@@ -107,27 +99,27 @@ function roomsClientProps(element: ReactElement) {
   return element.props as {
     membersLoadFailed?: boolean;
     organizationMembers?: unknown[];
+    coworkers?: unknown[];
     messages?: unknown[];
     messagesPromise?: Promise<unknown>;
+    rosterPromise?: Promise<unknown>;
     selectedRoomId?: string;
   };
+}
+
+function neverResolvingPromise<T>(): Promise<T> {
+  return new Promise(() => {
+    /* intentional hang for progressive-shell assertions */
+  });
 }
 
 describe("ChatRoomPage org deep-link guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSessionMock.mockResolvedValue({ user: { id: USER_ID } });
-    loadOrganizationMembersMock.mockResolvedValue({
-      members: [],
-      failed: false,
-    });
-    listCoworkersMock.mockResolvedValue([]);
-    // History starts but is not awaited — shell returns with a promise.
-    loadRoomMessagesMock.mockReturnValue(
-      new Promise(() => {
-        /* never resolves in shell tests */
-      }),
-    );
+    // Roster + history start but are not awaited — shell returns with promises.
+    loadRoomShellRosterMock.mockReturnValue(neverResolvingPromise());
+    loadRoomMessagesMock.mockReturnValue(neverResolvingPromise());
   });
 
   it("redirects when room belongs to a different active org", async () => {
@@ -144,6 +136,7 @@ describe("ChatRoomPage org deep-link guard", () => {
 
     expect(redirectMock).toHaveBeenCalledWith("/chat?notice=room-unavailable");
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
+    expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
   });
 
   it("redirects when active-org user opens a personal direct", async () => {
@@ -161,6 +154,7 @@ describe("ChatRoomPage org deep-link guard", () => {
     ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
 
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
+    expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
   });
 
   it("redirects when room is missing", async () => {
@@ -175,9 +169,10 @@ describe("ChatRoomPage org deep-link guard", () => {
       ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
     ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
+    expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
   });
 
-  it("paints shell with deferred messagesPromise (history not awaited)", async () => {
+  it("paints shell without awaiting members/coworkers (rosterPromise deferred)", async () => {
     getActiveOrganizationMock.mockResolvedValue({
       id: ORG_A,
       name: "Org A",
@@ -191,10 +186,14 @@ describe("ChatRoomPage org deep-link guard", () => {
 
     expect(redirectMock).not.toHaveBeenCalled();
     expect(loadRoomMessagesMock).toHaveBeenCalledWith(ROOM_ID);
+    expect(loadRoomShellRosterMock).toHaveBeenCalledWith(ORG_A);
     const props = roomsClientProps(element);
     expect(props.selectedRoomId).toBe(ROOM_ID);
     expect(props.messages).toEqual([]);
+    expect(props.organizationMembers).toEqual([]);
+    expect(props.coworkers).toEqual([]);
     expect(props.messagesPromise).toBeInstanceOf(Promise);
+    expect(props.rosterPromise).toBeInstanceOf(Promise);
     expect(props.membersLoadFailed).toBe(false);
   });
 
@@ -212,7 +211,10 @@ describe("ChatRoomPage org deep-link guard", () => {
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 
-    expect(roomsClientProps(element).messagesPromise).toBeInstanceOf(Promise);
+    const props = roomsClientProps(element);
+    expect(props.messagesPromise).toBeInstanceOf(Promise);
+    expect(props.rosterPromise).toBeInstanceOf(Promise);
+    expect(loadRoomShellRosterMock).toHaveBeenCalledWith(ORG_B);
   });
 
   it("renders guest channel progressive shell in personal workspace", async () => {
@@ -225,28 +227,35 @@ describe("ChatRoomPage org deep-link guard", () => {
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 
-    expect(roomsClientProps(element).messagesPromise).toBeInstanceOf(Promise);
+    const props = roomsClientProps(element);
+    expect(props.messagesPromise).toBeInstanceOf(Promise);
+    expect(props.rosterPromise).toBeInstanceOf(Promise);
+    expect(loadRoomShellRosterMock).toHaveBeenCalledWith(null);
   });
 
-  it("still renders progressive shell when organization members fail", async () => {
+  it("propagates membersLoadFailed through rosterPromise without blocking shell", async () => {
     getActiveOrganizationMock.mockResolvedValue({
       id: ORG_A,
       name: "Org A",
       slug: "org-a",
     });
     getRoomMock.mockResolvedValue(room({ organizationId: ORG_A }));
-    loadOrganizationMembersMock.mockResolvedValue({
-      members: [],
-      failed: true,
-    });
+    const failedRoster = {
+      organizationMembers: [],
+      membersLoadFailed: true,
+      coworkers: [],
+    };
+    loadRoomShellRosterMock.mockResolvedValue(failedRoster);
 
     const element = (await ChatRoomPageContent({
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 
     const props = roomsClientProps(element);
-    expect(props.membersLoadFailed).toBe(true);
+    // Shell paints with empty roster; failure arrives via promise.
+    expect(props.membersLoadFailed).toBe(false);
     expect(props.organizationMembers).toEqual([]);
+    await expect(props.rosterPromise).resolves.toEqual(failedRoster);
     expect(props.messagesPromise).toBeInstanceOf(Promise);
   });
 
@@ -260,10 +269,11 @@ describe("ChatRoomPage org deep-link guard", () => {
       params: Promise.resolve({ roomId: ROOM_ID }),
     })) as ReactElement;
 
-    expect(loadOrganizationMembersMock).not.toHaveBeenCalled();
+    expect(loadRoomShellRosterMock).toHaveBeenCalledWith(null);
     const props = roomsClientProps(element);
     expect(props.membersLoadFailed).toBe(false);
     expect(props.messagesPromise).toBeInstanceOf(Promise);
+    expect(props.rosterPromise).toBeInstanceOf(Promise);
   });
 });
 
@@ -277,11 +287,11 @@ describe("ChatRoomPage deferred history promise", () => {
       slug: "org-a",
     });
     getRoomMock.mockResolvedValue(room({ organizationId: ORG_A }));
-    loadOrganizationMembersMock.mockResolvedValue({
-      members: [],
-      failed: false,
+    loadRoomShellRosterMock.mockResolvedValue({
+      organizationMembers: [],
+      membersLoadFailed: false,
+      coworkers: [],
     });
-    listCoworkersMock.mockResolvedValue([]);
   });
 
   it("propagates load failure through messagesPromise", async () => {

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -172,6 +172,25 @@ describe("ChatRoomPage org deep-link guard", () => {
     expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
   });
 
+  it("redirects invalid room id without getRoom, roster, history, or RoomsClient", async () => {
+    getActiveOrganizationMock.mockResolvedValue({
+      id: ORG_A,
+      name: "Org A",
+      slug: "org-a",
+    });
+
+    await expect(
+      ChatRoomPageContent({
+        params: Promise.resolve({ roomId: "not-a-real-room-id" }),
+      }),
+    ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
+
+    expect(redirectMock).toHaveBeenCalledWith("/chat?notice=room-unavailable");
+    expect(getRoomMock).not.toHaveBeenCalled();
+    expect(loadRoomMessagesMock).not.toHaveBeenCalled();
+    expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
+  });
+
   it("paints shell without awaiting members/coworkers (rosterPromise deferred)", async () => {
     getActiveOrganizationMock.mockResolvedValue({
       id: ORG_A,

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/loading.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/loading.tsx
@@ -1,8 +1,9 @@
 import { RoomOpenLoadingView } from "@/app/chat/components/room-open-loading-view";
 
 /**
- * Instant / soft-nav into a room: real composer chrome + message-list skeleton.
- * No full-page spinner. Room-aware header/composer swap in after meta loads.
+ * Instant / soft-nav into a room: list skeleton only (no composer).
+ * Real title + composer arrive together from RoomsClient after getRoom.
+ * Composer-less so missing/invalid rooms never flash send UI before redirect.
  */
 export default function ChatRoomLoading() {
   return <RoomOpenLoadingView />;

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -79,12 +79,14 @@ function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
 /**
  * Open one room. Avoid `listRooms()` here — sidebar already owns the list.
  *
- * Progressive paint:
- * - Instant / outer Suspense: real composer chrome + message-list skeleton
- *   (no full-page spinner; no pulse fake composer).
- * - After room meta (`getRoom` only): room-aware header + composer + list skeleton.
- * - After history / roster: messages + members/coworkers into the same RoomsClient.
+ * Progressive paint (mobile LCP):
+ * Production traces show LCP locking onto Instant/Suspense loading bones
+ * (`empty:before` placeholder / list skeleton) when room meta is late.
+ * Await `getRoom` only so real title + composer replace `RoomOpenLoadingView`
+ * before that bone can win LCP. Members/coworkers stream via `rosterPromise`;
+ * history via `messagesPromise` (SOK-778).
  *
+ * Instant / outer Suspense: `RoomOpenLoadingView` (composer chrome + list bones).
  * Non-member / missing room → soft land on `/chat`, not 404.
  */
 export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/auth.server";
 import type { ChatRoom, Organization } from "@/lib/clients/generated/core";
 import { chatRoomService, userService } from "@/lib/services";
+import { isUuidString } from "@/lib/utils/uuid";
 
 interface ChatRoomPageProps {
   params: Promise<{ roomId: string }>;
@@ -23,6 +24,8 @@ interface ChatRoomShellProps {
   /** Null when personal workspace has no org roster to load. */
   organizationIdForRoster: string | null;
 }
+
+const ROOM_UNAVAILABLE_HREF = "/chat?notice=room-unavailable";
 
 function NoOrganizationCard({
   title,
@@ -87,7 +90,8 @@ function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
  * history via `messagesPromise` (SOK-778).
  *
  * Instant / outer Suspense: `RoomOpenLoadingView` (composer chrome + list bones).
- * Non-member / missing room → soft land on `/chat`, not 404.
+ * Non-member / missing / invalid room id → soft land on `/chat`, not error card.
+ * Do not start roster/history until access succeeds.
  */
 export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
   await connection();
@@ -101,11 +105,18 @@ export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
 
   const currentUserId = session?.user.id ?? "";
 
+  // Core path params are UUIDs — invalid ids 400 before 404. Redirect without
+  // calling getRoom / roster / history so Instant composer is not followed by
+  // RoomsClient or Chat Error.
+  if (!isUuidString(roomId)) {
+    redirect(ROOM_UNAVAILABLE_HREF);
+  }
+
   if (!activeOrganization) {
     const selectedRoom = await chatRoomService.getRoom(roomId);
 
     if (!selectedRoom) {
-      redirect("/chat?notice=room-unavailable");
+      redirect(ROOM_UNAVAILABLE_HREF);
     }
 
     const isPersonalDirect =
@@ -136,13 +147,13 @@ export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
   const selectedRoom = await chatRoomService.getRoom(roomId);
 
   if (!selectedRoom) {
-    redirect("/chat?notice=room-unavailable");
+    redirect(ROOM_UNAVAILABLE_HREF);
   }
 
   const isHostOrgRoom = selectedRoom.organizationId === activeOrganization.id;
   const isGuestRoom = selectedRoom.myAccess === "guest";
   if (!isHostOrgRoom && !isGuestRoom) {
-    redirect("/chat?notice=room-unavailable");
+    redirect(ROOM_UNAVAILABLE_HREF);
   }
 
   return progressiveRoomOpen(

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -4,18 +4,12 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { RoomOpenLoadingView } from "@/app/chat/components/room-open-loading-view";
 import { RoomsClient } from "@/app/chat/components/rooms-client";
-import { loadOrganizationMembers } from "@/app/chat/load-organization-members";
 import { loadRoomMessages } from "@/app/chat/load-room-messages";
+import { loadRoomShellRoster } from "@/app/chat/load-room-shell-roster";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/auth.server";
-import type {
-  ChatRoom,
-  Coworker,
-  Member,
-  Organization,
-} from "@/lib/clients/generated/core";
+import type { ChatRoom, Organization } from "@/lib/clients/generated/core";
 import { chatRoomService, userService } from "@/lib/services";
-import { coworkerService } from "@/lib/services/coworker.service";
 
 interface ChatRoomPageProps {
   params: Promise<{ roomId: string }>;
@@ -24,11 +18,10 @@ interface ChatRoomPageProps {
 interface ChatRoomShellProps {
   activeOrganization: Organization | null;
   rooms: ChatRoom[];
-  organizationMembers: Member[];
   currentUserId: string;
-  coworkers: Coworker[];
   selectedRoomId: string;
-  membersLoadFailed: boolean;
+  /** Null when personal workspace has no org roster to load. */
+  organizationIdForRoster: string | null;
 }
 
 function NoOrganizationCard({
@@ -55,28 +48,30 @@ function NoOrganizationCard({
 }
 
 /**
- * Real header + composer as soon as the room is known; history via promise
- * so the message list can skeleton without blocking chrome (SOK-778).
+ * Real header + composer as soon as the room is known; history + roster via
+ * promises so chrome is not blocked (SOK-778 history; roster deferred for LCP).
  * Instant / Suspense: RoomOpenLoadingView (real composer chrome + list bones).
  */
 function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
   const messagesPromise = loadRoomMessages(roomId);
+  const rosterPromise = loadRoomShellRoster(shell.organizationIdForRoster);
 
   return (
     <RoomsClient
       activeOrganization={shell.activeOrganization}
       rooms={shell.rooms}
-      organizationMembers={shell.organizationMembers}
+      organizationMembers={[]}
       currentUserId={shell.currentUserId}
-      coworkers={shell.coworkers}
+      coworkers={[]}
       selectedRoomId={shell.selectedRoomId}
       isCreateChannelRequested={false}
       isNewDirectMessage={false}
       messageLoadFailed={false}
-      membersLoadFailed={shell.membersLoadFailed}
+      membersLoadFailed={false}
       messages={[]}
       messagesNextCursor={null}
       messagesPromise={messagesPromise}
+      rosterPromise={rosterPromise}
     />
   );
 }
@@ -84,11 +79,11 @@ function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
 /**
  * Open one room. Avoid `listRooms()` here — sidebar already owns the list.
  *
- * Progressive paint (SOK-778):
+ * Progressive paint:
  * - Instant / outer Suspense: real composer chrome + message-list skeleton
  *   (no full-page spinner; no pulse fake composer).
- * - After room meta: room-aware header + composer + list skeleton.
- * - After history: real messages into the same RoomsClient.
+ * - After room meta (`getRoom` only): room-aware header + composer + list skeleton.
+ * - After history / roster: messages + members/coworkers into the same RoomsClient.
  *
  * Non-member / missing room → soft land on `/chat`, not 404.
  */
@@ -105,10 +100,7 @@ export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
   const currentUserId = session?.user.id ?? "";
 
   if (!activeOrganization) {
-    const [selectedRoom, coworkers] = await Promise.all([
-      chatRoomService.getRoom(roomId),
-      coworkerService.listCoworkers("chat"),
-    ]);
+    const selectedRoom = await chatRoomService.getRoom(roomId);
 
     if (!selectedRoom) {
       redirect("/chat?notice=room-unavailable");
@@ -131,21 +123,15 @@ export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
       {
         activeOrganization: null,
         rooms: [selectedRoom],
-        organizationMembers: [],
         currentUserId,
-        coworkers,
         selectedRoomId: selectedRoom.id,
-        membersLoadFailed: false,
+        organizationIdForRoster: null,
       },
       selectedRoom.id,
     );
   }
 
-  const [selectedRoom, membersPage, coworkers] = await Promise.all([
-    chatRoomService.getRoom(roomId),
-    loadOrganizationMembers(activeOrganization.id),
-    coworkerService.listCoworkers("chat"),
-  ]);
+  const selectedRoom = await chatRoomService.getRoom(roomId);
 
   if (!selectedRoom) {
     redirect("/chat?notice=room-unavailable");
@@ -161,11 +147,9 @@ export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {
     {
       activeOrganization,
       rooms: [selectedRoom],
-      organizationMembers: membersPage.members,
       currentUserId,
-      coworkers,
       selectedRoomId: selectedRoom.id,
-      membersLoadFailed: membersPage.failed,
+      organizationIdForRoster: activeOrganization.id,
     },
     selectedRoom.id,
   );

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -53,7 +53,7 @@ function NoOrganizationCard({
 /**
  * Real header + composer as soon as the room is known; history + roster via
  * promises so chrome is not blocked (SOK-778 history; roster deferred for LCP).
- * Instant / Suspense: RoomOpenLoadingView (real composer chrome + list bones).
+ * Instant / Suspense: composer-less RoomOpenLoadingView (list bones only).
  */
 function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
   const messagesPromise = loadRoomMessages(roomId);
@@ -83,13 +83,10 @@ function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
  * Open one room. Avoid `listRooms()` here — sidebar already owns the list.
  *
  * Progressive paint (mobile LCP):
- * Production traces show LCP locking onto Instant/Suspense loading bones
- * (`empty:before` placeholder / list skeleton) when room meta is late.
- * Await `getRoom` only so real title + composer replace `RoomOpenLoadingView`
- * before that bone can win LCP. Members/coworkers stream via `rosterPromise`;
- * history via `messagesPromise` (SOK-778).
+ * Instant/Suspense fallback is composer-less so missing rooms never flash send
+ * UI and an `empty:before` bone cannot win LCP. After `getRoom`, RoomsClient
+ * paints real title + composer together; roster/history stream in via promises.
  *
- * Instant / outer Suspense: `RoomOpenLoadingView` (composer chrome + list bones).
  * Non-member / missing / invalid room id → soft land on `/chat`, not error card.
  * Do not start roster/history until access succeeds.
  */

--- a/apps/web/src/lib/services/chat-room.service.ts
+++ b/apps/web/src/lib/services/chat-room.service.ts
@@ -207,7 +207,9 @@ export const chatRoomService = (() => {
     } catch (error) {
       if (
         error instanceof CoreApiRequestError &&
-        (error.status === 404 || error.status === 403)
+        // 400: path UUID validation (e.g. /rooms/not-a-real-room-id).
+        // 403/404: missing or unauthorized → soft-land on /chat.
+        (error.status === 400 || error.status === 403 || error.status === 404)
       ) {
         return null;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production mobile LCP on `/chat/rooms/[roomId]` locked onto Instant/Suspense **loading bones** (`empty:before` composer placeholder), not avatars or message text.

## Changes

1. **Await `getRoom` only** — roster/history stream via `rosterPromise` / `messagesPromise`. Access redirects unchanged.
2. **Composer-less Instant/Suspense** — `RoomOpenLoadingView` is list-skeleton only (no fake composer). Missing/invalid rooms redirect to `/chat?notice=room-unavailable` without flashing send UI.
3. **Invalid room ids** — early `isUuidString` redirect; `getRoom` maps Core 400→null.
4. **Title with first real chrome** — mobile header portal (and avatar stack) deferred to `useEffect` so getRoom title paints in-column with the composer on the first RoomsClient frame.

## CodeRabbit follow-ups

- Typed hydrate-test roster as `RoomShellRosterPage` with complete `Member` / `Coworker` DTOs; removed `as never`.
- Named `RoomShellRosterHydratorProps`.
- **Skipped:** mount-only participants `useEffect` (verified LCP title-with-composer paint; comment marks approved exception).
- **Skipped:** moving `coworkerService` mock — no existing `__mocks__` module for that service.

Synced with `origin/main` via merge (no history rewrite).

`/chat/chats` untouched for this PR’s room-route scope.

## Verification

- `pnpm --filter web test` on rooms-client-messages-pending, load-room-shell-roster, room page (23 passed)
- `pnpm check` + `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cacf0ef6-0145-4771-a64c-21c3c55ec32a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cacf0ef6-0145-4771-a64c-21c3c55ec32a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

