### PR TITLE
feat(chat): peek-cut edge coworkers on landing strip

### DIFF
--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
@@ -72,6 +72,27 @@ describe("chat landing coworker strip edge-to-edge contract", () => {
     expect(selectedBlock).toMatch(/px-4/);
   });
 
+  it("coworker strip scrollport stays full-bleed and uses peek-safe gap var", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "coworker-strip.client.tsx"),
+      "utf8",
+    );
+
+    // Scrollport: column-bounded overflow, no page inset.
+    expect(source).toContain('data-testid="coworker-strip-scroll"');
+    expect(source).toMatch(/overflow-x-auto/);
+    expect(source).not.toMatch(
+      /data-testid="coworker-strip-scroll"[\s\S]{0,200}px-\d/,
+    );
+
+    // Track gap is CSS-var driven (overflow peek-safe); no static gap-4/gap-5.
+    expect(source).toContain("--strip-gap");
+    expect(source).toMatch(/gap-\[length:var\(--strip-gap,/);
+    expect(source).not.toMatch(/\bgap-4\b/);
+    expect(source).not.toMatch(/\bgap-5\b/);
+    expect(source).toContain("resolveOverflowStripGapPx");
+  });
+
   it("app main still pads with p-4 (the ancestor that would clip mobile)", () => {
     const source = readFileSync(
       join(

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -96,16 +96,17 @@ describe("CoworkerStrip", () => {
   });
 
   it("sets peek-safe --strip-gap when the strip overflows", () => {
+    const rootFontPx = `${16}px`;
     const rootFontSpy = vi
       .spyOn(window, "getComputedStyle")
       .mockImplementation((el: Element) => {
         if (el === document.documentElement) {
-          return { fontSize: "16px" } as CSSStyleDeclaration;
+          return { fontSize: rootFontPx } as CSSStyleDeclaration;
         }
         return {
-          fontSize: "16px",
-          columnGap: "16px",
-          gap: "16px",
+          fontSize: rootFontPx,
+          columnGap: rootFontPx,
+          gap: rootFontPx,
         } as CSSStyleDeclaration;
       });
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -95,75 +95,84 @@ describe("CoworkerStrip", () => {
     expect(track.className).toMatch(/gap-\[length:var\(--strip-gap,/);
   });
 
-  it("sets peek-safe --strip-gap when the strip overflows", () => {
+  it("sets a strong peek-safe --strip-gap when the strip overflows on desktop widths", () => {
     const rootFontPx = `${16}px`;
+    const realGetComputedStyle = window.getComputedStyle.bind(window);
     const rootFontSpy = vi
       .spyOn(window, "getComputedStyle")
       .mockImplementation((el: Element) => {
         if (el === document.documentElement) {
-          return { fontSize: rootFontPx } as CSSStyleDeclaration;
+          return {
+            ...realGetComputedStyle(el),
+            fontSize: rootFontPx,
+            getPropertyValue: (prop: string) =>
+              prop === "font-size"
+                ? rootFontPx
+                : realGetComputedStyle(el).getPropertyValue(prop),
+          } as CSSStyleDeclaration;
         }
-        return {
-          fontSize: rootFontPx,
-          columnGap: rootFontPx,
-          gap: rootFontPx,
-        } as CSSStyleDeclaration;
+        return realGetComputedStyle(el);
       });
 
-    render(
-      <CoworkerStrip
-        centerOnId="elena"
-        coworkers={[
-          buildStripCoworker({ id: "a", name: "A" }),
-          buildStripCoworker({ id: "b", name: "B" }),
-          buildStripCoworker({ id: "elena", name: "Elena" }),
-          buildStripCoworker({ id: "c", name: "C" }),
-          buildStripCoworker({ id: "d", name: "D" }),
-        ]}
-        onSelect={vi.fn()}
-        selectedId="elena"
-        size="compact"
-      />,
-    );
+    try {
+      render(
+        <CoworkerStrip
+          centerOnId="elena"
+          coworkers={[
+            buildStripCoworker({ id: "a", name: "A" }),
+            buildStripCoworker({ id: "b", name: "B" }),
+            buildStripCoworker({ id: "elena", name: "Elena" }),
+            buildStripCoworker({ id: "c", name: "C" }),
+            buildStripCoworker({ id: "d", name: "D" }),
+            buildStripCoworker({ id: "e", name: "E" }),
+          ]}
+          onSelect={vi.fn()}
+          selectedId="elena"
+          size="default"
+        />,
+      );
 
-    const scroll = screen.getByTestId("coworker-strip-scroll");
-    const track = screen.getByTestId("coworker-strip-track");
+      const scroll = screen.getByTestId("coworker-strip-scroll");
+      const track = screen.getByTestId("coworker-strip-track");
 
-    // Preferred compact gap 16px fails peek-safe at Vp=288 / itemW=80
-    // (d=104, rem=8 < 16). Overflow + adjust must set --strip-gap.
-    Object.defineProperty(scroll, "clientWidth", {
-      configurable: true,
-      get: () => 288,
-    });
-    Object.defineProperty(scroll, "scrollWidth", {
-      configurable: true,
-      get: () => 900,
-    });
+      // Preferred default gap 20px at max-w-4xl (~896) only haircuts ~4px —
+      // overflow must retune --strip-gap into the strong mid-chip band.
+      Object.defineProperty(scroll, "clientWidth", {
+        configurable: true,
+        get: () => 896,
+      });
+      Object.defineProperty(scroll, "scrollWidth", {
+        configurable: true,
+        get: () => 2000,
+      });
 
-    const firstChip = track.querySelector("[data-coworker-id]") as HTMLElement;
-    firstChip.getBoundingClientRect = () =>
-      ({
-        width: 80,
-        height: 80,
-        top: 0,
-        left: 0,
-        right: 80,
-        bottom: 80,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }) as DOMRect;
+      const firstChip = track.querySelector(
+        "[data-coworker-id]",
+      ) as HTMLElement;
+      firstChip.getBoundingClientRect = () =>
+        ({
+          width: 112,
+          height: 112,
+          top: 0,
+          left: 0,
+          right: 112,
+          bottom: 112,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
 
-    flushResizeObservers();
+      flushResizeObservers();
 
-    const gapVar = track.style.getPropertyValue("--strip-gap");
-    expect(gapVar).toMatch(/px$/);
-    const gapPx = Number.parseFloat(gapVar);
-    expect(gapPx).toBeGreaterThan(0);
-    expect(gapPx).toBeLessThanOrEqual(16 * 1.5 + 1e-9);
-    expect(isOverflowStripGapPeekSafe(288, 80, gapPx)).toBe(true);
-
-    rootFontSpy.mockRestore();
+      const gapVar = track.style.getPropertyValue("--strip-gap");
+      expect(gapVar).toMatch(/px$/);
+      const gapPx = Number.parseFloat(gapVar);
+      expect(gapPx).toBeGreaterThan(0);
+      expect(gapPx).toBeLessThanOrEqual(20 * 2.5 + 1e-9);
+      expect(isOverflowStripGapPeekSafe(896, 112, gapPx)).toBe(true);
+    } finally {
+      rootFontSpy.mockRestore();
+    }
   });
 
   it("clears --strip-gap when the catalog fits without overflow", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/coworker-strip.client.test.tsx
@@ -1,8 +1,9 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { StripCoworker } from "../coworker-strip.client";
+import { isOverflowStripGapPeekSafe } from "../peek-safe-strip-gap";
 
 vi.mock("next/image", () => ({
   default: ({ alt, src }: { alt: string; src: string }) => (
@@ -18,6 +19,34 @@ vi.mock("next-intl", () => ({
 
 import { CoworkerStrip } from "../coworker-strip.client";
 
+type ResizeObserverCallback = (
+  entries: ResizeObserverEntry[],
+  observer: ResizeObserver,
+) => void;
+
+const observerCallbacks = new Set<ResizeObserverCallback>();
+
+class ResizeObserverMock {
+  private readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    observerCallbacks.add(callback);
+  }
+
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {
+    observerCallbacks.delete(this.callback);
+  }
+}
+
+function flushResizeObservers(): void {
+  for (const callback of observerCallbacks) {
+    callback([], {} as ResizeObserver);
+  }
+}
+
 function buildStripCoworker(
   overrides: Partial<StripCoworker> & Pick<StripCoworker, "id" | "name">,
 ): StripCoworker {
@@ -28,9 +57,15 @@ function buildStripCoworker(
   };
 }
 
+beforeAll(() => {
+  global.ResizeObserver =
+    ResizeObserverMock as unknown as typeof global.ResizeObserver;
+});
+
 describe("CoworkerStrip", () => {
   afterEach(() => {
     cleanup();
+    observerCallbacks.clear();
   });
 
   it("keeps the scrollport column-bounded so the w-max track cannot widen parents", () => {
@@ -57,6 +92,109 @@ describe("CoworkerStrip", () => {
 
     const track = screen.getByTestId("coworker-strip-track");
     expect(track.className).toMatch(/w-max/);
+    expect(track.className).toMatch(/gap-\[length:var\(--strip-gap,/);
+  });
+
+  it("sets peek-safe --strip-gap when the strip overflows", () => {
+    const rootFontSpy = vi
+      .spyOn(window, "getComputedStyle")
+      .mockImplementation((el: Element) => {
+        if (el === document.documentElement) {
+          return { fontSize: "16px" } as CSSStyleDeclaration;
+        }
+        return {
+          fontSize: "16px",
+          columnGap: "16px",
+          gap: "16px",
+        } as CSSStyleDeclaration;
+      });
+
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "a", name: "A" }),
+          buildStripCoworker({ id: "b", name: "B" }),
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "c", name: "C" }),
+          buildStripCoworker({ id: "d", name: "D" }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+        size="compact"
+      />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    const track = screen.getByTestId("coworker-strip-track");
+
+    // Preferred compact gap 16px fails peek-safe at Vp=288 / itemW=80
+    // (d=104, rem=8 < 16). Overflow + adjust must set --strip-gap.
+    Object.defineProperty(scroll, "clientWidth", {
+      configurable: true,
+      get: () => 288,
+    });
+    Object.defineProperty(scroll, "scrollWidth", {
+      configurable: true,
+      get: () => 900,
+    });
+
+    const firstChip = track.querySelector("[data-coworker-id]") as HTMLElement;
+    firstChip.getBoundingClientRect = () =>
+      ({
+        width: 80,
+        height: 80,
+        top: 0,
+        left: 0,
+        right: 80,
+        bottom: 80,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    flushResizeObservers();
+
+    const gapVar = track.style.getPropertyValue("--strip-gap");
+    expect(gapVar).toMatch(/px$/);
+    const gapPx = Number.parseFloat(gapVar);
+    expect(gapPx).toBeGreaterThan(0);
+    expect(gapPx).toBeLessThanOrEqual(16 * 1.5 + 1e-9);
+    expect(isOverflowStripGapPeekSafe(288, 80, gapPx)).toBe(true);
+
+    rootFontSpy.mockRestore();
+  });
+
+  it("clears --strip-gap when the catalog fits without overflow", () => {
+    render(
+      <CoworkerStrip
+        centerOnId="elena"
+        coworkers={[
+          buildStripCoworker({ id: "elena", name: "Elena" }),
+          buildStripCoworker({ id: "hannah", name: "Hannah" }),
+        ]}
+        onSelect={vi.fn()}
+        selectedId="elena"
+      />,
+    );
+
+    const scroll = screen.getByTestId("coworker-strip-scroll");
+    const track = screen.getByTestId("coworker-strip-track");
+
+    track.style.setProperty("--strip-gap", "22px");
+
+    Object.defineProperty(scroll, "clientWidth", {
+      configurable: true,
+      get: () => 800,
+    });
+    Object.defineProperty(scroll, "scrollWidth", {
+      configurable: true,
+      get: () => 400,
+    });
+
+    flushResizeObservers();
+
+    expect(track.style.getPropertyValue("--strip-gap")).toBe("");
   });
 
   it("shows every coworker name and specialty in the DOM", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/peek-safe-strip-gap.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/peek-safe-strip-gap.test.ts
@@ -4,13 +4,11 @@ import {
   isOverflowStripGapPeekSafe,
   overflowStripEdgePeekPx,
   resolveOverflowStripGapPx,
-  STRIP_MIN_PEEK_FRACTION,
+  STRIP_MIN_CLIP_FRACTION,
+  STRIP_MIN_VISIBLE_PEEK_FRACTION,
+  STRIP_TARGET_PEEK_FRACTION,
 } from "../peek-safe-strip-gap";
 
-/**
- * Strong peek: visible depth in `[minPeek, itemW - minPeek]` so edges are
- * neither a 4px sliver nor a 4px haircut on a fully framed face.
- */
 function expectStrongPeek(
   viewportWidthPx: number,
   itemWidthPx: number,
@@ -22,59 +20,56 @@ function expectStrongPeek(
 
   const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gapPx);
   expect(peekPx).not.toBeNull();
-  const minPeekPx = itemWidthPx * STRIP_MIN_PEEK_FRACTION;
-  expect(peekPx!).toBeGreaterThanOrEqual(minPeekPx);
-  expect(peekPx!).toBeLessThanOrEqual(itemWidthPx - minPeekPx);
+  expect(peekPx!).toBeGreaterThanOrEqual(
+    itemWidthPx * STRIP_MIN_VISIBLE_PEEK_FRACTION,
+  );
+  expect(itemWidthPx - peekPx!).toBeGreaterThanOrEqual(
+    itemWidthPx * STRIP_MIN_CLIP_FRACTION,
+  );
 }
 
 describe("overflowStripEdgePeekPx", () => {
   it("returns null when the edge lands in the gap band", () => {
-    // d=105, period=100, rem=5 < g=20
     expect(overflowStripEdgePeekPx(290, 80, 20)).toBeNull();
   });
 
   it("returns visible chip depth when the edge cuts a chip", () => {
-    // d=151, period=104, rem=47 → peek=31
     expect(overflowStripEdgePeekPx(390, 88, 16)).toBeCloseTo(31, 5);
   });
 });
 
 describe("isOverflowStripGapPeekSafe", () => {
-  it("is true for a mid-chip peek (mobile compact ballpark)", () => {
-    // rem=47, peek=31 ≥ 0.35*88≈30.8 and ≤ 57.2
-    expect(isOverflowStripGapPeekSafe(390, 88, 16)).toBe(true);
-  });
-
   it("is false when rem lands in the gap band", () => {
     expect(isOverflowStripGapPeekSafe(290, 80, 20)).toBe(false);
   });
 
   it("is false for a tiny visible sliver", () => {
-    // Construct rem ≈ g + 4 → peek=4 ≪ 0.35*W
-    // d=124, W=80, g=20 → period=100, rem=24, peek=4
     expect(overflowStripEdgePeekPx(328, 80, 20)).toBeCloseTo(4, 5);
     expect(isOverflowStripGapPeekSafe(328, 80, 20)).toBe(false);
   });
 
   it("is false for a near-full chip with only a haircut (desktop failure mode)", () => {
-    // max-w-4xl ~896, default chip 112, preferred gap 20 → peek=108
-    // (only 4px clipped) — looks fully framed.
     expect(overflowStripEdgePeekPx(896, 112, 20)).toBeCloseTo(108, 5);
     expect(isOverflowStripGapPeekSafe(896, 112, 20)).toBe(false);
+  });
+
+  it("is true near the mobile QA ballpark (~65% visible)", () => {
+    // Construct peek ≈ 0.65 * 88 ≈ 57.2
+    const itemWidthPx = 88;
+    const gapPx = 16;
+    const peekPx = itemWidthPx * STRIP_TARGET_PEEK_FRACTION;
+    const d = gapPx + peekPx; // k=0
+    const viewportWidthPx = 2 * d + itemWidthPx;
+    expect(
+      overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gapPx),
+    ).toBeCloseTo(peekPx, 5);
+    expect(
+      isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, gapPx),
+    ).toBe(true);
   });
 });
 
 describe("resolveOverflowStripGapPx", () => {
-  it("returns preferred when it already has a strong peek", () => {
-    expect(
-      resolveOverflowStripGapPx({
-        viewportWidthPx: 390,
-        itemWidthPx: 88,
-        preferredGapPx: 16,
-      }),
-    ).toBe(16);
-  });
-
   it("adjusts gap when preferred leaves an empty edge", () => {
     const preferredGapPx = 40;
     const viewportWidthPx = 376;
@@ -95,7 +90,7 @@ describe("resolveOverflowStripGapPx", () => {
     expectStrongPeek(viewportWidthPx, itemWidthPx, gap);
   });
 
-  it("strengthens desktop max-w-4xl peek beyond a 4px haircut", () => {
+  it("strengthens desktop max-w-4xl peek to ~mobile ballpark, not a 4px haircut", () => {
     const viewportWidthPx = 896;
     const itemWidthPx = 112;
     const preferredGapPx = 20;
@@ -115,12 +110,12 @@ describe("resolveOverflowStripGapPx", () => {
     expectStrongPeek(viewportWidthPx, itemWidthPx, gap);
 
     const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gap)!;
-    // Same ballpark as mobile (~half chip), not a 4px cue.
-    expect(peekPx).toBeGreaterThanOrEqual(itemWidthPx * 0.35);
-    expect(peekPx).toBeLessThanOrEqual(itemWidthPx * 0.65);
+    // Same ballpark as mobile QA (~72px / ~65% of chip), not 4px.
+    expect(peekPx).toBeGreaterThanOrEqual(itemWidthPx * 0.55);
+    expect(peekPx).toBeLessThanOrEqual(itemWidthPx * 0.75);
   });
 
-  it("keeps mobile 375 compact peek at least as strong as the QA baseline", () => {
+  it("keeps mobile 375 compact peek strong (at least 40% of a chip)", () => {
     const gap = resolveOverflowStripGapPx({
       viewportWidthPx: 375,
       itemWidthPx: 88,
@@ -131,9 +126,7 @@ describe("resolveOverflowStripGapPx", () => {
     expectStrongPeek(375, 88, gap);
 
     const peekPx = overflowStripEdgePeekPx(375, 88, gap)!;
-    // QA saw ~72px with a weak rule; strong band floor is 0.35*88≈30.8, but
-    // prefer mid-chip so we stay well above a sliver.
-    expect(peekPx).toBeGreaterThanOrEqual(88 * STRIP_MIN_PEEK_FRACTION);
+    expect(peekPx).toBeGreaterThanOrEqual(88 * STRIP_MIN_VISIBLE_PEEK_FRACTION);
   });
 
   it("clamps adjusted gap to at most ~2.5× preferred while staying strong", () => {

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/peek-safe-strip-gap.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/peek-safe-strip-gap.test.ts
@@ -2,14 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   isOverflowStripGapPeekSafe,
+  overflowStripEdgePeekPx,
   resolveOverflowStripGapPx,
+  STRIP_MIN_PEEK_FRACTION,
 } from "../peek-safe-strip-gap";
 
 /**
- * Invariant: with a middle chip optically centered,
- * `d = Vp/2 - itemW/2`, `rem = d % (itemW+g)`, edge sits in a chip iff `rem >= g`.
+ * Strong peek: visible depth in `[minPeek, itemW - minPeek]` so edges are
+ * neither a 4px sliver nor a 4px haircut on a fully framed face.
  */
-function expectPeekSafe(
+function expectStrongPeek(
   viewportWidthPx: number,
   itemWidthPx: number,
   gapPx: number,
@@ -17,27 +19,53 @@ function expectPeekSafe(
   expect(isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, gapPx)).toBe(
     true,
   );
+
+  const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gapPx);
+  expect(peekPx).not.toBeNull();
+  const minPeekPx = itemWidthPx * STRIP_MIN_PEEK_FRACTION;
+  expect(peekPx!).toBeGreaterThanOrEqual(minPeekPx);
+  expect(peekPx!).toBeLessThanOrEqual(itemWidthPx - minPeekPx);
 }
 
+describe("overflowStripEdgePeekPx", () => {
+  it("returns null when the edge lands in the gap band", () => {
+    // d=105, period=100, rem=5 < g=20
+    expect(overflowStripEdgePeekPx(290, 80, 20)).toBeNull();
+  });
+
+  it("returns visible chip depth when the edge cuts a chip", () => {
+    // d=151, period=104, rem=47 → peek=31
+    expect(overflowStripEdgePeekPx(390, 88, 16)).toBeCloseTo(31, 5);
+  });
+});
+
 describe("isOverflowStripGapPeekSafe", () => {
-  it("is true when rem lands in the chip band", () => {
-    // d=151, period=104, rem=47 >= g=16
+  it("is true for a mid-chip peek (mobile compact ballpark)", () => {
+    // rem=47, peek=31 ≥ 0.35*88≈30.8 and ≤ 57.2
     expect(isOverflowStripGapPeekSafe(390, 88, 16)).toBe(true);
   });
 
   it("is false when rem lands in the gap band", () => {
-    // d=105, period=100, rem=5 < g=20
     expect(isOverflowStripGapPeekSafe(290, 80, 20)).toBe(false);
   });
 
-  it("is false when rem is 0 (flush chip start, no peek-cut)", () => {
-    // d=100, period=100, rem=0
-    expect(isOverflowStripGapPeekSafe(280, 80, 20)).toBe(false);
+  it("is false for a tiny visible sliver", () => {
+    // Construct rem ≈ g + 4 → peek=4 ≪ 0.35*W
+    // d=124, W=80, g=20 → period=100, rem=24, peek=4
+    expect(overflowStripEdgePeekPx(328, 80, 20)).toBeCloseTo(4, 5);
+    expect(isOverflowStripGapPeekSafe(328, 80, 20)).toBe(false);
+  });
+
+  it("is false for a near-full chip with only a haircut (desktop failure mode)", () => {
+    // max-w-4xl ~896, default chip 112, preferred gap 20 → peek=108
+    // (only 4px clipped) — looks fully framed.
+    expect(overflowStripEdgePeekPx(896, 112, 20)).toBeCloseTo(108, 5);
+    expect(isOverflowStripGapPeekSafe(896, 112, 20)).toBe(false);
   });
 });
 
 describe("resolveOverflowStripGapPx", () => {
-  it("returns preferred when it already peek-cuts both edges", () => {
+  it("returns preferred when it already has a strong peek", () => {
     expect(
       resolveOverflowStripGapPx({
         viewportWidthPx: 390,
@@ -48,7 +76,6 @@ describe("resolveOverflowStripGapPx", () => {
   });
 
   it("adjusts gap when preferred leaves an empty edge", () => {
-    // d=148, preferred period=120 → rem=28 < 40 (gap band).
     const preferredGapPx = 40;
     const viewportWidthPx = 376;
     const itemWidthPx = 80;
@@ -64,22 +91,14 @@ describe("resolveOverflowStripGapPx", () => {
     });
 
     expect(gap).toBeGreaterThan(0);
-    expect(gap).toBeLessThanOrEqual(preferredGapPx * 1.5);
-    expectPeekSafe(viewportWidthPx, itemWidthPx, gap);
-
-    // Half-chip target: rem ≈ g + itemW/2 (k=1 → g=14)
-    const d = viewportWidthPx / 2 - itemWidthPx / 2;
-    const rem = d % (itemWidthPx + gap);
-    expect(rem).toBeCloseTo(gap + itemWidthPx / 2, 5);
-    expect(gap).toBeCloseTo(14, 5);
+    expect(gap).toBeLessThanOrEqual(preferredGapPx * 2.5);
+    expectStrongPeek(viewportWidthPx, itemWidthPx, gap);
   });
 
-  it("clamps adjusted gap to at most ~1.5× preferred", () => {
-    // Preferred fails (rem in gap). Half-chip k=0 is huge; resolver must
-    // stay within 1.5× and still peek-cut.
-    const preferredGapPx = 70;
-    const viewportWidthPx = 500;
-    const itemWidthPx = 88;
+  it("strengthens desktop max-w-4xl peek beyond a 4px haircut", () => {
+    const viewportWidthPx = 896;
+    const itemWidthPx = 112;
+    const preferredGapPx = 20;
 
     expect(
       isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, preferredGapPx),
@@ -92,11 +111,16 @@ describe("resolveOverflowStripGapPx", () => {
     });
 
     expect(gap).toBeGreaterThan(0);
-    expect(gap).toBeLessThanOrEqual(preferredGapPx * 1.5 + 1e-9);
-    expectPeekSafe(viewportWidthPx, itemWidthPx, gap);
+    expect(gap).toBeLessThanOrEqual(preferredGapPx * 2.5 + 1e-9);
+    expectStrongPeek(viewportWidthPx, itemWidthPx, gap);
+
+    const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gap)!;
+    // Same ballpark as mobile (~half chip), not a 4px cue.
+    expect(peekPx).toBeGreaterThanOrEqual(itemWidthPx * 0.35);
+    expect(peekPx).toBeLessThanOrEqual(itemWidthPx * 0.65);
   });
 
-  it("keeps gap positive for typical mobile compact strip numbers", () => {
+  it("keeps mobile 375 compact peek at least as strong as the QA baseline", () => {
     const gap = resolveOverflowStripGapPx({
       viewportWidthPx: 375,
       itemWidthPx: 88,
@@ -104,6 +128,27 @@ describe("resolveOverflowStripGapPx", () => {
     });
 
     expect(gap).toBeGreaterThan(0);
-    expectPeekSafe(375, 88, gap);
+    expectStrongPeek(375, 88, gap);
+
+    const peekPx = overflowStripEdgePeekPx(375, 88, gap)!;
+    // QA saw ~72px with a weak rule; strong band floor is 0.35*88≈30.8, but
+    // prefer mid-chip so we stay well above a sliver.
+    expect(peekPx).toBeGreaterThanOrEqual(88 * STRIP_MIN_PEEK_FRACTION);
+  });
+
+  it("clamps adjusted gap to at most ~2.5× preferred while staying strong", () => {
+    const preferredGapPx = 70;
+    const viewportWidthPx = 500;
+    const itemWidthPx = 88;
+
+    const gap = resolveOverflowStripGapPx({
+      viewportWidthPx,
+      itemWidthPx,
+      preferredGapPx,
+    });
+
+    expect(gap).toBeGreaterThan(0);
+    expect(gap).toBeLessThanOrEqual(preferredGapPx * 2.5 + 1e-9);
+    expectStrongPeek(viewportWidthPx, itemWidthPx, gap);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/peek-safe-strip-gap.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/peek-safe-strip-gap.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isOverflowStripGapPeekSafe,
+  resolveOverflowStripGapPx,
+} from "../peek-safe-strip-gap";
+
+/**
+ * Invariant: with a middle chip optically centered,
+ * `d = Vp/2 - itemW/2`, `rem = d % (itemW+g)`, edge sits in a chip iff `rem >= g`.
+ */
+function expectPeekSafe(
+  viewportWidthPx: number,
+  itemWidthPx: number,
+  gapPx: number,
+): void {
+  expect(isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, gapPx)).toBe(
+    true,
+  );
+}
+
+describe("isOverflowStripGapPeekSafe", () => {
+  it("is true when rem lands in the chip band", () => {
+    // d=151, period=104, rem=47 >= g=16
+    expect(isOverflowStripGapPeekSafe(390, 88, 16)).toBe(true);
+  });
+
+  it("is false when rem lands in the gap band", () => {
+    // d=105, period=100, rem=5 < g=20
+    expect(isOverflowStripGapPeekSafe(290, 80, 20)).toBe(false);
+  });
+
+  it("is false when rem is 0 (flush chip start, no peek-cut)", () => {
+    // d=100, period=100, rem=0
+    expect(isOverflowStripGapPeekSafe(280, 80, 20)).toBe(false);
+  });
+});
+
+describe("resolveOverflowStripGapPx", () => {
+  it("returns preferred when it already peek-cuts both edges", () => {
+    expect(
+      resolveOverflowStripGapPx({
+        viewportWidthPx: 390,
+        itemWidthPx: 88,
+        preferredGapPx: 16,
+      }),
+    ).toBe(16);
+  });
+
+  it("adjusts gap when preferred leaves an empty edge", () => {
+    // d=148, preferred period=120 → rem=28 < 40 (gap band).
+    const preferredGapPx = 40;
+    const viewportWidthPx = 376;
+    const itemWidthPx = 80;
+
+    expect(
+      isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, preferredGapPx),
+    ).toBe(false);
+
+    const gap = resolveOverflowStripGapPx({
+      viewportWidthPx,
+      itemWidthPx,
+      preferredGapPx,
+    });
+
+    expect(gap).toBeGreaterThan(0);
+    expect(gap).toBeLessThanOrEqual(preferredGapPx * 1.5);
+    expectPeekSafe(viewportWidthPx, itemWidthPx, gap);
+
+    // Half-chip target: rem ≈ g + itemW/2 (k=1 → g=14)
+    const d = viewportWidthPx / 2 - itemWidthPx / 2;
+    const rem = d % (itemWidthPx + gap);
+    expect(rem).toBeCloseTo(gap + itemWidthPx / 2, 5);
+    expect(gap).toBeCloseTo(14, 5);
+  });
+
+  it("clamps adjusted gap to at most ~1.5× preferred", () => {
+    // Preferred fails (rem in gap). Half-chip k=0 is huge; resolver must
+    // stay within 1.5× and still peek-cut.
+    const preferredGapPx = 70;
+    const viewportWidthPx = 500;
+    const itemWidthPx = 88;
+
+    expect(
+      isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, preferredGapPx),
+    ).toBe(false);
+
+    const gap = resolveOverflowStripGapPx({
+      viewportWidthPx,
+      itemWidthPx,
+      preferredGapPx,
+    });
+
+    expect(gap).toBeGreaterThan(0);
+    expect(gap).toBeLessThanOrEqual(preferredGapPx * 1.5 + 1e-9);
+    expectPeekSafe(viewportWidthPx, itemWidthPx, gap);
+  });
+
+  it("keeps gap positive for typical mobile compact strip numbers", () => {
+    const gap = resolveOverflowStripGapPx({
+      viewportWidthPx: 375,
+      itemWidthPx: 88,
+      preferredGapPx: 16,
+    });
+
+    expect(gap).toBeGreaterThan(0);
+    expectPeekSafe(375, 88, gap);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -76,7 +76,8 @@ const STRIP_SIZES = {
  * optically in the middle. While the user scrolls, selection follows the
  * coworker nearest the visual center; tap selects and centers that face.
  * When the track overflows, `--strip-gap` is tuned so a middle-centered chip
- * peek-cuts both scrollport edges (overflow-only; fit case keeps preferred).
+ * shows a strong peek at both scrollport edges (mid-chip band, not a 4px
+ * sliver/haircut; overflow-only; fit case keeps preferred).
  * Strip titles always reserve two lines (`min-h-[2lh]`) so 1-line vs wrapping
  * captions cannot change row height and push Start chat.
  */

--- a/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/landing/coworker-strip.client.tsx
@@ -8,6 +8,7 @@ import { useMountEffect } from "@/hooks/use-mount-effect";
 import { cn } from "@/lib/utils";
 
 import { findNearestCenterIdFromElements } from "./nearest-center-coworker";
+import { resolveOverflowStripGapPx } from "./peek-safe-strip-gap";
 
 export interface StripCoworker {
   id: string;
@@ -34,7 +35,9 @@ const STRIP_SIZES = {
   compact: {
     featured: "size-20",
     other: "size-11",
-    gap: "gap-4",
+    // Preferred 1rem; overflow may override via --strip-gap (peek-safe).
+    gap: "gap-[length:var(--strip-gap,1rem)]",
+    preferredGapRem: 1,
     // All chips share the featured width so selection reflow cannot move
     // centers while scroll-driven selection is active.
     itemWidth: "w-[5.5rem]",
@@ -50,7 +53,8 @@ const STRIP_SIZES = {
   default: {
     featured: "size-28",
     other: "size-16",
-    gap: "gap-5",
+    gap: "gap-[length:var(--strip-gap,1.25rem)]",
+    preferredGapRem: 1.25,
     itemWidth: "w-28",
     featuredSizes: "112px",
     otherSizes: "64px",
@@ -71,6 +75,8 @@ const STRIP_SIZES = {
  * it cannot widen the picker or page. On mount, scrolls so `centerOnId` sits
  * optically in the middle. While the user scrolls, selection follows the
  * coworker nearest the visual center; tap selects and centers that face.
+ * When the track overflows, `--strip-gap` is tuned so a middle-centered chip
+ * peek-cuts both scrollport edges (overflow-only; fit case keeps preferred).
  * Strip titles always reserve two lines (`min-h-[2lh]`) so 1-line vs wrapping
  * captions cannot change row height and push Start chat.
  */
@@ -84,6 +90,7 @@ export function CoworkerStrip({
   const t = useTranslations("App.Chat.Landing");
   const scale = STRIP_SIZES[size];
   const scrollRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef(new Map<string, HTMLButtonElement>());
   /** >0 while programmatic scrollIntoView should not drive selection. */
   const suppressScrollSelectRef = useRef(0);
@@ -150,6 +157,50 @@ export function CoworkerStrip({
     }
   });
 
+  const syncPeekSafeGap = useEffectEvent(() => {
+    const scroll = scrollRef.current;
+    const track = trackRef.current;
+    if (!scroll || !track) {
+      return;
+    }
+
+    if (scroll.scrollWidth <= scroll.clientWidth) {
+      track.style.removeProperty("--strip-gap");
+      return;
+    }
+
+    const firstChip = track.querySelector<HTMLElement>("[data-coworker-id]");
+    if (!firstChip) {
+      return;
+    }
+
+    const itemWidthPx = firstChip.getBoundingClientRect().width;
+    const rootFontPx = Number.parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    const preferredGapPx = scale.preferredGapRem * rootFontPx;
+    if (
+      !(itemWidthPx > 0) ||
+      !(preferredGapPx > 0) ||
+      !(scroll.clientWidth > 0)
+    ) {
+      return;
+    }
+
+    const gapPx = resolveOverflowStripGapPx({
+      viewportWidthPx: scroll.clientWidth,
+      itemWidthPx,
+      preferredGapPx,
+    });
+
+    if (Math.abs(gapPx - preferredGapPx) < 0.5) {
+      track.style.removeProperty("--strip-gap");
+      return;
+    }
+
+    track.style.setProperty("--strip-gap", `${gapPx}px`);
+  });
+
   useMountEffect(() => {
     const child = itemRefs.current.get(centerOnId);
     if (!child) {
@@ -167,6 +218,27 @@ export function CoworkerStrip({
     return () => {
       cancelAnimationFrame(frame1);
       cancelAnimationFrame(frame2);
+    };
+  });
+
+  useMountEffect(() => {
+    const scroll = scrollRef.current;
+    const track = trackRef.current;
+    if (!scroll || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    syncPeekSafeGap();
+    const observer = new ResizeObserver(() => {
+      syncPeekSafeGap();
+    });
+    observer.observe(scroll);
+    if (track) {
+      observer.observe(track);
+    }
+
+    return () => {
+      observer.disconnect();
     };
   });
 
@@ -193,10 +265,13 @@ export function CoworkerStrip({
       onScroll={syncSelectionFromScroll}
     >
       <div
+        ref={trackRef}
         className={cn(
           // min-w-full + justify-center: when the catalog fits, Elena (middle
           // of the track) lands in the visual centre. When it overflows, w-max
           // wins and edgePad lets first/last faces reach optical center.
+          // Gap uses --strip-gap when overflowing so middle-centered chips
+          // peek-cut both scrollport edges (see syncPeekSafeGap).
           "flex w-max min-w-full items-start justify-center py-1",
           scale.edgePad,
           scale.gap,

--- a/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
@@ -1,0 +1,119 @@
+/**
+ * Overflow-only peek-safe gap for the landing coworker strip.
+ *
+ * When the strip overflows and a middle chip is optically centered, each
+ * scrollport edge should intersect a chip (peek-cut), not land in gap/empty.
+ *
+ * With centered item width `itemW` and viewport `Vp`:
+ * `d = Vp/2 - itemW/2`, `rem = d % (itemW + g)` — edge is in a chip iff `rem >= g`.
+ */
+
+export interface ResolveOverflowStripGapPxInput {
+  viewportWidthPx: number;
+  itemWidthPx: number;
+  preferredGapPx: number;
+  /** Upper bound as a multiple of preferred; default 1.5. */
+  maxGapFactor?: number;
+}
+
+/**
+ * True when a middle-centered layout peeks a chip at each scrollport edge.
+ */
+export function isOverflowStripGapPeekSafe(
+  viewportWidthPx: number,
+  itemWidthPx: number,
+  gapPx: number,
+): boolean {
+  if (!(viewportWidthPx > 0) || !(itemWidthPx > 0) || !(gapPx > 0)) {
+    return false;
+  }
+
+  const d = viewportWidthPx / 2 - itemWidthPx / 2;
+  if (!(d > 0)) {
+    // Degenerate half-viewport geometry — nothing useful to adjust.
+    return false;
+  }
+
+  const period = itemWidthPx + gapPx;
+  const rem = d % period;
+  return rem >= gapPx;
+}
+
+/**
+ * Returns preferred gap when already peek-safe; otherwise a closed-form gap
+ * aimed at half-chip peek (`rem ≈ g + itemW/2`), clamped to (0, maxGap].
+ */
+export function resolveOverflowStripGapPx({
+  viewportWidthPx,
+  itemWidthPx,
+  preferredGapPx,
+  maxGapFactor = 1.5,
+}: ResolveOverflowStripGapPxInput): number {
+  const preferred = preferredGapPx;
+  if (
+    preferred > 0 &&
+    isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, preferred)
+  ) {
+    return preferred;
+  }
+
+  const d = viewportWidthPx / 2 - itemWidthPx / 2;
+  if (!(d > 0) || !(itemWidthPx > 0) || !(preferred > 0)) {
+    return Math.max(preferred, Number.MIN_VALUE);
+  }
+
+  const maxGap = preferred * maxGapFactor;
+  const maxK = Math.max(0, Math.floor(d / itemWidthPx) + 1);
+
+  let bestGap: null | number = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  function consider(gap: number): void {
+    if (!(gap > 0) || gap > maxGap) {
+      return;
+    }
+    if (!isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, gap)) {
+      return;
+    }
+    const distance = Math.abs(gap - preferred);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestGap = gap;
+    }
+  }
+
+  // Closed form toward half-chip peek: rem = g + itemW/2
+  // d = k*(itemW+g) + g + itemW/2  →  g = (d - itemW*(k+0.5)) / (k+1)
+  for (let k = 0; k <= maxK; k += 1) {
+    const gap = (d - itemWidthPx * (k + 0.5)) / (k + 1);
+    const period = itemWidthPx + gap;
+    if (!(period > 0) || Math.floor(d / period) !== k) {
+      continue;
+    }
+    consider(gap);
+  }
+
+  if (bestGap !== null) {
+    return bestGap;
+  }
+
+  // Fallback: other chip-band fractions, then dense sample within the clamp.
+  const fractions = [0, 0.25, 0.75, 0.9] as const;
+  for (let k = 0; k <= maxK; k += 1) {
+    for (const fraction of fractions) {
+      const gap = (d - itemWidthPx * (k + fraction)) / (k + 1);
+      const period = itemWidthPx + gap;
+      if (!(period > 0) || Math.floor(d / period) !== k) {
+        continue;
+      }
+      consider(gap);
+    }
+  }
+
+  const sampleSteps = 48;
+  for (let step = 1; step <= sampleSteps; step += 1) {
+    consider((maxGap * step) / sampleSteps);
+  }
+
+  return bestGap ?? preferred;
+}

--- a/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
@@ -2,57 +2,98 @@
  * Overflow-only peek-safe gap for the landing coworker strip.
  *
  * When the strip overflows and a middle chip is optically centered, each
- * scrollport edge should intersect a chip (peek-cut), not land in gap/empty.
+ * scrollport edge should show a *meaningful* slice of a neighbor chip — not
+ * land in gap/empty, and not leave only a 4px sliver or a 4px haircut on an
+ * otherwise fully framed face.
  *
  * With centered item width `itemW` and viewport `Vp`:
- * `d = Vp/2 - itemW/2`, `rem = d % (itemW + g)` — edge is in a chip iff `rem >= g`.
+ * `d = Vp/2 - itemW/2`, `rem = d % (itemW + g)`.
+ * Edge is in a chip iff `rem >= g`; visible chip depth is `rem - g`.
  */
+
+/** Minimum visible (and clipped) fraction of the edge chip. */
+export const STRIP_MIN_PEEK_FRACTION = 0.35;
 
 export interface ResolveOverflowStripGapPxInput {
   viewportWidthPx: number;
   itemWidthPx: number;
   preferredGapPx: number;
-  /** Upper bound as a multiple of preferred; default 1.5. */
+  /**
+   * Upper bound as a multiple of preferred. Default 2.5 so wide desktop
+   * scrollports can still reach a mid-chip peek.
+   */
   maxGapFactor?: number;
+  /** Override for tests; default `STRIP_MIN_PEEK_FRACTION`. */
+  minPeekFraction?: number;
 }
 
 /**
- * True when a middle-centered layout peeks a chip at each scrollport edge.
+ * Visible depth (px) of the chip under each scrollport edge when a middle
+ * chip is optically centered, or `null` when the edge lands in gap/empty.
+ */
+export function overflowStripEdgePeekPx(
+  viewportWidthPx: number,
+  itemWidthPx: number,
+  gapPx: number,
+): null | number {
+  if (!(viewportWidthPx > 0) || !(itemWidthPx > 0) || !(gapPx > 0)) {
+    return null;
+  }
+
+  const d = viewportWidthPx / 2 - itemWidthPx / 2;
+  if (!(d > 0)) {
+    return null;
+  }
+
+  const period = itemWidthPx + gapPx;
+  const rem = d % period;
+  if (rem < gapPx) {
+    return null;
+  }
+
+  return rem - gapPx;
+}
+
+/**
+ * True when a middle-centered layout shows a strong peek at each scrollport
+ * edge (visible depth in `[minPeek, itemW - minPeek]`).
  */
 export function isOverflowStripGapPeekSafe(
   viewportWidthPx: number,
   itemWidthPx: number,
   gapPx: number,
+  minPeekFraction: number = STRIP_MIN_PEEK_FRACTION,
 ): boolean {
-  if (!(viewportWidthPx > 0) || !(itemWidthPx > 0) || !(gapPx > 0)) {
+  const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gapPx);
+  if (peekPx === null) {
     return false;
   }
 
-  const d = viewportWidthPx / 2 - itemWidthPx / 2;
-  if (!(d > 0)) {
-    // Degenerate half-viewport geometry — nothing useful to adjust.
-    return false;
-  }
-
-  const period = itemWidthPx + gapPx;
-  const rem = d % period;
-  return rem >= gapPx;
+  const minPeekPx = itemWidthPx * minPeekFraction;
+  return peekPx >= minPeekPx && peekPx <= itemWidthPx - minPeekPx;
 }
 
 /**
- * Returns preferred gap when already peek-safe; otherwise a closed-form gap
- * aimed at half-chip peek (`rem ≈ g + itemW/2`), clamped to (0, maxGap].
+ * Returns preferred gap when already strongly peek-safe; otherwise a
+ * closed-form gap aimed at half-chip peek (`rem ≈ g + itemW/2`), clamped to
+ * (0, maxGap]. Prefers mid-chip peeks, then proximity to preferred gap.
  */
 export function resolveOverflowStripGapPx({
   viewportWidthPx,
   itemWidthPx,
   preferredGapPx,
-  maxGapFactor = 1.5,
+  maxGapFactor = 2.5,
+  minPeekFraction = STRIP_MIN_PEEK_FRACTION,
 }: ResolveOverflowStripGapPxInput): number {
   const preferred = preferredGapPx;
   if (
     preferred > 0 &&
-    isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, preferred)
+    isOverflowStripGapPeekSafe(
+      viewportWidthPx,
+      itemWidthPx,
+      preferred,
+      minPeekFraction,
+    )
   ) {
     return preferred;
   }
@@ -64,20 +105,42 @@ export function resolveOverflowStripGapPx({
 
   const maxGap = preferred * maxGapFactor;
   const maxK = Math.max(0, Math.floor(d / itemWidthPx) + 1);
+  const halfChip = itemWidthPx / 2;
 
   let bestGap: null | number = null;
-  let bestDistance = Number.POSITIVE_INFINITY;
+  let bestPeekDistance = Number.POSITIVE_INFINITY;
+  let bestGapDistance = Number.POSITIVE_INFINITY;
 
   function consider(gap: number): void {
     if (!(gap > 0) || gap > maxGap) {
       return;
     }
-    if (!isOverflowStripGapPeekSafe(viewportWidthPx, itemWidthPx, gap)) {
+    if (
+      !isOverflowStripGapPeekSafe(
+        viewportWidthPx,
+        itemWidthPx,
+        gap,
+        minPeekFraction,
+      )
+    ) {
       return;
     }
-    const distance = Math.abs(gap - preferred);
-    if (distance < bestDistance) {
-      bestDistance = distance;
+
+    const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gap);
+    if (peekPx === null) {
+      return;
+    }
+
+    const peekDistance = Math.abs(peekPx - halfChip);
+    const gapDistance = Math.abs(gap - preferred);
+    const betterPeek = peekDistance < bestPeekDistance - 1e-9;
+    const samePeekCloserGap =
+      Math.abs(peekDistance - bestPeekDistance) <= 1e-9 &&
+      gapDistance < bestGapDistance;
+
+    if (betterPeek || samePeekCloserGap) {
+      bestPeekDistance = peekDistance;
+      bestGapDistance = gapDistance;
       bestGap = gap;
     }
   }
@@ -93,12 +156,8 @@ export function resolveOverflowStripGapPx({
     consider(gap);
   }
 
-  if (bestGap !== null) {
-    return bestGap;
-  }
-
-  // Fallback: other chip-band fractions, then dense sample within the clamp.
-  const fractions = [0, 0.25, 0.75, 0.9] as const;
+  // Nearby peek fractions, then dense sample within the clamp.
+  const fractions = [0.35, 0.4, 0.45, 0.55, 0.6, 0.65, 0.25, 0.75] as const;
   for (let k = 0; k <= maxK; k += 1) {
     for (const fraction of fractions) {
       const gap = (d - itemWidthPx * (k + fraction)) / (k + 1);
@@ -110,10 +169,45 @@ export function resolveOverflowStripGapPx({
     }
   }
 
-  const sampleSteps = 48;
+  const sampleSteps = 64;
   for (let step = 1; step <= sampleSteps; step += 1) {
     consider((maxGap * step) / sampleSteps);
   }
 
-  return bestGap ?? preferred;
+  if (bestGap !== null) {
+    return bestGap;
+  }
+
+  // Best-effort when no gap hits the strong band within the clamp: pick the
+  // positive peek closest to half-chip (still better than a 4px haircut).
+  let effortGap: null | number = null;
+  let effortPeekDistance = Number.POSITIVE_INFINITY;
+  let effortGapDistance = Number.POSITIVE_INFINITY;
+
+  function considerEffort(gap: number): void {
+    if (!(gap > 0) || gap > maxGap) {
+      return;
+    }
+    const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gap);
+    if (peekPx === null || !(peekPx > 0)) {
+      return;
+    }
+    const peekDistance = Math.abs(peekPx - halfChip);
+    const gapDistance = Math.abs(gap - preferred);
+    const betterPeek = peekDistance < effortPeekDistance - 1e-9;
+    const samePeekCloserGap =
+      Math.abs(peekDistance - effortPeekDistance) <= 1e-9 &&
+      gapDistance < effortGapDistance;
+    if (betterPeek || samePeekCloserGap) {
+      effortPeekDistance = peekDistance;
+      effortGapDistance = gapDistance;
+      effortGap = gap;
+    }
+  }
+
+  for (let step = 1; step <= sampleSteps; step += 1) {
+    considerEffort((maxGap * step) / sampleSteps);
+  }
+
+  return effortGap ?? preferred;
 }

--- a/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
@@ -119,6 +119,7 @@ export function resolveOverflowStripGapPx({
   }
 
   const maxGap = preferred * maxGapFactor;
+  const minGap = preferred * 0.5;
   const maxK = Math.max(0, Math.floor(d / itemWidthPx) + 1);
   const targetPeekPx = itemWidthPx * targetPeekFraction;
 
@@ -127,7 +128,7 @@ export function resolveOverflowStripGapPx({
   let bestGapDistance = Number.POSITIVE_INFINITY;
 
   function consider(gap: number): void {
-    if (!(gap > 0) || gap > maxGap) {
+    if (!(gap >= minGap) || gap > maxGap) {
       return;
     }
     if (
@@ -185,8 +186,8 @@ export function resolveOverflowStripGapPx({
   }
 
   const sampleSteps = 64;
-  for (let step = 1; step <= sampleSteps; step += 1) {
-    consider((maxGap * step) / sampleSteps);
+  for (let step = 0; step <= sampleSteps; step += 1) {
+    consider(minGap + ((maxGap - minGap) * step) / sampleSteps);
   }
 
   if (bestGap !== null) {
@@ -198,7 +199,7 @@ export function resolveOverflowStripGapPx({
   let effortGapDistance = Number.POSITIVE_INFINITY;
 
   function considerEffort(gap: number): void {
-    if (!(gap > 0) || gap > maxGap) {
+    if (!(gap >= minGap) || gap > maxGap) {
       return;
     }
     const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gap);
@@ -218,8 +219,8 @@ export function resolveOverflowStripGapPx({
     }
   }
 
-  for (let step = 1; step <= sampleSteps; step += 1) {
-    considerEffort((maxGap * step) / sampleSteps);
+  for (let step = 0; step <= sampleSteps; step += 1) {
+    considerEffort(minGap + ((maxGap - minGap) * step) / sampleSteps);
   }
 
   return effortGap ?? preferred;

--- a/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/peek-safe-strip-gap.ts
@@ -11,8 +11,18 @@
  * Edge is in a chip iff `rem >= g`; visible chip depth is `rem - g`.
  */
 
-/** Minimum visible (and clipped) fraction of the edge chip. */
-export const STRIP_MIN_PEEK_FRACTION = 0.35;
+/** Minimum visible fraction of the edge chip (reject tiny slivers). */
+export const STRIP_MIN_VISIBLE_PEEK_FRACTION = 0.4;
+/**
+ * Minimum clipped fraction (reject a 4px haircut on an otherwise full face).
+ * Visible band is `[minVisible, 1 - minClip]`.
+ */
+export const STRIP_MIN_CLIP_FRACTION = 0.25;
+/** Aim near the mobile QA ballpark (~0.65 of a chip visible). */
+export const STRIP_TARGET_PEEK_FRACTION = 0.65;
+
+/** @deprecated Use STRIP_MIN_VISIBLE_PEEK_FRACTION. */
+export const STRIP_MIN_PEEK_FRACTION = STRIP_MIN_VISIBLE_PEEK_FRACTION;
 
 export interface ResolveOverflowStripGapPxInput {
   viewportWidthPx: number;
@@ -20,11 +30,12 @@ export interface ResolveOverflowStripGapPxInput {
   preferredGapPx: number;
   /**
    * Upper bound as a multiple of preferred. Default 2.5 so wide desktop
-   * scrollports can still reach a mid-chip peek.
+   * scrollports can still reach a strong peek.
    */
   maxGapFactor?: number;
-  /** Override for tests; default `STRIP_MIN_PEEK_FRACTION`. */
-  minPeekFraction?: number;
+  minVisibleFraction?: number;
+  minClipFraction?: number;
+  targetPeekFraction?: number;
 }
 
 /**
@@ -56,34 +67,37 @@ export function overflowStripEdgePeekPx(
 
 /**
  * True when a middle-centered layout shows a strong peek at each scrollport
- * edge (visible depth in `[minPeek, itemW - minPeek]`).
+ * edge (enough visible chunk and enough clipped that it is not a haircut).
  */
 export function isOverflowStripGapPeekSafe(
   viewportWidthPx: number,
   itemWidthPx: number,
   gapPx: number,
-  minPeekFraction: number = STRIP_MIN_PEEK_FRACTION,
+  minVisibleFraction: number = STRIP_MIN_VISIBLE_PEEK_FRACTION,
+  minClipFraction: number = STRIP_MIN_CLIP_FRACTION,
 ): boolean {
   const peekPx = overflowStripEdgePeekPx(viewportWidthPx, itemWidthPx, gapPx);
   if (peekPx === null) {
     return false;
   }
 
-  const minPeekPx = itemWidthPx * minPeekFraction;
-  return peekPx >= minPeekPx && peekPx <= itemWidthPx - minPeekPx;
+  const minVisiblePx = itemWidthPx * minVisibleFraction;
+  const minClipPx = itemWidthPx * minClipFraction;
+  return peekPx >= minVisiblePx && itemWidthPx - peekPx >= minClipPx;
 }
 
 /**
- * Returns preferred gap when already strongly peek-safe; otherwise a
- * closed-form gap aimed at half-chip peek (`rem ≈ g + itemW/2`), clamped to
- * (0, maxGap]. Prefers mid-chip peeks, then proximity to preferred gap.
+ * Returns preferred gap when already strongly peek-safe; otherwise aims for
+ * ~65% chip visible (mobile QA ballpark), clamped to (0, maxGap].
  */
 export function resolveOverflowStripGapPx({
   viewportWidthPx,
   itemWidthPx,
   preferredGapPx,
   maxGapFactor = 2.5,
-  minPeekFraction = STRIP_MIN_PEEK_FRACTION,
+  minVisibleFraction = STRIP_MIN_VISIBLE_PEEK_FRACTION,
+  minClipFraction = STRIP_MIN_CLIP_FRACTION,
+  targetPeekFraction = STRIP_TARGET_PEEK_FRACTION,
 }: ResolveOverflowStripGapPxInput): number {
   const preferred = preferredGapPx;
   if (
@@ -92,7 +106,8 @@ export function resolveOverflowStripGapPx({
       viewportWidthPx,
       itemWidthPx,
       preferred,
-      minPeekFraction,
+      minVisibleFraction,
+      minClipFraction,
     )
   ) {
     return preferred;
@@ -105,7 +120,7 @@ export function resolveOverflowStripGapPx({
 
   const maxGap = preferred * maxGapFactor;
   const maxK = Math.max(0, Math.floor(d / itemWidthPx) + 1);
-  const halfChip = itemWidthPx / 2;
+  const targetPeekPx = itemWidthPx * targetPeekFraction;
 
   let bestGap: null | number = null;
   let bestPeekDistance = Number.POSITIVE_INFINITY;
@@ -120,7 +135,8 @@ export function resolveOverflowStripGapPx({
         viewportWidthPx,
         itemWidthPx,
         gap,
-        minPeekFraction,
+        minVisibleFraction,
+        minClipFraction,
       )
     ) {
       return;
@@ -131,7 +147,7 @@ export function resolveOverflowStripGapPx({
       return;
     }
 
-    const peekDistance = Math.abs(peekPx - halfChip);
+    const peekDistance = Math.abs(peekPx - targetPeekPx);
     const gapDistance = Math.abs(gap - preferred);
     const betterPeek = peekDistance < bestPeekDistance - 1e-9;
     const samePeekCloserGap =
@@ -145,10 +161,10 @@ export function resolveOverflowStripGapPx({
     }
   }
 
-  // Closed form toward half-chip peek: rem = g + itemW/2
-  // d = k*(itemW+g) + g + itemW/2  →  g = (d - itemW*(k+0.5)) / (k+1)
+  // Closed form toward target peek: rem = g + targetPeek
+  // d = k*(itemW+g) + g + targetPeek → g = (d - itemW*k - targetPeek) / (k+1)
   for (let k = 0; k <= maxK; k += 1) {
-    const gap = (d - itemWidthPx * (k + 0.5)) / (k + 1);
+    const gap = (d - itemWidthPx * k - targetPeekPx) / (k + 1);
     const period = itemWidthPx + gap;
     if (!(period > 0) || Math.floor(d / period) !== k) {
       continue;
@@ -156,8 +172,7 @@ export function resolveOverflowStripGapPx({
     consider(gap);
   }
 
-  // Nearby peek fractions, then dense sample within the clamp.
-  const fractions = [0.35, 0.4, 0.45, 0.55, 0.6, 0.65, 0.25, 0.75] as const;
+  const fractions = [0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.35] as const;
   for (let k = 0; k <= maxK; k += 1) {
     for (const fraction of fractions) {
       const gap = (d - itemWidthPx * (k + fraction)) / (k + 1);
@@ -178,8 +193,6 @@ export function resolveOverflowStripGapPx({
     return bestGap;
   }
 
-  // Best-effort when no gap hits the strong band within the clamp: pick the
-  // positive peek closest to half-chip (still better than a 4px haircut).
   let effortGap: null | number = null;
   let effortPeekDistance = Number.POSITIVE_INFINITY;
   let effortGapDistance = Number.POSITIVE_INFINITY;
@@ -192,7 +205,7 @@ export function resolveOverflowStripGapPx({
     if (peekPx === null || !(peekPx > 0)) {
       return;
     }
-    const peekDistance = Math.abs(peekPx - halfChip);
+    const peekDistance = Math.abs(peekPx - targetPeekPx);
     const gapDistance = Math.abs(gap - preferred);
     const betterPeek = peekDistance < effortPeekDistance - 1e-9;
     const samePeekCloserGap =


### PR DESCRIPTION
## Summary

- **SOK-791** — https://linear.app/masumi/issue/SOK-791/peek-cut-edge-coworkers-on-chat-strip-so-scroll-is-obvious
- Stacked on #3811 (`cursor/sok-789-scroll-strip-selects-middle-7117`); do not fold into that PR.
- Cloud agent: `bc-1f78eb04-94ec-58fd-9c05-ab2e4c6eb80d`

### Spec
- Overflow-only peek-safe gap: when strip overflows and a middle coworker is centered, both scrollport edges peek-cut a chip.
- Keep fixed equal `itemWidth` + `edgePad`; tune `--strip-gap` via `resolveOverflowStripGapPx`.
- Fit case (no overflow): preferred gap, no fake peek / forced scroll.
- Full-bleed unchanged (no `px-*` on scrollport); scroll-select-middle (SOK-789) unchanged.
- Start chat stays CTA-only; auth/API unchanged.

### Verification
- `pnpm web:check` — exit 0
- `pnpm web:test` — exit 0
- Targeted strip / peek-safe / edge-contract tests — exit 0