### PR TITLE
feat(web): unify switcher create into one action

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -153,8 +153,7 @@
       "personalAccount": "Persönlicher Account",
       "organizationsHeading": "Organisationen",
       "createOrJoinOrganization": "Organisation erstellen oder beitreten",
-      "createOrganization": "Organisation erstellen",
-      "createPersonalWorkspace": "Persönlichen Workspace erstellen",
+      "createWorkspace": "Workspace erstellen",
       "userAvatarAlt": "Nutzer-Avatar"
     },
     "DataTable": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -151,8 +151,7 @@
     "OrganizationSwitcher": {
       "switchWorkspace": "Switch workspace",
       "personalAccount": "Personal Account",
-      "createOrganization": "Create Organization",
-      "createPersonalWorkspace": "Create personal workspace",
+      "createWorkspace": "Create workspace",
       "organizationsHeading": "Organizations",
       "createOrJoinOrganization": "Create or Join Organization",
       "userAvatarAlt": "User avatar"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -153,8 +153,7 @@
       "personalAccount": "Cuenta personal",
       "organizationsHeading": "Organizaciones",
       "createOrJoinOrganization": "Crear o unirse a una organización",
-      "createOrganization": "Crear organización",
-      "createPersonalWorkspace": "Crear espacio personal",
+      "createWorkspace": "Crear espacio de trabajo",
       "userAvatarAlt": "Avatar del usuario"
     },
     "DataTable": {

--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
@@ -10,6 +10,10 @@ import type { MemberWithOrganization } from "@/lib/clients/generated/core";
 
 import HeaderWorkspaceSwitch from "../header-workspace-switch.client";
 
+const { showCreateOrganizationModal } = vi.hoisted(() => ({
+  showCreateOrganizationModal: vi.fn(),
+}));
+
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
@@ -17,7 +21,7 @@ vi.mock("next-intl", () => ({
 vi.mock("@/hooks/use-modal", () => ({
   default: () => ({
     Component: null,
-    showModal: vi.fn(),
+    showModal: showCreateOrganizationModal,
   }),
 }));
 
@@ -42,11 +46,6 @@ const createdPersonalWorkspace = {
   ok: true as const,
   value: { workspaceId: "ws-1" },
 } satisfies Awaited<ReturnType<typeof createPersonalWorkspaceAction>>;
-
-const updatedUser = {
-  data: null,
-  error: null,
-} satisfies Awaited<ReturnType<typeof authClient.updateUser>>;
 
 const sessionUser: SessionUser = {
   id: "user-1",
@@ -159,7 +158,7 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     ).toBeInTheDocument();
   });
 
-  it("lists create personal instead of a Personal row for org-only users", async () => {
+  it("lists one create workspace action instead of split create rows", async () => {
     const user = userEvent.setup();
     render(
       <HeaderWorkspaceSwitch
@@ -174,11 +173,13 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
 
     await user.click(screen.getByRole("button", { name: /Org A/i }));
 
-    expect(screen.getByText("createPersonalWorkspace")).toBeInTheDocument();
+    expect(screen.getByText("createWorkspace")).toBeInTheDocument();
+    expect(screen.queryByText("createPersonalWorkspace")).toBeNull();
+    expect(screen.queryByText("createOrganization")).toBeNull();
     expect(screen.queryByRole("menuitem", { name: /Test User/ })).toBeNull();
   });
 
-  it("creates and activates personal when the user already has a name", async () => {
+  it("creates and activates personal after choosing Personal and Continue", async () => {
     const user = userEvent.setup();
     const onSelectWorkspace = vi.fn();
     vi.mocked(createPersonalWorkspaceAction).mockResolvedValue(
@@ -197,10 +198,35 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /Org A/i }));
-    await user.click(screen.getByText("createPersonalWorkspace"));
+    await user.click(screen.getByText("createWorkspace"));
+    await user.click(screen.getByRole("button", { name: "continue" }));
 
     expect(createPersonalWorkspaceAction).toHaveBeenCalledOnce();
     expect(onSelectWorkspace).toHaveBeenCalledWith(null);
+    expect(showCreateOrganizationModal).not.toHaveBeenCalled();
+    expect(authClient.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("opens the organization wizard after choosing Organization and Continue", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[orgMember]}
+        hasPersonalWorkspace={false}
+        activeOrganizationId="org-a"
+        isPending={false}
+        onSelectWorkspace={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Org A/i }));
+    await user.click(screen.getByText("createWorkspace"));
+    await user.click(screen.getByRole("radio", { name: /organizationTitle/ }));
+    await user.click(screen.getByRole("button", { name: "continue" }));
+
+    expect(showCreateOrganizationModal).toHaveBeenCalledOnce();
+    expect(createPersonalWorkspaceAction).not.toHaveBeenCalled();
   });
 
   it("toasts when create succeeds but activation throws", async () => {
@@ -227,7 +253,8 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /Org A/i }));
-    await user.click(screen.getByText("createPersonalWorkspace"));
+    await user.click(screen.getByText("createWorkspace"));
+    await user.click(screen.getByRole("button", { name: "continue" }));
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("personalActivateError");
@@ -236,14 +263,13 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("collects a name first when the user has none, then creates and activates", async () => {
+  it("creates personal without a name dialog when the user has no name", async () => {
     const user = userEvent.setup();
     const onSelectWorkspace = vi.fn();
     const namelessUser: SessionUser = { ...sessionUser, name: "" };
     vi.mocked(createPersonalWorkspaceAction).mockResolvedValue(
       createdPersonalWorkspace,
     );
-    vi.mocked(authClient.updateUser).mockResolvedValue(updatedUser);
 
     render(
       <HeaderWorkspaceSwitch
@@ -257,20 +283,13 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /Org A/i }));
-    await user.click(screen.getByText("createPersonalWorkspace"));
+    await user.click(screen.getByText("createWorkspace"));
 
-    expect(createPersonalWorkspaceAction).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).toBeNull();
 
-    await user.type(screen.getByRole("textbox"), "Ada Lovelace");
-    await user.click(
-      screen.getByRole("button", { name: "createPersonalWorkspace" }),
-    );
+    await user.click(screen.getByRole("button", { name: "continue" }));
 
-    await waitFor(() => {
-      expect(authClient.updateUser).toHaveBeenCalledWith({
-        name: "Ada Lovelace",
-      });
-    });
+    expect(authClient.updateUser).not.toHaveBeenCalled();
     expect(createPersonalWorkspaceAction).toHaveBeenCalledOnce();
     expect(onSelectWorkspace).toHaveBeenCalledWith(null);
   });
@@ -302,7 +321,8 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /Org A/i }));
-    await user.click(screen.getByText("createPersonalWorkspace"));
+    await user.click(screen.getByText("createWorkspace"));
+    await user.click(screen.getByRole("button", { name: "continue" }));
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("personalActivateError");
@@ -328,8 +348,35 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
 
     expect(screen.getByText("Test User")).toBeInTheDocument();
     expect(screen.getAllByText("Org A").length).toBeGreaterThan(0);
+    expect(screen.getByText("createWorkspace")).toBeInTheDocument();
+    expect(screen.queryByText("createPersonalWorkspace")).toBeNull();
+    expect(screen.queryByText("createOrganization")).toBeNull();
+  });
+
+  it("does not offer Personal when a personal workspace already exists", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[orgMember]}
+        hasPersonalWorkspace={true}
+        activeOrganizationId="org-a"
+        isPending={false}
+        onSelectWorkspace={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Org A/i }));
+    await user.click(screen.getByText("createWorkspace"));
+
+    expect(screen.queryByRole("radio", { name: /personalTitle/ })).toBeNull();
     expect(
-      screen.queryByText("createPersonalWorkspace"),
-    ).not.toBeInTheDocument();
+      screen.getByRole("radio", { name: /organizationTitle/ }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "continue" }));
+
+    expect(showCreateOrganizationModal).toHaveBeenCalledOnce();
+    expect(createPersonalWorkspaceAction).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
@@ -266,6 +266,11 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
 
     await user.click(screen.getByRole("button", { name: /Org A/i }));
     await user.click(screen.getByText("createWorkspace"));
+
+    expect(screen.getByText("personalTitle")).toBeInTheDocument();
+    expect(screen.getByText("organizationTitle")).toBeInTheDocument();
+    expect(screen.getByText("choiceHint")).toBeInTheDocument();
+
     await user.click(screen.getByRole("radio", { name: /organizationTitle/ }));
     await user.click(screen.getByRole("button", { name: "continue" }));
 

--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
@@ -201,10 +201,54 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     await user.click(screen.getByText("createWorkspace"));
     await user.click(screen.getByRole("button", { name: "continue" }));
 
-    expect(createPersonalWorkspaceAction).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(createPersonalWorkspaceAction).toHaveBeenCalledOnce();
+    });
     expect(onSelectWorkspace).toHaveBeenCalledWith(null);
     expect(showCreateOrganizationModal).not.toHaveBeenCalled();
     expect(authClient.updateUser).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("workspace-switcher-create-choice"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("toasts and keeps the choice dialog open when personal create fails", async () => {
+    const user = userEvent.setup();
+    const onSelectWorkspace = vi.fn();
+    vi.mocked(createPersonalWorkspaceAction).mockResolvedValue({
+      ok: false,
+      error: {
+        code: WorkspaceGateErrorCode.LAST_WORKSPACE,
+      },
+    } satisfies Awaited<ReturnType<typeof createPersonalWorkspaceAction>>);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <HeaderWorkspaceSwitch
+        sessionUser={sessionUser}
+        members={[orgMember]}
+        hasPersonalWorkspace={false}
+        activeOrganizationId="org-a"
+        isPending={false}
+        onSelectWorkspace={onSelectWorkspace}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Org A/i }));
+    await user.click(screen.getByText("createWorkspace"));
+    await user.click(screen.getByRole("button", { name: "continue" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("personalCreateError");
+    });
+    expect(onSelectWorkspace).not.toHaveBeenCalled();
+    expect(showCreateOrganizationModal).not.toHaveBeenCalled();
+    expect(
+      screen.getByTestId("workspace-switcher-create-choice"),
+    ).toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
   });
 
   it("opens the organization wizard after choosing Organization and Continue", async () => {
@@ -289,8 +333,10 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
 
     await user.click(screen.getByRole("button", { name: "continue" }));
 
+    await waitFor(() => {
+      expect(createPersonalWorkspaceAction).toHaveBeenCalledOnce();
+    });
     expect(authClient.updateUser).not.toHaveBeenCalled();
-    expect(createPersonalWorkspaceAction).toHaveBeenCalledOnce();
     expect(onSelectWorkspace).toHaveBeenCalledWith(null);
   });
 

--- a/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
+++ b/apps/web/src/app/(app)/components/header/__tests__/header-workspace-switch.client.test.tsx
@@ -353,7 +353,7 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     expect(screen.queryByText("createOrganization")).toBeNull();
   });
 
-  it("does not offer Personal when a personal workspace already exists", async () => {
+  it("opens the organization wizard directly when a personal workspace already exists", async () => {
     const user = userEvent.setup();
     render(
       <HeaderWorkspaceSwitch
@@ -369,14 +369,8 @@ describe("HeaderWorkspaceSwitch last-known members", () => {
     await user.click(screen.getByRole("button", { name: /Org A/i }));
     await user.click(screen.getByText("createWorkspace"));
 
-    expect(screen.queryByRole("radio", { name: /personalTitle/ })).toBeNull();
-    expect(
-      screen.getByRole("radio", { name: /organizationTitle/ }),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "continue" }));
-
     expect(showCreateOrganizationModal).toHaveBeenCalledOnce();
     expect(createPersonalWorkspaceAction).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("workspace-switcher-create-choice")).toBeNull();
   });
 });

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { SessionUser } from "@sokosumi/utils";
-import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { Check, ChevronsUpDown, Loader2, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -150,29 +150,27 @@ export default function HeaderWorkspaceSwitch({
     }
   }
 
-  async function createAndActivatePersonal(): Promise<void> {
-    const createResult = await createPersonalWorkspaceAction({});
-    if (!createResult.ok) {
-      if (
-        createResult.error.code ===
-        WorkspaceGateErrorCode.PERSONAL_WORKSPACE_ALREADY_EXISTS
-      ) {
-        await activateCreatedPersonalWorkspace();
-        return;
-      }
-      console.error("Create personal workspace failed", createResult.error);
-      toast.error(tIdentity("personalCreateError"));
-      return;
-    }
-    await activateCreatedPersonalWorkspace();
-  }
-
-  async function handleCreatePersonalWorkspace() {
-    setIsCreatingPersonal(true);
+  async function createAndActivatePersonal(): Promise<boolean> {
     try {
-      await createAndActivatePersonal();
-    } finally {
-      setIsCreatingPersonal(false);
+      const createResult = await createPersonalWorkspaceAction({});
+      if (!createResult.ok) {
+        if (
+          createResult.error.code ===
+          WorkspaceGateErrorCode.PERSONAL_WORKSPACE_ALREADY_EXISTS
+        ) {
+          await activateCreatedPersonalWorkspace();
+          return true;
+        }
+        console.error("Create personal workspace failed", createResult.error);
+        toast.error(tIdentity("personalCreateError"));
+        return false;
+      }
+      await activateCreatedPersonalWorkspace();
+      return true;
+    } catch (error) {
+      console.error("Create personal workspace failed", error);
+      toast.error(tIdentity("personalCreateError"));
+      return false;
     }
   }
 
@@ -186,13 +184,21 @@ export default function HeaderWorkspaceSwitch({
     setIsChoiceDialogOpen(true);
   }
 
-  function handleChoiceContinue() {
-    setIsChoiceDialogOpen(false);
-    if (workspaceChoice === "personal") {
-      void handleCreatePersonalWorkspace();
+  async function handleChoiceContinue() {
+    if (workspaceChoice === "organization") {
+      setIsChoiceDialogOpen(false);
+      showCreateOrganizationModal();
       return;
     }
-    showCreateOrganizationModal();
+
+    setIsCreatingPersonal(true);
+    try {
+      if (await createAndActivatePersonal()) {
+        setIsChoiceDialogOpen(false);
+      }
+    } finally {
+      setIsCreatingPersonal(false);
+    }
   }
 
   const personalWorkspace = useMemo<WorkspaceItem>(
@@ -341,6 +347,7 @@ export default function HeaderWorkspaceSwitch({
             aria-label={tIdentity("choiceLabel")}
             className="grid gap-3"
             data-testid="workspace-switcher-create-choice"
+            disabled={isCreatingPersonal}
           >
             <Label
               htmlFor="switcher-workspace-choice-personal"
@@ -390,8 +397,13 @@ export default function HeaderWorkspaceSwitch({
             <Button
               type="button"
               disabled={isCreatingPersonal}
-              onClick={handleChoiceContinue}
+              onClick={() => {
+                void handleChoiceContinue();
+              }}
             >
+              {isCreatingPersonal ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
               {tIdentity("continue")}
             </Button>
           </DialogFooter>

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -140,6 +140,9 @@ export default function HeaderWorkspaceSwitch({
   const [isCreatingPersonal, setIsCreatingPersonal] = useState(false);
   const tIdentity = useTranslations("WorkspaceGate.Identity");
   const canCreatePersonal = !hasPersonalWorkspace;
+  const effectiveChoice: WorkspaceChoice = canCreatePersonal
+    ? workspaceChoice
+    : "organization";
 
   async function activateCreatedPersonalWorkspace(): Promise<void> {
     try {
@@ -183,9 +186,8 @@ export default function HeaderWorkspaceSwitch({
   }
 
   function handleChoiceContinue() {
-    const nextChoice = canCreatePersonal ? workspaceChoice : "organization";
     setIsChoiceDialogOpen(false);
-    if (nextChoice === "personal") {
+    if (effectiveChoice === "personal") {
       void handleCreatePersonalWorkspace();
       return;
     }
@@ -329,7 +331,7 @@ export default function HeaderWorkspaceSwitch({
             </DialogTitle>
           </DialogHeader>
           <RadioGroup
-            value={canCreatePersonal ? workspaceChoice : "organization"}
+            value={effectiveChoice}
             onValueChange={(value) => {
               if (value === "personal" || value === "organization") {
                 setWorkspaceChoice(value);
@@ -367,8 +369,8 @@ export default function HeaderWorkspaceSwitch({
               htmlFor="switcher-workspace-choice-organization"
               className={cn(
                 "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
-                (canCreatePersonal ? workspaceChoice : "organization") ===
-                  "organization" && "border-primary bg-accent/30",
+                effectiveChoice === "organization" &&
+                  "border-primary bg-accent/30",
               )}
             >
               <RadioGroupItem

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -336,6 +337,7 @@ export default function HeaderWorkspaceSwitch({
             <DialogTitle>
               {tOrganizationSwitcher("createWorkspace")}
             </DialogTitle>
+            <DialogDescription>{tIdentity("choiceHint")}</DialogDescription>
           </DialogHeader>
           <RadioGroup
             value={workspaceChoice}

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
 import type { SessionUser } from "@sokosumi/utils";
 import { Check, ChevronsUpDown, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
-import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { CreateOrganizationWizard } from "@/components/organizations";
 import { Avatar } from "@/components/ui/avatar";
@@ -25,24 +23,17 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import useModal from "@/hooks/use-modal";
 import { WorkspaceGateErrorCode } from "@/lib/actions/errors";
 import { createPersonalWorkspaceAction } from "@/lib/actions/workspace-gate";
-import { authClient } from "@/lib/auth/auth.client";
 import type { MemberWithOrganization } from "@/lib/clients/generated/core";
-import { type NameFormType, nameFormSchema } from "@/lib/schemas";
 import { cn } from "@/lib/utils";
 
 import HeaderWorkspaceAvatar from "./header-workspace-avatar";
+
+type WorkspaceChoice = "personal" | "organization";
 
 interface HeaderWorkspaceSwitchProps {
   sessionUser: SessionUser;
@@ -143,33 +134,12 @@ export default function HeaderWorkspaceSwitch({
     showModal: showCreateOrganizationModal,
   } = useModal(CreateOrganizationWizard);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [isNameDialogOpen, setIsNameDialogOpen] = useState(false);
+  const [isChoiceDialogOpen, setIsChoiceDialogOpen] = useState(false);
+  const [workspaceChoice, setWorkspaceChoice] =
+    useState<WorkspaceChoice>("personal");
   const [isCreatingPersonal, setIsCreatingPersonal] = useState(false);
   const tIdentity = useTranslations("WorkspaceGate.Identity");
-  const tSchema = useTranslations("Library.Auth.Schema");
-  const nameForm = useForm<NameFormType>({
-    resolver: zodResolver(nameFormSchema(tSchema)),
-    defaultValues: { name: sessionUser.name ?? "" },
-  });
-
-  const hasDisplayName = Boolean(sessionUser.name?.trim());
-
-  async function persistDisplayName(name: string): Promise<boolean> {
-    try {
-      const updateUserResult = await authClient.updateUser({ name });
-      if (updateUserResult.error) {
-        toast.error(
-          updateUserResult.error.message ?? tIdentity("nameUpdateError"),
-        );
-        return false;
-      }
-      return true;
-    } catch (error) {
-      console.error("Create personal workspace name persist failed", error);
-      toast.error(tIdentity("nameUpdateError"));
-      return false;
-    }
-  }
+  const canCreatePersonal = !hasPersonalWorkspace;
 
   async function activateCreatedPersonalWorkspace(): Promise<void> {
     try {
@@ -198,12 +168,6 @@ export default function HeaderWorkspaceSwitch({
   }
 
   async function handleCreatePersonalWorkspace() {
-    setIsDropdownOpen(false);
-    if (!hasDisplayName) {
-      setIsNameDialogOpen(true);
-      return;
-    }
-
     setIsCreatingPersonal(true);
     try {
       await createAndActivatePersonal();
@@ -212,17 +176,20 @@ export default function HeaderWorkspaceSwitch({
     }
   }
 
-  async function handleNameDialogSubmit(values: NameFormType) {
-    setIsCreatingPersonal(true);
-    try {
-      if (!(await persistDisplayName(values.name))) {
-        return;
-      }
-      await createAndActivatePersonal();
-      setIsNameDialogOpen(false);
-    } finally {
-      setIsCreatingPersonal(false);
+  function handleOpenCreateWorkspace() {
+    setIsDropdownOpen(false);
+    setWorkspaceChoice(canCreatePersonal ? "personal" : "organization");
+    setIsChoiceDialogOpen(true);
+  }
+
+  function handleChoiceContinue() {
+    const nextChoice = canCreatePersonal ? workspaceChoice : "organization";
+    setIsChoiceDialogOpen(false);
+    if (nextChoice === "personal") {
+      void handleCreatePersonalWorkspace();
+      return;
     }
+    showCreateOrganizationModal();
   }
 
   const personalWorkspace = useMemo<WorkspaceItem>(
@@ -264,11 +231,6 @@ export default function HeaderWorkspaceSwitch({
     }
     setIsDropdownOpen(false);
     onSelectWorkspace(workspaceId);
-  };
-
-  const handleCreateOrganization = () => {
-    setIsDropdownOpen(false);
-    showCreateOrganizationModal();
   };
 
   return (
@@ -327,23 +289,10 @@ export default function HeaderWorkspaceSwitch({
               isPending={isPending || isCreatingPersonal}
               onSelect={handleWorkspaceSelect}
             />
-          ) : (
-            <DropdownMenuItem
-              className="flex cursor-pointer items-center gap-2 py-2"
-              disabled={isPending || isCreatingPersonal}
-              onClick={() => {
-                void handleCreatePersonalWorkspace();
-              }}
-            >
-              <Avatar className="bg-primary/10 flex size-6 items-center justify-center gap-2">
-                <Plus className="text-primary size-4" />
-              </Avatar>
-              <span>{tOrganizationSwitcher("createPersonalWorkspace")}</span>
-            </DropdownMenuItem>
-          )}
+          ) : null}
           {organizationWorkspaces.length > 0 ? (
             <>
-              <DropdownMenuSeparator />
+              {hasPersonalWorkspace ? <DropdownMenuSeparator /> : null}
               <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
                 {tOrganizationSwitcher("organizationsHeading")}
               </DropdownMenuLabel>
@@ -362,47 +311,90 @@ export default function HeaderWorkspaceSwitch({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="flex cursor-pointer items-center gap-2 py-2"
-            onClick={handleCreateOrganization}
+            disabled={isPending || isCreatingPersonal}
+            onClick={handleOpenCreateWorkspace}
           >
             <Avatar className="bg-primary/10 flex size-6 items-center justify-center gap-2">
               <Plus className="text-primary size-4" />
             </Avatar>
-            <span>{tOrganizationSwitcher("createOrganization")}</span>
+            <span>{tOrganizationSwitcher("createWorkspace")}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <Dialog open={isNameDialogOpen} onOpenChange={setIsNameDialogOpen}>
+      <Dialog open={isChoiceDialogOpen} onOpenChange={setIsChoiceDialogOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {tOrganizationSwitcher("createPersonalWorkspace")}
+              {tOrganizationSwitcher("createWorkspace")}
             </DialogTitle>
           </DialogHeader>
-          <Form {...nameForm}>
-            <form
-              onSubmit={nameForm.handleSubmit(handleNameDialogSubmit)}
-              className="space-y-4"
-            >
-              <FormField
-                control={nameForm.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{tIdentity("nameLabel")}</FormLabel>
-                    <FormControl>
-                      <Input {...field} autoComplete="name" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
+          <RadioGroup
+            value={canCreatePersonal ? workspaceChoice : "organization"}
+            onValueChange={(value) => {
+              if (value === "personal" || value === "organization") {
+                setWorkspaceChoice(value);
+              }
+            }}
+            aria-label={tIdentity("choiceLabel")}
+            className="grid gap-3"
+            data-testid="workspace-switcher-create-choice"
+          >
+            {canCreatePersonal ? (
+              <Label
+                htmlFor="switcher-workspace-choice-personal"
+                className={cn(
+                  "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
+                  workspaceChoice === "personal" &&
+                    "border-primary bg-accent/30",
                 )}
+              >
+                <RadioGroupItem
+                  value="personal"
+                  id="switcher-workspace-choice-personal"
+                  className="mt-0.5"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium">
+                    {tIdentity("personalTitle")}
+                  </span>
+                  <span className="text-muted-foreground block text-sm font-normal">
+                    {tIdentity("personalDescription")}
+                  </span>
+                </span>
+              </Label>
+            ) : null}
+            <Label
+              htmlFor="switcher-workspace-choice-organization"
+              className={cn(
+                "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
+                (canCreatePersonal ? workspaceChoice : "organization") ===
+                  "organization" && "border-primary bg-accent/30",
+              )}
+            >
+              <RadioGroupItem
+                value="organization"
+                id="switcher-workspace-choice-organization"
+                className="mt-0.5"
               />
-              <DialogFooter>
-                <Button type="submit" disabled={isCreatingPersonal}>
-                  {tOrganizationSwitcher("createPersonalWorkspace")}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
+              <span className="space-y-1">
+                <span className="block text-sm font-medium">
+                  {tIdentity("organizationTitle")}
+                </span>
+                <span className="text-muted-foreground block text-sm font-normal">
+                  {tIdentity("organizationDescription")}
+                </span>
+              </span>
+            </Label>
+          </RadioGroup>
+          <DialogFooter>
+            <Button
+              type="button"
+              disabled={isCreatingPersonal}
+              onClick={handleChoiceContinue}
+            >
+              {tIdentity("continue")}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>

--- a/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
+++ b/apps/web/src/app/(app)/components/header/header-workspace-switch.client.tsx
@@ -140,9 +140,6 @@ export default function HeaderWorkspaceSwitch({
   const [isCreatingPersonal, setIsCreatingPersonal] = useState(false);
   const tIdentity = useTranslations("WorkspaceGate.Identity");
   const canCreatePersonal = !hasPersonalWorkspace;
-  const effectiveChoice: WorkspaceChoice = canCreatePersonal
-    ? workspaceChoice
-    : "organization";
 
   async function activateCreatedPersonalWorkspace(): Promise<void> {
     try {
@@ -181,13 +178,17 @@ export default function HeaderWorkspaceSwitch({
 
   function handleOpenCreateWorkspace() {
     setIsDropdownOpen(false);
-    setWorkspaceChoice(canCreatePersonal ? "personal" : "organization");
+    if (!canCreatePersonal) {
+      showCreateOrganizationModal();
+      return;
+    }
+    setWorkspaceChoice("personal");
     setIsChoiceDialogOpen(true);
   }
 
   function handleChoiceContinue() {
     setIsChoiceDialogOpen(false);
-    if (effectiveChoice === "personal") {
+    if (workspaceChoice === "personal") {
       void handleCreatePersonalWorkspace();
       return;
     }
@@ -331,7 +332,7 @@ export default function HeaderWorkspaceSwitch({
             </DialogTitle>
           </DialogHeader>
           <RadioGroup
-            value={effectiveChoice}
+            value={workspaceChoice}
             onValueChange={(value) => {
               if (value === "personal" || value === "organization") {
                 setWorkspaceChoice(value);
@@ -341,35 +342,32 @@ export default function HeaderWorkspaceSwitch({
             className="grid gap-3"
             data-testid="workspace-switcher-create-choice"
           >
-            {canCreatePersonal ? (
-              <Label
-                htmlFor="switcher-workspace-choice-personal"
-                className={cn(
-                  "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
-                  workspaceChoice === "personal" &&
-                    "border-primary bg-accent/30",
-                )}
-              >
-                <RadioGroupItem
-                  value="personal"
-                  id="switcher-workspace-choice-personal"
-                  className="mt-0.5"
-                />
-                <span className="space-y-1">
-                  <span className="block text-sm font-medium">
-                    {tIdentity("personalTitle")}
-                  </span>
-                  <span className="text-muted-foreground block text-sm font-normal">
-                    {tIdentity("personalDescription")}
-                  </span>
+            <Label
+              htmlFor="switcher-workspace-choice-personal"
+              className={cn(
+                "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
+                workspaceChoice === "personal" && "border-primary bg-accent/30",
+              )}
+            >
+              <RadioGroupItem
+                value="personal"
+                id="switcher-workspace-choice-personal"
+                className="mt-0.5"
+              />
+              <span className="space-y-1">
+                <span className="block text-sm font-medium">
+                  {tIdentity("personalTitle")}
                 </span>
-              </Label>
-            ) : null}
+                <span className="text-muted-foreground block text-sm font-normal">
+                  {tIdentity("personalDescription")}
+                </span>
+              </span>
+            </Label>
             <Label
               htmlFor="switcher-workspace-choice-organization"
               className={cn(
                 "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
-                effectiveChoice === "organization" &&
+                workspaceChoice === "organization" &&
                   "border-primary bg-accent/30",
               )}
             >

--- a/apps/web/src/i18n/__tests__/message-namespaces.test.ts
+++ b/apps/web/src/i18n/__tests__/message-namespaces.test.ts
@@ -21,6 +21,13 @@ describe("message namespaces", () => {
     expect(APP_MESSAGE_PATHS).toContain("App.Account");
     expect(APP_MESSAGE_PATHS).toContain("App.Tasks");
     expect(APP_MESSAGE_PATHS).toContain("Components");
+    expect(APP_MESSAGE_PATHS).toContain("WorkspaceGate");
+  });
+
+  it("includes WorkspaceGate on app chrome bags for the switcher create dialog", () => {
+    expect(APP_SHELL_MESSAGE_PATHS).toContain("WorkspaceGate");
+    expect(HERMES_MESSAGE_PATHS).toContain("WorkspaceGate");
+    expect(ADMIN_MESSAGE_PATHS).toContain("WorkspaceGate");
   });
 
   it("builds Hermes bag from APP_SHELL + App.Hermes", () => {

--- a/apps/web/src/i18n/message-namespaces.ts
+++ b/apps/web/src/i18n/message-namespaces.ts
@@ -42,6 +42,8 @@ export const APP_SHELL_MESSAGE_PATHS = [
   // Account Legal drill reopens the banner; nested app/Hermes/Admin
   // boundaries replace the global bag, so CookieConsent must travel with them.
   "CookieConsent",
+  // Header switcher create dialog reuses WorkspaceGate.Identity cards.
+  "WorkspaceGate",
   "App.Sidebar",
   "App.Header",
   "App.Error",
@@ -72,6 +74,7 @@ export const APP_MESSAGE_PATHS = [
   "Components",
   "Library",
   "CookieConsent",
+  "WorkspaceGate",
   "notifications",
   ...appMessagePathsExcluding(APP_FEATURE_EXCLUSIONS),
 ] as const;


### PR DESCRIPTION
https://linear.app/masumi/issue/SOK-828/unify-switcher-create-into-one-workspace-action

One Create workspace action in the header switcher.
If the user has no personal workspace, opens a /setup-style
Personal vs Organization choice, then Continue.
If they already have a personal workspace, opens the organization wizard directly.
No name field. Personal create+activate and org wizard unchanged.
/setup identity onboarding unchanged.

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| Spec | `header-workspace-switch.client.tsx` | Choice cards duplicate `/setup` markup on purpose so identity onboarding stays untouched. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified “Create workspace” option to the workspace switcher.
  - Added a choice dialog for creating either a personal or organization workspace.
  - Personal workspace creation is available only when one does not already exist.
  - Organization creation opens directly when appropriate.

- **Localization**
  - Updated English, German, and Spanish workspace-creation labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->