### PR TITLE
fix(chat): show threads badge for dual-baseline attention including never-looked

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/get.ts
@@ -39,7 +39,7 @@ const querySchema = cursorPaginationQuerySchema.extend({
     .openapi({
       param: { name: "unread", in: "query" },
       description:
-        "When `true`, only unread threads (prior look + newer non-self replies). `cursor` and `limit` are ignored. When omitted or `false`, unread threads first then a recency page of the rest.",
+        "When `true`, only attention threads (`attentionReplyCount >= 1`, dual-baseline including qualifying never-looked). `cursor` and `limit` are ignored. When omitted or `false`, attention threads first then a recency page of the rest.",
       example: "true",
     }),
 });
@@ -49,7 +49,7 @@ const route = withGlobalHeaderParameters(
     method: "get",
     path: "/{id}/threads",
     description:
-      "List threads in a room. `unread=true` returns every unread thread (prior look + newer replies) and ignores `cursor`/`limit`. Otherwise returns unread threads first, then a recency page of looked and never-looked threads (`cursor`/`limit`). Independent of room mark-read.",
+      "List threads in a room. `unread=true` returns every attention thread (dual-baseline `attentionReplyCount`, including qualifying never-looked) and ignores `cursor`/`limit`. Otherwise returns attention threads first then a recency page of the rest (`cursor`/`limit`). Independent of room mark-read.",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,

--- a/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.test.ts
@@ -848,7 +848,7 @@ describe("getChatRoomThreadAggregates", () => {
     );
   });
 
-  it("filters unread threads in SQL after a prior look, newest unread first", async () => {
+  it("filters attention threads in SQL (dual-baseline), newest reply first", async () => {
     const queryRawUnsafe = vi.fn().mockResolvedValue([]);
     const tx = { $queryRawUnsafe: queryRawUnsafe } as never;
 
@@ -860,11 +860,15 @@ describe("getChatRoomThreadAggregates", () => {
     );
 
     const sql = String(queryRawUnsafe.mock.calls[0]?.[0]);
-    expect(sql).toContain('"unreadReplyCount" >= 1');
-    expect(sql).toContain('"lastUnreadReplyAt" DESC');
+    expect(sql).toContain('"attentionReplyCount" >= 1');
+    expect(sql).toContain(
+      'ORDER BY "lastReplyAt" DESC, "parentMessageId" DESC',
+    );
+    expect(sql).not.toContain('"unreadReplyCount" >= 1');
+    expect(sql).not.toContain('"lastUnreadReplyAt" DESC');
   });
 
-  it("pages looked and never-looked threads by last reply, excluding unreads", async () => {
+  it("pages looked and never-looked threads by last reply, excluding attention", async () => {
     const queryRawUnsafe = vi.fn().mockResolvedValue([]);
     const tx = { $queryRawUnsafe: queryRawUnsafe } as never;
 
@@ -881,7 +885,8 @@ describe("getChatRoomThreadAggregates", () => {
     );
 
     const sql = String(queryRawUnsafe.mock.calls[0]?.[0]);
-    expect(sql).toContain('"unreadReplyCount" = 0');
+    expect(sql).toContain('"attentionReplyCount" = 0');
+    expect(sql).not.toContain('"unreadReplyCount" = 0');
     expect(sql).toContain("LIMIT $4");
     expect(sql).toContain(
       'ORDER BY "lastReplyAt" DESC, "parentMessageId" DESC',
@@ -916,7 +921,7 @@ describe("getChatRoomThreadAggregates", () => {
     );
 
     const sql = String(queryRawUnsafe.mock.calls[0]?.[0]);
-    expect(sql).toContain('"unreadReplyCount" = 0');
+    expect(sql).toContain('"attentionReplyCount" = 0');
     expect(sql).toContain("LIMIT $3");
     expect(sql).not.toContain("$3::uuid IS NULL");
     expect(sql).not.toContain('SELECT MAX(r."createdAt")');

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -213,11 +213,10 @@ export interface ChatRoomThreadAggregate {
  * Parents (top-level messages) in a room that have ≥1 non-deleted reply,
  * with per-user unread counts.
  *
- * A thread is unread (ADR-0005 / Threads badge) only after a prior look row
- * (`ChatRoomThreadReadState.lastReadAt`). Never-looked threads have
- * unreadReplyCount 0. `attentionReplyCount` uses the sidebar dual-baseline so
- * the thread overview can style never-looked replies and Mark all can clear
- * them (SOK-811).
+ * `unreadReplyCount` follows ADR-0005 (prior look required; never-looked → 0).
+ * `attentionReplyCount` uses the sidebar dual-baseline. `unreadOnly` and the
+ * Threads badge filter on `attentionReplyCount >= 1` so never-looked attention
+ * matches overview Mark all (SOK-811).
  */
 export async function getChatRoomThreadAggregates(
   roomId: string,
@@ -305,7 +304,7 @@ export async function getChatRoomThreadAggregates(
   const recencySql = recency
     ? `
     SELECT * FROM (${innerSelect}) threads
-    WHERE "unreadReplyCount" = 0
+    WHERE "attentionReplyCount" = 0
     ${recencyCursorFilter}
     ORDER BY "lastReplyAt" DESC, "parentMessageId" DESC
     LIMIT $${recency.cursor ? 4 : 3}
@@ -313,8 +312,8 @@ export async function getChatRoomThreadAggregates(
     : unreadOnly
       ? `
     SELECT * FROM (${innerSelect}) threads
-    WHERE "unreadReplyCount" >= 1
-    ORDER BY "lastUnreadReplyAt" DESC, "parentMessageId" DESC
+    WHERE "attentionReplyCount" >= 1
+    ORDER BY "lastReplyAt" DESC, "parentMessageId" DESC
     `
       : `
     ${innerSelect}
@@ -393,8 +392,8 @@ async function mapThreadAggregates(
 }
 
 /**
- * List threads in a room. When `unreadOnly`, only parents with ≥1 unread
- * non-self reply after a prior look (ADR-0005).
+ * List threads in a room. When `unreadOnly`, only parents with
+ * `attentionReplyCount >= 1` (dual-baseline; includes qualifying never-looked).
  */
 export async function listChatRoomThreads(
   roomId: string,
@@ -415,8 +414,8 @@ export interface ChatRoomThreadListPage {
 }
 
 /**
- * Full room thread list: all unread threads, then a recency page of the rest
- * (looked + never-looked) by last reply. Cursor pages are recency-only.
+ * Full room thread list: all attention threads, then a recency page of the
+ * rest (attentionReplyCount = 0) by last reply. Cursor pages are recency-only.
  */
 export async function listChatRoomThreadListPage(
   roomId: string,
@@ -537,8 +536,8 @@ export async function markChatRoomThreadRead(
  * sidebar dual-baseline unread: looked threads with newer non-self replies,
  * and never-looked threads with non-self replies after room read-state
  * createdAt / -infinity. Does not change room ChatRoomReadState or CHAT
- * notifications. Broader than ADR-0005 unreadOnly (badge) so Mark all in the
- * thread overview can clear never-looked looks (SOK-811).
+ * notifications. Same dual-baseline set as `unreadOnly` / Threads badge /
+ * overview attention (SOK-811).
  */
 export async function markAllChatRoomThreadsRead(
   roomId: string,

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -500,9 +500,9 @@ export const restoredChatRoomSchema = chatRoomSchema;
 
 /**
  * A top-level room message that has ≥1 non-deleted reply, with per-user look
- * metadata. `unreadReplyCount` requires a prior look row (ADR-0005 / Threads
- * badge). `attentionReplyCount` uses the sidebar dual-baseline so never-looked
- * replies still surface in the thread overview and Mark all (SOK-811).
+ * metadata. `unreadReplyCount` requires a prior look row (ADR-0005).
+ * `attentionReplyCount` uses the sidebar dual-baseline; Threads badge /
+ * `unread=true` / overview Mark all use that count (SOK-811).
  */
 export const chatRoomThreadSchema = z
   .object({
@@ -532,7 +532,7 @@ export const chatRoomThreadSchema = z
     }),
     attentionReplyCount: z.number().int().min(0).openapi({
       description:
-        "Non-deleted replies from others after the dual-baseline look (thread lastReadAt, else room read-state createdAt, else -infinity). Used by the thread overview and Mark all; includes never-looked replies that still contribute to sidebar unread.",
+        "Non-deleted replies from others after the dual-baseline look (thread lastReadAt, else room read-state createdAt, else -infinity). Used by Threads badge (`unread=true`), thread overview, and Mark all; includes never-looked replies that still contribute to sidebar unread.",
       example: 3,
     }),
   })

--- a/apps/web/src/app/(app)/chat/components/__tests__/unread-threads-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/unread-threads-panel.test.tsx
@@ -132,6 +132,30 @@ describe("UnreadThreadsPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows badge for never-looked attention threads (ADR-0005 unreadReplyCount 0)", async () => {
+    listUnreadThreadsActionMock.mockResolvedValue({
+      ok: true,
+      value: [
+        unreadThreadItem({
+          unreadReplyCount: 0,
+          lastUnreadReplyAt: null,
+          hasLooked: false,
+          attentionReplyCount: 37,
+          replyCount: 37,
+        }),
+      ],
+    });
+
+    renderTrigger();
+
+    expect(
+      await screen.findByTestId("unread-threads-badge"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `${labels.open} (1)` }),
+    ).toBeInTheDocument();
+  });
+
   it("coalesces rapid attentionRefreshToken bumps into one fetch after 300ms", async () => {
     vi.useFakeTimers();
     const { rerender } = render(

--- a/apps/web/src/app/(app)/chat/components/unread-threads-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/unread-threads-panel.tsx
@@ -14,7 +14,7 @@ interface UnreadThreadsPanelProps {
   labels: UnreadThreadsPanelLabels;
   /**
    * Monotonic epoch from the parent. Values > 0 trigger a debounced
-   * unread-count refetch.
+   * attention-count refetch (same dual-baseline set as overview Mark all).
    */
   attentionRefreshToken: number;
   isOpen: boolean;

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -5440,7 +5440,7 @@ export const ChatRoomThreadSchema = {
         attentionReplyCount: {
             type: 'integer',
             minimum: 0,
-            description: 'Non-deleted replies from others after the dual-baseline look (thread lastReadAt, else room read-state createdAt, else -infinity). Used by the thread overview and Mark all; includes never-looked replies that still contribute to sidebar unread.',
+            description: 'Non-deleted replies from others after the dual-baseline look (thread lastReadAt, else room read-state createdAt, else -infinity). Used by Threads badge (`unread=true`), thread overview, and Mark all; includes never-looked replies that still contribute to sidebar unread.',
             example: 3
         }
     },

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -666,7 +666,7 @@ export const postChatsRoomsByIdUnread = <ThrowOnError extends boolean = false>(o
 });
 
 /**
- * List threads in a room. `unread=true` returns every unread thread (prior look + newer replies) and ignores `cursor`/`limit`. Otherwise returns unread threads first, then a recency page of looked and never-looked threads (`cursor`/`limit`). Independent of room mark-read.
+ * List threads in a room. `unread=true` returns every attention thread (dual-baseline `attentionReplyCount`, including qualifying never-looked) and ignores `cursor`/`limit`. Otherwise returns attention threads first then a recency page of the rest (`cursor`/`limit`). Independent of room mark-read.
  */
 export const getChatsRoomsByIdThreads = <ThrowOnError extends boolean = false>(options: Options<GetChatsRoomsByIdThreadsData, ThrowOnError>): RequestResult<GetChatsRoomsByIdThreadsResponses, GetChatsRoomsByIdThreadsErrors, ThrowOnError> => (options.client ?? client).get<GetChatsRoomsByIdThreadsResponses, GetChatsRoomsByIdThreadsErrors, ThrowOnError>({
     responseTransformer: getChatsRoomsByIdThreadsResponseTransformer,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1531,7 +1531,7 @@ export type ChatRoomThread = {
      */
     hasLooked: boolean;
     /**
-     * Non-deleted replies from others after the dual-baseline look (thread lastReadAt, else room read-state createdAt, else -infinity). Used by the thread overview and Mark all; includes never-looked replies that still contribute to sidebar unread.
+     * Non-deleted replies from others after the dual-baseline look (thread lastReadAt, else room read-state createdAt, else -infinity). Used by Threads badge (`unread=true`), thread overview, and Mark all; includes never-looked replies that still contribute to sidebar unread.
      */
     attentionReplyCount: number;
 };
@@ -12276,7 +12276,7 @@ export type GetChatsRoomsByIdThreadsData = {
          */
         limit?: number;
         /**
-         * When `true`, only unread threads (prior look + newer non-self replies). `cursor` and `limit` are ignored. When omitted or `false`, unread threads first then a recency page of the rest.
+         * When `true`, only attention threads (`attentionReplyCount >= 1`, dual-baseline including qualifying never-looked). `cursor` and `limit` are ignored. When omitted or `false`, attention threads first then a recency page of the rest.
          */
         unread?: 'true' | 'false';
     };

--- a/docs/adr/0005-thread-unread-requires-prior-look.md
+++ b/docs/adr/0005-thread-unread-requires-prior-look.md
@@ -1,11 +1,13 @@
 # Thread unread requires a prior look
 
-A **Thread** is an **unread thread** only if the user has already **looked** it and there is at least one non-self reply after that look. A never-looked Thread is not unread: it sorts by last reply only and does not count toward the Threads badge or mark-all.
+A **Thread** is an **unread thread** (`unreadReplyCount`) only if the user has already **looked** it and there is at least one non-self reply after that look. A never-looked Thread has `unreadReplyCount` 0 and sorts by last reply among non-attention rows.
 
-**Why look, not “any unseen reply”:** with no look row, the baseline is room-join or the beginning of history, so old threads flood the top of a full **Thread list** as unread. That made the unread-only panel noisy and would break “unreads on top” on a full list.
+**SOK-811 (product override):** Threads badge (`unread=true`), thread overview chrome, and Mark all use dual-baseline **`attentionReplyCount`**, which **does** include qualifying never-looked replies (same baseline as sidebar room unread). Do not re-gate the badge on ADR-0005 `unreadReplyCount` alone.
+
+**Why look, not “any unseen reply” for `unreadReplyCount`:** with no look row, the baseline is room-join or the beginning of history, so old threads flood a prior-look-only unread list. That metric stays prior-look-only.
 
 **Why not replied / participated:** unread means unseen activity in a Thread the user already chose to open. Requiring a reply (or parent authorship) blinds people who only read — including the parent author who never posts a reply.
 
-**Out of scope:** room sidebar dual-baseline unread still uses today’s thread look fallback (join / `-infinity`). Tightening that to match this rule is a follow-up.
+**Out of scope:** changing room sidebar dual-baseline unread itself.
 
-**Rejected:** never-looked counts as unread; unread = I replied; unread = I authored the parent or replied; sort-only change that leaves the badge counting fossils.
+**Rejected for `unreadReplyCount`:** never-looked counts as prior-look unread; unread = I replied; unread = I authored the parent or replied.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up for [SOK-811](https://linear.app/masumi/issue/SOK-811/marketing-channel-always-shows-unread) after [#3834](https://github.com/masumi-network/sokosumi/pull/3834) merged while the Bumblebee caveat was still open.

Bumblebee mainnet PASS on `5c8ffc2a` noted: `unread-threads-trigger` showed icon only (no badge) while the Threads overview had attention rows that were never-looked (`attentionReplyCount > 0`, ADR-0005 `unreadReplyCount` 0).

- **`GET …/threads?unread=true`** (and thus `listUnreadThreads` → Threads trigger badge) now filters on dual-baseline `attentionReplyCount >= 1`, same eligibility as overview chrome / Mark all — including qualifying never-looked.
- Recency page of the full thread list excludes attention rows the same way (no duplicate).
- ADR-0005 updated: `unreadReplyCount` stays prior-look-only; badge / Mark all / overview use `attentionReplyCount`.
- No sidebar unread split.

## Test plan

- [x] `pnpm --filter core test` helpers (unreadOnly SQL → `attentionReplyCount`)
- [x] `pnpm --filter web test` unread-threads-panel (never-looked fixture `unreadReplyCount: 0`, `attentionReplyCount: 37` → badge)
- [ ] Do not rely on Andreas’s `#marketing` rows (Mark all burned them); use a never-looked fixture or fresh attention thread

Draft only. Do not merge until reviewed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2575269f-f8b5-4410-8411-aa8a7879e285?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2575269f-f8b5-4410-8411-aa8a7879e285&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread attention and unread filtering to prioritize the most recently active threads.
  * Never-viewed threads with qualifying replies now display the correct attention badge, even without traditional unread counts.
  * Recency results now exclude threads already surfaced as requiring attention.

* **Documentation**
  * Clarified how attention counts, unread counts, thread badges, and “Mark all” behavior work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->