### PR TITLE
fix(auth): enforce temporary workspace onboarding

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4070,6 +4070,7 @@
           "authorizeError": "Anwendung konnte nicht autorisiert werden",
           "authorizeErrorRedirectUri": "Anwendung konnte nicht autorisiert werden. Bitte überprüfe deine Redirect-URI.",
           "authorizeErrorGeneric": "Bei der Autorisierung ist ein Fehler aufgetreten",
+          "workspacePrepareError": "Dein Workspace konnte nicht vorbereitet werden. Bitte versuche es erneut.",
           "authorizeSuccess": "Anwendung erfolgreich autorisiert",
           "denyError": "Anwendung konnte nicht abgelehnt werden"
         },
@@ -5626,6 +5627,7 @@
       "personalDescription": "Arbeite für dich allein.",
       "organizationTitle": "Organisation",
       "organizationDescription": "Arbeite mit deinem Team.",
+      "organizationUnavailable": "Derzeit nicht verfügbar",
       "continue": "Weiter",
       "nameUpdateError": "Wir konnten deinen Namen nicht aktualisieren.",
       "organizationActivateError": "Der Wechsel zu dieser Organisation war nicht möglich. Du kannst den Workspace wechseln, sobald du im Produkt bist.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4102,6 +4102,7 @@
           "authorizeError": "Failed to authorize application",
           "authorizeErrorRedirectUri": "Failed to authorize application. Please check your redirect URI.",
           "authorizeErrorGeneric": "An error occurred during authorization",
+          "workspacePrepareError": "Could not prepare your workspace. Please try again.",
           "authorizeSuccess": "Application authorized successfully",
           "denyError": "Failed to deny application"
         },
@@ -5626,6 +5627,7 @@
       "personalDescription": "Work on your own.",
       "organizationTitle": "Organization",
       "organizationDescription": "Work with your team.",
+      "organizationUnavailable": "Currently unavailable",
       "continue": "Continue",
       "nameUpdateError": "We could not update your name.",
       "organizationActivateError": "We could not switch you into that organization. You can switch workspaces after you enter.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4070,6 +4070,7 @@
           "authorizeError": "No se pudo autorizar la aplicación",
           "authorizeErrorRedirectUri": "No se pudo autorizar la aplicación. Por favor, verifica tu Redirect URI.",
           "authorizeErrorGeneric": "Ocurrió un error durante la autorización",
+          "workspacePrepareError": "No se pudo preparar tu espacio de trabajo. Inténtalo de nuevo.",
           "authorizeSuccess": "Aplicación autorizada correctamente",
           "denyError": "No se pudo rechazar la aplicación"
         },
@@ -5626,6 +5627,7 @@
       "personalDescription": "Trabaja por tu cuenta.",
       "organizationTitle": "Organización",
       "organizationDescription": "Trabaja con tu equipo.",
+      "organizationUnavailable": "No disponible actualmente",
       "continue": "Continuar",
       "nameUpdateError": "No pudimos actualizar tu nombre.",
       "organizationActivateError": "No pudimos cambiarte a esa organización. Puedes cambiar de espacio de trabajo cuando entres.",

--- a/apps/web/src/app/(auth)/oauth/consent/__tests__/consent-actions.test.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/__tests__/consent-actions.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConsentActions } from "../consent-actions";
 
 const mockConsent = vi.hoisted(() => vi.fn());
+const mockEnsureOAuthWorkspaceAction = vi.hoisted(() => vi.fn());
+const mockToastError = vi.hoisted(() => vi.fn());
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -11,9 +13,13 @@ vi.mock("next-intl", () => ({
 
 vi.mock("sonner", () => ({
   toast: {
-    error: vi.fn(),
+    error: mockToastError,
     success: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/actions/workspace-gate", () => ({
+  ensureOAuthWorkspaceAction: mockEnsureOAuthWorkspaceAction,
 }));
 
 vi.mock("@/lib/auth/auth.client", () => ({
@@ -29,6 +35,12 @@ describe("ConsentActions", () => {
 
   beforeEach(() => {
     mockConsent.mockReset();
+    mockEnsureOAuthWorkspaceAction.mockReset();
+    mockToastError.mockReset();
+    mockEnsureOAuthWorkspaceAction.mockResolvedValue({
+      ok: true,
+      value: { createdPersonalWorkspace: false },
+    });
     mockConsent.mockResolvedValue({
       data: null,
       error: { message: "Expected test error" },
@@ -41,11 +53,30 @@ describe("ConsentActions", () => {
     fireEvent.click(screen.getByRole("button", { name: "authorize" }));
 
     await waitFor(() => {
+      expect(mockEnsureOAuthWorkspaceAction).toHaveBeenCalledWith({});
       expect(mockConsent).toHaveBeenCalledWith({
         accept: true,
         oauth_query: oauthQuery,
       });
     });
+    expect(
+      mockEnsureOAuthWorkspaceAction.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockConsent.mock.invocationCallOrder[0]);
+  });
+
+  it("does not authorize when workspace preparation fails", async () => {
+    mockEnsureOAuthWorkspaceAction.mockResolvedValue({
+      ok: false,
+      error: { code: "INTERNAL", message: "Core unavailable" },
+    });
+    render(<ConsentActions oauthQuery={oauthQuery} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "authorize" }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("workspacePrepareError");
+    });
+    expect(mockConsent).not.toHaveBeenCalled();
   });
 
   it("submits the canonical signed query when denying", async () => {
@@ -59,5 +90,6 @@ describe("ConsentActions", () => {
         oauth_query: oauthQuery,
       });
     });
+    expect(mockEnsureOAuthWorkspaceAction).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(auth)/oauth/consent/consent-actions.tsx
+++ b/apps/web/src/app/(auth)/oauth/consent/consent-actions.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { ensureOAuthWorkspaceAction } from "@/lib/actions/workspace-gate";
 import { authClient } from "@/lib/auth/auth.client";
 
 interface ConsentActionsProps {
@@ -19,6 +20,13 @@ export function ConsentActions({ oauthQuery }: ConsentActionsProps) {
   async function handleAuthorize() {
     setIsAuthorizing(true);
     try {
+      const workspaceResult = await ensureOAuthWorkspaceAction({});
+      if (!workspaceResult.ok) {
+        toast.error(t("workspacePrepareError"));
+        setIsAuthorizing(false);
+        return;
+      }
+
       const result = await authClient.oauth2.consent({
         accept: true,
         ...(oauthQuery ? { oauth_query: oauthQuery } : {}),

--- a/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
+++ b/apps/web/src/app/(flows)/setup/components/__tests__/identity-onboarding-form.test.tsx
@@ -92,6 +92,7 @@ const messages = {
       personalDescription: "Work on your own.",
       organizationTitle: "Organization",
       organizationDescription: "Work with your team.",
+      organizationUnavailable: "Currently unavailable",
       continue: "Continue",
       nameUpdateError: "Name update failed",
       personalCreateError: "Create failed",
@@ -100,12 +101,17 @@ const messages = {
   },
 };
 
-function renderForm(initialName = "Ada Lovelace", workspaceReady = false) {
+function renderForm(
+  initialName = "Ada Lovelace",
+  workspaceReady = false,
+  organizationSetupEnabled = false,
+) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
       <IdentityOnboardingForm
         initialName={initialName}
         workspaceReady={workspaceReady}
+        organizationSetupEnabled={organizationSetupEnabled}
       />
     </NextIntlClientProvider>,
   );
@@ -181,9 +187,25 @@ describe("IdentityOnboardingForm", () => {
     });
   });
 
-  it("does not create a personal workspace when Organization is chosen", async () => {
+  it("shows organization setup as currently unavailable and blocks selection", async () => {
     const user = userEvent.setup();
     renderForm();
+
+    const organizationChoice = screen.getByRole("radio", {
+      name: /Organization/i,
+    });
+    expect(organizationChoice).toBeDisabled();
+    expect(screen.getByText("Currently unavailable")).toBeTruthy();
+
+    await user.click(organizationChoice);
+
+    expect(screen.getByRole("radio", { name: /Personal/i })).toBeChecked();
+    expect(screen.queryByTestId("create-org-wizard")).toBeNull();
+  });
+
+  it("does not create a personal workspace when Organization is chosen", async () => {
+    const user = userEvent.setup();
+    renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));
@@ -201,7 +223,7 @@ describe("IdentityOnboardingForm", () => {
 
   it("keeps an edited name after Back from the organization wizard", async () => {
     const user = userEvent.setup();
-    renderForm("Ada Lovelace");
+    renderForm("Ada Lovelace", false, true);
 
     const nameInput = screen.getByTestId("workspace-gate-identity-name");
     await user.clear(nameInput);
@@ -220,7 +242,7 @@ describe("IdentityOnboardingForm", () => {
     updateUserMock.mockResolvedValue({
       error: { message: "Name service down" },
     });
-    renderForm("Ada Lovelace");
+    renderForm("Ada Lovelace", false, true);
 
     const nameInput = screen.getByTestId("workspace-gate-identity-name");
     await user.clear(nameInput);
@@ -238,7 +260,7 @@ describe("IdentityOnboardingForm", () => {
 
   it("does not navigate away when the organization wizard opens", async () => {
     const user = userEvent.setup();
-    renderForm();
+    renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));
@@ -262,7 +284,7 @@ describe("IdentityOnboardingForm", () => {
 
   it("keeps the organization wizard mounted when workspace becomes ready", async () => {
     const user = userEvent.setup();
-    const view = renderForm();
+    const view = renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));
@@ -272,7 +294,11 @@ describe("IdentityOnboardingForm", () => {
 
     view.rerender(
       <NextIntlClientProvider locale="en" messages={messages}>
-        <IdentityOnboardingForm initialName="Ada Lovelace" workspaceReady />
+        <IdentityOnboardingForm
+          initialName="Ada Lovelace"
+          workspaceReady
+          organizationSetupEnabled
+        />
       </NextIntlClientProvider>,
     );
 
@@ -291,7 +317,7 @@ describe("IdentityOnboardingForm", () => {
           resolveActivate = resolve;
         }),
     );
-    const view = renderForm();
+    const view = renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));
@@ -301,7 +327,11 @@ describe("IdentityOnboardingForm", () => {
 
     view.rerender(
       <NextIntlClientProvider locale="en" messages={messages}>
-        <IdentityOnboardingForm initialName="Ada Lovelace" workspaceReady />
+        <IdentityOnboardingForm
+          initialName="Ada Lovelace"
+          workspaceReady
+          organizationSetupEnabled
+        />
       </NextIntlClientProvider>,
     );
 
@@ -319,7 +349,7 @@ describe("IdentityOnboardingForm", () => {
 
   it("leaves the gate into the created organization when the wizard is ready", async () => {
     const user = userEvent.setup();
-    renderForm();
+    renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));
@@ -339,7 +369,7 @@ describe("IdentityOnboardingForm", () => {
     activateOrganizationWorkspaceMock
       .mockRejectedValueOnce(new Error("setActive failed"))
       .mockResolvedValueOnce(undefined);
-    renderForm();
+    renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));
@@ -357,7 +387,7 @@ describe("IdentityOnboardingForm", () => {
     activateOrganizationWorkspaceMock.mockRejectedValue(
       new Error("setActive failed"),
     );
-    renderForm();
+    renderForm(undefined, false, true);
 
     await user.click(screen.getByRole("radio", { name: /Organization/i }));
     await user.click(screen.getByTestId("workspace-gate-identity-submit"));

--- a/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
+++ b/apps/web/src/app/(flows)/setup/components/identity-onboarding-form.client.tsx
@@ -28,14 +28,23 @@ import { cn } from "@/lib/utils";
 
 type WorkspaceChoice = "personal" | "organization";
 
+/**
+ * Temporary registration policy. Organization setup remains implemented below
+ * so re-enabling it later only requires changing this default.
+ */
+const ORGANIZATION_SETUP_ENABLED = false;
+
 interface IdentityOnboardingFormProps {
   initialName: string;
   workspaceReady: boolean;
+  /** Keeps the dormant organization path covered while its UI is disabled. */
+  organizationSetupEnabled?: boolean;
 }
 
 export function IdentityOnboardingForm({
   initialName,
   workspaceReady,
+  organizationSetupEnabled = ORGANIZATION_SETUP_ENABLED,
 }: IdentityOnboardingFormProps) {
   const t = useTranslations("WorkspaceGate.Identity");
   const tSchema = useTranslations("Library.Auth.Schema");
@@ -160,7 +169,7 @@ export function IdentityOnboardingForm({
   }
 
   function handleSetupSubmit(values: NameFormType) {
-    if (choice === "organization") {
+    if (choice === "organization" && organizationSetupEnabled) {
       void handleOrganizationContinue(values);
       return;
     }
@@ -206,7 +215,10 @@ export function IdentityOnboardingForm({
                 <RadioGroup
                   value={choice}
                   onValueChange={(value) => {
-                    if (value === "personal" || value === "organization") {
+                    if (
+                      value === "personal" ||
+                      (organizationSetupEnabled && value === "organization")
+                    ) {
                       setChoice(value);
                     }
                   }}
@@ -237,8 +249,12 @@ export function IdentityOnboardingForm({
                   </Label>
                   <Label
                     htmlFor="workspace-choice-organization"
+                    aria-disabled={!organizationSetupEnabled}
                     className={cn(
-                      "border-input hover:bg-accent/40 flex cursor-pointer items-start gap-3 rounded-lg border p-4",
+                      "border-input flex items-start gap-3 rounded-lg border p-4",
+                      organizationSetupEnabled
+                        ? "hover:bg-accent/40 cursor-pointer"
+                        : "cursor-not-allowed opacity-60",
                       choice === "organization" &&
                         "border-primary bg-accent/30",
                     )}
@@ -246,11 +262,19 @@ export function IdentityOnboardingForm({
                     <RadioGroupItem
                       value="organization"
                       id="workspace-choice-organization"
+                      disabled={!organizationSetupEnabled}
                       className="mt-0.5"
                     />
                     <span className="space-y-1">
-                      <span className="block text-sm font-medium">
-                        {t("organizationTitle")}
+                      <span className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium">
+                          {t("organizationTitle")}
+                        </span>
+                        {!organizationSetupEnabled ? (
+                          <span className="text-muted-foreground text-xs font-normal">
+                            {t("organizationUnavailable")}
+                          </span>
+                        ) : null}
                       </span>
                       <span className="text-muted-foreground block text-sm font-normal">
                         {t("organizationDescription")}

--- a/apps/web/src/lib/actions/workspace-gate/__tests__/action.test.ts
+++ b/apps/web/src/lib/actions/workspace-gate/__tests__/action.test.ts
@@ -5,6 +5,7 @@ import { CoreApiRequestError } from "@/lib/clients/core.client";
 
 const createMyPersonalWorkspaceMock = vi.fn();
 const deleteMyPersonalWorkspaceMock = vi.fn();
+const getMyWorkspaceAccessMock = vi.fn();
 const clearPendingOrganizationJoinTokenMock = vi.fn();
 const getPendingOrganizationJoinTokenMock = vi.fn();
 const resolveOrganizationInviteLinkMock = vi.fn();
@@ -22,6 +23,8 @@ vi.mock("@/lib/clients/core.client", async () => {
         createMyPersonalWorkspaceMock(...args),
       deleteMyPersonalWorkspace: (...args: unknown[]) =>
         deleteMyPersonalWorkspaceMock(...args),
+      getMyWorkspaceAccess: (...args: unknown[]) =>
+        getMyWorkspaceAccessMock(...args),
       resolveOrganizationInviteLink: (...args: unknown[]) =>
         resolveOrganizationInviteLinkMock(...args),
     },
@@ -61,7 +64,97 @@ import {
   clearPendingOrganizationJoinCookieAction,
   createPersonalWorkspaceAction,
   deletePersonalWorkspaceAction,
+  ensureOAuthWorkspaceAction,
 } from "@/lib/actions/workspace-gate/action";
+
+describe("ensureOAuthWorkspaceAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a personal workspace when the user has no workspace", async () => {
+    getMyWorkspaceAccessMock.mockResolvedValue({
+      data: {
+        hasPersonalWorkspace: false,
+        hasOrganizationMembership: false,
+      },
+    });
+    createMyPersonalWorkspaceMock.mockResolvedValue({
+      data: { workspaceId: "ws-1" },
+    });
+
+    const result = await ensureOAuthWorkspaceAction({});
+
+    expect(result).toEqual({
+      ok: true,
+      value: { createdPersonalWorkspace: true },
+    });
+    expect(createMyPersonalWorkspaceMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      hasPersonalWorkspace: true,
+      hasOrganizationMembership: false,
+    },
+    {
+      hasPersonalWorkspace: false,
+      hasOrganizationMembership: true,
+    },
+  ])("does not create when workspace access already exists", async (access) => {
+    getMyWorkspaceAccessMock.mockResolvedValue({ data: access });
+
+    const result = await ensureOAuthWorkspaceAction({});
+
+    expect(result).toEqual({
+      ok: true,
+      value: { createdPersonalWorkspace: false },
+    });
+    expect(createMyPersonalWorkspaceMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a concurrent personal-workspace create as success", async () => {
+    getMyWorkspaceAccessMock.mockResolvedValue({
+      data: {
+        hasPersonalWorkspace: false,
+        hasOrganizationMembership: false,
+      },
+    });
+    createMyPersonalWorkspaceMock.mockRejectedValue(
+      new CoreApiRequestError("Personal workspace already exists", {
+        status: 409,
+      }),
+    );
+
+    const result = await ensureOAuthWorkspaceAction({});
+
+    expect(result).toEqual({
+      ok: true,
+      value: { createdPersonalWorkspace: false },
+    });
+  });
+
+  it("returns an error when workspace access cannot be checked", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    getMyWorkspaceAccessMock.mockRejectedValue(
+      new CoreApiRequestError("Core backend timeout", { status: 503 }),
+    );
+
+    try {
+      const result = await ensureOAuthWorkspaceAction({});
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe(CommonErrorCode.INTERNAL_SERVER_ERROR);
+      }
+      expect(createMyPersonalWorkspaceMock).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
 
 describe("createPersonalWorkspaceAction", () => {
   beforeEach(() => {

--- a/apps/web/src/lib/actions/workspace-gate/action.ts
+++ b/apps/web/src/lib/actions/workspace-gate/action.ts
@@ -55,6 +55,44 @@ function toCreatePersonalWorkspaceError(error: unknown): ActionError {
   };
 }
 
+interface OAuthWorkspacePrepared {
+  createdPersonalWorkspace: boolean;
+}
+
+/**
+ * Temporary OAuth onboarding policy: before consent approval, ensure users
+ * without any personal or organization workspace receive a personal one.
+ * Existing workspace ownership is never changed.
+ */
+export const ensureOAuthWorkspaceAction = withSession<
+  AuthenticatedRequest,
+  ActionResultDto<OAuthWorkspacePrepared, ActionError>
+>(async () => {
+  try {
+    const { data: workspaceAccess } = await coreClient.getMyWorkspaceAccess();
+    if (
+      workspaceAccess.hasPersonalWorkspace ||
+      workspaceAccess.hasOrganizationMembership
+    ) {
+      return toActionResult(ok({ createdPersonalWorkspace: false }));
+    }
+
+    try {
+      await coreClient.createMyPersonalWorkspace();
+      return toActionResult(ok({ createdPersonalWorkspace: true }));
+    } catch (error) {
+      if (error instanceof CoreApiRequestError && error.status === 409) {
+        // Another request created it after the access check.
+        return toActionResult(ok({ createdPersonalWorkspace: false }));
+      }
+      throw error;
+    }
+  } catch (error) {
+    console.error("Failed to prepare workspace for OAuth", error);
+    return toActionResult(err(toCreatePersonalWorkspaceError(error)));
+  }
+});
+
 /**
  * Create exactly one personal workspace for the signed-in user.
  * Core clears preferredOrganizationId on success; 409 when one already exists.

--- a/apps/web/src/lib/actions/workspace-gate/index.ts
+++ b/apps/web/src/lib/actions/workspace-gate/index.ts
@@ -2,4 +2,5 @@ export {
   clearPendingOrganizationJoinCookieAction,
   createPersonalWorkspaceAction,
   deletePersonalWorkspaceAction,
+  ensureOAuthWorkspaceAction,
 } from "./action";


### PR DESCRIPTION
## Summary

- Keep Organization workspace setup visible but disabled with “Currently unavailable”; retain wizard path behind a documented temporary switch.
- Before OAuth Allow, create a Personal Workspace only when signed-in user has neither a personal workspace nor organization membership.
- Keep OAuth Deny side-effect free and treat concurrent personal-workspace creation as success.

## Why

OAuth consent can be approved by users with no workspace, while downstream OAuth consumers expect a workspace association. This temporary policy guarantees that association without changing users who already have workspace access. Organization creation remains available after onboarding through workspace switcher.

## Verification

- `pnpm --filter web test` — 555 files passed; 3,568 tests passed; 1 skipped
- `pnpm --filter web check`
- `pnpm --filter web typecheck`
- pre-commit `pnpm check && pnpm typecheck`

Local browser automation was unavailable in agent environment. Component interaction coverage verifies Organization option stays visible, disabled, and non-selectable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authorization now prepares workspace access before completing consent.
  * Personal workspaces are created when needed, while existing access is preserved.
  * Organization setup can be disabled, showing the option as unavailable.

* **Bug Fixes**
  * Failed workspace preparation now prevents authorization and displays an error message.
  * Added localized English, German, and Spanish messages for workspace-related errors and unavailable organizations.

* **Tests**
  * Added coverage for workspace preparation, authorization failures, organization setup states, and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->