### PR TITLE
fix(chat): keep thinking elapsed on remount

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1671,6 +1671,107 @@ describe("ChatMessageRow coworker Thought", () => {
     expect(screen.getByTestId("live-stream-elapsed")).toBeInTheDocument();
   });
 
+  it("anchors mention thinking elapsed to message createdAt (wall clock)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-10T12:02:00.000Z"));
+    try {
+      renderRow({
+        message: userMessage({
+          content: "@Maya draft the deck",
+          createdAt: new Date("2026-08-10T12:00:00.000Z"),
+          mentions: [
+            {
+              id: "mention-wall",
+              coworkerId: "cow-1",
+              status: "sent",
+              responseMessageId: null,
+            },
+          ],
+        }),
+        coworkersById: new Map([
+          [
+            "cow-1",
+            {
+              id: "cow-1",
+              name: "Maya",
+              slug: "maya",
+              caption: null,
+              image: null,
+              presence: "online",
+            },
+          ],
+        ]),
+      });
+      // ~2 minutes since the ask — not ~0 from client mount.
+      expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
+        "2m 0.0s",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps mention thinking elapsed across remount / reopen", () => {
+    vi.useFakeTimers();
+    const createdAt = new Date("2026-08-10T12:00:00.000Z");
+    const coworkersById = new Map([
+      [
+        "cow-1",
+        {
+          id: "cow-1",
+          name: "Maya",
+          slug: "maya",
+          caption: null,
+          image: null,
+          presence: "online" as const,
+        },
+      ],
+    ]);
+    const message = userMessage({
+      content: "@Maya draft the deck",
+      createdAt,
+      mentions: [
+        {
+          id: "mention-remount",
+          coworkerId: "cow-1",
+          status: "sent",
+          responseMessageId: null,
+        },
+      ],
+    });
+    try {
+      vi.setSystemTime(new Date("2026-08-10T12:01:30.000Z"));
+      const { unmount } = render(
+        <ChatMessageRow
+          message={message}
+          coworkersById={coworkersById}
+          coworkersBySlug={new Map()}
+          onToggleReaction={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
+        "1m 30.0s",
+      );
+      unmount();
+
+      // Leave and reopen ~10s later: elapsed continues from createdAt, not remount.
+      vi.setSystemTime(new Date("2026-08-10T12:01:40.000Z"));
+      render(
+        <ChatMessageRow
+          message={message}
+          coworkersById={coworkersById}
+          coworkersBySlug={new Map()}
+          onToggleReaction={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
+        "1m 40.0s",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("hides mention status when coworker replied; shows failed terminal only", () => {
     const coworkersById = new Map([
       [
@@ -1792,6 +1893,46 @@ describe("ChatMessageRow coworker Thought", () => {
       });
       expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
         "10.0s",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps stream overlay thinking elapsed across remount", () => {
+    vi.useFakeTimers();
+    const createdAt = new Date("2026-08-10T12:00:00.000Z");
+    const message = coworkerMessage({
+      id: "stream:asst-remount",
+      content: "",
+      createdAt,
+      metadata: { streaming: true },
+    });
+    try {
+      vi.setSystemTime(new Date("2026-08-10T12:00:45.000Z"));
+      const { unmount } = render(
+        <ChatMessageRow
+          message={message}
+          coworkersById={new Map()}
+          coworkersBySlug={new Map()}
+          onToggleReaction={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
+        "45.0s",
+      );
+      unmount();
+      vi.setSystemTime(new Date("2026-08-10T12:01:05.000Z"));
+      render(
+        <ChatMessageRow
+          message={message}
+          coworkersById={new Map()}
+          coworkersBySlug={new Map()}
+          onToggleReaction={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId("live-stream-elapsed")).toHaveTextContent(
+        "1m 5.0s",
       );
     } finally {
       vi.useRealTimers();

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1472,13 +1472,10 @@ function MessageMetaFooter({
   isDeleted: boolean;
 }) {
   const t = useTranslations("App.Channels");
-  /**
-   * First time this client mounts a pending/sent mention chip — wall clock for
-   * the loading elapsed timer. Avoids using user-message createdAt (reload of a
-   * stuck mention would show multi-minute age).
-   */
-  const mentionThinkStartMsByIdRef = useRef(new Map<string, number>());
   const isOutboundLocal = isOutboundLocalMessage(message);
+  // Wall clock from the ask (persisted message createdAt) — remount/reopen must
+  // continue elapsed time, not restart from client mount.
+  const mentionThinkingStartedAtMs = new Date(message.createdAt).getTime();
 
   return (
     <>
@@ -1541,21 +1538,11 @@ function MessageMetaFooter({
             // Channel @mentions have no client stream overlay — show Beautiful UI
             // loading here (pending/sent) so "Noodles is thinking" is not a dead badge.
             if (mention.status === "pending" || mention.status === "sent") {
-              let thinkStartMs = mentionThinkStartMsByIdRef.current.get(
-                mention.id,
-              );
-              if (thinkStartMs == null) {
-                thinkStartMs = Date.now();
-                mentionThinkStartMsByIdRef.current.set(
-                  mention.id,
-                  thinkStartMs,
-                );
-              }
               return (
                 <CoworkerLoadingState
                   key={mention.id}
                   label={label}
-                  startedAtMs={thinkStartMs}
+                  startedAtMs={mentionThinkingStartedAtMs}
                 />
               );
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SOK-792](https://linear.app/masumi/issue/SOK-792/live-thinking-elapsed-seconds-reset-when-reopening-a-chat) (related to [SOK-774](https://linear.app/masumi/issue/SOK-774/show-coworker-thought-in-room-chat-live-collapsed-disclosure) — coworker Thought in room chat).

Bug: in a chat room, the coworker live “thinking” elapsed timer (`Maya denkt nach 10.4s`) reset every time the user opened/re-entered the room, even when wall clock had already advanced minutes since the @mention.

Root cause: the mention-status loading chip seeded `startedAtMs` with `Date.now()` into a component ref on first mount. Leaving the room unmounted the row, so reopen reseeded from remount time (~0). Stream overlay already used persisted `message.createdAt`.

Fix: anchor the mention thinking timer to `message.createdAt` (same wall-clock contract as the stream overlay). Remount/reopen continues from real elapsed duration.

Own PR — do not mix with landing-strip PRs (#3808–#3813) or chats-list inset (#3812).

## Linear

- SOK-792: https://linear.app/masumi/issue/SOK-792/live-thinking-elapsed-seconds-reset-when-reopening-a-chat
- Related: SOK-774

## Verification

- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx` — 72 passed
- New tests lock:
  - mention thinking elapsed = wall clock from `message.createdAt`
  - remount/reopen keeps monotonically increasing elapsed (mention + stream overlay)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a803e2c-f351-4591-8451-22c16c6d9ef4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a803e2c-f351-4591-8451-22c16c6d9ef4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

