### PR TITLE
fix(chat): unbreak room thread list recency SQL

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -874,16 +874,49 @@ describe("getChatRoomThreadAggregates", () => {
 
     const sql = String(queryRawUnsafe.mock.calls[0]?.[0]);
     expect(sql).toContain('"unreadReplyCount" = 0');
-    expect(sql).toContain("LIMIT $");
+    expect(sql).toContain("LIMIT $4");
     expect(sql).toContain(
       'ORDER BY "lastReplyAt" DESC, "parentMessageId" DESC',
     );
-    expect(sql).toContain("COALESCE(");
-    expect(sql).toContain('p."createdAt"');
+    // Scalar subqueries only — no MAX(...) + p.createdAt without GROUP BY
+    // (Postgres 42803 / SOKOSUMI-CORE-32).
+    expect(sql).toContain('SELECT MAX(r."createdAt")');
+    expect(sql).toContain('SELECT p."createdAt"');
+    expect(sql).not.toMatch(/LEFT JOIN "chat_room_message" r[\s\S]*GROUP BY/i);
+    expect(sql).not.toContain(
+      'MAX(r."createdAt") FILTER (WHERE r."deletedAt" IS NULL)',
+    );
     expect(queryRawUnsafe.mock.calls[0]?.[3]).toBe(
       "550e8400-e29b-41d4-a716-446655440099",
     );
     expect(queryRawUnsafe.mock.calls[0]?.[4]).toBe(51);
+  });
+
+  it("first recency page omits cursor baseline so null $3 never hits Postgres", async () => {
+    const queryRawUnsafe = vi.fn().mockResolvedValue([]);
+    const tx = { $queryRawUnsafe: queryRawUnsafe } as never;
+
+    await getChatRoomThreadAggregates(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "user_123",
+      tx,
+      {
+        recency: {
+          limit: 50,
+        },
+      },
+    );
+
+    const sql = String(queryRawUnsafe.mock.calls[0]?.[0]);
+    expect(sql).toContain('"unreadReplyCount" = 0');
+    expect(sql).toContain("LIMIT $3");
+    expect(sql).not.toContain("$3::uuid IS NULL");
+    expect(sql).not.toContain('SELECT MAX(r."createdAt")');
+    expect(queryRawUnsafe.mock.calls[0]?.slice(1)).toEqual([
+      "550e8400-e29b-41d4-a716-446655440000",
+      "user_123",
+      51,
+    ]);
   });
 });
 

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -255,28 +255,39 @@ export async function getChatRoomThreadAggregates(
     HAVING COUNT(reply.id) >= 1
   `;
 
+  // Recency cursor baseline must be pure scalar subqueries. Joining parent to
+  // replies then selecting MAX(...) + p.createdAt without GROUP BY is Postgres
+  // 42803 (SOKOSUMI-CORE-32) — every GET …/threads?limit=… 500s in prod.
+  const recencyCursorFilter = recency?.cursor
+    ? `
+      AND ("lastReplyAt", "parentMessageId") < (
+        SELECT COALESCE(
+          (
+            SELECT MAX(r."createdAt")
+            FROM "chat_room_message" r
+            WHERE r."parentMessageId" = $3::uuid
+              AND r."deletedAt" IS NULL
+              AND r."roomId" = $1::uuid
+          ),
+          (
+            SELECT p."createdAt"
+            FROM "chat_room_message" p
+            WHERE p.id = $3::uuid
+              AND p."roomId" = $1::uuid
+          )
+        ),
+        $3::uuid
+      )
+    `
+    : "";
+
   const recencySql = recency
     ? `
     SELECT * FROM (${innerSelect}) threads
     WHERE "unreadReplyCount" = 0
-      AND (
-        $3::uuid IS NULL
-        OR ("lastReplyAt", "parentMessageId") < (
-          SELECT COALESCE(
-            MAX(r."createdAt") FILTER (WHERE r."deletedAt" IS NULL),
-            p."createdAt"
-          ),
-          p.id
-          FROM "chat_room_message" p
-          LEFT JOIN "chat_room_message" r
-            ON r."parentMessageId" = p.id
-            AND r."roomId" = p."roomId"
-          WHERE p.id = $3::uuid
-            AND p."roomId" = $1::uuid
-        )
-      )
+    ${recencyCursorFilter}
     ORDER BY "lastReplyAt" DESC, "parentMessageId" DESC
-    LIMIT $4
+    LIMIT $${recency.cursor ? 4 : 3}
     `
     : unreadOnly
       ? `
@@ -290,7 +301,9 @@ export async function getChatRoomThreadAggregates(
     `;
 
   const queryArgs = recency
-    ? [roomId, userId, recency.cursor ?? null, recency.limit + 1]
+    ? recency.cursor
+      ? [roomId, userId, recency.cursor, recency.limit + 1]
+      : [roomId, userId, recency.limit + 1]
     : parentMessageId
       ? [roomId, userId, parentMessageId]
       : [roomId, userId];


### PR DESCRIPTION
## Summary
- Production `GET /v1/chats/rooms/{id}/threads?limit=…` 500s with Postgres `42803` (`column "p.createdAt" must appear in the GROUP BY clause`) — Sentry **SOKOSUMI-CORE-32**.
- Root cause: recency cursor baseline joined parent→replies and selected `MAX(r.createdAt)` + `p.createdAt` without `GROUP BY`. Postgres plans that subquery even when cursor is null, so **every** full thread list load fails (including first page).
- Fix: scalar subqueries for last-reply / parent-createdAt baseline; omit cursor filter on first page.
- Side effect: room `#Marketing` unread could not clear via look / mark-all while this endpoint 500'd (dual baseline still counts thread replies until looked).

## Test plan
- [x] Neon repro of broken SQL → `42803`
- [x] Neon check of fixed scalar subquery + soft-delete fallback
- [x] `pnpm --filter core test` helpers + threads get tests (83)
- [ ] After deploy: open Marketing → Threads side panel loads (no "An unexpected error occurred")
- [ ] Mark all as read / open a thread → room sidebar unread drops

Fixes SOKOSUMI-CORE-32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat thread recency pagination for more accurate ordering when replies are present.
  * Corrected handling of deleted replies and threads without replies.
  * Fixed first-page pagination to avoid unnecessary cursor parameters and ensure consistent result limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->