### PR TITLE
chore: disable CodeRabbit auto-review and status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  review_status: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,4 @@
 reviews:
   review_status: false
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Summary

Stops CodeRabbit from reviewing PRs automatically and from posting review-status messages in the walkthrough.

Adds repo-root `.coderabbit.yaml`:

```yaml
reviews:
  review_status: false
  auto_review:
    enabled: false
```

On-demand reviews still work via `@coderabbitai review`.

## Verification

- [ ] New PR: CodeRabbit does not start a review on its own
- [ ] `@coderabbitai review` still runs a review
- [ ] Skipped or paused reviews do not post a review-status comment