### PR TITLE
build(web): run Vercel preview builds through turbo

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -95,6 +95,8 @@ pnpm test
 
 [`vercel.json`](./vercel.json) sets `installCommand` to `pnpm install --filter web...` so only the web app and its workspace deps (`@sokosumi/chat`, `@sokosumi/email`, `@sokosumi/masumi`, `@sokosumi/net`, `@sokosumi/utils`) are installed. `@sokosumi/database` is not a dependency and is not built on web deploys — no Neon/`DATABASE_URL*` vars are required.
 
+`buildCommand` runs [`scripts/vercel-build.mjs`](./scripts/vercel-build.mjs), which invokes `turbo run build --filter=web` (Vercel's global `turbo`; the filtered install does not include root `turbo`). Vercel Remote Cache is enabled automatically. Production (`VERCEL_ENV=production`) always uses `--force`. Preview may restore when inputs match. Unique deploy env (`VERCEL_URL`, related-project URLs) and Next Skew Protection often produce a miss; use the deployment Run Summary to confirm. Do not put `turbo` in the web `build` script (recursive turbo).
+
 ### Database setup
 
 The web app does not connect to Postgres directly. Bootstrap the database from the repo root (`pnpm prisma:migrate:dev`, `pnpm prisma:generate`) and configure `apps/core/.env` — see the root `AGENTS.md` setup section.

--- a/apps/web/scripts/vercel-build.mjs
+++ b/apps/web/scripts/vercel-build.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function turboBuildArgs(env = process.env) {
+  const args = ["run", "build", "--filter=web"];
+  if (env.VERCEL_ENV === "production") {
+    args.push("--force");
+  }
+  return args;
+}
+
+function isMainModule() {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return pathToFileURL(path.resolve(entry)).href === import.meta.url;
+}
+
+if (isMainModule()) {
+  const result = spawnSync("turbo", turboBuildArgs(), {
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --filter web...",
+  "buildCommand": "node ./scripts/vercel-build.mjs",
   "relatedProjects": [
     "prj_CSgdc8zCRyR5ZT1LH8VkDJBJTtff",
     "prj_GrqmJbIxWe0I6aYiZHZC2hiJYLiH"

--- a/docs/adr/0008-turbo-task-runner-on-pnpm.md
+++ b/docs/adr/0008-turbo-task-runner-on-pnpm.md
@@ -9,8 +9,10 @@ Vercel filtered installs still emit package `dist` via per-package `prepare`. Ap
 
 CI uses Vercel Remote Cache via GitHub OIDC (`vercel/setup-turborepo-remote-cache-action`). `turbo.json` lists hashed `globalEnv` and unhashed `globalPassThroughEnv`; default strict `envMode` (do not set `envMode: "loose"`). Do not add GitHub `actions/cache` on `.turbo`. The OIDC step continues on error so CI stays green until the Vercel Turborepo CLI OIDC policy exists. `dev`, Biome, Husky, and `pnpm --filter` aliases stay.
 
+Web Vercel deploys run `turbo run build --filter=web` (`apps/web/scripts/vercel-build.mjs`) so the platform Remote Cache is enabled. Production (`VERCEL_ENV=production`) always passes `--force` and never restores. Preview may restore when hashes match. Unique deploy env (`VERCEL_URL`, related-project URLs) and Next Skew Protection often miss every preview; that is acceptable. Core `vercel-build` stays tsup plus migrate.
+
 ## Considered Options
 
 - Keep `pnpm -r` and the hand-coded DAGs — no new tool, graph stays in scripts.
-- Nx or full turbo (`--affected` CI, Vercel `turbo run build`) — bigger than the pain.
-- Add turbo on pnpm for `build` / `typecheck` / `test` only — chosen.
+- Nx or full turbo (`--affected` CI) — bigger than the pain.
+- Add turbo on pnpm for `build` / `typecheck` / `test` only — chosen. Web Vercel `buildCommand` later adopted `turbo run build --filter=web` (SOK-851); Core `vercel-build` did not.

--- a/scripts/ci/__tests__/turbo-remote-cache.test.mjs
+++ b/scripts/ci/__tests__/turbo-remote-cache.test.mjs
@@ -145,3 +145,39 @@ describe("GitHub OIDC remote cache wiring", () => {
     }
   });
 });
+
+describe("Vercel web turbo build command", () => {
+  it("points web buildCommand at the vercel-build wrapper", async () => {
+    const web = JSON.parse(await readRepoFile("apps", "web", "vercel.json"));
+    assert.equal(web.buildCommand, "node ./scripts/vercel-build.mjs");
+  });
+
+  it("leaves Core vercel-build as tsup plus migrate", async () => {
+    const core = JSON.parse(await readRepoFile("apps", "core", "vercel.json"));
+    assert.equal(core.buildCommand, "pnpm vercel-build");
+  });
+
+  it("runs turbo --filter=web and forces production only", async () => {
+    const { turboBuildArgs } = await import(
+      "../../../apps/web/scripts/vercel-build.mjs"
+    );
+
+    assert.deepEqual(turboBuildArgs({ VERCEL_ENV: "preview" }), [
+      "run",
+      "build",
+      "--filter=web",
+    ]);
+    assert.deepEqual(turboBuildArgs({}), ["run", "build", "--filter=web"]);
+    assert.deepEqual(turboBuildArgs({ VERCEL_ENV: "development" }), [
+      "run",
+      "build",
+      "--filter=web",
+    ]);
+    assert.deepEqual(turboBuildArgs({ VERCEL_ENV: "production" }), [
+      "run",
+      "build",
+      "--filter=web",
+      "--force",
+    ]);
+  });
+});


### PR DESCRIPTION
https://linear.app/masumi/issue/SOK-851/speed-up-vercel-preview-builds-with-turborepo-remote-cache

Web Vercel `buildCommand` runs `turbo run build --filter=web` via `apps/web/scripts/vercel-build.mjs` so Remote Cache can restore identical preview builds.

Production (`VERCEL_ENV=production`) always passes `--force` and never restores a preview-shaped artifact.

Core `vercel-build` (tsup + migrate) and GitHub Actions remote cache (SOK-845) are unchanged.

Unique deploy env (`VERCEL_URL`, related-project URLs) and Next Skew Protection may still miss every preview. That is an acceptable v1 outcome. Use the Vercel Run Summary to confirm hits.