### PR TITLE
fix(chat): hide empty Channels and External

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5053,7 +5053,6 @@
       "Empty": {
         "noChannels": "No channels yet.",
         "noDirectMessages": "No direct messages yet.",
-        "onlyInOrganizations": "Demnächst",
         "noMessagesTitle": "No messages yet",
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
@@ -5284,7 +5283,6 @@
       },
       "External": {
         "title": "Extern",
-        "empty": "Noch keine externen Kanäle.",
         "accept": "Annehmen",
         "decline": "Ablehnen",
         "acceptSuccess": "Du bist {name} beigetreten.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5053,7 +5053,6 @@
       "Empty": {
         "noChannels": "No channels yet.",
         "noDirectMessages": "No direct messages yet.",
-        "onlyInOrganizations": "Coming soon",
         "noMessagesTitle": "No messages yet",
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
@@ -5284,7 +5283,6 @@
       },
       "External": {
         "title": "External",
-        "empty": "No external channels yet.",
         "accept": "Accept",
         "decline": "Decline",
         "acceptSuccess": "You joined {name}.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5053,7 +5053,6 @@
       "Empty": {
         "noChannels": "No channels yet.",
         "noDirectMessages": "No direct messages yet.",
-        "onlyInOrganizations": "Próximamente",
         "noMessagesTitle": "No messages yet",
         "noMessagesDescription": "Start the channel with a message or mention an AI coworker.",
         "messagesLoadFailedTitle": "Messages could not be loaded",
@@ -5284,7 +5283,6 @@
       },
       "External": {
         "title": "Externo",
-        "empty": "Aún no hay canales externos.",
         "accept": "Aceptar",
         "decline": "Rechazar",
         "acceptSuccess": "Te uniste a {name}.",

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-harness.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-harness.tsx
@@ -1,0 +1,256 @@
+import { render } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { vi } from "vitest";
+import type {
+  ChatRoom,
+  ChatRoomInvitation,
+} from "@/lib/clients/generated/core";
+
+import { OrganizationChatList } from "../organization-chat-list.client";
+
+const { acceptInvitationMock, listRoomsMock, listPendingMock } = vi.hoisted(
+  () => ({
+    acceptInvitationMock: vi.fn(),
+    listRoomsMock: vi.fn(),
+    listPendingMock: vi.fn(),
+  }),
+);
+
+export { acceptInvitationMock, listPendingMock, listRoomsMock };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/chat",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace?: string) => (key: string) =>
+    namespace ? `${namespace}.${key}` : key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/contexts/lazy-ably-provider", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/ably/use-chat-membership-revoked-control", () => ({
+  useChatMembershipRevokedControl: () => {},
+}));
+
+vi.mock("@/hooks/use-chat-unread-document-title", () => ({
+  useChatUnreadDocumentTitle: () => {},
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  acceptChatRoomInvitationAction: (
+    ...args: Parameters<typeof acceptInvitationMock>
+  ) => acceptInvitationMock(...args),
+  declineChatRoomInvitationAction: vi.fn(),
+  deleteRoomAction: vi.fn(),
+  listPendingChatRoomInvitationsAction: (
+    ...args: Parameters<typeof listPendingMock>
+  ) => listPendingMock(...args),
+  restoreRoomAction: vi.fn(),
+}));
+
+vi.mock("@/app/chat/components/browse-channels-dialog", () => ({
+  BrowseChannelsDialog: () => null,
+}));
+
+vi.mock("@/app/chat/components/room-helpers", () => ({
+  getRoomDisplayName: () => "room",
+}));
+
+vi.mock("../chat-room-sidebar-row", () => ({
+  ChatRoomSidebarRow: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+vi.mock("../direct-room-avatar-stack", () => ({
+  DirectRoomAvatarStack: () => null,
+}));
+
+vi.mock("../organization-chat-list.actions", () => ({
+  listOrganizationChatRoomsAction: (
+    ...args: Parameters<typeof listRoomsMock>
+  ) => listRoomsMock(...args),
+  listOrganizationArchivedChatRoomsAction: vi.fn(async () => ({
+    ok: true,
+    value: { rooms: [], nextCursor: null },
+  })),
+  loadMoreOrganizationArchivedChatRoomsAction: vi.fn(),
+  loadMoreOrganizationChatRoomsAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarMenu: ({ children }: { children: ReactNode }) => <ul>{children}</ul>,
+  SidebarMenuItem: ({ children }: { children: ReactNode }) => (
+    <li>{children}</li>
+  ),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AlertDialogAction: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CollapsibleTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+export const emptyRooms: ChatRoom[] = [];
+
+export interface OrganizationChatListHarnessOptions {
+  rooms?: ChatRoom[];
+  pendingInvitations?: ChatRoomInvitation[];
+  organizationId?: string | null;
+}
+
+export function emptyListResult(rooms: ChatRoom[] = []) {
+  return {
+    ok: true as const,
+    value: { rooms, nextCursor: null },
+  };
+}
+
+export function makeRoom(
+  overrides: Partial<ChatRoom> & Pick<ChatRoom, "id" | "kind" | "myAccess">,
+): ChatRoom {
+  return {
+    organizationId: "org-1",
+    organizationName: "Acme",
+    name: overrides.id,
+    slug: overrides.id,
+    directKey: null,
+    topic: null,
+    discoverability: overrides.kind === "channel" ? "public" : null,
+    createdByUserId: "user-1",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    pinnedAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    userMembers: [],
+    coworkerMembers: [],
+    ...overrides,
+  };
+}
+
+export function makeInvitation(
+  overrides: Partial<ChatRoomInvitation> = {},
+): ChatRoomInvitation {
+  return {
+    id: "inv-1",
+    roomId: "ext-1",
+    roomName: "Partners",
+    organizationId: "org-1",
+    organizationName: "Acme",
+    email: "guest@example.com",
+    status: "pending",
+    inviter: { id: "user-2", name: "Ada" },
+    expiresAt: new Date("2026-02-01T00:00:00.000Z"),
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+export function resetOrganizationChatListMocks() {
+  acceptInvitationMock.mockReset();
+  listRoomsMock.mockReset();
+  listPendingMock.mockReset();
+  listRoomsMock.mockResolvedValue(emptyListResult());
+  listPendingMock.mockResolvedValue({ ok: true, value: [] });
+  acceptInvitationMock.mockResolvedValue({
+    ok: true,
+    value: makeInvitation(),
+  });
+}
+
+export function createOrganizationChatList({
+  rooms = emptyRooms,
+  pendingInvitations,
+  organizationId = "org-1",
+}: OrganizationChatListHarnessOptions = {}): ReactElement {
+  return (
+    <OrganizationChatList
+      rooms={rooms}
+      roomsNextCursor={null}
+      archivedRooms={emptyRooms}
+      archivedRoomsNextCursor={null}
+      {...(pendingInvitations === undefined ? {} : { pendingInvitations })}
+      currentUserId="user-1"
+      organizationId={organizationId}
+      canDeleteArchivedRooms={false}
+      dismissSheetOnNavigate={false}
+    />
+  );
+}
+
+export function renderOrganizationChatList(
+  options?: OrganizationChatListHarnessOptions,
+) {
+  return render(createOrganizationChatList(options));
+}

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
@@ -1,9 +1,10 @@
 import { render } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import type { ChatRoom } from "@/lib/clients/generated/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { OrganizationChatList } from "../organization-chat-list.client";
+import {
+  createOrganizationChatList,
+  resetOrganizationChatListMocks,
+} from "./organization-chat-list-harness";
 
 /**
  * Production: mobile `/chat` mounts OrganizationChatList without
@@ -12,172 +13,19 @@ import { OrganizationChatList } from "../organization-chat-list.client";
  * never converges → React #301 → Chat Error boundary.
  */
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: vi.fn(),
-    refresh: vi.fn(),
-  }),
-  usePathname: () => "/chat",
-}));
-
-vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
-
-vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
-}));
-
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
-}));
-
-vi.mock("@/contexts/lazy-ably-provider", () => ({
-  default: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
-vi.mock("@/lib/ably/use-chat-membership-revoked-control", () => ({
-  useChatMembershipRevokedControl: () => {},
-}));
-
-vi.mock("@/hooks/use-chat-unread-document-title", () => ({
-  useChatUnreadDocumentTitle: () => {},
-}));
-
-vi.mock("@/app/chat/actions", () => ({
-  acceptChatRoomInvitationAction: vi.fn(),
-  declineChatRoomInvitationAction: vi.fn(),
-  deleteRoomAction: vi.fn(),
-  listPendingChatRoomInvitationsAction: vi.fn(async () => ({
-    ok: true,
-    value: [],
-  })),
-  restoreRoomAction: vi.fn(),
-}));
-
-vi.mock("@/app/chat/components/browse-channels-dialog", () => ({
-  BrowseChannelsDialog: () => null,
-}));
-
-vi.mock("@/app/chat/components/room-helpers", () => ({
-  getRoomDisplayName: () => "room",
-}));
-
-vi.mock("../chat-room-sidebar-row", () => ({
-  ChatRoomSidebarRow: () => null,
-}));
-
-vi.mock("../direct-room-avatar-stack", () => ({
-  DirectRoomAvatarStack: () => null,
-}));
-
-vi.mock("../organization-chat-list.actions", () => ({
-  listOrganizationChatRoomsAction: vi.fn(async () => ({
-    ok: true,
-    value: { rooms: [], nextCursor: null },
-  })),
-  listOrganizationArchivedChatRoomsAction: vi.fn(async () => ({
-    ok: true,
-    value: { rooms: [], nextCursor: null },
-  })),
-  loadMoreOrganizationArchivedChatRoomsAction: vi.fn(),
-  loadMoreOrganizationChatRoomsAction: vi.fn(),
-}));
-
-vi.mock("@/components/ui/sheet", () => ({
-  SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
-vi.mock("@/components/ui/sidebar", () => ({
-  SidebarGroup: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  SidebarGroupContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  SidebarMenu: ({ children }: { children: ReactNode }) => <ul>{children}</ul>,
-  SidebarMenuItem: ({ children }: { children: ReactNode }) => (
-    <li>{children}</li>
-  ),
-}));
-
-vi.mock("@/components/ui/alert-dialog", () => ({
-  AlertDialog: ({ children }: { children: ReactNode }) => <>{children}</>,
-  AlertDialogAction: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-  AlertDialogContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
-    <p>{children}</p>
-  ),
-  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
-    <h2>{children}</h2>
-  ),
-}));
-
-vi.mock("@/components/ui/collapsible", () => ({
-  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  CollapsibleContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  CollapsibleTrigger: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-}));
-
-vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
-    <>{children}</>
-  ),
-}));
-
-const emptyRooms: ChatRoom[] = [];
-
-function renderChatsTabList() {
-  return (
-    <OrganizationChatList
-      rooms={emptyRooms}
-      roomsNextCursor={null}
-      archivedRooms={emptyRooms}
-      archivedRoomsNextCursor={null}
-      currentUserId="user-1"
-      organizationId="org-1"
-      canDeleteArchivedRooms={false}
-      dismissSheetOnNavigate={false}
-    />
-  );
-}
-
 describe("OrganizationChatList pendingInvitations default (Chat Error / #301)", () => {
+  beforeEach(() => {
+    resetOrganizationChatListMocks();
+  });
+
   it("survives re-render when pendingInvitations prop is omitted", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
     try {
-      const { rerender } = render(renderChatsTabList());
+      const { rerender } = render(createOrganizationChatList());
       expect(() => {
-        rerender(renderChatsTabList());
+        rerender(createOrganizationChatList());
       }).not.toThrow();
       expect(
         consoleError.mock.calls.some((call) =>

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx
@@ -1,0 +1,301 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ChatRoom,
+  ChatRoomInvitation,
+} from "@/lib/clients/generated/core";
+
+import { OrganizationChatList } from "../organization-chat-list.client";
+
+const { listRoomsMock, listPendingMock } = vi.hoisted(() => ({
+  listRoomsMock: vi.fn(),
+  listPendingMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/chat",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace?: string) => (key: string) =>
+    namespace ? `${namespace}.${key}` : key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/contexts/lazy-ably-provider", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/ably/use-chat-membership-revoked-control", () => ({
+  useChatMembershipRevokedControl: () => {},
+}));
+
+vi.mock("@/hooks/use-chat-unread-document-title", () => ({
+  useChatUnreadDocumentTitle: () => {},
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  acceptChatRoomInvitationAction: vi.fn(),
+  declineChatRoomInvitationAction: vi.fn(),
+  deleteRoomAction: vi.fn(),
+  listPendingChatRoomInvitationsAction: (
+    ...args: Parameters<typeof listPendingMock>
+  ) => listPendingMock(...args),
+  restoreRoomAction: vi.fn(),
+}));
+
+vi.mock("@/app/chat/components/browse-channels-dialog", () => ({
+  BrowseChannelsDialog: () => null,
+}));
+
+vi.mock("@/app/chat/components/room-helpers", () => ({
+  getRoomDisplayName: () => "room",
+}));
+
+vi.mock("../chat-room-sidebar-row", () => ({
+  ChatRoomSidebarRow: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+vi.mock("../direct-room-avatar-stack", () => ({
+  DirectRoomAvatarStack: () => null,
+}));
+
+vi.mock("../organization-chat-list.actions", () => ({
+  listOrganizationChatRoomsAction: (
+    ...args: Parameters<typeof listRoomsMock>
+  ) => listRoomsMock(...args),
+  listOrganizationArchivedChatRoomsAction: vi.fn(async () => ({
+    ok: true,
+    value: { rooms: [], nextCursor: null },
+  })),
+  loadMoreOrganizationArchivedChatRoomsAction: vi.fn(),
+  loadMoreOrganizationChatRoomsAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarGroupContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SidebarMenu: ({ children }: { children: ReactNode }) => <ul>{children}</ul>,
+  SidebarMenuItem: ({ children }: { children: ReactNode }) => (
+    <li>{children}</li>
+  ),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AlertDialogAction: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CollapsibleTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const emptyRooms: ChatRoom[] = [];
+
+function emptyListResult(rooms: ChatRoom[] = []) {
+  return { ok: true as const, value: { rooms, nextCursor: null } };
+}
+
+function makeRoom(
+  overrides: Partial<ChatRoom> & Pick<ChatRoom, "id" | "kind" | "myAccess">,
+): ChatRoom {
+  return {
+    organizationId: "org-1",
+    organizationName: "Acme",
+    name: overrides.id,
+    slug: overrides.id,
+    directKey: null,
+    topic: null,
+    discoverability: overrides.kind === "channel" ? "public" : null,
+    createdByUserId: "user-1",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    pinnedAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    userMembers: [],
+    coworkerMembers: [],
+    ...overrides,
+  };
+}
+
+function makeInvitation(
+  overrides: Partial<ChatRoomInvitation> = {},
+): ChatRoomInvitation {
+  return {
+    id: "inv-1",
+    roomId: "ext-1",
+    roomName: "Partners",
+    organizationId: "org-1",
+    organizationName: "Acme",
+    email: "guest@example.com",
+    status: "pending",
+    inviter: { id: "user-2", name: "Ada" },
+    expiresAt: new Date("2026-02-01T00:00:00.000Z"),
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function renderList({
+  rooms = emptyRooms,
+  pendingInvitations,
+  organizationId,
+}: {
+  rooms?: ChatRoom[];
+  pendingInvitations?: ChatRoomInvitation[];
+  organizationId: string | null;
+}) {
+  return render(
+    <OrganizationChatList
+      rooms={rooms}
+      roomsNextCursor={null}
+      archivedRooms={emptyRooms}
+      archivedRoomsNextCursor={null}
+      pendingInvitations={pendingInvitations}
+      currentUserId="user-1"
+      organizationId={organizationId}
+      canDeleteArchivedRooms={false}
+      dismissSheetOnNavigate={false}
+    />,
+  );
+}
+
+describe("OrganizationChatList section visibility", () => {
+  beforeEach(() => {
+    listRoomsMock.mockReset();
+    listPendingMock.mockReset();
+    listRoomsMock.mockResolvedValue(emptyListResult());
+    listPendingMock.mockResolvedValue({ ok: true, value: [] });
+  });
+
+  it("hides Channels in a personal workspace", () => {
+    renderList({ organizationId: null });
+
+    expect(screen.queryByText("App.Channels.title")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("App.Channels.Empty.onlyInOrganizations"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("App.Channels.directMessages")).toBeInTheDocument();
+  });
+
+  it("keeps Channels in an organization workspace when empty", () => {
+    renderList({ organizationId: "org-1" });
+
+    expect(screen.getByText("App.Channels.title")).toBeInTheDocument();
+    expect(
+      screen.getByText("App.Channels.Empty.noChannels"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("App.Channels.directMessages")).toBeInTheDocument();
+  });
+
+  it("hides External when there are no joined rooms and no pending invitations", () => {
+    renderList({ organizationId: "org-1" });
+
+    expect(
+      screen.queryByText("App.Channels.External.title"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("App.Channels.External.empty"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows External when the user has joined an external room", async () => {
+    const external = makeRoom({
+      id: "ext-1",
+      kind: "channel",
+      myAccess: "guest",
+      discoverability: "external",
+      name: "Partners",
+    });
+    listRoomsMock.mockResolvedValue(emptyListResult([external]));
+
+    renderList({ organizationId: null, rooms: [external] });
+
+    expect(
+      await screen.findByText("App.Channels.External.title"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Partners")).toBeInTheDocument();
+    expect(screen.queryByText("App.Channels.title")).not.toBeInTheDocument();
+  });
+
+  it("shows External when a pending invitation exists", async () => {
+    const invitation = makeInvitation();
+    listPendingMock.mockResolvedValue({ ok: true, value: [invitation] });
+
+    renderList({
+      organizationId: "org-1",
+      pendingInvitations: [invitation],
+    });
+
+    expect(
+      await screen.findByText("App.Channels.External.title"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Partners")).toBeInTheDocument();
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx
@@ -1,251 +1,25 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  ChatRoom,
-  ChatRoomInvitation,
-} from "@/lib/clients/generated/core";
+import { beforeEach, describe, expect, it } from "vitest";
 
-import { OrganizationChatList } from "../organization-chat-list.client";
-
-const { acceptInvitationMock, listRoomsMock, listPendingMock } = vi.hoisted(
-  () => ({
-    acceptInvitationMock: vi.fn(),
-    listRoomsMock: vi.fn(),
-    listPendingMock: vi.fn(),
-  }),
-);
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: vi.fn(),
-    refresh: vi.fn(),
-  }),
-  usePathname: () => "/chat",
-}));
-
-vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
-
-vi.mock("next-intl", () => ({
-  useTranslations: (namespace?: string) => (key: string) =>
-    namespace ? `${namespace}.${key}` : key,
-}));
-
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
-}));
-
-vi.mock("@/contexts/lazy-ably-provider", () => ({
-  default: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
-vi.mock("@/lib/ably/use-chat-membership-revoked-control", () => ({
-  useChatMembershipRevokedControl: () => {},
-}));
-
-vi.mock("@/hooks/use-chat-unread-document-title", () => ({
-  useChatUnreadDocumentTitle: () => {},
-}));
-
-vi.mock("@/app/chat/actions", () => ({
-  acceptChatRoomInvitationAction: (
-    ...args: Parameters<typeof acceptInvitationMock>
-  ) => acceptInvitationMock(...args),
-  declineChatRoomInvitationAction: vi.fn(),
-  deleteRoomAction: vi.fn(),
-  listPendingChatRoomInvitationsAction: (
-    ...args: Parameters<typeof listPendingMock>
-  ) => listPendingMock(...args),
-  restoreRoomAction: vi.fn(),
-}));
-
-vi.mock("@/app/chat/components/browse-channels-dialog", () => ({
-  BrowseChannelsDialog: () => null,
-}));
-
-vi.mock("@/app/chat/components/room-helpers", () => ({
-  getRoomDisplayName: () => "room",
-}));
-
-vi.mock("../chat-room-sidebar-row", () => ({
-  ChatRoomSidebarRow: ({ label }: { label: string }) => <span>{label}</span>,
-}));
-
-vi.mock("../direct-room-avatar-stack", () => ({
-  DirectRoomAvatarStack: () => null,
-}));
-
-vi.mock("../organization-chat-list.actions", () => ({
-  listOrganizationChatRoomsAction: (
-    ...args: Parameters<typeof listRoomsMock>
-  ) => listRoomsMock(...args),
-  listOrganizationArchivedChatRoomsAction: vi.fn(async () => ({
-    ok: true,
-    value: { rooms: [], nextCursor: null },
-  })),
-  loadMoreOrganizationArchivedChatRoomsAction: vi.fn(),
-  loadMoreOrganizationChatRoomsAction: vi.fn(),
-}));
-
-vi.mock("@/components/ui/sheet", () => ({
-  SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
-vi.mock("@/components/ui/sidebar", () => ({
-  SidebarGroup: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  SidebarGroupContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  SidebarMenu: ({ children }: { children: ReactNode }) => <ul>{children}</ul>,
-  SidebarMenuItem: ({ children }: { children: ReactNode }) => (
-    <li>{children}</li>
-  ),
-}));
-
-vi.mock("@/components/ui/alert-dialog", () => ({
-  AlertDialog: ({ children }: { children: ReactNode }) => <>{children}</>,
-  AlertDialogAction: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-  AlertDialogContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
-    <p>{children}</p>
-  ),
-  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
-    <h2>{children}</h2>
-  ),
-}));
-
-vi.mock("@/components/ui/collapsible", () => ({
-  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  CollapsibleContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  CollapsibleTrigger: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-}));
-
-vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
-    <>{children}</>
-  ),
-}));
-
-const emptyRooms: ChatRoom[] = [];
-
-function emptyListResult(rooms: ChatRoom[] = []) {
-  return { ok: true as const, value: { rooms, nextCursor: null } };
-}
-
-function makeRoom(
-  overrides: Partial<ChatRoom> & Pick<ChatRoom, "id" | "kind" | "myAccess">,
-): ChatRoom {
-  return {
-    organizationId: "org-1",
-    organizationName: "Acme",
-    name: overrides.id,
-    slug: overrides.id,
-    directKey: null,
-    topic: null,
-    discoverability: overrides.kind === "channel" ? "public" : null,
-    createdByUserId: "user-1",
-    createdAt: new Date("2026-01-01T00:00:00.000Z"),
-    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    unreadCount: 0,
-    unreadMentionCount: 0,
-    pinnedAt: null,
-    mutedAt: null,
-    markedUnread: false,
-    userMembers: [],
-    coworkerMembers: [],
-    ...overrides,
-  };
-}
-
-function makeInvitation(
-  overrides: Partial<ChatRoomInvitation> = {},
-): ChatRoomInvitation {
-  return {
-    id: "inv-1",
-    roomId: "ext-1",
-    roomName: "Partners",
-    organizationId: "org-1",
-    organizationName: "Acme",
-    email: "guest@example.com",
-    status: "pending",
-    inviter: { id: "user-2", name: "Ada" },
-    expiresAt: new Date("2026-02-01T00:00:00.000Z"),
-    createdAt: new Date("2026-01-01T00:00:00.000Z"),
-    ...overrides,
-  };
-}
-
-function renderList({
-  rooms = emptyRooms,
-  pendingInvitations,
-  organizationId,
-}: {
-  rooms?: ChatRoom[];
-  pendingInvitations?: ChatRoomInvitation[];
-  organizationId: string | null;
-}) {
-  return render(
-    <OrganizationChatList
-      rooms={rooms}
-      roomsNextCursor={null}
-      archivedRooms={emptyRooms}
-      archivedRoomsNextCursor={null}
-      pendingInvitations={pendingInvitations}
-      currentUserId="user-1"
-      organizationId={organizationId}
-      canDeleteArchivedRooms={false}
-      dismissSheetOnNavigate={false}
-    />,
-  );
-}
+import {
+  acceptInvitationMock,
+  emptyListResult,
+  listPendingMock,
+  listRoomsMock,
+  makeInvitation,
+  makeRoom,
+  renderOrganizationChatList,
+  resetOrganizationChatListMocks,
+} from "./organization-chat-list-harness";
 
 describe("OrganizationChatList section visibility", () => {
   beforeEach(() => {
-    acceptInvitationMock.mockReset();
-    listRoomsMock.mockReset();
-    listPendingMock.mockReset();
-    listRoomsMock.mockResolvedValue(emptyListResult());
-    listPendingMock.mockResolvedValue({ ok: true, value: [] });
-    acceptInvitationMock.mockResolvedValue({
-      ok: true,
-      value: makeInvitation(),
-    });
+    resetOrganizationChatListMocks();
   });
 
   it("hides Channels in a personal workspace", () => {
-    renderList({ organizationId: null });
+    renderOrganizationChatList({ organizationId: null });
 
     expect(screen.queryByText("App.Channels.title")).not.toBeInTheDocument();
     expect(
@@ -255,7 +29,7 @@ describe("OrganizationChatList section visibility", () => {
   });
 
   it("keeps Channels in an organization workspace when empty", () => {
-    renderList({ organizationId: "org-1" });
+    renderOrganizationChatList({ organizationId: "org-1" });
 
     expect(screen.getByText("App.Channels.title")).toBeInTheDocument();
     expect(
@@ -265,7 +39,7 @@ describe("OrganizationChatList section visibility", () => {
   });
 
   it("hides External when there are no joined rooms and no pending invitations", () => {
-    renderList({ organizationId: "org-1" });
+    renderOrganizationChatList({ organizationId: "org-1" });
 
     expect(
       screen.queryByText("App.Channels.External.title"),
@@ -285,7 +59,7 @@ describe("OrganizationChatList section visibility", () => {
     });
     listRoomsMock.mockResolvedValue(emptyListResult([external]));
 
-    renderList({ organizationId: null, rooms: [external] });
+    renderOrganizationChatList({ organizationId: null, rooms: [external] });
 
     expect(
       await screen.findByText("App.Channels.External.title"),
@@ -298,7 +72,7 @@ describe("OrganizationChatList section visibility", () => {
     const invitation = makeInvitation();
     listPendingMock.mockResolvedValue({ ok: true, value: [invitation] });
 
-    renderList({
+    renderOrganizationChatList({
       organizationId: "org-1",
       pendingInvitations: [invitation],
     });
@@ -330,7 +104,7 @@ describe("OrganizationChatList section visibility", () => {
     );
     acceptInvitationMock.mockResolvedValue({ ok: true, value: invitation });
 
-    renderList({
+    renderOrganizationChatList({
       organizationId: "org-1",
       pendingInvitations: [invitation],
     });

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -8,10 +9,13 @@ import type {
 
 import { OrganizationChatList } from "../organization-chat-list.client";
 
-const { listRoomsMock, listPendingMock } = vi.hoisted(() => ({
-  listRoomsMock: vi.fn(),
-  listPendingMock: vi.fn(),
-}));
+const { acceptInvitationMock, listRoomsMock, listPendingMock } = vi.hoisted(
+  () => ({
+    acceptInvitationMock: vi.fn(),
+    listRoomsMock: vi.fn(),
+    listPendingMock: vi.fn(),
+  }),
+);
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -50,7 +54,9 @@ vi.mock("@/hooks/use-chat-unread-document-title", () => ({
 }));
 
 vi.mock("@/app/chat/actions", () => ({
-  acceptChatRoomInvitationAction: vi.fn(),
+  acceptChatRoomInvitationAction: (
+    ...args: Parameters<typeof acceptInvitationMock>
+  ) => acceptInvitationMock(...args),
   declineChatRoomInvitationAction: vi.fn(),
   deleteRoomAction: vi.fn(),
   listPendingChatRoomInvitationsAction: (
@@ -227,10 +233,15 @@ function renderList({
 
 describe("OrganizationChatList section visibility", () => {
   beforeEach(() => {
+    acceptInvitationMock.mockReset();
     listRoomsMock.mockReset();
     listPendingMock.mockReset();
     listRoomsMock.mockResolvedValue(emptyListResult());
     listPendingMock.mockResolvedValue({ ok: true, value: [] });
+    acceptInvitationMock.mockResolvedValue({
+      ok: true,
+      value: makeInvitation(),
+    });
   });
 
   it("hides Channels in a personal workspace", () => {
@@ -297,5 +308,60 @@ describe("OrganizationChatList section visibility", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Partners")).toBeInTheDocument();
     expect(screen.getByText("Acme")).toBeInTheDocument();
+  });
+
+  it("keeps External visible while the last pending invite is accepted", async () => {
+    const invitation = makeInvitation();
+    const joined = makeRoom({
+      id: invitation.roomId,
+      kind: "channel",
+      myAccess: "guest",
+      discoverability: "external",
+      name: invitation.roomName,
+    });
+    listPendingMock.mockResolvedValue({ ok: true, value: [invitation] });
+    listRoomsMock.mockReset();
+    listRoomsMock.mockResolvedValueOnce(emptyListResult());
+    let resolveRooms!: (value: ReturnType<typeof emptyListResult>) => void;
+    listRoomsMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRooms = resolve;
+      }),
+    );
+    acceptInvitationMock.mockResolvedValue({ ok: true, value: invitation });
+
+    renderList({
+      organizationId: "org-1",
+      pendingInvitations: [invitation],
+    });
+
+    expect(
+      await screen.findByText("App.Channels.External.title"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "App.Channels.External.accept" }),
+    );
+
+    await waitFor(() => {
+      expect(listRoomsMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.getByText("App.Channels.External.title")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "App.Channels.loading" }),
+    ).toBeInTheDocument();
+
+    resolveRooms(emptyListResult([joined]));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", {
+          name: "App.Channels.External.accept",
+        }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("App.Channels.External.title")).toBeInTheDocument();
+    expect(screen.getByText("Partners")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -613,17 +613,19 @@ export function OrganizationChatList({
     setRespondingInvitation({ id: invitation.id, action: "accept" });
     startInviteResponseTransition(async () => {
       const result = await acceptChatRoomInvitationAction(invitation.id);
-      setRespondingInvitation(null);
       if (!result.ok) {
+        setRespondingInvitation(null);
         toast.error(result.error.message || tExternal("acceptError"));
         return;
       }
       toast.success(tExternal("acceptSuccess", { name: invitation.roomName }));
+      // Drop pending and upsert rooms in the same tick so External does not
+      // unmount between the last invite and the joined guest room.
+      const roomsResult = await listOrganizationChatRoomsAction();
+      setRespondingInvitation(null);
       setPendingRows((current) =>
         current.filter((row) => row.id !== invitation.id),
       );
-      // Guest room appears on next list refresh; pull rooms immediately.
-      const roomsResult = await listOrganizationChatRoomsAction();
       if (roomsResult.ok) {
         setRoomRows((current) =>
           applyRoomReadOverlays(

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -671,144 +671,141 @@ export function OrganizationChatList({
     <SidebarGroup className="w-full">
       {membershipRevokedBridge}
       <SidebarGroupContent className="space-y-2">
-        <Collapsible
-          open={channelSectionOpen}
-          onOpenChange={setChannelSectionOpen}
-        >
-          <SectionHeader
-            href={hasOrganization ? "/?create=channel" : undefined}
-            isOpen={channelSectionOpen}
-            label={t("createChannel")}
-            secondaryAction={
-              hasOrganization ? <BrowseChannelsDialog /> : undefined
-            }
-            dismissSheetOnNavigate={dismissSheetOnNavigate}
+        {hasOrganization ? (
+          <Collapsible
+            open={channelSectionOpen}
+            onOpenChange={setChannelSectionOpen}
           >
-            {t("title")}
-          </SectionHeader>
-          <CollapsibleContent>
-            <SidebarMenu className="gap-0">
-              {namedChannels.map((room) => (
-                <ChatRoomSidebarRow
-                  key={room.id}
-                  room={room}
-                  href={`/chat/rooms/${room.id}`}
-                  label={room.name}
-                  isActive={activeRoomId === room.id}
-                  leading={
-                    <ChannelDiscoverabilityIcon
-                      discoverability={room.discoverability}
-                    />
-                  }
-                  onRoomUpdated={handleRoomUpdated}
-                  dismissSheetOnNavigate={dismissSheetOnNavigate}
-                />
-              ))}
-              {namedChannels.length === 0 ? (
-                <SidebarMenuItem>
-                  <div className="text-muted-foreground px-3 py-1.5 text-xs group-data-[collapsible=icon]:hidden">
-                    {hasOrganization
-                      ? t("Empty.noChannels")
-                      : t("Empty.onlyInOrganizations")}
-                  </div>
-                </SidebarMenuItem>
-              ) : null}
-            </SidebarMenu>
-          </CollapsibleContent>
-        </Collapsible>
-
-        <Collapsible open={externalOpen} onOpenChange={setExternalOpen}>
-          <SectionHeader isOpen={externalOpen}>
-            {tExternal("title")}
-          </SectionHeader>
-          <CollapsibleContent>
-            <SidebarMenu className="gap-0">
-              {pendingRows.map((invitation) => {
-                const anyBusy = respondingInvitation !== null;
-                const acceptBusy =
-                  respondingInvitation?.id === invitation.id &&
-                  respondingInvitation.action === "accept";
-                const declineBusy =
-                  respondingInvitation?.id === invitation.id &&
-                  respondingInvitation.action === "decline";
-                return (
-                  <SidebarMenuItem key={invitation.id}>
-                    <div
-                      aria-label={tExternal("pendingAria", {
-                        name: invitation.roomName,
-                        organization: invitation.organizationName,
-                      })}
-                      className="text-tertiary-foreground dark:text-muted-foreground flex min-h-auto w-full items-start gap-2 px-3 py-1.5 group-data-[collapsible=icon]:hidden"
-                    >
-                      <Globe2
-                        className="text-muted-foreground mt-0.5 size-3.5 shrink-0"
-                        aria-hidden
+            <SectionHeader
+              href="/?create=channel"
+              isOpen={channelSectionOpen}
+              label={t("createChannel")}
+              secondaryAction={<BrowseChannelsDialog />}
+              dismissSheetOnNavigate={dismissSheetOnNavigate}
+            >
+              {t("title")}
+            </SectionHeader>
+            <CollapsibleContent>
+              <SidebarMenu className="gap-0">
+                {namedChannels.map((room) => (
+                  <ChatRoomSidebarRow
+                    key={room.id}
+                    room={room}
+                    href={`/chat/rooms/${room.id}`}
+                    label={room.name}
+                    isActive={activeRoomId === room.id}
+                    leading={
+                      <ChannelDiscoverabilityIcon
+                        discoverability={room.discoverability}
                       />
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate font-medium text-foreground">
-                          {invitation.roomName}
-                        </div>
-                        <div className="text-muted-foreground truncate text-xs leading-tight">
-                          {invitation.organizationName}
-                        </div>
-                        <div className="mt-1.5 flex items-center gap-1.5">
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="default"
-                            className="h-6 px-2 text-xs"
-                            disabled={anyBusy}
-                            onClick={() => handleAcceptInvitation(invitation)}
-                          >
-                            {acceptBusy ? t("loading") : tExternal("accept")}
-                          </Button>
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            className="h-6 px-2 text-xs"
-                            disabled={anyBusy}
-                            onClick={() => handleDeclineInvitation(invitation)}
-                          >
-                            {declineBusy ? t("loading") : tExternal("decline")}
-                          </Button>
-                        </div>
-                      </div>
+                    }
+                    onRoomUpdated={handleRoomUpdated}
+                    dismissSheetOnNavigate={dismissSheetOnNavigate}
+                  />
+                ))}
+                {namedChannels.length === 0 ? (
+                  <SidebarMenuItem>
+                    <div className="text-muted-foreground px-3 py-1.5 text-xs group-data-[collapsible=icon]:hidden">
+                      {t("Empty.noChannels")}
                     </div>
                   </SidebarMenuItem>
-                );
-              })}
-              {externalJoined.map((room) => (
-                <ChatRoomSidebarRow
-                  key={room.id}
-                  room={room}
-                  href={`/chat/rooms/${room.id}`}
-                  label={room.name}
-                  subtitle={
-                    room.myAccess === "guest" && room.organizationName
-                      ? tExternal("hostOrganization", {
-                          organization: room.organizationName,
-                        })
-                      : undefined
-                  }
-                  isActive={activeRoomId === room.id}
-                  leading={
-                    <ChannelDiscoverabilityIcon discoverability="external" />
-                  }
-                  onRoomUpdated={handleRoomUpdated}
-                  dismissSheetOnNavigate={dismissSheetOnNavigate}
-                />
-              ))}
-              {pendingRows.length === 0 && externalJoined.length === 0 ? (
-                <SidebarMenuItem>
-                  <div className="text-muted-foreground px-3 py-1.5 text-xs group-data-[collapsible=icon]:hidden">
-                    {tExternal("empty")}
-                  </div>
-                </SidebarMenuItem>
-              ) : null}
-            </SidebarMenu>
-          </CollapsibleContent>
-        </Collapsible>
+                ) : null}
+              </SidebarMenu>
+            </CollapsibleContent>
+          </Collapsible>
+        ) : null}
+
+        {pendingRows.length > 0 || externalJoined.length > 0 ? (
+          <Collapsible open={externalOpen} onOpenChange={setExternalOpen}>
+            <SectionHeader isOpen={externalOpen}>
+              {tExternal("title")}
+            </SectionHeader>
+            <CollapsibleContent>
+              <SidebarMenu className="gap-0">
+                {pendingRows.map((invitation) => {
+                  const anyBusy = respondingInvitation !== null;
+                  const acceptBusy =
+                    respondingInvitation?.id === invitation.id &&
+                    respondingInvitation.action === "accept";
+                  const declineBusy =
+                    respondingInvitation?.id === invitation.id &&
+                    respondingInvitation.action === "decline";
+                  return (
+                    <SidebarMenuItem key={invitation.id}>
+                      <div
+                        aria-label={tExternal("pendingAria", {
+                          name: invitation.roomName,
+                          organization: invitation.organizationName,
+                        })}
+                        className="text-tertiary-foreground dark:text-muted-foreground flex min-h-auto w-full items-start gap-2 px-3 py-1.5 group-data-[collapsible=icon]:hidden"
+                      >
+                        <Globe2
+                          className="text-muted-foreground mt-0.5 size-3.5 shrink-0"
+                          aria-hidden
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-medium text-foreground">
+                            {invitation.roomName}
+                          </div>
+                          <div className="text-muted-foreground truncate text-xs leading-tight">
+                            {invitation.organizationName}
+                          </div>
+                          <div className="mt-1.5 flex items-center gap-1.5">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="default"
+                              className="h-6 px-2 text-xs"
+                              disabled={anyBusy}
+                              onClick={() => handleAcceptInvitation(invitation)}
+                            >
+                              {acceptBusy ? t("loading") : tExternal("accept")}
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="h-6 px-2 text-xs"
+                              disabled={anyBusy}
+                              onClick={() =>
+                                handleDeclineInvitation(invitation)
+                              }
+                            >
+                              {declineBusy
+                                ? t("loading")
+                                : tExternal("decline")}
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    </SidebarMenuItem>
+                  );
+                })}
+                {externalJoined.map((room) => (
+                  <ChatRoomSidebarRow
+                    key={room.id}
+                    room={room}
+                    href={`/chat/rooms/${room.id}`}
+                    label={room.name}
+                    subtitle={
+                      room.myAccess === "guest" && room.organizationName
+                        ? tExternal("hostOrganization", {
+                            organization: room.organizationName,
+                          })
+                        : undefined
+                    }
+                    isActive={activeRoomId === room.id}
+                    leading={
+                      <ChannelDiscoverabilityIcon discoverability="external" />
+                    }
+                    onRoomUpdated={handleRoomUpdated}
+                    dismissSheetOnNavigate={dismissSheetOnNavigate}
+                  />
+                ))}
+              </SidebarMenu>
+            </CollapsibleContent>
+          </Collapsible>
+        ) : null}
 
         {hasOrganization && sortedArchivedChannels.length > 0 ? (
           <Collapsible


### PR DESCRIPTION
## Summary

Hide empty chat sidebar sections so personal workspaces and empty orgs don't show placeholder chrome.

- **Channels** is hidden in a personal workspace (no more "Coming soon"). Organization workspaces still show the section, including the empty "No channels yet." state with create/browse.
- **External** is hidden when there are no joined external rooms and no pending invitations. It still appears when either exists (including guest rooms in a personal workspace).
- **Direct Messages** is always shown.

## Verification

- `pnpm --filter web exec vitest run src/components/chat/__tests__/organization-chat-list-section-visibility.test.tsx` — 5 passed
- Browser: personal workspace shows DMs only; org with no externals shows Channels + DMs; org with externals still shows External