### PR TITLE
fix(auth): pin Haller quote to aside corner

### DIFF
--- a/apps/web/src/app/(auth)/components/__tests__/auth-aside.test.tsx
+++ b/apps/web/src/app/(auth)/components/__tests__/auth-aside.test.tsx
@@ -20,10 +20,8 @@ vi.mock("next/image", () => ({
   },
 }));
 
-const publicRoot = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "../../../../../public",
-);
+const here = dirname(fileURLToPath(import.meta.url));
+const publicRoot = join(here, "../../../../../public");
 
 describe("auth aside", () => {
   it("ships every customer logo file", () => {
@@ -130,11 +128,40 @@ describe("auth aside", () => {
 
     expect(root).not.toHaveClass("overflow-y-auto");
     expect(scroller).toHaveClass("overflow-y-auto");
-    expect(scroller).toHaveClass("pb-44");
     expect(root.contains(scroller)).toBe(true);
     expect(scroller.querySelector("[class*='bg-gradient']")).toBeNull();
     expect(
       [...root.children].filter((child) => child !== scroller).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("pins the Haller quote to the bottom-right at the same inset as the photo padding", async () => {
+    const { default: AuthAside } = await import("../auth-aside");
+    render(await AuthAside());
+
+    const root = screen.getByTestId("auth-aside");
+    const scroller = screen.getByTestId("auth-aside-scroll");
+    const quote = screen.getByTestId("auth-aside-quote");
+
+    expect(scroller).toHaveClass("p-10");
+    expect(scroller).toHaveClass("xl:p-12");
+    expect(scroller).not.toHaveClass("pb-44");
+    expect(scroller).not.toHaveClass("xl:pb-48");
+
+    expect(quote).toHaveClass("absolute");
+    expect(quote).toHaveClass("bottom-10");
+    expect(quote).toHaveClass("right-10");
+    expect(quote).toHaveClass("xl:bottom-12");
+    expect(quote).toHaveClass("xl:right-12");
+    expect(root.contains(quote)).toBe(true);
+    expect(scroller.contains(quote)).toBe(false);
+
+    const background = readFileSync(
+      join(here, "../auth-background.tsx"),
+      "utf8",
+    );
+    expect(background).toMatch(
+      /absolute top-10 right-10 z-10 xl:top-12 xl:right-12/,
+    );
   });
 });

--- a/apps/web/src/app/(auth)/components/auth-aside.tsx
+++ b/apps/web/src/app/(auth)/components/auth-aside.tsx
@@ -11,10 +11,10 @@ const BULLET_KEYS = ["bullet1", "bullet2", "bullet3"] as const;
 /**
  * Marketing proof on the auth photo. Server-only so copy is in the first HTML.
  *
- * Diagonal composition: claim + proof top-left, endorsement bottom-right, photo
- * breathes in between. Scrims sit on a static layer so overflow scroll of the
- * copy does not drag them off the photo. Extra bottom padding keeps the quote
- * above the first-visit cookie banner at lg.
+ * Diagonal composition: claim + proof top-left, endorsement pinned bottom-right
+ * at the same inset as the Kanji mark (`p-10` / `xl:p-12`). Scrims and quote sit
+ * on a static layer so overflow scroll of the copy does not drag them off the
+ * photo.
  */
 export default async function AuthAside() {
   const t = await getTranslations("Auth.Aside");
@@ -43,7 +43,7 @@ export default async function AuthAside() {
 
       <div
         data-testid="auth-aside-scroll"
-        className="absolute inset-0 z-10 flex flex-col justify-between overflow-y-auto p-10 pb-44 xl:p-12 xl:pb-48"
+        className="absolute inset-0 z-10 overflow-y-auto p-10 xl:p-12"
       >
         <div className="relative z-10 max-w-md">
           <h2
@@ -109,39 +109,40 @@ export default async function AuthAside() {
             </div>
           </section>
         </div>
-
-        <figure className="relative z-10 mt-12 ml-auto max-w-md text-right">
-          <blockquote className="text-balance text-lg text-white leading-snug">
-            {t("quote")}
-          </blockquote>
-          <figcaption className="mt-5 flex items-center justify-end gap-3 text-sm">
-            <Image
-              src="/images/auth/florian-haller.webp"
-              alt=""
-              width={48}
-              height={48}
-              className="size-12 shrink-0 rounded-full object-cover object-center ring-1 ring-white/20"
-            />
-            <div className="text-left">
-              <div className="whitespace-nowrap text-white">
-                {t("quoteAuthor")}
-              </div>
-              <div className="whitespace-nowrap text-white">
-                {t("quoteRole")}
-              </div>
-            </div>
-            <div className="border-white/20 border-l pl-4">
-              <Image
-                src={AUTH_SERVICEPLAN_LOGO.src}
-                alt=""
-                width={AUTH_SERVICEPLAN_LOGO.width}
-                height={AUTH_SERVICEPLAN_LOGO.height}
-                className="opacity-90"
-              />
-            </div>
-          </figcaption>
-        </figure>
       </div>
+
+      <figure
+        data-testid="auth-aside-quote"
+        className="absolute right-10 bottom-10 z-10 max-w-md text-right xl:right-12 xl:bottom-12"
+      >
+        <blockquote className="text-balance text-lg text-white leading-snug">
+          {t("quote")}
+        </blockquote>
+        <figcaption className="mt-5 flex items-center justify-end gap-3 text-sm">
+          <Image
+            src="/images/auth/florian-haller.webp"
+            alt=""
+            width={48}
+            height={48}
+            className="size-12 shrink-0 rounded-full object-cover object-center ring-1 ring-white/20"
+          />
+          <div className="text-left">
+            <div className="whitespace-nowrap text-white">
+              {t("quoteAuthor")}
+            </div>
+            <div className="whitespace-nowrap text-white">{t("quoteRole")}</div>
+          </div>
+          <div className="border-white/20 border-l pl-4">
+            <Image
+              src={AUTH_SERVICEPLAN_LOGO.src}
+              alt=""
+              width={AUTH_SERVICEPLAN_LOGO.width}
+              height={AUTH_SERVICEPLAN_LOGO.height}
+              className="opacity-90"
+            />
+          </div>
+        </figcaption>
+      </figure>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The Florian Haller quote on the desktop auth photo sat too high. Extra `pb-44` / `xl:pb-48` on the scroll layer was meant to clear the first-visit cookie banner, but that banner is centered `max-w-2xl` and does not cover the aside’s bottom-right.

The quote is now pinned outside the scroll layer at `bottom-10 right-10` / `xl:bottom-12 xl:right-12` — the same inset as the Kanji mark at the top-right.

## User-facing impact

On desktop auth pages (`lg+`), the Haller quote sits in the bottom-right corner of the photo with the same padding as the top-right mark. Mobile is unchanged (aside stays hidden).

## Verification

- [x] `pnpm check` and `pnpm typecheck` (pre-commit)
- [x] `pnpm --filter web exec vitest run src/app/(auth)/components/__tests__/auth-aside.test.tsx`
- [x] Browser: `/signin` at 1440 (48px inset match) and 1024 (40px inset match)
- [x] Browser: `/signup` at 1440 (same 48px inset)
- [x] Browser: `/signin` at 390 (aside hidden, form intact)