### PR TITLE
fix(web): clear last chats list row above mobile tab bar

### DIFF
--- a/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
+++ b/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
@@ -40,7 +40,9 @@ describe("chat/chats page scroll clearance contract", () => {
     const source = readFileSync(join(here, "../page.tsx"), "utf8");
     const code = source.replace(/\/\*[\s\S]*?\*\//g, "");
 
-    expect(code).toMatch(/CHAT_CHATS_MOBILE_LIST_SHELL_CLASS/);
+    // Require the className binding — a bare import would still match the
+    // identifier alone and would not prove the shell mounts on the list root.
+    expect(code).toMatch(/className=\{CHAT_CHATS_MOBILE_LIST_SHELL_CLASS\}/);
     expect(code).not.toMatch(/LIST_MOBILE_CREATE_FAB_CLEARANCE/);
     expect(code).not.toMatch(/overflow-y-auto/);
     expect(code).not.toMatch(/\bmin-h-0\b/);

--- a/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
+++ b/apps/web/src/app/(app)/chat/chats/__tests__/chats-page-scroll-clearance.test.ts
@@ -3,24 +3,49 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+import { CHAT_CHATS_MOBILE_LIST_SHELL_CLASS } from "../chat-chats-list-shell";
+
 const here = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Mobile `/chat/chats` must grow with content so AppMobileChrome's in-flow
- * tab-bar spacer sits after the last DM in main's scroll. A nested
- * `min-h-0` + `overflow-y-auto` height-lock left the last row clipped under
- * the fixed bottom nav (padding on that flex overflow child does not clear).
+ * Mobile `/chat/chats` must clear the fixed bottom nav:
+ * 1. Grow with content so AppMobileChrome's in-flow tab-bar spacer sits after
+ *    the last DM in main's scroll (no nested min-h-0 + overflow-y-auto).
+ * 2. Cancel main `p-4` on top/sides only — never `-m-4` / `-mb-4` (negative
+ *    bottom margin pulls the spacer into the last rows).
+ * 3. Keep a small `pb-*` gap above the tab bar for comfortable clearance.
  * Create FAB is gone on this surface — do not reserve FAB bottom padding.
  */
 describe("chat/chats page scroll clearance contract", () => {
-  it("does not height-lock the list shell or reserve create-FAB clearance", () => {
-    const source = readFileSync(join(here, "../page.tsx"), "utf8");
+  it("locks the shared mobile list shell inset classes", () => {
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).toContain("md:hidden");
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).toContain("-mt-4");
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).toContain("-mx-4");
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).toContain("pb-3");
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).toContain("flex-1");
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).toContain("flex-col");
+    // Full four-side cancel (or any -mb) reintroduces the clip.
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).not.toMatch(
+      /(?:^|\s)-m-4(?:\s|$)/,
+    );
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).not.toMatch(/-mb-/);
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).not.toMatch(/overflow-y-auto/);
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).not.toMatch(/\bmin-h-0\b/);
+    expect(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS).not.toMatch(
+      /LIST_MOBILE_CREATE_FAB_CLEARANCE|pb-\[calc\(3\.5rem/,
+    );
+  });
 
-    // Drop block comments so docs mentioning the forbidden classes do not
-    // false-positive; still catch real className usage.
+  it("page mounts the shared shell class (no local -m-4 / overflow lock)", () => {
+    const source = readFileSync(join(here, "../page.tsx"), "utf8");
     const code = source.replace(/\/\*[\s\S]*?\*\//g, "");
+
+    expect(code).toMatch(/CHAT_CHATS_MOBILE_LIST_SHELL_CLASS/);
     expect(code).not.toMatch(/LIST_MOBILE_CREATE_FAB_CLEARANCE/);
     expect(code).not.toMatch(/overflow-y-auto/);
     expect(code).not.toMatch(/\bmin-h-0\b/);
+    // Inline four-side cancel would bypass the shared constant.
+    expect(code).not.toMatch(/className="[^"]*-m-4[^"]*"/);
+    expect(code).not.toMatch(/className=\{[^}]*-m-4[^}]*\}/);
   });
 });

--- a/apps/web/src/app/(app)/chat/chats/chat-chats-list-shell.ts
+++ b/apps/web/src/app/(app)/chat/chats/chat-chats-list-shell.ts
@@ -1,0 +1,14 @@
+/**
+ * Mobile `/chat/chats` list shell (page + Instant Nav skeleton).
+ *
+ * Cancel authenticated-app-frame main `p-4` on top/sides only so rows can go
+ * edge-to-edge. Do **not** use `-m-4` / `-mb-4`: negative bottom margin pulls
+ * AppMobileChrome's in-flow tab-bar spacer up into the last DM rows, so the
+ * fixed bottom nav clips them (Faizan / last-room bug).
+ *
+ * `pb-3` is comfortable gap above the tab bar after the spacer clears it.
+ * Grow with content — never nest `min-h-0` + `overflow-y-auto` here (that
+ * height-locks and leaves the spacer outside the list scrollport).
+ */
+export const CHAT_CHATS_MOBILE_LIST_SHELL_CLASS =
+  "bg-background md:hidden -mt-4 -mx-4 flex flex-1 flex-col pb-3" as const;

--- a/apps/web/src/app/(app)/chat/chats/page.tsx
+++ b/apps/web/src/app/(app)/chat/chats/page.tsx
@@ -14,6 +14,8 @@ import { isOrganizationOwnerOrAdmin } from "@/lib/helpers/organization-member";
 import { isHermesBetaAccessEmail } from "@/lib/hermes/beta-access";
 import type { ChatRoomsPage } from "@/lib/services";
 
+import { CHAT_CHATS_MOBILE_LIST_SHELL_CLASS } from "./chat-chats-list-shell";
+
 interface ChatChatsOrganizationListProps {
   cacheArgs: PrivateChatListCacheArgs;
   chatRoomsPage: ChatRoomsPage;
@@ -92,12 +94,11 @@ export default async function ChatChatsPage() {
   return (
     <Sheet open>
       {/*
-        Grow with content — do not height-lock with min-h-0 + overflow-y-auto.
-        AppMobileChrome's in-flow tab-bar spacer must sit after the last row in
-        main's scroll; padding on a nested overflow flex child does not clear
-        the fixed bottom nav (last DM was clipped).
+        Shell class: top/side main-pad cancel only — see chat-chats-list-shell.ts.
+        Grow with content so AppMobileChrome's in-flow tab-bar spacer sits after
+        the last row in main's scroll (no nested overflow height-lock).
       */}
-      <div className="bg-background md:hidden -m-4 flex flex-1 flex-col">
+      <div className={CHAT_CHATS_MOBILE_LIST_SHELL_CLASS}>
         <PersonalAssistantNav enabled={hermesMenuEnabled} />
         {hermesMenuEnabled ? <SidebarSeparator className="-mt-px" /> : null}
         <Suspense

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { CHAT_CHATS_MOBILE_LIST_SHELL_CLASS } from "@/app/chat/chats/chat-chats-list-shell";
+
 import { ChatChatsPageSkeleton } from "../chat-chats-loading-view";
 
 describe("ChatChatsPageSkeleton", () => {
@@ -11,16 +13,20 @@ describe("ChatChatsPageSkeleton", () => {
     expect(root.className).toMatch(/md:hidden/);
   });
 
-  it("grows with content (no nested overflow height-lock, no create-FAB pad)", () => {
+  it("uses the shared list shell so the last row clears the tab bar", () => {
     render(<ChatChatsPageSkeleton />);
 
     const root = screen.getByTestId("chat-chats-loading");
+    for (const token of CHAT_CHATS_MOBILE_LIST_SHELL_CLASS.split(/\s+/)) {
+      expect(root.className).toContain(token);
+    }
     // Nested min-h-0 + overflow-y-auto clips the last row under the fixed
     // tab bar; AppMobileChrome's in-flow spacer needs natural growth.
     expect(root.className).not.toMatch(/overflow-y-auto/);
     expect(root.className).not.toMatch(/\bmin-h-0\b/);
-    // Create FAB no longer mounts on /chat/chats.
-    expect(root.className).not.toMatch(/pb-\[/);
+    // Full four-side -m-4 pulls the spacer into the last rows.
+    expect(root.className).not.toMatch(/(?:^|\s)-m-4(?:\s|$)/);
+    expect(root.className).not.toMatch(/-mb-/);
   });
 
   it("omits Personal Assistant chrome (beta-gated on the real page)", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-chats-loading-view.test.tsx
@@ -18,7 +18,8 @@ describe("ChatChatsPageSkeleton", () => {
 
     const root = screen.getByTestId("chat-chats-loading");
     for (const token of CHAT_CHATS_MOBILE_LIST_SHELL_CLASS.split(/\s+/)) {
-      expect(root.className).toContain(token);
+      // Token match — substring `toContain("flex")` would pass on `flex-1`.
+      expect(root.classList.contains(token)).toBe(true);
     }
     // Nested min-h-0 + overflow-y-auto clips the last row under the fixed
     // tab bar; AppMobileChrome's in-flow spacer needs natural growth.

--- a/apps/web/src/app/(app)/chat/components/chat-chats-loading-view.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-chats-loading-view.tsx
@@ -1,4 +1,6 @@
+import { CHAT_CHATS_MOBILE_LIST_SHELL_CLASS } from "@/app/chat/chats/chat-chats-list-shell";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 /**
  * Sync Instant Nav shell for `/chat/chats` (no cookies/`connection()`/i18n).
@@ -6,15 +8,13 @@ import { Skeleton } from "@/components/ui/skeleton";
  * Personal Assistant is beta-gated and omitted here so non-beta users do not
  * flash PA chrome that never mounts.
  *
- * Grow with content so AppMobileChrome's in-flow tab-bar spacer clears the last
- * row (no nested overflow-y-auto height lock). No create-FAB clearance — that
- * FAB no longer mounts on this surface.
+ * Same bottom-inset shell as the page (`CHAT_CHATS_MOBILE_LIST_SHELL_CLASS`).
  */
 export function ChatChatsPageSkeleton(): React.ReactElement {
   return (
     <div
       data-testid="chat-chats-loading"
-      className="bg-background md:hidden -m-4 flex flex-1 flex-col p-4"
+      className={cn(CHAT_CHATS_MOBILE_LIST_SHELL_CLASS, "px-4 pt-4")}
     >
       <div className="mb-3 flex items-center justify-between">
         <Skeleton className="h-5 w-24" />

--- a/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/app-mobile-chrome.test.tsx
@@ -91,7 +91,7 @@ describe("AppMobileChrome", () => {
   it("keeps the bottom nav on /chat/chats and renders no FAB", () => {
     mockPathname = "/chat/chats";
 
-    render(
+    const { container } = render(
       <AppMobileChrome>
         <div>child</div>
       </AppMobileChrome>,
@@ -99,6 +99,9 @@ describe("AppMobileChrome", () => {
 
     expect(screen.getByRole("navigation", { name: "ariaLabel" })).toBeTruthy();
     expect(screen.queryByRole("link", { name: "openFab" })).toBeNull();
+    expect(getTabBarSpacer(container)?.className).toContain(
+      CHAT_MOBILE_TAB_BAR_CLEARANCE,
+    );
   });
 
   it("shows bottom nav without create FAB on main hub list routes", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SOK-790 — https://linear.app/masumi/issue/SOK-790/inset-mobile-chats-list-above-the-bottom-nav

## Summary

Mobile `/chat/chats` only: last room row was cut off by the floating bottom nav. This PR insets the list so the last DM scrolls fully above the tab bar.

**Cause:** List shell used `-m-4` to cancel main `p-4`. Negative **bottom** margin pulled `AppMobileChrome`’s in-flow tab-bar spacer into the last rows.

**Fix:** Shared `CHAT_CHATS_MOBILE_LIST_SHELL_CLASS` cancels pad on top/sides only (`-mt-4 -mx-4`), adds `pb-3`, keeps content-grow (no nested overflow height-lock). Page + Instant Nav skeleton share it. Desktop sidebar unchanged.

Not mixed with landing #3808 / #3809 / #3810 or SOK-789.

## Test plan

- [x] Chats scroll-clearance + loading-shell + AppMobileChrome `/chat/chats` spacer tests
- [ ] Mobile `/chat/chats`: scroll last DM fully above white pill tab bar
- [ ] Bottom nav still visible; room row content unchanged
- [ ] Desktop sidebar list unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf7a3427-251a-4f8f-ad8b-a415cfbb9e61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf7a3427-251a-4f8f-ad8b-a415cfbb9e61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

