### PR TITLE
feat(web): serve Welcome at / and link mobile header brand (SOK-794)

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4815,7 +4815,8 @@
         "search": "Suche",
         "ariaLabel": "Hauptnavigation",
         "backToChats": "Zurück zu Chats",
-        "back": "Zurück"
+        "back": "Zurück",
+        "goHome": "Zur Startseite"
       },
       "Actions": {
         "more": "Nachrichtenaktionen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4815,7 +4815,8 @@
         "search": "Search",
         "ariaLabel": "Main navigation",
         "backToChats": "Back to chats",
-        "back": "Back"
+        "back": "Back",
+        "goHome": "Go to home"
       },
       "Actions": {
         "more": "Message actions",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4815,7 +4815,8 @@
         "search": "Buscar",
         "ariaLabel": "Navegación principal",
         "backToChats": "Volver a chats",
-        "back": "Volver"
+        "back": "Volver",
+        "goHome": "Ir al inicio"
       },
       "Actions": {
         "more": "Acciones del mensaje",

--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -61,7 +61,7 @@ describe("proxy", () => {
     expect(getSessionCookieMock).not.toHaveBeenCalled();
   });
 
-  it("edge-redirects anonymous / to /signin without running the app shell", async () => {
+  it("edge-redirects anonymous / to /signin with returnUrl without running the app shell", async () => {
     const { NextRequest } = await import("next/server");
     const { proxy } = await import("../proxy");
     getSessionCookieMock.mockReturnValue(null);
@@ -73,7 +73,27 @@ describe("proxy", () => {
 
     expect(response?.status).toBe(307);
     expect(response?.headers.get("location")).toBe(
-      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/signin",
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/signin?returnUrl=%2F",
+    );
+    expect(response?.headers.get("Cross-Origin-Opener-Policy")).toBe(
+      CROSS_ORIGIN_OPENER_POLICY,
+    );
+    expect(getSessionCookieMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("edge-redirects anonymous /?dm=new to /signin preserving compose returnUrl", async () => {
+    const { NextRequest } = await import("next/server");
+    const { proxy } = await import("../proxy");
+    getSessionCookieMock.mockReturnValue(null);
+    const request = new NextRequest(
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/?dm=new",
+    );
+
+    const response = await proxy(request);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/signin?returnUrl=%2F%3Fdm%3Dnew",
     );
     expect(response?.headers.get("Cross-Origin-Opener-Policy")).toBe(
       CROSS_ORIGIN_OPENER_POLICY,

--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -81,8 +81,8 @@ describe("proxy", () => {
     expect(getSessionCookieMock).toHaveBeenCalledTimes(1);
   });
 
-  it("edge-redirects authenticated / to /chat without running the app shell", async () => {
-    const { NextRequest } = await import("next/server");
+  it("edge-redirects authenticated / through to Welcome (no redirect loop)", async () => {
+    const { NextRequest, NextResponse } = await import("next/server");
     const { proxy } = await import("../proxy");
     const request = new NextRequest(
       "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/",
@@ -90,10 +90,10 @@ describe("proxy", () => {
 
     const response = await proxy(request);
 
-    expect(response?.status).toBe(307);
-    expect(response?.headers.get("location")).toBe(
-      "https://sokosumi-app-preprod-git-codex-evaluate-cookie-prefix-usage.preview.sokosumi.com/chat",
-    );
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("x-pathname")).toBe("/");
     expect(response?.headers.get("Cross-Origin-Opener-Policy")).toBe(
       CROSS_ORIGIN_OPENER_POLICY,
     );

--- a/apps/web/src/app/(app)/(welcome)/layout.tsx
+++ b/apps/web/src/app/(app)/(welcome)/layout.tsx
@@ -1,0 +1,24 @@
+import type { Viewport } from "next";
+
+import { ChatRouteErrorBoundary } from "@/app/chat/components/chat-route-error-boundary.client";
+import { APP_VIEWPORT_BASE } from "@/lib/app-viewport";
+
+/**
+ * Welcome replaces the root viewport export. Spreads `APP_VIEWPORT_BASE`
+ * (fit cover + maximumScale 1). `resizes-content` lifts draft composers
+ * above the soft keyboard (same as chat rooms).
+ */
+export const viewport: Viewport = {
+  ...APP_VIEWPORT_BASE,
+  interactiveWidget: "resizes-content",
+};
+
+export default function WelcomeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Bottom nav lives in AppMobileChrome (app frame). Page boundary only here
+  // so Instant Navigations can still validate if page chrome throws.
+  return <ChatRouteErrorBoundary>{children}</ChatRouteErrorBoundary>;
+}

--- a/apps/web/src/app/(app)/(welcome)/loading.tsx
+++ b/apps/web/src/app/(app)/(welcome)/loading.tsx
@@ -1,0 +1,6 @@
+import { ChatHomePageSkeleton } from "@/app/chat/components/chat-home-loading-view";
+
+/** Sync shell only — no cookies/`connection()` (Instant Nav). */
+export default function WelcomeHomeLoading() {
+  return <ChatHomePageSkeleton />;
+}

--- a/apps/web/src/app/(app)/(welcome)/page.tsx
+++ b/apps/web/src/app/(app)/(welcome)/page.tsx
@@ -1,0 +1,181 @@
+import { connection } from "next/server";
+import { getTranslations } from "next-intl/server";
+
+import { ChatLandingNotice } from "@/app/chat/components/chat-landing-notice";
+import { ChatLanding } from "@/app/chat/components/landing/chat-landing";
+import { ChatLandingMobile } from "@/app/chat/components/landing/chat-landing.mobile";
+import { resolveLandingGreetingName } from "@/app/chat/components/landing/landing-content";
+import { RoomsClient } from "@/app/chat/components/rooms-client";
+import { loadOrganizationMembers } from "@/app/chat/load-organization-members";
+import { firstSearchValue } from "@/app/chat/load-room-messages";
+import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getSession } from "@/lib/auth/auth.server";
+import { userService } from "@/lib/services";
+import { coworkerService } from "@/lib/services/coworker.service";
+import { taskService } from "@/lib/services/task.service";
+
+interface WelcomePageProps {
+  searchParams: Promise<{
+    create?: string | string[];
+    dm?: string | string[];
+    notice?: string | string[];
+  }>;
+}
+
+/**
+ * `/` welcome: what happened while the user was away, and a way in via a
+ * coworker. This is the post-login landing on every breakpoint — desktop gets
+ * the full-page composition, mobile a version sized for a 390px column. The
+ * room list is its own surface (`/chat/chats` on mobile, the sidebar on
+ * desktop) rather than something stacked underneath the welcome.
+ *
+ * Draft modes via query: `?create=channel`, `?dm=new`.
+ * Open rooms: `/chat/rooms/[roomId]`.
+ *
+ * Instant Nav uses `(welcome)/loading.tsx` while this page streams after
+ * `connection()`. Room open uses `chat/rooms/[roomId]/loading.tsx`.
+ */
+export default async function WelcomePage({ searchParams }: WelcomePageProps) {
+  // Defer before any cookies()/headers()-bound work so PPR shell probing does
+  // not soft-reject dynamic APIs on this dynamic page.
+  await connection();
+
+  // Ordinary landing only needs session + coworkers. Draft create/DM paths
+  // load org context and channel copy below so the Instant-streamed landing
+  // stays light (heavy work only when draft query modes are active).
+  const [query, session] = await Promise.all([searchParams, getSession()]);
+
+  const isCreateChannelRequested = firstSearchValue(query.create) === "channel";
+  const isNewDirectMessage = firstSearchValue(query.dm) === "new";
+  const notice = firstSearchValue(query.notice);
+  const landingNotice = <ChatLandingNotice notice={notice} />;
+
+  if (isCreateChannelRequested || isNewDirectMessage) {
+    const [tChannels, activeOrganization] = await Promise.all([
+      getTranslations("App.Channels"),
+      userService.getActiveOrganization(),
+    ]);
+
+    // Channels / create stay org-only. Start New DM (`?dm=new`) also works in
+    // personal workspace: same DraftDirectMessage UI with empty members so the
+    // picker is coworkers-only (solo coworker sends via room ensure).
+    if (!activeOrganization) {
+      if (!isNewDirectMessage) {
+        return (
+          <>
+            {landingNotice}
+            <div className="min-h-full w-full px-4 py-6">
+              <div className="mx-auto max-w-3xl">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{tChannels("NoOrganization.title")}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-muted-foreground">
+                      {tChannels("NoOrganization.description")}
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </>
+        );
+      }
+
+      const coworkers = await coworkerService.listCoworkers("chat");
+
+      return (
+        <>
+          {landingNotice}
+          <RoomsClient
+            activeOrganization={null}
+            rooms={[]}
+            organizationMembers={[]}
+            currentUserId={session?.user.id ?? ""}
+            coworkers={coworkers}
+            selectedRoomId={null}
+            isCreateChannelRequested={false}
+            isNewDirectMessage
+            messageLoadFailed={false}
+            membersLoadFailed={false}
+            messages={[]}
+            messagesNextCursor={null}
+          />
+        </>
+      );
+    }
+
+    // Create/DM drafts do not need a rooms list — RoomsClient only looks up
+    // selectedRoom by id, and sidebar already owns paginated room history.
+    const [membersPage, coworkers, currentMember] = await Promise.all([
+      loadOrganizationMembers(activeOrganization.id),
+      coworkerService.listCoworkers("chat"),
+      userService.getMyMemberInOrganization(activeOrganization.id),
+    ]);
+
+    return (
+      <>
+        {landingNotice}
+        <RoomsClient
+          activeOrganization={activeOrganization}
+          rooms={[]}
+          organizationMembers={membersPage.members}
+          currentUserId={currentMember?.userId ?? ""}
+          coworkers={coworkers}
+          selectedRoomId={null}
+          isCreateChannelRequested={isCreateChannelRequested}
+          isNewDirectMessage={isNewDirectMessage}
+          messageLoadFailed={false}
+          membersLoadFailed={membersPage.failed}
+          messages={[]}
+          messagesNextCursor={null}
+        />
+      </>
+    );
+  }
+
+  const activeOrganizationId = await userService.getActiveOrganizationId();
+
+  const [coworkerRows, summary] = await Promise.all([
+    coworkerService.listCoworkers("chat"),
+    // Window is session-derived in Core (`max(Session.updatedAt)`). No stamp.
+    taskService.getActivitySummary({
+      // In an org the greeting talks about the team, so count the whole
+      // workspace rather than only the caller's own tasks.
+      scope: activeOrganizationId ? "workspace" : "owned",
+    }),
+  ]);
+  const coworkers = coworkerRows.map(mapDbCoworkerToChatCoworker);
+  const greetingName = resolveLandingGreetingName(session?.user.name);
+
+  return (
+    <>
+      {landingNotice}
+      {/* One welcome per breakpoint. The compositions differ enough — six 64px
+          teammates versus four at 44px — that CSS alone cannot bridge them. */}
+      <div className="hidden min-h-full min-w-0 flex-1 flex-col md:flex">
+        <ChatLanding
+          coworkers={coworkers}
+          isOrganizationWorkspace={activeOrganizationId !== null}
+          summary={summary}
+          userName={greetingName}
+        />
+      </div>
+      {/*
+        Cancel authenticated-app-frame main `p-4` on mobile (same `-m-4` as
+        `/chat/chats` + room shell). Without this, the coworker strip scrollport
+        is inset 16px and edge avatars clip at the pad, not the viewport.
+        Pitch/stats/selected keep their own `px-4` inside ChatLandingMobile.
+      */}
+      <div className="bg-background -m-4 flex min-h-full min-w-0 flex-1 flex-col md:hidden">
+        <ChatLandingMobile
+          coworkers={coworkers}
+          isOrganizationWorkspace={activeOrganizationId !== null}
+          summary={summary}
+          userName={greetingName}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/chat/__tests__/tab-destinations-instant-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/__tests__/tab-destinations-instant-contract.test.ts
@@ -21,13 +21,13 @@ function stripComments(source: string): string {
 
 describe("mobile tab destinations Instant Nav contract", () => {
   const pages = [
-    "chat/page.tsx",
+    "(welcome)/page.tsx",
     "chat/chats/page.tsx",
     "history/page.tsx",
   ] as const;
 
   const loadingShells = [
-    "chat/loading.tsx",
+    "(welcome)/loading.tsx",
     "chat/chats/loading.tsx",
     "history/loading.tsx",
     "chat/components/chat-home-loading-view.tsx",
@@ -49,8 +49,8 @@ describe("mobile tab destinations Instant Nav contract", () => {
     });
   }
 
-  it("chat/loading.tsx default export returns ChatHomePageSkeleton", () => {
-    const code = stripComments(readApp("chat/loading.tsx"));
+  it("(welcome)/loading.tsx default export returns ChatHomePageSkeleton", () => {
+    const code = stripComments(readApp("(welcome)/loading.tsx"));
     expect(code).toMatch(
       /export\s+default\s+function[\s\S]*?return\s+<\s*ChatHomePageSkeleton\s*\/>/,
     );

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -139,6 +139,7 @@ export async function createChannelAction(
       coworkerIds: cleanIds(input.coworkerIds),
     });
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(room);
   } catch (error) {
@@ -181,6 +182,7 @@ export async function createDirectRoomAction(
       coworkerIds,
     });
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(room);
   } catch (error) {
@@ -245,6 +247,7 @@ export async function sendNewDirectMessageAction(
       mentionedUserIds: cleanIds(input.mentionedUserIds),
     });
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk({ room, message });
   } catch (error) {
@@ -273,6 +276,7 @@ export async function updateRoomAction(
   try {
     const room = await chatRoomService.updateRoom(roomId, body);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(room);
   } catch (error) {
@@ -288,6 +292,7 @@ export async function archiveRoomAction(
     // The room disappears from every member's list, so the server-rendered
     // room list has to be rebuilt rather than patched client side.
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk({ id: archived.id });
   } catch (error) {
@@ -301,6 +306,7 @@ export async function restoreRoomAction(
   try {
     const restored = await chatRoomService.restoreRoom(roomId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(restored);
   } catch (error) {
@@ -314,6 +320,7 @@ export async function deleteRoomAction(
   try {
     await chatRoomService.deleteRoom(roomId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk({ id: roomId });
   } catch (error) {
@@ -327,6 +334,7 @@ export async function leaveRoomAction(
   try {
     const left = await chatRoomService.leaveRoom(roomId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk({ id: left.id });
   } catch (error) {
@@ -345,6 +353,7 @@ export async function joinRoomAction(
   try {
     const room = await chatRoomService.joinRoom(cleanRoomId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(room);
   } catch (error) {
@@ -393,6 +402,7 @@ export async function acceptChatRoomInvitationAction(
   try {
     const invitation = await chatRoomService.acceptInvitation(cleanId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(invitation);
   } catch (error) {
@@ -411,6 +421,7 @@ export async function declineChatRoomInvitationAction(
   try {
     const invitation = await chatRoomService.declineInvitation(cleanId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(invitation);
   } catch (error) {
@@ -559,6 +570,7 @@ export async function acceptRoomGuestInviteLinkAction(
   try {
     const result = await chatRoomService.acceptRoomGuestInviteLink(cleanToken);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(result);
   } catch (error) {
@@ -583,6 +595,7 @@ export async function removeRoomGuestAction(
   try {
     await chatRoomService.removeMember(cleanRoomId, cleanUserId);
     await invalidateSidebarChatList();
+    revalidatePath("/");
     revalidatePath("/chat");
     return roomOk(null);
   } catch (error) {

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-route-error-boundary.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-route-error-boundary.test.ts
@@ -4,31 +4,26 @@ import { chatRouteErrorBoundaryKey } from "../chat-route-error-boundary.client";
 
 describe("chatRouteErrorBoundaryKey", () => {
   it("uses pathname alone when there is no search", () => {
-    expect(chatRouteErrorBoundaryKey("/chat")).toBe("/chat");
-    expect(chatRouteErrorBoundaryKey("/chat", new URLSearchParams())).toBe(
-      "/chat",
-    );
+    expect(chatRouteErrorBoundaryKey("/")).toBe("/");
+    expect(chatRouteErrorBoundaryKey("/", new URLSearchParams())).toBe("/");
   });
 
-  it("includes search so draft /chat views remount separately", () => {
+  it("includes search so draft Welcome views remount separately", () => {
     expect(
-      chatRouteErrorBoundaryKey("/chat", new URLSearchParams("create=channel")),
-    ).toBe("/chat?create=channel");
-    expect(
-      chatRouteErrorBoundaryKey("/chat", new URLSearchParams("dm=new")),
-    ).toBe("/chat?dm=new");
+      chatRouteErrorBoundaryKey("/", new URLSearchParams("create=channel")),
+    ).toBe("/?create=channel");
+    expect(chatRouteErrorBoundaryKey("/", new URLSearchParams("dm=new"))).toBe(
+      "/?dm=new",
+    );
   });
 
   it("changes when soft-navigating between shared-pathname views", () => {
-    const home = chatRouteErrorBoundaryKey("/chat", new URLSearchParams());
+    const home = chatRouteErrorBoundaryKey("/", new URLSearchParams());
     const create = chatRouteErrorBoundaryKey(
-      "/chat",
+      "/",
       new URLSearchParams("create=channel"),
     );
-    const dm = chatRouteErrorBoundaryKey(
-      "/chat",
-      new URLSearchParams("dm=new"),
-    );
+    const dm = chatRouteErrorBoundaryKey("/", new URLSearchParams("dm=new"));
 
     expect(home).not.toBe(create);
     expect(create).not.toBe(dm);

--- a/apps/web/src/app/(app)/chat/components/chat-landing-notice.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-landing-notice.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 
 /**
  * Soft-land notice when `/chat/rooms/{id}` redirects for missing/forbidden room.
- * Query: `?notice=room-unavailable`
+ * Query: `?notice=room-unavailable` on Welcome (`/`).
  */
 export function ChatLandingNotice({ notice }: { notice: string | null }) {
   const t = useTranslations("App.Channels");
@@ -18,7 +18,7 @@ export function ChatLandingNotice({ notice }: { notice: string | null }) {
       return;
     }
     toast.error(t("roomUnavailable"));
-    router.replace("/chat", { scroll: false });
+    router.replace("/", { scroll: false });
   }, [notice, router, t]);
 
   return null;

--- a/apps/web/src/app/(app)/chat/components/chat-route-error-boundary.client.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-route-error-boundary.client.tsx
@@ -10,8 +10,8 @@ type SearchParamsLike = { toString(): string } | null | undefined;
 
 /**
  * Remount key for the page error boundary. Pathname alone is not enough:
- * `/chat`, `/chat?create=channel`, and `/chat?dm=new` share a pathname but
- * are distinct soft-navigations within the chat layout.
+ * `/`, `/?create=channel`, and `/?dm=new` share a pathname but
+ * are distinct soft-navigations within the welcome layout.
  */
 export function chatRouteErrorBoundaryKey(
   pathname: string,

--- a/apps/web/src/app/(app)/chat/components/create-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/create-channel-dialog.tsx
@@ -76,7 +76,7 @@ export function CreateChannelDialog({
   }
 
   function clearCreateQuery() {
-    router.replace("/chat");
+    router.replace("/");
   }
 
   function handleOpenChange(nextOpen: boolean) {

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -184,7 +184,7 @@ export function EditChannelDialog({
     notifyOrganizationChatRoomsChanged();
     // The room is gone for this user either way, so land them back on the
     // room list rather than a view they can no longer read.
-    router.replace("/chat");
+    router.replace("/");
     router.refresh();
   }
 

--- a/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
+++ b/apps/web/src/app/(app)/chat/components/landing/__tests__/chat-landing-strip-edge-contract.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * Coworker strip on `/chat` landing must span the full content column
+ * Coworker strip on Welcome (`/`) landing must span the full content column
  * (edge-to-edge). Horizontal page padding on an overflow-y ancestor clips
  * edge avatars — CSS promotes overflow-x to auto when overflow-y is not
  * visible — so pitch/stats/selected get `px-*`, not the strip column.
@@ -83,7 +83,7 @@ describe("chat landing coworker strip edge-to-edge contract", () => {
 
     expect(source).toContain("data-app-main");
     // Load-bearing: mobile landing -m-4 cancels this. If pad moves, update
-    // chat/page.tsx mobile shell in the same change. className with p-4 is
+    // (welcome)/page.tsx mobile shell in the same change. className with p-4 is
     // declared before the data-app-main attribute on <main>.
     expect(source).toMatch(
       /<main[\s\S]*?\bp-4\b[\s\S]*?data-app-main[\s\S]*?>/,
@@ -91,9 +91,9 @@ describe("chat landing coworker strip edge-to-edge contract", () => {
     expect(source).toMatch(/overflow-x-hidden/);
   });
 
-  it("mobile /chat landing shell cancels app-main p-4 so the strip can hit the viewport edge", () => {
+  it("mobile Welcome landing shell cancels app-main p-4 so the strip can hit the viewport edge", () => {
     const source = readFileSync(
-      join(import.meta.dirname, "../../../page.tsx"),
+      join(import.meta.dirname, "../../../../(welcome)/page.tsx"),
       "utf8",
     );
 

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1117,11 +1117,11 @@ export function RoomsClient({
 
   const breadcrumbOverride = useMemo(
     () => ({
-      pathname: selectedRoom ? `/chat/rooms/${selectedRoom.id}` : "/chat",
+      pathname: selectedRoom ? `/chat/rooms/${selectedRoom.id}` : "/",
       segments: [
         {
           label: tBreadcrumb("chat"),
-          href: "/chat",
+          href: "/",
         },
         ...(selectedRoom
           ? [
@@ -1134,14 +1134,14 @@ export function RoomsClient({
             ? [
                 {
                   label: t("CreateWizard.title"),
-                  href: "/chat?create=channel",
+                  href: "/?create=channel",
                 },
               ]
             : isNewDirectMessage
               ? [
                   {
                     label: t("Draft.breadcrumb"),
-                    href: "/chat?dm=new",
+                    href: "/?dm=new",
                   },
                 ]
               : []),
@@ -2584,7 +2584,7 @@ export function RoomsClient({
                   <Button
                     type="button"
                     variant="primary"
-                    onClick={() => router.push("/chat?create=channel")}
+                    onClick={() => router.push("/?create=channel")}
                   >
                     {t("createChannel")}
                   </Button>

--- a/apps/web/src/app/(app)/chat/invites/[id]/components/chat-room-invitation-card.tsx
+++ b/apps/web/src/app/(app)/chat/invites/[id]/components/chat-room-invitation-card.tsx
@@ -65,7 +65,7 @@ export default function ChatRoomInvitationCard({
     }
     toast.success(t("Actions.Success.decline"));
     notifyOrganizationChatRoomsChanged();
-    router.push("/chat");
+    router.push("/");
     router.refresh();
   };
 
@@ -136,7 +136,7 @@ export default function ChatRoomInvitationCard({
         </CardContent>
         <CardFooter>
           <Button variant="outline" asChild className="w-full">
-            <Link href="/chat">{t("goToChat")}</Link>
+            <Link href="/">{t("goToChat")}</Link>
           </Button>
         </CardFooter>
       </Card>
@@ -213,7 +213,7 @@ export function ChatRoomInvitationErrorCard({
       </CardContent>
       <CardFooter>
         <Button variant="outline" asChild className="w-full">
-          <Link href="/chat">{t("footer")}</Link>
+          <Link href="/">{t("footer")}</Link>
         </Button>
       </CardFooter>
     </Card>

--- a/apps/web/src/app/(app)/chat/join/[token]/components/chat-join-card.tsx
+++ b/apps/web/src/app/(app)/chat/join/[token]/components/chat-join-card.tsx
@@ -84,7 +84,7 @@ export function ChatJoinInvalidCard({
         <CardContent className="space-y-4">
           <p className="text-muted-foreground text-sm">{t(messageKey)}</p>
           <Button variant="outline" asChild className="w-full">
-            <Link href="/chat">{t("Invalid.back")}</Link>
+            <Link href="/">{t("Invalid.back")}</Link>
           </Button>
         </CardContent>
       </Card>

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -1,180 +1,29 @@
-import { connection } from "next/server";
-import { getTranslations } from "next-intl/server";
-import { ChatLandingNotice } from "@/app/chat/components/chat-landing-notice";
-import { mapDbCoworkerToChatCoworker } from "@/app/chat/utils/coworker-utils";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getSession } from "@/lib/auth/auth.server";
-import { userService } from "@/lib/services";
-import { coworkerService } from "@/lib/services/coworker.service";
-import { taskService } from "@/lib/services/task.service";
-import { ChatLanding } from "./components/landing/chat-landing";
-import { ChatLandingMobile } from "./components/landing/chat-landing.mobile";
-import { resolveLandingGreetingName } from "./components/landing/landing-content";
-import { RoomsClient } from "./components/rooms-client";
-import { loadOrganizationMembers } from "./load-organization-members";
-import { firstSearchValue } from "./load-room-messages";
+import { redirect } from "next/navigation";
 
 interface ChatPageProps {
-  searchParams: Promise<{
-    create?: string | string[];
-    dm?: string | string[];
-    notice?: string | string[];
-  }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 /**
- * `/chat` welcome: what happened while the user was away, and a way in via a
- * coworker. This is the post-login landing on every breakpoint — desktop gets
- * the full-page composition, mobile a version sized for a 390px column. The
- * room list is its own surface (`/chat/chats` on mobile, the sidebar on
- * desktop) rather than something stacked underneath the welcome.
- *
- * Draft modes via query: `?create=channel`, `?dm=new`.
- * Open rooms: `/chat/rooms/[roomId]`.
- *
- * Instant Nav uses `chat/loading.tsx` while this page streams after
- * `connection()`. Room open uses `rooms/[roomId]/loading.tsx`.
+ * Bare `/chat` redirects to Welcome at `/`, preserving searchParams
+ * (`?dm=new`, `?create=channel`, `?notice=…`). Nested `/chat/chats` and
+ * `/chat/rooms/...` are unchanged.
  */
 export default async function ChatPage({ searchParams }: ChatPageProps) {
-  // Defer before any cookies()/headers()-bound work so PPR shell probing does
-  // not soft-reject dynamic APIs on this dynamic page.
-  await connection();
-
-  // Ordinary landing only needs session + coworkers. Draft create/DM paths
-  // load org context and channel copy below so the Instant-streamed landing
-  // stays light (heavy work only when draft query modes are active).
-  const [query, session] = await Promise.all([searchParams, getSession()]);
-
-  const isCreateChannelRequested = firstSearchValue(query.create) === "channel";
-  const isNewDirectMessage = firstSearchValue(query.dm) === "new";
-  const notice = firstSearchValue(query.notice);
-  const landingNotice = <ChatLandingNotice notice={notice} />;
-
-  if (isCreateChannelRequested || isNewDirectMessage) {
-    const [tChannels, activeOrganization] = await Promise.all([
-      getTranslations("App.Channels"),
-      userService.getActiveOrganization(),
-    ]);
-
-    // Channels / create stay org-only. Start New DM (`?dm=new`) also works in
-    // personal workspace: same DraftDirectMessage UI with empty members so the
-    // picker is coworkers-only (solo coworker sends via room ensure).
-    if (!activeOrganization) {
-      if (!isNewDirectMessage) {
-        return (
-          <>
-            {landingNotice}
-            <div className="min-h-full w-full px-4 py-6">
-              <div className="mx-auto max-w-3xl">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{tChannels("NoOrganization.title")}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-muted-foreground">
-                      {tChannels("NoOrganization.description")}
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          </>
-        );
-      }
-
-      const coworkers = await coworkerService.listCoworkers("chat");
-
-      return (
-        <>
-          {landingNotice}
-          <RoomsClient
-            activeOrganization={null}
-            rooms={[]}
-            organizationMembers={[]}
-            currentUserId={session?.user.id ?? ""}
-            coworkers={coworkers}
-            selectedRoomId={null}
-            isCreateChannelRequested={false}
-            isNewDirectMessage
-            messageLoadFailed={false}
-            membersLoadFailed={false}
-            messages={[]}
-            messagesNextCursor={null}
-          />
-        </>
-      );
+  const params = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
     }
-
-    // Create/DM drafts do not need a rooms list — RoomsClient only looks up
-    // selectedRoom by id, and sidebar already owns paginated room history.
-    const [membersPage, coworkers, currentMember] = await Promise.all([
-      loadOrganizationMembers(activeOrganization.id),
-      coworkerService.listCoworkers("chat"),
-      userService.getMyMemberInOrganization(activeOrganization.id),
-    ]);
-
-    return (
-      <>
-        {landingNotice}
-        <RoomsClient
-          activeOrganization={activeOrganization}
-          rooms={[]}
-          organizationMembers={membersPage.members}
-          currentUserId={currentMember?.userId ?? ""}
-          coworkers={coworkers}
-          selectedRoomId={null}
-          isCreateChannelRequested={isCreateChannelRequested}
-          isNewDirectMessage={isNewDirectMessage}
-          messageLoadFailed={false}
-          membersLoadFailed={membersPage.failed}
-          messages={[]}
-          messagesNextCursor={null}
-        />
-      </>
-    );
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        qs.append(key, entry);
+      }
+    } else {
+      qs.set(key, value);
+    }
   }
-
-  const activeOrganizationId = await userService.getActiveOrganizationId();
-
-  const [coworkerRows, summary] = await Promise.all([
-    coworkerService.listCoworkers("chat"),
-    // Window is session-derived in Core (`max(Session.updatedAt)`). No stamp.
-    taskService.getActivitySummary({
-      // In an org the greeting talks about the team, so count the whole
-      // workspace rather than only the caller's own tasks.
-      scope: activeOrganizationId ? "workspace" : "owned",
-    }),
-  ]);
-  const coworkers = coworkerRows.map(mapDbCoworkerToChatCoworker);
-  const greetingName = resolveLandingGreetingName(session?.user.name);
-
-  return (
-    <>
-      {landingNotice}
-      {/* One welcome per breakpoint. The compositions differ enough — six 64px
-          teammates versus four at 44px — that CSS alone cannot bridge them. */}
-      <div className="hidden min-h-full min-w-0 flex-1 flex-col md:flex">
-        <ChatLanding
-          coworkers={coworkers}
-          isOrganizationWorkspace={activeOrganizationId !== null}
-          summary={summary}
-          userName={greetingName}
-        />
-      </div>
-      {/*
-        Cancel authenticated-app-frame main `p-4` on mobile (same `-m-4` as
-        `/chat/chats` + room shell). Without this, the coworker strip scrollport
-        is inset 16px and edge avatars clip at the pad, not the viewport.
-        Pitch/stats/selected keep their own `px-4` inside ChatLandingMobile.
-      */}
-      <div className="bg-background -m-4 flex min-h-full min-w-0 flex-1 flex-col md:hidden">
-        <ChatLandingMobile
-          coworkers={coworkers}
-          isOrganizationWorkspace={activeOrganizationId !== null}
-          summary={summary}
-          userName={greetingName}
-        />
-      </div>
-    </>
-  );
+  const search = qs.toString();
+  redirect(search.length > 0 ? `/?${search}` : "/");
 }

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/__tests__/page.test.tsx
@@ -132,9 +132,9 @@ describe("ChatRoomPage org deep-link guard", () => {
 
     await expect(
       ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
-    ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
+    ).rejects.toThrow(`REDIRECT:/?notice=room-unavailable`);
 
-    expect(redirectMock).toHaveBeenCalledWith("/chat?notice=room-unavailable");
+    expect(redirectMock).toHaveBeenCalledWith("/?notice=room-unavailable");
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
     expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
   });
@@ -151,7 +151,7 @@ describe("ChatRoomPage org deep-link guard", () => {
 
     await expect(
       ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
-    ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
+    ).rejects.toThrow(`REDIRECT:/?notice=room-unavailable`);
 
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
     expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
@@ -167,7 +167,7 @@ describe("ChatRoomPage org deep-link guard", () => {
 
     await expect(
       ChatRoomPageContent({ params: Promise.resolve({ roomId: ROOM_ID }) }),
-    ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
+    ).rejects.toThrow(`REDIRECT:/?notice=room-unavailable`);
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
     expect(loadRoomShellRosterMock).not.toHaveBeenCalled();
   });
@@ -183,9 +183,9 @@ describe("ChatRoomPage org deep-link guard", () => {
       ChatRoomPageContent({
         params: Promise.resolve({ roomId: "not-a-real-room-id" }),
       }),
-    ).rejects.toThrow(`REDIRECT:/chat?notice=room-unavailable`);
+    ).rejects.toThrow(`REDIRECT:/?notice=room-unavailable`);
 
-    expect(redirectMock).toHaveBeenCalledWith("/chat?notice=room-unavailable");
+    expect(redirectMock).toHaveBeenCalledWith("/?notice=room-unavailable");
     expect(getRoomMock).not.toHaveBeenCalled();
     expect(loadRoomMessagesMock).not.toHaveBeenCalled();
     expect(loadRoomShellRosterMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
+++ b/apps/web/src/app/(app)/chat/rooms/[roomId]/page.tsx
@@ -25,7 +25,7 @@ interface ChatRoomShellProps {
   organizationIdForRoster: string | null;
 }
 
-const ROOM_UNAVAILABLE_HREF = "/chat?notice=room-unavailable";
+const ROOM_UNAVAILABLE_HREF = "/?notice=room-unavailable";
 
 function NoOrganizationCard({
   title,
@@ -87,7 +87,7 @@ function progressiveRoomOpen(shell: ChatRoomShellProps, roomId: string) {
  * UI and an `empty:before` bone cannot win LCP. After `getRoom`, RoomsClient
  * paints real title + composer together; roster/history stream in via promises.
  *
- * Non-member / missing / invalid room id → soft land on `/chat`, not error card.
+ * Non-member / missing / invalid room id → soft land on `/`, not error card.
  * Do not start roster/history until access succeeds.
  */
 export async function ChatRoomPageContent({ params }: ChatRoomPageProps) {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/chat-route-base.test.ts
@@ -19,6 +19,7 @@ describe("chat-route-base", () => {
     expect(isChatShellPathname("/chat")).toBe(true);
     expect(isChatShellPathname("/chat/rooms/r1")).toBe(true);
     expect(isChatShellPathname("/chat/chats")).toBe(true);
+    expect(isChatShellPathname("/")).toBe(false);
     expect(isChatShellPathname("/new-chat")).toBe(false);
     expect(isChatShellPathname("/new-chat/foo")).toBe(false);
     expect(isChatShellPathname(null)).toBe(false);
@@ -51,14 +52,29 @@ describe("chat-route-base", () => {
       expect(classifyChatChromeSurface("/chat/chats")).toBe("chats");
     });
 
-    it("returns home for bare /chat", () => {
+    it("returns home for Welcome at / (and legacy bare /chat)", () => {
+      expect(classifyChatChromeSurface("/")).toBe("home");
+      expect(classifyChatChromeSurface("/", new URLSearchParams())).toBe(
+        "home",
+      );
       expect(classifyChatChromeSurface("/chat")).toBe("home");
       expect(classifyChatChromeSurface("/chat", new URLSearchParams())).toBe(
         "home",
       );
     });
 
-    it("returns draft for compose query on /chat", () => {
+    it("returns draft for compose query on Welcome", () => {
+      expect(
+        classifyChatChromeSurface("/", new URLSearchParams("create=channel")),
+      ).toBe("draft");
+      expect(
+        classifyChatChromeSurface("/", new URLSearchParams("dm=new")),
+      ).toBe("draft");
+      expect(
+        classifyChatChromeSurface("/", {
+          get: (k) => (k === "dm" ? "new" : null),
+        }),
+      ).toBe("draft");
       expect(
         classifyChatChromeSurface(
           "/chat",
@@ -75,12 +91,12 @@ describe("chat-route-base", () => {
       ).toBe("draft");
     });
 
-    it("returns draft for welcome compose on /chat", () => {
+    it("returns draft for welcome compose on /", () => {
       expect(
-        classifyChatChromeSurface("/chat", new URLSearchParams("dm=new")),
+        classifyChatChromeSurface("/", new URLSearchParams("dm=new")),
       ).toBe("draft");
       expect(
-        classifyChatChromeSurface("/chat", {
+        classifyChatChromeSurface("/", {
           get: (k) => (k === "dm" ? "new" : null),
         }),
       ).toBe("draft");

--- a/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-route-base.ts
@@ -77,9 +77,15 @@ function readSearchParam(
   return null;
 }
 
+function isWelcomeHomePathname(pathname: string | null | undefined): boolean {
+  return pathname === "/" || pathname === CHAT_APP_ROUTE_PREFIX;
+}
+
 /**
  * Classifies chat mobile chrome by pathname (+ optional search).
- * Callers outside chat still get `"other-chat"` (safe default for hamburger).
+ * Welcome home is `/` (and legacy bare `/chat` before redirect). Callers
+ * outside chat still get `"other-chat"` (safe default for hamburger).
+ * Do not treat `/` as a chat shell path — use `isChatShellPathname` for that.
  */
 export function classifyChatChromeSurface(
   pathname: string | null | undefined,
@@ -93,10 +99,10 @@ export function classifyChatChromeSurface(
     return "chats";
   }
 
-  if (pathname === CHAT_APP_ROUTE_PREFIX) {
+  if (isWelcomeHomePathname(pathname)) {
     const create = readSearchParam(searchParams, "create");
     const dm = readSearchParam(searchParams, "dm");
-    // Compose flows share `/chat` but use room-style chrome (no tab bar, back).
+    // Compose flows share Welcome but use room-style chrome (no tab bar, back).
     if (create === "channel" || dm === "new") {
       return "draft";
     }

--- a/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
@@ -91,23 +91,21 @@ describe("mobile-app-chrome", () => {
   });
 
   describe("shouldShowMobileBottomNav", () => {
-    it("shows on chat shell except rooms and drafts", () => {
+    it("shows on Welcome home and chats list except rooms and drafts", () => {
+      expect(shouldShowMobileBottomNav("/")).toBe(true);
       expect(shouldShowMobileBottomNav("/chat")).toBe(true);
       expect(shouldShowMobileBottomNav("/chat/chats")).toBe(true);
       // `welcome=1` used to open the questionnaire, which hid the nav. The
       // param is retired, so a stale link must now behave like bare home.
       expect(
-        shouldShowMobileBottomNav("/chat", new URLSearchParams("welcome=1")),
+        shouldShowMobileBottomNav("/", new URLSearchParams("welcome=1")),
       ).toBe(true);
       expect(shouldShowMobileBottomNav("/chat/rooms/r1")).toBe(false);
       expect(
-        shouldShowMobileBottomNav("/chat", new URLSearchParams("dm=new")),
+        shouldShowMobileBottomNav("/", new URLSearchParams("dm=new")),
       ).toBe(false);
       expect(
-        shouldShowMobileBottomNav(
-          "/chat",
-          new URLSearchParams("create=channel"),
-        ),
+        shouldShowMobileBottomNav("/", new URLSearchParams("create=channel")),
       ).toBe(false);
     });
 
@@ -131,12 +129,13 @@ describe("mobile-app-chrome", () => {
   });
 
   describe("shouldShowMobileBrandLeading", () => {
-    it("shows brand on chats and every bottom-nav tab root", () => {
+    it("shows brand on Welcome, chats, and every bottom-nav tab root", () => {
+      expect(shouldShowMobileBrandLeading("/")).toBe(true);
       expect(shouldShowMobileBrandLeading("/chat")).toBe(true);
       expect(shouldShowMobileBrandLeading("/chat/chats")).toBe(true);
       // Retired param: falls through to home, so the brand stays.
       expect(
-        shouldShowMobileBrandLeading("/chat", new URLSearchParams("welcome=1")),
+        shouldShowMobileBrandLeading("/", new URLSearchParams("welcome=1")),
       ).toBe(true);
       expect(shouldShowMobileBrandLeading("/tasks")).toBe(true);
       expect(shouldShowMobileBrandLeading("/agents")).toBe(true);
@@ -148,12 +147,12 @@ describe("mobile-app-chrome", () => {
       expect(shouldShowMobileBrandLeading("/chat/rooms/r1")).toBe(false);
       expect(
         shouldShowMobileBrandLeading(
-          "/chat",
+          "/",
           new URLSearchParams("create=channel"),
         ),
       ).toBe(false);
       expect(
-        shouldShowMobileBrandLeading("/chat", new URLSearchParams("dm=new")),
+        shouldShowMobileBrandLeading("/", new URLSearchParams("dm=new")),
       ).toBe(false);
       expect(shouldShowMobileBrandLeading("/tasks/t1")).toBe(false);
       expect(shouldShowMobileBrandLeading("/personal-assistant")).toBe(false);

--- a/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TASKS_RETURN_PATH_SESSION_KEY } from "@/app/tasks/components/task-navigation";
 
-let mockPathname = "/chat";
+let mockPathname = "/";
 let mockSearchParams = new URLSearchParams();
 const routerPushMock = vi.fn();
 
@@ -45,21 +45,29 @@ import { HeaderLeadingControl } from "../header-leading-control.client";
 
 describe("HeaderLeadingControl", () => {
   beforeEach(() => {
-    mockPathname = "/chat";
+    mockPathname = "/";
     mockSearchParams = new URLSearchParams();
     window.sessionStorage.clear();
     routerPushMock.mockClear();
   });
 
-  it("shows brand on home", () => {
+  it("shows brand link to home on Welcome", () => {
     render(<HeaderLeadingControl />);
     expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "goHome" })).toHaveAttribute(
+      "href",
+      "/",
+    );
   });
 
-  it("shows brand on chats list", () => {
+  it("shows brand link to home on chats list", () => {
     mockPathname = "/chat/chats";
     render(<HeaderLeadingControl />);
     expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "goHome" })).toHaveAttribute(
+      "href",
+      "/",
+    );
   });
 
   it("shows back to chats on room", () => {
@@ -100,18 +108,24 @@ describe("HeaderLeadingControl", () => {
     expect(back).toHaveAttribute("href", "/chat/chats");
   });
 
-  it("shows brand on tasks list root", () => {
+  it("shows brand link to home on tasks list root", () => {
     mockPathname = "/tasks";
     render(<HeaderLeadingControl />);
-    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByRole("link", { name: "goHome" })).toHaveAttribute(
+      "href",
+      "/",
+    );
     expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
   });
 
-  it("shows brand on agents, projects, and search tab roots", () => {
+  it("shows brand link to home on agents, projects, and search tab roots", () => {
     for (const path of ["/agents", "/projects", "/history"]) {
       mockPathname = path;
       const { unmount } = render(<HeaderLeadingControl />);
-      expect(screen.queryByRole("link")).toBeNull();
+      expect(screen.getByRole("link", { name: "goHome" })).toHaveAttribute(
+        "href",
+        "/",
+      );
       expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
       unmount();
     }

--- a/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-leading-control.client.tsx
@@ -17,7 +17,7 @@ import { SokosumiIcon } from "@/components/masumi-logos";
 
 /**
  * Mobile header leading slot (`md:hidden` size-8):
- * - chats + bottom-nav tab roots → Sokosumi icon (no back / hamburger)
+ * - Welcome home + chats + bottom-nav tab roots → Sokosumi icon Link to `/`
  * - chat room / draft compose → back to `/chat/chats`
  * - nested tasks → back to stored list URL (view/filters) when present
  * - other nested list pages → back to list root
@@ -35,9 +35,13 @@ export function HeaderLeadingControl(): React.ReactElement {
 
   if (shouldShowMobileBrandLeading(pathname, searchParams)) {
     return (
-      <span className="inline-flex size-8 shrink-0 items-center justify-center">
+      <Link
+        href="/"
+        aria-label={t("goHome")}
+        className="inline-flex size-8 shrink-0 items-center justify-center"
+      >
         <SokosumiIcon animated={false} className="size-8" />
-      </span>
+      </Link>
     );
   }
 
@@ -87,11 +91,16 @@ export function HeaderLeadingControl(): React.ReactElement {
   );
 }
 
-/** Suspense fallback while search params resolve — brand, never hamburger. */
+/** Suspense fallback while search params resolve — brand link, never hamburger. */
 export function HeaderLeadingBrandFallback(): React.ReactElement {
+  const t = useTranslations("App.Channels.MobileNav");
   return (
-    <span className="inline-flex size-8 shrink-0 items-center justify-center">
+    <Link
+      href="/"
+      aria-label={t("goHome")}
+      className="inline-flex size-8 shrink-0 items-center justify-center"
+    >
       <SokosumiIcon animated={false} className="size-8" />
-    </span>
+    </Link>
   );
 }

--- a/apps/web/src/app/(app)/components/mobile-app-chrome.ts
+++ b/apps/web/src/app/(app)/components/mobile-app-chrome.ts
@@ -94,9 +94,10 @@ export function resolveMobileAppBackTarget(
 }
 
 /**
- * Fixed tab bar: chat shell (except rooms/drafts) + main list routes.
- * Drafts (`?dm=new`, `?create=channel`) share `/chat`
- * but hide the tab bar like rooms.
+ * Fixed tab bar: Welcome home / chats list / other chat shell (except
+ * rooms/drafts) + main list routes. Drafts (`?dm=new`, `?create=channel`)
+ * share Welcome at `/` but hide the tab bar like rooms. `/` is home chrome,
+ * not a chat shell path.
  */
 export function shouldShowMobileBottomNav(
   pathname: string | null | undefined,
@@ -108,8 +109,12 @@ export function shouldShowMobileBottomNav(
   if (isChatRoomPathname(pathname)) {
     return false;
   }
-  if (classifyChatChromeSurface(pathname, searchParams) === "draft") {
+  const surface = classifyChatChromeSurface(pathname, searchParams);
+  if (surface === "draft") {
     return false;
+  }
+  if (surface === "home" || surface === "chats") {
+    return true;
   }
   if (isChatShellPathname(pathname)) {
     return true;

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,7 +1,0 @@
-import { redirect } from "next/navigation";
-
-import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
-
-export default async function Page() {
-  redirect(DEFAULT_AUTHENTICATED_LANDING_PATH);
-}

--- a/apps/web/src/components/breadcrumb-navigation/__tests__/breadcrumb-navigation.client.test.tsx
+++ b/apps/web/src/components/breadcrumb-navigation/__tests__/breadcrumb-navigation.client.test.tsx
@@ -47,7 +47,7 @@ function BreadcrumbOverrideFixture({ label }: { label: string }) {
     segments: [
       {
         label: "Chat",
-        href: "/chat",
+        href: "/",
       },
       {
         label,
@@ -80,7 +80,7 @@ function ChatBucketBreadcrumbFixture({
     segments: [
       {
         label: "Chat",
-        href: "/chat",
+        href: "/",
       },
       {
         label,
@@ -146,7 +146,7 @@ describe("BreadcrumbNavigationClient", () => {
 
     expect(screen.getByRole("link", { name: "Chat" })).toHaveAttribute(
       "href",
-      "/chat",
+      "/",
     );
     expect(screen.getByText("Test Channel")).toBeInTheDocument();
     expect(screen.queryByText("rooms")).not.toBeInTheDocument();
@@ -183,7 +183,7 @@ describe("BreadcrumbNavigationClient", () => {
     expect(screen.queryByText("elena")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Chat" })).toHaveAttribute(
       "href",
-      "/chat",
+      "/",
     );
   });
 

--- a/apps/web/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
+++ b/apps/web/src/components/breadcrumb-navigation/breadcrumb-navigation.client.tsx
@@ -187,7 +187,7 @@ function generateChatRoomSegments(
     return [
       {
         label: chatLabel,
-        href: "/chat",
+        href: "/",
         isCurrent: true,
       },
     ];
@@ -196,7 +196,7 @@ function generateChatRoomSegments(
   return [
     {
       label: chatLabel,
-      href: "/chat",
+      href: "/",
     },
     {
       label: roomLabel,

--- a/apps/web/src/components/chat/__tests__/apply-chat-membership-revoked-ui.test.ts
+++ b/apps/web/src/components/chat/__tests__/apply-chat-membership-revoked-ui.test.ts
@@ -35,7 +35,7 @@ describe("applyChatMembershipRevokedUi", () => {
     });
 
     expect(notifyRemoved).toHaveBeenCalledWith("room-kicked");
-    expect(replace).toHaveBeenCalledWith("/chat");
+    expect(replace).toHaveBeenCalledWith("/");
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
+++ b/apps/web/src/components/chat/__tests__/chat-room-sidebar-row.test.tsx
@@ -441,7 +441,7 @@ describe("ChatRoomSidebarRow leave menu", () => {
     });
     expect(toast.success).toHaveBeenCalledWith("You left general.");
     expect(notifyMock).toHaveBeenCalledWith({ removedRoomId: "room-1" });
-    expect(replaceMock).toHaveBeenCalledWith("/chat");
+    expect(replaceMock).toHaveBeenCalledWith("/");
     expect(refreshMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/chat/apply-chat-membership-revoked-ui.ts
+++ b/apps/web/src/components/chat/apply-chat-membership-revoked-ui.ts
@@ -20,7 +20,7 @@ export function applyChatMembershipRevokedUi(
   notifyRemoved(roomId);
 
   if (activeRoomId === roomId) {
-    replace("/chat");
+    replace("/");
     refresh();
   }
 }

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -151,7 +151,7 @@ export function ChatRoomSidebarRow({
     notifyOrganizationChatRoomsChanged({ removedRoomId: room.id });
     if (isActive) {
       // Land on chat home — `/chat/chats` is mobile-only (`md:hidden`).
-      router.replace("/chat");
+      router.replace("/");
       router.refresh();
     }
   }

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -676,7 +676,7 @@ export function OrganizationChatList({
           onOpenChange={setChannelSectionOpen}
         >
           <SectionHeader
-            href={hasOrganization ? "/chat?create=channel" : undefined}
+            href={hasOrganization ? "/?create=channel" : undefined}
             isOpen={channelSectionOpen}
             label={t("createChannel")}
             secondaryAction={
@@ -985,12 +985,12 @@ export function OrganizationChatList({
         <Collapsible open={directOpen} onOpenChange={setDirectOpen}>
           {/*
             Sidebar rows = messaged history only. `+` opens Start New DM
-            (`/chat?dm=new`): org members + coworkers (1:1 only). Personal
+            (`/?dm=new`): org members + coworkers (1:1 only). Personal
             workspace soft-gates named channels but still mounts the same draft
             with empty members (coworkers only).
           */}
           <SectionHeader
-            href="/chat?dm=new"
+            href="/?dm=new"
             isOpen={directOpen}
             label={t("Draft.title")}
             dismissSheetOnNavigate={dismissSheetOnNavigate}

--- a/apps/web/src/components/modals/logout-modal.tsx
+++ b/apps/web/src/components/modals/logout-modal.tsx
@@ -42,7 +42,7 @@ export default function LogoutModal({
         },
         onSuccess: () => {
           const returnUrl =
-            window.location.pathname + window.location.search || "/chat";
+            window.location.pathname + window.location.search || "/";
           router.push(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
         },
       },

--- a/apps/web/src/lib/utils/landing-path.ts
+++ b/apps/web/src/lib/utils/landing-path.ts
@@ -1,4 +1,4 @@
 /**
  * Default authenticated landing path for all users.
  */
-export const DEFAULT_AUTHENTICATED_LANDING_PATH = "/chat";
+export const DEFAULT_AUTHENTICATED_LANDING_PATH = "/";

--- a/apps/web/src/lib/utils/url.ts
+++ b/apps/web/src/lib/utils/url.ts
@@ -34,15 +34,14 @@ export function buildFaviconCandidates(rawUrl: string): string[] {
 
 /**
  * Returns the current location (pathname + search) suitable for use as returnUrl
- * in sign-in redirects. Normalizes "/" to "/chat" so credential and social sign-in
- * behave consistently.
+ * in sign-in redirects. Keeps `/` as Welcome (authenticated landing).
  */
 export function getReturnUrlFromCurrentLocation(): string {
   const path =
     typeof window !== "undefined"
       ? window.location.pathname + window.location.search
-      : "/chat";
-  return path === "/" || path === "" ? "/chat" : path;
+      : "/";
+  return path === "" ? "/" : path;
 }
 
 export function buildJobTransactionUrl(

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -55,15 +55,19 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  // Unauthenticated `/` → sign-in. Authenticated `/` is Welcome — fall through
-  // to Next (do not redirect; landing path is `/` and would loop forever).
+  // Unauthenticated `/` → sign-in with returnUrl (same as other protected
+  // routes) so `/?dm=new` / `/?create=channel` survive login. Authenticated
+  // `/` is Welcome — fall through to Next (do not redirect; landing path is
+  // `/` and would loop forever).
   if (pathname === "/") {
     const sessionCookie = getSessionCookie(request, {
       cookiePrefix: betterAuthCookiePrefix,
     });
     if (!sessionCookie) {
+      const currentUrl = pathname + searchParams;
+      const returnUrl = encodeURIComponent(currentUrl);
       const redirectResponse = NextResponse.redirect(
-        new URL("/signin", request.url),
+        new URL(`/signin?returnUrl=${returnUrl}`, request.url),
       );
       applyDocumentSecurityHeaders(redirectResponse);
       return redirectResponse;

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -4,7 +4,6 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { applyDocumentSecurityHeaders } from "@/config/document-security-headers";
 import { getEnvSecrets } from "@/config/env.secrets";
-import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
 const EXCLUDED_PATHS = [
   "/auth/",
@@ -56,20 +55,19 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  // `/` is only an entry hop: resolve destination at the edge so we never run
-  // root + (app) RSC (metadata, messages, layout) before the first redirect.
+  // Unauthenticated `/` → sign-in. Authenticated `/` is Welcome — fall through
+  // to Next (do not redirect; landing path is `/` and would loop forever).
   if (pathname === "/") {
     const sessionCookie = getSessionCookie(request, {
       cookiePrefix: betterAuthCookiePrefix,
     });
-    const destination = sessionCookie
-      ? DEFAULT_AUTHENTICATED_LANDING_PATH
-      : "/signin";
-    const redirectResponse = NextResponse.redirect(
-      new URL(destination, request.url),
-    );
-    applyDocumentSecurityHeaders(redirectResponse);
-    return redirectResponse;
+    if (!sessionCookie) {
+      const redirectResponse = NextResponse.redirect(
+        new URL("/signin", request.url),
+      );
+      applyDocumentSecurityHeaders(redirectResponse);
+      return redirectResponse;
+    }
   }
 
   // Create response early so we can always set pathname + document headers


### PR DESCRIPTION
## Linear

https://linear.app/masumi/issue/SOK-794/welcome-at-mobile-header-logo-link

## Summary

- Move Welcome UI from `chat/page.tsx` to `(welcome)/` at `/` (layout + Instant loading + error boundary).
- Bare `/chat` redirects to `/` preserving searchParams; `/chat/chats` and rooms unchanged.
- Proxy: unauth `/` → `/signin`; auth `/` falls through (no redirect loop).
- Mobile header brand + fallback → `<Link href="/">`; desktop sidebar logo already `/`.
- Back chevron unchanged on rooms/drafts/nested; Welcome hrefs/notices/revalidate updated.

## Test plan

- `pnpm web:check` + `pnpm web:test` (passed).
- Desktop sidebar logo → Welcome `/`.
- Mobile logo on tab roots/home → Welcome; back-chevron on rooms/drafts.
- `/chat` (+ `?dm=new` / `?create=channel`) redirects to `/` with params; `/chat/chats` + rooms unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated home landing page at `/` with responsive desktop and mobile layouts.
  * Added support for starting channels and direct messages directly from the home page.
  * Added localized “Go to home” navigation labels in English, German, and Spanish.
  * Updated mobile navigation and branding to provide clear links back to Home.

* **Bug Fixes**
  * Improved navigation after leaving, archiving, deleting, or accessing unavailable chats.
  * Preserved query parameters when redirecting legacy chat links to the new home page.
  * Improved loading and error handling for the home experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->