### PR TITLE
perf(web): stream /chat/chats rooms before archived chrome

### DIFF
--- a/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-progressive-rooms.test.tsx
+++ b/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-progressive-rooms.test.tsx
@@ -56,7 +56,7 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarSeparator: () => <hr />,
 }));
 
-import ChatChatsPage from "../page";
+import ChatChatsPage from "@/app/chat/chats/page";
 
 const USER_ID = "user_1";
 const ORG_ID = "org_1";

--- a/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-progressive-rooms.test.tsx
+++ b/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-progressive-rooms.test.tsx
@@ -1,0 +1,183 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const getSessionMock = vi.fn();
+const getPrivateCachedMembershipVisibleRoomsMock = vi.fn();
+const getPrivateCachedChatListArchivedAndMembersMock = vi.fn();
+
+vi.mock("next/server", () => ({
+  connection: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/auth/auth.server", () => ({
+  getSession: (...args: unknown[]) => getSessionMock(...args),
+}));
+
+vi.mock("@/lib/hermes/beta-access", () => ({
+  isHermesBetaAccessEmail: () => false,
+}));
+
+vi.mock("@/app/components/private-sidebar-cache", () => ({
+  getPrivateCachedMembershipVisibleRooms: (...args: unknown[]) =>
+    getPrivateCachedMembershipVisibleRoomsMock(...args),
+  getPrivateCachedChatListArchivedAndMembers: (...args: unknown[]) =>
+    getPrivateCachedChatListArchivedAndMembersMock(...args),
+}));
+
+vi.mock(
+  "@/app/components/sidebar/components/personal-assistant-nav.client",
+  () => ({
+    default: () => <div data-testid="personal-assistant-nav" />,
+  }),
+);
+
+vi.mock("@/components/chat/organization-chat-list.client", () => ({
+  OrganizationChatList: (props: {
+    rooms: Array<{ id: string; name?: string | null }>;
+    archivedRooms: unknown[];
+    canDeleteArchivedRooms?: boolean;
+  }) => (
+    <div
+      data-testid="organization-chat-list"
+      data-room-names={props.rooms.map((room) => room.name).join("|")}
+      data-archived-count={String(props.archivedRooms.length)}
+      data-can-delete={String(Boolean(props.canDeleteArchivedRooms))}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarSeparator: () => <hr />,
+}));
+
+import ChatChatsPage from "../page";
+
+const USER_ID = "user_1";
+const ORG_ID = "org_1";
+
+interface OrganizationChatListProps {
+  rooms: Array<{ id: string; name?: string | null }>;
+  archivedRooms: unknown[];
+  canDeleteArchivedRooms?: boolean;
+  dismissSheetOnNavigate?: boolean;
+}
+
+interface SuspenseLikeProps {
+  fallback?: ReactElement;
+  children?: ReactNode;
+}
+
+interface ClassNameProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+function findElement(
+  node: ReactNode,
+  predicate: (element: ReactElement) => boolean,
+): ReactElement | null {
+  if (node == null || typeof node === "boolean" || typeof node === "string") {
+    return null;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findElement(child, predicate);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+  if (!isValidElement(node)) {
+    return null;
+  }
+  if (predicate(node)) {
+    return node;
+  }
+  const props = node.props as { children?: ReactNode };
+  return findElement(props.children, predicate);
+}
+
+function suspenseProps(element: ReactElement): SuspenseLikeProps {
+  return element.props as SuspenseLikeProps;
+}
+
+function listProps(element: ReactElement): OrganizationChatListProps {
+  return element.props as OrganizationChatListProps;
+}
+
+describe("ChatChatsPage progressive rooms (mobile LCP)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({
+      user: { id: USER_ID, email: "alice@example.com" },
+      session: { activeOrganizationId: ORG_ID },
+    });
+    getPrivateCachedMembershipVisibleRoomsMock.mockResolvedValue({
+      rooms: [{ id: "room-1", name: "Plan.Net Studios x NMKR" }],
+      nextCursor: null,
+    });
+  });
+
+  it("paints OrganizationChatList room labels while archived+members stay pending", async () => {
+    getPrivateCachedChatListArchivedAndMembersMock.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    const tree = await ChatChatsPage();
+
+    // Parent finishes after membership rooms; Suspense fallback already has
+    // real row text. Deferred chrome is a sibling child, not awaited here.
+    expect(getPrivateCachedMembershipVisibleRoomsMock).toHaveBeenCalledTimes(1);
+    expect(getPrivateCachedMembershipVisibleRoomsMock).toHaveBeenCalledWith({
+      userId: USER_ID,
+      activeOrganizationId: ORG_ID,
+    });
+
+    const suspense = findElement(tree, (el) => {
+      const props = el.props as SuspenseLikeProps;
+      return props.fallback != null && props.children != null;
+    });
+
+    expect(suspense).not.toBeNull();
+    const fallback = suspenseProps(suspense as ReactElement).fallback;
+    expect(fallback).toBeDefined();
+    const props = listProps(fallback as ReactElement);
+    expect(props.rooms).toEqual([
+      { id: "room-1", name: "Plan.Net Studios x NMKR" },
+    ]);
+    expect(props.archivedRooms).toEqual([]);
+    expect(props.canDeleteArchivedRooms).toBe(false);
+    expect(props.dismissSheetOnNavigate).toBe(false);
+
+    // Deferred fetch is started by the Suspense child type, not by the parent
+    // await — calling the page must not require archived/members to resolve.
+    expect(
+      getPrivateCachedChatListArchivedAndMembersMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("keeps md:hidden mobile-only shell", async () => {
+    getPrivateCachedChatListArchivedAndMembersMock.mockResolvedValue({
+      archivedChatRoomsPage: { rooms: [], nextCursor: null },
+      members: [],
+    });
+
+    const tree = await ChatChatsPage();
+    const shell = findElement(tree, (el) => {
+      const props = el.props as ClassNameProps;
+      return (
+        typeof props.className === "string" &&
+        props.className.includes("md:hidden")
+      );
+    });
+
+    expect(shell).not.toBeNull();
+  });
+});

--- a/apps/web/src/app/(app)/chat/chats/page.tsx
+++ b/apps/web/src/app/(app)/chat/chats/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import {
   getPrivateCachedChatListArchivedAndMembers,
   getPrivateCachedMembershipVisibleRooms,
+  type PrivateChatListCacheArgs,
 } from "@/app/components/private-sidebar-cache";
 import PersonalAssistantNav from "@/app/components/sidebar/components/personal-assistant-nav.client";
 import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
@@ -13,13 +14,8 @@ import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 import type { ChatRoomsPage } from "@/lib/services";
 
-interface ChatListCacheArgs {
-  userId: string;
-  activeOrganizationId: string | null;
-}
-
 interface ChatChatsOrganizationListProps {
-  cacheArgs: ChatListCacheArgs;
+  cacheArgs: PrivateChatListCacheArgs;
   chatRoomsPage: ChatRoomsPage;
   currentUserId: string;
   activeOrganizationId: string | null;
@@ -83,7 +79,7 @@ export default async function ChatChatsPage() {
   const session = await getSession();
   const activeOrganizationId = session?.session.activeOrganizationId ?? null;
   const currentUserId = session?.user.id ?? "";
-  const cacheArgs: ChatListCacheArgs = {
+  const cacheArgs: PrivateChatListCacheArgs = {
     userId: currentUserId,
     activeOrganizationId,
   };

--- a/apps/web/src/app/(app)/chat/chats/page.tsx
+++ b/apps/web/src/app/(app)/chat/chats/page.tsx
@@ -1,5 +1,9 @@
 import { connection } from "next/server";
-import { getPrivateCachedChatListChrome } from "@/app/components/private-sidebar-cache";
+import { Suspense } from "react";
+import {
+  getPrivateCachedChatListArchivedAndMembers,
+  getPrivateCachedMembershipVisibleRooms,
+} from "@/app/components/private-sidebar-cache";
 import PersonalAssistantNav from "@/app/components/sidebar/components/personal-assistant-nav.client";
 import { OrganizationChatList } from "@/components/chat/organization-chat-list.client";
 import { Sheet } from "@/components/ui/sheet";
@@ -7,31 +11,33 @@ import { SidebarSeparator } from "@/components/ui/sidebar";
 import { getSession } from "@/lib/auth/auth.server";
 import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
+import type { ChatRoomsPage } from "@/lib/services";
+
+interface ChatListCacheArgs {
+  userId: string;
+  activeOrganizationId: string | null;
+}
+
+interface ChatChatsOrganizationListProps {
+  cacheArgs: ChatListCacheArgs;
+  chatRoomsPage: ChatRoomsPage;
+  currentUserId: string;
+  activeOrganizationId: string | null;
+}
 
 /**
- * Mobile Chats tab: Personal Assistant (beta-gated) above Channels + DMs
- * (`md:hidden`). Desktop keeps the sidebar list; this route shows nothing
- * meaningful above `md`.
- *
- * Instant Nav uses `chats/loading.tsx` while this page streams after
- * `connection()`.
- *
- * Membership-visible rooms come from the same private-cache slice as the app
- * sidebar (`getPrivateCachedChatListChrome`) so cold load does not double-hit
- * Core (SOK-779). Cache key must match sidebar: session user id + active org.
+ * Streams archived + admin-delete after membership rooms already painted.
+ * Suspense fallback on the page mounts OrganizationChatList with real row
+ * labels so LCP is not a late skeleton→text swap.
  */
-export default async function ChatChatsPage() {
-  await connection();
-
-  const session = await getSession();
-  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
-  const currentUserId = session?.user.id ?? "";
-
-  const { chatRoomsPage, archivedChatRoomsPage, members } =
-    await getPrivateCachedChatListChrome({
-      userId: currentUserId,
-      activeOrganizationId,
-    });
+async function ChatChatsListWithArchived({
+  cacheArgs,
+  chatRoomsPage,
+  currentUserId,
+  activeOrganizationId,
+}: ChatChatsOrganizationListProps) {
+  const { archivedChatRoomsPage, members } =
+    await getPrivateCachedChatListArchivedAndMembers(cacheArgs);
 
   const canDeleteArchivedRooms = Boolean(
     activeOrganizationId &&
@@ -42,7 +48,50 @@ export default async function ChatChatsPage() {
       ),
   );
 
+  return (
+    <OrganizationChatList
+      key={activeOrganizationId ?? "personal"}
+      rooms={chatRoomsPage.rooms}
+      roomsNextCursor={chatRoomsPage.nextCursor}
+      archivedRooms={archivedChatRoomsPage.rooms}
+      archivedRoomsNextCursor={archivedChatRoomsPage.nextCursor}
+      currentUserId={currentUserId}
+      organizationId={activeOrganizationId}
+      canDeleteArchivedRooms={canDeleteArchivedRooms}
+      dismissSheetOnNavigate={false}
+    />
+  );
+}
+
+/**
+ * Mobile Chats tab: Personal Assistant (beta-gated) above Channels + DMs
+ * (`md:hidden`). Desktop keeps the sidebar list; this route shows nothing
+ * meaningful above `md`.
+ *
+ * Instant Nav uses `chats/loading.tsx` while this page streams after
+ * `connection()`.
+ *
+ * Membership-visible rooms come from the same private-cache slice as the app
+ * sidebar (`getPrivateCachedMembershipVisibleRooms`) so cold load does not
+ * double-hit Core (SOK-779). Cache key must match sidebar: session user id +
+ * active org. Archived + members stream after so channel-row text can win LCP
+ * without waiting on that chrome.
+ */
+export default async function ChatChatsPage() {
+  await connection();
+
+  const session = await getSession();
+  const activeOrganizationId = session?.session.activeOrganizationId ?? null;
+  const currentUserId = session?.user.id ?? "";
+  const cacheArgs: ChatListCacheArgs = {
+    userId: currentUserId,
+    activeOrganizationId,
+  };
+
+  const chatRoomsPage = await getPrivateCachedMembershipVisibleRooms(cacheArgs);
+
   const hermesMenuEnabled = isHermesBetaAccessEmail(session?.user.email);
+  const listKey = activeOrganizationId ?? "personal";
 
   return (
     <Sheet open>
@@ -55,17 +104,28 @@ export default async function ChatChatsPage() {
       <div className="bg-background md:hidden -m-4 flex flex-1 flex-col">
         <PersonalAssistantNav enabled={hermesMenuEnabled} />
         {hermesMenuEnabled ? <SidebarSeparator className="-mt-px" /> : null}
-        <OrganizationChatList
-          key={activeOrganizationId ?? "personal"}
-          rooms={chatRoomsPage.rooms}
-          roomsNextCursor={chatRoomsPage.nextCursor}
-          archivedRooms={archivedChatRoomsPage.rooms}
-          archivedRoomsNextCursor={archivedChatRoomsPage.nextCursor}
-          currentUserId={currentUserId}
-          organizationId={activeOrganizationId}
-          canDeleteArchivedRooms={canDeleteArchivedRooms}
-          dismissSheetOnNavigate={false}
-        />
+        <Suspense
+          fallback={
+            <OrganizationChatList
+              key={listKey}
+              rooms={chatRoomsPage.rooms}
+              roomsNextCursor={chatRoomsPage.nextCursor}
+              archivedRooms={[]}
+              archivedRoomsNextCursor={null}
+              currentUserId={currentUserId}
+              organizationId={activeOrganizationId}
+              canDeleteArchivedRooms={false}
+              dismissSheetOnNavigate={false}
+            />
+          }
+        >
+          <ChatChatsListWithArchived
+            cacheArgs={cacheArgs}
+            chatRoomsPage={chatRoomsPage}
+            currentUserId={currentUserId}
+            activeOrganizationId={activeOrganizationId}
+          />
+        </Suspense>
       </div>
     </Sheet>
   );

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -87,8 +87,39 @@ describe("loadChatListChromeData", () => {
   });
 });
 
+describe("loadMembershipVisibleRooms progressive paint", () => {
+  beforeEach(() => {
+    listRoomsMock.mockReset();
+    listArchivedRoomsMock.mockReset();
+    getMyMembersWithOrganizationsMock.mockReset();
+  });
+
+  it("resolves room row labels without calling archived or members", async () => {
+    listRoomsMock.mockResolvedValue({
+      rooms: [{ id: "room-1", name: "Plan.Net Studios x NMKR" }],
+      nextCursor: null,
+    });
+    // Hang forever — proves rooms paint path does not await these.
+    listArchivedRoomsMock.mockReturnValue(new Promise(() => {}));
+    getMyMembersWithOrganizationsMock.mockReturnValue(new Promise(() => {}));
+
+    const { loadMembershipVisibleRooms } = await import(
+      "@/app/components/private-sidebar-cache"
+    );
+
+    const roomsPage = await loadMembershipVisibleRooms();
+
+    expect(roomsPage.rooms).toEqual([
+      { id: "room-1", name: "Plan.Net Studios x NMKR" },
+    ]);
+    expect(listRoomsMock).toHaveBeenCalledTimes(1);
+    expect(listArchivedRoomsMock).not.toHaveBeenCalled();
+    expect(getMyMembersWithOrganizationsMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("chat list chrome single-source composition contract", () => {
-  it("sidebar and chats page both call getPrivateCachedChatListChrome", async () => {
+  it("sidebar shares private chrome slices; chats page awaits rooms first", async () => {
     const { readFileSync } = await import("node:fs");
     const { dirname, join } = await import("node:path");
     const { fileURLToPath } = await import("node:url");
@@ -102,11 +133,18 @@ describe("chat list chrome single-source composition contract", () => {
       join(dir, "../../chat/chats/page.tsx"),
       "utf8",
     );
+    const cacheSource = readFileSync(
+      join(dir, "../private-sidebar-cache.ts"),
+      "utf8",
+    );
 
     expect(sidebar).toMatch(/getPrivateCachedChatListChrome/);
-    expect(chatsPage).toMatch(/getPrivateCachedChatListChrome/);
+    // Chats awaits membership rooms, then Suspense-streams archived+members.
+    expect(chatsPage).toMatch(/getPrivateCachedMembershipVisibleRooms/);
+    expect(chatsPage).toMatch(/getPrivateCachedChatListArchivedAndMembers/);
+    expect(chatsPage).toMatch(/<Suspense/);
     // Page must not re-issue raw listRooms / listArchived / members after the
-    // shared private-cache slice owns that cold composition work.
+    // shared private-cache slices own that cold composition work.
     expect(chatsPage).not.toMatch(/chatRoomService\s*\.\s*listRooms\s*\(/);
     expect(chatsPage).not.toMatch(
       /chatRoomService\s*\.\s*listArchivedRooms\s*\(/,
@@ -114,6 +152,15 @@ describe("chat list chrome single-source composition contract", () => {
     expect(chatsPage).not.toMatch(
       /userService\s*\.\s*getMyMembersWithOrganizations\s*\(/,
     );
+    // Composer still exists for sidebar/header; rooms + deferred are separate
+    // private-cache entries with the same tags (SOK-779).
+    expect(cacheSource).toMatch(
+      /function getPrivateCachedMembershipVisibleRooms/,
+    );
+    expect(cacheSource).toMatch(
+      /function getPrivateCachedChatListArchivedAndMembers/,
+    );
+    expect(cacheSource).toMatch(/function getPrivateCachedChatListChrome/);
   });
 
   it("header workspace switcher reads members from getPrivateCachedChatListChrome", async () => {
@@ -190,5 +237,9 @@ describe("chat list chrome single-source composition contract", () => {
     expect(source).toMatch(/privateSidebarUserTag/);
     expect(source).toMatch(/privateSidebarOrgTag/);
     expect(source).toMatch(/function getPrivateCachedChatListChrome/);
+    expect(source).toMatch(/function getPrivateCachedMembershipVisibleRooms/);
+    expect(source).toMatch(
+      /function getPrivateCachedChatListArchivedAndMembers/,
+    );
   });
 });

--- a/apps/web/src/app/(app)/components/private-sidebar-cache.ts
+++ b/apps/web/src/app/(app)/components/private-sidebar-cache.ts
@@ -32,10 +32,49 @@ export interface PrivateCachedChatListChrome {
   members: MemberWithOrganization[];
 }
 
+export interface PrivateCachedChatListArchivedAndMembers {
+  archivedChatRoomsPage: ChatRoomsPage;
+  members: MemberWithOrganization[];
+}
+
+interface PrivateChatListCacheArgs {
+  userId: string;
+  activeOrganizationId: string | null;
+}
+
+/**
+ * Membership-visible rooms only (no archived / members). Fail-soft to empty
+ * page on service errors.
+ */
+export async function loadMembershipVisibleRooms(): Promise<ChatRoomsPage> {
+  return chatRoomService.listRooms().catch(() => EMPTY_ROOMS_PAGE);
+}
+
+/**
+ * Archived rooms + org memberships for admin-delete. Fail-soft empties.
+ */
+export async function loadChatListArchivedAndMembers(
+  activeOrganizationId: string | null,
+): Promise<PrivateCachedChatListArchivedAndMembers> {
+  const archivedChatRoomsPromise = activeOrganizationId
+    ? chatRoomService.listArchivedRooms().catch(() => EMPTY_ROOMS_PAGE)
+    : Promise.resolve(EMPTY_ROOMS_PAGE);
+  const membersPromise = userService
+    .getMyMembersWithOrganizations()
+    .catch(() => []);
+
+  const [archivedChatRoomsPage, members] = await Promise.all([
+    archivedChatRoomsPromise,
+    membersPromise,
+  ]);
+
+  return { archivedChatRoomsPage, members };
+}
+
 /**
  * Testable body for membership-visible rooms + archived + members.
- * Prefer {@link getPrivateCachedChatListChrome} from RSC so sidebar and chats
- * list share one private-cache slice (React.cache does not cross use-cache).
+ * Prefer the private-cache wrappers from RSC so sidebar and chats list share
+ * slices (React.cache does not cross use-cache).
  *
  * Fail-soft: service errors become empty pages/arrays (same as pre-SOK-779
  * sidebar/page). When used under private cache those empties are shared until
@@ -46,41 +85,68 @@ export interface PrivateCachedChatListChrome {
 export async function loadChatListChromeData(
   activeOrganizationId: string | null,
 ): Promise<PrivateCachedChatListChrome> {
-  const chatRoomsPromise = chatRoomService
-    .listRooms()
-    .catch(() => EMPTY_ROOMS_PAGE);
-  const archivedChatRoomsPromise = activeOrganizationId
-    ? chatRoomService.listArchivedRooms().catch(() => EMPTY_ROOMS_PAGE)
-    : Promise.resolve(EMPTY_ROOMS_PAGE);
-  const membersPromise = userService
-    .getMyMembersWithOrganizations()
-    .catch(() => []);
-
-  const [chatRoomsPage, archivedChatRoomsPage, members] = await Promise.all([
-    chatRoomsPromise,
-    archivedChatRoomsPromise,
-    membersPromise,
+  const [chatRoomsPage, deferred] = await Promise.all([
+    loadMembershipVisibleRooms(),
+    loadChatListArchivedAndMembers(activeOrganizationId),
   ]);
 
-  return { chatRoomsPage, archivedChatRoomsPage, members };
+  return {
+    chatRoomsPage,
+    archivedChatRoomsPage: deferred.archivedChatRoomsPage,
+    members: deferred.members,
+  };
 }
 
 /**
- * Membership-visible rooms chrome shared by private sidebar + `/chat/chats`.
- * Same private tags/life as sidebar so cold composition hits Core once.
+ * Membership-visible rooms chrome (SOK-779). Same private tags/life as the
+ * archived+members slice so sidebar + `/chat/chats` share one Core hit for
+ * rooms; chats can await this without waiting on archived/members.
  */
-export async function getPrivateCachedChatListChrome(args: {
-  userId: string;
-  activeOrganizationId: string | null;
-}): Promise<PrivateCachedChatListChrome> {
+export async function getPrivateCachedMembershipVisibleRooms(
+  args: PrivateChatListCacheArgs,
+): Promise<ChatRoomsPage> {
   "use cache: private";
   cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
   cacheTag(privateSidebarUserTag(args.userId));
   if (args.activeOrganizationId) {
     cacheTag(privateSidebarOrgTag(args.activeOrganizationId));
   }
+  return loadMembershipVisibleRooms();
+}
 
-  return loadChatListChromeData(args.activeOrganizationId);
+/**
+ * Archived rooms + members for admin-delete. Same tags as membership rooms.
+ */
+export async function getPrivateCachedChatListArchivedAndMembers(
+  args: PrivateChatListCacheArgs,
+): Promise<PrivateCachedChatListArchivedAndMembers> {
+  "use cache: private";
+  cacheLife({ stale: 300, revalidate: 60, expire: 3600 });
+  cacheTag(privateSidebarUserTag(args.userId));
+  if (args.activeOrganizationId) {
+    cacheTag(privateSidebarOrgTag(args.activeOrganizationId));
+  }
+  return loadChatListArchivedAndMembers(args.activeOrganizationId);
+}
+
+/**
+ * Full chat-list chrome: composes the rooms + archived/members private-cache
+ * slices (same tags/life). Sidebar / header keep this one-call API; `/chat/chats`
+ * awaits rooms first then streams archived+members.
+ */
+export async function getPrivateCachedChatListChrome(
+  args: PrivateChatListCacheArgs,
+): Promise<PrivateCachedChatListChrome> {
+  const [chatRoomsPage, deferred] = await Promise.all([
+    getPrivateCachedMembershipVisibleRooms(args),
+    getPrivateCachedChatListArchivedAndMembers(args),
+  ]);
+
+  return {
+    chatRoomsPage,
+    archivedChatRoomsPage: deferred.archivedChatRoomsPage,
+    members: deferred.members,
+  };
 }
 
 /**

--- a/apps/web/src/app/(app)/components/private-sidebar-cache.ts
+++ b/apps/web/src/app/(app)/components/private-sidebar-cache.ts
@@ -37,7 +37,7 @@ export interface PrivateCachedChatListArchivedAndMembers {
   members: MemberWithOrganization[];
 }
 
-interface PrivateChatListCacheArgs {
+export interface PrivateChatListCacheArgs {
   userId: string;
   activeOrganizationId: string | null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chats follow-up to #3805 (room route progressive roster). `/chat/rooms` is untouched.

Production mobile LCP on `/chat/chats` (signed-in, 375×667) was measured as **channel-row text** (e.g. `Plan.Net Studios x NMKR`) after `ChatChatsPageSkeleton` swapped to `OrganizationChatList` — not avatars, header, or Personal Assistant. Desktop is fine (`md:hidden`).

Root delay: the page awaited the full private-cache chrome slice (`rooms + archived + members`) before any row labels existed, so Instant Nav skeleton won the wait and lost LCP to the late text swap.

## What this PR changes

1. **Split private chat-list chrome** into membership-visible rooms vs archived+members (same user/org tags + life as SOK-779; sidebar/header still use the composer so Core is not double-hit).
2. **`/chat/chats` awaits rooms first**, paints `OrganizationChatList` with real row labels via Suspense fallback, then streams archived + `canDeleteArchivedRooms`.
3. **No avatar / next/image work**, no product copy changes, mobile-only shell preserved, PA chrome still omitted from Instant Nav skeleton for non-beta users.

## Follow-ups

- Shared `PrivateChatListCacheArgs` export + `@/app/chat/chats/page` test import (CodeRabbit nits).

## Verification

- `loadMembershipVisibleRooms` resolves while archived/members hang
- Page test: Suspense fallback gets room labels without awaiting archived+members
- Contract tests updated for rooms-first + shared private-cache slices
- Covering web tests for chats page / chrome cache pass
- `pnpm check` + `pnpm typecheck` (pre-commit)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e90947-a1e0-4d4f-ab88-7f85d8612e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e90947-a1e0-4d4f-ab88-7f85d8612e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

