### PR TITLE
fix(chat): drop duplicate identity from landing detail

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
@@ -492,10 +492,13 @@ describe("RoomsClient scroll on own send", () => {
 
     screen.getByTestId("send-message").click();
 
-    const failedShell = await screen.findByTestId(
-      "message-pending:client-msg-1",
-    );
-    expect(failedShell).toHaveAttribute("data-outbound-status", "failed");
+    // Pending shell mounts first; wait for the failed transition — findByTestId
+    // alone resolves while status is still "pending" under CI load.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("message-pending:client-msg-1"),
+      ).toHaveAttribute("data-outbound-status", "failed");
+    });
     expect(screen.getByTestId("retry-outbound")).toBeTruthy();
 
     screen.getByTestId("retry-outbound").click();
@@ -519,9 +522,11 @@ describe("RoomsClient scroll on own send", () => {
 
     screen.getByTestId("send-message").click();
 
-    expect(
-      await screen.findByTestId("message-pending:client-msg-1"),
-    ).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("message-pending:client-msg-1"),
+      ).toHaveAttribute("data-outbound-status", "failed");
+    });
 
     screen.getByTestId("remove-outbound").click();
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
@@ -10,8 +10,8 @@ import { describe, expect, it } from "vitest";
  * pinned (`shrink-0` + test id) at the bottom of the viewport-tall column,
  * always mounted (including zero chips), never gated on non-zero activity.
  *
- * The middle column must be top-aligned (`justify-start`) so description /
- * caption length cannot vertically re-center Start chat.
+ * The middle column must be top-aligned (`justify-start`) so description
+ * length cannot vertically re-center Start chat.
  */
 describe("chat landing stats row contract", () => {
   it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-content.test.ts
@@ -9,7 +9,6 @@ import {
   LANDING_DESCRIPTION_MAX_CHARS,
   orderStripCoworkers,
   resolveFeaturedCoworker,
-  selectedCoworkerCaption,
   selectedCoworkerDescription,
   toStripCoworker,
 } from "../landing-content";
@@ -71,28 +70,6 @@ describe("resolveFeaturedCoworker", () => {
 
   it("returns null when there are no coworkers at all", () => {
     expect(resolveFeaturedCoworker([])).toBeNull();
-  });
-});
-
-describe("selectedCoworkerCaption", () => {
-  it("returns a trimmed caption", () => {
-    expect(
-      selectedCoworkerCaption(
-        buildCoworker({ id: "elena", caption: "  Strategy  " }),
-      ),
-    ).toBe("Strategy");
-  });
-
-  it("returns null when caption is empty — no useCase fallback", () => {
-    expect(
-      selectedCoworkerCaption(
-        buildCoworker({
-          id: "hannah",
-          caption: "   ",
-          useCase: "Research briefs",
-        }),
-      ),
-    ).toBeNull();
   });
 });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -41,12 +41,9 @@ function buildCoworker(overrides: Partial<Coworker> & { id: string }) {
 }
 
 function blockOrder(): string[] {
-  return [
-    "landing-selected-name",
-    "landing-selected-caption",
-    "landing-selected-description",
-    "landing-start-chat",
-  ].filter((id) => screen.queryByTestId(id) !== null);
+  return ["landing-selected-description", "landing-start-chat"].filter(
+    (id) => screen.queryByTestId(id) !== null,
+  );
 }
 
 describe("LandingCoworkerPicker", () => {
@@ -123,61 +120,81 @@ describe("LandingCoworkerPicker", () => {
     expect(optionIds).toEqual(["a", "b", "elena", "c", "d"]);
   });
 
-  it("orders name, caption, description, then Start chat", () => {
+  it("orders description then Start chat — no name or role in the detail block", () => {
     render(
       <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
 
     expect(blockOrder()).toEqual([
-      "landing-selected-name",
-      "landing-selected-caption",
       "landing-selected-description",
       "landing-start-chat",
     ]);
+    expect(
+      screen.queryByTestId("landing-selected-name"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("landing-selected-caption"),
+    ).not.toBeInTheDocument();
 
-    const name = screen.getByTestId("landing-selected-name");
-    const caption = screen.getByTestId("landing-selected-caption");
     const description = screen.getByTestId("landing-selected-description");
     const cta = screen.getByTestId("landing-start-chat");
 
-    expect(name.compareDocumentPosition(caption)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(caption.compareDocumentPosition(description)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
     expect(description.compareDocumentPosition(cta)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
 
-  it("keeps a reserved caption slot so omitting caption cannot remove CTA spacing", async () => {
+  it("keeps strip name + role and does not repeat them below the strip", () => {
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const elenaOption = screen.getByRole("option", {
+      name: 'team.select:{"name":"Elena"}',
+    });
+    expect(elenaOption).toHaveTextContent("Elena");
+    expect(elenaOption).toHaveTextContent("Strategy");
+
+    expect(
+      screen.queryByTestId("landing-selected-name"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("landing-selected-caption"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("landing-selected-description"),
+    ).toHaveTextContent("Elena turns goals into planned work.");
+    expect(
+      screen.getByTestId("landing-selected-description"),
+    ).not.toHaveTextContent("Strategy");
+    expect(screen.getByTestId("landing-start-chat")).toBeInTheDocument();
+  });
+
+  it("does not repeat identity when selecting another coworker", async () => {
     const user = userEvent.setup();
 
     render(
       <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
     );
 
-    const caption = screen.getByTestId("landing-selected-caption");
-    expect(caption.className).toMatch(/min-h-/);
-    expect(caption).toHaveTextContent("Strategy");
-
     await user.click(
       screen.getByRole("option", {
-        name: 'team.select:{"name":"Deckster"}',
+        name: 'team.select:{"name":"Hannah"}',
       }),
     );
 
-    expect(screen.getByTestId("landing-selected-caption").className).toMatch(
-      /min-h-/,
-    );
-    expect(screen.getByTestId("landing-start-chat")).toBeInTheDocument();
     expect(
-      screen
-        .getByTestId("landing-selected-caption")
-        .compareDocumentPosition(screen.getByTestId("landing-start-chat")) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+      screen.queryByTestId("landing-selected-name"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("landing-selected-caption"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("landing-selected-description").textContent,
+    ).toContain("Hannah digs into sources");
+    expect(
+      screen.getByTestId("landing-selected-description"),
+    ).not.toHaveTextContent("Research");
   });
 
   it("reserves collapsed description height above Start chat including empty", async () => {
@@ -222,6 +239,7 @@ describe("LandingCoworkerPicker", () => {
     expect(
       screen.queryByTestId("landing-description-toggle"),
     ).not.toBeInTheDocument();
+    expect(screen.getByTestId("landing-start-chat")).toBeInTheDocument();
 
     await user.click(
       screen.getByRole("option", {
@@ -255,16 +273,16 @@ describe("LandingCoworkerPicker", () => {
 
     const stack = screen.getByTestId("landing-selected-cta-stack");
     expect(stack.className).toMatch(/shrink-0/);
-    expect(stack.contains(screen.getByTestId("landing-selected-name"))).toBe(
-      true,
-    );
-    expect(stack.contains(screen.getByTestId("landing-selected-caption"))).toBe(
-      true,
-    );
     expect(
       stack.contains(screen.getByTestId("landing-selected-description")),
     ).toBe(true);
     expect(stack.contains(screen.getByTestId("landing-start-chat"))).toBe(true);
+    expect(
+      screen.queryByTestId("landing-selected-name"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("landing-selected-caption"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps description above Start chat across selection", async () => {
@@ -362,8 +380,6 @@ describe("LandingCoworkerPicker", () => {
     );
 
     expect(blockOrder()).toEqual([
-      "landing-selected-name",
-      "landing-selected-caption",
       "landing-selected-description",
       "landing-start-chat",
     ]);
@@ -372,7 +388,7 @@ describe("LandingCoworkerPicker", () => {
     ).toBe("\u00a0");
   });
 
-  it("updates caption, description, and Start chat when a strip face is tapped", async () => {
+  it("updates description and Start chat when a strip face is tapped", async () => {
     const user = userEvent.setup();
 
     render(
@@ -386,9 +402,6 @@ describe("LandingCoworkerPicker", () => {
     );
 
     expect(openCoworkerRoom).not.toHaveBeenCalled();
-    expect(screen.getByTestId("landing-selected-caption")).toHaveTextContent(
-      "Research",
-    );
     expect(
       screen.getByTestId("landing-selected-description").textContent,
     ).toContain("Hannah digs into sources");

--- a/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-content.ts
@@ -33,17 +33,8 @@ export function resolveFeaturedCoworker(
 }
 
 /**
- * Short specialty under the selected name (above Start chat).
- * DB `caption` only — omit when empty (no useCase fallback here).
- */
-export function selectedCoworkerCaption(
-  coworker: Pick<Coworker, "caption">,
-): string | null {
-  return nonEmptySpecialty(coworker.caption);
-}
-
-/**
  * Body copy above Start chat. DB `description` only — never caption/useCase.
+ * Name + role stay under the strip avatar; the selected block does not repeat them.
  */
 export function selectedCoworkerDescription(
   coworker: Pick<Coworker, "description">,

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -8,7 +8,6 @@ import { cn } from "@/lib/utils";
 import { CoworkerStrip } from "./coworker-strip.client";
 import {
   orderStripCoworkers,
-  selectedCoworkerCaption,
   selectedCoworkerDescription,
 } from "./landing-content";
 import { LandingSelectedDescription } from "./landing-selected-description.client";
@@ -26,11 +25,12 @@ interface LandingCoworkerPickerProps {
 /**
  * Landing strip + details + Start chat.
  *
- * Order under the strip: name → caption → description → Start chat.
+ * The strip already shows name + role under each avatar. The selected block
+ * below is description → Start chat only — no second identity heading.
  * The picker is viewport-bounded (`w-full min-w-0`) so the strip's w-max track
- * cannot widen Start chat. Caption and collapsed description slots keep fixed
- * min-heights (including empty) so selection cannot jump the CTA. Expanding
- * More grows the description downward and may shift Start chat; Less restores.
+ * cannot widen Start chat. Collapsed description slots keep fixed min-heights
+ * (including empty) so selection cannot jump the CTA. Expanding More grows
+ * the description downward and may shift Start chat; Less restores.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -51,7 +51,6 @@ export function LandingCoworkerPicker({
     coworkers.find((coworker) => coworker.id === selectedId) ?? initial;
 
   const stripCoworkers = orderStripCoworkers(coworkers, initial);
-  const selectedCaption = selectedCoworkerCaption(selected);
   const selectedDescription = selectedCoworkerDescription(selected) ?? "";
 
   return (
@@ -75,8 +74,9 @@ export function LandingCoworkerPicker({
       </div>
 
       {/* Featured block is its own width budget — never inherits strip track width.
-          Name → caption → description → CTA; reserved slots keep CTA stable
-          across selection; More is the only intentional CTA shift. */}
+          Description → CTA only; identity (name + role) lives under the strip
+          avatar. Reserved description slots keep CTA stable across selection;
+          More is the only intentional CTA shift. */}
       <div
         className={cn(
           "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center justify-start",
@@ -88,30 +88,6 @@ export function LandingCoworkerPicker({
           className="flex w-full shrink-0 flex-col items-center"
           data-testid="landing-selected-cta-stack"
         >
-          <p
-            className={cn(
-              "font-semibold tracking-[-0.01em]",
-              size === "compact" ? "text-lg" : "text-xl",
-            )}
-            data-testid="landing-selected-name"
-          >
-            {selected.name}
-          </p>
-
-          {/* Always reserve two caption lines so empty/wrapping captions cannot
-              shift Start chat relative to the top-aligned stack. */}
-          <p
-            className={cn(
-              "text-muted-foreground line-clamp-2 w-full leading-snug",
-              size === "compact"
-                ? "mt-1 min-h-[2.4375rem] text-[0.8125rem]"
-                : "mt-1.5 min-h-[2.5rem] text-sm",
-            )}
-            data-testid="landing-selected-caption"
-          >
-            {selectedCaption ?? "\u00a0"}
-          </p>
-
           <LandingSelectedDescription
             coworkerId={selected.id}
             description={selectedDescription}

--- a/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-selected-description.client.tsx
@@ -55,8 +55,8 @@ function LandingSelectedDescriptionBody({
       className={cn(
         "text-muted-foreground w-full min-w-0 text-balance",
         size === "compact"
-          ? "mt-3 text-[0.8125rem] leading-[1.5]"
-          : "mt-4 text-[0.9375rem] leading-[1.55]",
+          ? "text-[0.8125rem] leading-[1.5]"
+          : "text-[0.9375rem] leading-[1.55]",
       )}
       data-testid="landing-selected-description"
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3807 / [SOK-786](https://linear.app/masumi/issue/SOK-786/scrollable-db-backed-coworker-strip-on-chat-landing-replaces).

Selected coworker detail on `/chat` landing was repeating the strip identity: name + role under the avatar, then name + role again above the bio.

Detail panel is now **bio (description) + Chat CTA only**. Name and role stay under the strip avatar only — every coworker, mobile and desktop.

## Changes

- Remove name heading and role/caption from `LandingCoworkerPicker` selected block
- Delete unused `selectedCoworkerCaption` helper
- Keep reserved description height, more/less, select-then-start, Elena-middle strip order
- Update landing picker tests to assert no duplicated identity
- Harden classic channel outbound failed assertion (`waitFor` pending→failed) so Test Web does not flake under CI load

## Test plan

- [x] `pnpm --filter web test` landing `__tests__/` + `rooms-client-scroll-on-send`
- [x] `pnpm check` + `pnpm typecheck` (on identity commit)
- [ ] Open `/chat` landing, select Jamal — strip shows “Jamal” + “Experience”; detail shows bio + “Chat with Jamal” only (no second name/role)
- [ ] Same for Hannah / Elena / Maya
- [ ] Check mobile and desktop layouts
- [ ] CI Test Web green on this SHA
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee641e0f-0466-4e75-a5ad-8acb2e782f4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee641e0f-0466-4e75-a5ad-8acb2e782f4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

