### PR TITLE
feat(chat): select middle coworker when scrolling landing strip

### DIFF
--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -113,9 +113,11 @@ describe("CoworkerStrip", () => {
     expect(scroll.querySelector('[data-coworker-id="elena"]')).toBeTruthy();
   });
 
-  it("selects a coworker on tap without opening a room", async () => {
+  it("selects a coworker on tap without opening a room and centers that face", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
 
     render(
       <CoworkerStrip
@@ -129,6 +131,8 @@ describe("CoworkerStrip", () => {
       />,
     );
 
+    scrollIntoView.mockClear();
+
     await user.click(
       screen.getByRole("option", {
         name: 'team.select:{"name":"Hannah"}',
@@ -137,6 +141,89 @@ describe("CoworkerStrip", () => {
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith("hannah");
+    expect(scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ inline: "center" }),
+    );
+  });
+
+  it("selects the coworker nearest the scrollport center while scrolling", () => {
+    const onSelect = vi.fn();
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "deckster", name: "Deckster" }),
+          buildStripCoworker({ id: "apol", name: "Apol" }),
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+        ]}
+        onSelect={onSelect}
+        selectedId="elena"
+      />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    scroll.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 80,
+        right: 300,
+        bottom: 80,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    function place(id: string, left: number, width: number): void {
+      const node = scroll.querySelector(
+        `[data-coworker-id="${id}"]`,
+      ) as HTMLElement;
+      node.getBoundingClientRect = () =>
+        ({
+          left,
+          width,
+          top: 0,
+          height: 80,
+          right: left + width,
+          bottom: 80,
+          x: left,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+    }
+
+    // Viewport center at 150; Apol centered there.
+    place("deckster", -40, 80);
+    place("apol", 110, 80);
+    place("elena", 260, 80);
+
+    onSelect.mockClear();
+    fireEvent.scroll(scroll);
+
+    expect(onSelect).toHaveBeenCalledWith("apol");
+  });
+
+  it("keeps a stable chip width so selection reflow cannot move centers", () => {
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "hannah", name: "Hannah" }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+        size="compact"
+      />,
+    );
+
+    const options = screen.getAllByRole("option");
+    for (const option of options) {
+      expect(option.className).toMatch(/w-\[5\.5rem\]/);
+    }
   });
 
   it("marks the selected coworker as aria-selected", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -203,6 +209,87 @@ describe("CoworkerStrip", () => {
     onSelect.mockClear();
     fireEvent.scroll(scroll);
 
+    expect(onSelect).toHaveBeenCalledWith("apol");
+  });
+
+  it("keeps nearest-center suppressed until auto programmatic center settles", async () => {
+    const onSelect = vi.fn();
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "deckster", name: "Deckster" }),
+          buildStripCoworker({ id: "apol", name: "Apol" }),
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+        ]}
+        onSelect={onSelect}
+        selectedId="elena"
+      />,
+    );
+
+    // Flush mount double-rAF → auto scrollIntoView (suppress held until settle).
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        behavior: "auto",
+        inline: "center",
+      }),
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    scroll.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 80,
+        right: 300,
+        bottom: 80,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    function place(id: string, left: number, width: number): void {
+      const node = scroll.querySelector(
+        `[data-coworker-id="${id}"]`,
+      ) as HTMLElement;
+      node.getBoundingClientRect = () =>
+        ({
+          left,
+          width,
+          top: 0,
+          height: 80,
+          right: left + width,
+          bottom: 80,
+          x: left,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+    }
+
+    place("deckster", -40, 80);
+    place("apol", 110, 80);
+    place("elena", 260, 80);
+
+    onSelect.mockClear();
+    // Late scroll while auto center is still suppressed must not desync.
+    fireEvent.scroll(scroll);
+    expect(onSelect).not.toHaveBeenCalled();
+
+    fireEvent(scroll, new Event("scrollend"));
+
+    fireEvent.scroll(scroll);
     expect(onSelect).toHaveBeenCalledWith("apol");
   });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/landing-coworker-picker.client.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -435,6 +435,68 @@ describe("LandingCoworkerPicker", () => {
         name: 'cta.button:{"name":"Hannah"}',
       }),
     ).toBeInTheDocument();
+  });
+
+  it("updates description and Start chat when scroll centers another coworker", () => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+
+    render(
+      <LandingCoworkerPicker coworkers={coworkers} initialSelectedId="elena" />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    scroll.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 80,
+        right: 300,
+        bottom: 80,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    function place(id: string, left: number, width: number): void {
+      const node = scroll.querySelector(
+        `[data-coworker-id="${id}"]`,
+      ) as HTMLElement;
+      node.getBoundingClientRect = () =>
+        ({
+          left,
+          width,
+          top: 0,
+          height: 80,
+          right: left + width,
+          bottom: 80,
+          x: left,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+    }
+
+    // Strip order is [hannah, elena, deckster] with Elena featured.
+    place("hannah", 110, 80);
+    place("elena", 260, 80);
+    place("deckster", 410, 80);
+
+    fireEvent.scroll(scroll);
+
+    expect(openCoworkerRoom).not.toHaveBeenCalled();
+    expect(
+      screen.getByTestId("landing-selected-description").textContent,
+    ).toContain("Hannah digs into sources");
+    expect(
+      screen.getByRole("button", {
+        name: 'cta.button:{"name":"Hannah"}',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", {
+        name: 'team.select:{"name":"Hannah"}',
+      }),
+    ).toHaveAttribute("aria-selected", "true");
   });
 
   it("opens a DM only from Start chat after selection", async () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/nearest-center-coworker.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/nearest-center-coworker.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findNearestCenterId,
+  findNearestCenterIdFromElements,
+} from "../nearest-center-coworker";
+
+describe("findNearestCenterId", () => {
+  it("returns null when there are no candidates", () => {
+    expect(findNearestCenterId(100, [])).toBeNull();
+  });
+
+  it("picks the candidate whose center is nearest the viewport center", () => {
+    expect(
+      findNearestCenterId(200, [
+        { id: "a", centerX: 50 },
+        { id: "b", centerX: 190 },
+        { id: "c", centerX: 350 },
+      ]),
+    ).toBe("b");
+  });
+
+  it("keeps the earlier candidate on an exact tie", () => {
+    expect(
+      findNearestCenterId(100, [
+        { id: "left", centerX: 80 },
+        { id: "right", centerX: 120 },
+      ]),
+    ).toBe("left");
+  });
+
+  it("selects the sole candidate regardless of distance", () => {
+    expect(findNearestCenterId(0, [{ id: "only", centerX: 999 }])).toBe("only");
+  });
+});
+
+describe("findNearestCenterIdFromElements", () => {
+  it("measures scrollport and items to pick the middle coworker", () => {
+    const scrollport = document.createElement("div");
+    scrollport.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 40,
+        right: 300,
+        bottom: 40,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    function itemAt(left: number, width: number): HTMLElement {
+      const element = document.createElement("button");
+      element.getBoundingClientRect = () =>
+        ({
+          left,
+          width,
+          top: 0,
+          height: 40,
+          right: left + width,
+          bottom: 40,
+          x: left,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      return element;
+    }
+
+    const items = new Map<string, HTMLElement>([
+      ["deckster", itemAt(-40, 80)],
+      ["apol", itemAt(110, 80)],
+      ["elena", itemAt(260, 80)],
+    ]);
+
+    // Viewport center at 150; Apol's center at 150.
+    expect(findNearestCenterIdFromElements(scrollport, items)).toBe("apol");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -2,10 +2,12 @@
 
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { useRef } from "react";
+import { useEffectEvent, useRef } from "react";
 
 import { useMountEffect } from "@/hooks/use-mount-effect";
 import { cn } from "@/lib/utils";
+
+import { findNearestCenterIdFromElements } from "./nearest-center-coworker";
 
 export interface StripCoworker {
   id: string;
@@ -20,8 +22,7 @@ interface CoworkerStripProps {
   /** Currently selected coworker — larger face, Start chat target. */
   selectedId: string;
   /**
-   * Coworker to optically centre on first paint (Elena / fallback). Selection
-   * changes do not re-scroll — browsing stays where the user left it.
+   * Coworker to optically centre on first paint (Elena / fallback).
    */
   centerOnId: string;
   onSelect: (coworkerId: string) => void;
@@ -34,27 +35,30 @@ const STRIP_SIZES = {
     featured: "size-20",
     other: "size-11",
     gap: "gap-4",
-    itemWidth: "w-[4.5rem]",
-    featuredItemWidth: "w-[5.5rem]",
+    // All chips share the featured width so selection reflow cannot move
+    // centers while scroll-driven selection is active.
+    itemWidth: "w-[5.5rem]",
     featuredSizes: "80px",
     otherSizes: "44px",
     featuredInitial: "text-xl",
     otherInitial: "text-xs",
     name: "text-xs",
     title: "text-[0.625rem]",
+    // Half featured width: lets first/last faces reach optical center.
+    edgePad: "px-[max(0.25rem,calc(50%-2.75rem))]",
   },
   default: {
     featured: "size-28",
     other: "size-16",
     gap: "gap-5",
-    itemWidth: "w-24",
-    featuredItemWidth: "w-28",
+    itemWidth: "w-28",
     featuredSizes: "112px",
     otherSizes: "64px",
     featuredInitial: "text-2xl",
     otherInitial: "text-sm",
     name: "text-sm",
     title: "text-xs",
+    edgePad: "px-[max(0.25rem,calc(50%-3.5rem))]",
   },
 } as const;
 
@@ -65,9 +69,10 @@ const STRIP_SIZES = {
  * full-bleed parent (no page `px-*` on overflow ancestors) so edge faces are
  * not inset-and-clipped. The `w-max` track lives *inside* overflow-x-auto so
  * it cannot widen the picker or page. On mount, scrolls so `centerOnId` sits
- * optically in the middle. Strip titles always reserve two lines
- * (`min-h-[2lh]`) so 1-line vs wrapping captions cannot change row height and
- * push Start chat.
+ * optically in the middle. While the user scrolls, selection follows the
+ * coworker nearest the visual center; tap selects and centers that face.
+ * Strip titles always reserve two lines (`min-h-[2lh]`) so 1-line vs wrapping
+ * captions cannot change row height and push Start chat.
  */
 export function CoworkerStrip({
   coworkers,
@@ -80,6 +85,70 @@ export function CoworkerStrip({
   const scale = STRIP_SIZES[size];
   const scrollRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef(new Map<string, HTMLButtonElement>());
+  /** >0 while programmatic scrollIntoView should not drive selection. */
+  const suppressScrollSelectRef = useRef(0);
+
+  function runProgrammaticCenter(
+    child: HTMLElement,
+    behavior: ScrollBehavior,
+  ): void {
+    const scroll = scrollRef.current;
+    suppressScrollSelectRef.current += 1;
+    let released = false;
+
+    function release(): void {
+      if (released) {
+        return;
+      }
+      released = true;
+      suppressScrollSelectRef.current = Math.max(
+        0,
+        suppressScrollSelectRef.current - 1,
+      );
+      scroll?.removeEventListener("scrollend", release);
+    }
+
+    try {
+      child.scrollIntoView({
+        behavior,
+        block: "nearest",
+        inline: "center",
+      });
+    } catch {
+      // jsdom / older engines may lack scrollIntoView — still release suppress.
+      release();
+      return;
+    }
+
+    if (behavior === "smooth" && scroll) {
+      scroll.addEventListener("scrollend", release, { once: true });
+      window.setTimeout(release, 500);
+      return;
+    }
+
+    // `auto` centering is synchronous; any scroll events from it already ran
+    // while suppress was elevated.
+    release();
+  }
+
+  const syncSelectionFromScroll = useEffectEvent(() => {
+    if (suppressScrollSelectRef.current > 0) {
+      return;
+    }
+
+    const scroll = scrollRef.current;
+    if (!scroll) {
+      return;
+    }
+
+    const nearestId = findNearestCenterIdFromElements(
+      scroll,
+      itemRefs.current.entries(),
+    );
+    if (nearestId && nearestId !== selectedId) {
+      onSelect(nearestId);
+    }
+  });
 
   useMountEffect(() => {
     const child = itemRefs.current.get(centerOnId);
@@ -91,11 +160,7 @@ export function CoworkerStrip({
     let frame2 = 0;
     const frame1 = requestAnimationFrame(() => {
       frame2 = requestAnimationFrame(() => {
-        child.scrollIntoView({
-          behavior: "auto",
-          block: "nearest",
-          inline: "center",
-        });
+        runProgrammaticCenter(child, "auto");
       });
     });
 
@@ -104,6 +169,15 @@ export function CoworkerStrip({
       cancelAnimationFrame(frame2);
     };
   });
+
+  function handleSelect(coworkerId: string): void {
+    onSelect(coworkerId);
+    const child = itemRefs.current.get(coworkerId);
+    if (!child) {
+      return;
+    }
+    runProgrammaticCenter(child, "smooth");
+  }
 
   return (
     <div
@@ -116,13 +190,15 @@ export function CoworkerStrip({
       data-testid="coworker-strip-scroll"
       role="listbox"
       aria-label={t("team.stripLabel")}
+      onScroll={syncSelectionFromScroll}
     >
       <div
         className={cn(
           // min-w-full + justify-center: when the catalog fits, Elena (middle
           // of the track) lands in the visual centre. When it overflows, w-max
-          // wins and the scrollport alone handles overflow.
-          "flex w-max min-w-full items-start justify-center px-1 py-1",
+          // wins and edgePad lets first/last faces reach optical center.
+          "flex w-max min-w-full items-start justify-center py-1",
+          scale.edgePad,
           scale.gap,
         )}
         data-testid="coworker-strip-track"
@@ -148,9 +224,9 @@ export function CoworkerStrip({
               className={cn(
                 "flex shrink-0 cursor-pointer flex-col items-center gap-2 text-center transition-opacity outline-none",
                 "focus-visible:ring-ring rounded-md focus-visible:ring-2 focus-visible:ring-offset-2",
-                isSelected ? scale.featuredItemWidth : scale.itemWidth,
+                scale.itemWidth,
               )}
-              onClick={() => onSelect(coworker.id)}
+              onClick={() => handleSelect(coworker.id)}
             >
               <span
                 className={cn(

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -120,14 +120,15 @@ export function CoworkerStrip({
       return;
     }
 
-    if (behavior === "smooth" && scroll) {
+    // Keep suppress until scroll settles for both `auto` and `smooth`. A late
+    // `scroll` after `scrollIntoView` returns can otherwise overwrite the
+    // intended selection (mount Elena / tap-to-center).
+    if (scroll) {
       scroll.addEventListener("scrollend", release, { once: true });
       window.setTimeout(release, 500);
       return;
     }
 
-    // `auto` centering is synchronous; any scroll events from it already ran
-    // while suppress was elevated.
     release();
   }
 

--- a/apps/web/src/app/(app)/chat/components/landing/nearest-center-coworker.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/nearest-center-coworker.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure geometry for scroll → select on the landing coworker strip.
+ * Pick the item whose horizontal center is nearest the scrollport center.
+ */
+
+export interface CenterCandidate {
+  id: string;
+  /** Item midpoint in the same coordinate space as `viewportCenterX`. */
+  centerX: number;
+}
+
+/**
+ * Returns the id of the candidate nearest `viewportCenterX`, or null when
+ * there are no candidates. Ties keep the earlier candidate (stable).
+ */
+export function findNearestCenterId(
+  viewportCenterX: number,
+  candidates: readonly CenterCandidate[],
+): null | string {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  let bestId = candidates[0].id;
+  let bestDistance = Math.abs(candidates[0].centerX - viewportCenterX);
+
+  for (let index = 1; index < candidates.length; index += 1) {
+    const candidate = candidates[index];
+    const distance = Math.abs(candidate.centerX - viewportCenterX);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestId = candidate.id;
+    }
+  }
+
+  return bestId;
+}
+
+/**
+ * Measures the scrollport and item elements, then returns the nearest-center id.
+ */
+export function findNearestCenterIdFromElements(
+  scrollport: HTMLElement,
+  items: Iterable<readonly [string, HTMLElement]>,
+): null | string {
+  const portRect = scrollport.getBoundingClientRect();
+  const viewportCenterX = portRect.left + portRect.width / 2;
+  const candidates: CenterCandidate[] = [];
+
+  for (const [id, element] of items) {
+    const rect = element.getBoundingClientRect();
+    candidates.push({
+      id,
+      centerX: rect.left + rect.width / 2,
+    });
+  }
+
+  return findNearestCenterId(viewportCenterX, candidates);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**SOK-789** — https://linear.app/masumi/issue/SOK-789/scroll-chat-coworker-strip-selects-the-middle-coworker

Scrolling the `/chat` coworker strip selects whoever is nearest the visual center.

- Scroll → nearest-center coworker becomes selected (featured face + bio + Start chat stay in sync)
- Tap still selects and scrolls that face to center
- No mandatory scroll-snap; continuous nearest-center threshold
- Stable chip widths so selection reflow does not fight center detection

Scope: scroll-selects-middle only. Not #3808 (identity), #3809 / SOK-787 (logo), or #3810 / SOK-788 (edge-to-edge). Branched from `main` after those landed.

## Verification

- `pnpm --filter web check` + `pnpm --filter web test` (landing + full web suite)
- CI green on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5d09cf2-cf38-45cb-b257-85ba4fde7117?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5d09cf2-cf38-45cb-b257-85ba4fde7117&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

