### PR TITLE
fix(web): keep org wizard mounted after first-workspace create

### DIFF
--- a/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
+++ b/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
@@ -57,8 +57,17 @@ vi.mock("../components/workspace-gate-retry.client", () => ({
 }));
 
 vi.mock("../components/identity-onboarding-form.client", () => ({
-  IdentityOnboardingForm: ({ initialName }: { initialName: string }) => (
-    <div data-testid="identity-onboarding-form">{initialName}</div>
+  IdentityOnboardingForm: ({
+    initialName,
+    workspaceReady,
+  }: {
+    initialName: string;
+    workspaceReady: boolean;
+  }) => (
+    <div data-testid="identity-onboarding-form">
+      {initialName}
+      {workspaceReady ? "workspace-ready" : ""}
+    </div>
   ),
 }));
 
@@ -86,21 +95,7 @@ describe("WorkspaceGatePage", () => {
     getPendingOrganizationJoinTokenMock.mockResolvedValue(null);
   });
 
-  it("redirects ready users away from the gate", async () => {
-    getWorkspaceAccessMock.mockResolvedValue({
-      gate: "ready",
-      hasPersonalWorkspace: true,
-      hasOrganizationMembership: false,
-      hasPendingOrganizationInvites: false,
-    });
-
-    const { default: WorkspaceGatePage } = await import("../page");
-
-    await expect(WorkspaceGatePage()).rejects.toThrow("REDIRECT:/");
-    expect(redirectMock).toHaveBeenCalledWith("/");
-  });
-
-  it("does not bounce a ready user who is still finishing the organization wizard", async () => {
+  it("keeps a ready user on the identity form so an open wizard can survive refresh", async () => {
     getWorkspaceAccessMock.mockResolvedValue({
       gate: "ready",
       hasPersonalWorkspace: false,
@@ -110,15 +105,42 @@ describe("WorkspaceGatePage", () => {
 
     const { default: WorkspaceGatePage } = await import("../page");
 
-    const ui = await WorkspaceGatePage({
-      searchParams: Promise.resolve({ creating: "1" }),
-    });
+    const ui = await WorkspaceGatePage();
 
     expect(redirectMock).not.toHaveBeenCalled();
     expect(ui).toBeTruthy();
     const serialized = JSON.stringify(ui);
     expect(serialized).toContain("identityTitle");
     expect(serialized).toContain('"initialName":"Ada Lovelace"');
+    expect(serialized).toContain('"workspaceReady":true');
+    expect(serialized).not.toContain("pendingInvitesTitle");
+  });
+
+  it("does not swap a ready user onto the pending-invites queue", async () => {
+    getWorkspaceAccessMock.mockResolvedValue({
+      gate: "ready",
+      hasPersonalWorkspace: false,
+      hasOrganizationMembership: true,
+      hasPendingOrganizationInvites: true,
+    });
+    getMyPendingOrganizationInvitationsMock.mockResolvedValue([
+      {
+        id: "inv_1",
+        organizationId: "org_1",
+        organization: { name: "Acme", slug: "acme" },
+      },
+    ]);
+
+    const { default: WorkspaceGatePage } = await import("../page");
+    const ui = await WorkspaceGatePage();
+
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(getMyPendingOrganizationInvitationsMock).not.toHaveBeenCalled();
+    const serialized = JSON.stringify(ui);
+    expect(serialized).toContain("identityTitle");
+    expect(serialized).toContain('"workspaceReady":true');
+    expect(serialized).not.toContain("pendingInvitesTitle");
+    expect(serialized).not.toContain("Acme");
   });
 
   it("renders the identity form when workspace access is identity-onboarding", async () => {

--- a/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
+++ b/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
@@ -110,7 +110,7 @@ describe("WorkspaceGatePage", () => {
     expect(redirectMock).not.toHaveBeenCalled();
     expect(ui).toBeTruthy();
     const serialized = JSON.stringify(ui);
-    expect(serialized).toContain("identityTitle");
+    expect(serialized).not.toContain("identityTitle");
     expect(serialized).toContain('"initialName":"Ada Lovelace"');
     expect(serialized).toContain('"workspaceReady":true');
     expect(serialized).not.toContain("pendingInvitesTitle");
@@ -137,7 +137,7 @@ describe("WorkspaceGatePage", () => {
     expect(redirectMock).not.toHaveBeenCalled();
     expect(getMyPendingOrganizationInvitationsMock).not.toHaveBeenCalled();
     const serialized = JSON.stringify(ui);
-    expect(serialized).toContain("identityTitle");
+    expect(serialized).not.toContain("identityTitle");
     expect(serialized).toContain('"workspaceReady":true');
     expect(serialized).not.toContain("pendingInvitesTitle");
     expect(serialized).not.toContain("Acme");

--- a/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
+++ b/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
@@ -100,6 +100,27 @@ describe("WorkspaceGatePage", () => {
     expect(redirectMock).toHaveBeenCalledWith("/");
   });
 
+  it("does not bounce a ready user who is still finishing the organization wizard", async () => {
+    getWorkspaceAccessMock.mockResolvedValue({
+      gate: "ready",
+      hasPersonalWorkspace: false,
+      hasOrganizationMembership: true,
+      hasPendingOrganizationInvites: false,
+    });
+
+    const { default: WorkspaceGatePage } = await import("../page");
+
+    const ui = await WorkspaceGatePage({
+      searchParams: Promise.resolve({ creating: "1" }),
+    });
+
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(ui).toBeTruthy();
+    const serialized = JSON.stringify(ui);
+    expect(serialized).toContain("identityTitle");
+    expect(serialized).toContain('"initialName":"Ada Lovelace"');
+  });
+
   it("renders the identity form when workspace access is identity-onboarding", async () => {
     getWorkspaceAccessMock.mockResolvedValue({
       gate: "identity-onboarding",

--- a/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
+++ b/apps/web/src/app/(flows)/setup/__tests__/page.test.tsx
@@ -6,14 +6,7 @@ const getMyPendingOrganizationInvitationsMock = vi.fn();
 const getPendingOrganizationJoinTokenMock = vi.fn();
 const clearPendingOrganizationJoinTokenMock = vi.fn();
 const resolveOrganizationInviteLinkMock = vi.fn();
-const redirectMock = vi.fn((path: string) => {
-  throw new Error(`REDIRECT:${path}`);
-});
 const getTranslationsMock = vi.fn();
-
-vi.mock("next/navigation", () => ({
-  redirect: (path: string) => redirectMock(path),
-}));
 
 vi.mock("next-intl/server", () => ({
   getTranslations: (...args: unknown[]) => getTranslationsMock(...args),
@@ -107,7 +100,6 @@ describe("WorkspaceGatePage", () => {
 
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     expect(ui).toBeTruthy();
     const serialized = JSON.stringify(ui);
     expect(serialized).not.toContain("identityTitle");
@@ -134,7 +126,6 @@ describe("WorkspaceGatePage", () => {
     const { default: WorkspaceGatePage } = await import("../page");
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     expect(getMyPendingOrganizationInvitationsMock).not.toHaveBeenCalled();
     const serialized = JSON.stringify(ui);
     expect(serialized).not.toContain("identityTitle");
@@ -154,7 +145,6 @@ describe("WorkspaceGatePage", () => {
     const { default: WorkspaceGatePage } = await import("../page");
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     expect(ui).toBeTruthy();
     const serialized = JSON.stringify(ui);
     expect(serialized).toContain("identityTitle");
@@ -203,7 +193,6 @@ describe("WorkspaceGatePage", () => {
     const { default: WorkspaceGatePage } = await import("../page");
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     const serialized = JSON.stringify(ui);
     expect(serialized).toContain("pendingInvitesTitle");
     expect(serialized).toContain("Acme");
@@ -230,7 +219,6 @@ describe("WorkspaceGatePage", () => {
     const { default: WorkspaceGatePage } = await import("../page");
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     const serialized = JSON.stringify(ui);
     expect(serialized).toContain("pendingInvitesTitle");
     expect(serialized).toContain("Join Co");
@@ -244,7 +232,6 @@ describe("WorkspaceGatePage", () => {
     const { default: WorkspaceGatePage } = await import("../page");
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     const serialized = JSON.stringify(ui);
     expect(serialized).toContain("unavailableTitle");
     expect(serialized).toContain("unavailableBody");
@@ -260,7 +247,6 @@ describe("WorkspaceGatePage", () => {
     const { default: WorkspaceGatePage } = await import("../page");
     const ui = await WorkspaceGatePage();
 
-    expect(redirectMock).not.toHaveBeenCalled();
     const serialized = JSON.stringify(ui);
     expect(serialized).toContain("unavailableTitle");
     expect(serialized).toContain("data-workspace-gate-actions");

--- a/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
@@ -197,6 +197,7 @@ describe("IdentityOnboardingForm", () => {
     await user.click(screen.getByTestId("wizard-back"));
     expect(screen.getByTestId("workspace-gate-identity-form")).toBeTruthy();
     expect(screen.queryByTestId("create-org-wizard")).toBeNull();
+    expect(routerReplaceMock).toHaveBeenCalledWith("/setup");
   });
 
   it("keeps an edited name after Back from the organization wizard", async () => {
@@ -234,6 +235,20 @@ describe("IdentityOnboardingForm", () => {
     expect(screen.queryByTestId("create-org-wizard")).toBeNull();
     expect(createPersonalWorkspaceActionMock).not.toHaveBeenCalled();
     expect(routerReplaceMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps /setup from bouncing while the organization wizard is open", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("radio", { name: /Organization/i }));
+    await user.click(screen.getByTestId("workspace-gate-identity-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
+    });
+    expect(routerReplaceMock).toHaveBeenCalledWith("/setup?creating=1");
+    expect(routerReplaceMock).not.toHaveBeenCalledWith("/");
   });
 
   it("leaves the gate into the created organization when the wizard is ready", async () => {

--- a/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
@@ -277,6 +277,8 @@ describe("IdentityOnboardingForm", () => {
     );
 
     expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
+    expect(screen.queryByTestId("workspace-gate-identity-form")).toBeNull();
+    expect(screen.getByTestId("workspace-gate-leaving")).toBeTruthy();
     expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
@@ -109,10 +109,13 @@ const messages = {
   },
 };
 
-function renderForm(initialName = "Ada Lovelace") {
+function renderForm(initialName = "Ada Lovelace", workspaceReady = false) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
-      <IdentityOnboardingForm initialName={initialName} />
+      <IdentityOnboardingForm
+        initialName={initialName}
+        workspaceReady={workspaceReady}
+      />
     </NextIntlClientProvider>,
   );
 }
@@ -197,7 +200,7 @@ describe("IdentityOnboardingForm", () => {
     await user.click(screen.getByTestId("wizard-back"));
     expect(screen.getByTestId("workspace-gate-identity-form")).toBeTruthy();
     expect(screen.queryByTestId("create-org-wizard")).toBeNull();
-    expect(routerReplaceMock).toHaveBeenCalledWith("/setup");
+    expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
   it("keeps an edited name after Back from the organization wizard", async () => {
@@ -237,7 +240,7 @@ describe("IdentityOnboardingForm", () => {
     expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
-  it("keeps /setup from bouncing while the organization wizard is open", async () => {
+  it("does not navigate away when the organization wizard opens", async () => {
     const user = userEvent.setup();
     renderForm();
 
@@ -247,8 +250,74 @@ describe("IdentityOnboardingForm", () => {
     await waitFor(() => {
       expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
     });
-    expect(routerReplaceMock).toHaveBeenCalledWith("/setup?creating=1");
-    expect(routerReplaceMock).not.toHaveBeenCalledWith("/");
+    expect(routerReplaceMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the gate when workspace is already ready and the wizard is closed", async () => {
+    renderForm("Ada Lovelace", true);
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith("/");
+    });
+    expect(routerRefreshMock).toHaveBeenCalled();
+    expect(activateOrganizationWorkspaceMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("workspace-gate-identity-form")).toBeNull();
+  });
+
+  it("keeps the organization wizard mounted when workspace becomes ready", async () => {
+    const user = userEvent.setup();
+    const view = renderForm();
+
+    await user.click(screen.getByRole("radio", { name: /Organization/i }));
+    await user.click(screen.getByTestId("workspace-gate-identity-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
+    });
+
+    view.rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <IdentityOnboardingForm initialName="Ada Lovelace" workspaceReady />
+      </NextIntlClientProvider>,
+    );
+
+    expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
+    expect(routerReplaceMock).not.toHaveBeenCalled();
+  });
+
+  it("activates the organization before leaving when the wizard finishes after the gate is ready", async () => {
+    const user = userEvent.setup();
+    let resolveActivate: () => void = () => {};
+    activateOrganizationWorkspaceMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveActivate = resolve;
+        }),
+    );
+    const view = renderForm();
+
+    await user.click(screen.getByRole("radio", { name: /Organization/i }));
+    await user.click(screen.getByTestId("workspace-gate-identity-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
+    });
+
+    view.rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <IdentityOnboardingForm initialName="Ada Lovelace" workspaceReady />
+      </NextIntlClientProvider>,
+    );
+
+    await user.click(await screen.findByTestId("wizard-complete"));
+
+    expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org-1");
+    expect(routerReplaceMock).not.toHaveBeenCalled();
+
+    resolveActivate();
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).toHaveBeenCalledOnce();
+    });
   });
 
   it("leaves the gate into the created organization when the wizard is ready", async () => {

--- a/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
@@ -11,6 +11,7 @@ const createPersonalWorkspaceActionMock = vi.fn();
 const activateOrganizationWorkspaceMock = vi.fn();
 const routerReplaceMock = vi.fn();
 const routerRefreshMock = vi.fn();
+const locationAssignMock = vi.fn();
 
 vi.mock("sonner", () => ({
   toast: {
@@ -125,6 +126,11 @@ describe("IdentityOnboardingForm", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    locationAssignMock.mockReset();
+    vi.stubGlobal("location", {
+      ...window.location,
+      assign: locationAssignMock,
+    });
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     updateUserMock.mockResolvedValue({ error: null });
     createPersonalWorkspaceActionMock.mockResolvedValue({
@@ -136,6 +142,7 @@ describe("IdentityOnboardingForm", () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    vi.unstubAllGlobals();
   });
 
   it("prefills the display name and requires at least 2 characters", async () => {
@@ -166,7 +173,8 @@ describe("IdentityOnboardingForm", () => {
       expect(createPersonalWorkspaceActionMock).toHaveBeenCalledOnce();
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith(null);
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).toHaveBeenCalledOnce();
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).not.toHaveBeenCalled();
     });
   });
 
@@ -258,10 +266,12 @@ describe("IdentityOnboardingForm", () => {
 
     await waitFor(() => {
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
     });
-    expect(routerRefreshMock).toHaveBeenCalled();
+    expect(routerRefreshMock).not.toHaveBeenCalled();
     expect(activateOrganizationWorkspaceMock).not.toHaveBeenCalled();
     expect(screen.queryByTestId("workspace-gate-identity-form")).toBeNull();
+    expect(screen.getByTestId("workspace-gate-leaving")).toBeTruthy();
   });
 
   it("keeps the organization wizard mounted when workspace becomes ready", async () => {
@@ -316,7 +326,8 @@ describe("IdentityOnboardingForm", () => {
 
     await waitFor(() => {
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).toHaveBeenCalledOnce();
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).not.toHaveBeenCalled();
     });
   });
 
@@ -332,7 +343,8 @@ describe("IdentityOnboardingForm", () => {
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledOnce();
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org-1");
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).toHaveBeenCalledOnce();
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).not.toHaveBeenCalled();
     });
     expect(createPersonalWorkspaceActionMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("workspace-gate-identity-submit")).toBeDisabled();
@@ -373,7 +385,8 @@ describe("IdentityOnboardingForm", () => {
         "Could not switch into that organization",
       );
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).toHaveBeenCalledOnce();
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).not.toHaveBeenCalled();
     });
   });
 
@@ -438,7 +451,8 @@ describe("IdentityOnboardingForm", () => {
     await waitFor(() => {
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith(null);
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).toHaveBeenCalledOnce();
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).not.toHaveBeenCalled();
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
@@ -455,7 +469,8 @@ describe("IdentityOnboardingForm", () => {
     await waitFor(() => {
       expect(createPersonalWorkspaceActionMock).toHaveBeenCalledOnce();
       expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).toHaveBeenCalledOnce();
+      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(routerRefreshMock).not.toHaveBeenCalled();
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
@@ -9,23 +9,13 @@ const toastErrorMock = vi.fn();
 const updateUserMock = vi.fn();
 const createPersonalWorkspaceActionMock = vi.fn();
 const activateOrganizationWorkspaceMock = vi.fn();
-const routerReplaceMock = vi.fn();
-const routerRefreshMock = vi.fn();
-const locationAssignMock = vi.fn();
+const locationReplaceMock = vi.fn();
 
 vi.mock("sonner", () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),
     success: vi.fn(),
   },
-}));
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: routerReplaceMock,
-    refresh: routerRefreshMock,
-    push: vi.fn(),
-  }),
 }));
 
 vi.mock("@/lib/auth/auth.client", () => ({
@@ -126,10 +116,10 @@ describe("IdentityOnboardingForm", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    locationAssignMock.mockReset();
+    locationReplaceMock.mockReset();
     vi.stubGlobal("location", {
       ...window.location,
-      assign: locationAssignMock,
+      replace: locationReplaceMock,
     });
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     updateUserMock.mockResolvedValue({ error: null });
@@ -172,9 +162,7 @@ describe("IdentityOnboardingForm", () => {
       expect(updateUserMock).not.toHaveBeenCalled();
       expect(createPersonalWorkspaceActionMock).toHaveBeenCalledOnce();
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith(null);
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).not.toHaveBeenCalled();
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -208,7 +196,7 @@ describe("IdentityOnboardingForm", () => {
     await user.click(screen.getByTestId("wizard-back"));
     expect(screen.getByTestId("workspace-gate-identity-form")).toBeTruthy();
     expect(screen.queryByTestId("create-org-wizard")).toBeNull();
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 
   it("keeps an edited name after Back from the organization wizard", async () => {
@@ -245,7 +233,7 @@ describe("IdentityOnboardingForm", () => {
     });
     expect(screen.queryByTestId("create-org-wizard")).toBeNull();
     expect(createPersonalWorkspaceActionMock).not.toHaveBeenCalled();
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 
   it("does not navigate away when the organization wizard opens", async () => {
@@ -258,17 +246,15 @@ describe("IdentityOnboardingForm", () => {
     await waitFor(() => {
       expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
     });
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 
   it("leaves the gate when workspace is already ready and the wizard is closed", async () => {
     renderForm("Ada Lovelace", true);
 
     await waitFor(() => {
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
-    expect(routerRefreshMock).not.toHaveBeenCalled();
     expect(activateOrganizationWorkspaceMock).not.toHaveBeenCalled();
     expect(screen.queryByTestId("workspace-gate-identity-form")).toBeNull();
     expect(screen.getByTestId("workspace-gate-leaving")).toBeTruthy();
@@ -291,7 +277,7 @@ describe("IdentityOnboardingForm", () => {
     );
 
     expect(screen.getByTestId("create-org-wizard")).toBeTruthy();
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 
   it("activates the organization before leaving when the wizard finishes after the gate is ready", async () => {
@@ -320,14 +306,12 @@ describe("IdentityOnboardingForm", () => {
     await user.click(await screen.findByTestId("wizard-complete"));
 
     expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org-1");
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
 
     resolveActivate();
 
     await waitFor(() => {
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).not.toHaveBeenCalled();
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -342,9 +326,7 @@ describe("IdentityOnboardingForm", () => {
     await waitFor(() => {
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledOnce();
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org-1");
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).not.toHaveBeenCalled();
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
     expect(createPersonalWorkspaceActionMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("workspace-gate-identity-submit")).toBeDisabled();
@@ -363,7 +345,7 @@ describe("IdentityOnboardingForm", () => {
 
     await waitFor(() => {
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledTimes(2);
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
@@ -384,9 +366,7 @@ describe("IdentityOnboardingForm", () => {
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Could not switch into that organization",
       );
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).not.toHaveBeenCalled();
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -406,7 +386,7 @@ describe("IdentityOnboardingForm", () => {
       expect(toastErrorMock).toHaveBeenCalledWith("Name service down");
     });
     expect(createPersonalWorkspaceActionMock).not.toHaveBeenCalled();
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 
   it("toasts i18n copy for non-409 create errors instead of raw Core text", async () => {
@@ -432,7 +412,7 @@ describe("IdentityOnboardingForm", () => {
         message: "ECONNRESET from core-internal-host:8787",
       },
     );
-    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(locationReplaceMock).not.toHaveBeenCalled();
   });
 
   it("leaves the gate when Core reports the personal workspace already exists", async () => {
@@ -450,9 +430,7 @@ describe("IdentityOnboardingForm", () => {
 
     await waitFor(() => {
       expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith(null);
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).not.toHaveBeenCalled();
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
@@ -468,9 +446,7 @@ describe("IdentityOnboardingForm", () => {
 
     await waitFor(() => {
       expect(createPersonalWorkspaceActionMock).toHaveBeenCalledOnce();
-      expect(routerReplaceMock).toHaveBeenCalledWith("/");
-      expect(locationAssignMock).toHaveBeenCalledWith("/");
-      expect(routerRefreshMock).not.toHaveBeenCalled();
+      expect(locationReplaceMock).toHaveBeenCalledWith("/");
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { CreateOrganizationWizard } from "@/components/organizations";
@@ -31,10 +31,12 @@ type WorkspaceChoice = "personal" | "organization";
 
 interface IdentityOnboardingFormProps {
   initialName: string;
+  workspaceReady: boolean;
 }
 
 export function IdentityOnboardingForm({
   initialName,
+  workspaceReady,
 }: IdentityOnboardingFormProps) {
   const t = useTranslations("WorkspaceGate.Identity");
   const tSchema = useTranslations("Library.Auth.Schema");
@@ -50,6 +52,14 @@ export function IdentityOnboardingForm({
       name: initialName,
     },
   });
+
+  useEffect(() => {
+    if (!workspaceReady || wizardOpen || leavingGateRef.current) {
+      return;
+    }
+    router.replace("/");
+    router.refresh();
+  }, [workspaceReady, wizardOpen, router]);
 
   async function leaveGateAfterWorkspace(organizationId: string | null) {
     leavingGateRef.current = true;
@@ -139,7 +149,6 @@ export function IdentityOnboardingForm({
       if (!(await persistDisplayName(values.name))) {
         return;
       }
-      router.replace("/setup?creating=1");
       setWizardOpen(true);
     } finally {
       setSubmitting(false);
@@ -158,112 +167,114 @@ export function IdentityOnboardingForm({
   const { isSubmitting } = form.formState;
   const busy = submitting || isSubmitting;
 
+  const showIdentityFields = !workspaceReady || wizardOpen;
+
   return (
     <>
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(handleSetupSubmit)}
-          className="space-y-6"
-          data-testid="workspace-gate-identity-form"
-        >
-          <fieldset className="space-y-6" disabled={busy}>
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t("nameLabel")}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t("namePlaceholder")}
-                      autoComplete="name"
-                      data-testid="workspace-gate-identity-name"
-                      {...field}
+      {showIdentityFields ? (
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSetupSubmit)}
+            className="space-y-6"
+            data-testid="workspace-gate-identity-form"
+          >
+            <fieldset className="space-y-6" disabled={busy}>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("nameLabel")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t("namePlaceholder")}
+                        autoComplete="name"
+                        data-testid="workspace-gate-identity-name"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="space-y-3">
+                <RadioGroup
+                  value={choice}
+                  onValueChange={(value) => {
+                    if (value === "personal" || value === "organization") {
+                      setChoice(value);
+                    }
+                  }}
+                  aria-label={t("choiceLabel")}
+                  className="grid gap-3"
+                  data-testid="workspace-gate-identity-choice"
+                >
+                  <Label
+                    htmlFor="workspace-choice-personal"
+                    className={cn(
+                      "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
+                      choice === "personal" && "border-primary bg-accent/30",
+                    )}
+                  >
+                    <RadioGroupItem
+                      value="personal"
+                      id="workspace-choice-personal"
+                      className="mt-0.5"
                     />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <span className="space-y-1">
+                      <span className="block text-sm font-medium">
+                        {t("personalTitle")}
+                      </span>
+                      <span className="text-muted-foreground block text-sm font-normal">
+                        {t("personalDescription")}
+                      </span>
+                    </span>
+                  </Label>
+                  <Label
+                    htmlFor="workspace-choice-organization"
+                    className={cn(
+                      "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
+                      choice === "organization" &&
+                        "border-primary bg-accent/30",
+                    )}
+                  >
+                    <RadioGroupItem
+                      value="organization"
+                      id="workspace-choice-organization"
+                      className="mt-0.5"
+                    />
+                    <span className="space-y-1">
+                      <span className="block text-sm font-medium">
+                        {t("organizationTitle")}
+                      </span>
+                      <span className="text-muted-foreground block text-sm font-normal">
+                        {t("organizationDescription")}
+                      </span>
+                    </span>
+                  </Label>
+                </RadioGroup>
+                <p className="text-muted-foreground text-sm">
+                  {t("choiceHint")}
+                </p>
+              </div>
 
-            <div className="space-y-3">
-              <RadioGroup
-                value={choice}
-                onValueChange={(value) => {
-                  if (value === "personal" || value === "organization") {
-                    setChoice(value);
-                  }
-                }}
-                aria-label={t("choiceLabel")}
-                className="grid gap-3"
-                data-testid="workspace-gate-identity-choice"
+              <Button
+                type="submit"
+                disabled={busy}
+                className="w-full"
+                data-testid="workspace-gate-identity-submit"
               >
-                <Label
-                  htmlFor="workspace-choice-personal"
-                  className={cn(
-                    "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
-                    choice === "personal" && "border-primary bg-accent/30",
-                  )}
-                >
-                  <RadioGroupItem
-                    value="personal"
-                    id="workspace-choice-personal"
-                    className="mt-0.5"
-                  />
-                  <span className="space-y-1">
-                    <span className="block text-sm font-medium">
-                      {t("personalTitle")}
-                    </span>
-                    <span className="text-muted-foreground block text-sm font-normal">
-                      {t("personalDescription")}
-                    </span>
-                  </span>
-                </Label>
-                <Label
-                  htmlFor="workspace-choice-organization"
-                  className={cn(
-                    "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
-                    choice === "organization" && "border-primary bg-accent/30",
-                  )}
-                >
-                  <RadioGroupItem
-                    value="organization"
-                    id="workspace-choice-organization"
-                    className="mt-0.5"
-                  />
-                  <span className="space-y-1">
-                    <span className="block text-sm font-medium">
-                      {t("organizationTitle")}
-                    </span>
-                    <span className="text-muted-foreground block text-sm font-normal">
-                      {t("organizationDescription")}
-                    </span>
-                  </span>
-                </Label>
-              </RadioGroup>
-              <p className="text-muted-foreground text-sm">{t("choiceHint")}</p>
-            </div>
-
-            <Button
-              type="submit"
-              disabled={busy}
-              className="w-full"
-              data-testid="workspace-gate-identity-submit"
-            >
-              {busy ? <Loader2 className="size-4 animate-spin" /> : null}
-              {t("continue")}
-            </Button>
-          </fieldset>
-        </form>
-      </Form>
+                {busy ? <Loader2 className="size-4 animate-spin" /> : null}
+                {t("continue")}
+              </Button>
+            </fieldset>
+          </form>
+        </Form>
+      ) : null}
       <CreateOrganizationWizard
         open={wizardOpen}
-        onOpenChange={(open) => {
-          setWizardOpen(open);
-          if (!open && !leavingGateRef.current) {
-            router.replace("/setup");
-          }
-        }}
+        onOpenChange={setWizardOpen}
         onOrganizationReady={(organizationId) => {
           void leaveGateAfterWorkspace(organizationId);
         }}

--- a/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -40,7 +39,6 @@ export function IdentityOnboardingForm({
 }: IdentityOnboardingFormProps) {
   const t = useTranslations("WorkspaceGate.Identity");
   const tSchema = useTranslations("Library.Auth.Schema");
-  const router = useRouter();
   const [choice, setChoice] = useState<WorkspaceChoice>("personal");
   const [wizardOpen, setWizardOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -54,13 +52,12 @@ export function IdentityOnboardingForm({
   });
 
   const leaveToApp = useCallback(() => {
-    router.replace("/");
     // activateOrganizationWorkspace persists preferred org via a server
-    // action, which refreshes the current URL. router.refresh() after
-    // replace("/") does the same. Either one remounts /setup and cancels
-    // the leave. Hard navigation survives that refresh.
-    window.location.assign("/");
-  }, [router]);
+    // action, which refreshes the current URL. Soft router.replace +
+    // refresh remounts /setup and cancels the leave. replace (not assign)
+    // keeps /setup off the history stack so Back does not bounce-loop.
+    window.location.replace("/");
+  }, []);
 
   useEffect(() => {
     if (!workspaceReady || wizardOpen || leavingGateRef.current) {

--- a/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
@@ -171,7 +171,7 @@ export function IdentityOnboardingForm({
   const { isSubmitting } = form.formState;
   const busy = submitting || isSubmitting;
 
-  const showIdentityFields = !workspaceReady || wizardOpen;
+  const showIdentityFields = !workspaceReady;
 
   return (
     <>

--- a/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { CreateOrganizationWizard } from "@/components/organizations";
@@ -53,13 +53,21 @@ export function IdentityOnboardingForm({
     },
   });
 
+  const leaveToApp = useCallback(() => {
+    router.replace("/");
+    // activateOrganizationWorkspace persists preferred org via a server
+    // action, which refreshes the current URL. router.refresh() after
+    // replace("/") does the same. Either one remounts /setup and cancels
+    // the leave. Hard navigation survives that refresh.
+    window.location.assign("/");
+  }, [router]);
+
   useEffect(() => {
     if (!workspaceReady || wizardOpen || leavingGateRef.current) {
       return;
     }
-    router.replace("/");
-    router.refresh();
-  }, [workspaceReady, wizardOpen, router]);
+    leaveToApp();
+  }, [workspaceReady, wizardOpen, leaveToApp]);
 
   async function leaveGateAfterWorkspace(organizationId: string | null) {
     leavingGateRef.current = true;
@@ -86,8 +94,7 @@ export function IdentityOnboardingForm({
         }
       }
     }
-    router.replace("/");
-    router.refresh();
+    leaveToApp();
   }
 
   async function persistDisplayName(name: string): Promise<boolean> {
@@ -271,7 +278,14 @@ export function IdentityOnboardingForm({
             </fieldset>
           </form>
         </Form>
-      ) : null}
+      ) : (
+        <div
+          className="flex justify-center py-6"
+          data-testid="workspace-gate-leaving"
+        >
+          <Loader2 className="size-4 animate-spin" />
+        </div>
+      )}
       <CreateOrganizationWizard
         open={wizardOpen}
         onOpenChange={setWizardOpen}

--- a/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { CreateOrganizationWizard } from "@/components/organizations";
@@ -42,6 +42,7 @@ export function IdentityOnboardingForm({
   const [choice, setChoice] = useState<WorkspaceChoice>("personal");
   const [wizardOpen, setWizardOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const leavingGateRef = useRef(false);
 
   const form = useForm<NameFormType>({
     resolver: zodResolver(nameFormSchema(tSchema)),
@@ -51,6 +52,7 @@ export function IdentityOnboardingForm({
   });
 
   async function leaveGateAfterWorkspace(organizationId: string | null) {
+    leavingGateRef.current = true;
     setSubmitting(true);
     try {
       await activateOrganizationWorkspace(organizationId);
@@ -137,6 +139,7 @@ export function IdentityOnboardingForm({
       if (!(await persistDisplayName(values.name))) {
         return;
       }
+      router.replace("/setup?creating=1");
       setWizardOpen(true);
     } finally {
       setSubmitting(false);
@@ -255,7 +258,12 @@ export function IdentityOnboardingForm({
       </Form>
       <CreateOrganizationWizard
         open={wizardOpen}
-        onOpenChange={setWizardOpen}
+        onOpenChange={(open) => {
+          setWizardOpen(open);
+          if (!open && !leavingGateRef.current) {
+            router.replace("/setup");
+          }
+        }}
         onOrganizationReady={(organizationId) => {
           void leaveGateAfterWorkspace(organizationId);
         }}

--- a/apps/web/src/app/(flows)/setup/page.tsx
+++ b/apps/web/src/app/(flows)/setup/page.tsx
@@ -27,8 +27,13 @@ import {
 import { WorkspaceGateRetry } from "./components/workspace-gate-retry.client";
 import { WorkspaceGateSignOut } from "./components/workspace-gate-sign-out.client";
 
-export default async function WorkspaceGatePage() {
+export default async function WorkspaceGatePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ creating?: string }>;
+} = {}) {
   const session = await getSessionOrRedirect();
+  const creatingOrganization = (await searchParams)?.creating === "1";
 
   let gate: string | null = null;
   let workspaceAccessLoadFailed = false;
@@ -48,7 +53,11 @@ export default async function WorkspaceGatePage() {
     workspaceAccessLoadFailed = true;
   }
 
-  if (!workspaceAccessLoadFailed && isWorkspaceReady(gate)) {
+  if (
+    !workspaceAccessLoadFailed &&
+    isWorkspaceReady(gate) &&
+    !creatingOrganization
+  ) {
     redirect("/");
   }
 
@@ -57,14 +66,16 @@ export default async function WorkspaceGatePage() {
     : await loadWorkspaceGateQueueItems();
   const queueItems = queue.items;
 
-  const surface: WorkspaceGateSurface = resolveWorkspaceGateSurface({
-    workspaceAccessLoadFailed,
-    gate,
-    invitationCount: queueItems.filter((item) => item.kind === "invitation")
-      .length,
-    invitationsLoadFailed: queue.invitationsLoadFailed,
-    hasJoinLink: queueItems.some((item) => item.kind === "join"),
-  });
+  const surface: WorkspaceGateSurface = creatingOrganization
+    ? "identity-onboarding"
+    : resolveWorkspaceGateSurface({
+        workspaceAccessLoadFailed,
+        gate,
+        invitationCount: queueItems.filter((item) => item.kind === "invitation")
+          .length,
+        invitationsLoadFailed: queue.invitationsLoadFailed,
+        hasJoinLink: queueItems.some((item) => item.kind === "join"),
+      });
 
   const t = await getTranslations("WorkspaceGate");
 

--- a/apps/web/src/app/(flows)/setup/page.tsx
+++ b/apps/web/src/app/(flows)/setup/page.tsx
@@ -12,6 +12,7 @@ import { getSessionOrRedirect } from "@/lib/auth/auth.server";
 import { coreClient } from "@/lib/clients/core.client";
 import { getPendingOrganizationJoinToken } from "@/lib/pending-organization-join-cookie";
 import { organizationService, userService } from "@/lib/services";
+import { cn } from "@/lib/utils";
 import { isWorkspaceReady } from "@/lib/workspace-gate";
 import {
   resolveWorkspaceGateSurface,
@@ -91,12 +92,21 @@ export default async function WorkspaceGatePage() {
   const showPendingQueue = surface === "pending-invites";
 
   return (
-    <Card className="w-full" data-workspace-gate-page data-gate={surface}>
-      <CardHeader>
-        <CardTitle>{t(titleKey)}</CardTitle>
-        <CardDescription>{t(descriptionKey)}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+    <Card
+      className={cn(
+        "w-full",
+        workspaceReady && "border-0 bg-transparent py-0 shadow-none",
+      )}
+      data-workspace-gate-page
+      data-gate={surface}
+    >
+      {workspaceReady ? null : (
+        <CardHeader>
+          <CardTitle>{t(titleKey)}</CardTitle>
+          <CardDescription>{t(descriptionKey)}</CardDescription>
+        </CardHeader>
+      )}
+      <CardContent className={cn("space-y-4", workspaceReady && "px-0")}>
         {showIdentityForm ? (
           <IdentityOnboardingForm
             initialName={session.user.name?.trim() ?? ""}

--- a/apps/web/src/app/(flows)/setup/page.tsx
+++ b/apps/web/src/app/(flows)/setup/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import {
@@ -27,13 +26,8 @@ import {
 import { WorkspaceGateRetry } from "./components/workspace-gate-retry.client";
 import { WorkspaceGateSignOut } from "./components/workspace-gate-sign-out.client";
 
-export default async function WorkspaceGatePage({
-  searchParams,
-}: {
-  searchParams?: Promise<{ creating?: string }>;
-} = {}) {
+export default async function WorkspaceGatePage() {
   const session = await getSessionOrRedirect();
-  const creatingOrganization = (await searchParams)?.creating === "1";
 
   let gate: string | null = null;
   let workspaceAccessLoadFailed = false;
@@ -53,20 +47,19 @@ export default async function WorkspaceGatePage({
     workspaceAccessLoadFailed = true;
   }
 
-  if (
-    !workspaceAccessLoadFailed &&
-    isWorkspaceReady(gate) &&
-    !creatingOrganization
-  ) {
-    redirect("/");
-  }
+  // Org create flips the gate to ready while the wizard is still open.
+  // Stay on this page and keep the identity form mounted so client state
+  // survives the server-action refresh. The form leaves when the wizard
+  // is not open.
+  const workspaceReady = !workspaceAccessLoadFailed && isWorkspaceReady(gate);
 
-  const queue = workspaceAccessLoadFailed
-    ? { items: [] as WorkspaceGateQueueItem[], invitationsLoadFailed: false }
-    : await loadWorkspaceGateQueueItems();
+  const queue =
+    workspaceAccessLoadFailed || workspaceReady
+      ? { items: [] as WorkspaceGateQueueItem[], invitationsLoadFailed: false }
+      : await loadWorkspaceGateQueueItems();
   const queueItems = queue.items;
 
-  const surface: WorkspaceGateSurface = creatingOrganization
+  const surface: WorkspaceGateSurface = workspaceReady
     ? "identity-onboarding"
     : resolveWorkspaceGateSurface({
         workspaceAccessLoadFailed,
@@ -107,6 +100,7 @@ export default async function WorkspaceGatePage({
         {showIdentityForm ? (
           <IdentityOnboardingForm
             initialName={session.user.name?.trim() ?? ""}
+            workspaceReady={workspaceReady}
           />
         ) : showPendingQueue ? (
           <PendingInvitesQueue

--- a/apps/web/src/app/(flows)/setup/page.tsx
+++ b/apps/web/src/app/(flows)/setup/page.tsx
@@ -109,6 +109,7 @@ export default async function WorkspaceGatePage() {
       <CardContent className={cn("space-y-4", workspaceReady && "px-0")}>
         {showIdentityForm ? (
           <IdentityOnboardingForm
+            key="identity-onboarding"
             initialName={session.user.name?.trim() ?? ""}
             workspaceReady={workspaceReady}
           />


### PR DESCRIPTION
## Summary

On identity onboarding, creating an organization (name + URL) makes the workspace gate `ready`. Later wizard steps run server actions; Next then refreshes `/setup`. The page used to `redirect("/")`, which unmounted the invite screen.

`/setup` no longer redirects when the gate is ready. It keeps the identity form mounted so `wizardOpen` survives that refresh. The form leaves to `/` only when the workspace is ready and the wizard is not open.

Finish activates the organization, then hard-navigates to `/`. A server-action refresh of `/setup` (preferred-org persist) cannot cancel that leave the way `router.replace` + `router.refresh` could.

No `?creating=1`. Chat error after dismiss (Ably) is unchanged and not this bug.

## Verification

- `pnpm --filter web test src/app/(flows)/setup/__tests__/page.test.tsx src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx`
- Register a new user → Organization → fill name + website → advance to the invite step. That step stays until Finish. Finish enters the app.