### PR TITLE
feat(auth): accept all or selected setup invites

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5560,7 +5560,6 @@
       "selectItem": "{organizationName} auswählen",
       "batchError": "Konnte nicht annehmen: {names}.",
       "rejectAll": "Alle ablehnen",
-      "rejectAllHint": "Wenn du alle Einladungen ablehnst, kannst du einen eigenen ersten Workspace erstellen.",
       "acceptError": "Die Einladung konnte nicht angenommen werden.",
       "joinError": "Der Beitritt zur Organisation ist fehlgeschlagen.",
       "rejectError": "Die übrigen Einladungen konnten nicht abgelehnt werden.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5555,6 +5555,10 @@
     "Pending": {
       "accept": "Annehmen",
       "join": "Beitreten",
+      "acceptAll": "Alle annehmen",
+      "acceptSelected": "Auswahl annehmen",
+      "selectItem": "{organizationName} auswählen",
+      "batchError": "Konnte nicht annehmen: {names}.",
       "rejectAll": "Alle ablehnen",
       "rejectAllHint": "Wenn du alle Einladungen ablehnst, kannst du einen eigenen ersten Workspace erstellen.",
       "acceptError": "Die Einladung konnte nicht angenommen werden.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5555,6 +5555,10 @@
     "Pending": {
       "accept": "Accept",
       "join": "Join",
+      "acceptAll": "Accept all",
+      "acceptSelected": "Accept selected",
+      "selectItem": "Select {organizationName}",
+      "batchError": "We could not accept: {names}.",
       "rejectAll": "Reject all",
       "rejectAllHint": "Rejecting every invitation lets you create your own first workspace.",
       "acceptError": "We could not accept that invitation.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5560,7 +5560,6 @@
       "selectItem": "Select {organizationName}",
       "batchError": "We could not accept: {names}.",
       "rejectAll": "Reject all",
-      "rejectAllHint": "Rejecting every invitation lets you create your own first workspace.",
       "acceptError": "We could not accept that invitation.",
       "joinError": "We could not join that organization.",
       "rejectError": "We could not reject the remaining invitations.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5555,6 +5555,10 @@
     "Pending": {
       "accept": "Aceptar",
       "join": "Unirse",
+      "acceptAll": "Aceptar todas",
+      "acceptSelected": "Aceptar selección",
+      "selectItem": "Seleccionar {organizationName}",
+      "batchError": "No pudimos aceptar: {names}.",
       "rejectAll": "Rechazar todas",
       "rejectAllHint": "Si rechazas todas las invitaciones, podrás crear tu primer espacio de trabajo.",
       "acceptError": "No pudimos aceptar esa invitación.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5560,7 +5560,6 @@
       "selectItem": "Seleccionar {organizationName}",
       "batchError": "No pudimos aceptar: {names}.",
       "rejectAll": "Rechazar todas",
-      "rejectAllHint": "Si rechazas todas las invitaciones, podrás crear tu primer espacio de trabajo.",
       "acceptError": "No pudimos aceptar esa invitación.",
       "joinError": "No pudimos unirte a esa organización.",
       "rejectError": "No pudimos rechazar las invitaciones restantes.",

--- a/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
@@ -374,10 +374,12 @@ describe("PendingInvitesQueue", () => {
   it("puts Reject all on the right of Accept all when more than one invite is pending", () => {
     renderQueue();
 
-    expect(screen.getByTestId("workspace-gate-accept-all")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("workspace-gate-accept-selected"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-gate-accept-all")).toHaveClass(
+      "bg-secondary",
+    );
+    expect(screen.getByTestId("workspace-gate-accept-selected")).toHaveClass(
+      "bg-quinary",
+    );
     expect(screen.getByTestId("workspace-gate-reject-all")).toHaveClass(
       "ml-auto",
     );

--- a/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
@@ -85,7 +85,6 @@ const messages = {
       selectItem: "Select {organizationName}",
       batchError: "We could not accept: {names}.",
       rejectAll: "Reject all",
-      rejectAllHint: "Rejecting every invitation lets you create your own.",
       acceptError: "Accept failed",
       joinError: "Join failed",
       rejectError: "Reject failed",
@@ -327,6 +326,21 @@ describe("PendingInvitesQueue", () => {
     expect(
       screen.getByTestId("workspace-gate-accept-invitation-inv_1"),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-gate-reject-all")).not.toHaveClass(
+      "ml-auto",
+    );
+  });
+
+  it("puts Reject all on the right of Accept all when more than one invite is pending", () => {
+    renderQueue();
+
+    expect(screen.getByTestId("workspace-gate-accept-all")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("workspace-gate-accept-selected"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-gate-reject-all")).toHaveClass(
+      "ml-auto",
+    );
   });
 
   it("accepts every pending item, activates the first success, and leaves", async () => {

--- a/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
@@ -165,6 +165,46 @@ describe("PendingInvitesQueue", () => {
     expect(updateUserMock).not.toHaveBeenCalled();
   });
 
+  it("collects a name before accept-all when the user has none", async () => {
+    const user = userEvent.setup();
+    acceptInvitationMock.mockResolvedValue({
+      data: { member: { organizationId: "org_1" } },
+      error: null,
+    });
+    acceptOrganizationInviteLinkMock.mockResolvedValue({
+      ok: true,
+      value: { organizationId: "org_join", organizationSlug: "join-co" },
+    });
+    let resolveUpdate: (value: { error: null }) => void = () => {};
+    updateUserMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+
+    renderQueue("");
+    await user.type(screen.getByTestId("collect-user-name"), "Ada Lovelace");
+    await user.click(screen.getByTestId("workspace-gate-accept-all"));
+
+    await waitFor(() => {
+      expect(updateUserMock).toHaveBeenCalledWith({ name: "Ada Lovelace" });
+    });
+    expect(acceptInvitationMock).not.toHaveBeenCalled();
+    expect(acceptOrganizationInviteLinkMock).not.toHaveBeenCalled();
+
+    resolveUpdate({ error: null });
+
+    await waitFor(() => {
+      expect(acceptInvitationMock).toHaveBeenCalledWith({
+        invitationId: "inv_1",
+      });
+    });
+    expect(acceptOrganizationInviteLinkMock).toHaveBeenCalledWith({
+      token: "join_token_1",
+    });
+  });
+
   it("collects a name before accepting when the user has none", async () => {
     const user = userEvent.setup();
     acceptInvitationMock.mockResolvedValue({
@@ -436,7 +476,9 @@ describe("PendingInvitesQueue", () => {
         token: "join_token_1",
       });
     });
-    expect(toastErrorMock).toHaveBeenCalledWith("We could not accept: Acme.");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "We could not accept: Acme (seat full).",
+    );
     expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org_join");
     expect(clearPendingOrganizationJoinCookieActionMock).toHaveBeenCalledWith({
       organizationSlug: "join-co",
@@ -461,7 +503,7 @@ describe("PendingInvitesQueue", () => {
 
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalledWith(
-        "We could not accept: Acme, Join Co.",
+        "We could not accept: Acme (seat full), Join Co (expired).",
       );
     });
     expect(activateOrganizationWorkspaceMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/pending-invites-queue.test.tsx
@@ -54,6 +54,8 @@ vi.mock("@/lib/activate-organization-workspace", () => ({
     activateOrganizationWorkspaceMock(...args),
 }));
 
+import type { WorkspaceGateQueueItem } from "@/lib/workspace-gate-queue";
+
 import { PendingInvitesQueue } from "../pending-invites-queue.client";
 
 const messages = {
@@ -78,6 +80,10 @@ const messages = {
     Pending: {
       accept: "Accept",
       join: "Join",
+      acceptAll: "Accept all",
+      acceptSelected: "Accept selected",
+      selectItem: "Select {organizationName}",
+      batchError: "We could not accept: {names}.",
       rejectAll: "Reject all",
       rejectAllHint: "Rejecting every invitation lets you create your own.",
       acceptError: "Accept failed",
@@ -89,27 +95,34 @@ const messages = {
   },
 };
 
-function renderQueue(initialName = "Ada Lovelace") {
+const invitationItem: WorkspaceGateQueueItem = {
+  kind: "invitation",
+  id: "inv_1",
+  organizationId: "org_1",
+  organizationName: "Acme",
+  organizationSlug: "acme",
+};
+const secondInvitationItem: WorkspaceGateQueueItem = {
+  kind: "invitation",
+  id: "inv_2",
+  organizationId: "org_2",
+  organizationName: "Beta",
+  organizationSlug: "beta",
+};
+const joinItem: WorkspaceGateQueueItem = {
+  kind: "join",
+  token: "join_token_1",
+  organizationName: "Join Co",
+  organizationSlug: "join-co",
+};
+
+function renderQueue(
+  initialName = "Ada Lovelace",
+  items: WorkspaceGateQueueItem[] = [invitationItem, joinItem],
+) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
-      <PendingInvitesQueue
-        initialName={initialName}
-        items={[
-          {
-            kind: "invitation",
-            id: "inv_1",
-            organizationId: "org_1",
-            organizationName: "Acme",
-            organizationSlug: "acme",
-          },
-          {
-            kind: "join",
-            token: "join_token_1",
-            organizationName: "Join Co",
-            organizationSlug: "join-co",
-          },
-        ]}
-      />
+      <PendingInvitesQueue initialName={initialName} items={items} />
     </NextIntlClientProvider>,
   );
 }
@@ -297,5 +310,148 @@ describe("PendingInvitesQueue", () => {
     expect(clearPendingOrganizationJoinCookieActionMock).toHaveBeenCalledWith({
       organizationSlug: "acme",
     });
+  });
+
+  it("hides Accept all and row checkboxes on a one-item list", () => {
+    renderQueue("Ada Lovelace", [invitationItem]);
+
+    expect(
+      screen.queryByTestId("workspace-gate-accept-all"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("workspace-gate-accept-selected"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("workspace-gate-select-invitation-inv_1"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("workspace-gate-accept-invitation-inv_1"),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts every pending item, activates the first success, and leaves", async () => {
+    const user = userEvent.setup();
+    acceptInvitationMock.mockResolvedValue({
+      data: { member: { organizationId: "org_1" } },
+      error: null,
+    });
+    acceptOrganizationInviteLinkMock.mockResolvedValue({
+      ok: true,
+      value: { organizationId: "org_join", organizationSlug: "join-co" },
+    });
+
+    renderQueue();
+    await user.click(screen.getByTestId("workspace-gate-accept-all"));
+
+    await waitFor(() => {
+      expect(acceptInvitationMock).toHaveBeenCalledWith({
+        invitationId: "inv_1",
+      });
+    });
+    expect(acceptOrganizationInviteLinkMock).toHaveBeenCalledWith({
+      token: "join_token_1",
+    });
+    expect(activateOrganizationWorkspaceMock).toHaveBeenCalledTimes(1);
+    expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org_1");
+    expect(clearPendingOrganizationJoinCookieActionMock).toHaveBeenCalledWith({
+      organizationSlug: "acme",
+      acceptedJoinToken: "join_token_1",
+    });
+    expect(routerReplaceMock).toHaveBeenCalledWith("/");
+  });
+
+  it("keeps Accept selected disabled until a row is checked", async () => {
+    const user = userEvent.setup();
+    renderQueue();
+
+    expect(screen.getByTestId("workspace-gate-accept-selected")).toBeDisabled();
+
+    await user.click(
+      screen.getByTestId("workspace-gate-select-invitation-inv_1"),
+    );
+
+    expect(
+      screen.getByTestId("workspace-gate-accept-selected"),
+    ).not.toBeDisabled();
+  });
+
+  it("accepts only the selected rows", async () => {
+    const user = userEvent.setup();
+    acceptInvitationMock.mockResolvedValue({
+      data: { member: { organizationId: "org_2" } },
+      error: null,
+    });
+
+    renderQueue("Ada Lovelace", [
+      invitationItem,
+      secondInvitationItem,
+      joinItem,
+    ]);
+    await user.click(
+      screen.getByTestId("workspace-gate-select-invitation-inv_2"),
+    );
+    await user.click(screen.getByTestId("workspace-gate-accept-selected"));
+
+    await waitFor(() => {
+      expect(acceptInvitationMock).toHaveBeenCalledWith({
+        invitationId: "inv_2",
+      });
+    });
+    expect(acceptInvitationMock).toHaveBeenCalledTimes(1);
+    expect(acceptOrganizationInviteLinkMock).not.toHaveBeenCalled();
+    expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org_2");
+    expect(routerReplaceMock).toHaveBeenCalledWith("/");
+  });
+
+  it("continues the batch after a failure, toasts the failed orgs, and still leaves", async () => {
+    const user = userEvent.setup();
+    acceptInvitationMock.mockResolvedValue({
+      data: null,
+      error: { message: "seat full" },
+    });
+    acceptOrganizationInviteLinkMock.mockResolvedValue({
+      ok: true,
+      value: { organizationId: "org_join", organizationSlug: "join-co" },
+    });
+
+    renderQueue();
+    await user.click(screen.getByTestId("workspace-gate-accept-all"));
+
+    await waitFor(() => {
+      expect(acceptOrganizationInviteLinkMock).toHaveBeenCalledWith({
+        token: "join_token_1",
+      });
+    });
+    expect(toastErrorMock).toHaveBeenCalledWith("We could not accept: Acme.");
+    expect(activateOrganizationWorkspaceMock).toHaveBeenCalledWith("org_join");
+    expect(clearPendingOrganizationJoinCookieActionMock).toHaveBeenCalledWith({
+      organizationSlug: "join-co",
+      acceptedJoinToken: "join_token_1",
+    });
+    expect(routerReplaceMock).toHaveBeenCalledWith("/");
+  });
+
+  it("stays on the queue when every selected accept fails", async () => {
+    const user = userEvent.setup();
+    acceptInvitationMock.mockResolvedValue({
+      data: null,
+      error: { message: "seat full" },
+    });
+    acceptOrganizationInviteLinkMock.mockResolvedValue({
+      ok: false,
+      error: { message: "expired" },
+    });
+
+    renderQueue();
+    await user.click(screen.getByTestId("workspace-gate-accept-all"));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "We could not accept: Acme, Join Co.",
+      );
+    });
+    expect(activateOrganizationWorkspaceMock).not.toHaveBeenCalled();
+    expect(routerReplaceMock).not.toHaveBeenCalled();
+    expect(routerRefreshMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import { err, ok, type Result } from "neverthrow";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -28,6 +29,12 @@ interface PendingInvitesQueueProps {
   initialName: string;
 }
 
+interface AcceptedQueueOrganization {
+  organizationId: string;
+  organizationSlug: string;
+  acceptedJoinToken?: string;
+}
+
 export function PendingInvitesQueue({
   items,
   initialName,
@@ -38,11 +45,8 @@ export function PendingInvitesQueue({
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
     () => new Set(),
   );
-  const [retryTarget, setRetryTarget] = useState<{
-    organizationId: string;
-    organizationSlug: string;
-    acceptedJoinToken?: string;
-  } | null>(null);
+  const [retryTarget, setRetryTarget] =
+    useState<AcceptedQueueOrganization | null>(null);
   const { persistIfNeeded, NameFields } = useCollectUserName(initialName);
   const showBatchActions = shouldShowPendingInvitesBatchActions(items.length);
 
@@ -150,47 +154,32 @@ export function PendingInvitesQueue({
     });
   }
 
-  async function acceptQueueItem(item: WorkspaceGateQueueItem): Promise<
-    | {
-        ok: true;
-        value: {
-          organizationId: string;
-          organizationSlug: string;
-          acceptedJoinToken?: string;
-        };
-      }
-    | { ok: false }
-  > {
+  async function acceptQueueItem(
+    item: WorkspaceGateQueueItem,
+  ): Promise<Result<AcceptedQueueOrganization, "failed">> {
     if (item.kind === "invitation") {
       const result = await authClient.organization.acceptInvitation({
         invitationId: item.id,
       });
       if (result.error) {
-        return { ok: false };
+        return err("failed");
       }
-      return {
-        ok: true,
-        value: {
-          organizationId:
-            result.data?.member.organizationId ?? item.organizationId,
-          organizationSlug: item.organizationSlug,
-        },
-      };
+      return ok({
+        organizationId:
+          result.data?.member.organizationId ?? item.organizationId,
+        organizationSlug: item.organizationSlug,
+      });
     }
 
     const result = await acceptOrganizationInviteLink({ token: item.token });
     if (!result.ok) {
-      return { ok: false };
+      return err("failed");
     }
-    return {
-      ok: true,
-      value: {
-        organizationId: result.value.organizationId,
-        organizationSlug:
-          result.value.organizationSlug ?? item.organizationSlug,
-        acceptedJoinToken: item.token,
-      },
-    };
+    return ok({
+      organizationId: result.value.organizationId,
+      organizationSlug: result.value.organizationSlug ?? item.organizationSlug,
+      acceptedJoinToken: item.token,
+    });
   }
 
   async function handleAcceptBatch(mode: PendingInvitesBatchMode) {
@@ -206,17 +195,13 @@ export function PendingInvitesQueue({
       if (!(await persistIfNeeded())) {
         return;
       }
-      const successes: Array<{
-        organizationId: string;
-        organizationSlug: string;
-        acceptedJoinToken?: string;
-      }> = [];
+      const successes: AcceptedQueueOrganization[] = [];
       const failedNames: string[] = [];
 
       for (const item of targets) {
         try {
           const accepted = await acceptQueueItem(item);
-          if (!accepted.ok) {
+          if (accepted.isErr()) {
             failedNames.push(item.organizationName);
             continue;
           }

--- a/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
@@ -342,41 +342,41 @@ export function PendingInvitesQueue({
           {t("activateRetry")}
         </Button>
       ) : null}
-      {showBatchActions ? (
-        <div className="flex flex-wrap gap-2">
-          <Button
-            type="button"
-            disabled={busy || awaitingActivationRetry}
-            onClick={() => {
-              void handleAcceptBatch("all");
-            }}
-            data-testid="workspace-gate-accept-all"
-          >
-            {busyKey === "accept-all" ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            {t("acceptAll")}
-          </Button>
-          <Button
-            type="button"
-            disabled={busy || awaitingActivationRetry || selectedCount === 0}
-            onClick={() => {
-              void handleAcceptBatch("selected");
-            }}
-            data-testid="workspace-gate-accept-selected"
-          >
-            {busyKey === "accept-selected" ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            {t("acceptSelected")}
-          </Button>
-        </div>
-      ) : null}
-      <div className="space-y-2">
-        <p className="text-muted-foreground text-sm">{t("rejectAllHint")}</p>
+      <div className="flex flex-wrap items-center gap-2">
+        {showBatchActions ? (
+          <>
+            <Button
+              type="button"
+              disabled={busy || awaitingActivationRetry}
+              onClick={() => {
+                void handleAcceptBatch("all");
+              }}
+              data-testid="workspace-gate-accept-all"
+            >
+              {busyKey === "accept-all" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              {t("acceptAll")}
+            </Button>
+            <Button
+              type="button"
+              disabled={busy || awaitingActivationRetry || selectedCount === 0}
+              onClick={() => {
+                void handleAcceptBatch("selected");
+              }}
+              data-testid="workspace-gate-accept-selected"
+            >
+              {busyKey === "accept-selected" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              {t("acceptSelected")}
+            </Button>
+          </>
+        ) : null}
         <Button
           type="button"
           variant="outline"
+          className={showBatchActions ? "ml-auto" : undefined}
           disabled={busy || awaitingActivationRetry}
           onClick={() => {
             void handleRejectAll();

--- a/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
@@ -8,29 +8,20 @@ import { toast } from "sonner";
 
 import { useCollectUserName } from "@/components/auth/collect-user-name";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { acceptOrganizationInviteLink } from "@/lib/actions";
 import { clearPendingOrganizationJoinCookieAction } from "@/lib/actions/workspace-gate";
 import { activateOrganizationWorkspaceWithRetry } from "@/lib/activate-organization-workspace";
 import { authClient } from "@/lib/auth/auth.client";
-
-export interface WorkspaceGateQueueInvitation {
-  kind: "invitation";
-  id: string;
-  organizationId: string;
-  organizationName: string;
-  organizationSlug: string;
-}
-
-export interface WorkspaceGateQueueJoinLink {
-  kind: "join";
-  token: string;
-  organizationName: string;
-  organizationSlug: string;
-}
-
-export type WorkspaceGateQueueItem =
-  | WorkspaceGateQueueInvitation
-  | WorkspaceGateQueueJoinLink;
+import {
+  itemsForBatchAccept,
+  type PendingInvitesBatchMode,
+  queueItemKey,
+  shouldShowPendingInvitesBatchActions,
+  type WorkspaceGateQueueInvitation,
+  type WorkspaceGateQueueItem,
+  type WorkspaceGateQueueJoinLink,
+} from "@/lib/workspace-gate-queue";
 
 interface PendingInvitesQueueProps {
   items: WorkspaceGateQueueItem[];
@@ -44,12 +35,16 @@ export function PendingInvitesQueue({
   const t = useTranslations("WorkspaceGate.Pending");
   const router = useRouter();
   const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [retryTarget, setRetryTarget] = useState<{
     organizationId: string;
     organizationSlug: string;
     acceptedJoinToken?: string;
   } | null>(null);
   const { persistIfNeeded, NameFields } = useCollectUserName(initialName);
+  const showBatchActions = shouldShowPendingInvitesBatchActions(items.length);
 
   async function leaveGateAfterOrganization(input: {
     organizationId: string;
@@ -143,6 +138,121 @@ export function PendingInvitesQueue({
     }
   }
 
+  function handleToggleSelected(key: string, checked: boolean) {
+    setSelectedKeys((previous) => {
+      const next = new Set(previous);
+      if (checked) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  }
+
+  async function acceptQueueItem(item: WorkspaceGateQueueItem): Promise<
+    | {
+        ok: true;
+        value: {
+          organizationId: string;
+          organizationSlug: string;
+          acceptedJoinToken?: string;
+        };
+      }
+    | { ok: false }
+  > {
+    if (item.kind === "invitation") {
+      const result = await authClient.organization.acceptInvitation({
+        invitationId: item.id,
+      });
+      if (result.error) {
+        return { ok: false };
+      }
+      return {
+        ok: true,
+        value: {
+          organizationId:
+            result.data?.member.organizationId ?? item.organizationId,
+          organizationSlug: item.organizationSlug,
+        },
+      };
+    }
+
+    const result = await acceptOrganizationInviteLink({ token: item.token });
+    if (!result.ok) {
+      return { ok: false };
+    }
+    return {
+      ok: true,
+      value: {
+        organizationId: result.value.organizationId,
+        organizationSlug:
+          result.value.organizationSlug ?? item.organizationSlug,
+        acceptedJoinToken: item.token,
+      },
+    };
+  }
+
+  async function handleAcceptBatch(mode: PendingInvitesBatchMode) {
+    if (busyKey) {
+      return;
+    }
+    const targets = itemsForBatchAccept(items, mode, selectedKeys);
+    if (targets.length === 0) {
+      return;
+    }
+    setBusyKey(mode === "all" ? "accept-all" : "accept-selected");
+    try {
+      if (!(await persistIfNeeded())) {
+        return;
+      }
+      const successes: Array<{
+        organizationId: string;
+        organizationSlug: string;
+        acceptedJoinToken?: string;
+      }> = [];
+      const failedNames: string[] = [];
+
+      for (const item of targets) {
+        try {
+          const accepted = await acceptQueueItem(item);
+          if (!accepted.ok) {
+            failedNames.push(item.organizationName);
+            continue;
+          }
+          successes.push(accepted.value);
+        } catch (error) {
+          console.error("Workspace gate accept item failed", error);
+          failedNames.push(item.organizationName);
+        }
+      }
+
+      if (failedNames.length > 0) {
+        toast.error(t("batchError", { names: failedNames.join(", ") }));
+      }
+
+      const firstSuccess = successes[0];
+      if (!firstSuccess) {
+        router.refresh();
+        return;
+      }
+
+      const acceptedJoinToken = successes.find(
+        (success) => success.acceptedJoinToken,
+      )?.acceptedJoinToken;
+      await leaveGateAfterOrganization({
+        organizationId: firstSuccess.organizationId,
+        organizationSlug: firstSuccess.organizationSlug,
+        acceptedJoinToken: firstSuccess.acceptedJoinToken ?? acceptedJoinToken,
+      });
+    } catch (error) {
+      console.error("Workspace gate accept batch failed", error);
+      toast.error(t("acceptError"));
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
   async function handleRejectAll() {
     if (busyKey) {
       return;
@@ -174,24 +284,44 @@ export function PendingInvitesQueue({
 
   const busy = busyKey !== null;
   const awaitingActivationRetry = retryTarget !== null;
+  const selectedCount = itemsForBatchAccept(
+    items,
+    "selected",
+    selectedKeys,
+  ).length;
 
   return (
     <div className="space-y-4" data-testid="workspace-gate-pending-queue">
       <NameFields disabled={busy || awaitingActivationRetry} />
       <ul className="space-y-3">
         {items.map((item) => {
-          const key = item.kind === "invitation" ? item.id : item.token;
+          const key = queueItemKey(item);
           const itemBusy = busyKey === key;
           return (
             <li
               key={`${item.kind}:${key}`}
               className="border-input flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
             >
-              <div className="min-w-0">
-                <p className="text-sm font-medium">{item.organizationName}</p>
-                <p className="text-muted-foreground truncate text-sm">
-                  {item.organizationSlug}
-                </p>
+              <div className="flex min-w-0 items-center gap-3">
+                {showBatchActions ? (
+                  <Checkbox
+                    checked={selectedKeys.has(key)}
+                    disabled={busy || awaitingActivationRetry}
+                    onCheckedChange={(checked) => {
+                      handleToggleSelected(key, checked === true);
+                    }}
+                    aria-label={t("selectItem", {
+                      organizationName: item.organizationName,
+                    })}
+                    data-testid={`workspace-gate-select-${item.kind}-${key}`}
+                  />
+                ) : null}
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">{item.organizationName}</p>
+                  <p className="text-muted-foreground truncate text-sm">
+                    {item.organizationSlug}
+                  </p>
+                </div>
               </div>
               <Button
                 type="button"
@@ -226,6 +356,36 @@ export function PendingInvitesQueue({
           ) : null}
           {t("activateRetry")}
         </Button>
+      ) : null}
+      {showBatchActions ? (
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            disabled={busy || awaitingActivationRetry}
+            onClick={() => {
+              void handleAcceptBatch("all");
+            }}
+            data-testid="workspace-gate-accept-all"
+          >
+            {busyKey === "accept-all" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            {t("acceptAll")}
+          </Button>
+          <Button
+            type="button"
+            disabled={busy || awaitingActivationRetry || selectedCount === 0}
+            onClick={() => {
+              void handleAcceptBatch("selected");
+            }}
+            data-testid="workspace-gate-accept-selected"
+          >
+            {busyKey === "accept-selected" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            {t("acceptSelected")}
+          </Button>
+        </div>
       ) : null}
       <div className="space-y-2">
         <p className="text-muted-foreground text-sm">{t("rejectAllHint")}</p>

--- a/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
@@ -332,6 +332,7 @@ export function PendingInvitesQueue({
             </Button>
             <Button
               type="button"
+              variant="secondary"
               disabled={busy || awaitingActivationRetry || selectedCount === 0}
               onClick={() => {
                 void handleAcceptBatch("selected");

--- a/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/pending-invites-queue.client.tsx
@@ -19,9 +19,7 @@ import {
   type PendingInvitesBatchMode,
   queueItemKey,
   shouldShowPendingInvitesBatchActions,
-  type WorkspaceGateQueueInvitation,
   type WorkspaceGateQueueItem,
-  type WorkspaceGateQueueJoinLink,
 } from "@/lib/workspace-gate-queue";
 
 interface PendingInvitesQueueProps {
@@ -33,6 +31,13 @@ interface AcceptedQueueOrganization {
   organizationId: string;
   organizationSlug: string;
   acceptedJoinToken?: string;
+}
+
+function failedQueueItemLabel(
+  organizationName: string,
+  reason: string,
+): string {
+  return `${organizationName} (${reason})`;
 }
 
 export function PendingInvitesQueue({
@@ -84,59 +89,52 @@ export function PendingInvitesQueue({
     }
   }
 
-  async function handleAcceptInvitation(item: WorkspaceGateQueueInvitation) {
-    if (busyKey) {
-      return;
-    }
-    setBusyKey(item.id);
-    try {
-      if (!(await persistIfNeeded())) {
-        return;
-      }
+  async function acceptQueueItem(
+    item: WorkspaceGateQueueItem,
+  ): Promise<Result<AcceptedQueueOrganization, string>> {
+    if (item.kind === "invitation") {
       const result = await authClient.organization.acceptInvitation({
         invitationId: item.id,
       });
       if (result.error) {
-        toast.error(result.error.message ?? t("acceptError"));
-        return;
+        return err(result.error.message ?? t("acceptError"));
       }
-      const organizationId =
-        result.data?.member.organizationId ?? item.organizationId;
-      await leaveGateAfterOrganization({
-        organizationId,
+      return ok({
+        organizationId:
+          result.data?.member.organizationId ?? item.organizationId,
         organizationSlug: item.organizationSlug,
       });
-    } catch (error) {
-      console.error("Workspace gate accept invitation failed", error);
-      toast.error(t("acceptError"));
-    } finally {
-      setBusyKey(null);
     }
+
+    const result = await acceptOrganizationInviteLink({ token: item.token });
+    if (!result.ok) {
+      return err(result.error.message ?? t("joinError"));
+    }
+    return ok({
+      organizationId: result.value.organizationId,
+      organizationSlug: result.value.organizationSlug ?? item.organizationSlug,
+      acceptedJoinToken: item.token,
+    });
   }
 
-  async function handleJoin(item: WorkspaceGateQueueJoinLink) {
+  async function handleAcceptItem(item: WorkspaceGateQueueItem) {
     if (busyKey) {
       return;
     }
-    setBusyKey(item.token);
+    setBusyKey(queueItemKey(item));
     try {
       if (!(await persistIfNeeded())) {
         return;
       }
-      const result = await acceptOrganizationInviteLink({ token: item.token });
-      if (!result.ok) {
-        toast.error(result.error.message ?? t("joinError"));
+      const accepted = await acceptQueueItem(item);
+      if (accepted.isErr()) {
+        toast.error(accepted.error);
         return;
       }
-      await leaveGateAfterOrganization({
-        organizationId: result.value.organizationId,
-        organizationSlug:
-          result.value.organizationSlug ?? item.organizationSlug,
-        acceptedJoinToken: item.token,
-      });
+      await leaveGateAfterOrganization(accepted.value);
     } catch (error) {
-      console.error("Workspace gate join failed", error);
-      toast.error(t("joinError"));
+      console.error("Workspace gate accept item failed", error);
+      toast.error(item.kind === "join" ? t("joinError") : t("acceptError"));
     } finally {
       setBusyKey(null);
     }
@@ -151,34 +149,6 @@ export function PendingInvitesQueue({
         next.delete(key);
       }
       return next;
-    });
-  }
-
-  async function acceptQueueItem(
-    item: WorkspaceGateQueueItem,
-  ): Promise<Result<AcceptedQueueOrganization, "failed">> {
-    if (item.kind === "invitation") {
-      const result = await authClient.organization.acceptInvitation({
-        invitationId: item.id,
-      });
-      if (result.error) {
-        return err("failed");
-      }
-      return ok({
-        organizationId:
-          result.data?.member.organizationId ?? item.organizationId,
-        organizationSlug: item.organizationSlug,
-      });
-    }
-
-    const result = await acceptOrganizationInviteLink({ token: item.token });
-    if (!result.ok) {
-      return err("failed");
-    }
-    return ok({
-      organizationId: result.value.organizationId,
-      organizationSlug: result.value.organizationSlug ?? item.organizationSlug,
-      acceptedJoinToken: item.token,
     });
   }
 
@@ -202,13 +172,20 @@ export function PendingInvitesQueue({
         try {
           const accepted = await acceptQueueItem(item);
           if (accepted.isErr()) {
-            failedNames.push(item.organizationName);
+            failedNames.push(
+              failedQueueItemLabel(item.organizationName, accepted.error),
+            );
             continue;
           }
           successes.push(accepted.value);
         } catch (error) {
           console.error("Workspace gate accept item failed", error);
-          failedNames.push(item.organizationName);
+          failedNames.push(
+            failedQueueItemLabel(
+              item.organizationName,
+              item.kind === "join" ? t("joinError") : t("acceptError"),
+            ),
+          );
         }
       }
 
@@ -222,13 +199,12 @@ export function PendingInvitesQueue({
         return;
       }
 
-      const acceptedJoinToken = successes.find(
-        (success) => success.acceptedJoinToken,
-      )?.acceptedJoinToken;
       await leaveGateAfterOrganization({
         organizationId: firstSuccess.organizationId,
         organizationSlug: firstSuccess.organizationSlug,
-        acceptedJoinToken: firstSuccess.acceptedJoinToken ?? acceptedJoinToken,
+        acceptedJoinToken: successes.find(
+          (success) => success.acceptedJoinToken,
+        )?.acceptedJoinToken,
       });
     } catch (error) {
       console.error("Workspace gate accept batch failed", error);
@@ -312,11 +288,7 @@ export function PendingInvitesQueue({
                 type="button"
                 disabled={busy || awaitingActivationRetry}
                 onClick={() => {
-                  if (item.kind === "invitation") {
-                    void handleAcceptInvitation(item);
-                    return;
-                  }
-                  void handleJoin(item);
+                  void handleAcceptItem(item);
                 }}
                 data-testid={`workspace-gate-accept-${item.kind}-${key}`}
               >

--- a/apps/web/src/app/(flows)/setup/page.tsx
+++ b/apps/web/src/app/(flows)/setup/page.tsx
@@ -18,14 +18,12 @@ import {
   isJoinLinkDuplicateOfInvitation,
   pendingInvitesDescriptionKey,
   resolveWorkspaceGateSurface,
+  type WorkspaceGateQueueItem,
   type WorkspaceGateSurface,
 } from "@/lib/workspace-gate-queue";
 
 import { IdentityOnboardingForm } from "./components/identity-onboarding-form.client";
-import {
-  PendingInvitesQueue,
-  type WorkspaceGateQueueItem,
-} from "./components/pending-invites-queue.client";
+import { PendingInvitesQueue } from "./components/pending-invites-queue.client";
 import { WorkspaceGateRetry } from "./components/workspace-gate-retry.client";
 import { WorkspaceGateSignOut } from "./components/workspace-gate-sign-out.client";
 

--- a/apps/web/src/lib/__tests__/workspace-gate-queue.test.ts
+++ b/apps/web/src/lib/__tests__/workspace-gate-queue.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   isJoinLinkDuplicateOfInvitation,
+  itemsForBatchAccept,
   pendingInvitesDescriptionKey,
+  queueItemKey,
   resolveWorkspaceGateSurface,
+  shouldShowPendingInvitesBatchActions,
   shouldShowPendingInvitesQueue,
 } from "../workspace-gate-queue";
 
@@ -91,6 +94,67 @@ describe("pendingInvitesDescriptionKey", () => {
         hasJoinLink: true,
       }),
     ).toBe("pendingInvitesDescriptionBoth");
+  });
+});
+
+const invitationA = {
+  kind: "invitation" as const,
+  id: "inv_1",
+  organizationId: "org_1",
+  organizationName: "Acme",
+  organizationSlug: "acme",
+};
+const invitationB = {
+  kind: "invitation" as const,
+  id: "inv_2",
+  organizationId: "org_2",
+  organizationName: "Beta",
+  organizationSlug: "beta",
+};
+const joinLink = {
+  kind: "join" as const,
+  token: "join_token_1",
+  organizationName: "Join Co",
+  organizationSlug: "join-co",
+};
+
+describe("queueItemKey", () => {
+  it("uses invitation id and join token", () => {
+    expect(queueItemKey(invitationA)).toBe("inv_1");
+    expect(queueItemKey(joinLink)).toBe("join_token_1");
+  });
+});
+
+describe("shouldShowPendingInvitesBatchActions", () => {
+  it("hides Accept all on a one-item list", () => {
+    expect(shouldShowPendingInvitesBatchActions(1)).toBe(false);
+    expect(shouldShowPendingInvitesBatchActions(0)).toBe(false);
+  });
+
+  it("shows Accept all when more than one invite is pending", () => {
+    expect(shouldShowPendingInvitesBatchActions(2)).toBe(true);
+  });
+});
+
+describe("itemsForBatchAccept", () => {
+  const items = [invitationA, invitationB, joinLink];
+
+  it("returns every item for accept-all, including the join link", () => {
+    expect(itemsForBatchAccept(items, "all", new Set())).toEqual(items);
+  });
+
+  it("returns only selected items in queue order", () => {
+    expect(
+      itemsForBatchAccept(
+        items,
+        "selected",
+        new Set(["inv_2", "join_token_1"]),
+      ),
+    ).toEqual([invitationB, joinLink]);
+  });
+
+  it("returns an empty list when nothing is selected", () => {
+    expect(itemsForBatchAccept(items, "selected", new Set())).toEqual([]);
   });
 });
 

--- a/apps/web/src/lib/workspace-gate-queue.ts
+++ b/apps/web/src/lib/workspace-gate-queue.ts
@@ -1,9 +1,52 @@
+export interface WorkspaceGateQueueInvitation {
+  kind: "invitation";
+  id: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+}
+
+export interface WorkspaceGateQueueJoinLink {
+  kind: "join";
+  token: string;
+  organizationName: string;
+  organizationSlug: string;
+}
+
+export type WorkspaceGateQueueItem =
+  | WorkspaceGateQueueInvitation
+  | WorkspaceGateQueueJoinLink;
+
+export type PendingInvitesBatchMode = "all" | "selected";
+
 /** Invitation row wins when a recovered join cookie points at the same org. */
 export function isJoinLinkDuplicateOfInvitation(
   invitationSlugs: readonly string[],
   joinSlug: string,
 ): boolean {
   return invitationSlugs.includes(joinSlug);
+}
+
+export function queueItemKey(item: WorkspaceGateQueueItem): string {
+  return item.kind === "invitation" ? item.id : item.token;
+}
+
+/** Accept all / Accept selected only when more than one invite is pending. */
+export function shouldShowPendingInvitesBatchActions(
+  itemCount: number,
+): boolean {
+  return itemCount > 1;
+}
+
+export function itemsForBatchAccept(
+  items: readonly WorkspaceGateQueueItem[],
+  mode: PendingInvitesBatchMode,
+  selectedKeys: ReadonlySet<string>,
+): WorkspaceGateQueueItem[] {
+  if (mode === "all") {
+    return [...items];
+  }
+  return items.filter((item) => selectedKeys.has(queueItemKey(item)));
 }
 
 /**


### PR DESCRIPTION
https://linear.app/masumi/issue/SOK-826/accept-all-or-selected-pending-invitations-on-setup

- `/setup` pending queue with 2+ items gets Accept all, row checkboxes, and Accept selected
- One-item list stays a single Accept/Join; Reject all is unchanged
- Join-link rows are included in select / accept-all via the existing join path
- Sequential accept continues after a failure and toasts the failed org names
- First successful org becomes the active workspace, then the user enters Sokosumi

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| smell | `pending-invites-queue.client.tsx` `handleAcceptInvitation` / `handleJoin` | Per-row accept still duplicates batch helper so row-level error copy stays specific |