### PR TITLE
test(database): reject duplicate migration prefixes

### DIFF
--- a/packages/database/AGENTS.md
+++ b/packages/database/AGENTS.md
@@ -147,6 +147,7 @@ export const userRepository = {
 - Create migrations with `pnpm prisma:migrate:dev`
 - Migration files are in `prisma/migrations/`
 - Use descriptive migration names
+- **Timestamps must be unique.** Prisma applies folders by the 14-digit prefix (`YYYYMMDDHHMMSS`), then the rest of the name. Do not reuse a nearby `YYYYMMDD120000` noon stamp from another PR — bump from the current tip. Two historical collisions are allowlisted in `src/helpers/migration-prefix-uniqueness.ts` (already applied in production); do not add a third folder with those prefixes, and do not rename the existing folders.
 - **Vercel (Core):** After a successful Core app build, `pnpm vercel-build` runs `prisma migrate deploy` against that deployment’s database (Production and Preview). Order is build-then-migrate (do not migrate if the app fails to compile). Prisma CLI prefers `DATABASE_URL_UNPOOLED` (injected by the Vercel Neon integration), then `DATABASE_URL`. `prisma.config.ts` runs `checkMigrateDeployEnv` only for DB-mutating CLI commands (`migrate …`, `db …`): Preview without `DATABASE_URL_UNPOOLED` fails closed (including raw `prisma migrate deploy`); other Vercel envs warn if unpooled is missing. `prisma generate` (this package’s prepare) skips the preflight. Web Vercel installs use `pnpm install --filter web...` and never install this package. Keep migrations backward-compatible with the previous Core release for the brief window before the new deployment activates.
 
 ## Package-Specific Commands

--- a/packages/database/src/helpers/__tests__/migration-prefix-uniqueness.test.ts
+++ b/packages/database/src/helpers/__tests__/migration-prefix-uniqueness.test.ts
@@ -1,0 +1,110 @@
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  ALLOWED_DUPLICATE_MIGRATION_PREFIX_FOLDERS,
+  findDuplicateMigrationPrefixViolations,
+} from "../migration-prefix-uniqueness.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const migrationsDir = join(packageRoot, "prisma/migrations");
+
+function migrationFolders(): string[] {
+  return readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+describe("findDuplicateMigrationPrefixViolations", () => {
+  it("accepts unique prefixes", () => {
+    expect(
+      findDuplicateMigrationPrefixViolations([
+        "20260101120000_one",
+        "20260102120000_two",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("accepts the allowlisted historical pairs", () => {
+    expect(
+      findDuplicateMigrationPrefixViolations([
+        "20260203120000_add_task_transaction",
+        "20260203120000_drop_transaction_included_fee",
+        "20260802120000_chat_room_message_deleted_at",
+        "20260802120000_chat_room_message_edited_at",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("rejects a new duplicate prefix", () => {
+    expect(
+      findDuplicateMigrationPrefixViolations([
+        "20260819130000_task_x402_payment",
+        "20260819130000_oops",
+      ]),
+    ).toEqual([
+      {
+        prefix: "20260819130000",
+        folders: ["20260819130000_oops", "20260819130000_task_x402_payment"],
+        reason: "unallowed",
+      },
+    ]);
+  });
+
+  it("rejects a third folder on an allowlisted prefix", () => {
+    expect(
+      findDuplicateMigrationPrefixViolations([
+        "20260203120000_add_task_transaction",
+        "20260203120000_drop_transaction_included_fee",
+        "20260203120000_something_else",
+      ]),
+    ).toEqual([
+      {
+        prefix: "20260203120000",
+        folders: [
+          "20260203120000_add_task_transaction",
+          "20260203120000_drop_transaction_included_fee",
+          "20260203120000_something_else",
+        ],
+        reason: "allowlist-mismatch",
+      },
+    ]);
+  });
+
+  it("rejects an allowlisted prefix whose folder names drifted", () => {
+    expect(
+      findDuplicateMigrationPrefixViolations([
+        "20260802120000_chat_room_message_deleted_at",
+        "20260802120000_renamed",
+      ]),
+    ).toEqual([
+      {
+        prefix: "20260802120000",
+        folders: [
+          "20260802120000_chat_room_message_deleted_at",
+          "20260802120000_renamed",
+        ],
+        reason: "allowlist-mismatch",
+      },
+    ]);
+  });
+});
+
+describe("prisma/migrations prefixes", () => {
+  it("has no unallowed duplicate prefixes", () => {
+    expect(findDuplicateMigrationPrefixViolations(migrationFolders())).toEqual(
+      [],
+    );
+  });
+
+  it("still contains every allowlisted collision folder", () => {
+    const folders = new Set(migrationFolders());
+    for (const expected of Object.values(
+      ALLOWED_DUPLICATE_MIGRATION_PREFIX_FOLDERS,
+    ).flat()) {
+      expect(folders.has(expected), expected).toBe(true);
+    }
+  });
+});

--- a/packages/database/src/helpers/migration-prefix-uniqueness.ts
+++ b/packages/database/src/helpers/migration-prefix-uniqueness.ts
@@ -1,0 +1,70 @@
+/**
+ * Prisma applies migrations by the 14-digit folder prefix, then the rest of
+ * the name. Duplicate prefixes are collisions: apply order is no longer
+ * uniquely determined by the timestamp.
+ *
+ * Two collisions already shipped and applied in production. They stay on disk
+ * unchanged (renaming applied folders rewrites `_prisma_migrations`). This
+ * allowlist is the exact folder sets, not a license to add a third.
+ */
+
+export const ALLOWED_DUPLICATE_MIGRATION_PREFIX_FOLDERS = {
+  "20260203120000": [
+    "20260203120000_add_task_transaction",
+    "20260203120000_drop_transaction_included_fee",
+  ],
+  "20260802120000": [
+    "20260802120000_chat_room_message_deleted_at",
+    "20260802120000_chat_room_message_edited_at",
+  ],
+} as const satisfies Record<string, readonly string[]>;
+
+export interface DuplicateMigrationPrefixViolation {
+  prefix: string;
+  folders: string[];
+  reason: "unallowed" | "allowlist-mismatch";
+}
+
+const PREFIX = /^(\d{14})/;
+
+export function findDuplicateMigrationPrefixViolations(
+  folderNames: readonly string[],
+  allowed: Readonly<
+    Record<string, readonly string[]>
+  > = ALLOWED_DUPLICATE_MIGRATION_PREFIX_FOLDERS,
+): DuplicateMigrationPrefixViolation[] {
+  const byPrefix = new Map<string, string[]>();
+  for (const name of folderNames) {
+    const prefix = PREFIX.exec(name)?.[1];
+    if (!prefix) {
+      continue;
+    }
+    const folders = byPrefix.get(prefix);
+    if (folders) {
+      folders.push(name);
+    } else {
+      byPrefix.set(prefix, [name]);
+    }
+  }
+
+  const violations: DuplicateMigrationPrefixViolation[] = [];
+  for (const [prefix, folders] of byPrefix) {
+    if (folders.length < 2) {
+      continue;
+    }
+    folders.sort();
+    const expected = allowed[prefix];
+    if (!expected) {
+      violations.push({ prefix, folders, reason: "unallowed" });
+      continue;
+    }
+    const expectedSorted = [...expected].sort();
+    if (
+      folders.length !== expectedSorted.length ||
+      folders.some((folder, index) => folder !== expectedSorted[index])
+    ) {
+      violations.push({ prefix, folders, reason: "allowlist-mismatch" });
+    }
+  }
+  return violations;
+}


### PR DESCRIPTION
## Summary

CI guard against a third Prisma migration folder sharing an existing timestamp prefix.

Two collisions are already on `main` and applied in production and preprod (`20260203120000_*`, `20260802120000_*`). Prisma IDs the full folder name, so those rows stay. Renaming them would rewrite `_prisma_migrations` in every environment. This PR allowlists the **exact** folder pairs and fails if a new duplicate prefix appears, or if a third folder is added to an allowlisted prefix.

## Changes

- `findDuplicateMigrationPrefixViolations` + Packages-job vitest against `prisma/migrations/`
- Agent note in `packages/database/AGENTS.md`: prefixes must be unique; bump from the current tip; do not reuse `YYYYMMDD120000`

No migration files renamed or edited.

## Verification

- [x] `pnpm --filter @sokosumi/database test` — 269 passed, 2 skipped
- [x] `pnpm check` + `pnpm typecheck` (pre-commit)
- [x] `_prisma_migrations` on Neon `sokosumi-mainnet` and `sokosumi-preprod` `main`: all four folders `finished_at` set, `rolled_back_at` null