### PR TITLE
fix(web): defer passkey autofill until email focus (SOK-808)

### DIFF
--- a/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
+++ b/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import SocialButtons from "../social-buttons";
@@ -121,6 +122,25 @@ function MockSocialButton({ onClick, text }: MockSocialButtonProps) {
       {text}
     </button>
   );
+}
+
+function renderWithSignInEmailField(ui: React.ReactElement) {
+  return render(
+    <>
+      <input
+        data-testid="auth-field-email"
+        autoComplete="username webauthn"
+        aria-label="email"
+      />
+      {ui}
+    </>,
+  );
+}
+
+async function focusSignInEmailField() {
+  await act(async () => {
+    fireEvent.focusIn(screen.getByTestId("auth-field-email"));
+  });
 }
 
 function createDeferred<T>() {
@@ -366,28 +386,41 @@ describe("SocialButtons", () => {
     await expect(waitForAuthSessionOptions.getSession()).resolves.toBeNull();
   });
 
-  it("starts conditional passkey UI only when supported", async () => {
-    mockIsConditionalMediationAvailable.mockResolvedValueOnce(true);
+  it("does not start conditional passkey autofill on mount", async () => {
+    mockIsConditionalMediationAvailable.mockResolvedValue(true);
 
-    render(<SocialButtons showPasskey />);
+    renderWithSignInEmailField(<SocialButtons showPasskey />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockPasskeySignIn).not.toHaveBeenCalled();
+    expect(mockIsConditionalMediationAvailable).not.toHaveBeenCalled();
+  });
+
+  it("starts conditional passkey autofill once after email focus when supported", async () => {
+    mockIsConditionalMediationAvailable.mockResolvedValue(true);
+
+    renderWithSignInEmailField(<SocialButtons showPasskey />);
+
+    await focusSignInEmailField();
 
     await waitFor(() => {
       expect(mockPasskeySignIn).toHaveBeenCalledWith({
         autoFill: true,
       });
     });
+
+    expect(mockPasskeySignIn).toHaveBeenCalledTimes(1);
+
+    await focusSignInEmailField();
+
+    expect(mockPasskeySignIn).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores stale conditional passkey results after return url changes", async () => {
+  it("does not restart conditional passkey autofill when return url changes", async () => {
     const firstPasskeyRequest = createDeferred<{
-      data: {
-        session: {
-          id: string;
-        };
-      };
-      error: null;
-    }>();
-    const secondPasskeyRequest = createDeferred<{
       data: {
         session: {
           id: string;
@@ -397,43 +430,38 @@ describe("SocialButtons", () => {
     }>();
 
     mockIsConditionalMediationAvailable.mockResolvedValue(true);
-    mockPasskeySignIn
-      .mockReturnValueOnce(firstPasskeyRequest.promise)
-      .mockReturnValueOnce(secondPasskeyRequest.promise);
+    mockPasskeySignIn.mockReturnValueOnce(firstPasskeyRequest.promise);
 
-    const { rerender } = render(
+    const { rerender } = renderWithSignInEmailField(
       <SocialButtons returnUrl="/jobs" showPasskey />,
     );
+
+    await focusSignInEmailField();
 
     await waitFor(() => {
       expect(mockPasskeySignIn).toHaveBeenCalledTimes(1);
     });
 
-    rerender(<SocialButtons returnUrl="/profile" showPasskey />);
+    rerender(
+      <>
+        <input
+          data-testid="auth-field-email"
+          autoComplete="username webauthn"
+          aria-label="email"
+        />
+        <SocialButtons returnUrl="/profile" showPasskey />
+      </>,
+    );
 
-    await waitFor(() => {
-      expect(mockPasskeySignIn).toHaveBeenCalledTimes(2);
-    });
+    await focusSignInEmailField();
+
+    expect(mockPasskeySignIn).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       firstPasskeyRequest.resolve({
         data: {
           session: {
-            id: "session-old",
-          },
-        },
-        error: null,
-      });
-      await Promise.resolve();
-    });
-
-    expect(mockRouterReplace).not.toHaveBeenCalled();
-
-    await act(async () => {
-      secondPasskeyRequest.resolve({
-        data: {
-          session: {
-            id: "session-new",
+            id: "session-id",
           },
         },
         error: null,
@@ -452,11 +480,15 @@ describe("SocialButtons", () => {
       value: undefined,
     });
 
-    render(<SocialButtons showPasskey />);
+    renderWithSignInEmailField(<SocialButtons showPasskey />);
 
-    await waitFor(() => {
-      expect(mockPasskeySignIn).not.toHaveBeenCalled();
+    await focusSignInEmailField();
+
+    await act(async () => {
+      await Promise.resolve();
     });
+
+    expect(mockPasskeySignIn).not.toHaveBeenCalled();
   });
 
   it("reveals the magic-link panel and requests a Magic Link", async () => {

--- a/apps/web/src/app/(auth)/components/social-buttons.tsx
+++ b/apps/web/src/app/(auth)/components/social-buttons.tsx
@@ -11,6 +11,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -134,6 +135,9 @@ export default function SocialButtons({
     }
   };
 
+  const finishPasskeySignInRef = useRef(finishPasskeySignIn);
+  finishPasskeySignInRef.current = finishPasskeySignIn;
+
   useEffect(() => {
     if (!showPasskey) {
       return;
@@ -148,6 +152,7 @@ export default function SocialButtons({
     }
 
     let isMounted = true;
+    let hasStartedConditionalAutofill = false;
 
     const startConditionalPasskeySignIn = async () => {
       try {
@@ -164,18 +169,37 @@ export default function SocialButtons({
           return;
         }
 
-        await finishPasskeySignIn();
+        await finishPasskeySignInRef.current();
       } catch {
         return undefined;
       }
     };
 
-    void startConditionalPasskeySignIn();
+    const handleEmailFocusIn = (event: FocusEvent) => {
+      if (hasStartedConditionalAutofill || !isMounted) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (!target.matches('input[data-testid="auth-field-email"]')) {
+        return;
+      }
+
+      hasStartedConditionalAutofill = true;
+      void startConditionalPasskeySignIn();
+    };
+
+    document.addEventListener("focusin", handleEmailFocusIn);
 
     return () => {
       isMounted = false;
+      document.removeEventListener("focusin", handleEmailFocusIn);
     };
-  }, [finishPasskeySignIn, showPasskey]);
+  }, [showPasskey]);
 
   const handleMagicLinkSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/apps/web/src/app/(auth)/signin/__tests__/data.test.ts
+++ b/apps/web/src/app/(auth)/signin/__tests__/data.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { signInFormData } from "../data";
+
+describe("signInFormData", () => {
+  it("sets current-password autocomplete on the password field", () => {
+    const passwordField = signInFormData.find(
+      (item) => item.name === "currentPassword",
+    );
+
+    expect(passwordField?.autoComplete).toBe("current-password");
+  });
+});

--- a/apps/web/src/app/(auth)/signin/data.ts
+++ b/apps/web/src/app/(auth)/signin/data.ts
@@ -14,6 +14,7 @@ export const signInFormData: FormData<
     name: "currentPassword",
     placeholderKey: "Fields.Password.placeholder",
     type: "password",
+    autoComplete: "current-password",
   },
   {
     name: "rememberMe",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/masumi/issue/SOK-808/login-first-attempt-only-locks-email-password-must-be-retyped

## Summary
- Defer conditional passkey autofill (`signIn.passkey({ autoFill: true })`) until the sign-in email field is focused; do not start on mount.
- Add `autoComplete: "current-password"` on the sign-in password field.
- Own PR from `main` (not stacked on #3821 / SOK-795).

## Verification
- `pnpm web:check`
- `pnpm web:test` (social-buttons + signin data coverage)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d404b169-2552-404e-9caf-1edff58b7ac0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d404b169-2552-404e-9caf-1edff58b7ac0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

