### PR TITLE
feat(core): let coworker originate org 1:1

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,16 @@ _Avoid_: Onboarding (retired intro slides + plan checkout), account setup, onboa
 The dedicated authenticated route used when the user cannot use the product yet. It is where they resolve pending organization invitations and join links, or complete identity onboarding. No app chrome. Leaving is sign out or finish.
 _Avoid_: Onboarding page, welcome, accept-invitation as a separate post-signup product (the gate owns that moment)
 
+### Chat rooms
+
+**Direct**:
+A chat room whose identity is its participant set, not a named channel. Human 1:1, multi-human group, or coworker 1:1. Scoped to an Organization, except coworker 1:1s which may also be personal (no Organization).
+_Avoid_: Conversation (retired), Channel (when meaning this), Slack DM (as the domain object)
+
+**Coworker 1:1**:
+A Direct with exactly one human member and exactly one coworker.
+_Avoid_: Channel @mention thread, mixing extra humans or coworkers into this shape
+
 ### Chat membership
 
 **Membership-visible rooms**:

--- a/apps/core/src/helpers/chat-direct-message-notifications.test.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.test.ts
@@ -161,6 +161,29 @@ describe("emitChatDirectMessageNotifications", () => {
     );
   });
 
+  it("notifies all humans when the author is a coworker", async () => {
+    await emitChatDirectMessageNotifications({
+      roomId: ROOM_ID,
+      roomName: "Hannah",
+      organizationId: "org_1",
+      messageId: MESSAGE_ID,
+      authorUserId: null,
+      authorName: "Hannah",
+      recipientUserIds: [PEER_ID],
+    });
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: PEER_ID,
+        messageParams: {
+          authorName: "Hannah",
+          roomName: "Hannah",
+        },
+      }),
+    );
+  });
+
   it("filters the author and no-ops when nobody remains", async () => {
     await emitChatDirectMessageNotifications({
       roomId: ROOM_ID,

--- a/apps/core/src/helpers/chat-direct-message-notifications.ts
+++ b/apps/core/src/helpers/chat-direct-message-notifications.ts
@@ -26,7 +26,8 @@ export interface EmitChatDirectMessageNotificationsParams {
   roomName: string;
   organizationId: string | null;
   messageId: string;
-  authorUserId: string;
+  /** Human author to skip. Null when the author is a coworker. */
+  authorUserId: string | null;
   authorName: string;
   recipientUserIds: readonly string[];
 }
@@ -38,7 +39,8 @@ export async function emitChatDirectMessageNotifications(
   const recipientUserIds = [
     ...new Set(
       params.recipientUserIds.filter(
-        (userId) => userId !== params.authorUserId,
+        (userId) =>
+          params.authorUserId === null || userId !== params.authorUserId,
       ),
     ),
   ];

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -14,6 +14,7 @@ const {
   messageFindUniqueMock,
   messageFindManyMock,
   messageCreateMock,
+  membershipFindManyMock,
   readStateUpsertMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
@@ -30,6 +31,7 @@ const {
   messageFindUniqueMock: vi.fn(),
   messageFindManyMock: vi.fn(),
   messageCreateMock: vi.fn(),
+  membershipFindManyMock: vi.fn(),
   readStateUpsertMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
@@ -49,6 +51,9 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     chatRoomMessage: {
       findUnique: messageFindUniqueMock,
+    },
+    chatRoomUserMember: {
+      findMany: membershipFindManyMock,
     },
   },
 }));
@@ -382,8 +387,12 @@ describe("POST /chats/rooms/{id}/messages", () => {
           where: expect.objectContaining({
             coworkerMembers: { some: { coworkerId: COWORKER_ID } },
           }),
+          select: expect.not.objectContaining({
+            userMembers: expect.anything(),
+          }),
         }),
       );
+      expect(membershipFindManyMock).not.toHaveBeenCalled();
     });
 
     it("emits a CHAT Direct notification to the human in a coworker 1:1", async () => {
@@ -392,8 +401,8 @@ describe("POST /chats/rooms/{id}/messages", () => {
         name: "Hannah",
         kind: "direct",
         organizationId: "org_1",
-        userMembers: [{ userId: ALICE_ID }],
       });
+      membershipFindManyMock.mockResolvedValue([{ userId: ALICE_ID }]);
       messageCreateMock.mockResolvedValue(
         createdMessage({ senderCoworkerId: COWORKER_ID }),
       );
@@ -406,6 +415,10 @@ describe("POST /chats/rooms/{id}/messages", () => {
       });
 
       expect(response.status).toBe(201);
+      expect(membershipFindManyMock).toHaveBeenCalledWith({
+        where: { roomId: ROOM_ID },
+        select: { userId: true },
+      });
       expect(emitChatDirectMessageNotificationsMock).toHaveBeenCalledWith({
         roomId: ROOM_ID,
         roomName: "Hannah",
@@ -424,7 +437,6 @@ describe("POST /chats/rooms/{id}/messages", () => {
         name: "general",
         kind: "channel",
         organizationId: "org_1",
-        userMembers: [{ userId: ALICE_ID }, { userId: BOB_ID }],
       });
       messageCreateMock.mockResolvedValue(
         createdMessage({ senderCoworkerId: COWORKER_ID }),
@@ -438,6 +450,7 @@ describe("POST /chats/rooms/{id}/messages", () => {
       });
 
       expect(response.status).toBe(201);
+      expect(membershipFindManyMock).not.toHaveBeenCalled();
       expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
       expect(waitUntilMock).toHaveBeenCalledTimes(1);
     });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.test.ts
@@ -336,7 +336,13 @@ beforeEach(() => {
 describe("POST /chats/rooms/{id}/messages", () => {
   describe("coworker actor", () => {
     it("lets a member coworker post as itself without mention rows", async () => {
-      roomFindFirstMock.mockResolvedValue({ id: ROOM_ID });
+      roomFindFirstMock.mockResolvedValue({
+        id: ROOM_ID,
+        name: "general",
+        kind: "channel",
+        organizationId: "org_1",
+        userMembers: [],
+      });
       messageCreateMock.mockResolvedValue(
         createdMessage({ senderCoworkerId: COWORKER_ID }),
       );
@@ -378,6 +384,62 @@ describe("POST /chats/rooms/{id}/messages", () => {
           }),
         }),
       );
+    });
+
+    it("emits a CHAT Direct notification to the human in a coworker 1:1", async () => {
+      roomFindFirstMock.mockResolvedValue({
+        id: ROOM_ID,
+        name: "Hannah",
+        kind: "direct",
+        organizationId: "org_1",
+        userMembers: [{ userId: ALICE_ID }],
+      });
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderCoworkerId: COWORKER_ID }),
+      );
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "you were assigned a task" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatDirectMessageNotificationsMock).toHaveBeenCalledWith({
+        roomId: ROOM_ID,
+        roomName: "Hannah",
+        organizationId: "org_1",
+        messageId: MESSAGE_ID,
+        authorUserId: null,
+        authorName: "Hannah",
+        recipientUserIds: [ALICE_ID],
+      });
+      expect(waitUntilMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not emit a Direct notification for coworker posts in a channel", async () => {
+      roomFindFirstMock.mockResolvedValue({
+        id: ROOM_ID,
+        name: "general",
+        kind: "channel",
+        organizationId: "org_1",
+        userMembers: [{ userId: ALICE_ID }, { userId: BOB_ID }],
+      });
+      messageCreateMock.mockResolvedValue(
+        createdMessage({ senderCoworkerId: COWORKER_ID }),
+      );
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request(`/${ROOM_ID}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "hello channel" }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(emitChatDirectMessageNotificationsMock).not.toHaveBeenCalled();
+      expect(waitUntilMock).toHaveBeenCalledTimes(1);
     });
 
     it("rejects a coworker that is not a room member", async () => {
@@ -1066,7 +1128,13 @@ describe("POST /chats/rooms/{id}/messages", () => {
     });
 
     it("lets a coworker post with a quote snapshot", async () => {
-      roomFindFirstMock.mockResolvedValue({ id: ROOM_ID });
+      roomFindFirstMock.mockResolvedValue({
+        id: ROOM_ID,
+        name: "general",
+        kind: "channel",
+        organizationId: "org_1",
+        userMembers: [],
+      });
       messageFindFirstMock.mockResolvedValue(quotedSourceMessage());
       messageCreateMock.mockResolvedValue(
         createdMessage({

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -129,24 +129,32 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
 
-      const memberUserIds = room.userMembers.map((member) => member.userId);
-      if (
-        shouldEmitChatDirectMessageNotifications({
-          kind: room.kind,
-          memberUserIds,
-        })
-      ) {
-        waitUntil(
-          emitChatDirectMessageNotifications({
-            roomId: room.id,
-            roomName: room.name,
-            organizationId: room.organizationId,
-            messageId: message.id,
-            authorUserId: null,
-            authorName: message.senderCoworker?.name ?? "Someone",
-            recipientUserIds: memberUserIds,
-          }),
-        );
+      if (room.kind === "direct") {
+        const memberUserIds = (
+          await prisma.chatRoomUserMember.findMany({
+            where: { roomId: room.id },
+            select: { userId: true },
+          })
+        ).map((member) => member.userId);
+
+        if (
+          shouldEmitChatDirectMessageNotifications({
+            kind: room.kind,
+            memberUserIds,
+          })
+        ) {
+          waitUntil(
+            emitChatDirectMessageNotifications({
+              roomId: room.id,
+              roomName: room.name,
+              organizationId: room.organizationId,
+              messageId: message.id,
+              authorUserId: null,
+              authorName: message.senderCoworker?.name ?? "Someone",
+              recipientUserIds: memberUserIds,
+            }),
+          );
+        }
       }
 
       return created(

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/post.ts
@@ -54,7 +54,7 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/{id}/messages",
     description:
-      "Post a room message. Mentioned AI coworkers — and, for thread replies, every coworker already part of the thread — are called asynchronously and reply into the room. Coworker API keys may post as the coworker itself into rooms it is a member of.",
+      "Post a room message. Mentioned AI coworkers — and, for thread replies, every coworker already part of the thread — are called asynchronously and reply into the room. Coworker API keys may post as the coworker itself into rooms it is a member of. Coworker posts into a Direct with at most two human members emit the same CHAT Direct notification as a human sender (mute honored; the coworker has no user id to skip).",
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
@@ -89,7 +89,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     // dispatch loops.
     if (isCoworkerAuthContext(authContext)) {
       const coworkerId = authContext.coworkerId;
-      const message = await prisma.$transaction(async (tx) => {
+      const persisted = await prisma.$transaction(async (tx) => {
         const room = await requireChatRoomCoworkerAccess(id, coworkerId, tx);
 
         const parentMessageId = await resolveThreadParentMessageId(
@@ -120,12 +120,34 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           data: { updatedAt: new Date() },
         });
 
-        return message;
+        return { message, room };
       });
+
+      const { message, room } = persisted;
 
       await publishChatRoomMessageRealtime(message, "create");
 
       waitUntil(scheduleChatRoomMessageUnfurls(message.id));
+
+      const memberUserIds = room.userMembers.map((member) => member.userId);
+      if (
+        shouldEmitChatDirectMessageNotifications({
+          kind: room.kind,
+          memberUserIds,
+        })
+      ) {
+        waitUntil(
+          emitChatDirectMessageNotifications({
+            roomId: room.id,
+            roomName: room.name,
+            organizationId: room.organizationId,
+            messageId: message.id,
+            authorUserId: null,
+            authorName: message.senderCoworker?.name ?? "Someone",
+            recipientUserIds: memberUserIds,
+          }),
+        );
+      }
 
       return created(
         c,

--- a/apps/core/src/routes/v1/chats/rooms/auth.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/auth.test.ts
@@ -322,7 +322,13 @@ describe("chat room user auth guards", () => {
       async (callback: (tx: unknown) => Promise<unknown>) =>
         callback({
           chatRoom: {
-            findFirst: vi.fn().mockResolvedValue({ id: ROOM_ID }),
+            findFirst: vi.fn().mockResolvedValue({
+              id: ROOM_ID,
+              name: "general",
+              kind: "channel",
+              organizationId: ORG_ID,
+              userMembers: [],
+            }),
             update: vi.fn(),
           },
           chatRoomMessage: {

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -1695,7 +1695,13 @@ export async function requireChatRoomCoworkerAccess(
   roomId: string,
   coworkerId: string,
   tx: Prisma.TransactionClient,
-): Promise<{ id: string }> {
+): Promise<{
+  id: string;
+  name: string;
+  kind: string;
+  organizationId: string | null;
+  userMembers: Array<{ userId: string }>;
+}> {
   const room = await tx.chatRoom.findFirst({
     where: {
       id: roomId,
@@ -1704,7 +1710,13 @@ export async function requireChatRoomCoworkerAccess(
         some: { coworkerId },
       },
     },
-    select: { id: true },
+    select: {
+      id: true,
+      name: true,
+      kind: true,
+      organizationId: true,
+      userMembers: { select: { userId: true } },
+    },
   });
 
   if (!room) {

--- a/apps/core/src/routes/v1/chats/rooms/helpers.ts
+++ b/apps/core/src/routes/v1/chats/rooms/helpers.ts
@@ -1700,7 +1700,6 @@ export async function requireChatRoomCoworkerAccess(
   name: string;
   kind: string;
   organizationId: string | null;
-  userMembers: Array<{ userId: string }>;
 }> {
   const room = await tx.chatRoom.findFirst({
     where: {
@@ -1715,7 +1714,6 @@ export async function requireChatRoomCoworkerAccess(
       name: true,
       kind: true,
       organizationId: true,
-      userMembers: { select: { userId: true } },
     },
   });
 

--- a/apps/core/src/routes/v1/chats/rooms/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.test.ts
@@ -11,6 +11,7 @@ const {
   roomFindFirstMock,
   roomFindManyMock,
   roomCreateMock,
+  roomUpdateMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
   memberFindManyMock,
@@ -24,6 +25,7 @@ const {
   roomFindFirstMock: vi.fn(),
   roomFindManyMock: vi.fn(),
   roomCreateMock: vi.fn(),
+  roomUpdateMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
   memberFindManyMock: vi.fn(),
@@ -65,6 +67,7 @@ const tx = {
     findFirst: roomFindFirstMock,
     findMany: roomFindManyMock,
     create: roomCreateMock,
+    update: roomUpdateMock,
   },
   organization: {
     findUnique: organizationFindUniqueMock,
@@ -99,11 +102,21 @@ function createApp(authContext: AuthVariables["authContext"]) {
   return app;
 }
 
+const COWORKER_ID = "cow_123";
+const COWORKER_DIRECT_KEY = `coworker:${OTHER_USER_ID}:${COWORKER_ID}`;
+
 const userAuthContext: AuthVariables["authContext"] = {
   actor: "user",
   userId: USER_ID,
   organizationId: ORG_ID,
   role: "user",
+};
+
+const coworkerAuthContext: AuthVariables["authContext"] = {
+  actor: "coworker",
+  coworkerId: COWORKER_ID,
+  vendorId: "01960001-0001-7001-8001-000000000001",
+  context: { userId: USER_ID, organizationId: ORG_ID },
 };
 
 const DIRECT_KEY = `${USER_ID}:${OTHER_USER_ID}`;
@@ -162,6 +175,38 @@ function directRoom(overrides: Record<string, unknown> = {}) {
           email: "bob@example.com",
           image: null,
           sessions: [],
+        },
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function coworkerDirectRoom(overrides: Record<string, unknown> = {}) {
+  return directRoom({
+    name: "Elena",
+    slug: "elena",
+    directKey: COWORKER_DIRECT_KEY,
+    createdByUserId: OTHER_USER_ID,
+    userMembers: [
+      {
+        user: {
+          id: OTHER_USER_ID,
+          name: "Bob",
+          email: "bob@example.com",
+          image: null,
+          sessions: [],
+        },
+      },
+    ],
+    coworkerMembers: [
+      {
+        coworker: {
+          id: COWORKER_ID,
+          name: "Elena",
+          slug: "elena",
+          caption: null,
+          image: null,
         },
       },
     ],
@@ -730,7 +775,6 @@ describe("POST /chats/rooms", () => {
         where: expect.objectContaining({
           organizationId: ORG_ID,
           directKey: GROUP_DIRECT_KEY,
-          archivedAt: null,
         }),
       }),
     );
@@ -901,7 +945,6 @@ describe("POST /chats/rooms", () => {
         where: expect.objectContaining({
           organizationId: ORG_ID,
           directKey: DIRECT_KEY,
-          archivedAt: null,
         }),
       }),
     );
@@ -953,5 +996,181 @@ describe("POST /chats/rooms", () => {
     expect(response.status).toBe(409);
     expect(await response.text()).toBe("Room already exists");
     expect(roomCreateMock).toHaveBeenCalledTimes(3);
+  });
+
+  describe("coworker actor", () => {
+    it("creates an org-scoped coworker 1:1 with the target member", async () => {
+      const created = coworkerDirectRoom();
+      roomFindFirstMock.mockResolvedValueOnce(null);
+      roomCreateMock.mockResolvedValueOnce(created);
+      coworkerFindManyMock.mockResolvedValue([
+        { id: COWORKER_ID, baseURL: "https://chat.example.com" },
+      ]);
+      userFindManyMock.mockResolvedValue([
+        { id: OTHER_USER_ID, name: "Bob", email: "bob@example.com" },
+      ]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(body.data.kind).toBe("direct");
+      expect(body.data.directKey).toBe(COWORKER_DIRECT_KEY);
+      expect(body.data.createdByUserId).toBe(OTHER_USER_ID);
+      expect(roomCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            organizationId: ORG_ID,
+            createdByUserId: OTHER_USER_ID,
+            kind: "direct",
+            directKey: COWORKER_DIRECT_KEY,
+            userMembers: {
+              create: [{ userId: OTHER_USER_ID }],
+            },
+            coworkerMembers: {
+              create: [{ coworkerId: COWORKER_ID }],
+            },
+          }),
+        }),
+      );
+    });
+
+    it("returns the existing coworker 1:1 for the same pair", async () => {
+      const existing = coworkerDirectRoom();
+      roomFindFirstMock.mockResolvedValueOnce(existing);
+      coworkerFindManyMock.mockResolvedValue([
+        { id: COWORKER_ID, baseURL: "https://chat.example.com" },
+      ]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data.id).toBe(ROOM_ID);
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("unarchives a stale coworker 1:1 with the same directKey", async () => {
+      const archived = coworkerDirectRoom({
+        archivedAt: new Date("2025-06-01T00:00:00.000Z"),
+      });
+      const restored = coworkerDirectRoom({ archivedAt: null });
+      roomFindFirstMock.mockResolvedValueOnce(archived);
+      roomUpdateMock.mockResolvedValueOnce(restored);
+      coworkerFindManyMock.mockResolvedValue([
+        { id: COWORKER_ID, baseURL: "https://chat.example.com" },
+      ]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(roomUpdateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: ROOM_ID },
+          data: { archivedAt: null },
+        }),
+      );
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects channel create with 403", async () => {
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "channel",
+          name: "Launch Room",
+        }),
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toBe("User authentication required");
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects personal originate when no organization context with 400", async () => {
+      const app = createApp({
+        ...coworkerAuthContext,
+        context: { userId: USER_ID, organizationId: null },
+      });
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe(
+        "Switch to an organization to message a teammate.",
+      );
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects coworkerIds in the body with 400", async () => {
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+          coworkerIds: [COWORKER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe(
+        "Group direct messages cannot include coworkers.",
+      );
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a coworker that is not usable in the workspace with 400", async () => {
+      coworkerFindManyMock.mockResolvedValue([]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe(
+        "Room AI coworkers must be active chat coworkers",
+      );
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/post.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/lib/db/prisma", () => ({
     $transaction: prismaTransactionMock,
     chatRoom: {
       findFirst: roomFindFirstMock,
+      update: roomUpdateMock,
     },
     chatRoomUserMember: {
       findMany: membershipFindManyMock,
@@ -999,7 +1000,7 @@ describe("POST /chats/rooms", () => {
   });
 
   describe("coworker actor", () => {
-    it("creates an org-scoped coworker 1:1 with the target member", async () => {
+    it("creates an org-scoped coworker 1:1 with the target as createdByUserId when context user differs", async () => {
       const created = coworkerDirectRoom();
       roomFindFirstMock.mockResolvedValueOnce(null);
       roomCreateMock.mockResolvedValueOnce(created);
@@ -1041,6 +1042,38 @@ describe("POST /chats/rooms", () => {
           }),
         }),
       );
+    });
+
+    it("does not return the target human's sidebar flags", async () => {
+      const created = coworkerDirectRoom();
+      roomFindFirstMock.mockResolvedValueOnce(null);
+      roomCreateMock.mockResolvedValueOnce(created);
+      coworkerFindManyMock.mockResolvedValue([
+        { id: COWORKER_ID, baseURL: "https://chat.example.com" },
+      ]);
+      membershipFindManyMock.mockResolvedValue([
+        {
+          roomId: ROOM_ID,
+          pinnedAt: new Date("2025-01-01T00:00:00.000Z"),
+          mutedAt: new Date("2025-01-02T00:00:00.000Z"),
+        },
+      ]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(body.data.pinnedAt).toBeNull();
+      expect(body.data.mutedAt).toBeNull();
+      expect(body.data.markedUnread).toBe(false);
     });
 
     it("returns the existing coworker 1:1 for the same pair", async () => {
@@ -1109,7 +1142,9 @@ describe("POST /chats/rooms", () => {
       });
 
       expect(response.status).toBe(403);
-      expect(await response.text()).toBe("User authentication required");
+      expect(await response.text()).toBe(
+        "Coworker API keys cannot create channels",
+      );
       expect(roomCreateMock).not.toHaveBeenCalled();
     });
 
@@ -1148,9 +1183,77 @@ describe("POST /chats/rooms", () => {
 
       expect(response.status).toBe(400);
       expect(await response.text()).toBe(
-        "Group direct messages cannot include coworkers.",
+        "Coworker API keys cannot include coworkerIds",
       );
       expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects omitted memberUserIds with 400", async () => {
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Choose a direct message target");
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects more than one memberUserId with 400", async () => {
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID, THIRD_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Choose a direct message target");
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("unarchives on directKey unique-retry when the winner is archived", async () => {
+      const archived = coworkerDirectRoom({
+        archivedAt: new Date("2025-06-01T00:00:00.000Z"),
+      });
+      const restored = coworkerDirectRoom({ archivedAt: null });
+      roomFindFirstMock
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(archived);
+      roomCreateMock.mockRejectedValue({
+        code: "P2002",
+        meta: { target: ["organizationId", "directKey"] },
+      });
+      roomUpdateMock.mockResolvedValueOnce(restored);
+      coworkerFindManyMock.mockResolvedValue([
+        { id: COWORKER_ID, baseURL: "https://chat.example.com" },
+      ]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(roomUpdateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: ROOM_ID },
+          data: { archivedAt: null },
+        }),
+      );
+      expect(roomCreateMock).toHaveBeenCalled();
     });
 
     it("rejects a coworker that is not usable in the workspace with 400", async () => {
@@ -1169,6 +1272,30 @@ describe("POST /chats/rooms", () => {
       expect(response.status).toBe(400);
       expect(await response.text()).toBe(
         "Room AI coworkers must be active chat coworkers",
+      );
+      expect(roomCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a target who is not an organization member with 400", async () => {
+      coworkerFindManyMock.mockResolvedValue([
+        { id: COWORKER_ID, baseURL: "https://chat.example.com" },
+      ]);
+      memberFindUniqueMock.mockResolvedValue(null);
+      memberFindManyMock.mockResolvedValue([]);
+
+      const app = createApp(coworkerAuthContext);
+      const response = await app.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "direct",
+          memberUserIds: [OTHER_USER_ID],
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe(
+        "Room human members must belong to the organization",
       );
       expect(roomCreateMock).not.toHaveBeenCalled();
     });

--- a/apps/core/src/routes/v1/chats/rooms/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.ts
@@ -29,6 +29,7 @@ import {
   buildUniqueRoomSlug,
   chatRoomInclude,
   isOrganizationOwnerOrAdmin,
+  mapChatRoom,
   mapChatRoomWithSidebarFlags,
   normalizeUniqueStrings,
   requireActiveOrganizationId,
@@ -205,7 +206,7 @@ async function createOrGetCoworkerOriginatedDirect(params: {
   kind: "channel" | "direct";
 }): Promise<{ room: ChatRoom; created: boolean }> {
   if (params.kind !== "direct") {
-    throw forbidden("User authentication required");
+    throw forbidden("Coworker API keys cannot create channels");
   }
 
   if (!params.organizationId) {
@@ -213,7 +214,7 @@ async function createOrGetCoworkerOriginatedDirect(params: {
   }
 
   if (params.coworkerIds.length > 0) {
-    throw badRequest("Group direct messages cannot include coworkers.");
+    throw badRequest("Coworker API keys cannot include coworkerIds");
   }
 
   if (params.memberUserIds.length !== 1) {
@@ -225,6 +226,7 @@ async function createOrGetCoworkerOriginatedDirect(params: {
     currentUserId: params.memberUserIds[0]!,
     memberUserIds: [],
     coworkerIds: [params.coworkerId],
+    viewerUserId: null,
   });
 }
 
@@ -255,6 +257,17 @@ async function findOrRestoreDirectByKey(
     data: { archivedAt: null },
     include: chatRoomInclude,
   });
+}
+
+async function serializeDirectRoomForViewer(
+  room: Parameters<typeof mapChatRoom>[0],
+  viewerUserId: string | null,
+): Promise<ChatRoom> {
+  return chatRoomSchema.parse(
+    viewerUserId
+      ? await mapChatRoomWithSidebarFlags(room, viewerUserId, prisma)
+      : mapChatRoom(room),
+  );
 }
 
 /**
@@ -331,8 +344,12 @@ async function createOrGetDirectRoom(params: {
   currentUserId: string;
   memberUserIds: readonly string[];
   coworkerIds: readonly string[];
+  /** Sidebar viewer. Null skips pin/mute/unread (coworker actor has none). */
+  viewerUserId?: string | null;
 }): Promise<{ room: ChatRoom; created: boolean }> {
   const { currentUserId } = params;
+  const viewerUserId =
+    params.viewerUserId === undefined ? currentUserId : params.viewerUserId;
   const shape = parseDirectCreateShape({
     currentUserId,
     memberUserIds: params.memberUserIds,
@@ -357,11 +374,22 @@ async function createOrGetDirectRoom(params: {
     try {
       const result = await prisma.$transaction(async (tx) => {
         if (roomOrganizationId) {
-          await resolveMemberOrganizationById({
-            id: roomOrganizationId,
-            userId: currentUserId,
-            tx,
-          });
+          if (shape.kind === "human-direct") {
+            await resolveMemberOrganizationById({
+              id: roomOrganizationId,
+              userId: currentUserId,
+              tx,
+            });
+          } else {
+            // Coworker 1:1 owner is the human on the room (user actor or
+            // originated target). A missing owner is a bad target, not
+            // "you are not a member".
+            await validateOrganizationUserIds(
+              roomOrganizationId,
+              [currentUserId],
+              tx,
+            );
+          }
         }
 
         const memberUserIds = roomOrganizationId
@@ -464,9 +492,7 @@ async function createOrGetDirectRoom(params: {
       });
 
       return {
-        room: chatRoomSchema.parse(
-          await mapChatRoomWithSidebarFlags(result.room, currentUserId, prisma),
-        ),
+        room: await serializeDirectRoomForViewer(result.room, viewerUserId),
         created: result.created,
       };
     } catch (error) {
@@ -479,13 +505,7 @@ async function createOrGetDirectRoom(params: {
 
         if (existing) {
           return {
-            room: chatRoomSchema.parse(
-              await mapChatRoomWithSidebarFlags(
-                existing,
-                currentUserId,
-                prisma,
-              ),
-            ),
+            room: await serializeDirectRoomForViewer(existing, viewerUserId),
             created: false,
           };
         }

--- a/apps/core/src/routes/v1/chats/rooms/post.ts
+++ b/apps/core/src/routes/v1/chats/rooms/post.ts
@@ -13,7 +13,10 @@ import {
   type OpenAPIHonoWithAuth,
   withGlobalHeaderParameters,
 } from "@/lib/hono";
-import { requireUserAuthContext } from "@/middleware/auth";
+import {
+  isCoworkerAuthContext,
+  requireUserAuthContext,
+} from "@/middleware/auth";
 import {
   type ChatRoom,
   chatRoomSchema,
@@ -45,7 +48,7 @@ const route = withGlobalHeaderParameters(
     method: "post",
     path: "/",
     description:
-      'Create a chat room. `kind: "channel"` requires an active organization. `kind: "direct"` creates or returns a direct room (1:1 or multi-human group) scoped to the active organization when one is set. Coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.',
+      'Create a chat room. `kind: "channel"` requires an active organization and a user session. `kind: "direct"` creates or returns a direct room (1:1 or multi-human group) scoped to the active organization when one is set. Coworker API keys may create-or-get an org-scoped coworker 1:1 with `{ kind: "direct", memberUserIds: [targetUserId] }` when the coworker is usable in that workspace; they cannot create channels, human Directs, groups, or personal coworker 1:1s. User-started coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.',
     tags: ["Chat Rooms"],
     request: {
       body: {
@@ -77,8 +80,22 @@ const route = withGlobalHeaderParameters(
 
 export default function mount(app: OpenAPIHonoWithAuth) {
   app.openapi(route, async (c) => {
-    const userContext = requireUserAuthContext(c.var.authContext);
+    const authContext = c.var.authContext;
     const body = c.req.valid("json");
+
+    if (isCoworkerAuthContext(authContext)) {
+      const direct = await createOrGetCoworkerOriginatedDirect({
+        coworkerId: authContext.coworkerId,
+        organizationId: authContext.context?.organizationId ?? null,
+        memberUserIds: body.kind === "direct" ? (body.memberUserIds ?? []) : [],
+        coworkerIds: body.kind === "direct" ? (body.coworkerIds ?? []) : [],
+        kind: body.kind,
+      });
+
+      return direct.created ? created(c, direct.room) : ok(c, direct.room);
+    }
+
+    const userContext = requireUserAuthContext(authContext);
 
     if (body.kind === "direct") {
       const direct = await createOrGetDirectRoom({
@@ -172,6 +189,71 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       }
       throw error;
     }
+  });
+}
+
+/**
+ * Coworker API keys may create-or-get an org-scoped coworker 1:1 with exactly
+ * one organization member. The coworker id is the auth actor, not the body.
+ * Channels, human Directs, groups, and personal coworker 1:1s stay user-only.
+ */
+async function createOrGetCoworkerOriginatedDirect(params: {
+  coworkerId: string;
+  organizationId: string | null;
+  memberUserIds: readonly string[];
+  coworkerIds: readonly string[];
+  kind: "channel" | "direct";
+}): Promise<{ room: ChatRoom; created: boolean }> {
+  if (params.kind !== "direct") {
+    throw forbidden("User authentication required");
+  }
+
+  if (!params.organizationId) {
+    throw badRequest("Switch to an organization to message a teammate.");
+  }
+
+  if (params.coworkerIds.length > 0) {
+    throw badRequest("Group direct messages cannot include coworkers.");
+  }
+
+  if (params.memberUserIds.length !== 1) {
+    throw badRequest("Choose a direct message target");
+  }
+
+  return await createOrGetDirectRoom({
+    organizationId: params.organizationId,
+    currentUserId: params.memberUserIds[0]!,
+    memberUserIds: [],
+    coworkerIds: [params.coworkerId],
+  });
+}
+
+async function findOrRestoreDirectByKey(
+  tx: {
+    chatRoom: Pick<typeof prisma.chatRoom, "findFirst" | "update">;
+  },
+  params: { organizationId: string | null; directKey: string },
+) {
+  const existing = await tx.chatRoom.findFirst({
+    where: {
+      organizationId: params.organizationId,
+      directKey: params.directKey,
+    },
+    include: chatRoomInclude,
+  });
+
+  if (!existing) {
+    return null;
+  }
+
+  if (!existing.archivedAt) {
+    return existing;
+  }
+
+  return await tx.chatRoom.update({
+    where: { id: existing.id },
+    data: { archivedAt: null },
+    include: chatRoomInclude,
   });
 }
 
@@ -306,15 +388,11 @@ async function createOrGetDirectRoom(params: {
         });
         directKeyRef.current = directKey;
 
-        // Future archive must unarchive-or-clear-directKey on create-or-get:
-        // archived rows still hold the unique directKey slot.
-        const existing = await tx.chatRoom.findFirst({
-          where: {
-            organizationId: roomOrganizationId,
-            directKey,
-            archivedAt: null,
-          },
-          include: chatRoomInclude,
+        // Archived Directs still hold the unique directKey slot. Create-or-get
+        // unarchives that row instead of inserting a second room.
+        const existing = await findOrRestoreDirectByKey(tx, {
+          organizationId: roomOrganizationId,
+          directKey,
         });
 
         if (existing) {
@@ -394,13 +472,9 @@ async function createOrGetDirectRoom(params: {
     } catch (error) {
       // directKey race: another request won the create — return that room.
       if (isDirectKeyUniqueConstraintError(error) && directKeyRef.current) {
-        const existing = await prisma.chatRoom.findFirst({
-          where: {
-            organizationId: roomOrganizationId,
-            directKey: directKeyRef.current,
-            archivedAt: null,
-          },
-          include: chatRoomInclude,
+        const existing = await findOrRestoreDirectByKey(prisma, {
+          organizationId: roomOrganizationId,
+          directKey: directKeyRef.current,
         });
 
         if (existing) {

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -212,7 +212,7 @@ export const createChatRoomRequestSchema = z
       .object({
         kind: z.literal("direct").openapi({
           description:
-            "Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization. Discoverability is not allowed on directs.",
+            "Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. User-started coworker DMs may be personal with no active org; human DMs require an active organization. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.",
         }),
         memberUserIds: roomMemberUserIdsSchema,
         coworkerIds: roomCoworkerIdsSchema,

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -5742,7 +5742,7 @@ export const CreateChatRoomRequestSchema = {
                     enum: [
                         'direct'
                     ],
-                    description: 'Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization. Discoverability is not allowed on directs.'
+                    description: 'Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. User-started coworker DMs may be personal with no active org; human DMs require an active organization. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.'
                 },
                 memberUserIds: {
                     type: 'array',

--- a/apps/web/src/lib/clients/generated/core/sdk.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/sdk.gen.ts
@@ -514,7 +514,7 @@ export const getChatsRooms = <ThrowOnError extends boolean = false>(options?: Op
 });
 
 /**
- * Create a chat room. `kind: "channel"` requires an active organization. `kind: "direct"` creates or returns a direct room (1:1 or multi-human group) scoped to the active organization when one is set. Coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.
+ * Create a chat room. `kind: "channel"` requires an active organization and a user session. `kind: "direct"` creates or returns a direct room (1:1 or multi-human group) scoped to the active organization when one is set. Coworker API keys may create-or-get an org-scoped coworker 1:1 with `{ kind: "direct", memberUserIds: [targetUserId] }` when the coworker is usable in that workspace; they cannot create channels, human Directs, groups, or personal coworker 1:1s. User-started coworker DMs may be personal (`organizationId` null) with no active org; human DMs always require an active organization.
  */
 export const postChatsRooms = <ThrowOnError extends boolean = false>(options?: Options<PostChatsRoomsData, ThrowOnError>): RequestResult<PostChatsRoomsResponses, PostChatsRoomsErrors, ThrowOnError> => (options?.client ?? client).post<PostChatsRoomsResponses, PostChatsRoomsErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsResponseTransformer,
@@ -809,7 +809,7 @@ export const getChatsRoomsByIdMessages = <ThrowOnError extends boolean = false>(
 });
 
 /**
- * Post a room message. Mentioned AI coworkers — and, for thread replies, every coworker already part of the thread — are called asynchronously and reply into the room. Coworker API keys may post as the coworker itself into rooms it is a member of.
+ * Post a room message. Mentioned AI coworkers — and, for thread replies, every coworker already part of the thread — are called asynchronously and reply into the room. Coworker API keys may post as the coworker itself into rooms it is a member of. Coworker posts into a Direct with at most two human members emit the same CHAT Direct notification as a human sender (mute honored; the coworker has no user id to skip).
  */
 export const postChatsRoomsByIdMessages = <ThrowOnError extends boolean = false>(options: Options<PostChatsRoomsByIdMessagesData, ThrowOnError>): RequestResult<PostChatsRoomsByIdMessagesResponses, PostChatsRoomsByIdMessagesErrors, ThrowOnError> => (options.client ?? client).post<PostChatsRoomsByIdMessagesResponses, PostChatsRoomsByIdMessagesErrors, ThrowOnError>({
     responseTransformer: postChatsRoomsByIdMessagesResponseTransformer,

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1631,7 +1631,7 @@ export type CreateChatRoomRequest = {
     coworkerIds?: Array<string>;
 } | {
     /**
-     * Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. Coworker DMs may be personal with no active org; human DMs require an active organization. Discoverability is not allowed on directs.
+     * Creates or returns a direct room: one or more organization members (1:1 or multi-human group), or exactly one coworker. Human and coworker targets cannot be mixed. Scoped to the active organization when set. User-started coworker DMs may be personal with no active org; human DMs require an active organization. Coworker API keys may create-or-get an org-scoped coworker 1:1 with memberUserIds: [target] and no coworkerIds (the actor is the coworker). Discoverability is not allowed on directs.
      */
     kind: 'direct';
     /**

--- a/docs/adr/0010-coworker-originated-coworker-1to1.md
+++ b/docs/adr/0010-coworker-originated-coworker-1to1.md
@@ -1,0 +1,10 @@
+# ADR 0010: Coworker may originate an org-scoped coworker 1:1
+
+- Status: Accepted
+- Date: 2026-08-21
+
+A coworker API key may create-or-get an org-scoped **coworker 1:1** with an organization member, then post into it. Humans no longer have to open that Direct first.
+
+Unsolicited Direct is treated like a human adding the coworker to a room: originate requires the coworker to be usable in that workspace (whitelist or GRANTED) plus `chat` and `baseURL`. That is stricter than other coworker actor routes, which only check active + capability. Posting into a room the coworker already belongs to stays membership-only.
+
+Personal coworker 1:1s stay user-started. Coworker keys cannot create channels, human Directs, or groups. The target human is `createdByUserId`. Create-or-get uses the same `directKey` as the user-opened room so both actors land on one row, and unarchives if a stale archived row still holds that key.

--- a/docs/adr/0011-coworker-originated-coworker-1to1.md
+++ b/docs/adr/0011-coworker-originated-coworker-1to1.md
@@ -1,4 +1,4 @@
-# ADR 0010: Coworker may originate an org-scoped coworker 1:1
+# ADR 0011: Coworker may originate an org-scoped coworker 1:1
 
 - Status: Accepted
 - Date: 2026-08-21


### PR DESCRIPTION
## Summary

A coworker API key can open a coworker 1:1 with an organization member who never messaged that coworker first. That unblocks assignment DMs and any other coworker-originated Direct.

`POST /v1/chats/rooms` with `{ "kind": "direct", "memberUserIds": ["<targetUserId>"] }` create-or-gets the same org-scoped room a user would get (`directKey` `coworker:{userId}:{coworkerId}`). Then the existing `POST /v1/chats/rooms/{id}/messages` path posts as the coworker.

## Behavior

- Org-scoped only. Personal coworker 1:1s stay user-started.
- Target must be an organization member (`400` if not — not first-person `403`). Coworker id is the auth actor, not the body.
- Originate requires the coworker to be usable in that workspace (`chat` + `baseURL` + whitelist or GRANTED), same as a human adding them to a room.
- Channels, human Directs, groups, and `coworkerIds` in the body stay 403/400.
- Create-or-get unarchives a stale Direct that still holds the `directKey`. That restore applies to **all** Directs, not only coworker-originated.
- `createdByUserId` is the target human. The coworker response does not include that human's pin/mute/unread flags.
- Coworker posts into a Direct with at most two humans emit the same CHAT Direct notification as a human sender. Mute is honored. Channel coworker posts do not load the room roster for that check.

See ADR [0011](docs/adr/0011-coworker-originated-coworker-1to1.md).

## Verification

- `pnpm --filter core test src/routes/v1/chats/rooms/post.test.ts`
- `pnpm --filter core test src/routes/v1/chats/rooms/[id]/messages/post.test.ts`
- `pnpm --filter core test src/helpers/chat-direct-message-notifications.test.ts`
- `pnpm --filter core test src/routes/v1/chats/rooms/auth.test.ts`
- Husky `pnpm check && pnpm typecheck` on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coworker integrations can create or retrieve organization-scoped 1:1 chat rooms with human participants.
  * Coworker-authored messages in eligible 1:1 rooms now notify human recipients, respecting mute settings.
  * Archived direct rooms are automatically restored when reused.

* **Documentation**
  * Added guidance defining Direct rooms and coworker 1:1 rooms.
  * Documented coworker-originated 1:1 room behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
