### PR TITLE
fix(chat): remove duplicate Sokosumi logo on mobile landing

### DIFF
--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-stats-contract.test.ts
@@ -50,4 +50,16 @@ describe("chat landing stats row contract", () => {
       );
     },
   );
+
+  it("mobile landing omits content-area brand mark (header owns the logo)", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "chat-landing.mobile.tsx"),
+      "utf8",
+    );
+
+    // HeaderLeadingControl already renders the mark on `/chat`; forbid a
+    // second instance in this column (import or JSX). Doc comments may name it.
+    expect(source).not.toMatch(/from ["']@\/components\/masumi-logos["']/);
+    expect(source).not.toMatch(/<SokosumiIcon\b/);
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -1,7 +1,6 @@
 import { getFormatter, getTranslations } from "next-intl/server";
 
 import type { Coworker } from "@/app/chat/utils/types";
-import { SokosumiIcon } from "@/components/masumi-logos";
 import type { TaskActivitySummary } from "@/lib/clients/generated/core";
 
 import { buildActivityStats, resolveFeaturedCoworker } from "./landing-content";
@@ -20,10 +19,11 @@ interface ChatLandingMobileProps {
 /**
  * Mobile composition of the `/chat` welcome (`chat-landing.mobile.tsx`).
  *
- * Pair of {@link ChatLanding} (`chat-landing.tsx`): same three zones (mark,
- * pitch, stats) scaled for a narrow column. Middle column is top-aligned so
- * Start chat stays put across coworker selection. Stats stay pinned at the
- * bottom — always mounted with zero chips when idle.
+ * Pair of {@link ChatLanding} (`chat-landing.tsx`): pitch + stats for a narrow
+ * column. Brand mark lives only in the mobile header leading slot — do not
+ * re-render `SokosumiIcon` here. Middle column is top-aligned so Start chat
+ * stays put across coworker selection. Stats stay pinned at the bottom —
+ * always mounted with zero chips when idle.
  */
 export async function ChatLandingMobile({
   coworkers,
@@ -40,13 +40,6 @@ export async function ChatLandingMobile({
 
   return (
     <section className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch px-4 pt-4 pb-3 text-center">
-      <SokosumiIcon
-        animated={false}
-        className="text-foreground shrink-0 self-center"
-        height={32}
-        width={32}
-      />
-
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch justify-start overflow-y-auto py-4">
         <h1 className="text-foreground shrink-0 text-2xl font-light text-balance">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-787](https://linear.app/masumi/issue/SOK-787/remove-duplicate-sokosumi-logo-on-mobile-chat-landing) — remove duplicate Sokosumi logo on mobile chat landing (logo-only).

On mobile `/chat`, the Sokosumi mark appeared twice: once in the header leading slot (`HeaderLeadingControl`) and again as a centered `SokosumiIcon` above the welcome heading in `ChatLandingMobile`.

This PR removes the content-area logo on mobile only. Welcome heading, intro, coworker strip, selected bio, Chat CTA, stats chips, bottom nav, and the header logo are unchanged. Desktop `ChatLanding` still keeps its content mark (no stacked header duplicate there).

Out of scope: identity fix (#3808), edge-to-edge strip work. Branched from `main`.

## Changes

- Drop `SokosumiIcon` from `chat-landing.mobile.tsx`
- Contract test: mobile landing must not import/render the brand mark

## Test plan

- [x] `pnpm --filter web test` on `chat-landing-stats-contract.test.ts`
- [ ] Mobile `/chat`: one Sokosumi logo (header only); welcome + strip + CTA + stats + bottom nav still present
- [ ] Desktop `/chat`: content logo unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e52b744-2fa9-4d2c-a5b9-9ab3b4e56642?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e52b744-2fa9-4d2c-a5b9-9ab3b4e56642&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

