### PR TITLE
fix(chat): edge-to-edge coworker strip on landing

### DIFF
--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
@@ -8,6 +8,11 @@ import { describe, expect, it } from "vitest";
  * (edge-to-edge). Horizontal page padding on an overflow-y ancestor clips
  * edge avatars — CSS promotes overflow-x to auto when overflow-y is not
  * visible — so pitch/stats/selected get `px-*`, not the strip column.
+ *
+ * Mobile also sits under authenticated-app-frame `main` `p-4` (+ overflow-x
+ * hidden). The md:hidden landing shell must cancel that pad (`-m-4`, same
+ * pattern as `/chat/chats` + room shell) or the strip scrollport stays
+ * 16→344 on a 375 viewport.
  */
 describe("chat landing coworker strip edge-to-edge contract", () => {
   it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(
@@ -65,5 +70,46 @@ describe("chat landing coworker strip edge-to-edge contract", () => {
     );
     expect(selectedBlock).toMatch(/max-w-xs/);
     expect(selectedBlock).toMatch(/px-4/);
+  });
+
+  it("app main still pads with p-4 (the ancestor that would clip mobile)", () => {
+    const source = readFileSync(
+      join(
+        import.meta.dirname,
+        "../../../../components/authenticated-app-frame.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(source).toContain("data-app-main");
+    // Load-bearing: mobile landing -m-4 cancels this. If pad moves, update
+    // chat/page.tsx mobile shell in the same change. className with p-4 is
+    // declared before the data-app-main attribute on <main>.
+    expect(source).toMatch(
+      /<main[\s\S]*?\bp-4\b[\s\S]*?data-app-main[\s\S]*?>/,
+    );
+    expect(source).toMatch(/overflow-x-hidden/);
+  });
+
+  it("mobile /chat landing shell cancels app-main p-4 so the strip can hit the viewport edge", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../../../page.tsx"),
+      "utf8",
+    );
+
+    // Drop block comments so docs mentioning class names do not false-positive.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "");
+
+    expect(code).toContain("ChatLandingMobile");
+    // Same cancel as /chat/chats + room shell. Bare w-full without -m-4 leaves
+    // scrollport at 16→344 under main p-4.
+    expect(code).toMatch(/-m-4[^"'\n]*md:hidden|md:hidden[^"'\n]*-m-4/);
+    expect(code).toMatch(
+      /className="[^"]*-m-4[^"]*md:hidden[^"]*"|className="[^"]*md:hidden[^"]*-m-4[^"]*"/,
+    );
+
+    // Desktop landing must not pick up the mobile cancel (md:flex stays separate).
+    expect(code).toMatch(/hidden[^"'\n]*md:flex/);
+    expect(code).toContain("ChatLanding");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Coworker strip on `/chat` landing must span the full content column
+ * (edge-to-edge). Horizontal page padding on an overflow-y ancestor clips
+ * edge avatars — CSS promotes overflow-x to auto when overflow-y is not
+ * visible — so pitch/stats/selected get `px-*`, not the strip column.
+ */
+describe("chat landing coworker strip edge-to-edge contract", () => {
+  it.each(["chat-landing.tsx", "chat-landing.mobile.tsx"])(
+    "%s keeps horizontal pad off the overflow-y column that hosts the strip",
+    (filename) => {
+      const source = readFileSync(
+        join(import.meta.dirname, "..", filename),
+        "utf8",
+      );
+
+      // The scrollable middle column must not carry px-* (that insets + clips
+      // the strip). Greeting/intro may pad themselves; strip stays full width.
+      expect(source).toMatch(/overflow-y-auto/);
+      expect(source).not.toMatch(/overflow-y-auto[^\n]*px-\d/);
+      expect(source).not.toMatch(/px-\d[^\n]*overflow-y-auto/);
+
+      // Landing still pads non-strip surfaces so text/stats aren't flush.
+      expect(source).toMatch(/px-4/);
+      expect(source).toContain("LandingCoworkerPicker");
+    },
+  );
+
+  it("mobile section itself is not the horizontal pad wrapper", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "chat-landing.mobile.tsx"),
+      "utf8",
+    );
+
+    // Section used to be `… items-stretch px-4 pt-4 …` which inset the strip.
+    expect(source).not.toMatch(/items-stretch px-\d/);
+    expect(source).toMatch(/items-stretch pt-4/);
+  });
+
+  it("picker keeps the strip full-bleed and pads only the selected block", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "landing-coworker-picker.client.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('data-testid="landing-coworker-strip"');
+    expect(source).toContain('data-testid="landing-selected-block"');
+
+    // Selected block (name → CTA) stays inset; strip wrapper must not.
+    const stripBlock = source.slice(
+      source.indexOf('data-testid="landing-coworker-strip"') - 200,
+      source.indexOf('data-testid="landing-coworker-strip"') + 80,
+    );
+    expect(stripBlock).not.toMatch(/px-\d/);
+    expect(stripBlock).toMatch(/w-full/);
+    expect(stripBlock).toMatch(/max-w-full/);
+
+    const selectedBlock = source.slice(
+      source.indexOf('data-testid="landing-selected-block"') - 280,
+      source.indexOf('data-testid="landing-selected-block"') + 80,
+    );
+    expect(selectedBlock).toMatch(/max-w-xs/);
+    expect(selectedBlock).toMatch(/px-4/);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -33,7 +33,7 @@ describe("CoworkerStrip", () => {
     cleanup();
   });
 
-  it("keeps the scrollport viewport-bounded so the w-max track cannot widen parents", () => {
+  it("keeps the scrollport column-bounded so the w-max track cannot widen parents", () => {
     render(
       <CoworkerStrip
         centerOnId="elena"
@@ -52,6 +52,8 @@ describe("CoworkerStrip", () => {
     expect(scroll.className).toMatch(/min-w-0/);
     expect(scroll.className).toMatch(/max-w-full/);
     expect(scroll.className).toMatch(/overflow-x-auto/);
+    // Scrollport itself must not add page inset — landing pads elsewhere.
+    expect(scroll.className).not.toMatch(/px-\d/);
 
     const track = screen.getByTestId("coworker-strip-track");
     expect(track.className).toMatch(/w-max/);

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -93,10 +93,35 @@ describe("LandingCoworkerPicker", () => {
     expect(selected.className).toMatch(/max-w-xs/);
     expect(selected.className).toMatch(/w-full/);
     expect(selected.className).toMatch(/min-w-0/);
+    // Selected copy/CTA stay inset; strip itself must not inherit this pad.
+    expect(selected.className).toMatch(/px-4/);
 
     const scroll = screen.getByTestId("coworker-strip-scroll");
     expect(scroll.className).toMatch(/min-w-0/);
     expect(scroll.className).toMatch(/overflow-x-auto/);
+  });
+
+  it("keeps the coworker strip full-bleed (no page px / max-w inset on the track)", () => {
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const strip = screen.getByTestId("landing-coworker-strip");
+    expect(strip.className).toMatch(/w-full/);
+    expect(strip.className).toMatch(/min-w-0/);
+    expect(strip.className).toMatch(/max-w-full/);
+    expect(strip.className).not.toMatch(/px-\d/);
+    expect(strip.className).not.toMatch(/max-w-xs/);
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    expect(strip.contains(scroll)).toBe(true);
+    expect(scroll.className).toMatch(/w-full/);
+    expect(scroll.className).toMatch(/overflow-x-auto/);
+
+    // Selected block is a sibling, not a padded ancestor of the strip.
+    const selected = screen.getByTestId("landing-selected-block");
+    expect(strip.contains(selected)).toBe(false);
+    expect(selected.contains(strip)).toBe(false);
   });
 
   it("renders Elena in the middle of the full strip order", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -43,6 +43,9 @@ export async function ChatLandingMobile({
     // block only. The coworker strip must span the full content width — page
     // padding on an overflow-y ancestor would clip edge faces (CSS forces
     // overflow-x:auto when overflow-y is not visible).
+    // Mobile: `/chat` page shell also uses `-m-4` to cancel app-main `p-4`
+    // above this section (same pattern as `/chat/chats`); without that the
+    // strip stays inset 16px even when this section has no px.
     <section className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch pt-4 pb-3 text-center">
       <SokosumiIcon
         animated={false}

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.mobile.tsx
@@ -39,7 +39,11 @@ export async function ChatLandingMobile({
   const stats = buildActivityStats(summary, isOrganizationWorkspace, t);
 
   return (
-    <section className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch px-4 pt-4 pb-3 text-center">
+    // No section/column `px-*`: horizontal padding on pitch + stats + selected
+    // block only. The coworker strip must span the full content width — page
+    // padding on an overflow-y ancestor would clip edge faces (CSS forces
+    // overflow-x:auto when overflow-y is not visible).
+    <section className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch pt-4 pb-3 text-center">
       <SokosumiIcon
         animated={false}
         className="text-foreground shrink-0 self-center"
@@ -48,11 +52,11 @@ export async function ChatLandingMobile({
       />
 
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch justify-start overflow-y-auto py-4">
-        <h1 className="text-foreground shrink-0 text-2xl font-light text-balance">
+        <h1 className="text-foreground shrink-0 px-4 text-2xl font-light text-balance">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}
         </h1>
 
-        <p className="text-muted-foreground mx-auto mt-2 max-w-[42ch] shrink-0 text-sm leading-[1.6] text-balance">
+        <p className="text-muted-foreground mx-auto mt-2 max-w-[42ch] shrink-0 px-4 text-sm leading-[1.6] text-balance">
           {t("intro")}
         </p>
 
@@ -69,7 +73,7 @@ export async function ChatLandingMobile({
       </div>
 
       <div
-        className="flex w-full shrink-0 flex-col items-center gap-2 pt-1"
+        className="flex w-full shrink-0 flex-col items-center gap-2 px-4 pt-1"
         data-testid="landing-activity-stats"
       >
         <p className="text-muted-foreground/70 text-xs">

--- a/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/chat-landing.tsx
@@ -42,6 +42,9 @@ export async function ChatLanding({
   const stats = buildActivityStats(summary, isOrganizationWorkspace, t);
 
   return (
+    // No middle-column `px-*`: pad pitch + stats + selected block only so the
+    // coworker strip can span the full content width. Padding on an overflow-y
+    // ancestor clips edge faces (overflow-x becomes auto with overflow-y).
     <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col items-stretch">
       <SokosumiIcon
         animated={false}
@@ -50,12 +53,12 @@ export async function ChatLanding({
         width={48}
       />
 
-      <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col items-stretch justify-start overflow-y-auto px-4 py-6 text-center">
-        <h1 className="text-foreground shrink-0 text-2xl font-light text-balance md:text-4xl">
+      <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col items-stretch justify-start overflow-y-auto py-6 text-center">
+        <h1 className="text-foreground shrink-0 px-4 text-2xl font-light text-balance md:text-4xl">
           {userName ? t("greetingWithName", { name: userName }) : t("greeting")}
         </h1>
 
-        <p className="text-muted-foreground mx-auto mt-4 max-w-[62ch] shrink-0 text-base leading-[1.65] text-balance md:text-lg">
+        <p className="text-muted-foreground mx-auto mt-4 max-w-[62ch] shrink-0 px-4 text-base leading-[1.65] text-balance md:text-lg">
           {t("intro")}
         </p>
 

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -61,11 +61,13 @@ const STRIP_SIZES = {
 /**
  * Horizontal scrollable strip for browsing coworkers on the landing.
  *
- * The scrollport is always viewport-bounded (`w-full min-w-0`). The `w-max`
- * track lives *inside* overflow-x-auto so it cannot widen the picker or page.
- * On mount, scrolls so `centerOnId` sits optically in the middle. Strip titles
- * always reserve two lines (`min-h-[2lh]`) so 1-line vs wrapping captions
- * cannot change row height and push Start chat.
+ * The scrollport is always column-bounded (`w-full min-w-0`) and expects a
+ * full-bleed parent (no page `px-*` on overflow ancestors) so edge faces are
+ * not inset-and-clipped. The `w-max` track lives *inside* overflow-x-auto so
+ * it cannot widen the picker or page. On mount, scrolls so `centerOnId` sits
+ * optically in the middle. Strip titles always reserve two lines
+ * (`min-h-[2lh]`) so 1-line vs wrapping captions cannot change row height and
+ * push Start chat.
  */
 export function CoworkerStrip({
   coworkers,

--- a/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/landing-coworker-picker.client.tsx
@@ -27,10 +27,13 @@ interface LandingCoworkerPickerProps {
  * Landing strip + details + Start chat.
  *
  * Order under the strip: name → caption → description → Start chat.
- * The picker is viewport-bounded (`w-full min-w-0`) so the strip's w-max track
- * cannot widen Start chat. Caption and collapsed description slots keep fixed
- * min-heights (including empty) so selection cannot jump the CTA. Expanding
- * More grows the description downward and may shift Start chat; Less restores.
+ * The strip is full-bleed within the landing column (no horizontal page pad on
+ * the strip or its overflow ancestors). The selected block keeps `px-4` +
+ * `max-w-xs` so name/caption/CTA stay inset. The picker is viewport-bounded
+ * (`w-full min-w-0`) so the strip's w-max track cannot widen Start chat.
+ * Caption and collapsed description slots keep fixed min-heights (including
+ * empty) so selection cannot jump the CTA. Expanding More grows the
+ * description downward and may shift Start chat; Less restores.
  */
 export function LandingCoworkerPicker({
   coworkers,
@@ -59,11 +62,14 @@ export function LandingCoworkerPicker({
       className="w-full min-w-0 max-w-full"
       data-testid="landing-coworker-picker"
     >
+      {/* Full-width strip — must not sit inside page `px-*` / max-w that would
+          inset + clip edge avatars. Landing compositions pad pitch/stats only. */}
       <div
         className={cn(
           "w-full min-w-0 max-w-full",
           size === "compact" ? "mt-6" : "mt-10",
         )}
+        data-testid="landing-coworker-strip"
       >
         <CoworkerStrip
           centerOnId={initial.id}
@@ -79,7 +85,7 @@ export function LandingCoworkerPicker({
           across selection; More is the only intentional CTA shift. */}
       <div
         className={cn(
-          "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center justify-start",
+          "mx-auto flex w-full min-w-0 max-w-xs flex-col items-center justify-start px-4",
           size === "compact" ? "mt-4" : "mt-5",
         )}
         data-testid="landing-selected-block"

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -159,7 +159,13 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
           userName={session?.user.name ?? null}
         />
       </div>
-      <div className="flex min-h-full min-w-0 w-full flex-1 flex-col md:hidden">
+      {/*
+        Cancel authenticated-app-frame main `p-4` on mobile (same `-m-4` as
+        `/chat/chats` + room shell). Without this, the coworker strip scrollport
+        is inset 16px and edge avatars clip at the pad, not the viewport.
+        Pitch/stats/selected keep their own `px-4` inside ChatLandingMobile.
+      */}
+      <div className="bg-background -m-4 flex min-h-full min-w-0 flex-1 flex-col md:hidden">
         <ChatLandingMobile
           coworkers={coworkers}
           isOrganizationWorkspace={activeOrganizationId !== null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-788](https://linear.app/masumi/issue/SOK-788/make-chat-landing-coworker-strip-edge-to-edge) — make the chat landing coworker strip edge-to-edge.

On `/chat` landing, the horizontal coworker strip was inset so edge avatars looked clipped on both sides (especially mobile).

### Root cause (mobile QA)

1. Landing compositions had page `px-4` on the overflow column (fixed first).
2. **Mobile still failed at 375×667** because `authenticated-app-frame` `main` applies `p-4` above the `md:hidden` landing — scrollport stayed 16→344. Fixed by canceling with `-m-4` on the mobile landing shell (same pattern as `/chat/chats` + room shell).

Pitch, stats, and selected CTA keep their own inset. Desktop `max-w-4xl` column unchanged.

### Merge

Merged `origin/main` into this branch (`a62176f8e`). Conflict resolution kept SOK-788 bleed plus later landing fixes already on main: #3809 / SOK-787 (no duplicate mobile logo) and #3808 (identity only under strip avatars).

Scope: edge-to-edge strip only. Branched from `main`; not stacked on those PRs.

## Verification

- `pnpm --filter web test` for landing `__tests__/` (55 passed)
- `pnpm check` + typecheck green after merge
- Manual mobile 375×667: strip scrollport ~0→375 (not 16→344)
- Manual desktop ~1280: strip still spans the `max-w-4xl` content column
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de4f6d34-bbfb-49ab-b0a0-571ef4c0f957?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de4f6d34-bbfb-49ab-b0a0-571ef4c0f957&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

