### PR TITLE
feat(web): From Drive picker folder navigation (SOK-839)

### DIFF
--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -11,7 +11,6 @@ import {
 import { useFormatter, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -314,7 +313,10 @@ export function DriveFilePicker({
                 {searchQuery ? t("noMatchTitle") : t("pickerEmptyMessage")}
               </div>
             ) : (
-              <ScrollArea className="h-[400px] pr-4 min-w-0 w-full">
+              <ScrollArea
+                className="h-[400px] pr-4 min-w-0 w-full"
+                shrinkContent
+              >
                 <div className="space-y-1">
                   {items.map((item) => {
                     const itemKey =
@@ -324,60 +326,56 @@ export function DriveFilePicker({
 
                     if (item.type === "folder") {
                       return (
-                        <Button
+                        <button
                           key={itemKey}
-                          variant="ghost"
-                          className="h-auto w-full min-w-0 max-w-full justify-start overflow-hidden whitespace-normal p-3 hover:bg-accent"
+                          type="button"
+                          className="flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left hover:bg-accent"
                           onClick={() => navigateToFolder(item.name)}
                         >
-                          <span className="flex min-w-0 w-full max-w-full items-start gap-3 overflow-hidden">
-                            <Folder className="text-muted-foreground size-5 shrink-0" />
-                            <span className="min-w-0 flex-1 overflow-hidden text-left">
-                              <span
-                                className="block min-w-0 max-w-full truncate text-foreground font-medium"
-                                title={item.name}
-                              >
-                                {item.name}
-                              </span>
-                              <span className="text-muted-foreground text-xs">
-                                {t("folder")}
-                              </span>
-                            </span>
-                          </span>
-                        </Button>
-                      );
-                    }
-
-                    return (
-                      <Button
-                        key={itemKey}
-                        variant="ghost"
-                        className="h-auto w-full min-w-0 max-w-full justify-start overflow-hidden whitespace-normal p-3 hover:bg-accent"
-                        onClick={() => handleFileClick(item)}
-                      >
-                        <span className="flex min-w-0 w-full max-w-full items-start gap-3 overflow-hidden">
-                          <FileIcon className="text-muted-foreground size-5 shrink-0" />
-                          <span className="min-w-0 flex-1 overflow-hidden text-left">
+                          <Folder className="text-muted-foreground size-5 shrink-0" />
+                          <span className="flex min-w-0 w-0 flex-1 flex-col overflow-hidden">
                             <span
-                              className="block min-w-0 max-w-full truncate text-foreground font-medium"
+                              className="block truncate font-medium"
                               title={item.name}
                             >
                               {item.name}
                             </span>
-                            <span className="text-muted-foreground flex gap-2 text-xs">
-                              {item.size ? (
-                                <span>{formatBytes(item.size)}</span>
-                              ) : null}
-                              <span>
-                                {formatter.dateTime(new Date(item.uploadedAt), {
-                                  month: "short",
-                                  day: "numeric",
-                                })}
-                              </span>
+                            <span className="text-muted-foreground text-xs">
+                              {t("folder")}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    }
+
+                    return (
+                      <button
+                        key={itemKey}
+                        type="button"
+                        className="flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left hover:bg-accent"
+                        onClick={() => handleFileClick(item)}
+                      >
+                        <FileIcon className="text-muted-foreground size-5 shrink-0" />
+                        <span className="flex min-w-0 w-0 flex-1 flex-col overflow-hidden">
+                          <span
+                            className="block truncate font-medium"
+                            title={item.name}
+                          >
+                            {item.name}
+                          </span>
+                          <span className="text-muted-foreground flex gap-2 text-xs">
+                            {item.size ? (
+                              <span>{formatBytes(item.size)}</span>
+                            ) : null}
+                            <span>
+                              {formatter.dateTime(new Date(item.uploadedAt), {
+                                month: "short",
+                                day: "numeric",
+                              })}
                             </span>
                           </span>
                         </span>
-                      </Button>
+                      </button>
                     );
                   })}
                 </div>

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FileIcon, Loader2, Search } from "lucide-react";
+import { ChevronRight, FileIcon, Folder, Loader2, Search } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
@@ -18,9 +18,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getEnvPublicConfig } from "@/config/env.public";
 import { useSession } from "@/lib/auth/auth.client";
 import { getBrowserCoreClient } from "@/lib/clients/core.browser.client";
-import type { DriveFile } from "@/lib/clients/generated/core";
+import type { DriveFile, DriveItem } from "@/lib/clients/generated/core";
 import { getUsersByIdOrganizations } from "@/lib/clients/generated/core";
-import { listDriveFiles } from "@/lib/utils/drive-file-list.client";
+import { cn } from "@/lib/utils";
+import { listDriveItems } from "@/lib/utils/drive-file-list.client";
 import { formatBytes } from "@/lib/utils/format-bytes";
 
 interface DriveFilePickerProps {
@@ -39,12 +40,13 @@ export function DriveFilePicker({
   const { data: session } = useSession();
   const activeOrganizationId = session?.session.activeOrganizationId ?? null;
   const [scope, setScope] = useState<"me" | "org">("me");
-  const [files, setFiles] = useState<DriveFile[]>([]);
+  const [items, setItems] = useState<DriveItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [organizationName, setOrganizationName] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+  const [currentFolder, setCurrentFolder] = useState("");
 
   const loadFilesAbortRef = useRef<AbortController | null>(null);
   const fetchOrgNameAbortRef = useRef<AbortController | null>(null);
@@ -58,7 +60,7 @@ export function DriveFilePicker({
     debouncedSetSearchQuery(value);
   }
 
-  const loadFiles = useCallback(async () => {
+  const loadItems = useCallback(async () => {
     loadFilesAbortRef.current?.abort();
     const controller = new AbortController();
     loadFilesAbortRef.current = controller;
@@ -68,23 +70,28 @@ export function DriveFilePicker({
     try {
       if (scope === "org" && !activeOrganizationId) {
         if (!controller.signal.aborted) {
-          setFiles([]);
+          setItems([]);
         }
         return;
       }
 
-      const loaded = await listDriveFiles({
+      const loaded = await listDriveItems({
         scope,
         ...(scope === "org" && activeOrganizationId
           ? { organizationId: activeOrganizationId }
           : {}),
+        ...(currentFolder ? { folder: currentFolder } : {}),
         ...(debouncedSearchQuery.trim()
           ? { q: debouncedSearchQuery.trim() }
           : {}),
         signal: controller.signal,
       });
+
       if (!controller.signal.aborted) {
-        setFiles(loaded);
+        const filteredItems = loaded.filter(
+          (item) => item.name !== "__drive_folder__",
+        );
+        setItems(filteredItems);
       }
     } catch (err) {
       if (!controller.signal.aborted) {
@@ -95,13 +102,13 @@ export function DriveFilePicker({
         setLoading(false);
       }
     }
-  }, [scope, activeOrganizationId, debouncedSearchQuery, t]);
+  }, [scope, activeOrganizationId, currentFolder, debouncedSearchQuery, t]);
 
   useEffect(() => {
     if (open) {
-      void loadFiles();
+      void loadItems();
     }
-  }, [open, loadFiles]);
+  }, [open, loadItems]);
 
   useEffect(() => {
     async function fetchOrganizationName() {
@@ -146,8 +153,28 @@ export function DriveFilePicker({
   function handleTabChange(value: string) {
     if (value === "me" || value === "org") {
       setScope(value);
+      setCurrentFolder("");
     }
   }
+
+  function navigateToFolder(folderName: string) {
+    const newPath = currentFolder
+      ? `${currentFolder}/${folderName}`
+      : folderName;
+    setCurrentFolder(newPath);
+  }
+
+  function navigateToBreadcrumb(index: number) {
+    if (index === -1) {
+      setCurrentFolder("");
+    } else {
+      const segments = currentFolder.split("/");
+      const newPath = segments.slice(0, index + 1).join("/");
+      setCurrentFolder(newPath);
+    }
+  }
+
+  const breadcrumbSegments = currentFolder ? currentFolder.split("/") : [];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -169,6 +196,38 @@ export function DriveFilePicker({
                 </TabsTrigger>
               )}
             </TabsList>
+
+            {breadcrumbSegments.length > 0 && (
+              <nav
+                className="text-muted-foreground flex items-center gap-1 text-sm"
+                aria-label="Breadcrumb"
+              >
+                <button
+                  type="button"
+                  onClick={() => navigateToBreadcrumb(-1)}
+                  className="hover:text-foreground transition-colors"
+                >
+                  {t("myDriveTab")}
+                </button>
+                {breadcrumbSegments.map((segment, index) => (
+                  <span key={index} className="flex items-center gap-1">
+                    <ChevronRight className="size-4" aria-hidden />
+                    <button
+                      type="button"
+                      onClick={() => navigateToBreadcrumb(index)}
+                      className={cn(
+                        "hover:text-foreground transition-colors",
+                        index === breadcrumbSegments.length - 1 &&
+                          "text-foreground font-medium",
+                      )}
+                    >
+                      {segment}
+                    </button>
+                  </span>
+                ))}
+              </nav>
+            )}
+
             <div className="relative">
               <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
               <Input
@@ -190,41 +249,71 @@ export function DriveFilePicker({
               <div className="flex items-center justify-center py-8">
                 <Loader2 className="text-muted-foreground size-6 animate-spin" />
               </div>
-            ) : files.length === 0 ? (
+            ) : items.length === 0 ? (
               <div className="text-muted-foreground text-center py-8 text-sm">
                 {searchQuery ? t("noMatchTitle") : t("pickerEmptyMessage")}
               </div>
             ) : (
               <ScrollArea className="h-[400px] pr-4">
                 <div className="space-y-1">
-                  {files.map((file) => (
-                    <Button
-                      key={file.pathname}
-                      variant="ghost"
-                      className="h-auto w-full justify-start p-3 hover:bg-accent"
-                      onClick={() => handleFileClick(file)}
-                    >
-                      <div className="flex w-full items-start gap-3">
-                        <FileIcon className="text-muted-foreground size-5 shrink-0" />
-                        <div className="min-w-0 flex-1 text-left">
-                          <div className="truncate font-medium">
-                            {file.name}
+                  {items.map((item) => {
+                    const itemKey =
+                      item.type === "file"
+                        ? item.pathname
+                        : `folder:${item.name}`;
+
+                    if (item.type === "folder") {
+                      return (
+                        <Button
+                          key={itemKey}
+                          variant="ghost"
+                          className="h-auto w-full justify-start p-3 hover:bg-accent"
+                          onClick={() => navigateToFolder(item.name)}
+                        >
+                          <div className="flex w-full items-start gap-3">
+                            <Folder className="text-muted-foreground size-5 shrink-0" />
+                            <div className="min-w-0 flex-1 text-left">
+                              <div className="truncate font-medium">
+                                {item.name}
+                              </div>
+                              <div className="text-muted-foreground text-xs">
+                                {t("folder")}
+                              </div>
+                            </div>
                           </div>
-                          <div className="text-muted-foreground flex gap-2 text-xs">
-                            {file.size ? (
-                              <span>{formatBytes(file.size)}</span>
-                            ) : null}
-                            <span>
-                              {formatter.dateTime(new Date(file.uploadedAt), {
-                                month: "short",
-                                day: "numeric",
-                              })}
-                            </span>
+                        </Button>
+                      );
+                    }
+
+                    return (
+                      <Button
+                        key={itemKey}
+                        variant="ghost"
+                        className="h-auto w-full justify-start p-3 hover:bg-accent"
+                        onClick={() => handleFileClick(item)}
+                      >
+                        <div className="flex w-full items-start gap-3">
+                          <FileIcon className="text-muted-foreground size-5 shrink-0" />
+                          <div className="min-w-0 flex-1 text-left">
+                            <div className="truncate font-medium">
+                              {item.name}
+                            </div>
+                            <div className="text-muted-foreground flex gap-2 text-xs">
+                              {item.size ? (
+                                <span>{formatBytes(item.size)}</span>
+                              ) : null}
+                              <span>
+                                {formatter.dateTime(new Date(item.uploadedAt), {
+                                  month: "short",
+                                  day: "numeric",
+                                })}
+                              </span>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </Button>
-                  ))}
+                      </Button>
+                    );
+                  })}
                 </div>
               </ScrollArea>
             )}

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -159,6 +159,13 @@ export function DriveFilePicker({
   }
 
   function navigateToFolder(folderName: string) {
+    const segments = currentFolder ? currentFolder.split("/") : [];
+    const lastSegment = segments[segments.length - 1];
+
+    if (lastSegment === folderName) {
+      return;
+    }
+
     const newPath = currentFolder
       ? `${currentFolder}/${folderName}`
       : folderName;
@@ -179,14 +186,18 @@ export function DriveFilePicker({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl min-w-0 overflow-hidden">
         <DialogHeader>
           <DialogTitle>{t("selectTitle")}</DialogTitle>
           <DialogDescription>{t("selectDescription")}</DialogDescription>
         </DialogHeader>
 
-        <Tabs value={scope} onValueChange={handleTabChange}>
-          <div className="space-y-3">
+        <Tabs
+          value={scope}
+          onValueChange={handleTabChange}
+          className="min-w-0 w-full"
+        >
+          <div className="space-y-3 min-w-0 w-full">
             <TabsList className="w-full">
               <TabsTrigger value="me" className="flex-1">
                 {t("myDriveTab")}
@@ -198,42 +209,47 @@ export function DriveFilePicker({
               )}
             </TabsList>
 
-            <nav
-              className="text-muted-foreground flex items-center gap-1 overflow-x-auto text-sm"
-              aria-label="Breadcrumb"
-            >
-              <button
-                type="button"
-                onClick={() => navigateToBreadcrumb(-1)}
-                className={cn(
-                  "hover:text-foreground whitespace-nowrap transition-colors",
-                  breadcrumbSegments.length === 0 &&
-                    "text-foreground font-medium",
-                )}
+            <div className="min-w-0 overflow-x-auto">
+              <nav
+                className="text-muted-foreground flex flex-nowrap items-center gap-1 text-sm"
+                aria-label="Breadcrumb"
               >
-                {scope === "org" && organizationName
-                  ? organizationName
-                  : t("myDriveTab")}
-              </button>
-              {breadcrumbSegments.map((segment, index) => (
-                <span key={index} className="flex shrink-0 items-center gap-1">
-                  <ChevronRight className="size-4" aria-hidden />
-                  <button
-                    type="button"
-                    onClick={() => navigateToBreadcrumb(index)}
-                    className={cn(
-                      "hover:text-foreground whitespace-nowrap transition-colors",
-                      index === breadcrumbSegments.length - 1 &&
-                        "text-foreground font-medium",
-                    )}
+                <button
+                  type="button"
+                  onClick={() => navigateToBreadcrumb(-1)}
+                  className={cn(
+                    "hover:text-foreground shrink-0 whitespace-nowrap transition-colors",
+                    breadcrumbSegments.length === 0 &&
+                      "text-foreground font-medium",
+                  )}
+                >
+                  {scope === "org" && organizationName
+                    ? organizationName
+                    : t("myDriveTab")}
+                </button>
+                {breadcrumbSegments.map((segment, index) => (
+                  <span
+                    key={index}
+                    className="flex shrink-0 items-center gap-1"
                   >
-                    {segment}
-                  </button>
-                </span>
-              ))}
-            </nav>
+                    <ChevronRight className="size-4" aria-hidden />
+                    <button
+                      type="button"
+                      onClick={() => navigateToBreadcrumb(index)}
+                      className={cn(
+                        "hover:text-foreground shrink-0 whitespace-nowrap transition-colors",
+                        index === breadcrumbSegments.length - 1 &&
+                          "text-foreground font-medium",
+                      )}
+                    >
+                      {segment}
+                    </button>
+                  </span>
+                ))}
+              </nav>
+            </div>
 
-            <div className="relative">
+            <div className="relative min-w-0">
               <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
               <Input
                 type="text"
@@ -245,7 +261,7 @@ export function DriveFilePicker({
             </div>
           </div>
 
-          <TabsContent value={scope} className="mt-4">
+          <TabsContent value={scope} className="mt-4 min-w-0 w-full">
             {error ? (
               <div className="text-destructive text-center py-8 text-sm">
                 {error}
@@ -272,7 +288,7 @@ export function DriveFilePicker({
                 {searchQuery ? t("noMatchTitle") : t("pickerEmptyMessage")}
               </div>
             ) : (
-              <ScrollArea className="h-[400px] pr-4">
+              <ScrollArea className="h-[400px] pr-4 min-w-0 w-full">
                 <div className="space-y-1">
                   {items.map((item) => {
                     const itemKey =
@@ -285,7 +301,7 @@ export function DriveFilePicker({
                         <Button
                           key={itemKey}
                           variant="ghost"
-                          className="h-auto w-full justify-start p-3 hover:bg-accent"
+                          className="h-auto w-full min-w-0 justify-start overflow-hidden p-3 hover:bg-accent"
                           onClick={() => navigateToFolder(item.name)}
                         >
                           <div className="flex w-full items-start gap-3">
@@ -307,7 +323,7 @@ export function DriveFilePicker({
                       <Button
                         key={itemKey}
                         variant="ghost"
-                        className="h-auto w-full justify-start p-3 hover:bg-accent"
+                        className="h-auto w-full min-w-0 justify-start overflow-hidden p-3 hover:bg-accent"
                         onClick={() => handleFileClick(item)}
                       >
                         <div className="flex w-full items-start gap-3">

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -12,6 +12,7 @@ import {
 import { useFormatter, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -228,13 +229,13 @@ export function DriveFilePicker({
                       "text-foreground font-medium",
                   )}
                   aria-label={
-                    scope === "org" && organizationName
-                      ? organizationName
+                    scope === "org"
+                      ? organizationName || t("organizationTabFallback")
                       : t("myDriveTab")
                   }
                   title={
-                    scope === "org" && organizationName
-                      ? organizationName
+                    scope === "org"
+                      ? organizationName || t("organizationTabFallback")
                       : t("myDriveTab")
                   }
                 >
@@ -322,7 +323,10 @@ export function DriveFilePicker({
                         <button
                           key={itemKey}
                           type="button"
-                          className="flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left hover:bg-accent"
+                          className={cn(
+                            buttonVariants({ variant: "ghost" }),
+                            "flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left",
+                          )}
                           onClick={() => navigateToFolder(item.name)}
                         >
                           <Folder className="text-muted-foreground size-5 shrink-0" />
@@ -345,7 +349,10 @@ export function DriveFilePicker({
                       <button
                         key={itemKey}
                         type="button"
-                        className="flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left hover:bg-accent"
+                        className={cn(
+                          buttonVariants({ variant: "ghost" }),
+                          "flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left",
+                        )}
                         onClick={() => handleFileClick(item)}
                       >
                         <FileIcon className="text-muted-foreground size-5 shrink-0" />

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight, FileIcon, Folder, Loader2, Search } from "lucide-react";
+import { ChevronRight, FileIcon, Folder, Search } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getEnvPublicConfig } from "@/config/env.public";
 import { useSession } from "@/lib/auth/auth.client";
@@ -246,11 +247,24 @@ export function DriveFilePicker({
                 {error}
               </div>
             ) : loading ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="text-muted-foreground size-6 animate-spin" />
+              <div className="min-h-[400px]">
+                <div className="space-y-1">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="flex w-full items-start gap-3 rounded-md p-3"
+                    >
+                      <Skeleton className="size-5 shrink-0 rounded" />
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <Skeleton className="h-4 w-48" />
+                        <Skeleton className="h-3 w-24" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
             ) : items.length === 0 ? (
-              <div className="text-muted-foreground text-center py-8 text-sm">
+              <div className="text-muted-foreground flex min-h-[400px] items-center justify-center text-center text-sm">
                 {searchQuery ? t("noMatchTitle") : t("pickerEmptyMessage")}
               </div>
             ) : (

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -327,23 +327,23 @@ export function DriveFilePicker({
                         <Button
                           key={itemKey}
                           variant="ghost"
-                          className="h-auto w-full min-w-0 justify-start overflow-hidden p-3 hover:bg-accent"
+                          className="h-auto w-full min-w-0 max-w-full justify-start overflow-hidden whitespace-normal p-3 hover:bg-accent"
                           onClick={() => navigateToFolder(item.name)}
                         >
-                          <div className="flex min-w-0 w-full max-w-full items-start gap-3">
+                          <span className="flex min-w-0 w-full max-w-full items-start gap-3 overflow-hidden">
                             <Folder className="text-muted-foreground size-5 shrink-0" />
-                            <div className="min-w-0 flex-1 overflow-hidden text-left">
-                              <div
-                                className="text-foreground line-clamp-1 font-medium"
+                            <span className="min-w-0 flex-1 overflow-hidden text-left">
+                              <span
+                                className="block min-w-0 max-w-full truncate text-foreground font-medium"
                                 title={item.name}
                               >
                                 {item.name}
-                              </div>
-                              <div className="text-muted-foreground text-xs">
+                              </span>
+                              <span className="text-muted-foreground text-xs">
                                 {t("folder")}
-                              </div>
-                            </div>
-                          </div>
+                              </span>
+                            </span>
+                          </span>
                         </Button>
                       );
                     }
@@ -352,19 +352,19 @@ export function DriveFilePicker({
                       <Button
                         key={itemKey}
                         variant="ghost"
-                        className="h-auto w-full min-w-0 justify-start overflow-hidden p-3 hover:bg-accent"
+                        className="h-auto w-full min-w-0 max-w-full justify-start overflow-hidden whitespace-normal p-3 hover:bg-accent"
                         onClick={() => handleFileClick(item)}
                       >
-                        <div className="flex min-w-0 w-full max-w-full items-start gap-3">
+                        <span className="flex min-w-0 w-full max-w-full items-start gap-3 overflow-hidden">
                           <FileIcon className="text-muted-foreground size-5 shrink-0" />
-                          <div className="min-w-0 flex-1 overflow-hidden text-left">
-                            <div
-                              className="text-foreground line-clamp-1 font-medium"
+                          <span className="min-w-0 flex-1 overflow-hidden text-left">
+                            <span
+                              className="block min-w-0 max-w-full truncate text-foreground font-medium"
                               title={item.name}
                             >
                               {item.name}
-                            </div>
-                            <div className="text-muted-foreground flex gap-2 text-xs">
+                            </span>
+                            <span className="text-muted-foreground flex gap-2 text-xs">
                               {item.size ? (
                                 <span>{formatBytes(item.size)}</span>
                               ) : null}
@@ -374,9 +374,9 @@ export function DriveFilePicker({
                                   day: "numeric",
                                 })}
                               </span>
-                            </div>
-                          </div>
-                        </div>
+                            </span>
+                          </span>
+                        </span>
                       </Button>
                     );
                   })}

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChevronRight, FileIcon, Folder, Search } from "lucide-react";
+import {
+  Building2,
+  ChevronRight,
+  FileIcon,
+  Folder,
+  Home,
+  Search,
+} from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
@@ -228,10 +235,22 @@ export function DriveFilePicker({
                     breadcrumbSegments.length === 0 &&
                       "text-foreground font-medium",
                   )}
+                  aria-label={
+                    scope === "org" && organizationName
+                      ? organizationName
+                      : t("myDriveTab")
+                  }
+                  title={
+                    scope === "org" && organizationName
+                      ? organizationName
+                      : t("myDriveTab")
+                  }
                 >
-                  {scope === "org" && organizationName
-                    ? organizationName
-                    : t("myDriveTab")}
+                  {scope === "org" ? (
+                    <Building2 className="size-4" aria-hidden />
+                  ) : (
+                    <Home className="size-4" aria-hidden />
+                  )}
                 </button>
                 {breadcrumbSegments.map((segment, index) => (
                   <span

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -325,7 +325,7 @@ export function DriveFilePicker({
                           type="button"
                           className={cn(
                             buttonVariants({ variant: "ghost" }),
-                            "flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left",
+                            "h-auto whitespace-normal flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left",
                           )}
                           onClick={() => navigateToFolder(item.name)}
                         >
@@ -351,7 +351,7 @@ export function DriveFilePicker({
                         type="button"
                         className={cn(
                           buttonVariants({ variant: "ghost" }),
-                          "flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left",
+                          "h-auto whitespace-normal flex w-full min-w-0 max-w-full items-start gap-3 overflow-hidden rounded-md p-3 text-left",
                         )}
                         onClick={() => handleFileClick(item)}
                       >

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isDriveFolderMarkerName } from "@sokosumi/utils";
 import {
   Building2,
   ChevronRight,
@@ -96,7 +97,7 @@ export function DriveFilePicker({
 
       if (!controller.signal.aborted) {
         const filteredItems = loaded.filter(
-          (item) => item.name !== "__drive_folder__",
+          (item) => !isDriveFolderMarkerName(item.name),
         );
         setItems(filteredItems);
       }
@@ -173,14 +174,6 @@ export function DriveFilePicker({
       return;
     }
 
-    const newSegments = newPath.split("/");
-    if (newSegments.length >= 2) {
-      const lastTwo = newSegments.slice(-2);
-      if (lastTwo[0] === lastTwo[1]) {
-        return;
-      }
-    }
-
     setCurrentFolder(newPath);
   }
 
@@ -224,7 +217,7 @@ export function DriveFilePicker({
             <div className="min-w-0 overflow-x-auto">
               <nav
                 className="text-muted-foreground flex flex-nowrap items-center gap-1 text-sm"
-                aria-label="Breadcrumb"
+                aria-label={t("breadcrumbNavLabel")}
               >
                 <button
                   type="button"

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -159,16 +159,22 @@ export function DriveFilePicker({
   }
 
   function navigateToFolder(folderName: string) {
-    const segments = currentFolder ? currentFolder.split("/") : [];
-    const lastSegment = segments[segments.length - 1];
-
-    if (lastSegment === folderName) {
-      return;
-    }
-
     const newPath = currentFolder
       ? `${currentFolder}/${folderName}`
       : folderName;
+
+    if (newPath === currentFolder) {
+      return;
+    }
+
+    const newSegments = newPath.split("/");
+    if (newSegments.length >= 2) {
+      const lastTwo = newSegments.slice(-2);
+      if (lastTwo[0] === lastTwo[1]) {
+        return;
+      }
+    }
+
     setCurrentFolder(newPath);
   }
 

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -266,6 +266,7 @@ export function DriveFilePicker({
                         index === breadcrumbSegments.length - 1 &&
                           "text-foreground font-medium",
                       )}
+                      title={segment}
                     >
                       {segment}
                     </button>
@@ -329,10 +330,13 @@ export function DriveFilePicker({
                           className="h-auto w-full min-w-0 justify-start overflow-hidden p-3 hover:bg-accent"
                           onClick={() => navigateToFolder(item.name)}
                         >
-                          <div className="flex w-full items-start gap-3">
+                          <div className="flex min-w-0 w-full max-w-full items-start gap-3">
                             <Folder className="text-muted-foreground size-5 shrink-0" />
-                            <div className="min-w-0 flex-1 text-left">
-                              <div className="truncate font-medium">
+                            <div className="min-w-0 flex-1 overflow-hidden text-left">
+                              <div
+                                className="text-foreground line-clamp-1 font-medium"
+                                title={item.name}
+                              >
                                 {item.name}
                               </div>
                               <div className="text-muted-foreground text-xs">
@@ -351,10 +355,13 @@ export function DriveFilePicker({
                         className="h-auto w-full min-w-0 justify-start overflow-hidden p-3 hover:bg-accent"
                         onClick={() => handleFileClick(item)}
                       >
-                        <div className="flex w-full items-start gap-3">
+                        <div className="flex min-w-0 w-full max-w-full items-start gap-3">
                           <FileIcon className="text-muted-foreground size-5 shrink-0" />
-                          <div className="min-w-0 flex-1 text-left">
-                            <div className="truncate font-medium">
+                          <div className="min-w-0 flex-1 overflow-hidden text-left">
+                            <div
+                              className="text-foreground line-clamp-1 font-medium"
+                              title={item.name}
+                            >
                               {item.name}
                             </div>
                             <div className="text-muted-foreground flex gap-2 text-xs">

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -198,36 +198,40 @@ export function DriveFilePicker({
               )}
             </TabsList>
 
-            {breadcrumbSegments.length > 0 && (
-              <nav
-                className="text-muted-foreground flex items-center gap-1 text-sm"
-                aria-label="Breadcrumb"
+            <nav
+              className="text-muted-foreground flex items-center gap-1 overflow-x-auto text-sm"
+              aria-label="Breadcrumb"
+            >
+              <button
+                type="button"
+                onClick={() => navigateToBreadcrumb(-1)}
+                className={cn(
+                  "hover:text-foreground whitespace-nowrap transition-colors",
+                  breadcrumbSegments.length === 0 &&
+                    "text-foreground font-medium",
+                )}
               >
-                <button
-                  type="button"
-                  onClick={() => navigateToBreadcrumb(-1)}
-                  className="hover:text-foreground transition-colors"
-                >
-                  {t("myDriveTab")}
-                </button>
-                {breadcrumbSegments.map((segment, index) => (
-                  <span key={index} className="flex items-center gap-1">
-                    <ChevronRight className="size-4" aria-hidden />
-                    <button
-                      type="button"
-                      onClick={() => navigateToBreadcrumb(index)}
-                      className={cn(
-                        "hover:text-foreground transition-colors",
-                        index === breadcrumbSegments.length - 1 &&
-                          "text-foreground font-medium",
-                      )}
-                    >
-                      {segment}
-                    </button>
-                  </span>
-                ))}
-              </nav>
-            )}
+                {scope === "org" && organizationName
+                  ? organizationName
+                  : t("myDriveTab")}
+              </button>
+              {breadcrumbSegments.map((segment, index) => (
+                <span key={index} className="flex shrink-0 items-center gap-1">
+                  <ChevronRight className="size-4" aria-hidden />
+                  <button
+                    type="button"
+                    onClick={() => navigateToBreadcrumb(index)}
+                    className={cn(
+                      "hover:text-foreground whitespace-nowrap transition-colors",
+                      index === breadcrumbSegments.length - 1 &&
+                        "text-foreground font-medium",
+                    )}
+                  >
+                    {segment}
+                  </button>
+                </span>
+              ))}
+            </nav>
 
             <div className="relative">
               <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />

--- a/apps/web/src/components/drive/drive-file-picker.tsx
+++ b/apps/web/src/components/drive/drive-file-picker.tsx
@@ -335,7 +335,7 @@ export function DriveFilePicker({
                           <Folder className="text-muted-foreground size-5 shrink-0" />
                           <span className="flex min-w-0 w-0 flex-1 flex-col overflow-hidden">
                             <span
-                              className="block truncate font-medium"
+                              className="block min-w-0 truncate font-medium"
                               title={item.name}
                             >
                               {item.name}
@@ -358,7 +358,7 @@ export function DriveFilePicker({
                         <FileIcon className="text-muted-foreground size-5 shrink-0" />
                         <span className="flex min-w-0 w-0 flex-1 flex-col overflow-hidden">
                           <span
-                            className="block truncate font-medium"
+                            className="block min-w-0 truncate font-medium"
                             title={item.name}
                           >
                             {item.name}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements SOK-839: From Drive picker can now navigate folders.

**Stacked on #3872 (SOK-838)** — requires that PR to be merged first.

## Changes

- Picker uses `listDriveItems()` instead of `listDriveFiles()` to show folders + files
- Folder navigation: click folder to open, breadcrumb to go back
- Folders display with Folder icon and label (not attachable)
- Files remain attachable with existing behavior (saves `fileUrl` only)
- Search works in current folder (preserves existing debounce)
- `__drive_folder__` markers filtered out
- Switching tabs (My Drive / Org) resets to root folder
- Uses existing `App.Drive` i18n keys (no new keys added)

## Links

- Linear: https://linear.app/masumi/issue/SOK-839
- Parent: SOK-836
- Base PR: #3872 (SOK-838)

## Testing

- Files inside folders can be attached to chat compose and task description
- Folder navigation works (My Drive / org tabs)
- Breadcrumb navigation back to root
- Search filters files in current folder
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd89bfcb-e692-4b4f-8831-bb042ccd0030?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd89bfcb-e692-4b4f-8831-bb042ccd0030&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added folder navigation to the drive file picker.
  * Added breadcrumb navigation for quickly returning to parent folders or the root.
  * Added visual folder entries that can be opened directly.
  * Improved layout behavior for narrow screens with horizontally scrollable controls.

* **UI Improvements**
  * Replaced the loading spinner with skeleton placeholders.
  * Improved folder and file presentation with updated icons and navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->