### PR TITLE
feat(chat): scrollable full coworker strip on landing

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1566,7 +1566,9 @@
           "recent": "In den letzten 24 Stunden"
         },
         "team": {
-          "avatarAlt": "{name}"
+          "avatarAlt": "{name}",
+          "stripLabel": "Verfügbare Coworker",
+          "select": "{name} auswählen"
         }
       }
     },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1550,7 +1550,6 @@
         "greeting": "Willkommen bei Sokosumi!",
         "greetingWithName": "Willkommen bei Sokosumi, {name}!",
         "intro": "Bei Sokosumi arbeitest du mit KI-Coworkern – du sagst, was zu tun ist, sie planen es und erledigen es.",
-        "role": "Projektmanagerin - du kannst ihr jede Aufgabe geben und sie findet den perfekten Coworker dafür",
         "cta": {
           "avatarAlt": "{name}",
           "button": "Mit {name} chatten",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1567,7 +1567,9 @@
         "team": {
           "avatarAlt": "{name}",
           "stripLabel": "Verfügbare Coworker",
-          "select": "{name} auswählen"
+          "select": "{name} auswählen",
+          "showMore": "Mehr",
+          "showLess": "Weniger"
         }
       }
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1566,7 +1566,9 @@
           "recent": "In the last 24 hours"
         },
         "team": {
-          "avatarAlt": "{name}"
+          "avatarAlt": "{name}",
+          "stripLabel": "Available coworkers",
+          "select": "Select {name}"
         }
       }
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1567,7 +1567,9 @@
         "team": {
           "avatarAlt": "{name}",
           "stripLabel": "Available coworkers",
-          "select": "Select {name}"
+          "select": "Select {name}",
+          "showMore": "More",
+          "showLess": "Less"
         }
       }
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1550,7 +1550,6 @@
         "greeting": "Welcome to Sokosumi!",
         "greetingWithName": "Welcome to Sokosumi, {name}!",
         "intro": "Sokosumi is where you work with AI coworkers — you say what needs doing, they plan it and get it done.",
-        "role": "Project Manager - you can give her any task and she will find the perfect coworker for it",
         "cta": {
           "avatarAlt": "{name}",
           "button": "Chat with {name}",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1567,7 +1567,9 @@
         "team": {
           "avatarAlt": "{name}",
           "stripLabel": "Compañeros disponibles",
-          "select": "Seleccionar a {name}"
+          "select": "Seleccionar a {name}",
+          "showMore": "Más",
+          "showLess": "Menos"
         }
       }
     },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1566,7 +1566,9 @@
           "recent": "En las últimas 24 horas"
         },
         "team": {
-          "avatarAlt": "{name}"
+          "avatarAlt": "{name}",
+          "stripLabel": "Compañeros disponibles",
+          "select": "Seleccionar a {name}"
         }
       }
     },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1550,7 +1550,6 @@
         "greeting": "¡Bienvenido a Sokosumi!",
         "greetingWithName": "¡Bienvenido a Sokosumi, {name}!",
         "intro": "En Sokosumi trabajas con compañeros de IA: tú dices qué hace falta y ellos lo planifican y lo hacen.",
-        "role": "Jefa de proyecto - puedes darle cualquier tarea y encontrará al compañero perfecto para ella",
         "cta": {
           "avatarAlt": "{name}",
           "button": "Chatear con {name}",

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
@@ -7,7 +7,11 @@ import { describe, expect, it } from "vitest";
  * The activity/stats row must stay on the landing composition so the first
  * viewport still answers "what happened while I was gone". Clamping the
  * selected-coworker block must not delete that row — and the row must be
- * pinned (`shrink-0` + test id) at the bottom of the viewport-tall column.
+ * pinned (`shrink-0` + test id) at the bottom of the viewport-tall column,
+ * always mounted (including zero chips), never gated on non-zero activity.
+ *
+ * The middle column must be top-aligned (`justify-start`) so description /
+ * caption length cannot vertically re-center Start chat.
  */
 describe("chat landing stats row contract", () => {
   it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(
@@ -19,11 +23,31 @@ describe("chat landing stats row contract", () => {
       );
 
       expect(source).toContain("buildActivityStats");
-      expect(source).toContain("hasReportableActivity");
+      expect(source).not.toContain("hasReportableActivity");
       expect(source).toContain("stats.map");
       expect(source).toContain('data-testid="landing-activity-stats"');
       expect(source).toContain("shrink-0");
       expect(source).toContain("min-w-0");
+      // Always mounted — no activity / summary gate before the test id.
+      expect(source).not.toMatch(/hasAnyActivity[\s\S]*landing-activity-stats/);
+      expect(source).not.toMatch(/summary\s*&&[\s\S]*landing-activity-stats/);
+    },
+  );
+
+  it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(
+    "%s top-aligns the middle column so CTA cannot re-center",
+    (filename) => {
+      const source = readFileSync(
+        join(import.meta.dirname, "..", filename),
+        "utf8",
+      );
+
+      expect(source).toContain("justify-start");
+      // Vertically centering the pitch+picker re-positions Start chat when
+      // description height changes across coworkers — forbid that pattern.
+      expect(source).not.toMatch(
+        /flex-1[\s\S]*justify-center[\s\S]*LandingCoworkerPicker/,
+      );
     },
   );
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
@@ -6,11 +6,12 @@ import { describe, expect, it } from "vitest";
 /**
  * The activity/stats row must stay on the landing composition so the first
  * viewport still answers "what happened while I was gone". Clamping the
- * selected-coworker block must not delete that row.
+ * selected-coworker block must not delete that row — and the row must be
+ * pinned (`shrink-0` + test id) at the bottom of the viewport-tall column.
  */
 describe("chat landing stats row contract", () => {
   it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(
-    "%s still renders the activity stats row",
+    "%s still pins the activity stats row",
     (filename) => {
       const source = readFileSync(
         join(import.meta.dirname, "..", filename),
@@ -20,6 +21,9 @@ describe("chat landing stats row contract", () => {
       expect(source).toContain("buildActivityStats");
       expect(source).toContain("hasReportableActivity");
       expect(source).toContain("stats.map");
+      expect(source).toContain('data-testid="landing-activity-stats"');
+      expect(source).toContain("shrink-0");
+      expect(source).toContain("min-w-0");
     },
   );
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The activity/stats row must stay on the landing composition so the first
+ * viewport still answers "what happened while I was gone". Clamping the
+ * selected-coworker block must not delete that row.
+ */
+describe("chat landing stats row contract", () => {
+  it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(
+    "%s still renders the activity stats row",
+    (filename) => {
+      const source = readFileSync(
+        join(import.meta.dirname, "..", filename),
+        "utf8",
+      );
+
+      expect(source).toContain("buildActivityStats");
+      expect(source).toContain("hasReportableActivity");
+      expect(source).toContain("stats.map");
+    },
+  );
+});

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -33,6 +33,30 @@ describe("CoworkerStrip", () => {
     cleanup();
   });
 
+  it("keeps the scrollport viewport-bounded so the w-max track cannot widen parents", () => {
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "a", name: "A" }),
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "b", name: "B" }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+      />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    expect(scroll.className).toMatch(/w-full/);
+    expect(scroll.className).toMatch(/min-w-0/);
+    expect(scroll.className).toMatch(/max-w-full/);
+    expect(scroll.className).toMatch(/overflow-x-auto/);
+
+    const track = screen.getByTestId("coworker-strip-track");
+    expect(track.className).toMatch(/w-max/);
+  });
+
   it("shows every coworker name and specialty in the DOM", () => {
     const coworkers = [
       buildStripCoworker({
@@ -67,23 +91,6 @@ describe("CoworkerStrip", () => {
     for (const title of ["Project Manager", "Research", "Data"]) {
       expect(screen.getByText(title)).toBeInTheDocument();
     }
-  });
-
-  it("uses a horizontally scrollable overflow container", () => {
-    render(
-      <CoworkerStrip
-        centerOnId="elena"
-        coworkers={[
-          buildStripCoworker({ id: "elena", name: "Elena" }),
-          buildStripCoworker({ id: "hannah", name: "Hannah", title: "Ops" }),
-        ]}
-        onSelect={vi.fn()}
-        selectedId="elena"
-      />,
-    );
-
-    const scroll = screen.getByTestId("coworker-strip-scroll");
-    expect(scroll.className).toMatch(/overflow-x-auto/);
   });
 
   it("keeps a data hook for the centered coworker", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -161,4 +161,68 @@ describe("CoworkerStrip", () => {
       }),
     ).toHaveAttribute("aria-selected", "false");
   });
+
+  it("reserves two title lines on every chip so 1-line vs 2-line captions cannot resize the row", () => {
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({
+            id: "elena",
+            name: "Elena",
+            title: "Strategy",
+          }),
+          buildStripCoworker({
+            id: "pheme",
+            name: "Pheme",
+            title: "Communications and media outreach",
+          }),
+          buildStripCoworker({
+            id: "deckster",
+            name: "Deckster",
+            title: null,
+          }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+      />,
+    );
+
+    const titles = screen.getAllByTestId("coworker-strip-title");
+    expect(titles).toHaveLength(3);
+
+    for (const title of titles) {
+      expect(title.className).toMatch(/line-clamp-2/);
+      expect(title.className).toMatch(/min-h-\[2lh\]/);
+    }
+
+    expect(titles[0]).toHaveTextContent("Strategy");
+    expect(titles[1]).toHaveTextContent("Communications and media outreach");
+    // Empty title stays mounted (nbsp) so chip height matches the others.
+    expect(titles[2]?.textContent).toBe("\u00a0");
+  });
+
+  it("keeps the same title min-height class in compact size", () => {
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "elena", name: "Elena", title: "Ops" }),
+          buildStripCoworker({
+            id: "pheme",
+            name: "Pheme",
+            title: "Long specialty that wraps",
+          }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+        size="compact"
+      />,
+    );
+
+    for (const title of screen.getAllByTestId("coworker-strip-title")) {
+      expect(title.className).toMatch(/min-h-\[2lh\]/);
+      expect(title.className).toMatch(/line-clamp-2/);
+    }
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { StripCoworker } from "../coworker-strip.client";
@@ -13,14 +14,6 @@ vi.mock("next/image", () => ({
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, values?: Record<string, unknown>) =>
     values ? `${key}:${JSON.stringify(values)}` : key,
-}));
-
-vi.mock("../use-open-coworker-room", () => ({
-  useOpenCoworkerRoom: () => ({
-    isPending: false,
-    openCoworkerRoom: vi.fn(),
-    openingId: null,
-  }),
 }));
 
 import { CoworkerStrip } from "../coworker-strip.client";
@@ -41,12 +34,12 @@ describe("CoworkerStrip", () => {
   });
 
   it("shows every coworker name and specialty in the DOM", () => {
-    const featured = buildStripCoworker({
-      id: "elena",
-      name: "Elena",
-      title: "Project Manager",
-    });
-    const others = [
+    const coworkers = [
+      buildStripCoworker({
+        id: "elena",
+        name: "Elena",
+        title: "Project Manager",
+      }),
       buildStripCoworker({
         id: "hannah",
         name: "Hannah",
@@ -59,7 +52,13 @@ describe("CoworkerStrip", () => {
       }),
     ];
 
-    render(<CoworkerStrip featured={featured} others={others} />);
+    render(
+      <CoworkerStrip
+        coworkers={coworkers}
+        onSelect={vi.fn()}
+        selectedId="elena"
+      />,
+    );
 
     for (const name of ["Elena", "Hannah", "Alex"]) {
       expect(screen.getByText(name)).toBeInTheDocument();
@@ -70,18 +69,67 @@ describe("CoworkerStrip", () => {
   });
 
   it("uses a horizontally scrollable overflow container", () => {
-    const featured = buildStripCoworker({ id: "elena", name: "Elena" });
-
     render(
       <CoworkerStrip
-        featured={featured}
-        others={[
+        coworkers={[
+          buildStripCoworker({ id: "elena", name: "Elena" }),
           buildStripCoworker({ id: "hannah", name: "Hannah", title: "Ops" }),
         ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
       />,
     );
 
     const scroll = screen.getByTestId("coworker-strip-scroll");
     expect(scroll.className).toMatch(/overflow-x-auto/);
+  });
+
+  it("selects a coworker on tap without opening a room", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <CoworkerStrip
+        coworkers={[
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "hannah", name: "Hannah", title: "Ops" }),
+        ]}
+        onSelect={onSelect}
+        selectedId="elena"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("hannah");
+  });
+
+  it("marks the selected coworker as aria-selected", () => {
+    render(
+      <CoworkerStrip
+        coworkers={[
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "hannah", name: "Hannah" }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="hannah"
+      />,
+    );
+
+    expect(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Elena"}',
+      }),
+    ).toHaveAttribute("aria-selected", "false");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -54,6 +54,7 @@ describe("CoworkerStrip", () => {
 
     render(
       <CoworkerStrip
+        centerOnId="elena"
         coworkers={coworkers}
         onSelect={vi.fn()}
         selectedId="elena"
@@ -71,6 +72,7 @@ describe("CoworkerStrip", () => {
   it("uses a horizontally scrollable overflow container", () => {
     render(
       <CoworkerStrip
+        centerOnId="elena"
         coworkers={[
           buildStripCoworker({ id: "elena", name: "Elena" }),
           buildStripCoworker({ id: "hannah", name: "Hannah", title: "Ops" }),
@@ -84,12 +86,31 @@ describe("CoworkerStrip", () => {
     expect(scroll.className).toMatch(/overflow-x-auto/);
   });
 
+  it("keeps a data hook for the centered coworker", () => {
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "a", name: "A" }),
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "b", name: "B" }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+      />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    expect(scroll.querySelector('[data-coworker-id="elena"]')).toBeTruthy();
+  });
+
   it("selects a coworker on tap without opening a room", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
 
     render(
       <CoworkerStrip
+        centerOnId="elena"
         coworkers={[
           buildStripCoworker({ id: "elena", name: "Elena" }),
           buildStripCoworker({ id: "hannah", name: "Hannah", title: "Ops" }),
@@ -112,6 +133,7 @@ describe("CoworkerStrip", () => {
   it("marks the selected coworker as aria-selected", () => {
     render(
       <CoworkerStrip
+        centerOnId="elena"
         coworkers={[
           buildStripCoworker({ id: "elena", name: "Elena" }),
           buildStripCoworker({ id: "hannah", name: "Hannah" }),

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { StripCoworker } from "../coworker-strip.client";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+    values ? `${key}:${JSON.stringify(values)}` : key,
+}));
+
+vi.mock("../use-open-coworker-room", () => ({
+  useOpenCoworkerRoom: () => ({
+    isPending: false,
+    openCoworkerRoom: vi.fn(),
+    openingId: null,
+  }),
+}));
+
+import { CoworkerStrip } from "../coworker-strip.client";
+
+function buildStripCoworker(
+  overrides: Partial<StripCoworker> & Pick<StripCoworker, "id" | "name">,
+): StripCoworker {
+  return {
+    imageUrl: null,
+    title: null,
+    ...overrides,
+  };
+}
+
+describe("CoworkerStrip", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows every coworker name and specialty in the DOM", () => {
+    const featured = buildStripCoworker({
+      id: "elena",
+      name: "Elena",
+      title: "Project Manager",
+    });
+    const others = [
+      buildStripCoworker({
+        id: "hannah",
+        name: "Hannah",
+        title: "Research",
+      }),
+      buildStripCoworker({
+        id: "alex",
+        name: "Alex",
+        title: "Data",
+      }),
+    ];
+
+    render(<CoworkerStrip featured={featured} others={others} />);
+
+    for (const name of ["Elena", "Hannah", "Alex"]) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+    for (const title of ["Project Manager", "Research", "Data"]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+  });
+
+  it("uses a horizontally scrollable overflow container", () => {
+    const featured = buildStripCoworker({ id: "elena", name: "Elena" });
+
+    render(
+      <CoworkerStrip
+        featured={featured}
+        others={[
+          buildStripCoworker({ id: "hannah", name: "Hannah", title: "Ops" }),
+        ]}
+      />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    expect(scroll.className).toMatch(/overflow-x-auto/);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -6,7 +6,6 @@ import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 import {
   buildActivityStats,
   clampLandingDescription,
-  hasReportableActivity,
   LANDING_DESCRIPTION_MAX_CHARS,
   orderStripCoworkers,
   resolveFeaturedCoworker,
@@ -213,9 +212,13 @@ describe("orderStripCoworkers", () => {
 });
 
 describe("buildActivityStats", () => {
-  it("omits every zero metric in a personal workspace", () => {
+  it("still emits zero chips in a personal workspace with no activity", () => {
     const stats = buildActivityStats(buildSummary(), false, fakeTranslator);
-    expect(stats).toEqual([]);
+    expect(stats).toEqual([
+      'stats.completed:{"count":0}',
+      'stats.worked:{"minutes":0}',
+      'stats.awaiting:{"count":0}',
+    ]);
   });
 
   it("lists completed, worked, and awaiting in display order", () => {
@@ -235,16 +238,26 @@ describe("buildActivityStats", () => {
   it("keeps the teammates chip at zero inside an organization", () => {
     // "what my teammates added" is a question the row should answer, not omit.
     const stats = buildActivityStats(buildSummary(), true, fakeTranslator);
-    expect(stats).toEqual(['stats.byTeammates:{"count":0}']);
+    expect(stats).toEqual([
+      'stats.completed:{"count":0}',
+      'stats.worked:{"minutes":0}',
+      'stats.awaiting:{"count":0}',
+      'stats.byTeammates:{"count":0}',
+    ]);
   });
 
-  it("returns nothing when the summary could not be loaded", () => {
-    expect(buildActivityStats(null, true, fakeTranslator)).toEqual([]);
+  it("still emits zero chips when the summary could not be loaded", () => {
+    expect(buildActivityStats(null, true, fakeTranslator)).toEqual([
+      'stats.completed:{"count":0}',
+      'stats.worked:{"minutes":0}',
+      'stats.awaiting:{"count":0}',
+      'stats.byTeammates:{"count":0}',
+    ]);
   });
 
   it("still lists metrics when lastVisitAt is null (no sessions)", () => {
     // Window is session-derived; null lastVisitAt only means no sessions, not
-    // "hide chips". Chips follow non-zero metrics only.
+    // "hide chips". Chips always render, including zeros for idle metrics.
     const stats = buildActivityStats(
       buildSummary({
         awaitingInput: 3,
@@ -258,26 +271,8 @@ describe("buildActivityStats", () => {
     );
     expect(stats).toEqual([
       'stats.completed:{"count":2}',
+      'stats.worked:{"minutes":0}',
       'stats.awaiting:{"count":3}',
     ]);
-  });
-});
-
-describe("hasReportableActivity", () => {
-  it("is false for a failed summary", () => {
-    expect(hasReportableActivity(null)).toBe(false);
-  });
-
-  it("is false for a brand-new account with nothing to report", () => {
-    expect(hasReportableActivity(buildSummary())).toBe(false);
-  });
-
-  it.each([
-    ["completed", { completed: 1 }],
-    ["workedMinutes", { workedMinutes: 1 }],
-    ["awaitingInput", { awaitingInput: 1 }],
-    ["createdByOtherHumans", { createdByOtherHumans: 1 }],
-  ])("is true when %s is non-zero", (_label, overrides) => {
-    expect(hasReportableActivity(buildSummary(overrides))).toBe(true);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -180,6 +180,18 @@ describe("toStripCoworker", () => {
     expect(strip.imageUrl).toBe(jamalUrl);
   });
 
+  it("keeps avatars from any *.serviceplan-agents.com subdomain", () => {
+    const fooUrl = "https://foo.serviceplan-agents.com/images/maya.webp";
+    const strip = toStripCoworker(
+      buildCoworker({
+        id: "maya-id",
+        slug: "maya",
+        avatar: fooUrl,
+      }),
+    );
+    expect(strip.imageUrl).toBe(fooUrl);
+  });
+
   it("keeps .webp on already-allowed blob hosts", () => {
     const blobWebp =
       "https://yhpsw8jlcoagsrkq.public.blob.vercel-storage.com/coworkers/maya.webp";

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -17,8 +17,8 @@ import {
 
 function buildCoworker(overrides: Partial<Coworker> & { id: string }) {
   return {
-    avatar: null,
-    caption: null,
+    avatar: undefined,
+    caption: undefined,
     description: "",
     name: overrides.id,
     slug: overrides.id,

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -166,6 +166,43 @@ describe("toStripCoworker", () => {
     );
     expect(strip.title).toBeNull();
   });
+
+  it("keeps Serviceplan .webp avatar URLs for the strip (Jamal/Maya)", () => {
+    const jamalUrl =
+      "https://usecases.serviceplan-agents.com/images/jamal.webp";
+    const strip = toStripCoworker(
+      buildCoworker({
+        id: "jamal-id",
+        slug: "jamal",
+        avatar: jamalUrl,
+      }),
+    );
+    expect(strip.imageUrl).toBe(jamalUrl);
+  });
+
+  it("keeps .webp on already-allowed blob hosts", () => {
+    const blobWebp =
+      "https://yhpsw8jlcoagsrkq.public.blob.vercel-storage.com/coworkers/maya.webp";
+    const strip = toStripCoworker(
+      buildCoworker({
+        id: "maya-id",
+        slug: "maya",
+        avatar: blobWebp,
+      }),
+    );
+    expect(strip.imageUrl).toBe(blobWebp);
+  });
+
+  it("still nulls avatars on unknown hosts so next/image cannot crash the page", () => {
+    const strip = toStripCoworker(
+      buildCoworker({
+        id: "evil",
+        slug: "evil",
+        avatar: "https://evil.example.com/face.webp",
+      }),
+    );
+    expect(strip.imageUrl).toBeNull();
+  });
 });
 
 describe("orderStripCoworkers", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -7,8 +7,9 @@ import {
   buildActivityStats,
   featuredCoworkerRole,
   hasReportableActivity,
+  opticalCenterScrollLeft,
+  orderStripCoworkers,
   resolveFeaturedCoworker,
-  selectStripCoworkers,
   toStripCoworker,
 } from "../landing-content";
 
@@ -130,36 +131,81 @@ describe("toStripCoworker", () => {
   });
 });
 
-describe("selectStripCoworkers", () => {
+describe("orderStripCoworkers", () => {
   const featured = buildCoworker({ id: "elena", slug: "elena" });
   const others = ["a", "b", "c", "d", "e", "f", "g"].map((id) =>
     buildCoworker({ id }),
   );
 
-  it("never includes the featured coworker", () => {
-    const picked = selectStripCoworkers([featured, ...others], featured);
-    expect(picked.map((c) => c.id)).not.toContain("elena");
+  it("places the featured coworker at the exact middle for an odd count", () => {
+    // 1 featured + 4 others = 5 → index 2
+    const four = others.slice(0, 4);
+    const ordered = orderStripCoworkers([featured, ...four], featured);
+    expect(ordered.map((c) => c.id)).toEqual(["a", "b", "elena", "c", "d"]);
+    expect(ordered).toHaveLength(5);
   });
 
-  it("returns every non-featured coworker", () => {
-    const picked = selectStripCoworkers([featured, ...others], featured);
-    expect(picked.map((c) => c.id)).toEqual([
-      "a",
-      "b",
-      "c",
-      "d",
-      "e",
-      "f",
-      "g",
-    ]);
+  it("places the featured coworker left-of-centre for an even count", () => {
+    // 1 featured + 3 others = 4 → index 1 (left of the two centre slots)
+    const three = others.slice(0, 3);
+    const ordered = orderStripCoworkers([featured, ...three], featured);
+    expect(ordered.map((c) => c.id)).toEqual(["a", "elena", "b", "c"]);
+    expect(ordered).toHaveLength(4);
+  });
+
+  it("keeps every coworker — never drops for even flanks", () => {
+    const ordered = orderStripCoworkers([featured, ...others], featured);
+    expect(ordered).toHaveLength(1 + others.length);
+    expect(ordered.map((c) => c.id).sort()).toEqual(
+      ["elena", ...others.map((c) => c.id)].sort(),
+    );
+    // 8 items → index floor(7/2)=3
+    expect(ordered[3]?.id).toBe("elena");
   });
 
   it("returns an empty list when nothing is featured", () => {
-    expect(selectStripCoworkers(others, null)).toEqual([]);
+    expect(orderStripCoworkers(others, null)).toEqual([]);
   });
 
-  it("returns an empty list for a lone featured coworker", () => {
-    expect(selectStripCoworkers([featured], featured)).toEqual([]);
+  it("returns a lone featured coworker alone", () => {
+    expect(orderStripCoworkers([featured], featured).map((c) => c.id)).toEqual([
+      "elena",
+    ]);
+  });
+});
+
+describe("opticalCenterScrollLeft", () => {
+  it("centres a mid-strip child in an overflowing viewport", () => {
+    expect(
+      opticalCenterScrollLeft({
+        childOffsetLeft: 400,
+        childWidth: 100,
+        containerWidth: 200,
+        scrollWidth: 900,
+      }),
+    ).toBe(350);
+  });
+
+  it("clamps to zero when the strip fits the viewport", () => {
+    expect(
+      opticalCenterScrollLeft({
+        childOffsetLeft: 40,
+        childWidth: 80,
+        containerWidth: 400,
+        scrollWidth: 300,
+      }),
+    ).toBe(0);
+  });
+
+  it("clamps to max scroll near the end of the strip", () => {
+    expect(
+      opticalCenterScrollLeft({
+        childOffsetLeft: 800,
+        childWidth: 100,
+        containerWidth: 200,
+        scrollWidth: 900,
+      }),
+    ).toBe(700);
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -5,11 +5,11 @@ import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
 import {
   buildActivityStats,
-  featuredCoworkerRole,
   hasReportableActivity,
   opticalCenterScrollLeft,
   orderStripCoworkers,
   resolveFeaturedCoworker,
+  selectedCoworkerDescription,
   toStripCoworker,
 } from "../landing-content";
 
@@ -73,30 +73,25 @@ describe("resolveFeaturedCoworker", () => {
   });
 });
 
-describe("featuredCoworkerRole", () => {
-  const elenaPitch = "Project Manager - you can give her any task";
-
-  it("uses product copy for Elena", () => {
+describe("selectedCoworkerDescription", () => {
+  it("returns a trimmed description", () => {
     const elena = buildCoworker({
       id: "elena",
       slug: "elena",
       caption: "Strategy",
+      description: "  Turns goals into work.  ",
     });
-    expect(featuredCoworkerRole(elena, elenaPitch)).toBe(elenaPitch);
+    expect(selectedCoworkerDescription(elena)).toBe("Turns goals into work.");
   });
 
-  it("uses caption for a non-Elena featured coworker", () => {
+  it("returns null when description is empty — no caption fallback", () => {
     const hannah = buildCoworker({
       id: "hannah",
       slug: "hannah",
       caption: "Research",
+      description: "   ",
     });
-    expect(featuredCoworkerRole(hannah, elenaPitch)).toBe("Research");
-  });
-
-  it("returns null when a non-Elena featured coworker has no caption", () => {
-    const hannah = buildCoworker({ id: "hannah", slug: "hannah" });
-    expect(featuredCoworkerRole(hannah, elenaPitch)).toBeNull();
+    expect(selectedCoworkerDescription(hannah)).toBeNull();
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -9,14 +9,17 @@ import {
   hasReportableActivity,
   resolveFeaturedCoworker,
   selectStripCoworkers,
+  toStripCoworker,
 } from "../landing-content";
 
 function buildCoworker(overrides: Partial<Coworker> & { id: string }) {
   return {
     avatar: null,
     caption: null,
+    description: "",
     name: overrides.id,
     slug: overrides.id,
+    useCase: "",
     ...overrides,
   } as Coworker;
 }
@@ -96,6 +99,37 @@ describe("featuredCoworkerRole", () => {
   });
 });
 
+describe("toStripCoworker", () => {
+  it("maps a non-empty caption to title", () => {
+    const strip = toStripCoworker(
+      buildCoworker({
+        id: "hannah",
+        caption: "Research lead",
+        useCase: "Should not win",
+      }),
+    );
+    expect(strip.title).toBe("Research lead");
+  });
+
+  it("falls back to useCase when caption is empty", () => {
+    const strip = toStripCoworker(
+      buildCoworker({
+        id: "alex",
+        caption: "   ",
+        useCase: "Data analysis",
+      }),
+    );
+    expect(strip.title).toBe("Data analysis");
+  });
+
+  it("returns null title when caption and useCase are empty", () => {
+    const strip = toStripCoworker(
+      buildCoworker({ id: "blake", caption: "", useCase: "  " }),
+    );
+    expect(strip.title).toBeNull();
+  });
+});
+
 describe("selectStripCoworkers", () => {
   const featured = buildCoworker({ id: "elena", slug: "elena" });
   const others = ["a", "b", "c", "d", "e", "f", "g"].map((id) =>
@@ -103,29 +137,29 @@ describe("selectStripCoworkers", () => {
   );
 
   it("never includes the featured coworker", () => {
-    const picked = selectStripCoworkers([featured, ...others], featured, 6);
+    const picked = selectStripCoworkers([featured, ...others], featured);
     expect(picked.map((c) => c.id)).not.toContain("elena");
   });
 
-  it("drops the odd one out so the flanks balance", () => {
-    // Five candidates, max six: an odd count would shove the featured face off
-    // the optical centre, so it takes four.
-    const five = others.slice(0, 5);
-    const picked = selectStripCoworkers([featured, ...five], featured, 6);
-    expect(picked).toHaveLength(4);
-  });
-
-  it("caps at max even when more coworkers exist", () => {
-    const picked = selectStripCoworkers([featured, ...others], featured, 4);
-    expect(picked).toHaveLength(4);
+  it("returns every non-featured coworker", () => {
+    const picked = selectStripCoworkers([featured, ...others], featured);
+    expect(picked.map((c) => c.id)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+    ]);
   });
 
   it("returns an empty list when nothing is featured", () => {
-    expect(selectStripCoworkers(others, null, 6)).toEqual([]);
+    expect(selectStripCoworkers(others, null)).toEqual([]);
   });
 
-  it("never returns a negative slice for a lone coworker", () => {
-    expect(selectStripCoworkers([featured], featured, 6)).toEqual([]);
+  it("returns an empty list for a lone featured coworker", () => {
+    expect(selectStripCoworkers([featured], featured)).toEqual([]);
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -8,7 +8,6 @@ import {
   clampLandingDescription,
   hasReportableActivity,
   LANDING_DESCRIPTION_MAX_CHARS,
-  opticalCenterScrollLeft,
   orderStripCoworkers,
   resolveFeaturedCoworker,
   selectedCoworkerCaption,
@@ -210,41 +209,6 @@ describe("orderStripCoworkers", () => {
     expect(orderStripCoworkers([featured], featured).map((c) => c.id)).toEqual([
       "elena",
     ]);
-  });
-});
-
-describe("opticalCenterScrollLeft", () => {
-  it("centres a mid-strip child in an overflowing viewport", () => {
-    expect(
-      opticalCenterScrollLeft({
-        childOffsetLeft: 400,
-        childWidth: 100,
-        containerWidth: 200,
-        scrollWidth: 900,
-      }),
-    ).toBe(350);
-  });
-
-  it("clamps to zero when the strip fits the viewport", () => {
-    expect(
-      opticalCenterScrollLeft({
-        childOffsetLeft: 40,
-        childWidth: 80,
-        containerWidth: 400,
-        scrollWidth: 300,
-      }),
-    ).toBe(0);
-  });
-
-  it("clamps to max scroll near the end of the strip", () => {
-    expect(
-      opticalCenterScrollLeft({
-        childOffsetLeft: 800,
-        childWidth: 100,
-        containerWidth: 200,
-        scrollWidth: 900,
-      }),
-    ).toBe(700);
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -5,10 +5,13 @@ import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
 import {
   buildActivityStats,
+  clampLandingDescription,
   hasReportableActivity,
+  LANDING_DESCRIPTION_MAX_CHARS,
   opticalCenterScrollLeft,
   orderStripCoworkers,
   resolveFeaturedCoworker,
+  selectedCoworkerCaption,
   selectedCoworkerDescription,
   toStripCoworker,
 } from "../landing-content";
@@ -73,6 +76,28 @@ describe("resolveFeaturedCoworker", () => {
   });
 });
 
+describe("selectedCoworkerCaption", () => {
+  it("returns a trimmed caption", () => {
+    expect(
+      selectedCoworkerCaption(
+        buildCoworker({ id: "elena", caption: "  Strategy  " }),
+      ),
+    ).toBe("Strategy");
+  });
+
+  it("returns null when caption is empty — no useCase fallback", () => {
+    expect(
+      selectedCoworkerCaption(
+        buildCoworker({
+          id: "hannah",
+          caption: "   ",
+          useCase: "Research briefs",
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
 describe("selectedCoworkerDescription", () => {
   it("returns a trimmed description", () => {
     const elena = buildCoworker({
@@ -92,6 +117,25 @@ describe("selectedCoworkerDescription", () => {
       description: "   ",
     });
     expect(selectedCoworkerDescription(hannah)).toBeNull();
+  });
+});
+
+describe("clampLandingDescription", () => {
+  it("leaves short copy untouched", () => {
+    expect(clampLandingDescription("Short pitch.")).toEqual({
+      isTruncated: false,
+      preview: "Short pitch.",
+    });
+  });
+
+  it("truncates long copy near the character budget with an ellipsis", () => {
+    const long = "word ".repeat(50).trim();
+    const result = clampLandingDescription(long);
+    expect(result.isTruncated).toBe(true);
+    expect(result.preview.endsWith("…")).toBe(true);
+    expect(result.preview.length).toBeLessThanOrEqual(
+      LANDING_DESCRIPTION_MAX_CHARS + 1,
+    );
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -44,16 +44,9 @@ function blockOrder(): string[] {
   return [
     "landing-selected-name",
     "landing-selected-caption",
-    "landing-start-chat",
     "landing-selected-description",
-  ].filter((id) => {
-    const node = screen.queryByTestId(id);
-    if (!node) {
-      return false;
-    }
-    // Caption slot is always mounted; treat empty nbsp as "present".
-    return true;
-  });
+    "landing-start-chat",
+  ].filter((id) => screen.queryByTestId(id) !== null);
 }
 
 describe("LandingCoworkerPicker", () => {
@@ -82,7 +75,7 @@ describe("LandingCoworkerPicker", () => {
       name: "Deckster",
       slug: "deckster",
       caption: undefined,
-      description: "Deckster builds decks.",
+      description: "",
     }),
   ];
 
@@ -130,7 +123,7 @@ describe("LandingCoworkerPicker", () => {
     expect(optionIds).toEqual(["a", "b", "elena", "c", "d"]);
   });
 
-  it("orders name, caption slot, Start chat, then description", () => {
+  it("orders name, caption, description, then Start chat", () => {
     render(
       <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
@@ -138,22 +131,22 @@ describe("LandingCoworkerPicker", () => {
     expect(blockOrder()).toEqual([
       "landing-selected-name",
       "landing-selected-caption",
-      "landing-start-chat",
       "landing-selected-description",
+      "landing-start-chat",
     ]);
 
     const name = screen.getByTestId("landing-selected-name");
     const caption = screen.getByTestId("landing-selected-caption");
-    const cta = screen.getByTestId("landing-start-chat");
     const description = screen.getByTestId("landing-selected-description");
+    const cta = screen.getByTestId("landing-start-chat");
 
     expect(name.compareDocumentPosition(caption)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(caption.compareDocumentPosition(cta)).toBe(
+    expect(caption.compareDocumentPosition(description)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(cta.compareDocumentPosition(description)).toBe(
+    expect(description.compareDocumentPosition(cta)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
@@ -175,7 +168,6 @@ describe("LandingCoworkerPicker", () => {
       }),
     );
 
-    // Slot stays mounted with reserved height; empty caption is nbsp only.
     expect(screen.getByTestId("landing-selected-caption").className).toMatch(
       /min-h-/,
     );
@@ -188,9 +180,71 @@ describe("LandingCoworkerPicker", () => {
     ).toBeTruthy();
   });
 
-  it("top-aligns the selected stack so caption/description cannot own CTA position", async () => {
+  it("reserves collapsed description height above Start chat including empty", async () => {
     const user = userEvent.setup();
 
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const description = screen.getByTestId("landing-selected-description");
+    const text = screen.getByTestId("landing-selected-description-text");
+    const toggleSlot = screen.getByTestId("landing-description-toggle-slot");
+
+    expect(text.className).toMatch(/line-clamp-3/);
+    expect(text.className).toMatch(/min-h-\[3lh\]/);
+    expect(toggleSlot.className).toMatch(/min-h-\[1\.25rem\]/);
+    expect(
+      description.compareDocumentPosition(
+        screen.getByTestId("landing-start-chat"),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Deckster"}',
+      }),
+    );
+
+    // Empty description still mounts the reserved slot (nbsp + min-height).
+    expect(
+      screen.getByTestId("landing-selected-description"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("landing-selected-description-text").textContent,
+    ).toBe("\u00a0");
+    expect(
+      screen.getByTestId("landing-selected-description-text").className,
+    ).toMatch(/min-h-\[3lh\]/);
+    expect(
+      screen.getByTestId("landing-description-toggle-slot").className,
+    ).toMatch(/min-h-\[1\.25rem\]/);
+    expect(
+      screen.queryByTestId("landing-description-toggle"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    );
+
+    // Long collapsed copy keeps the same reserve classes above the CTA.
+    expect(
+      screen.getByTestId("landing-selected-description-text").className,
+    ).toMatch(/min-h-\[3lh\]/);
+    expect(
+      screen.getByTestId("landing-description-toggle"),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId("landing-selected-description")
+        .compareDocumentPosition(screen.getByTestId("landing-start-chat")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("top-aligns the selected stack with description above Start chat", () => {
     render(
       <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
@@ -207,60 +261,13 @@ describe("LandingCoworkerPicker", () => {
     expect(stack.contains(screen.getByTestId("landing-selected-caption"))).toBe(
       true,
     );
-    expect(stack.contains(screen.getByTestId("landing-start-chat"))).toBe(true);
     expect(
       stack.contains(screen.getByTestId("landing-selected-description")),
-    ).toBe(false);
-
-    const cta = screen.getByTestId("landing-start-chat");
-    const descriptionBefore = screen.getByTestId(
-      "landing-selected-description",
-    );
-    expect(cta.compareDocumentPosition(descriptionBefore)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-
-    // Empty caption (Deckster) must keep CTA after the reserved caption slot
-    // and must not pull description into the CTA stack.
-    await user.click(
-      screen.getByRole("option", {
-        name: 'team.select:{"name":"Deckster"}',
-      }),
-    );
-    expect(
-      screen
-        .getByTestId("landing-selected-cta-stack")
-        .contains(screen.getByTestId("landing-start-chat")),
     ).toBe(true);
-    expect(
-      screen
-        .getByTestId("landing-start-chat")
-        .compareDocumentPosition(
-          screen.getByTestId("landing-selected-description"),
-        ) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-
-    // Long description (Hannah) still sits below CTA — not inside the stack.
-    await user.click(
-      screen.getByRole("option", {
-        name: 'team.select:{"name":"Hannah"}',
-      }),
-    );
-    expect(
-      screen
-        .getByTestId("landing-selected-cta-stack")
-        .contains(screen.getByTestId("landing-selected-description")),
-    ).toBe(false);
-    expect(
-      screen
-        .getByTestId("landing-start-chat")
-        .compareDocumentPosition(
-          screen.getByTestId("landing-selected-description"),
-        ) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+    expect(stack.contains(screen.getByTestId("landing-start-chat"))).toBe(true);
   });
 
-  it("keeps Start chat above description so long copy cannot shift the CTA", async () => {
+  it("keeps description above Start chat across selection", async () => {
     const user = userEvent.setup();
 
     render(
@@ -268,9 +275,9 @@ describe("LandingCoworkerPicker", () => {
     );
 
     const cta = screen.getByTestId("landing-start-chat");
-    const before = cta.compareDocumentPosition(
-      screen.getByTestId("landing-selected-description"),
-    );
+    const before = screen
+      .getByTestId("landing-selected-description")
+      .compareDocumentPosition(cta);
 
     await user.click(
       screen.getByRole("option", {
@@ -278,15 +285,18 @@ describe("LandingCoworkerPicker", () => {
       }),
     );
 
-    const description = screen.getByTestId("landing-selected-description");
-    expect(cta.compareDocumentPosition(description)).toBe(before);
+    expect(
+      screen
+        .getByTestId("landing-selected-description")
+        .compareDocumentPosition(screen.getByTestId("landing-start-chat")),
+    ).toBe(before);
     expect(before & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(
       screen.getByTestId("landing-description-toggle"),
     ).toBeInTheDocument();
   });
 
-  it("clamps long description behind a more/less control", async () => {
+  it("clamps long description behind a more/less control above Start chat", async () => {
     const user = userEvent.setup();
     const long =
       "Hannah researches deeply across many sources and produces concise briefs for the team. ".repeat(
@@ -314,15 +324,28 @@ describe("LandingCoworkerPicker", () => {
       "landing-selected-description",
     ).textContent;
     expect(collapsed?.includes("…")).toBe(true);
+    expect(
+      screen.getByTestId("landing-selected-description-text").className,
+    ).toMatch(/min-h-\[3lh\]/);
 
     await user.click(toggle);
     expect(toggle).toHaveTextContent("team.showLess");
     expect(
       screen.getByTestId("landing-selected-description").textContent,
     ).toContain(long.trim());
+    // Expanded copy drops the collapsed reserve so More can grow downward.
+    expect(
+      screen.getByTestId("landing-selected-description-text").className,
+    ).not.toMatch(/min-h-\[3lh\]/);
+
+    await user.click(toggle);
+    expect(toggle).toHaveTextContent("team.showMore");
+    expect(
+      screen.getByTestId("landing-selected-description-text").className,
+    ).toMatch(/min-h-\[3lh\]/);
   });
 
-  it("omits the description block when description is empty", () => {
+  it("still mounts the description slot when description is empty", () => {
     render(
       <LandingCoworkerPicker
         coworkers={[
@@ -341,11 +364,12 @@ describe("LandingCoworkerPicker", () => {
     expect(blockOrder()).toEqual([
       "landing-selected-name",
       "landing-selected-caption",
+      "landing-selected-description",
       "landing-start-chat",
     ]);
     expect(
-      screen.queryByTestId("landing-selected-description"),
-    ).not.toBeInTheDocument();
+      screen.getByTestId("landing-selected-description-text").textContent,
+    ).toBe("\u00a0");
   });
 
   it("updates caption, description, and Start chat when a strip face is tapped", async () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -30,8 +30,8 @@ import { LandingCoworkerPicker } from "../landing-coworker-picker.client";
 
 function buildCoworker(overrides: Partial<Coworker> & { id: string }) {
   return {
-    avatar: null,
-    caption: null,
+    avatar: undefined,
+    caption: undefined,
     description: "",
     name: overrides.id,
     slug: overrides.id,
@@ -81,7 +81,7 @@ describe("LandingCoworkerPicker", () => {
       id: "deckster",
       name: "Deckster",
       slug: "deckster",
-      caption: null,
+      caption: undefined,
       description: "Deckster builds decks.",
     }),
   ];

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -52,12 +52,14 @@ describe("LandingCoworkerPicker", () => {
       name: "Elena",
       slug: "elena",
       caption: "Strategy",
+      description: "Elena turns goals into planned work.",
     }),
     buildCoworker({
       id: "hannah",
       name: "Hannah",
       slug: "hannah",
       caption: "Research",
+      description: "Hannah digs into sources and briefs.",
     }),
   ];
 
@@ -76,11 +78,7 @@ describe("LandingCoworkerPicker", () => {
     ];
 
     render(
-      <LandingCoworkerPicker
-        coworkers={catalog}
-        elenaRole="Project Manager - you can give her any task"
-        initialSelectedId="elena"
-      />,
+      <LandingCoworkerPicker coworkers={catalog} initialSelectedId="elena" />,
     );
 
     const optionIds = screen
@@ -90,13 +88,9 @@ describe("LandingCoworkerPicker", () => {
     expect(optionIds).toEqual(["a", "b", "elena", "c", "d"]);
   });
 
-  it("defaults selection to the initial coworker and binds Start chat to them", () => {
+  it("shows the selected coworker description above Start chat", () => {
     render(
-      <LandingCoworkerPicker
-        coworkers={coworkers}
-        elenaRole="Project Manager - you can give her any task"
-        initialSelectedId="elena"
-      />,
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
 
     expect(
@@ -105,8 +99,10 @@ describe("LandingCoworkerPicker", () => {
       }),
     ).toHaveAttribute("aria-selected", "true");
     expect(
-      screen.getByText("Project Manager - you can give her any task"),
-    ).toBeInTheDocument();
+      screen.getByTestId("landing-selected-description"),
+    ).toHaveTextContent("Elena turns goals into planned work.");
+    // Strip chips still show the short caption.
+    expect(screen.getByText("Strategy")).toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: 'cta.button:{"name":"Elena"}',
@@ -114,15 +110,33 @@ describe("LandingCoworkerPicker", () => {
     ).toBeInTheDocument();
   });
 
-  it("updates featured copy and Start chat target when a strip face is tapped", async () => {
+  it("omits the description paragraph when description is empty", () => {
+    render(
+      <LandingCoworkerPicker
+        coworkers={[
+          buildCoworker({
+            id: "elena",
+            name: "Elena",
+            slug: "elena",
+            caption: "Strategy",
+            description: "   ",
+          }),
+        ]}
+        initialSelectedId="elena"
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("landing-selected-description"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Strategy")).toBeInTheDocument();
+  });
+
+  it("updates description and Start chat when a strip face is tapped", async () => {
     const user = userEvent.setup();
 
     render(
-      <LandingCoworkerPicker
-        coworkers={coworkers}
-        elenaRole="Project Manager - you can give her any task"
-        initialSelectedId="elena"
-      />,
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
 
     await user.click(
@@ -132,7 +146,11 @@ describe("LandingCoworkerPicker", () => {
     );
 
     expect(openCoworkerRoom).not.toHaveBeenCalled();
-    expect(screen.getAllByText("Research").length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByTestId("landing-selected-description"),
+    ).toHaveTextContent("Hannah digs into sources and briefs.");
+    // Caption remains on the strip chip.
+    expect(screen.getByText("Research")).toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: 'cta.button:{"name":"Hannah"}',
@@ -144,11 +162,7 @@ describe("LandingCoworkerPicker", () => {
     const user = userEvent.setup();
 
     render(
-      <LandingCoworkerPicker
-        coworkers={coworkers}
-        elenaRole="Project Manager - you can give her any task"
-        initialSelectedId="elena"
-      />,
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
 
     await user.click(

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -46,7 +46,14 @@ function blockOrder(): string[] {
     "landing-selected-caption",
     "landing-start-chat",
     "landing-selected-description",
-  ].filter((id) => screen.queryByTestId(id));
+  ].filter((id) => {
+    const node = screen.queryByTestId(id);
+    if (!node) {
+      return false;
+    }
+    // Caption slot is always mounted; treat empty nbsp as "present".
+    return true;
+  });
 }
 
 describe("LandingCoworkerPicker", () => {
@@ -70,7 +77,34 @@ describe("LandingCoworkerPicker", () => {
       caption: "Research",
       description: `Hannah digs into sources and briefs. ${"detail ".repeat(40)}`,
     }),
+    buildCoworker({
+      id: "deckster",
+      name: "Deckster",
+      slug: "deckster",
+      caption: null,
+      description: "Deckster builds decks.",
+    }),
   ];
+
+  it("bounds the picker and featured CTA so the strip cannot widen them", () => {
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const picker = screen.getByTestId("landing-coworker-picker");
+    expect(picker.className).toMatch(/w-full/);
+    expect(picker.className).toMatch(/min-w-0/);
+    expect(picker.className).toMatch(/max-w-full/);
+
+    const selected = screen.getByTestId("landing-selected-block");
+    expect(selected.className).toMatch(/max-w-xs/);
+    expect(selected.className).toMatch(/w-full/);
+    expect(selected.className).toMatch(/min-w-0/);
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    expect(scroll.className).toMatch(/min-w-0/);
+    expect(scroll.className).toMatch(/overflow-x-auto/);
+  });
 
   it("renders Elena in the middle of the full strip order", () => {
     const catalog = [
@@ -96,7 +130,7 @@ describe("LandingCoworkerPicker", () => {
     expect(optionIds).toEqual(["a", "b", "elena", "c", "d"]);
   });
 
-  it("orders name, caption, Start chat, then description", () => {
+  it("orders name, caption slot, Start chat, then description", () => {
     render(
       <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
@@ -122,6 +156,36 @@ describe("LandingCoworkerPicker", () => {
     expect(cta.compareDocumentPosition(description)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+  });
+
+  it("keeps a reserved caption slot so omitting caption cannot remove CTA spacing", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const caption = screen.getByTestId("landing-selected-caption");
+    expect(caption.className).toMatch(/min-h-/);
+    expect(caption).toHaveTextContent("Strategy");
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Deckster"}',
+      }),
+    );
+
+    // Slot stays mounted with reserved height; empty caption is nbsp only.
+    expect(screen.getByTestId("landing-selected-caption").className).toMatch(
+      /min-h-/,
+    );
+    expect(screen.getByTestId("landing-start-chat")).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId("landing-selected-caption")
+        .compareDocumentPosition(screen.getByTestId("landing-start-chat")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("keeps Start chat above description so long copy cannot shift the CTA", async () => {
@@ -186,7 +250,7 @@ describe("LandingCoworkerPicker", () => {
     ).toContain(long.trim());
   });
 
-  it("omits caption and description blocks when those fields are empty", () => {
+  it("omits the description block when description is empty", () => {
     render(
       <LandingCoworkerPicker
         coworkers={[
@@ -194,7 +258,7 @@ describe("LandingCoworkerPicker", () => {
             id: "elena",
             name: "Elena",
             slug: "elena",
-            caption: "   ",
+            caption: "Strategy",
             description: "",
           }),
         ]}
@@ -204,11 +268,9 @@ describe("LandingCoworkerPicker", () => {
 
     expect(blockOrder()).toEqual([
       "landing-selected-name",
+      "landing-selected-caption",
       "landing-start-chat",
     ]);
-    expect(
-      screen.queryByTestId("landing-selected-caption"),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("landing-selected-description"),
     ).not.toBeInTheDocument();

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -188,6 +188,78 @@ describe("LandingCoworkerPicker", () => {
     ).toBeTruthy();
   });
 
+  it("top-aligns the selected stack so caption/description cannot own CTA position", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const selected = screen.getByTestId("landing-selected-block");
+    expect(selected.className).toMatch(/justify-start/);
+    expect(selected.className).not.toMatch(/justify-center/);
+
+    const stack = screen.getByTestId("landing-selected-cta-stack");
+    expect(stack.className).toMatch(/shrink-0/);
+    expect(stack.contains(screen.getByTestId("landing-selected-name"))).toBe(
+      true,
+    );
+    expect(stack.contains(screen.getByTestId("landing-selected-caption"))).toBe(
+      true,
+    );
+    expect(stack.contains(screen.getByTestId("landing-start-chat"))).toBe(true);
+    expect(
+      stack.contains(screen.getByTestId("landing-selected-description")),
+    ).toBe(false);
+
+    const cta = screen.getByTestId("landing-start-chat");
+    const descriptionBefore = screen.getByTestId(
+      "landing-selected-description",
+    );
+    expect(cta.compareDocumentPosition(descriptionBefore)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+
+    // Empty caption (Deckster) must keep CTA after the reserved caption slot
+    // and must not pull description into the CTA stack.
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Deckster"}',
+      }),
+    );
+    expect(
+      screen
+        .getByTestId("landing-selected-cta-stack")
+        .contains(screen.getByTestId("landing-start-chat")),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("landing-start-chat")
+        .compareDocumentPosition(
+          screen.getByTestId("landing-selected-description"),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // Long description (Hannah) still sits below CTA — not inside the stack.
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    );
+    expect(
+      screen
+        .getByTestId("landing-selected-cta-stack")
+        .contains(screen.getByTestId("landing-selected-description")),
+    ).toBe(false);
+    expect(
+      screen
+        .getByTestId("landing-start-chat")
+        .compareDocumentPosition(
+          screen.getByTestId("landing-selected-description"),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("keeps Start chat above description so long copy cannot shift the CTA", async () => {
     const user = userEvent.setup();
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -61,6 +61,35 @@ describe("LandingCoworkerPicker", () => {
     }),
   ];
 
+  it("renders Elena in the middle of the full strip order", () => {
+    const catalog = [
+      buildCoworker({ id: "a", name: "A", slug: "a" }),
+      buildCoworker({ id: "b", name: "B", slug: "b" }),
+      buildCoworker({
+        id: "elena",
+        name: "Elena",
+        slug: "elena",
+        caption: "Strategy",
+      }),
+      buildCoworker({ id: "c", name: "C", slug: "c" }),
+      buildCoworker({ id: "d", name: "D", slug: "d" }),
+    ];
+
+    render(
+      <LandingCoworkerPicker
+        coworkers={catalog}
+        elenaRole="Project Manager - you can give her any task"
+        initialSelectedId="elena"
+      />,
+    );
+
+    const optionIds = screen
+      .getAllByRole("option")
+      .map((node) => node.getAttribute("data-coworker-id"));
+    // 5 coworkers → Elena at exact middle (index 2); nothing dropped.
+    expect(optionIds).toEqual(["a", "b", "elena", "c", "d"]);
+  });
+
   it("defaults selection to the initial coworker and binds Start chat to them", () => {
     render(
       <LandingCoworkerPicker

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -1,0 +1,141 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Coworker } from "@/app/chat/utils/types";
+
+const openCoworkerRoom = vi.fn();
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+    values ? `${key}:${JSON.stringify(values)}` : key,
+}));
+
+vi.mock("../use-open-coworker-room", () => ({
+  useOpenCoworkerRoom: () => ({
+    isPending: false,
+    openCoworkerRoom,
+    openingId: null,
+  }),
+}));
+
+import { LandingCoworkerPicker } from "../landing-coworker-picker.client";
+
+function buildCoworker(overrides: Partial<Coworker> & { id: string }) {
+  return {
+    avatar: null,
+    caption: null,
+    description: "",
+    name: overrides.id,
+    slug: overrides.id,
+    useCase: "",
+    ...overrides,
+  } as Coworker;
+}
+
+describe("LandingCoworkerPicker", () => {
+  afterEach(() => {
+    cleanup();
+    openCoworkerRoom.mockClear();
+  });
+
+  const coworkers = [
+    buildCoworker({
+      id: "elena",
+      name: "Elena",
+      slug: "elena",
+      caption: "Strategy",
+    }),
+    buildCoworker({
+      id: "hannah",
+      name: "Hannah",
+      slug: "hannah",
+      caption: "Research",
+    }),
+  ];
+
+  it("defaults selection to the initial coworker and binds Start chat to them", () => {
+    render(
+      <LandingCoworkerPicker
+        coworkers={coworkers}
+        elenaRole="Project Manager - you can give her any task"
+        initialSelectedId="elena"
+      />,
+    );
+
+    expect(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Elena"}',
+      }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByText("Project Manager - you can give her any task"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: 'cta.button:{"name":"Elena"}',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("updates featured copy and Start chat target when a strip face is tapped", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LandingCoworkerPicker
+        coworkers={coworkers}
+        elenaRole="Project Manager - you can give her any task"
+        initialSelectedId="elena"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    );
+
+    expect(openCoworkerRoom).not.toHaveBeenCalled();
+    expect(screen.getAllByText("Research").length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByRole("button", {
+        name: 'cta.button:{"name":"Hannah"}',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens a DM only from Start chat after selection", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LandingCoworkerPicker
+        coworkers={coworkers}
+        elenaRole="Project Manager - you can give her any task"
+        initialSelectedId="elena"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    );
+    expect(openCoworkerRoom).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: 'cta.button:{"name":"Hannah"}',
+      }),
+    );
+
+    expect(openCoworkerRoom).toHaveBeenCalledTimes(1);
+    expect(openCoworkerRoom).toHaveBeenCalledWith("hannah");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -40,6 +40,15 @@ function buildCoworker(overrides: Partial<Coworker> & { id: string }) {
   } as Coworker;
 }
 
+function blockOrder(): string[] {
+  return [
+    "landing-selected-name",
+    "landing-selected-caption",
+    "landing-start-chat",
+    "landing-selected-description",
+  ].filter((id) => screen.queryByTestId(id));
+}
+
 describe("LandingCoworkerPicker", () => {
   afterEach(() => {
     cleanup();
@@ -59,7 +68,7 @@ describe("LandingCoworkerPicker", () => {
       name: "Hannah",
       slug: "hannah",
       caption: "Research",
-      description: "Hannah digs into sources and briefs.",
+      description: `Hannah digs into sources and briefs. ${"detail ".repeat(40)}`,
     }),
   ];
 
@@ -84,33 +93,100 @@ describe("LandingCoworkerPicker", () => {
     const optionIds = screen
       .getAllByRole("option")
       .map((node) => node.getAttribute("data-coworker-id"));
-    // 5 coworkers → Elena at exact middle (index 2); nothing dropped.
     expect(optionIds).toEqual(["a", "b", "elena", "c", "d"]);
   });
 
-  it("shows the selected coworker description above Start chat", () => {
+  it("orders name, caption, Start chat, then description", () => {
     render(
       <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
 
-    expect(
-      screen.getByRole("option", {
-        name: 'team.select:{"name":"Elena"}',
-      }),
-    ).toHaveAttribute("aria-selected", "true");
-    expect(
+    expect(blockOrder()).toEqual([
+      "landing-selected-name",
+      "landing-selected-caption",
+      "landing-start-chat",
+      "landing-selected-description",
+    ]);
+
+    const name = screen.getByTestId("landing-selected-name");
+    const caption = screen.getByTestId("landing-selected-caption");
+    const cta = screen.getByTestId("landing-start-chat");
+    const description = screen.getByTestId("landing-selected-description");
+
+    expect(name.compareDocumentPosition(caption)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(caption.compareDocumentPosition(cta)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(cta.compareDocumentPosition(description)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("keeps Start chat above description so long copy cannot shift the CTA", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const cta = screen.getByTestId("landing-start-chat");
+    const before = cta.compareDocumentPosition(
       screen.getByTestId("landing-selected-description"),
-    ).toHaveTextContent("Elena turns goals into planned work.");
-    // Strip chips still show the short caption.
-    expect(screen.getByText("Strategy")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", {
-        name: 'cta.button:{"name":"Elena"}',
+    );
+
+    await user.click(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
       }),
+    );
+
+    const description = screen.getByTestId("landing-selected-description");
+    expect(cta.compareDocumentPosition(description)).toBe(before);
+    expect(before & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      screen.getByTestId("landing-description-toggle"),
     ).toBeInTheDocument();
   });
 
-  it("omits the description paragraph when description is empty", () => {
+  it("clamps long description behind a more/less control", async () => {
+    const user = userEvent.setup();
+    const long =
+      "Hannah researches deeply across many sources and produces concise briefs for the team. ".repeat(
+        4,
+      );
+
+    render(
+      <LandingCoworkerPicker
+        coworkers={[
+          buildCoworker({
+            id: "hannah",
+            name: "Hannah",
+            slug: "hannah",
+            caption: "Research",
+            description: long,
+          }),
+        ]}
+        initialSelectedId="hannah"
+      />,
+    );
+
+    const toggle = screen.getByTestId("landing-description-toggle");
+    expect(toggle).toHaveTextContent("team.showMore");
+    const collapsed = screen.getByTestId(
+      "landing-selected-description",
+    ).textContent;
+    expect(collapsed?.includes("…")).toBe(true);
+
+    await user.click(toggle);
+    expect(toggle).toHaveTextContent("team.showLess");
+    expect(
+      screen.getByTestId("landing-selected-description").textContent,
+    ).toContain(long.trim());
+  });
+
+  it("omits caption and description blocks when those fields are empty", () => {
     render(
       <LandingCoworkerPicker
         coworkers={[
@@ -118,21 +194,27 @@ describe("LandingCoworkerPicker", () => {
             id: "elena",
             name: "Elena",
             slug: "elena",
-            caption: "Strategy",
-            description: "   ",
+            caption: "   ",
+            description: "",
           }),
         ]}
         initialSelectedId="elena"
       />,
     );
 
+    expect(blockOrder()).toEqual([
+      "landing-selected-name",
+      "landing-start-chat",
+    ]);
+    expect(
+      screen.queryByTestId("landing-selected-caption"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("landing-selected-description"),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Strategy")).toBeInTheDocument();
   });
 
-  it("updates description and Start chat when a strip face is tapped", async () => {
+  it("updates caption, description, and Start chat when a strip face is tapped", async () => {
     const user = userEvent.setup();
 
     render(
@@ -146,11 +228,12 @@ describe("LandingCoworkerPicker", () => {
     );
 
     expect(openCoworkerRoom).not.toHaveBeenCalled();
+    expect(screen.getByTestId("landing-selected-caption")).toHaveTextContent(
+      "Research",
+    );
     expect(
-      screen.getByTestId("landing-selected-description"),
-    ).toHaveTextContent("Hannah digs into sources and briefs.");
-    // Caption remains on the strip chip.
-    expect(screen.getByText("Research")).toBeInTheDocument();
+      screen.getByTestId("landing-selected-description").textContent,
+    ).toContain("Hannah digs into sources");
     expect(
       screen.getByRole("button", {
         name: 'cta.button:{"name":"Hannah"}',

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -16,12 +16,6 @@ import {
 import { StartChatButton } from "./start-chat-button.client";
 import { OpenCoworkerRoomProvider } from "./use-open-coworker-room";
 
-/**
- * Four teammates plus the 80px featured face fit a 390px viewport with room to
- * breathe. Even, so the flanks balance and Elena stays centred.
- */
-const MAX_STRIP_COWORKERS = 4;
-
 interface ChatLandingMobileProps {
   coworkers: Coworker[];
   /** True only for an organization workspace, where other humans exist. */
@@ -36,7 +30,7 @@ interface ChatLandingMobileProps {
  *
  * Pair of {@link ChatLanding} (`chat-landing.tsx`): same three zones (mark,
  * centred pitch, stats) and the same `landing-content` decisions, scaled for
- * a 390px column — 32px mark, an 80px featured face flanked by four at 44px,
+ * a 390px column — 32px mark, scrollable strip with an 80px featured face,
  * and a full-width CTA. Owns `/chat` below `md`; the room list stays at
  * `/chat/chats`.
  */
@@ -51,7 +45,7 @@ export async function ChatLandingMobile({
     getFormatter(),
   ]);
   const featured = resolveFeaturedCoworker(coworkers);
-  const others = selectStripCoworkers(coworkers, featured, MAX_STRIP_COWORKERS);
+  const others = selectStripCoworkers(coworkers, featured);
   const featuredRole = featured
     ? featuredCoworkerRole(featured, t("role"))
     : null;

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -4,11 +4,7 @@ import type { Coworker } from "@/app/chat/utils/types";
 import { SokosumiIcon } from "@/components/masumi-logos";
 import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
-import {
-  buildActivityStats,
-  hasReportableActivity,
-  resolveFeaturedCoworker,
-} from "./landing-content";
+import { buildActivityStats, resolveFeaturedCoworker } from "./landing-content";
 import { LandingCoworkerPicker } from "./landing-coworker-picker.client";
 import { OpenCoworkerRoomProvider } from "./use-open-coworker-room";
 
@@ -16,7 +12,7 @@ interface ChatLandingMobileProps {
   coworkers: Coworker[];
   /** True only for an organization workspace, where other humans exist. */
   isOrganizationWorkspace: boolean;
-  /** Null when Core could not be reached; the greeting renders without stats. */
+  /** Null when Core could not be reached; chips still render as zeros. */
   summary: TaskActivitySummary | null;
   userName: null | string;
 }
@@ -25,9 +21,9 @@ interface ChatLandingMobileProps {
  * Mobile composition of the `/chat` welcome (`chat-landing.mobile.tsx`).
  *
  * Pair of {@link ChatLanding} (`chat-landing.tsx`): same three zones (mark,
- * pitch, stats) scaled for a narrow column. Stats stay pinned at the bottom of
- * the viewport-tall column; the strip scrolls inside a min-w-0 viewport so it
- * cannot widen Start chat off-screen.
+ * pitch, stats) scaled for a narrow column. Middle column is top-aligned so
+ * Start chat stays put across coworker selection. Stats stay pinned at the
+ * bottom — always mounted with zero chips when idle.
  */
 export async function ChatLandingMobile({
   coworkers,
@@ -41,7 +37,6 @@ export async function ChatLandingMobile({
   ]);
   const featured = resolveFeaturedCoworker(coworkers);
   const stats = buildActivityStats(summary, isOrganizationWorkspace, t);
-  const hasAnyActivity = hasReportableActivity(summary);
 
   return (
     <section className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch px-4 pt-4 pb-3 text-center">
@@ -52,7 +47,7 @@ export async function ChatLandingMobile({
         width={32}
       />
 
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch justify-center overflow-y-auto py-4">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch justify-start overflow-y-auto py-4">
         <h1 className="text-foreground shrink-0 text-2xl font-light text-balance">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}
         </h1>
@@ -73,30 +68,28 @@ export async function ChatLandingMobile({
         ) : null}
       </div>
 
-      {summary && hasAnyActivity && stats.length > 0 ? (
-        <div
-          className="flex w-full shrink-0 flex-col items-center gap-2 pt-1"
-          data-testid="landing-activity-stats"
-        >
-          <p className="text-muted-foreground/70 text-xs">
-            {summary.basis === "lastVisit"
-              ? t("stats.sinceLastActivity", {
-                  when: format.relativeTime(summary.since),
-                })
-              : t("stats.recent")}
-          </p>
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            {stats.map((stat) => (
-              <span
-                className="bg-card text-muted-foreground rounded-full border px-2.5 py-1 text-xs tabular-nums"
-                key={stat}
-              >
-                {stat}
-              </span>
-            ))}
-          </div>
+      <div
+        className="flex w-full shrink-0 flex-col items-center gap-2 pt-1"
+        data-testid="landing-activity-stats"
+      >
+        <p className="text-muted-foreground/70 text-xs">
+          {summary?.basis === "lastVisit"
+            ? t("stats.sinceLastActivity", {
+                when: format.relativeTime(summary.since),
+              })
+            : t("stats.recent")}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {stats.map((stat) => (
+            <span
+              className="bg-card text-muted-foreground rounded-full border px-2.5 py-1 text-xs tabular-nums"
+              key={stat}
+            >
+              {stat}
+            </span>
+          ))}
         </div>
-      ) : null}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -25,10 +25,9 @@ interface ChatLandingMobileProps {
  * Mobile composition of the `/chat` welcome (`chat-landing.mobile.tsx`).
  *
  * Pair of {@link ChatLanding} (`chat-landing.tsx`): same three zones (mark,
- * centred pitch, stats) and the same `landing-content` decisions, scaled for
- * a 390px column — 32px mark, scrollable selectable strip with an 80px
- * featured face, and a full-width CTA. Owns `/chat` below `md`; the room list
- * stays at `/chat/chats`.
+ * pitch, stats) scaled for a narrow column. Stats stay pinned at the bottom of
+ * the viewport-tall column; the strip scrolls inside a min-w-0 viewport so it
+ * cannot widen Start chat off-screen.
  */
 export async function ChatLandingMobile({
   coworkers,
@@ -45,22 +44,20 @@ export async function ChatLandingMobile({
   const hasAnyActivity = hasReportableActivity(summary);
 
   return (
-    // Same three zones as the desktop landing: the mark holds the top edge, the
-    // pitch centres in what is left, and the stats close out the bottom.
-    <section className="flex min-h-full w-full flex-col items-center px-4 pt-4 pb-5 text-center">
+    <section className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch px-4 pt-4 pb-3 text-center">
       <SokosumiIcon
         animated={false}
-        className="text-foreground shrink-0"
+        className="text-foreground shrink-0 self-center"
         height={32}
         width={32}
       />
 
-      <div className="flex w-full flex-1 flex-col items-center justify-center py-6">
-        <h1 className="text-foreground text-2xl font-light text-balance">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch justify-center overflow-y-auto py-4">
+        <h1 className="text-foreground shrink-0 text-2xl font-light text-balance">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}
         </h1>
 
-        <p className="text-muted-foreground mt-3 max-w-[42ch] text-sm leading-[1.6] text-balance">
+        <p className="text-muted-foreground mx-auto mt-2 max-w-[42ch] shrink-0 text-sm leading-[1.6] text-balance">
           {t("intro")}
         </p>
 
@@ -77,7 +74,10 @@ export async function ChatLandingMobile({
       </div>
 
       {summary && hasAnyActivity && stats.length > 0 ? (
-        <div className="flex w-full shrink-0 flex-col items-center gap-2.5">
+        <div
+          className="flex w-full shrink-0 flex-col items-center gap-2 pt-1"
+          data-testid="landing-activity-stats"
+        >
           <p className="text-muted-foreground/70 text-xs">
             {summary.basis === "lastVisit"
               ? t("stats.sinceLastActivity", {

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -68,7 +68,6 @@ export async function ChatLandingMobile({
           <OpenCoworkerRoomProvider>
             <LandingCoworkerPicker
               coworkers={coworkers}
-              elenaRole={t("role")}
               initialSelectedId={featured.id}
               size="compact"
               startChatClassName="w-full"

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -4,16 +4,12 @@ import type { Coworker } from "@/app/chat/utils/types";
 import { SokosumiIcon } from "@/components/masumi-logos";
 import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
-import { CoworkerStrip } from "./coworker-strip.client";
 import {
   buildActivityStats,
-  featuredCoworkerRole,
   hasReportableActivity,
   resolveFeaturedCoworker,
-  selectStripCoworkers,
-  toStripCoworker,
 } from "./landing-content";
-import { StartChatButton } from "./start-chat-button.client";
+import { LandingCoworkerPicker } from "./landing-coworker-picker.client";
 import { OpenCoworkerRoomProvider } from "./use-open-coworker-room";
 
 interface ChatLandingMobileProps {
@@ -30,9 +26,9 @@ interface ChatLandingMobileProps {
  *
  * Pair of {@link ChatLanding} (`chat-landing.tsx`): same three zones (mark,
  * centred pitch, stats) and the same `landing-content` decisions, scaled for
- * a 390px column — 32px mark, scrollable strip with an 80px featured face,
- * and a full-width CTA. Owns `/chat` below `md`; the room list stays at
- * `/chat/chats`.
+ * a 390px column — 32px mark, scrollable selectable strip with an 80px
+ * featured face, and a full-width CTA. Owns `/chat` below `md`; the room list
+ * stays at `/chat/chats`.
  */
 export async function ChatLandingMobile({
   coworkers,
@@ -45,10 +41,6 @@ export async function ChatLandingMobile({
     getFormatter(),
   ]);
   const featured = resolveFeaturedCoworker(coworkers);
-  const others = selectStripCoworkers(coworkers, featured);
-  const featuredRole = featured
-    ? featuredCoworkerRole(featured, t("role"))
-    : null;
   const stats = buildActivityStats(summary, isOrganizationWorkspace, t);
   const hasAnyActivity = hasReportableActivity(summary);
 
@@ -74,30 +66,13 @@ export async function ChatLandingMobile({
 
         {featured ? (
           <OpenCoworkerRoomProvider>
-            <div className="mt-8 w-full">
-              <CoworkerStrip
-                featured={toStripCoworker(featured)}
-                others={others}
-                size="compact"
-              />
-            </div>
-
-            <p className="mt-4 text-lg font-semibold tracking-[-0.01em]">
-              {featured.name}
-            </p>
-            {featuredRole ? (
-              <p className="text-muted-foreground mt-1.5 max-w-[40ch] text-[0.8125rem] leading-[1.5] text-balance">
-                {featuredRole}
-              </p>
-            ) : null}
-
-            <div className="mt-6 w-full max-w-xs">
-              <StartChatButton
-                className="w-full"
-                coworkerId={featured.id}
-                coworkerName={featured.name}
-              />
-            </div>
+            <LandingCoworkerPicker
+              coworkers={coworkers}
+              elenaRole={t("role")}
+              initialSelectedId={featured.id}
+              size="compact"
+              startChatClassName="w-full"
+            />
           </OpenCoworkerRoomProvider>
         ) : null}
       </div>

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
@@ -68,7 +68,6 @@ export async function ChatLanding({
           <OpenCoworkerRoomProvider>
             <LandingCoworkerPicker
               coworkers={coworkers}
-              elenaRole={t("role")}
               initialSelectedId={featured.id}
             />
           </OpenCoworkerRoomProvider>

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
@@ -4,16 +4,12 @@ import type { Coworker } from "@/app/chat/utils/types";
 import { SokosumiIcon } from "@/components/masumi-logos";
 import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
-import { CoworkerStrip } from "./coworker-strip.client";
 import {
   buildActivityStats,
-  featuredCoworkerRole,
   hasReportableActivity,
   resolveFeaturedCoworker,
-  selectStripCoworkers,
-  toStripCoworker,
 } from "./landing-content";
-import { StartChatButton } from "./start-chat-button.client";
+import { LandingCoworkerPicker } from "./landing-coworker-picker.client";
 import { OpenCoworkerRoomProvider } from "./use-open-coworker-room";
 
 interface ChatLandingProps {
@@ -43,10 +39,6 @@ export async function ChatLanding({
     getFormatter(),
   ]);
   const featured = resolveFeaturedCoworker(coworkers);
-  const others = selectStripCoworkers(coworkers, featured);
-  const featuredRole = featured
-    ? featuredCoworkerRole(featured, t("role"))
-    : null;
   const stats = buildActivityStats(summary, isOrganizationWorkspace, t);
   const hasAnyActivity = hasReportableActivity(summary);
 
@@ -74,28 +66,11 @@ export async function ChatLanding({
 
         {featured ? (
           <OpenCoworkerRoomProvider>
-            <div className="mt-12 w-full">
-              <CoworkerStrip
-                featured={toStripCoworker(featured)}
-                others={others}
-              />
-            </div>
-
-            <p className="mt-5 text-xl font-semibold tracking-[-0.01em]">
-              {featured.name}
-            </p>
-            {featuredRole ? (
-              <p className="text-muted-foreground mx-auto mt-2 max-w-[46ch] text-[0.9375rem] leading-[1.55] text-balance">
-                {featuredRole}
-              </p>
-            ) : null}
-
-            <div className="mt-6">
-              <StartChatButton
-                coworkerId={featured.id}
-                coworkerName={featured.name}
-              />
-            </div>
+            <LandingCoworkerPicker
+              coworkers={coworkers}
+              elenaRole={t("role")}
+              initialSelectedId={featured.id}
+            />
           </OpenCoworkerRoomProvider>
         ) : null}
       </div>

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
@@ -27,6 +27,10 @@ interface ChatLandingProps {
  * Pair of {@link ChatLandingMobile} (`chat-landing.mobile.tsx`): same content
  * decisions from `landing-content`, larger strip and type. Owns `/chat` at
  * `md` and up.
+ *
+ * Stats stay `shrink-0` at the bottom of the viewport-tall column so the
+ * activity row remains on the first view; the middle zone may scroll if the
+ * strip + selection block needs more room.
  */
 export async function ChatLanding({
   coworkers,
@@ -43,24 +47,20 @@ export async function ChatLanding({
   const hasAnyActivity = hasReportableActivity(summary);
 
   return (
-    // Three zones: the mark keeps the page's top edge aligned with every other
-    // route, the pitch centres in whatever height is left, and the stats close
-    // out the bottom.
-    <div className="flex min-h-full w-full flex-col items-center">
+    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch">
       <SokosumiIcon
         animated={false}
-        className="text-foreground shrink-0"
+        className="text-foreground shrink-0 self-center"
         height={48}
         width={48}
       />
 
-      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col items-center justify-center py-10 text-center">
-        {/* Same treatment as the agents page heading. */}
-        <h1 className="text-foreground text-2xl font-light text-balance md:text-4xl">
+      <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col items-stretch justify-center overflow-y-auto px-4 py-6 text-center">
+        <h1 className="text-foreground shrink-0 text-2xl font-light text-balance md:text-4xl">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}
         </h1>
 
-        <p className="text-muted-foreground mx-auto mt-5 max-w-[62ch] text-base leading-[1.65] text-balance md:text-lg">
+        <p className="text-muted-foreground mx-auto mt-4 max-w-[62ch] shrink-0 text-base leading-[1.65] text-balance md:text-lg">
           {t("intro")}
         </p>
 
@@ -75,7 +75,10 @@ export async function ChatLanding({
       </div>
 
       {summary && hasAnyActivity && stats.length > 0 ? (
-        <div className="flex w-full shrink-0 flex-col items-center gap-4">
+        <div
+          className="flex w-full shrink-0 flex-col items-center gap-3 px-4 pb-4"
+          data-testid="landing-activity-stats"
+        >
           <p className="text-muted-foreground/70 text-[0.8125rem]">
             {summary.basis === "lastVisit"
               ? t("stats.sinceLastActivity", {

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
@@ -16,12 +16,6 @@ import {
 import { StartChatButton } from "./start-chat-button.client";
 import { OpenCoworkerRoomProvider } from "./use-open-coworker-room";
 
-/**
- * Enough to read as a team without the row wrapping on a laptop. Kept even so
- * the flanks balance and the featured coworker stays optically centred.
- */
-const MAX_STRIP_COWORKERS = 6;
-
 interface ChatLandingProps {
   coworkers: Coworker[];
   /** True only for an organization workspace, where other humans exist. */
@@ -49,7 +43,7 @@ export async function ChatLanding({
     getFormatter(),
   ]);
   const featured = resolveFeaturedCoworker(coworkers);
-  const others = selectStripCoworkers(coworkers, featured, MAX_STRIP_COWORKERS);
+  const others = selectStripCoworkers(coworkers, featured);
   const featuredRole = featured
     ? featuredCoworkerRole(featured, t("role"))
     : null;

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
@@ -4,11 +4,7 @@ import type { Coworker } from "@/app/chat/utils/types";
 import { SokosumiIcon } from "@/components/masumi-logos";
 import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
-import {
-  buildActivityStats,
-  hasReportableActivity,
-  resolveFeaturedCoworker,
-} from "./landing-content";
+import { buildActivityStats, resolveFeaturedCoworker } from "./landing-content";
 import { LandingCoworkerPicker } from "./landing-coworker-picker.client";
 import { OpenCoworkerRoomProvider } from "./use-open-coworker-room";
 
@@ -16,7 +12,7 @@ interface ChatLandingProps {
   coworkers: Coworker[];
   /** True only for an organization workspace, where other humans exist. */
   isOrganizationWorkspace: boolean;
-  /** Null when Core could not be reached; the greeting renders without stats. */
+  /** Null when Core could not be reached; chips still render as zeros. */
   summary: TaskActivitySummary | null;
   userName: null | string;
 }
@@ -28,9 +24,9 @@ interface ChatLandingProps {
  * decisions from `landing-content`, larger strip and type. Owns `/chat` at
  * `md` and up.
  *
- * Stats stay `shrink-0` at the bottom of the viewport-tall column so the
- * activity row remains on the first view; the middle zone may scroll if the
- * strip + selection block needs more room.
+ * Middle column is top-aligned so description length cannot re-center Start
+ * chat. Stats stay `shrink-0` at the bottom of the viewport-tall column —
+ * always mounted, including zero chips — so the first view keeps the row.
  */
 export async function ChatLanding({
   coworkers,
@@ -44,7 +40,6 @@ export async function ChatLanding({
   ]);
   const featured = resolveFeaturedCoworker(coworkers);
   const stats = buildActivityStats(summary, isOrganizationWorkspace, t);
-  const hasAnyActivity = hasReportableActivity(summary);
 
   return (
     <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch">
@@ -55,7 +50,7 @@ export async function ChatLanding({
         width={48}
       />
 
-      <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col items-stretch justify-center overflow-y-auto px-4 py-6 text-center">
+      <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col items-stretch justify-start overflow-y-auto px-4 py-6 text-center">
         <h1 className="text-foreground shrink-0 text-2xl font-light text-balance md:text-4xl">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}
         </h1>
@@ -74,30 +69,28 @@ export async function ChatLanding({
         ) : null}
       </div>
 
-      {summary && hasAnyActivity && stats.length > 0 ? (
-        <div
-          className="flex w-full shrink-0 flex-col items-center gap-3 px-4 pb-4"
-          data-testid="landing-activity-stats"
-        >
-          <p className="text-muted-foreground/70 text-[0.8125rem]">
-            {summary.basis === "lastVisit"
-              ? t("stats.sinceLastActivity", {
-                  when: format.relativeTime(summary.since),
-                })
-              : t("stats.recent")}
-          </p>
-          <div className="flex flex-wrap items-center justify-center gap-3">
-            {stats.map((stat) => (
-              <span
-                className="bg-card text-muted-foreground rounded-full border px-3 py-1.5 text-[0.8125rem] tabular-nums"
-                key={stat}
-              >
-                {stat}
-              </span>
-            ))}
-          </div>
+      <div
+        className="flex w-full shrink-0 flex-col items-center gap-3 px-4 pb-4"
+        data-testid="landing-activity-stats"
+      >
+        <p className="text-muted-foreground/70 text-[0.8125rem]">
+          {summary?.basis === "lastVisit"
+            ? t("stats.sinceLastActivity", {
+                when: format.relativeTime(summary.since),
+              })
+            : t("stats.recent")}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          {stats.map((stat) => (
+            <span
+              className="bg-card text-muted-foreground rounded-full border px-3 py-1.5 text-[0.8125rem] tabular-nums"
+              key={stat}
+            >
+              {stat}
+            </span>
+          ))}
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -63,7 +63,9 @@ const STRIP_SIZES = {
  *
  * The scrollport is always viewport-bounded (`w-full min-w-0`). The `w-max`
  * track lives *inside* overflow-x-auto so it cannot widen the picker or page.
- * On mount, scrolls so `centerOnId` sits optically in the middle.
+ * On mount, scrolls so `centerOnId` sits optically in the middle. Strip titles
+ * always reserve two lines (`min-h-[2lh]`) so 1-line vs wrapping captions
+ * cannot change row height and push Start chat.
  */
 export function CoworkerStrip({
   coworkers,
@@ -188,16 +190,19 @@ export function CoworkerStrip({
                 >
                   {coworker.name}
                 </span>
-                {coworker.title ? (
-                  <span
-                    className={cn(
-                      "text-muted-foreground line-clamp-2 leading-snug",
-                      scale.title,
-                    )}
-                  >
-                    {coworker.title}
-                  </span>
-                ) : null}
+                {/* Always reserve two title lines so 1-line / empty / wrapping
+                    captions cannot grow or shrink the strip row (and Start chat).
+                    `2lh` follows the element's line-height (twMerge drops
+                    `leading-*` next to `line-clamp-*`). */}
+                <span
+                  className={cn(
+                    "text-muted-foreground line-clamp-2 min-h-[2lh]",
+                    scale.title,
+                  )}
+                  data-testid="coworker-strip-title"
+                >
+                  {coworker.title ?? "\u00a0"}
+                </span>
               </span>
             </button>
           );

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -3,11 +3,6 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import { useOpenCoworkerRoom } from "./use-open-coworker-room";
@@ -16,13 +11,13 @@ export interface StripCoworker {
   id: string;
   imageUrl: null | string;
   name: string;
-  /** The coworker's speciality, shown in the tooltip. Null when unset. */
+  /** Specialty shown under the name. Null when unset. */
   title: null | string;
 }
 
 interface CoworkerStripProps {
   featured: StripCoworker;
-  /** Rendered around the featured coworker, split evenly left and right. */
+  /** Remaining teammates, rendered after the featured coworker. */
   others: StripCoworker[];
   /** `compact` fits the row inside a 390px viewport. */
   size?: "compact" | "default";
@@ -32,25 +27,33 @@ const STRIP_SIZES = {
   compact: {
     featured: "size-20",
     other: "size-11",
-    gap: "gap-3",
+    gap: "gap-4",
+    itemWidth: "w-[4.5rem]",
+    featuredItemWidth: "w-[5.5rem]",
     featuredSizes: "80px",
     otherSizes: "44px",
     featuredInitial: "text-xl",
     otherInitial: "text-xs",
+    name: "text-xs",
+    title: "text-[0.625rem]",
   },
   default: {
     featured: "size-28",
     other: "size-16",
-    gap: "gap-5 sm:gap-8",
+    gap: "gap-5",
+    itemWidth: "w-24",
+    featuredItemWidth: "w-28",
     featuredSizes: "112px",
     otherSizes: "64px",
     featuredInitial: "text-2xl",
     otherInitial: "text-sm",
+    name: "text-sm",
+    title: "text-xs",
   },
 } as const;
 
 /**
- * The featured coworker flanked by the rest of the team.
+ * Horizontal scrollable strip: featured coworker first, then the rest.
  *
  * Every face opens that coworker's direct room, so the strip doubles as a
  * picker — the point being that Elena is a starting suggestion, not the only
@@ -64,71 +67,93 @@ export function CoworkerStrip({
   const t = useTranslations("App.Chat.Landing");
   const { isPending, openCoworkerRoom, openingId } = useOpenCoworkerRoom();
   const scale = STRIP_SIZES[size];
-
-  // Callers pass an even list, so the flanks match and the featured face lands
-  // on the optical centre.
-  const half = Math.floor(others.length / 2);
-  const left = others.slice(0, half);
-  const right = others.slice(half);
-
-  function renderCoworker(coworker: StripCoworker, isFeatured: boolean) {
-    return (
-      <Tooltip key={coworker.id}>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label={t("cta.button", { name: coworker.name })}
-            className={cn(
-              // Ring on every face, not just the featured one: several
-              // coworker portraits are dark-on-dark and vanish into the page
-              // in dark mode without an edge to hold them.
-              "focus-visible:ring-ring ring-border bg-muted relative shrink-0 cursor-pointer overflow-hidden rounded-full ring-1 transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-              isFeatured
-                ? scale.featured
-                : cn("opacity-70 hover:opacity-100", scale.other),
-              openingId === coworker.id && "opacity-50",
-            )}
-            disabled={isPending}
-            onClick={() => openCoworkerRoom(coworker.id)}
-          >
-            {coworker.imageUrl ? (
-              <Image
-                alt={t("team.avatarAlt", { name: coworker.name })}
-                className="object-cover object-top"
-                fill
-                priority={isFeatured}
-                sizes={isFeatured ? scale.featuredSizes : scale.otherSizes}
-                src={coworker.imageUrl}
-              />
-            ) : (
-              <span
-                className={cn(
-                  "text-muted-foreground flex size-full items-center justify-center font-medium",
-                  isFeatured ? scale.featuredInitial : scale.otherInitial,
-                )}
-              >
-                {coworker.name.charAt(0).toUpperCase()}
-              </span>
-            )}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <span className="font-medium">{coworker.name}</span>
-          {/* The featured coworker's title is already spelled out under the
-              strip, so repeating it here would only contradict it. */}
-          {!isFeatured && coworker.title ? (
-            <span className="block opacity-80">{coworker.title}</span>
-          ) : null}
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
+  const strip = [featured, ...others];
 
   return (
-    <div className={cn("flex w-full items-center justify-center", scale.gap)}>
-      {left.map((coworker) => renderCoworker(coworker, false))}
-      {renderCoworker(featured, true)}
-      {right.map((coworker) => renderCoworker(coworker, false))}
+    <div
+      className={cn(
+        "w-full overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+      )}
+      data-testid="coworker-strip-scroll"
+    >
+      <div
+        className={cn(
+          "flex w-max min-w-full items-start justify-center px-1 py-1",
+          scale.gap,
+        )}
+      >
+        {strip.map((coworker) => {
+          const isFeatured = coworker.id === featured.id;
+
+          return (
+            <button
+              key={coworker.id}
+              type="button"
+              aria-label={t("cta.button", { name: coworker.name })}
+              className={cn(
+                "flex shrink-0 cursor-pointer flex-col items-center gap-2 text-center transition-opacity outline-none",
+                "focus-visible:ring-ring rounded-md focus-visible:ring-2 focus-visible:ring-offset-2",
+                isFeatured ? scale.featuredItemWidth : scale.itemWidth,
+                openingId === coworker.id && "opacity-50",
+              )}
+              disabled={isPending}
+              onClick={() => openCoworkerRoom(coworker.id)}
+            >
+              <span
+                className={cn(
+                  // Ring on every face: several coworker portraits are
+                  // dark-on-dark and vanish into the page in dark mode without
+                  // an edge to hold them.
+                  "ring-border bg-muted relative shrink-0 overflow-hidden rounded-full ring-1",
+                  isFeatured
+                    ? scale.featured
+                    : cn("opacity-70 hover:opacity-100", scale.other),
+                )}
+              >
+                {coworker.imageUrl ? (
+                  <Image
+                    alt={t("team.avatarAlt", { name: coworker.name })}
+                    className="object-cover object-top"
+                    fill
+                    priority={isFeatured}
+                    sizes={isFeatured ? scale.featuredSizes : scale.otherSizes}
+                    src={coworker.imageUrl}
+                  />
+                ) : (
+                  <span
+                    className={cn(
+                      "text-muted-foreground flex size-full items-center justify-center font-medium",
+                      isFeatured ? scale.featuredInitial : scale.otherInitial,
+                    )}
+                  >
+                    {coworker.name.charAt(0).toUpperCase()}
+                  </span>
+                )}
+              </span>
+              <span className="flex min-w-0 flex-col gap-0.5">
+                <span
+                  className={cn(
+                    "text-foreground truncate font-medium leading-tight",
+                    scale.name,
+                  )}
+                >
+                  {coworker.name}
+                </span>
+                {coworker.title ? (
+                  <span
+                    className={cn(
+                      "text-muted-foreground line-clamp-2 leading-snug",
+                      scale.title,
+                    )}
+                  >
+                    {coworker.title}
+                  </span>
+                ) : null}
+              </span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -2,8 +2,12 @@
 
 import Image from "next/image";
 import { useTranslations } from "next-intl";
+import { useRef } from "react";
 
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import { cn } from "@/lib/utils";
+
+import { opticalCenterScrollLeft } from "./landing-content";
 
 export interface StripCoworker {
   id: string;
@@ -17,6 +21,11 @@ interface CoworkerStripProps {
   coworkers: StripCoworker[];
   /** Currently selected coworker — larger face, Start chat target. */
   selectedId: string;
+  /**
+   * Coworker to optically centre on first paint (Elena / fallback). Selection
+   * changes do not re-scroll — browsing stays where the user left it.
+   */
+  centerOnId: string;
   onSelect: (coworkerId: string) => void;
   /** `compact` fits the row inside a 390px viewport. */
   size?: "compact" | "default";
@@ -55,18 +64,38 @@ const STRIP_SIZES = {
  * Horizontal scrollable strip for browsing coworkers on the landing.
  *
  * Tap selects a coworker for the Start chat CTA — it does not open a DM.
+ * On mount, scrolls so `centerOnId` sits optically in the middle of the
+ * viewport (full catalog stays in the row; nothing is dropped).
  */
 export function CoworkerStrip({
   coworkers,
   selectedId,
+  centerOnId,
   onSelect,
   size = "default",
 }: CoworkerStripProps) {
   const t = useTranslations("App.Chat.Landing");
   const scale = STRIP_SIZES[size];
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  useMountEffect(() => {
+    const root = scrollRef.current;
+    const child = itemRefs.current.get(centerOnId);
+    if (!root || !child) {
+      return;
+    }
+    root.scrollLeft = opticalCenterScrollLeft({
+      childOffsetLeft: child.offsetLeft,
+      childWidth: child.offsetWidth,
+      containerWidth: root.clientWidth,
+      scrollWidth: root.scrollWidth,
+    });
+  });
 
   return (
     <div
+      ref={scrollRef}
       className={cn(
         "w-full overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
       )}
@@ -86,10 +115,18 @@ export function CoworkerStrip({
           return (
             <button
               key={coworker.id}
+              ref={(node) => {
+                if (node) {
+                  itemRefs.current.set(coworker.id, node);
+                } else {
+                  itemRefs.current.delete(coworker.id);
+                }
+              }}
               type="button"
               role="option"
               aria-selected={isSelected}
               aria-label={t("team.select", { name: coworker.name })}
+              data-coworker-id={coworker.id}
               className={cn(
                 "flex shrink-0 cursor-pointer flex-col items-center gap-2 text-center transition-opacity outline-none",
                 "focus-visible:ring-ring rounded-md focus-visible:ring-2 focus-visible:ring-offset-2",

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -7,8 +7,6 @@ import { useRef } from "react";
 import { useMountEffect } from "@/hooks/use-mount-effect";
 import { cn } from "@/lib/utils";
 
-import { opticalCenterScrollLeft } from "./landing-content";
-
 export interface StripCoworker {
   id: string;
   imageUrl: null | string;
@@ -63,9 +61,9 @@ const STRIP_SIZES = {
 /**
  * Horizontal scrollable strip for browsing coworkers on the landing.
  *
- * Tap selects a coworker for the Start chat CTA — it does not open a DM.
- * On mount, scrolls so `centerOnId` sits optically in the middle of the
- * viewport (full catalog stays in the row; nothing is dropped).
+ * The scrollport is always viewport-bounded (`w-full min-w-0`). The `w-max`
+ * track lives *inside* overflow-x-auto so it cannot widen the picker or page.
+ * On mount, scrolls so `centerOnId` sits optically in the middle.
  */
 export function CoworkerStrip({
   coworkers,
@@ -80,24 +78,36 @@ export function CoworkerStrip({
   const itemRefs = useRef(new Map<string, HTMLButtonElement>());
 
   useMountEffect(() => {
-    const root = scrollRef.current;
     const child = itemRefs.current.get(centerOnId);
-    if (!root || !child) {
+    if (!child) {
       return;
     }
-    root.scrollLeft = opticalCenterScrollLeft({
-      childOffsetLeft: child.offsetLeft,
-      childWidth: child.offsetWidth,
-      containerWidth: root.clientWidth,
-      scrollWidth: root.scrollWidth,
+
+    // Double rAF: wait until flex widths settle so centre isn't measured at 0.
+    let frame2 = 0;
+    const frame1 = requestAnimationFrame(() => {
+      frame2 = requestAnimationFrame(() => {
+        child.scrollIntoView({
+          behavior: "auto",
+          block: "nearest",
+          inline: "center",
+        });
+      });
     });
+
+    return () => {
+      cancelAnimationFrame(frame1);
+      cancelAnimationFrame(frame2);
+    };
   });
 
   return (
     <div
       ref={scrollRef}
       className={cn(
-        "w-full overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        // min-w-0 is load-bearing: without it, a flex ancestor sizes to the
+        // w-max track and the Start chat `w-full` stretches to ~900px.
+        "w-full min-w-0 max-w-full overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
       )}
       data-testid="coworker-strip-scroll"
       role="listbox"
@@ -105,9 +115,13 @@ export function CoworkerStrip({
     >
       <div
         className={cn(
+          // min-w-full + justify-center: when the catalog fits, Elena (middle
+          // of the track) lands in the visual centre. When it overflows, w-max
+          // wins and the scrollport alone handles overflow.
           "flex w-max min-w-full items-start justify-center px-1 py-1",
           scale.gap,
         )}
+        data-testid="coworker-strip-track"
       >
         {coworkers.map((coworker) => {
           const isSelected = coworker.id === selectedId;

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -5,8 +5,6 @@ import { useTranslations } from "next-intl";
 
 import { cn } from "@/lib/utils";
 
-import { useOpenCoworkerRoom } from "./use-open-coworker-room";
-
 export interface StripCoworker {
   id: string;
   imageUrl: null | string;
@@ -16,9 +14,10 @@ export interface StripCoworker {
 }
 
 interface CoworkerStripProps {
-  featured: StripCoworker;
-  /** Remaining teammates, rendered after the featured coworker. */
-  others: StripCoworker[];
+  coworkers: StripCoworker[];
+  /** Currently selected coworker — larger face, Start chat target. */
+  selectedId: string;
+  onSelect: (coworkerId: string) => void;
   /** `compact` fits the row inside a 390px viewport. */
   size?: "compact" | "default";
 }
@@ -53,21 +52,18 @@ const STRIP_SIZES = {
 } as const;
 
 /**
- * Horizontal scrollable strip: featured coworker first, then the rest.
+ * Horizontal scrollable strip for browsing coworkers on the landing.
  *
- * Every face opens that coworker's direct room, so the strip doubles as a
- * picker — the point being that Elena is a starting suggestion, not the only
- * coworker available.
+ * Tap selects a coworker for the Start chat CTA — it does not open a DM.
  */
 export function CoworkerStrip({
-  featured,
-  others,
+  coworkers,
+  selectedId,
+  onSelect,
   size = "default",
 }: CoworkerStripProps) {
   const t = useTranslations("App.Chat.Landing");
-  const { isPending, openCoworkerRoom, openingId } = useOpenCoworkerRoom();
   const scale = STRIP_SIZES[size];
-  const strip = [featured, ...others];
 
   return (
     <div
@@ -75,6 +71,8 @@ export function CoworkerStrip({
         "w-full overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
       )}
       data-testid="coworker-strip-scroll"
+      role="listbox"
+      aria-label={t("team.stripLabel")}
     >
       <div
         className={cn(
@@ -82,22 +80,22 @@ export function CoworkerStrip({
           scale.gap,
         )}
       >
-        {strip.map((coworker) => {
-          const isFeatured = coworker.id === featured.id;
+        {coworkers.map((coworker) => {
+          const isSelected = coworker.id === selectedId;
 
           return (
             <button
               key={coworker.id}
               type="button"
-              aria-label={t("cta.button", { name: coworker.name })}
+              role="option"
+              aria-selected={isSelected}
+              aria-label={t("team.select", { name: coworker.name })}
               className={cn(
                 "flex shrink-0 cursor-pointer flex-col items-center gap-2 text-center transition-opacity outline-none",
                 "focus-visible:ring-ring rounded-md focus-visible:ring-2 focus-visible:ring-offset-2",
-                isFeatured ? scale.featuredItemWidth : scale.itemWidth,
-                openingId === coworker.id && "opacity-50",
+                isSelected ? scale.featuredItemWidth : scale.itemWidth,
               )}
-              disabled={isPending}
-              onClick={() => openCoworkerRoom(coworker.id)}
+              onClick={() => onSelect(coworker.id)}
             >
               <span
                 className={cn(
@@ -105,7 +103,7 @@ export function CoworkerStrip({
                   // dark-on-dark and vanish into the page in dark mode without
                   // an edge to hold them.
                   "ring-border bg-muted relative shrink-0 overflow-hidden rounded-full ring-1",
-                  isFeatured
+                  isSelected
                     ? scale.featured
                     : cn("opacity-70 hover:opacity-100", scale.other),
                 )}
@@ -115,15 +113,15 @@ export function CoworkerStrip({
                     alt={t("team.avatarAlt", { name: coworker.name })}
                     className="object-cover object-top"
                     fill
-                    priority={isFeatured}
-                    sizes={isFeatured ? scale.featuredSizes : scale.otherSizes}
+                    priority={isSelected}
+                    sizes={isSelected ? scale.featuredSizes : scale.otherSizes}
                     src={coworker.imageUrl}
                   />
                 ) : (
                   <span
                     className={cn(
                       "text-muted-foreground flex size-full items-center justify-center font-medium",
-                      isFeatured ? scale.featuredInitial : scale.otherInitial,
+                      isSelected ? scale.featuredInitial : scale.otherInitial,
                     )}
                   >
                     {coworker.name.charAt(0).toUpperCase()}

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -33,13 +33,46 @@ export function resolveFeaturedCoworker(
 }
 
 /**
- * Body copy under the selected coworker name (above Start chat).
- * DB `description` only — never caption, useCase, or Elena i18n pitch.
+ * Short specialty under the selected name (above Start chat).
+ * DB `caption` only — omit when empty (no useCase fallback here).
+ */
+export function selectedCoworkerCaption(
+  coworker: Pick<Coworker, "caption">,
+): string | null {
+  return nonEmptySpecialty(coworker.caption);
+}
+
+/**
+ * Body copy under Start chat. DB `description` only — never caption/useCase.
  */
 export function selectedCoworkerDescription(
   coworker: Pick<Coworker, "description">,
 ): string | null {
   return nonEmptySpecialty(coworker.description);
+}
+
+/** Collapsed landing description budget (~3 lines of body copy). */
+export const LANDING_DESCRIPTION_MAX_CHARS = 180;
+
+/**
+ * Truncate a landing description for the collapsed state.
+ * Returns the full string when it already fits; otherwise a word-aware preview
+ * capped near `maxChars` with an ellipsis, and `isTruncated: true`.
+ */
+export function clampLandingDescription(
+  description: string,
+  maxChars: number = LANDING_DESCRIPTION_MAX_CHARS,
+): { isTruncated: boolean; preview: string } {
+  if (description.length <= maxChars) {
+    return { isTruncated: false, preview: description };
+  }
+
+  const slice = description.slice(0, maxChars);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut =
+    lastSpace > Math.floor(maxChars * 0.6) ? slice.slice(0, lastSpace) : slice;
+
+  return { isTruncated: true, preview: `${cut.trimEnd()}…` };
 }
 
 function nonEmptySpecialty(value: null | string | undefined): null | string {

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -121,22 +121,6 @@ export function orderStripCoworkers(
   return [...left, featured, ...right].map(toStripCoworker);
 }
 
-/**
- * Horizontal scroll offset that puts a child at the optical centre of its
- * scrollport. Clamped so short strips (or edge children) do not overscroll.
- */
-export function opticalCenterScrollLeft(input: {
-  childOffsetLeft: number;
-  childWidth: number;
-  containerWidth: number;
-  scrollWidth: number;
-}): number {
-  const childCenter = input.childOffsetLeft + input.childWidth / 2;
-  const target = childCenter - input.containerWidth / 2;
-  const maxScroll = Math.max(0, input.scrollWidth - input.containerWidth);
-  return Math.min(maxScroll, Math.max(0, target));
-}
-
 type StatsTranslator = (
   key: string,
   values?: Record<string, number | string>,

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -71,11 +71,13 @@ export function toStripCoworker(coworker: Coworker): StripCoworker {
 }
 
 /**
- * Every non-featured coworker for the scrollable landing strip.
+ * Full catalog ordered with the featured coworker (Elena / fallback) in the
+ * optical middle. Odd counts → exact centre; even → left of the two centre
+ * slots (`floor(others/2)` flanks left). Never drops anyone.
  *
  * Empty when nothing is featured — the strip only renders with a lead face.
  */
-export function selectStripCoworkers(
+export function orderStripCoworkers(
   coworkers: Coworker[],
   featured: Coworker | null,
 ): StripCoworker[] {
@@ -83,9 +85,28 @@ export function selectStripCoworkers(
     return [];
   }
 
-  return coworkers
-    .filter((coworker) => coworker.id !== featured.id)
-    .map(toStripCoworker);
+  const others = coworkers.filter((coworker) => coworker.id !== featured.id);
+  const leftCount = Math.floor(others.length / 2);
+  const left = others.slice(0, leftCount);
+  const right = others.slice(leftCount);
+
+  return [...left, featured, ...right].map(toStripCoworker);
+}
+
+/**
+ * Horizontal scroll offset that puts a child at the optical centre of its
+ * scrollport. Clamped so short strips (or edge children) do not overscroll.
+ */
+export function opticalCenterScrollLeft(input: {
+  childOffsetLeft: number;
+  childWidth: number;
+  containerWidth: number;
+  scrollWidth: number;
+}): number {
+  const childCenter = input.childOffsetLeft + input.childWidth / 2;
+  const target = childCenter - input.containerWidth / 2;
+  const maxScroll = Math.max(0, input.scrollWidth - input.containerWidth);
+  return Math.min(maxScroll, Math.max(0, target));
 }
 
 type StatsTranslator = (

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -33,18 +33,13 @@ export function resolveFeaturedCoworker(
 }
 
 /**
- * Pitch under the featured face. Elena keeps product-managed copy; anyone else
- * (fallback when Elena is unavailable) uses their DB caption or nothing —
- * never Elena's gendered "Project Manager" line.
+ * Body copy under the selected coworker name (above Start chat).
+ * DB `description` only — never caption, useCase, or Elena i18n pitch.
  */
-export function featuredCoworkerRole(
-  coworker: Coworker,
-  elenaRole: string,
+export function selectedCoworkerDescription(
+  coworker: Pick<Coworker, "description">,
 ): string | null {
-  if (isElenaCoworker(coworker)) {
-    return elenaRole;
-  }
-  return coworker.caption ?? null;
+  return nonEmptySpecialty(coworker.description);
 }
 
 function nonEmptySpecialty(value: null | string | undefined): null | string {

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -43,7 +43,7 @@ export function selectedCoworkerCaption(
 }
 
 /**
- * Body copy under Start chat. DB `description` only — never caption/useCase.
+ * Body copy above Start chat. DB `description` only — never caption/useCase.
  */
 export function selectedCoworkerDescription(
   coworker: Pick<Coworker, "description">,

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -47,6 +47,11 @@ export function featuredCoworkerRole(
   return coworker.caption ?? null;
 }
 
+function nonEmptySpecialty(value: null | string | undefined): null | string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
 export function toStripCoworker(coworker: Coworker): StripCoworker {
   // Keyed by SLUG on purpose: the static fallback map is slug-keyed, so
   // passing the id (as most call sites do) silently yields null.
@@ -58,30 +63,29 @@ export function toStripCoworker(coworker: Coworker): StripCoworker {
     // next/image throw and takes the whole page down, so fall back to initials.
     imageUrl: imageUrl && canUseNextImageSrc(imageUrl) ? imageUrl : null,
     name: coworker.name,
-    title: coworker.caption ?? null,
+    title:
+      nonEmptySpecialty(coworker.caption) ??
+      nonEmptySpecialty(coworker.useCase) ??
+      null,
   };
 }
 
 /**
- * The teammates flanking the featured coworker.
+ * Every non-featured coworker for the scrollable landing strip.
  *
- * Both landings pass an even `max` (6 desktop / 4 mobile). Odd counts are
- * dropped so flanks balance and the featured face stays optically centred.
+ * Empty when nothing is featured — the strip only renders with a lead face.
  */
 export function selectStripCoworkers(
   coworkers: Coworker[],
   featured: Coworker | null,
-  max: number,
 ): StripCoworker[] {
   if (!featured) {
     return [];
   }
 
-  const others = coworkers.filter((coworker) => coworker.id !== featured.id);
-  const capped = Math.min(max, others.length);
-  const limit = capped - (capped % 2);
-
-  return others.slice(0, Math.max(0, limit)).map(toStripCoworker);
+  return coworkers
+    .filter((coworker) => coworker.id !== featured.id)
+    .map(toStripCoworker);
 }
 
 type StatsTranslator = (

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -127,52 +127,28 @@ type StatsTranslator = (
 ) => string;
 
 /**
- * Chip labels for the "while you were gone" row, in display order.
+ * Chip labels for the landing activity row, in display order.
  *
- * The teammates chip is included at zero inside an organization: "what my
- * teammates added" is a question the row should answer rather than omit.
- * Window is session-derived activity, so any non-zero metric can show.
+ * Always returns chips — including zeros — so the first viewport keeps a
+ * reserved stats footer even when the account has no activity yet (or Core
+ * could not be reached). Teammates chip stays org-only.
  */
 export function buildActivityStats(
   summary: TaskActivitySummary | null,
   isOrganizationWorkspace: boolean,
   t: StatsTranslator,
 ): string[] {
-  if (!summary) {
-    return [];
-  }
+  const completed = summary?.completed ?? 0;
+  const workedMinutes = summary?.workedMinutes ?? 0;
+  const awaitingInput = summary?.awaitingInput ?? 0;
+  const createdByOtherHumans = summary?.createdByOtherHumans ?? 0;
 
   return [
-    ...(summary.completed > 0
-      ? [t("stats.completed", { count: summary.completed })]
-      : []),
-    ...(summary.workedMinutes > 0
-      ? [t("stats.worked", { minutes: summary.workedMinutes })]
-      : []),
-    ...(summary.awaitingInput > 0
-      ? [t("stats.awaiting", { count: summary.awaitingInput })]
-      : []),
+    t("stats.completed", { count: completed }),
+    t("stats.worked", { minutes: workedMinutes }),
+    t("stats.awaiting", { count: awaitingInput }),
     ...(isOrganizationWorkspace
-      ? [t("stats.byTeammates", { count: summary.createdByOtherHumans })]
+      ? [t("stats.byTeammates", { count: createdByOtherHumans })]
       : []),
   ];
-}
-
-/**
- * Whether the summary has anything worth a chip row at all.
- *
- * Needs at least one non-zero metric; a lone "0 tasks from your team" chip is
- * worse than no row. Window is session-derived (last activity), not a stamped
- * visit — so there is no separate "first visit" hide.
- */
-export function hasReportableActivity(
-  summary: TaskActivitySummary | null,
-): boolean {
-  return (
-    summary !== null &&
-    (summary.completed > 0 ||
-      summary.workedMinutes > 0 ||
-      summary.awaitingInput > 0 ||
-      summary.createdByOtherHumans > 0)
-  );
 }

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -27,9 +27,9 @@ interface LandingCoworkerPickerProps {
  * Landing strip + details + Start chat.
  *
  * Order under the strip: name → caption → Start chat → description.
- * Description lives below the CTA so length / more-less never moves the button.
- * Default featured (Elena) sits in the middle of the full catalog and is
- * scrolled into optical centre on first paint.
+ * The picker is viewport-bounded (`w-full min-w-0`) so the strip's w-max track
+ * cannot widen Start chat. Caption slot keeps a fixed min-height so omitting
+ * or wrapping caption does not jump the CTA. Description stays below the CTA.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -54,8 +54,16 @@ export function LandingCoworkerPicker({
   const selectedDescription = selectedCoworkerDescription(selected);
 
   return (
-    <div data-testid="landing-coworker-picker">
-      <div className={cn(size === "compact" ? "mt-8" : "mt-12", "w-full")}>
+    <div
+      className="w-full min-w-0 max-w-full"
+      data-testid="landing-coworker-picker"
+    >
+      <div
+        className={cn(
+          "w-full min-w-0 max-w-full",
+          size === "compact" ? "mt-6" : "mt-10",
+        )}
+      >
         <CoworkerStrip
           centerOnId={initial.id}
           coworkers={stripCoworkers}
@@ -65,47 +73,54 @@ export function LandingCoworkerPicker({
         />
       </div>
 
-      <p
+      {/* Featured block is its own width budget — never inherits strip track width. */}
+      <div
         className={cn(
-          "font-semibold tracking-[-0.01em]",
-          size === "compact" ? "mt-4 text-lg" : "mt-5 text-xl",
+          "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center",
+          size === "compact" ? "mt-4" : "mt-5",
         )}
-        data-testid="landing-selected-name"
+        data-testid="landing-selected-block"
       >
-        {selected.name}
-      </p>
-      {selectedCaption ? (
         <p
           className={cn(
-            "text-muted-foreground",
+            "font-semibold tracking-[-0.01em]",
+            size === "compact" ? "text-lg" : "text-xl",
+          )}
+          data-testid="landing-selected-name"
+        >
+          {selected.name}
+        </p>
+
+        {/* Always reserve two caption lines so empty/wrapping captions cannot
+            shift Start chat when the middle column is vertically centred. */}
+        <p
+          className={cn(
+            "text-muted-foreground line-clamp-2 w-full leading-snug",
             size === "compact"
-              ? "mt-1 text-[0.8125rem] leading-snug"
-              : "mt-1.5 text-sm leading-snug",
+              ? "mt-1 min-h-[2.4375rem] text-[0.8125rem]"
+              : "mt-1.5 min-h-[2.5rem] text-sm",
           )}
           data-testid="landing-selected-caption"
         >
-          {selectedCaption}
+          {selectedCaption ?? "\u00a0"}
         </p>
-      ) : null}
 
-      <div
-        className={cn("mt-6", size === "compact" && "w-full max-w-xs")}
-        data-testid="landing-start-chat"
-      >
-        <StartChatButton
-          className={startChatClassName}
-          coworkerId={selected.id}
-          coworkerName={selected.name}
-        />
+        <div className="mt-4 w-full min-w-0" data-testid="landing-start-chat">
+          <StartChatButton
+            className={cn("w-full", startChatClassName)}
+            coworkerId={selected.id}
+            coworkerName={selected.name}
+          />
+        </div>
+
+        {selectedDescription ? (
+          <LandingSelectedDescription
+            coworkerId={selected.id}
+            description={selectedDescription}
+            size={size}
+          />
+        ) : null}
       </div>
-
-      {selectedDescription ? (
-        <LandingSelectedDescription
-          coworkerId={selected.id}
-          description={selectedDescription}
-          size={size}
-        />
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -26,11 +26,11 @@ interface LandingCoworkerPickerProps {
 /**
  * Landing strip + details + Start chat.
  *
- * Order under the strip: name → caption → Start chat → description.
+ * Order under the strip: name → caption → description → Start chat.
  * The picker is viewport-bounded (`w-full min-w-0`) so the strip's w-max track
- * cannot widen Start chat. Caption slot keeps a fixed min-height so omitting
- * or wrapping caption does not jump the CTA. Name → caption → CTA is a
- * shrink-0 stack; description stays below so selection / more-less grows down.
+ * cannot widen Start chat. Caption and collapsed description slots keep fixed
+ * min-heights (including empty) so selection cannot jump the CTA. Expanding
+ * More grows the description downward and may shift Start chat; Less restores.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -52,7 +52,7 @@ export function LandingCoworkerPicker({
 
   const stripCoworkers = orderStripCoworkers(coworkers, initial);
   const selectedCaption = selectedCoworkerCaption(selected);
-  const selectedDescription = selectedCoworkerDescription(selected);
+  const selectedDescription = selectedCoworkerDescription(selected) ?? "";
 
   return (
     <div
@@ -75,8 +75,8 @@ export function LandingCoworkerPicker({
       </div>
 
       {/* Featured block is its own width budget — never inherits strip track width.
-          Name → caption → CTA is a shrink-0 stack; description grows below so
-          selection / more-less cannot shift Start chat (parent is top-aligned). */}
+          Name → caption → description → CTA; reserved slots keep CTA stable
+          across selection; More is the only intentional CTA shift. */}
       <div
         className={cn(
           "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center justify-start",
@@ -112,6 +112,12 @@ export function LandingCoworkerPicker({
             {selectedCaption ?? "\u00a0"}
           </p>
 
+          <LandingSelectedDescription
+            coworkerId={selected.id}
+            description={selectedDescription}
+            size={size}
+          />
+
           <div className="mt-4 w-full min-w-0" data-testid="landing-start-chat">
             <StartChatButton
               className={cn("w-full", startChatClassName)}
@@ -120,14 +126,6 @@ export function LandingCoworkerPicker({
             />
           </div>
         </div>
-
-        {selectedDescription ? (
-          <LandingSelectedDescription
-            coworkerId={selected.id}
-            description={selectedDescription}
-            size={size}
-          />
-        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Coworker } from "@/app/chat/utils/types";
+import { cn } from "@/lib/utils";
+
+import { CoworkerStrip } from "./coworker-strip.client";
+import { featuredCoworkerRole, toStripCoworker } from "./landing-content";
+import { StartChatButton } from "./start-chat-button.client";
+
+interface LandingCoworkerPickerProps {
+  coworkers: Coworker[];
+  /** Elena (or fallback) — default selection before the user taps. */
+  initialSelectedId: string;
+  /** Product pitch for Elena under the strip. */
+  elenaRole: string;
+  size?: "compact" | "default";
+  /** Mobile passes `w-full` so the CTA spans the column. */
+  startChatClassName?: string;
+}
+
+/**
+ * Landing strip + details + Start chat.
+ *
+ * Strip taps only change selection. Opening a DM waits for Start chat.
+ */
+export function LandingCoworkerPicker({
+  coworkers,
+  initialSelectedId,
+  elenaRole,
+  size = "default",
+  startChatClassName,
+}: LandingCoworkerPickerProps) {
+  const [selectedId, setSelectedId] = useState(initialSelectedId);
+
+  const initial =
+    coworkers.find((coworker) => coworker.id === initialSelectedId) ??
+    coworkers[0];
+  if (!initial) {
+    return null;
+  }
+
+  const selected =
+    coworkers.find((coworker) => coworker.id === selectedId) ?? initial;
+
+  // Stable browse order: default featured first, then the rest of the catalog.
+  const ordered = [
+    initial,
+    ...coworkers.filter((coworker) => coworker.id !== initial.id),
+  ];
+  const stripCoworkers = ordered.map(toStripCoworker);
+  const selectedRole = featuredCoworkerRole(selected, elenaRole);
+
+  return (
+    <>
+      <div className={cn(size === "compact" ? "mt-8" : "mt-12", "w-full")}>
+        <CoworkerStrip
+          coworkers={stripCoworkers}
+          onSelect={setSelectedId}
+          selectedId={selected.id}
+          size={size}
+        />
+      </div>
+
+      <p
+        className={cn(
+          "font-semibold tracking-[-0.01em]",
+          size === "compact" ? "mt-4 text-lg" : "mt-5 text-xl",
+        )}
+      >
+        {selected.name}
+      </p>
+      {selectedRole ? (
+        <p
+          className={cn(
+            "text-muted-foreground text-balance",
+            size === "compact"
+              ? "mt-1.5 max-w-[40ch] text-[0.8125rem] leading-[1.5]"
+              : "mx-auto mt-2 max-w-[46ch] text-[0.9375rem] leading-[1.55]",
+          )}
+        >
+          {selectedRole}
+        </p>
+      ) : null}
+
+      <div className={cn("mt-6", size === "compact" && "w-full max-w-xs")}>
+        <StartChatButton
+          className={startChatClassName}
+          coworkerId={selected.id}
+          coworkerName={selected.name}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -8,8 +8,10 @@ import { cn } from "@/lib/utils";
 import { CoworkerStrip } from "./coworker-strip.client";
 import {
   orderStripCoworkers,
+  selectedCoworkerCaption,
   selectedCoworkerDescription,
 } from "./landing-content";
+import { LandingSelectedDescription } from "./landing-selected-description.client";
 import { StartChatButton } from "./start-chat-button.client";
 
 interface LandingCoworkerPickerProps {
@@ -24,10 +26,10 @@ interface LandingCoworkerPickerProps {
 /**
  * Landing strip + details + Start chat.
  *
- * Strip taps only change selection. Opening a DM waits for Start chat.
+ * Order under the strip: name → caption → Start chat → description.
+ * Description lives below the CTA so length / more-less never moves the button.
  * Default featured (Elena) sits in the middle of the full catalog and is
- * scrolled into optical centre on first paint. Under-name copy is the
- * selected coworker's DB description (caption stays on strip chips only).
+ * scrolled into optical centre on first paint.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -48,10 +50,11 @@ export function LandingCoworkerPicker({
     coworkers.find((coworker) => coworker.id === selectedId) ?? initial;
 
   const stripCoworkers = orderStripCoworkers(coworkers, initial);
+  const selectedCaption = selectedCoworkerCaption(selected);
   const selectedDescription = selectedCoworkerDescription(selected);
 
   return (
-    <>
+    <div data-testid="landing-coworker-picker">
       <div className={cn(size === "compact" ? "mt-8" : "mt-12", "w-full")}>
         <CoworkerStrip
           centerOnId={initial.id}
@@ -67,30 +70,42 @@ export function LandingCoworkerPicker({
           "font-semibold tracking-[-0.01em]",
           size === "compact" ? "mt-4 text-lg" : "mt-5 text-xl",
         )}
+        data-testid="landing-selected-name"
       >
         {selected.name}
       </p>
-      {selectedDescription ? (
+      {selectedCaption ? (
         <p
           className={cn(
-            "text-muted-foreground text-balance",
+            "text-muted-foreground",
             size === "compact"
-              ? "mt-1.5 max-w-[40ch] text-[0.8125rem] leading-[1.5]"
-              : "mx-auto mt-2 max-w-[46ch] text-[0.9375rem] leading-[1.55]",
+              ? "mt-1 text-[0.8125rem] leading-snug"
+              : "mt-1.5 text-sm leading-snug",
           )}
-          data-testid="landing-selected-description"
+          data-testid="landing-selected-caption"
         >
-          {selectedDescription}
+          {selectedCaption}
         </p>
       ) : null}
 
-      <div className={cn("mt-6", size === "compact" && "w-full max-w-xs")}>
+      <div
+        className={cn("mt-6", size === "compact" && "w-full max-w-xs")}
+        data-testid="landing-start-chat"
+      >
         <StartChatButton
           className={startChatClassName}
           coworkerId={selected.id}
           coworkerName={selected.name}
         />
       </div>
-    </>
+
+      {selectedDescription ? (
+        <LandingSelectedDescription
+          coworkerId={selected.id}
+          description={selectedDescription}
+          size={size}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -6,15 +6,16 @@ import type { Coworker } from "@/app/chat/utils/types";
 import { cn } from "@/lib/utils";
 
 import { CoworkerStrip } from "./coworker-strip.client";
-import { featuredCoworkerRole, orderStripCoworkers } from "./landing-content";
+import {
+  orderStripCoworkers,
+  selectedCoworkerDescription,
+} from "./landing-content";
 import { StartChatButton } from "./start-chat-button.client";
 
 interface LandingCoworkerPickerProps {
   coworkers: Coworker[];
   /** Elena (or fallback) — default selection before the user taps. */
   initialSelectedId: string;
-  /** Product pitch for Elena under the strip. */
-  elenaRole: string;
   size?: "compact" | "default";
   /** Mobile passes `w-full` so the CTA spans the column. */
   startChatClassName?: string;
@@ -25,12 +26,12 @@ interface LandingCoworkerPickerProps {
  *
  * Strip taps only change selection. Opening a DM waits for Start chat.
  * Default featured (Elena) sits in the middle of the full catalog and is
- * scrolled into optical centre on first paint.
+ * scrolled into optical centre on first paint. Under-name copy is the
+ * selected coworker's DB description (caption stays on strip chips only).
  */
 export function LandingCoworkerPicker({
   coworkers,
   initialSelectedId,
-  elenaRole,
   size = "default",
   startChatClassName,
 }: LandingCoworkerPickerProps) {
@@ -47,7 +48,7 @@ export function LandingCoworkerPicker({
     coworkers.find((coworker) => coworker.id === selectedId) ?? initial;
 
   const stripCoworkers = orderStripCoworkers(coworkers, initial);
-  const selectedRole = featuredCoworkerRole(selected, elenaRole);
+  const selectedDescription = selectedCoworkerDescription(selected);
 
   return (
     <>
@@ -69,7 +70,7 @@ export function LandingCoworkerPicker({
       >
         {selected.name}
       </p>
-      {selectedRole ? (
+      {selectedDescription ? (
         <p
           className={cn(
             "text-muted-foreground text-balance",
@@ -77,8 +78,9 @@ export function LandingCoworkerPicker({
               ? "mt-1.5 max-w-[40ch] text-[0.8125rem] leading-[1.5]"
               : "mx-auto mt-2 max-w-[46ch] text-[0.9375rem] leading-[1.55]",
           )}
+          data-testid="landing-selected-description"
         >
-          {selectedRole}
+          {selectedDescription}
         </p>
       ) : null}
 

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -29,7 +29,8 @@ interface LandingCoworkerPickerProps {
  * Order under the strip: name → caption → Start chat → description.
  * The picker is viewport-bounded (`w-full min-w-0`) so the strip's w-max track
  * cannot widen Start chat. Caption slot keeps a fixed min-height so omitting
- * or wrapping caption does not jump the CTA. Description stays below the CTA.
+ * or wrapping caption does not jump the CTA. Name → caption → CTA is a
+ * shrink-0 stack; description stays below so selection / more-less grows down.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -73,44 +74,51 @@ export function LandingCoworkerPicker({
         />
       </div>
 
-      {/* Featured block is its own width budget — never inherits strip track width. */}
+      {/* Featured block is its own width budget — never inherits strip track width.
+          Name → caption → CTA is a shrink-0 stack; description grows below so
+          selection / more-less cannot shift Start chat (parent is top-aligned). */}
       <div
         className={cn(
-          "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center",
+          "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center justify-start",
           size === "compact" ? "mt-4" : "mt-5",
         )}
         data-testid="landing-selected-block"
       >
-        <p
-          className={cn(
-            "font-semibold tracking-[-0.01em]",
-            size === "compact" ? "text-lg" : "text-xl",
-          )}
-          data-testid="landing-selected-name"
+        <div
+          className="flex w-full shrink-0 flex-col items-center"
+          data-testid="landing-selected-cta-stack"
         >
-          {selected.name}
-        </p>
+          <p
+            className={cn(
+              "font-semibold tracking-[-0.01em]",
+              size === "compact" ? "text-lg" : "text-xl",
+            )}
+            data-testid="landing-selected-name"
+          >
+            {selected.name}
+          </p>
 
-        {/* Always reserve two caption lines so empty/wrapping captions cannot
-            shift Start chat when the middle column is vertically centred. */}
-        <p
-          className={cn(
-            "text-muted-foreground line-clamp-2 w-full leading-snug",
-            size === "compact"
-              ? "mt-1 min-h-[2.4375rem] text-[0.8125rem]"
-              : "mt-1.5 min-h-[2.5rem] text-sm",
-          )}
-          data-testid="landing-selected-caption"
-        >
-          {selectedCaption ?? "\u00a0"}
-        </p>
+          {/* Always reserve two caption lines so empty/wrapping captions cannot
+              shift Start chat relative to the top-aligned stack. */}
+          <p
+            className={cn(
+              "text-muted-foreground line-clamp-2 w-full leading-snug",
+              size === "compact"
+                ? "mt-1 min-h-[2.4375rem] text-[0.8125rem]"
+                : "mt-1.5 min-h-[2.5rem] text-sm",
+            )}
+            data-testid="landing-selected-caption"
+          >
+            {selectedCaption ?? "\u00a0"}
+          </p>
 
-        <div className="mt-4 w-full min-w-0" data-testid="landing-start-chat">
-          <StartChatButton
-            className={cn("w-full", startChatClassName)}
-            coworkerId={selected.id}
-            coworkerName={selected.name}
-          />
+          <div className="mt-4 w-full min-w-0" data-testid="landing-start-chat">
+            <StartChatButton
+              className={cn("w-full", startChatClassName)}
+              coworkerId={selected.id}
+              coworkerName={selected.name}
+            />
+          </div>
         </div>
 
         {selectedDescription ? (

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -6,7 +6,7 @@ import type { Coworker } from "@/app/chat/utils/types";
 import { cn } from "@/lib/utils";
 
 import { CoworkerStrip } from "./coworker-strip.client";
-import { featuredCoworkerRole, toStripCoworker } from "./landing-content";
+import { featuredCoworkerRole, orderStripCoworkers } from "./landing-content";
 import { StartChatButton } from "./start-chat-button.client";
 
 interface LandingCoworkerPickerProps {
@@ -24,6 +24,8 @@ interface LandingCoworkerPickerProps {
  * Landing strip + details + Start chat.
  *
  * Strip taps only change selection. Opening a DM waits for Start chat.
+ * Default featured (Elena) sits in the middle of the full catalog and is
+ * scrolled into optical centre on first paint.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -44,18 +46,14 @@ export function LandingCoworkerPicker({
   const selected =
     coworkers.find((coworker) => coworker.id === selectedId) ?? initial;
 
-  // Stable browse order: default featured first, then the rest of the catalog.
-  const ordered = [
-    initial,
-    ...coworkers.filter((coworker) => coworker.id !== initial.id),
-  ];
-  const stripCoworkers = ordered.map(toStripCoworker);
+  const stripCoworkers = orderStripCoworkers(coworkers, initial);
   const selectedRole = featuredCoworkerRole(selected, elenaRole);
 
   return (
     <>
       <div className={cn(size === "compact" ? "mt-8" : "mt-12", "w-full")}>
         <CoworkerStrip
+          centerOnId={initial.id}
           coworkers={stripCoworkers}
           onSelect={setSelectedId}
           selectedId={selected.id}

--- a/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
@@ -45,10 +45,10 @@ function LandingSelectedDescriptionBody({
   return (
     <div
       className={cn(
-        "text-muted-foreground text-balance",
+        "text-muted-foreground w-full min-w-0 text-balance",
         size === "compact"
-          ? "mt-4 max-w-[40ch] text-[0.8125rem] leading-[1.5]"
-          : "mx-auto mt-5 max-w-[46ch] text-[0.9375rem] leading-[1.55]",
+          ? "mt-3 text-[0.8125rem] leading-[1.5]"
+          : "mt-4 text-[0.9375rem] leading-[1.55]",
       )}
       data-testid="landing-selected-description"
     >

--- a/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { clampLandingDescription } from "./landing-content";
+
+interface LandingSelectedDescriptionProps {
+  /** Remount key — selection id so more/less resets when the user taps another face. */
+  coworkerId: string;
+  description: string;
+  size?: "compact" | "default";
+}
+
+/**
+ * Description sits *below* Start chat so expanding more/less grows downward
+ * without moving the CTA. Collapsed to ~3 lines / ~180 characters.
+ */
+export function LandingSelectedDescription({
+  coworkerId,
+  description,
+  size = "default",
+}: LandingSelectedDescriptionProps) {
+  return (
+    <LandingSelectedDescriptionBody
+      key={coworkerId}
+      description={description}
+      size={size}
+    />
+  );
+}
+
+function LandingSelectedDescriptionBody({
+  description,
+  size = "default",
+}: Omit<LandingSelectedDescriptionProps, "coworkerId">) {
+  const t = useTranslations("App.Chat.Landing");
+  const [expanded, setExpanded] = useState(false);
+  const { isTruncated, preview } = clampLandingDescription(description);
+  const text = expanded || !isTruncated ? description : preview;
+
+  return (
+    <div
+      className={cn(
+        "text-muted-foreground text-balance",
+        size === "compact"
+          ? "mt-4 max-w-[40ch] text-[0.8125rem] leading-[1.5]"
+          : "mx-auto mt-5 max-w-[46ch] text-[0.9375rem] leading-[1.55]",
+      )}
+      data-testid="landing-selected-description"
+    >
+      <p className={cn(!expanded && isTruncated && "line-clamp-3")}>{text}</p>
+      {isTruncated ? (
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="text-foreground mt-1 h-auto px-0 text-xs font-medium"
+          aria-expanded={expanded}
+          data-testid="landing-description-toggle"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded ? t("team.showLess") : t("team.showMore")}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
@@ -11,13 +11,16 @@ import { clampLandingDescription } from "./landing-content";
 interface LandingSelectedDescriptionProps {
   /** Remount key — selection id so more/less resets when the user taps another face. */
   coworkerId: string;
+  /** Empty string still mounts the reserved collapsed slot. */
   description: string;
   size?: "compact" | "default";
 }
 
 /**
- * Description sits *below* Start chat so expanding more/less grows downward
- * without moving the CTA. Collapsed to ~3 lines / ~180 characters.
+ * Clamped description sits *above* Start chat. Collapsed state always reserves
+ * ~3 lines (`min-h-[3lh]`) plus a toggle-row slot so empty / short / long
+ * previews cannot move the CTA. Expanding More grows downward and may shift
+ * Start chat; Less restores the reserved height.
  */
 export function LandingSelectedDescription({
   coworkerId,
@@ -39,8 +42,13 @@ function LandingSelectedDescriptionBody({
 }: Omit<LandingSelectedDescriptionProps, "coworkerId">) {
   const t = useTranslations("App.Chat.Landing");
   const [expanded, setExpanded] = useState(false);
-  const { isTruncated, preview } = clampLandingDescription(description);
-  const text = expanded || !isTruncated ? description : preview;
+  const trimmed = description.trim();
+  const { isTruncated, preview } = clampLandingDescription(trimmed);
+  const text = !trimmed
+    ? "\u00a0"
+    : expanded || !isTruncated
+      ? trimmed
+      : preview;
 
   return (
     <div
@@ -52,20 +60,39 @@ function LandingSelectedDescriptionBody({
       )}
       data-testid="landing-selected-description"
     >
-      <p className={cn(!expanded && isTruncated && "line-clamp-3")}>{text}</p>
-      {isTruncated ? (
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="text-foreground mt-1 h-auto px-0 text-xs font-medium"
-          aria-expanded={expanded}
-          data-testid="landing-description-toggle"
-          onClick={() => setExpanded((current) => !current)}
-        >
-          {expanded ? t("team.showLess") : t("team.showMore")}
-        </Button>
-      ) : null}
+      <p
+        className={cn(
+          // `3lh` follows the element's line-height (twMerge drops `leading-*`
+          // next to `line-clamp-*`). Collapsed reserve is always three lines.
+          !expanded && "line-clamp-3 min-h-[3lh]",
+        )}
+        data-testid="landing-selected-description-text"
+      >
+        {text}
+      </p>
+      {/* Toggle row stays reserved when collapsed so coworkers without a More
+          control (short / empty) match truncated ones for CTA position. */}
+      <div
+        className={cn(
+          "mt-1 flex min-h-[1.25rem] items-start justify-center",
+          expanded && isTruncated && "min-h-0",
+        )}
+        data-testid="landing-description-toggle-slot"
+      >
+        {isTruncated ? (
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="text-foreground h-auto px-0 text-xs font-medium"
+            aria-expanded={expanded}
+            data-testid="landing-description-toggle"
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded ? t("team.showLess") : t("team.showMore")}
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -151,7 +151,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
       {landingNotice}
       {/* One welcome per breakpoint. The compositions differ enough — six 64px
           teammates versus four at 44px — that CSS alone cannot bridge them. */}
-      <div className="hidden md:contents">
+      <div className="hidden min-h-full min-w-0 flex-1 flex-col md:flex">
         <ChatLanding
           coworkers={coworkers}
           isOrganizationWorkspace={activeOrganizationId !== null}
@@ -159,7 +159,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
           userName={session?.user.name ?? null}
         />
       </div>
-      <div className="flex min-h-full w-full flex-col md:hidden">
+      <div className="flex min-h-full min-w-0 w-full flex-1 flex-col md:hidden">
         <ChatLandingMobile
           coworkers={coworkers}
           isOrganizationWorkspace={activeOrganizationId !== null}

--- a/apps/web/src/config/__tests__/next-image.test.ts
+++ b/apps/web/src/config/__tests__/next-image.test.ts
@@ -30,4 +30,32 @@ describe("canUseNextImageSrc", () => {
   it("allows relative paths", () => {
     expect(canUseNextImageSrc("/static/local.png")).toBe(true);
   });
+
+  it("allows Serviceplan usecase hosts used by Jamal/Maya WebP avatars", () => {
+    expect(
+      canUseNextImageSrc(
+        "https://usecases.serviceplan-agents.com/images/jamal.webp",
+      ),
+    ).toBe(true);
+    expect(
+      canUseNextImageSrc(
+        "https://usecases.serviceplan-agents.com/images/maya.webp",
+      ),
+    ).toBe(true);
+    expect(
+      canUseNextImageSrc("https://serviceplan-agents.com/images/jamal.webp"),
+    ).toBe(true);
+  });
+
+  it("does not reject .webp on already-allowed hosts (format is not the gate)", () => {
+    expect(
+      canUseNextImageSrc(
+        "https://yhpsw8jlcoagsrkq.public.blob.vercel-storage.com/coworkers/avatar.webp",
+      ),
+    ).toBe(true);
+    expect(canUseNextImageSrc("/images/coworkers/elena.webp")).toBe(true);
+    expect(
+      canUseNextImageSrc("https://cdn.azurecontainerapps.io/path/to/face.webp"),
+    ).toBe(true);
+  });
 });

--- a/apps/web/src/config/__tests__/next-image.test.ts
+++ b/apps/web/src/config/__tests__/next-image.test.ts
@@ -31,20 +31,31 @@ describe("canUseNextImageSrc", () => {
     expect(canUseNextImageSrc("/static/local.png")).toBe(true);
   });
 
-  it("allows Serviceplan usecase hosts used by Jamal/Maya WebP avatars", () => {
+  it("allows any single subdomain under serviceplan-agents.com plus the apex", () => {
     expect(
       canUseNextImageSrc(
         "https://usecases.serviceplan-agents.com/images/jamal.webp",
       ),
     ).toBe(true);
     expect(
+      canUseNextImageSrc("https://foo.serviceplan-agents.com/images/maya.webp"),
+    ).toBe(true);
+    expect(
       canUseNextImageSrc(
-        "https://usecases.serviceplan-agents.com/images/maya.webp",
+        "https://cdn.serviceplan-agents.com/avatars/elena.png",
       ),
     ).toBe(true);
     expect(
       canUseNextImageSrc("https://serviceplan-agents.com/images/jamal.webp"),
     ).toBe(true);
+  });
+
+  it("rejects nested Serviceplan subdomains beyond one segment", () => {
+    expect(
+      canUseNextImageSrc(
+        "https://a.b.serviceplan-agents.com/images/jamal.webp",
+      ),
+    ).toBe(false);
   });
 
   it("does not reject .webp on already-allowed hosts (format is not the gate)", () => {

--- a/apps/web/src/config/next-image.ts
+++ b/apps/web/src/config/next-image.ts
@@ -17,12 +17,17 @@ export const NEXT_IMAGE_REMOTE_PATTERNS = [
     hostname: "**.utxoag.com",
   },
   /**
-   * Serviceplan usecase hosts (Jamal, Maya, …). Avatars are often `.webp`;
-   * allowlisting is by hostname — next/image already accepts webp bytes.
+   * Serviceplan coworker hosts (Jamal, Maya, …). `*` = one subdomain segment
+   * (e.g. usecases. / foo.); apex listed separately because Next `*` does not
+   * match the bare domain.
    */
   {
     protocol: "https",
-    hostname: "**.serviceplan-agents.com",
+    hostname: "*.serviceplan-agents.com",
+  },
+  {
+    protocol: "https",
+    hostname: "serviceplan-agents.com",
   },
 ] as const;
 

--- a/apps/web/src/config/next-image.ts
+++ b/apps/web/src/config/next-image.ts
@@ -16,6 +16,14 @@ export const NEXT_IMAGE_REMOTE_PATTERNS = [
     protocol: "https",
     hostname: "**.utxoag.com",
   },
+  /**
+   * Serviceplan usecase hosts (Jamal, Maya, …). Avatars are often `.webp`;
+   * allowlisting is by hostname — next/image already accepts webp bytes.
+   */
+  {
+    protocol: "https",
+    hostname: "**.serviceplan-agents.com",
+  },
 ] as const;
 
 export function canUseNextImageSrc(url: string): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scrollable DB-backed coworker strip on `/chat` landing (SOK-786).

## Image allowlist

- `*.serviceplan-agents.com` (one subdomain: usecases, foo, …) plus apex `serviceplan-agents.com` in `NEXT_IMAGE_REMOTE_PATTERNS` / `canUseNextImageSrc`.
- Existing blob / IPFS / azure / utxoag entries unchanged.

## Verification

- `pnpm --filter web test src/config/__tests__/next-image.test.ts src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts`

## Linear

https://linear.app/masumi/issue/SOK-786/scrollable-db-backed-coworker-strip-on-chat-landing-replaces

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49189928-89da-4962-b549-1a7928ce0f3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49189928-89da-4962-b549-1a7928ce0f3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

