### PR TITLE
fix(auth): keep credential submit spinner until navigation

### DIFF
--- a/apps/web/src/app/(auth)/components/form/submit-button.tsx
+++ b/apps/web/src/app/(auth)/components/form/submit-button.tsx
@@ -4,30 +4,44 @@ import { Loader2 } from "lucide-react";
 import type { ComponentProps } from "react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type ButtonProps = ComponentProps<typeof Button>;
 
 interface SubmitButtonProps extends Omit<ButtonProps, "form"> {
   isSubmitting: boolean;
   label: string;
+  spinnerPosition?: "inline" | "start";
 }
 
 export function SubmitButton({
   isSubmitting,
   label,
   className,
+  spinnerPosition = "inline",
   ...props
 }: SubmitButtonProps) {
+  const isStart = spinnerPosition === "start";
+
   return (
     <Button
       type="submit"
       variant="primary"
-      className={className}
+      className={cn(isStart && "relative", className)}
       disabled={isSubmitting}
       {...props}
     >
-      {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-      {label}
+      {isSubmitting && (
+        <Loader2
+          aria-hidden="true"
+          className={
+            isStart
+              ? "absolute top-1/2 left-4 size-4 -translate-y-1/2 animate-spin"
+              : "mr-2 h-4 w-4 animate-spin"
+          }
+        />
+      )}
+      {isStart ? <span className="w-full text-center">{label}</span> : label}
     </Button>
   );
 }

--- a/apps/web/src/app/(auth)/components/form/submit-button.tsx
+++ b/apps/web/src/app/(auth)/components/form/submit-button.tsx
@@ -25,11 +25,11 @@ export function SubmitButton({
 
   return (
     <Button
+      {...props}
       type="submit"
       variant="primary"
       className={cn(isStart && "relative", className)}
-      disabled={isSubmitting}
-      {...props}
+      disabled={isSubmitting || Boolean(props.disabled)}
     >
       {isSubmitting && (
         <Loader2
@@ -37,7 +37,7 @@ export function SubmitButton({
           className={
             isStart
               ? "absolute top-1/2 left-4 size-4 -translate-y-1/2 animate-spin"
-              : "mr-2 h-4 w-4 animate-spin"
+              : "mr-2 size-4 animate-spin"
           }
         />
       )}

--- a/apps/web/src/app/(auth)/signin/components/__tests__/form.test.tsx
+++ b/apps/web/src/app/(auth)/signin/components/__tests__/form.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import SignInForm from "../form";
 
@@ -84,6 +92,25 @@ vi.mock("@/lib/auth/auth.utils", async () => {
 });
 
 describe("SignInForm", () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        href: "http://localhost/",
+        origin: "http://localhost",
+      } as Location,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
   beforeEach(() => {
     mockReplace.mockReset();
     mockSignInEmail.mockReset();
@@ -91,6 +118,7 @@ describe("SignInForm", () => {
     mockWaitForAuthSession.mockReset();
     mockWaitForAuthSession.mockResolvedValue(undefined);
     mockSearchParams = new URLSearchParams();
+    window.location.href = "http://localhost/";
   });
 
   async function submitValidSignInForm() {
@@ -266,13 +294,39 @@ describe("SignInForm", () => {
 
     await submitValidSignInForm();
 
+    const submitButton = screen.getByRole("button", { name: "submit" });
+
     await waitFor(() => {
-      expect(mockSignInEmail).toHaveBeenCalledTimes(1);
+      expect(submitButton).toBeEnabled();
+    });
+
+    expect(submitButton.querySelector("svg.animate-spin")).toBeNull();
+  });
+
+  it("keeps a left-edge submit spinner until oauth redirect navigation", async () => {
+    mockSignInEmail.mockResolvedValue({
+      data: {
+        redirect: true,
+        url: "/auth/oauth2/authorize?client_id=test-client",
+      },
+      error: null,
+    });
+
+    render(<SignInForm />);
+
+    await submitValidSignInForm();
+
+    await waitFor(() => {
+      expect(window.location.href).toContain(
+        "/auth/oauth2/authorize?client_id=test-client",
+      );
     });
 
     const submitButton = screen.getByRole("button", { name: "submit" });
+    const spinner = submitButton.querySelector("svg.animate-spin");
 
-    expect(submitButton).toBeEnabled();
-    expect(submitButton.querySelector("svg.animate-spin")).toBeNull();
+    expect(submitButton).toBeDisabled();
+    expect(spinner).not.toBeNull();
+    expect(spinner).toHaveClass("absolute", "left-4");
   });
 });

--- a/apps/web/src/app/(auth)/signin/components/__tests__/form.test.tsx
+++ b/apps/web/src/app/(auth)/signin/components/__tests__/form.test.tsx
@@ -228,4 +228,51 @@ describe("SignInForm", () => {
       );
     });
   });
+
+  it("keeps a left-edge submit spinner after credential login succeeds", async () => {
+    mockSignInEmail.mockResolvedValue({
+      data: {},
+      error: null,
+    });
+
+    render(<SignInForm />);
+
+    await submitValidSignInForm();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole("button", { name: "submit" });
+    const spinner = submitButton.querySelector("svg.animate-spin");
+
+    expect(submitButton).toBeDisabled();
+    expect(spinner).not.toBeNull();
+    expect(spinner).toHaveClass(
+      "absolute",
+      "top-1/2",
+      "left-4",
+      "-translate-y-1/2",
+    );
+  });
+
+  it("releases the submit spinner after credential login fails", async () => {
+    mockSignInEmail.mockResolvedValue({
+      data: null,
+      error: { message: "Invalid credentials" },
+    });
+
+    render(<SignInForm />);
+
+    await submitValidSignInForm();
+
+    await waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole("button", { name: "submit" });
+
+    expect(submitButton).toBeEnabled();
+    expect(submitButton.querySelector("svg.animate-spin")).toBeNull();
+  });
 });

--- a/apps/web/src/app/(auth)/signin/components/form.tsx
+++ b/apps/web/src/app/(auth)/signin/components/form.tsx
@@ -3,17 +3,15 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as Sentry from "@sentry/nextjs";
 import { track } from "@vercel/analytics";
-import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
-import { AuthForm } from "@/auth/components/form";
+import { AuthForm, SubmitButton } from "@/auth/components/form";
 import { signInFormData } from "@/auth/signin/data";
-import { Button } from "@/components/ui/button";
 import { AuthErrorCode } from "@/lib/actions";
 import { authClient, signIn } from "@/lib/auth/auth.client";
 import {
@@ -42,6 +40,7 @@ export default function SignInForm({
 }: SignInFormProps) {
   const t = useTranslations("Auth.Pages.SignIn.Form");
   const loginAreaFormStart = useRef(false);
+  const [isLeaving, setIsLeaving] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
   const effectiveReturnUrl = useMemo(
@@ -102,6 +101,7 @@ export default function SignInForm({
 
     const oauthRedirect = getAuthOAuthRedirect(result.data);
     if (oauthRedirect.redirect && oauthRedirect.redirectUrl) {
+      setIsLeaving(true);
       window.location.href = oauthRedirect.redirectUrl;
       return;
     }
@@ -116,6 +116,7 @@ export default function SignInForm({
 
     fireGTMEvent.signIn("credential");
     toast.success(t("success"));
+    setIsLeaving(true);
     router.replace(normalizeAuthReturnUrl(effectiveReturnUrl));
   };
 
@@ -144,6 +145,7 @@ export default function SignInForm({
   );
 
   const { isSubmitting } = form.formState;
+  const isPending = isSubmitting || isLeaving;
 
   return (
     <AuthForm
@@ -162,21 +164,13 @@ export default function SignInForm({
               {t("lastUsed")}
             </span>
           )}
-          <Button
-            type="submit"
-            variant="primary"
-            className="relative w-full"
-            disabled={isSubmitting}
+          <SubmitButton
+            isSubmitting={isPending}
+            spinnerPosition="start"
+            label={t("submit")}
+            className="w-full"
             data-testid="auth-submit"
-          >
-            {isSubmitting && (
-              <Loader2
-                aria-hidden="true"
-                className="absolute top-1/2 left-4 size-4 -translate-y-1/2 animate-spin"
-              />
-            )}
-            <span className="w-full text-center">{t("submit")}</span>
-          </Button>
+          />
         </div>
         <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
           <div className="flex flex-row items-center gap-2">

--- a/apps/web/src/app/(auth)/signup/components/__tests__/form.test.tsx
+++ b/apps/web/src/app/(auth)/signup/components/__tests__/form.test.tsx
@@ -339,13 +339,12 @@ describe("SignUpForm OAuth workflow", () => {
 
     await submitValidSignUpForm();
 
-    await waitFor(() => {
-      expect(mockSignUpEmail).toHaveBeenCalledTimes(1);
-    });
-
     const submitButton = screen.getByRole("button", { name: "submit" });
 
-    expect(submitButton).toBeEnabled();
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+
     expect(submitButton.querySelector("svg.animate-spin")).toBeNull();
   });
 

--- a/apps/web/src/app/(auth)/signup/components/__tests__/form.test.tsx
+++ b/apps/web/src/app/(auth)/signup/components/__tests__/form.test.tsx
@@ -299,4 +299,80 @@ describe("SignUpForm OAuth workflow", () => {
     expect(signUpPayload.callbackURL).toContain("exp=1772367377");
     expect(signUpPayload.callbackURL).toContain("sig=signed-value");
   });
+
+  it("keeps a left-edge submit spinner after credential signup succeeds", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      data: {
+        user: { id: "user-5" },
+      },
+      error: null,
+    });
+
+    render(<SignUpForm />);
+
+    await submitValidSignUpForm();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole("button", { name: "submit" });
+    const spinner = submitButton.querySelector("svg.animate-spin");
+
+    expect(submitButton).toBeDisabled();
+    expect(spinner).not.toBeNull();
+    expect(spinner).toHaveClass(
+      "absolute",
+      "top-1/2",
+      "left-4",
+      "-translate-y-1/2",
+    );
+  });
+
+  it("releases the submit spinner after credential signup fails", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      data: null,
+      error: { message: "Email already in use" },
+    });
+
+    render(<SignUpForm />);
+
+    await submitValidSignUpForm();
+
+    await waitFor(() => {
+      expect(mockSignUpEmail).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole("button", { name: "submit" });
+
+    expect(submitButton).toBeEnabled();
+    expect(submitButton.querySelector("svg.animate-spin")).toBeNull();
+  });
+
+  it("keeps a left-edge submit spinner until oauth redirect navigation", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      data: {
+        user: { id: "user-6" },
+        redirect: true,
+        url: "/auth/oauth2/authorize?client_id=test-client",
+      },
+      error: null,
+    });
+
+    render(<SignUpForm />);
+
+    await submitValidSignUpForm();
+
+    await waitFor(() => {
+      expect(window.location.href).toContain(
+        "/auth/oauth2/authorize?client_id=test-client",
+      );
+    });
+
+    const submitButton = screen.getByRole("button", { name: "submit" });
+    const spinner = submitButton.querySelector("svg.animate-spin");
+
+    expect(submitButton).toBeDisabled();
+    expect(spinner).toHaveClass("absolute", "left-4");
+  });
 });

--- a/apps/web/src/app/(auth)/signup/components/form.tsx
+++ b/apps/web/src/app/(auth)/signup/components/form.tsx
@@ -6,7 +6,7 @@ import { track } from "@vercel/analytics";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -38,6 +38,7 @@ export default function SignUpForm({
 }: SignUpFormProps) {
   const t = useTranslations("Auth.Pages.SignUp.Form");
   const registerFormStart = useRef(false);
+  const [isLeaving, setIsLeaving] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
   const effectiveReturnUrl = useMemo(
@@ -106,6 +107,7 @@ export default function SignUpForm({
 
     const oauthRedirect = getAuthOAuthRedirect(result.data);
     if (oauthRedirect.redirect && oauthRedirect.redirectUrl) {
+      setIsLeaving(true);
       window.location.href = oauthRedirect.redirectUrl;
       return;
     }
@@ -120,6 +122,7 @@ export default function SignUpForm({
 
     fireGTMEvent.signUp("credential");
     toast.success(t("success"));
+    setIsLeaving(true);
     router.replace(normalizeAuthReturnUrl(effectiveReturnUrl));
   };
 
@@ -135,6 +138,7 @@ export default function SignUpForm({
     );
 
   const { isSubmitting } = form.formState;
+  const isPending = isSubmitting || isLeaving;
 
   return (
     <AuthForm
@@ -145,10 +149,11 @@ export default function SignUpForm({
     >
       <div className="flex flex-col gap-4">
         <SubmitButton
-          isSubmitting={isSubmitting}
+          isSubmitting={isPending}
+          spinnerPosition="start"
           label={t("submit")}
           className="w-full"
-          disabled={!termsAccepted || isSubmitting}
+          disabled={!termsAccepted || isPending}
         />
         <div className="flex flex-col items-center gap-2 sm:flex-row">
           <span className="text-muted-foreground text-sm">

--- a/apps/web/src/app/(auth)/signup/components/form.tsx
+++ b/apps/web/src/app/(auth)/signup/components/form.tsx
@@ -153,7 +153,7 @@ export default function SignUpForm({
           spinnerPosition="start"
           label={t("submit")}
           className="w-full"
-          disabled={!termsAccepted || isPending}
+          disabled={!termsAccepted}
         />
         <div className="flex flex-col items-center gap-2 sm:flex-row">
           <span className="text-muted-foreground text-sm">


### PR DESCRIPTION
https://linear.app/masumi/issue/SOK-820/align-sign-in-and-sign-up-submit-loading-states

`/signin` and `/signup` credential submit CTAs now share the left-edge spinner.
After a successful submit the button stays disabled with the spinner until `router.replace` or `location.href` leaves the page.
Failed submit clears the spinner and re-enables the button.
Forgot-password, reset-password, and social login CTAs are unchanged.
Post-auth destination rules are unchanged.

Verify: `pnpm web:check`, `pnpm web:test`.

### Review notes - medium (human review)

| Area | Location | Finding |
|------|----------|---------|
| defect | `signin/components/form.tsx`, `signup/components/form.tsx` | `isLeaving` latch is duplicated in both forms instead of one helper |
| Spec | form tests | Pending assertions couple to spinner CSS classes (`left-4`) |