### PR TITLE
feat(core): make allowed deletion succeed

### DIFF
--- a/apps/core/src/clients/stripe.client.test.ts
+++ b/apps/core/src/clients/stripe.client.test.ts
@@ -6,6 +6,7 @@ const {
   stripeCheckoutSessionsRetrieveMock,
   stripeCouponsRetrieveMock,
   stripeCustomersCreateMock,
+  stripeCustomersDelMock,
   stripeCustomersRetrieveMock,
   stripeInvoiceItemsCreateMock,
   stripeInvoicesCreateMock,
@@ -19,6 +20,7 @@ const {
   stripeCheckoutSessionsRetrieveMock: vi.fn(),
   stripeCouponsRetrieveMock: vi.fn(),
   stripeCustomersCreateMock: vi.fn(),
+  stripeCustomersDelMock: vi.fn(),
   stripeCustomersRetrieveMock: vi.fn(),
   stripeInvoiceItemsCreateMock: vi.fn(),
   stripeInvoicesCreateMock: vi.fn(),
@@ -32,6 +34,7 @@ vi.mock("stripe", () => ({
   default: class StripeMock {
     customers = {
       create: (...args: unknown[]) => stripeCustomersCreateMock(...args),
+      del: (...args: unknown[]) => stripeCustomersDelMock(...args),
       retrieve: (...args: unknown[]) => stripeCustomersRetrieveMock(...args),
     };
 
@@ -153,6 +156,38 @@ describe("stripeClient", () => {
         timeout: 2500,
       },
     );
+  });
+
+  it("deletes a Stripe customer", async () => {
+    stripeCustomersDelMock.mockResolvedValue({
+      id: "cus_123",
+      deleted: true,
+      object: "customer",
+    });
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.deleteCustomer("cus_123");
+
+    expect(stripeCustomersDelMock).toHaveBeenCalledWith(
+      "cus_123",
+      undefined,
+      undefined,
+    );
+  });
+
+  it("forwards request options as Stripe customers.del options", async () => {
+    stripeCustomersDelMock.mockResolvedValue({
+      id: "cus_123",
+      deleted: true,
+      object: "customer",
+    });
+    const { stripeClient } = await import("./stripe.client");
+
+    await stripeClient.deleteCustomer("cus_123", { timeout: 2500 });
+
+    expect(stripeCustomersDelMock).toHaveBeenCalledWith("cus_123", undefined, {
+      timeout: 2500,
+    });
   });
 
   it("returns null when a coupon lookup fails", async () => {

--- a/apps/core/src/clients/stripe.client.ts
+++ b/apps/core/src/clients/stripe.client.ts
@@ -266,6 +266,13 @@ export const stripeClient = {
     );
   },
 
+  async deleteCustomer(
+    customerId: string,
+    requestOptions?: Stripe.RequestOptions,
+  ): Promise<Stripe.DeletedCustomer> {
+    return await stripe.customers.del(customerId, undefined, requestOptions);
+  },
+
   async retrieveCustomerBillingDetails(
     customerId: string,
     requestOptions?: Stripe.RequestOptions,

--- a/apps/core/src/helpers/stripe-customer-delete.test.ts
+++ b/apps/core/src/helpers/stripe-customer-delete.test.ts
@@ -87,6 +87,34 @@ describe("deleteStripeCustomerBestEffort", () => {
     expect(deleteCustomerMock).not.toHaveBeenCalled();
   });
 
+  it("skips Stripe customer delete when subscription lookup fails", async () => {
+    const lookupDown = new Error("subscription lookup failed");
+    subscriptionFindFirstMock.mockRejectedValue(lookupDown);
+
+    await expect(
+      deleteStripeCustomerBestEffort({
+        stripeCustomerId: "cus_1",
+        ownerType: "user",
+        ownerId: "user_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(deleteCustomerMock).not.toHaveBeenCalled();
+    expect(captureExternalServiceErrorMock).toHaveBeenCalledWith(lookupDown, {
+      label: "stripe_customer_delete",
+      sentry: {
+        tags: {
+          context: "stripe_customer_delete",
+          ownerType: "user",
+        },
+      },
+      extra: {
+        ownerId: "user_1",
+        stripeCustomerId: "cus_1",
+      },
+    });
+  });
+
   it("logs a thrown Stripe delete and does not fail allow", async () => {
     const stripeDown = new Error("stripe unavailable");
     deleteCustomerMock.mockRejectedValue(stripeDown);

--- a/apps/core/src/helpers/stripe-customer-delete.test.ts
+++ b/apps/core/src/helpers/stripe-customer-delete.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { deleteStripeCustomerBestEffort } from "./stripe-customer-delete";
+
+const { deleteCustomerMock, captureExternalServiceErrorMock } = vi.hoisted(
+  () => ({
+    deleteCustomerMock: vi.fn(),
+    captureExternalServiceErrorMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/clients/stripe.client", () => ({
+  stripeClient: {
+    deleteCustomer: (...args: unknown[]) => deleteCustomerMock(...args),
+  },
+}));
+
+vi.mock("@/lib/external-service-errors", () => ({
+  captureExternalServiceError: (...args: unknown[]) =>
+    captureExternalServiceErrorMock(...args),
+}));
+
+describe("deleteStripeCustomerBestEffort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteCustomerMock.mockResolvedValue({ id: "cus_1", deleted: true });
+  });
+
+  it("skips Stripe when there is no customer id", async () => {
+    await expect(
+      deleteStripeCustomerBestEffort({
+        stripeCustomerId: null,
+        ownerType: "user",
+        ownerId: "user_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(deleteCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("deletes the Stripe customer after allow", async () => {
+    await expect(
+      deleteStripeCustomerBestEffort({
+        stripeCustomerId: "cus_1",
+        ownerType: "organization",
+        ownerId: "org_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(deleteCustomerMock).toHaveBeenCalledWith("cus_1");
+    expect(captureExternalServiceErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("logs a thrown Stripe delete and does not fail allow", async () => {
+    const stripeDown = new Error("stripe unavailable");
+    deleteCustomerMock.mockRejectedValue(stripeDown);
+
+    await expect(
+      deleteStripeCustomerBestEffort({
+        stripeCustomerId: "cus_1",
+        ownerType: "user",
+        ownerId: "user_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captureExternalServiceErrorMock).toHaveBeenCalledWith(stripeDown, {
+      label: "stripe_customer_delete",
+      sentry: {
+        tags: {
+          context: "stripe_customer_delete",
+          ownerType: "user",
+        },
+      },
+      extra: {
+        ownerId: "user_1",
+        stripeCustomerId: "cus_1",
+      },
+    });
+  });
+});

--- a/apps/core/src/helpers/stripe-customer-delete.test.ts
+++ b/apps/core/src/helpers/stripe-customer-delete.test.ts
@@ -2,12 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { deleteStripeCustomerBestEffort } from "./stripe-customer-delete";
 
-const { deleteCustomerMock, captureExternalServiceErrorMock } = vi.hoisted(
-  () => ({
-    deleteCustomerMock: vi.fn(),
-    captureExternalServiceErrorMock: vi.fn(),
-  }),
-);
+const {
+  deleteCustomerMock,
+  captureExternalServiceErrorMock,
+  subscriptionFindFirstMock,
+} = vi.hoisted(() => ({
+  deleteCustomerMock: vi.fn(),
+  captureExternalServiceErrorMock: vi.fn(),
+  subscriptionFindFirstMock: vi.fn(),
+}));
 
 vi.mock("@/clients/stripe.client", () => ({
   stripeClient: {
@@ -20,10 +23,19 @@ vi.mock("@/lib/external-service-errors", () => ({
     captureExternalServiceErrorMock(...args),
 }));
 
+vi.mock("@/lib/db/prisma", () => ({
+  default: {
+    subscription: {
+      findFirst: (...args: unknown[]) => subscriptionFindFirstMock(...args),
+    },
+  },
+}));
+
 describe("deleteStripeCustomerBestEffort", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     deleteCustomerMock.mockResolvedValue({ id: "cus_1", deleted: true });
+    subscriptionFindFirstMock.mockResolvedValue(null);
   });
 
   it("skips Stripe when there is no customer id", async () => {
@@ -47,8 +59,32 @@ describe("deleteStripeCustomerBestEffort", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(deleteCustomerMock).toHaveBeenCalledWith("cus_1");
+    expect(deleteCustomerMock).toHaveBeenCalledWith("cus_1", {
+      timeout: 2500,
+    });
     expect(captureExternalServiceErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("skips Stripe customer delete when a running subscription remains", async () => {
+    subscriptionFindFirstMock.mockResolvedValue({ id: "sub_running" });
+
+    await expect(
+      deleteStripeCustomerBestEffort({
+        stripeCustomerId: "cus_1",
+        ownerType: "user",
+        ownerId: "user_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(subscriptionFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        referenceId: "user_1",
+        stripeSubscriptionId: { not: null },
+        status: { in: ["active", "trialing", "past_due", "unpaid"] },
+      },
+      select: { id: true },
+    });
+    expect(deleteCustomerMock).not.toHaveBeenCalled();
   });
 
   it("logs a thrown Stripe delete and does not fail allow", async () => {
@@ -63,6 +99,9 @@ describe("deleteStripeCustomerBestEffort", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(deleteCustomerMock).toHaveBeenCalledWith("cus_1", {
+      timeout: 2500,
+    });
     expect(captureExternalServiceErrorMock).toHaveBeenCalledWith(stripeDown, {
       label: "stripe_customer_delete",
       sentry: {
@@ -76,5 +115,19 @@ describe("deleteStripeCustomerBestEffort", () => {
         stripeCustomerId: "cus_1",
       },
     });
+  });
+
+  it("treats Stripe resource_missing as success", async () => {
+    deleteCustomerMock.mockRejectedValue({ code: "resource_missing" });
+
+    await expect(
+      deleteStripeCustomerBestEffort({
+        stripeCustomerId: "cus_1",
+        ownerType: "user",
+        ownerId: "user_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captureExternalServiceErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/helpers/stripe-customer-delete.ts
+++ b/apps/core/src/helpers/stripe-customer-delete.ts
@@ -40,14 +40,32 @@ export async function deleteStripeCustomerBestEffort(
     return;
   }
 
-  const runningSubscription = await prisma.subscription.findFirst({
-    where: {
-      referenceId: input.ownerId,
-      stripeSubscriptionId: { not: null },
-      status: { in: [...RUNNING_STRIPE_SUBSCRIPTION_STATUSES] },
-    },
-    select: { id: true },
-  });
+  let runningSubscription: { id: string } | null;
+  try {
+    runningSubscription = await prisma.subscription.findFirst({
+      where: {
+        referenceId: input.ownerId,
+        stripeSubscriptionId: { not: null },
+        status: { in: [...RUNNING_STRIPE_SUBSCRIPTION_STATUSES] },
+      },
+      select: { id: true },
+    });
+  } catch (error) {
+    captureExternalServiceError(error, {
+      label: "stripe_customer_delete",
+      sentry: {
+        tags: {
+          context: "stripe_customer_delete",
+          ownerType: input.ownerType,
+        },
+      },
+      extra: {
+        ownerId: input.ownerId,
+        stripeCustomerId: input.stripeCustomerId,
+      },
+    });
+    return;
+  }
   if (runningSubscription) {
     console.warn(
       `Skipping Stripe customer ${input.stripeCustomerId} delete: running subscription still present for ${input.ownerType} ${input.ownerId}`,

--- a/apps/core/src/helpers/stripe-customer-delete.ts
+++ b/apps/core/src/helpers/stripe-customer-delete.ts
@@ -1,0 +1,39 @@
+import { stripeClient } from "@/clients/stripe.client";
+import { captureExternalServiceError } from "@/lib/external-service-errors";
+
+interface DeleteStripeCustomerBestEffortInput {
+  stripeCustomerId: string | null | undefined;
+  ownerType: "user" | "organization";
+  ownerId: string;
+}
+
+/**
+ * Best-effort Stripe customer delete after User or Organization deletion is
+ * allowed. Failure is logged and must not fail the wipe. Never cancels a
+ * subscription — running subscriptions are a deletion blocker, not a cancel.
+ */
+export async function deleteStripeCustomerBestEffort(
+  input: DeleteStripeCustomerBestEffortInput,
+): Promise<void> {
+  if (!input.stripeCustomerId) {
+    return;
+  }
+
+  try {
+    await stripeClient.deleteCustomer(input.stripeCustomerId);
+  } catch (error) {
+    captureExternalServiceError(error, {
+      label: "stripe_customer_delete",
+      sentry: {
+        tags: {
+          context: "stripe_customer_delete",
+          ownerType: input.ownerType,
+        },
+      },
+      extra: {
+        ownerId: input.ownerId,
+        stripeCustomerId: input.stripeCustomerId,
+      },
+    });
+  }
+}

--- a/apps/core/src/helpers/stripe-customer-delete.ts
+++ b/apps/core/src/helpers/stripe-customer-delete.ts
@@ -1,5 +1,15 @@
 import { stripeClient } from "@/clients/stripe.client";
+import prisma from "@/lib/db/prisma";
 import { captureExternalServiceError } from "@/lib/external-service-errors";
+
+const STRIPE_CUSTOMER_DELETE_TIMEOUT_MS = 2500;
+
+const RUNNING_STRIPE_SUBSCRIPTION_STATUSES = [
+  "active",
+  "trialing",
+  "past_due",
+  "unpaid",
+] as const;
 
 interface DeleteStripeCustomerBestEffortInput {
   stripeCustomerId: string | null | undefined;
@@ -7,10 +17,21 @@ interface DeleteStripeCustomerBestEffortInput {
   ownerId: string;
 }
 
+function isStripeResourceMissing(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code: unknown }).code === "resource_missing"
+  );
+}
+
 /**
  * Best-effort Stripe customer delete after User or Organization deletion is
  * allowed. Failure is logged and must not fail the wipe. Never cancels a
- * subscription — running subscriptions are a deletion blocker, not a cancel.
+ * subscription — `customers.del` would cancel active Stripe subscriptions, so
+ * a still-running local subscription skips delete until evaluate blocks that
+ * case (SOK-843/844).
  */
 export async function deleteStripeCustomerBestEffort(
   input: DeleteStripeCustomerBestEffortInput,
@@ -19,9 +40,30 @@ export async function deleteStripeCustomerBestEffort(
     return;
   }
 
+  const runningSubscription = await prisma.subscription.findFirst({
+    where: {
+      referenceId: input.ownerId,
+      stripeSubscriptionId: { not: null },
+      status: { in: [...RUNNING_STRIPE_SUBSCRIPTION_STATUSES] },
+    },
+    select: { id: true },
+  });
+  if (runningSubscription) {
+    console.warn(
+      `Skipping Stripe customer ${input.stripeCustomerId} delete: running subscription still present for ${input.ownerType} ${input.ownerId}`,
+    );
+    return;
+  }
+
   try {
-    await stripeClient.deleteCustomer(input.stripeCustomerId);
+    await stripeClient.deleteCustomer(input.stripeCustomerId, {
+      timeout: STRIPE_CUSTOMER_DELETE_TIMEOUT_MS,
+    });
   } catch (error) {
+    if (isStripeResourceMissing(error)) {
+      return;
+    }
+
     captureExternalServiceError(error, {
       label: "stripe_customer_delete",
       sentry: {

--- a/apps/core/src/helpers/user-deletion-tasks.test.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.test.ts
@@ -10,6 +10,9 @@ const {
   taskUpdateMock,
   taskDeleteManyMock,
   taskPaymentClaimDeleteManyMock,
+  chatRoomFindManyMock,
+  chatRoomUpdateMock,
+  chatRoomDeleteMock,
   transactionMock,
   deleteTaskFileIfOwnedMock,
 } = vi.hoisted(() => ({
@@ -19,6 +22,9 @@ const {
   taskUpdateMock: vi.fn(),
   taskDeleteManyMock: vi.fn(),
   taskPaymentClaimDeleteManyMock: vi.fn(),
+  chatRoomFindManyMock: vi.fn(),
+  chatRoomUpdateMock: vi.fn(),
+  chatRoomDeleteMock: vi.fn(),
   transactionMock: vi.fn(),
   deleteTaskFileIfOwnedMock: vi.fn(),
 }));
@@ -32,6 +38,9 @@ describe("prepareTasksForUserDeletion", () => {
     vi.clearAllMocks();
     taskFileFindManyMock.mockResolvedValue([]);
     taskPaymentClaimDeleteManyMock.mockResolvedValue({ count: 0 });
+    chatRoomFindManyMock.mockResolvedValue([]);
+    chatRoomUpdateMock.mockResolvedValue({});
+    chatRoomDeleteMock.mockResolvedValue({});
     deleteTaskFileIfOwnedMock.mockResolvedValue(undefined);
     transactionMock.mockImplementation(async (callback) =>
       callback({
@@ -48,6 +57,11 @@ describe("prepareTasksForUserDeletion", () => {
         },
         taskPaymentClaim: {
           deleteMany: taskPaymentClaimDeleteManyMock,
+        },
+        chatRoom: {
+          findMany: chatRoomFindManyMock,
+          update: chatRoomUpdateMock,
+          delete: chatRoomDeleteMock,
         },
       }),
     );
@@ -171,5 +185,60 @@ describe("prepareTasksForUserDeletion", () => {
       "https://abc.public.blob.vercel-storage.com/tasks/tsk_owned/a.pdf",
       "tsk_owned",
     );
+  });
+
+  it("repoints chat room createdByUserId to a remaining member", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+    chatRoomFindManyMock.mockResolvedValue([
+      {
+        id: "room_keep",
+        userMembers: [{ userId: "user_other" }],
+      },
+    ]);
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    expect(chatRoomFindManyMock).toHaveBeenCalledWith({
+      where: { createdByUserId: "user_delete" },
+      select: {
+        id: true,
+        userMembers: {
+          where: { userId: { not: "user_delete" } },
+          select: { userId: true },
+          take: 1,
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+    expect(chatRoomUpdateMock).toHaveBeenCalledWith({
+      where: { id: "room_keep" },
+      data: { createdByUserId: "user_other" },
+    });
+    expect(chatRoomDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("deletes creator-only chat rooms so Restrict does not block allow", async () => {
+    coworkerAssignmentFindManyMock.mockResolvedValue([]);
+    taskFindManyMock.mockResolvedValue([]);
+    taskDeleteManyMock.mockResolvedValue({ count: 0 });
+    chatRoomFindManyMock.mockResolvedValue([
+      {
+        id: "room_solo",
+        userMembers: [],
+      },
+    ]);
+
+    await prepareTasksForUserDeletion("user_delete", {
+      $transaction: transactionMock,
+    } as never);
+
+    expect(chatRoomDeleteMock).toHaveBeenCalledWith({
+      where: { id: "room_solo" },
+    });
+    expect(chatRoomUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/core/src/helpers/user-deletion-tasks.ts
+++ b/apps/core/src/helpers/user-deletion-tasks.ts
@@ -16,6 +16,9 @@ type PrismaClient = ReturnType<typeof createPrismaClient>;
  * - Payment-claim blockers live in `evaluateUserDeletion`. This prep runs only
  *   after that list is empty. Terminal claims are removed so their RESTRICT
  *   transaction relations do not block user cascade.
+ * - Chat rooms this user created re-point `createdByUserId` to another remaining
+ *   human member. Rooms with no other human member are deleted so Restrict does
+ *   not 500 an allowed wipe.
  * - Public blob files for owned tasks are best-effort deleted after the DB
  *   cascade (URLs remain public if blob GC fails).
  */
@@ -76,6 +79,34 @@ export async function prepareTasksForUserDeletion(
     await tx.task.deleteMany({
       where: { ownerId: userId },
     });
+
+    const createdRooms = await tx.chatRoom.findMany({
+      where: { createdByUserId: userId },
+      select: {
+        id: true,
+        userMembers: {
+          where: { userId: { not: userId } },
+          select: { userId: true },
+          take: 1,
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    for (const room of createdRooms) {
+      const nextCreatorId = room.userMembers[0]?.userId;
+      if (nextCreatorId) {
+        await tx.chatRoom.update({
+          where: { id: room.id },
+          data: { createdByUserId: nextCreatorId },
+        });
+        continue;
+      }
+
+      await tx.chatRoom.delete({
+        where: { id: room.id },
+      });
+    }
 
     return ownedFiles;
   });

--- a/apps/core/src/lib/auth.test.ts
+++ b/apps/core/src/lib/auth.test.ts
@@ -56,6 +56,7 @@ const {
   ensureCanAcceptOrganizationInvitationMock,
   syncLocalFreeSeatsAndCreditsForCurrentMembersMock,
   upgradeGuestChatRoomMembershipsToMemberMock,
+  deleteStripeCustomerBestEffortMock,
   listOrganizationExitChatRoomIdsForAblyMock,
   publishOrganizationExitChatRevocationMock,
   prepareStripeEmailSyncForUserUpdateMock,
@@ -74,12 +75,18 @@ const {
     async (callback: (tx: unknown) => unknown) => callback({}),
   );
   const prismaUserUpdateManyMock = vi.fn();
+  const prismaUserFindUniqueMock = vi.fn();
+  const prismaOrganizationFindUniqueMock = vi.fn();
   const prismaMock = {
     __prisma: true,
     $transaction: (callback: (tx: unknown) => unknown) =>
       prismaTransactionMock(callback),
     user: {
       updateMany: prismaUserUpdateManyMock,
+      findUnique: prismaUserFindUniqueMock,
+    },
+    organization: {
+      findUnique: prismaOrganizationFindUniqueMock,
     },
   };
 
@@ -113,6 +120,8 @@ const {
     prismaMock,
     prismaTransactionMock,
     prismaUserUpdateManyMock,
+    prismaUserFindUniqueMock,
+    prismaOrganizationFindUniqueMock,
     reconcileActiveStripeBackedSubscriptionMock: vi.fn(),
     renderMagicLinkEmailMock: vi.fn(),
     resolveActiveOrganizationIdForSessionMock: vi.fn(),
@@ -127,6 +136,7 @@ const {
     ensureCanAcceptOrganizationInvitationMock: vi.fn(),
     syncLocalFreeSeatsAndCreditsForCurrentMembersMock: vi.fn(),
     upgradeGuestChatRoomMembershipsToMemberMock: vi.fn(),
+    deleteStripeCustomerBestEffortMock: vi.fn(),
     listOrganizationExitChatRoomIdsForAblyMock: vi.fn(),
     publishOrganizationExitChatRevocationMock: vi.fn(),
     prepareStripeEmailSyncForUserUpdateMock: vi.fn(),
@@ -331,6 +341,11 @@ vi.mock("@/helpers/chat-room-guest-upgrade", () => ({
     upgradeGuestChatRoomMembershipsToMemberMock(...args),
 }));
 
+vi.mock("@/helpers/stripe-customer-delete", () => ({
+  deleteStripeCustomerBestEffort: (...args: unknown[]) =>
+    deleteStripeCustomerBestEffortMock(...args),
+}));
+
 vi.mock("@/helpers/chat-room-organization-exit", () => ({
   listOrganizationExitChatRoomIdsForAbly: (...args: unknown[]) =>
     listOrganizationExitChatRoomIdsForAblyMock(...args),
@@ -401,6 +416,11 @@ describe("core auth config", () => {
     stripePluginMock.mockReturnValue("stripe-plugin");
     workspaceUpsertMock.mockResolvedValue({ id: "workspace_123" });
     isLastWorkspaceMock.mockResolvedValue(false);
+    prismaMock.user.findUnique.mockResolvedValue({ stripeCustomerId: null });
+    prismaMock.organization.findUnique.mockResolvedValue({
+      stripeCustomerId: null,
+    });
+    deleteStripeCustomerBestEffortMock.mockResolvedValue(undefined);
     prismaTransactionMock.mockImplementation(async (callback) => callback({}));
     betterAuthMock.mockReturnValue({ api: {}, handler: vi.fn() });
     getBetterAuthProductionUrlMock.mockReturnValue("https://example.com/auth");

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -74,6 +74,7 @@ import {
   applyDesignMdMetadataGuardToUserCreate,
   applyDesignMdMetadataGuardToUserUpdate,
 } from "@/helpers/design-md-metadata-auth";
+import { deleteStripeCustomerBestEffort } from "@/helpers/stripe-customer-delete";
 import { prepareTasksForUserDeletion } from "@/helpers/user-deletion-tasks";
 import { uploadProfileImage } from "@/lib/blob";
 import prisma from "@/lib/db/prisma";
@@ -552,6 +553,20 @@ export const auth = betterAuth({
         const evaluation = await evaluateUserDeletion(user.id, prisma);
         throwIfUserDeletionBlocked(user.id, evaluation);
         await prepareTasksForUserDeletion(user.id, prisma);
+        const userCustomer = await prisma.user.findUnique({
+          where: { id: user.id },
+          select: { stripeCustomerId: true },
+        });
+        (user as { stripeCustomerId?: string | null }).stripeCustomerId =
+          userCustomer?.stripeCustomerId ?? null;
+      },
+      afterDelete: async (user) => {
+        await deleteStripeCustomerBestEffort({
+          stripeCustomerId: (user as { stripeCustomerId?: string | null })
+            .stripeCustomerId,
+          ownerType: "user",
+          ownerId: user.id,
+        });
       },
     },
     additionalFields: betterAuthUserAdditionalFields,
@@ -693,6 +708,19 @@ export const auth = betterAuth({
             prisma,
           );
           throwIfOrganizationDeletionBlocked(evaluation);
+          const organizationCustomer = await prisma.organization.findUnique({
+            where: { id: organization.id },
+            select: { stripeCustomerId: true },
+          });
+          organization.stripeCustomerId =
+            organizationCustomer?.stripeCustomerId ?? null;
+        },
+        afterDeleteOrganization: async ({ organization }) => {
+          await deleteStripeCustomerBestEffort({
+            stripeCustomerId: organization.stripeCustomerId,
+            ownerType: "organization",
+            ownerId: organization.id,
+          });
         },
       },
       schema: {

--- a/apps/core/src/lib/auth.ts
+++ b/apps/core/src/lib/auth.ts
@@ -561,12 +561,14 @@ export const auth = betterAuth({
           userCustomer?.stripeCustomerId ?? null;
       },
       afterDelete: async (user) => {
-        await deleteStripeCustomerBestEffort({
-          stripeCustomerId: (user as { stripeCustomerId?: string | null })
-            .stripeCustomerId,
-          ownerType: "user",
-          ownerId: user.id,
-        });
+        waitUntil(
+          deleteStripeCustomerBestEffort({
+            stripeCustomerId: (user as { stripeCustomerId?: string | null })
+              .stripeCustomerId,
+            ownerType: "user",
+            ownerId: user.id,
+          }),
+        );
       },
     },
     additionalFields: betterAuthUserAdditionalFields,
@@ -716,11 +718,13 @@ export const auth = betterAuth({
             organizationCustomer?.stripeCustomerId ?? null;
         },
         afterDeleteOrganization: async ({ organization }) => {
-          await deleteStripeCustomerBestEffort({
-            stripeCustomerId: organization.stripeCustomerId,
-            ownerType: "organization",
-            ownerId: organization.id,
-          });
+          waitUntil(
+            deleteStripeCustomerBestEffort({
+              stripeCustomerId: organization.stripeCustomerId,
+              ownerType: "organization",
+              ownerId: organization.id,
+            }),
+          );
         },
       },
       schema: {

--- a/docs/adr/0008-user-and-organization-deletion-policy.md
+++ b/docs/adr/0008-user-and-organization-deletion-policy.md
@@ -1,0 +1,53 @@
+# ADR 0008: User and Organization deletion blocks instead of canceling Stripe
+
+- Status: Accepted
+- Date: 2026-08-20
+- Deciders: sokosumi core team
+- Technical story: SOK-840 / SOK-842 — allowed User deletion and Organization
+  deletion must succeed without canceling billing or leaving Restrict leftovers
+
+## Context
+
+A User can delete themselves, and an Organization owner can delete the
+Organization. Today those wipes only gate a few local conditions (task payment
+claims for User deletion; extra members and last workspace for Organization
+deletion). They do not encode billing or in-flight work, they can 500 on
+`ChatRoom.createdByUserId` Restrict, and they can leave a Stripe customer
+behind — or fail the wipe when Stripe is down.
+
+The product already has a Stripe billing portal. Canceling a subscription is
+that portal, not an in-app cancel on delete.
+
+## Decision
+
+**Block, do not cancel Stripe.** A running subscription (paid Stripe
+subscription whose status is `active`, `trialing`, `past_due`, or `unpaid`,
+including `cancelAtPeriodEnd` until the period ends) refuses User deletion
+(`referenceId = userId`) and Organization deletion (`referenceId =
+organizationId`). An active enterprise contract refuses Organization deletion
+only. This path never calls Stripe subscription cancel.
+
+**Free is not running.** A local free subscription (`plan: free`, no Stripe
+subscription id) does not block deletion.
+
+**Forfeit unused credits.** Leftover credit balance is not a blocker. When the
+wipe is allowed, unused credits go away with the User or Organization.
+
+**In-flight includes unsettled on-chain.** An in-flight Job is a non-terminal
+agent status **or** a purchase whose on-chain status is not finalized
+(`DISPUTED_WITHDRAWN`, `FUNDS_WITHDRAWN`, `REFUND_WITHDRAWN`,
+`FUNDS_OR_DATUM_INVALID`). An in-flight Task is not `COMPLETED`, `FAILED`, or
+`CANCELED`. Those refuse deletion; terminal + finalized work does not.
+
+**After allow, the wipe must actually succeed.** User-deletion prep re-points
+cheap Restrict leftovers (`Task.creatorUserId`, `ChatRoom.createdByUserId`) so
+Better Auth can delete the User. Stripe customer delete for the User or
+Organization is best-effort: failure is logged and does not fail the wipe.
+
+## Rejected
+
+- Auto-cancel Stripe (or refund) on delete
+- Treating local free as a running subscription
+- Blocking on leftover credit balance
+- Cooling-off, scheduled deletion, anonymization, or a GDPR 30-day job
+- Schema change to make `ChatRoom.createdByUserId` nullable / SetNull

--- a/docs/adr/0008-user-and-organization-deletion-policy.md
+++ b/docs/adr/0008-user-and-organization-deletion-policy.md
@@ -25,7 +25,9 @@ subscription whose status is `active`, `trialing`, `past_due`, or `unpaid`,
 including `cancelAtPeriodEnd` until the period ends) refuses User deletion
 (`referenceId = userId`) and Organization deletion (`referenceId =
 organizationId`). An active enterprise contract refuses Organization deletion
-only. This path never calls Stripe subscription cancel.
+only. This path never calls Stripe subscription cancel. Evaluate blockers for
+running subscription / enterprise / in-flight land in SOK-843/844; until then
+best-effort `customers.del` skips when a local running subscription remains.
 
 **Free is not running.** A local free subscription (`plan: free`, no Stripe
 subscription id) does not block deletion.

--- a/docs/adr/0009-user-and-organization-deletion-policy.md
+++ b/docs/adr/0009-user-and-organization-deletion-policy.md
@@ -1,4 +1,4 @@
-# ADR 0008: User and Organization deletion blocks instead of canceling Stripe
+# ADR 0009: User and Organization deletion blocks instead of canceling Stripe
 
 - Status: Accepted
 - Date: 2026-08-20


### PR DESCRIPTION
https://linear.app/masumi/issue/SOK-842/make-allowed-user-and-organization-deletion-actually-succeed

After evaluate is empty, User and Organization deletion complete:
- User-deletion prep re-points `ChatRoom.createdByUserId` to a remaining member, or deletes creator-only rooms so Restrict does not 500 the wipe
- Best-effort Stripe customer delete runs after the local wipe (`afterDelete`); failure is logged and does not fail deletion
- This path never cancels a Stripe subscription
- ADR 0009 records the deletion policy (block ≠ cancel Stripe; free ≠ running; forfeit credits; in-flight includes unsettled on-chain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User and organization deletion now cleans up associated Stripe customers when safe, without blocking the deletion process.
  - Deletion is prevented from removing customers with active subscriptions; missing Stripe records are handled gracefully.
  - Chat rooms created by a deleted user are reassigned to the earliest remaining member or removed when no members remain.

- **Documentation**
  - Added a deletion policy covering subscriptions, contracts, credits, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->