### PR TITLE
fix(web): land on Welcome after login and signup (SOK-809)

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-dialog.test.tsx
@@ -119,7 +119,7 @@ describe("OnboardingDialog organization subscription", () => {
     markSubscriptionOnboardingGateSessionSeenMock.mockResolvedValue(undefined);
     window.localStorage.clear();
     completeOnboardingMock.mockResolvedValue({
-      value: { redirectUrl: "/tasks" },
+      value: { redirectUrl: "/" },
       ok: true,
     });
     upgradeOrganizationSubscriptionMock.mockResolvedValue({
@@ -180,7 +180,7 @@ describe("OnboardingDialog organization subscription", () => {
       expect(upgradeOrganizationSubscriptionMock).toHaveBeenCalledWith({
         organizationId: "org-1",
         plan: "standard",
-        returnPath: "/tasks?onboarding_subscription=1",
+        returnPath: "/?onboarding_subscription=1",
         seats: 6,
       });
     });
@@ -326,7 +326,7 @@ describe("OnboardingDialog full intro Skip", () => {
     markSubscriptionOnboardingGateSessionSeenMock.mockResolvedValue(undefined);
     window.localStorage.clear();
     completeOnboardingMock.mockResolvedValue({
-      value: { redirectUrl: "/tasks" },
+      value: { redirectUrl: "/" },
       ok: true,
     });
   });
@@ -345,7 +345,7 @@ describe("OnboardingDialog full intro Skip", () => {
       expect(completeOnboardingMock).toHaveBeenCalled();
     });
     expect(trackMock).toHaveBeenCalledWith("Onboarding skipped");
-    expect(pushMock).toHaveBeenCalledWith("/tasks");
+    expect(pushMock).toHaveBeenCalledWith("/");
     expect(
       markSubscriptionOnboardingGateSessionSeenMock,
     ).not.toHaveBeenCalled();

--- a/apps/web/src/app/(app)/components/__tests__/onboarding-subscription-return-handler.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/onboarding-subscription-return-handler.test.tsx
@@ -52,7 +52,7 @@ describe("OnboardingSubscriptionReturnHandler", () => {
     );
     completeOnboardingMock.mockResolvedValue({
       ok: true,
-      value: { redirectUrl: "/tasks" },
+      value: { redirectUrl: "/" },
     });
 
     render(<OnboardingSubscriptionReturnHandler />);
@@ -60,7 +60,7 @@ describe("OnboardingSubscriptionReturnHandler", () => {
     await waitFor(() => {
       expect(completeOnboardingMock).toHaveBeenCalledTimes(1);
       expect(onboardingCompleteMock).toHaveBeenCalledTimes(1);
-      expect(replaceMock).toHaveBeenCalledWith("/tasks");
+      expect(replaceMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -72,7 +72,7 @@ describe("OnboardingSubscriptionReturnHandler", () => {
     render(<OnboardingSubscriptionReturnHandler />);
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith("/tasks");
+      expect(replaceMock).toHaveBeenCalledWith("/");
     });
 
     expect(completeOnboardingMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/(app)/components/onboarding-dialog.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-dialog.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/lib/actions/subscription";
 import { fireGTMEvent } from "@/lib/gtm-events";
 import { markSubscriptionOnboardingGateSeenSafely } from "@/lib/onboarding/mark-subscription-onboarding-gate-seen.client";
+import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
 const INTRO_STEP_COUNT = 5;
 const DEFAULT_SELECTED_PLAN: PaidSubscriptionPlanName = "standard";
@@ -508,7 +509,8 @@ export function OnboardingDialog({
         // activation signal — counting it would inflate the funnel step that
         // is supposed to measure people who actually went through it.
         if (!skipped) fireGTMEvent.onboardingComplete();
-        const redirectUrl = result.value.redirectUrl ?? "/agents";
+        const redirectUrl =
+          result.value.redirectUrl ?? DEFAULT_AUTHENTICATED_LANDING_PATH;
         setOpen(false);
         router.push(redirectUrl);
       } else {
@@ -598,12 +600,12 @@ export function OnboardingDialog({
         ? await upgradeOrganizationSubscription({
             organizationId,
             plan: selectedPlan,
-            returnPath: "/tasks?onboarding_subscription=1",
+            returnPath: "/?onboarding_subscription=1",
             seats: targetSeats,
           })
         : await upgradePersonalSubscription({
             plan: selectedPlan,
-            returnPath: "/tasks?onboarding_subscription=1",
+            returnPath: "/?onboarding_subscription=1",
           });
 
       if (!result.ok) {

--- a/apps/web/src/app/(app)/components/onboarding-subscription-return-handler.tsx
+++ b/apps/web/src/app/(app)/components/onboarding-subscription-return-handler.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { completeOnboarding } from "@/lib/actions/onboarding";
 import { fireGTMEvent } from "@/lib/gtm-events";
+import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
 export function OnboardingSubscriptionReturnHandler() {
   const router = useRouter();
@@ -27,7 +28,7 @@ export function OnboardingSubscriptionReturnHandler() {
 
     if (status === "cancel") {
       hasHandledRef.current = true;
-      router.replace("/tasks");
+      router.replace(DEFAULT_AUTHENTICATED_LANDING_PATH);
       return;
     }
 
@@ -47,7 +48,9 @@ export function OnboardingSubscriptionReturnHandler() {
         }
 
         fireGTMEvent.onboardingComplete();
-        router.replace(result.value.redirectUrl ?? "/tasks");
+        router.replace(
+          result.value.redirectUrl ?? DEFAULT_AUTHENTICATED_LANDING_PATH,
+        );
       } catch {
         hasHandledRef.current = false;
         toast.error(tErrors("unexpectedError"));

--- a/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
+++ b/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
@@ -104,7 +104,7 @@ vi.mock("@/lib/auth/auth.utils", async () => {
 
   return {
     ...actual,
-    normalizeAuthReturnUrl: (value?: string) => value ?? "/chat",
+    normalizeAuthReturnUrl: (value?: string) => value ?? "/",
     waitForAuthSession: (options: MockWaitForAuthSessionOptions) =>
       mockWaitForAuthSession(options),
   };

--- a/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
+++ b/apps/web/src/app/(auth)/components/__tests__/social-buttons.test.tsx
@@ -104,7 +104,7 @@ vi.mock("@/lib/auth/auth.utils", async () => {
 
   return {
     ...actual,
-    normalizeAuthReturnUrl: (value?: string) => value ?? "/",
+    normalizeAuthReturnUrl: (value?: string) => value ?? "/chat",
     waitForAuthSession: (options: MockWaitForAuthSessionOptions) =>
       mockWaitForAuthSession(options),
   };

--- a/apps/web/src/lib/actions/onboarding/action.ts
+++ b/apps/web/src/lib/actions/onboarding/action.ts
@@ -13,6 +13,7 @@ import { type ActionError, CommonErrorCode } from "@/lib/actions/errors";
 import { getSession } from "@/lib/auth/auth.server";
 import { userService } from "@/lib/services";
 import { SUBSCRIPTION_ONBOARDING_GATE_SESSION_COOKIE_NAME } from "@/lib/subscription-onboarding-gate-cookie";
+import { DEFAULT_AUTHENTICATED_LANDING_PATH } from "@/lib/utils/landing-path";
 
 const SUBSCRIPTION_ONBOARDING_GATE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 400;
 
@@ -68,7 +69,9 @@ export async function completeOnboarding(): Promise<
     }
 
     revalidatePath("/");
-    return toActionResult(ok({ redirectUrl: "/tasks" }));
+    return toActionResult(
+      ok({ redirectUrl: DEFAULT_AUTHENTICATED_LANDING_PATH }),
+    );
   } catch (error) {
     console.error("Error completing onboarding:", error);
     const t = await getTranslations("Onboarding.Actions.Errors");


### PR DESCRIPTION
## Linear

https://linear.app/masumi/issue/SOK-809/after-loginsignup-land-on-welcome-not-tasks

## Spec summary (SOK-809)

- Default post-auth / onboarding-complete landing is Welcome `/` via `DEFAULT_AUTHENTICATED_LANDING_PATH`.
- `completeOnboarding()` returns that path (not `/tasks`).
- Onboarding subscription cancel + nullish fallback land on Welcome `/`.
- Stripe onboarding `returnPath` is `/?onboarding_subscription=1` (not `/tasks?...`).
- Dialog nullish fallback uses Welcome `/` instead of `/agents`.
- Explicit `returnUrl` to `/tasks` still works; genuine in-app task-board links unchanged.
- `manifest.ts` `start_url: "/"` unchanged; auth layout/signin/signup/social stay on `/`.

## Verification

- `pnpm web:check` (exit 0)
- Targeted tests: onboarding-subscription-return-handler, onboarding-dialog, social-buttons (exit 0)