### PR TITLE
fix(web): center Drive mobile upload FAB progress ring

### DIFF
--- a/apps/web/src/app/(app)/components/__tests__/list-mobile-create-fab.test.tsx
+++ b/apps/web/src/app/(app)/components/__tests__/list-mobile-create-fab.test.tsx
@@ -34,4 +34,25 @@ describe("ListMobileCreateFab", () => {
     await user.click(screen.getByRole("button", { name: "Create project" }));
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
+
+  it("renders progress ring with correct viewBox when progress is provided", () => {
+    const onOpen = vi.fn();
+    const { container } = render(
+      <ListMobileCreateFab
+        ariaLabel="Upload file"
+        onOpen={onOpen}
+        progress={75}
+      />,
+    );
+
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("viewBox")).toBe("0 0 56 56");
+
+    const circles = container.querySelectorAll("circle");
+    expect(circles).toHaveLength(2);
+    expect(circles[0]?.getAttribute("cx")).toBe("28");
+    expect(circles[0]?.getAttribute("cy")).toBe("28");
+    expect(circles[0]?.getAttribute("r")).toBe("26");
+  });
 });

--- a/apps/web/src/app/(app)/components/list-mobile-create-fab.tsx
+++ b/apps/web/src/app/(app)/components/list-mobile-create-fab.tsx
@@ -47,6 +47,7 @@ export function ListMobileCreateFab({
           {showProgress && (
             <svg
               className="absolute inset-0 size-14 -rotate-90"
+              viewBox="0 0 56 56"
               aria-hidden="true"
             >
               <circle


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes off-center progress ring on Drive mobile upload FAB.

**Problem:** The progress SVG was missing a `viewBox` attribute, causing the circles to render in the default 300×150 user space instead of the intended 56×56 coordinate system. This made the white progress ring and percentage text appear off-center (high and left) within the FAB at ~75% progress.

**Solution:** Added `viewBox="0 0 56 56"` to the progress SVG element so the circles at `cx="28" cy="28" r="26"` render concentrically with the `size-14` (56px) rounded button.

**Changes:**
- Added `viewBox="0 0 56 56"` to progress SVG in `list-mobile-create-fab.tsx`
- Added test case to verify the viewBox attribute is present when progress prop is provided
- No changes to FAB size, colors, upload behavior, or Projects/Tasks Plus FABs

**Closes:** [SOK-835](https://linear.app/masumi/issue/SOK-835/drive-mobile-upload-fab-progress-ring-is-off-center) (child of [SOK-824](https://linear.app/masumi/issue/SOK-824/drive-web-drive-page-and-account-menu-entry))

**Verification:**
- ✅ No conflict markers
- ✅ Biome check passed
- ✅ Typecheck passed (all workspaces)
- ✅ Tests passed (553 files, 3544 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a0cb39f-dcec-4bac-8996-cfa1679e8c5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a0cb39f-dcec-4bac-8996-cfa1679e8c5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

