### PR TITLE
fix(auth): preserve OAuth consent signatures

### DIFF
--- a/apps/web/src/app/(auth)/oauth/consent/__tests__/consent-actions.test.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/__tests__/consent-actions.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConsentActions } from "../consent-actions";
+
+const mockConsent = vi.hoisted(() => vi.fn());
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth/auth.client", () => ({
+  authClient: {
+    oauth2: {
+      consent: mockConsent,
+    },
+  },
+}));
+
+describe("ConsentActions", () => {
+  const oauthQuery = "client_id=client_1&exp=1772367377&sig=abc%2Bdef%2Fghi%3D";
+
+  beforeEach(() => {
+    mockConsent.mockReset();
+    mockConsent.mockResolvedValue({
+      data: null,
+      error: { message: "Expected test error" },
+    });
+  });
+
+  it("submits the canonical signed query when authorizing", async () => {
+    render(<ConsentActions oauthQuery={oauthQuery} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "authorize" }));
+
+    await waitFor(() => {
+      expect(mockConsent).toHaveBeenCalledWith({
+        accept: true,
+        oauth_query: oauthQuery,
+      });
+    });
+  });
+
+  it("submits the canonical signed query when denying", async () => {
+    render(<ConsentActions oauthQuery={oauthQuery} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "deny" }));
+
+    await waitFor(() => {
+      expect(mockConsent).toHaveBeenCalledWith({
+        accept: false,
+        oauth_query: oauthQuery,
+      });
+    });
+  });
+});

--- a/apps/web/src/app/(auth)/oauth/consent/consent-actions.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/consent-actions.tsx
@@ -7,7 +7,11 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth/auth.client";
 
-export function ConsentActions() {
+interface ConsentActionsProps {
+  oauthQuery?: string;
+}
+
+export function ConsentActions({ oauthQuery }: ConsentActionsProps) {
   const t = useTranslations("App.Account.OAuthConsent.actions");
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [isDenying, setIsDenying] = useState(false);
@@ -17,6 +21,7 @@ export function ConsentActions() {
     try {
       const result = await authClient.oauth2.consent({
         accept: true,
+        ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
       });
 
       if (result.error) {
@@ -41,7 +46,10 @@ export function ConsentActions() {
 
   async function handleDeny() {
     setIsDenying(true);
-    const result = await authClient.oauth2.consent({ accept: false });
+    const result = await authClient.oauth2.consent({
+      accept: false,
+      ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
+    });
 
     if (result.error) {
       toast.error(result.error.message || t("denyError"));

--- a/apps/web/src/app/(auth)/oauth/consent/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/page.tsx
@@ -10,6 +10,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { getOAuthClientPublic, getSession } from "@/lib/auth/auth.server";
+import {
+  buildSignedOAuthConsentQueryFromSearchParams,
+  serializeOAuthConsentSearchParams,
+} from "@/lib/auth/auth.utils";
 
 import { ConsentActions } from "./consent-actions";
 import { getOAuthConsentScopeFlags } from "./oauth-consent-scope-flags";
@@ -37,6 +41,9 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
   }
 
   const client_id = oauthSearchParams.get("client_id");
+  const redirectQuery = serializeOAuthConsentSearchParams(oauthSearchParams);
+  const signedOAuthQuery =
+    buildSignedOAuthConsentQueryFromSearchParams(oauthSearchParams);
   const { requestsCoreApi, requestsOfflineAccess } = getOAuthConsentScopeFlags(
     oauthSearchParams.get("scope"),
   );
@@ -58,8 +65,7 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
   const session = await getSession();
 
   if (!session?.session) {
-    const queryString = oauthSearchParams.toString();
-    redirect(queryString ? `/signin?${queryString}` : "/signin");
+    redirect(redirectQuery ? `/signin?${redirectQuery}` : "/signin");
   }
 
   // Fetch public client info for display on consent page
@@ -121,7 +127,7 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
             ) : null}
           </div>
 
-          <ConsentActions />
+          <ConsentActions oauthQuery={signedOAuthQuery} />
         </CardContent>
       </Card>
     </div>

--- a/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.utils.test.ts
@@ -3,6 +3,7 @@ import {
   buildAuthCallbackUrl,
   buildOAuthConsentReturnUrl,
   buildOAuthConsentReturnUrlFromSearchParams,
+  buildSignedOAuthConsentQueryFromSearchParams,
   buildSignUpUrlFromSignIn,
   createAuthSessionGetter,
   getAbsoluteAuthRedirectUrl,
@@ -11,6 +12,26 @@ import {
   normalizeAuthReturnUrl,
   waitForAuthSession,
 } from "@/lib/auth/auth.utils";
+
+describe("buildSignedOAuthConsentQueryFromSearchParams", () => {
+  it("repairs base64 plus characters and keeps only signed parameters", () => {
+    const params = new URLSearchParams(
+      "client_id=client_1&exp=1772367377&ba_param=ba_param&ba_param=client_id&ba_param=exp&debug=unsigned&sig=abc+def%2Fghi%3D",
+    );
+
+    expect(buildSignedOAuthConsentQueryFromSearchParams(params)).toBe(
+      "client_id=client_1&exp=1772367377&ba_param=ba_param&ba_param=client_id&ba_param=exp&sig=abc%2Bdef%2Fghi%3D",
+    );
+  });
+
+  it("returns undefined for an unsigned query", () => {
+    expect(
+      buildSignedOAuthConsentQueryFromSearchParams(
+        new URLSearchParams("client_id=client_1"),
+      ),
+    ).toBeUndefined();
+  });
+});
 
 describe("getAuthOAuthRedirect", () => {
   it("returns redirect metadata from top-level payload", () => {
@@ -322,6 +343,16 @@ describe("buildOAuthConsentReturnUrlFromSearchParams", () => {
 
     expect(buildOAuthConsentReturnUrlFromSearchParams(params)).toBe(
       "/oauth/consent?client_id=client_1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=challenge_1&code_challenge_method=S256&scope=openid&state=state_1&response_type=code&exp=1772367377&sig=signed-value",
+    );
+  });
+
+  it("repairs a base64 signature whose encoded plus was decoded as a space", () => {
+    const params = new URLSearchParams(
+      "client_id=client_1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=challenge_1&exp=1772367377&sig=mVXxByc5E32WEKh8YvwTBB+vbGZAR42ECbHJf8K%2F24s%3D",
+    );
+
+    expect(buildOAuthConsentReturnUrlFromSearchParams(params)).toBe(
+      "/oauth/consent?client_id=client_1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_challenge=challenge_1&exp=1772367377&sig=mVXxByc5E32WEKh8YvwTBB%2BvbGZAR42ECbHJf8K%2F24s%3D",
     );
   });
 });

--- a/apps/web/src/lib/auth/auth.utils.ts
+++ b/apps/web/src/lib/auth/auth.utils.ts
@@ -4,6 +4,7 @@ const AUTH_SESSION_INITIAL_WAIT_MS = 200;
 const AUTH_SESSION_RETRY_WAIT_MS = 500;
 const OAUTH_CONSENT_PATH = "/oauth/consent";
 const AUTH_REDIRECT_EXCLUDED_QUERY_KEYS = new Set(["returnUrl", "email"]);
+const SIGNED_OAUTH_QUERY_PARAMETER_NAMES_KEY = "ba_param";
 
 const OAUTH_CONSENT_QUERY_KEYS = [
   "client_id",
@@ -271,6 +272,60 @@ type OAuthConsentParamRecord = Partial<
   Record<(typeof OAUTH_CONSENT_QUERY_KEYS)[number], string | undefined>
 >;
 
+function normalizeOAuthConsentQueryValue(key: string, value: string): string {
+  // Better Auth signs with standard base64. Its magic-link verifier decodes an
+  // already-parsed callback URL, turning `%2B` into `+`; subsequent form-style
+  // query parsing turns that `+` into a space. Restore the signature before
+  // serializing it back to `%2B`.
+  return key === "sig" ? value.replaceAll(" ", "+") : value;
+}
+
+export function serializeOAuthConsentSearchParams(
+  searchParams: URLSearchParams,
+): string {
+  const normalizedSearchParams = new URLSearchParams();
+
+  for (const [key, value] of searchParams.entries()) {
+    normalizedSearchParams.append(
+      key,
+      normalizeOAuthConsentQueryValue(key, value),
+    );
+  }
+
+  return normalizedSearchParams.toString();
+}
+
+export function buildSignedOAuthConsentQueryFromSearchParams(
+  searchParams: URLSearchParams,
+): string | undefined {
+  if (
+    !searchParams.has("client_id") ||
+    !searchParams.has("exp") ||
+    !searchParams.has("sig")
+  ) {
+    return undefined;
+  }
+
+  const signedParameterNames = new Set(
+    searchParams.getAll(SIGNED_OAUTH_QUERY_PARAMETER_NAMES_KEY),
+  );
+  const signedSearchParams = new URLSearchParams();
+
+  for (const [key, value] of searchParams.entries()) {
+    const isSignedParameter =
+      signedParameterNames.size === 0 ||
+      key === "sig" ||
+      key === SIGNED_OAUTH_QUERY_PARAMETER_NAMES_KEY ||
+      signedParameterNames.has(key);
+
+    if (isSignedParameter && !AUTH_REDIRECT_EXCLUDED_QUERY_KEYS.has(key)) {
+      signedSearchParams.append(key, value);
+    }
+  }
+
+  return serializeOAuthConsentSearchParams(signedSearchParams);
+}
+
 export function buildOAuthConsentReturnUrl(
   params: OAuthConsentParamRecord,
 ): string | undefined {
@@ -283,7 +338,7 @@ export function buildOAuthConsentReturnUrl(
   for (const key of OAUTH_CONSENT_QUERY_KEYS) {
     const value = params[key];
     if (value) {
-      searchParams.set(key, value);
+      searchParams.set(key, normalizeOAuthConsentQueryValue(key, value));
     }
   }
 
@@ -300,13 +355,11 @@ export function buildOAuthConsentReturnUrlFromSearchParams(
     }
   }
 
-  const hasSignedOAuthQuery =
-    filteredSearchParams.has("client_id") &&
-    filteredSearchParams.has("exp") &&
-    filteredSearchParams.has("sig");
+  const signedOAuthQuery =
+    buildSignedOAuthConsentQueryFromSearchParams(filteredSearchParams);
 
-  if (hasSignedOAuthQuery) {
-    return `${OAUTH_CONSENT_PATH}?${filteredSearchParams.toString()}`;
+  if (signedOAuthQuery) {
+    return `${OAUTH_CONSENT_PATH}?${signedOAuthQuery}`;
   }
 
   return buildOAuthConsentReturnUrl({


### PR DESCRIPTION
## Summary

- repair standard-base64 `+` characters corrupted during Better Auth magic-link callback decoding
- rebuild and submit canonical signed `oauth_query` values for both consent approval and denial
- preserve canonical OAuth parameters when redirecting unauthenticated users through sign-in
- add regression coverage for signature repair and consent submissions

## Root cause

Better Auth magic-link verification decodes an already-parsed `callbackURL`. Signed OAuth query values containing `%2B` become literal `+`; later form-style query parsing converts `+` to a space, so OAuth consent verification returns `invalid_signature`.

## Verification

- local HTTP E2E with isolated database and real Core/Web servers on Node 24
  - reproduced corrupted literal-`+` request returning HTTP 400
  - verified consent page canonicalized signature back to `%2B`
  - verified approval returned HTTP 200 and authorization-code callback with intact state
- `pnpm --filter web test src/lib/auth/__tests__/auth.utils.test.ts src/app/\(auth\)/oauth/consent/__tests__/consent-actions.test.tsx` (39 tests)
- `pnpm --filter web typecheck`
- targeted Biome check
- pre-commit `pnpm check && pnpm typecheck`