### PR TITLE
feat(mobile): keep home tab active on /agents, show back button (SOK-818)

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
@@ -68,7 +68,7 @@ describe("resolveChatMobileActiveTabId", () => {
     ).toBe("chats");
     expect(resolveChatMobileActiveTabId("/chat/rooms/abc")).toBeNull();
     expect(resolveChatMobileActiveTabId("/tasks/t1")).toBeNull();
-    expect(resolveChatMobileActiveTabId("/agents")).toBeNull();
+    expect(resolveChatMobileActiveTabId("/agents")).toBe("home");
     expect(resolveChatMobileActiveTabId("/agents/a1")).toBeNull();
     expect(resolveChatMobileActiveTabId("/projects/p1")).toBeNull();
     expect(resolveChatMobileActiveTabId("/account")).toBeNull();

--- a/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/chat-mobile-bottom-nav.test.tsx
@@ -167,6 +167,19 @@ describe("ChatMobileBottomNav", () => {
     );
   });
 
+  it("sets aria-current on Home for /agents", () => {
+    mockPathname = "/agents";
+    render(<ChatMobileBottomNav />);
+
+    expect(screen.getByRole("link", { name: "home" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: "tasks" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
   it("does not set aria-current on any tab for unmatched paths", () => {
     mockPathname = "/account";
     render(<ChatMobileBottomNav />);

--- a/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
+++ b/apps/web/src/app/(app)/chat/components/chat-mobile-tab-registry.ts
@@ -141,7 +141,8 @@ export const CHAT_MOBILE_TABS: readonly ChatMobileTab[] = [
     labelKey: "home",
     icon: Home,
     isActive: (pathname, searchParams) =>
-      classifyChatChromeSurface(pathname, searchParams) === "home",
+      classifyChatChromeSurface(pathname, searchParams) === "home" ||
+      pathname === "/agents",
   },
   {
     id: "tasks",

--- a/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/mobile-app-chrome.test.ts
@@ -29,9 +29,15 @@ describe("mobile-app-chrome", () => {
   describe("resolveMobileAppBackTarget", () => {
     it("returns null on tab list roots (no leading back)", () => {
       expect(resolveMobileAppBackTarget("/tasks")).toBeNull();
-      expect(resolveMobileAppBackTarget("/agents")).toBeNull();
       expect(resolveMobileAppBackTarget("/projects")).toBeNull();
       expect(resolveMobileAppBackTarget("/history")).toBeNull();
+    });
+
+    it("sends agents root back to home", () => {
+      expect(resolveMobileAppBackTarget("/agents")).toEqual({
+        href: "/",
+        labelKey: "back",
+      });
     });
 
     it("sends non-tab hub roots back to Chats", () => {
@@ -136,12 +142,11 @@ describe("mobile-app-chrome", () => {
         shouldShowMobileBrandLeading("/", new URLSearchParams("welcome=1")),
       ).toBe(true);
       expect(shouldShowMobileBrandLeading("/tasks")).toBe(true);
-      expect(shouldShowMobileBrandLeading("/agents")).toBe(true);
       expect(shouldShowMobileBrandLeading("/projects")).toBe(true);
       expect(shouldShowMobileBrandLeading("/history")).toBe(true);
     });
 
-    it("hides brand for rooms, drafts, hubs, and nested detail", () => {
+    it("hides brand for rooms, drafts, hubs, nested detail, and agents", () => {
       expect(shouldShowMobileBrandLeading("/chat/rooms/r1")).toBe(false);
       expect(
         shouldShowMobileBrandLeading(
@@ -153,6 +158,7 @@ describe("mobile-app-chrome", () => {
         shouldShowMobileBrandLeading("/", new URLSearchParams("dm=new")),
       ).toBe(false);
       expect(shouldShowMobileBrandLeading("/tasks/t1")).toBe(false);
+      expect(shouldShowMobileBrandLeading("/agents")).toBe(false);
       expect(shouldShowMobileBrandLeading("/personal-assistant")).toBe(false);
       expect(shouldShowMobileBrandLeading("/account")).toBe(false);
     });

--- a/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-leading-control.client.test.tsx
@@ -118,8 +118,8 @@ describe("HeaderLeadingControl", () => {
     expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
   });
 
-  it("shows brand link to home on agents, projects, and search tab roots", () => {
-    for (const path of ["/agents", "/projects", "/history"]) {
+  it("shows brand link to home on projects and search tab roots", () => {
+    for (const path of ["/projects", "/history"]) {
       mockPathname = path;
       const { unmount } = render(<HeaderLeadingControl />);
       expect(screen.getByRole("link", { name: "goHome" })).toHaveAttribute(
@@ -129,6 +129,13 @@ describe("HeaderLeadingControl", () => {
       expect(screen.getByTestId("sokosumi-icon")).toBeTruthy();
       unmount();
     }
+  });
+
+  it("shows back to home on agents root", () => {
+    mockPathname = "/agents";
+    render(<HeaderLeadingControl />);
+    const back = screen.getByRole("link", { name: "back" });
+    expect(back).toHaveAttribute("href", "/");
   });
 
   it("shows back to chats on personal-assistant root", () => {

--- a/apps/web/src/app/(app)/components/mobile-app-chrome.ts
+++ b/apps/web/src/app/(app)/components/mobile-app-chrome.ts
@@ -73,7 +73,7 @@ function findMainAppListRoot(pathname: string): MainAppMobileListPath | null {
 
 /**
  * Back target for main list routes and their nested pages.
- * Tab list roots → null; non-tab hub roots → Chats; nested → list root.
+ * Tab list roots → null; Agents root → home; non-tab hub roots → Chats; nested → list root.
  */
 export function resolveMobileAppBackTarget(
   pathname: string | null | undefined,
@@ -86,6 +86,9 @@ export function resolveMobileAppBackTarget(
     return null;
   }
   if (pathname === root) {
+    if (root === "/agents") {
+      return { href: "/", labelKey: "back" };
+    }
     if (MOBILE_TAB_LIST_PATH_SET.has(root)) {
       return null;
     }
@@ -125,7 +128,7 @@ export function shouldShowMobileBottomNav(
 
 /**
  * Leading slot shows Sokosumi brand on Chats list and every bottom-nav tab
- * root (Tasks / Agents / Projects / Search). Nested pages keep back.
+ * root (Tasks / Projects / Search). Agents shows back to home. Nested pages keep back.
  */
 export function shouldShowMobileBrandLeading(
   pathname: string | null | undefined,
@@ -136,6 +139,9 @@ export function shouldShowMobileBrandLeading(
     return true;
   }
   if (!pathname) {
+    return false;
+  }
+  if (pathname === "/agents") {
     return false;
   }
   return MOBILE_TAB_LIST_PATH_SET.has(pathname);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements SOK-818: https://linear.app/masumi/issue/SOK-818/mobile-keep-home-tab-active-on-search-agents-show-back-on-agents

Home tab stays active on `/agents`, back button navigates to `/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13922c9b-87de-4f07-b946-07a017d1df23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13922c9b-87de-4f07-b946-07a017d1df23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

