### PR TITLE
fix(core): accept client_secret_post at the oauth2 token endpoint

### DIFF
--- a/apps/core/src/routes/auth/index.ts
+++ b/apps/core/src/routes/auth/index.ts
@@ -8,6 +8,7 @@ import { cors } from "hono/cors";
 import { TIME } from "@/config/constants";
 import { resolveCorsAllowOrigin } from "@/config/cors-allow-origin";
 import { auth } from "@/lib/auth.js";
+import { withClientSecretPostShim } from "@/routes/auth/oauth2-token-secret-shim.js";
 import { handleSetPassword } from "@/routes/auth/set-password.route.js";
 
 const oauthAuthServerMetadataHandler = oauthProviderAuthServerMetadata(auth);
@@ -40,9 +41,11 @@ app.get("/.well-known/openid-configuration", (c) =>
   oauthOpenIdConfigHandler(c.req.raw),
 );
 
-// Mount Auth routes
-app.on(["POST", "GET"], "*", (c) => {
-  return auth.handler(c.req.raw);
+// Mount Auth routes. The token-endpoint shim (temporary) rewrites
+// client_secret_post requests into the client_secret_basic form Better Auth
+// requires — see oauth2-token-secret-shim.ts.
+app.on(["POST", "GET"], "*", async (c) => {
+  return auth.handler(await withClientSecretPostShim(c.req.raw));
 });
 
 export default app;

--- a/apps/core/src/routes/auth/oauth2-token-secret-shim.test.ts
+++ b/apps/core/src/routes/auth/oauth2-token-secret-shim.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { withClientSecretPostShim } from "./oauth2-token-secret-shim";
+
+const TOKEN_URL = "http://localhost:3001/auth/oauth2/token";
+
+function formRequest(
+  body: Record<string, string>,
+  init?: { url?: string; method?: string; headers?: Record<string, string> },
+): Request {
+  return new Request(init?.url ?? TOKEN_URL, {
+    method: init?.method ?? "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...init?.headers,
+    },
+    body: new URLSearchParams(body).toString(),
+  });
+}
+
+describe("withClientSecretPostShim", () => {
+  it("moves a body client_secret into a Basic Authorization header", async () => {
+    const request = formRequest({
+      grant_type: "authorization_code",
+      code: "code-1",
+      client_id: "client-1",
+      client_secret: "secret-1",
+      code_verifier: "verifier-1",
+    });
+
+    const result = await withClientSecretPostShim(request);
+
+    const expected = Buffer.from("client-1:secret-1").toString("base64");
+    expect(result.headers.get("authorization")).toBe(`Basic ${expected}`);
+    const body = new URLSearchParams(await result.text());
+    expect(body.get("client_secret")).toBeNull();
+    expect(body.get("client_id")).toBe("client-1");
+    expect(body.get("code")).toBe("code-1");
+    expect(body.get("code_verifier")).toBe("verifier-1");
+  });
+
+  it("leaves requests with an existing Authorization header untouched", async () => {
+    const request = formRequest(
+      { client_id: "client-1", client_secret: "secret-1" },
+      { headers: { authorization: "Basic already-there" } },
+    );
+
+    const result = await withClientSecretPostShim(request);
+
+    expect(result).toBe(request);
+  });
+
+  it("leaves non-token paths untouched", async () => {
+    const request = formRequest(
+      { client_id: "client-1", client_secret: "secret-1" },
+      { url: "http://localhost:3001/auth/oauth2/revoke" },
+    );
+
+    const result = await withClientSecretPostShim(request);
+
+    expect(result).toBe(request);
+  });
+
+  it("leaves non-POST and non-form requests untouched", async () => {
+    const get = new Request(TOKEN_URL, { method: "GET" });
+    expect(await withClientSecretPostShim(get)).toBe(get);
+
+    const json = new Request(TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_id: "c", client_secret: "s" }),
+    });
+    expect(await withClientSecretPostShim(json)).toBe(json);
+  });
+
+  it("leaves requests without a body secret untouched", async () => {
+    const request = formRequest({
+      grant_type: "authorization_code",
+      code: "code-1",
+      client_id: "client-1",
+      code_verifier: "verifier-1",
+    });
+
+    const result = await withClientSecretPostShim(request);
+
+    expect(result).toBe(request);
+  });
+});

--- a/apps/core/src/routes/auth/oauth2-token-secret-shim.ts
+++ b/apps/core/src/routes/auth/oauth2-token-secret-shim.ts
@@ -1,0 +1,60 @@
+/**
+ * TEMPORARY compatibility shim for the OAuth2 token endpoint.
+ *
+ * Better Auth registers OAuth clients as `client_secret_basic` and hard-rejects
+ * a `client_secret` sent in the form body (`client_secret_post`):
+ * `400 invalid_client — "client registered for client_secret_basic cannot use
+ * client_secret_post"`. Existing integrators (Serviceplan's agentic-coworkers,
+ * pre plan-net/agentic-coworkers#2032) send the secret in the body, so every
+ * token exchange failed and OAuth onboarding dead-ended at "No identity".
+ *
+ * This shim rewrites such requests into the Basic form Better Auth accepts:
+ * secret moves from the body into an `Authorization: Basic` header. It only
+ * touches `POST …/oauth2/token` form requests that carry a body secret and no
+ * Authorization header — everything else passes through untouched, and client
+ * authentication itself stays entirely with Better Auth.
+ *
+ * Remove once all integrators authenticate with `client_secret_basic`.
+ */
+
+const TOKEN_PATH_SUFFIX = "/oauth2/token";
+const FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+
+export async function withClientSecretPostShim(
+  request: Request,
+): Promise<Request> {
+  if (request.method !== "POST") {
+    return request;
+  }
+  if (!new URL(request.url).pathname.endsWith(TOKEN_PATH_SUFFIX)) {
+    return request;
+  }
+  if (request.headers.get("authorization")) {
+    return request;
+  }
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes(FORM_CONTENT_TYPE)) {
+    return request;
+  }
+
+  const params = new URLSearchParams(await request.clone().text());
+  const clientId = params.get("client_id");
+  const clientSecret = params.get("client_secret");
+  if (!clientId || !clientSecret) {
+    return request;
+  }
+
+  params.delete("client_secret");
+  const headers = new Headers(request.headers);
+  headers.set(
+    "authorization",
+    `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+  );
+  headers.delete("content-length");
+
+  return new Request(request.url, {
+    method: "POST",
+    headers,
+    body: params.toString(),
+  });
+}


### PR DESCRIPTION
## Problem

Better Auth registers OAuth clients as `client_secret_basic` and hard-rejects a `client_secret` sent in the token-request body:

> `400 invalid_client — "client registered for client_secret_basic cannot use client_secret_post"`

Existing integrators — Serviceplan's coworkers (Hannah et al., before plan-net/agentic-coworkers#2032) — send the secret in the body. Every token exchange failed, no `id_token` was issued, and their OAuth onboarding dead-ended at a "No identity" page. Likely regressed when Better Auth introduced strict `token_endpoint_auth_method` enforcement.

## Fix — **TEMPORARY** compatibility shim

`withClientSecretPostShim` wraps the Better Auth mount: a `POST …/oauth2/token` form request carrying a body `client_secret` and **no** Authorization header is rewritten into the `client_secret_basic` form (secret moves into a Basic header, RFC 6749 §2.3.1). Everything else — GETs, JSON bodies, requests already using Basic, other auth routes — passes through untouched. Secret **verification** stays entirely with Better Auth; the shim only changes transport.

**Remove once all integrators authenticate with `client_secret_basic`** (Hannah-side fix is already merged-pending in plan-net/agentic-coworkers#2032).

## Verification

- 5 unit tests (`oauth2-token-secret-shim.test.ts`): rewrite happens, body secret removed, client_id/code/verifier preserved; pass-through for existing-Authorization, non-token paths, non-POST/non-form, and secretless requests
- Live against local core: the previously failing body-secret exchange now returns `invalid_grant: invalid code` (client auth passed) instead of `invalid_client`
- `pnpm --filter core test src/routes/auth/oauth2-token-secret-shim.test.ts` green; precommit (biome + typecheck) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwwHjEhB4cLiLPaYeVq1eW