### PR TITLE
feat(web): show all membership-visible rooms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,7 +95,7 @@ _Avoid_: Channel @mention thread, mixing extra humans or coworkers into this sha
 ### Chat membership
 
 **Membership-visible rooms**:
-The set of chat rooms the current user is a member of and may see in the chat room list (sidebar / chats list). Losing membership removes a room from this set.
+The set of chat rooms the current user is a member of and may see in the chat room list (sidebar / chats list) for the current workspace. The list shows that whole set. Losing membership removes a room from this set.
 _Avoid_: Roster (for this set), channel list (unless referring to a specific UI label)
 
 **Room roster**:

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5042,9 +5042,7 @@
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflowCount": "{count} weitere Teilnehmer",
       "directMessages": "Direct Messages",
-      "loadMore": "Mehr laden",
       "loading": "Wird geladen...",
-      "loadMoreError": "Weitere Chats konnten nicht geladen werden",
       "composerPlaceholder": "Message this channel. Type @ to mention an AI coworker.",
       "NoOrganization": {
         "title": "Channels kommen bald",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5042,9 +5042,7 @@
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflowCount": "{count} more participants",
       "directMessages": "Direct Messages",
-      "loadMore": "Load more",
       "loading": "Loading...",
-      "loadMoreError": "Failed to load more chats",
       "composerPlaceholder": "Message this channel. Type @ to mention an AI coworker.",
       "NoOrganization": {
         "title": "Channels coming soon",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5042,9 +5042,7 @@
       "coworkerCount": "{count, plural, one {# AI coworker} other {# AI coworkers}}",
       "participantOverflowCount": "{count} participantes más",
       "directMessages": "Direct Messages",
-      "loadMore": "Cargar más",
       "loading": "Cargando...",
-      "loadMoreError": "No se pudieron cargar más chats",
       "composerPlaceholder": "Message this channel. Type @ to mention an AI coworker.",
       "NoOrganization": {
         "title": "Canales próximamente",

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -63,9 +63,7 @@ async function ChatChatsListWithArchived({
     <OrganizationChatList
       key={activeOrganizationId ?? "personal"}
       rooms={chatRoomsPage.rooms}
-      roomsNextCursor={chatRoomsPage.nextCursor}
       archivedRooms={archivedChatRoomsPage.rooms}
-      archivedRoomsNextCursor={archivedChatRoomsPage.nextCursor}
       currentUserId={currentUserId}
       organizationId={activeOrganizationId}
       canDeleteArchivedRooms={canDeleteArchivedRooms}
@@ -128,9 +126,7 @@ export default async function ChatPage({ searchParams }: ChatPageProps) {
               <OrganizationChatList
                 key={listKey}
                 rooms={chatRoomsPage.rooms}
-                roomsNextCursor={chatRoomsPage.nextCursor}
                 archivedRooms={[]}
-                archivedRoomsNextCursor={null}
                 currentUserId={currentUserId}
                 organizationId={activeOrganizationId}
                 canDeleteArchivedRooms={false}

--- a/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
+++ b/apps/web/src/app/(app)/components/__tests__/chat-list-chrome-cache.test.ts
@@ -24,7 +24,7 @@ describe("loadChatListChromeData", () => {
     getMyMembersWithOrganizationsMock.mockReset();
     listRoomsMock.mockResolvedValue({
       rooms: [{ id: "room-1" }],
-      nextCursor: "next",
+      nextCursor: null,
     });
     listArchivedRoomsMock.mockResolvedValue({
       rooms: [{ id: "archived-1" }],

--- a/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
+++ b/apps/web/src/app/(app)/components/private-cached-app-sidebar.tsx
@@ -82,10 +82,7 @@ async function PrivateCachedSidebarRooms({
 
   const { members } = chatListChrome;
   const chatRooms = chatListChrome.chatRoomsPage.rooms;
-  const chatRoomsNextCursor = chatListChrome.chatRoomsPage.nextCursor;
   const archivedChatRooms = chatListChrome.archivedChatRoomsPage.rooms;
-  const archivedChatRoomsNextCursor =
-    chatListChrome.archivedChatRoomsPage.nextCursor;
 
   const canDeleteArchivedRooms = Boolean(
     activeOrganizationId &&
@@ -100,9 +97,7 @@ async function PrivateCachedSidebarRooms({
     <OrganizationChatList
       key={activeOrganizationId ?? "personal"}
       rooms={chatRooms}
-      roomsNextCursor={chatRoomsNextCursor}
       archivedRooms={archivedChatRooms}
-      archivedRoomsNextCursor={archivedChatRoomsNextCursor}
       currentUserId={userId}
       organizationId={activeOrganizationId}
       canDeleteArchivedRooms={canDeleteArchivedRooms}

--- a/apps/web/src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
+++ b/apps/web/src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx
@@ -83,8 +83,6 @@ vi.mock("../organization-chat-list.actions", () => ({
     ok: true,
     value: { rooms: [], nextCursor: null },
   })),
-  loadMoreOrganizationArchivedChatRoomsAction: vi.fn(),
-  loadMoreOrganizationChatRoomsAction: vi.fn(),
 }));
 
 vi.mock("@/components/ui/sheet", () => ({
@@ -158,9 +156,7 @@ function renderChatsTabList() {
   return (
     <OrganizationChatList
       rooms={emptyRooms}
-      roomsNextCursor={null}
       archivedRooms={emptyRooms}
-      archivedRoomsNextCursor={null}
       currentUserId="user-1"
       organizationId="org-1"
       canDeleteArchivedRooms={false}

--- a/apps/web/src/components/chat/chat-room-sidebar-row.tsx
+++ b/apps/web/src/components/chat/chat-room-sidebar-row.tsx
@@ -147,8 +147,6 @@ export function ChatRoomSidebarRow({
 
     toast.success(tActions("leaveSuccess", { name: label }));
     setLeaveConfirmOpen(false);
-    // Explicit remove — bare refetch + upsertFirstPageRooms keeps left rooms
-    // as stale "older" rows and they stick in the sidebar.
     notifyOrganizationChatRoomsChanged({ removedRoomId: room.id });
     if (isActive) {
       // Land on chat home / list (`/chat` — mobile list; desktop redirects).

--- a/apps/web/src/components/chat/organization-chat-events.ts
+++ b/apps/web/src/components/chat/organization-chat-events.ts
@@ -7,9 +7,8 @@ export interface OrganizationChatRoomsChangedDetail {
   /** Upsert this membership room into the sidebar (join/create/edit). */
   room?: ChatRoom | null;
   /**
-   * Drop this room from the sidebar (leave). Required so a subsequent first-
-   * page refetch cannot re-surface it via upsertFirstPageRooms' "keep older
-   * rows" merge.
+   * Drop this room from the sidebar (leave) immediately, without waiting
+   * for the next membership-visible rooms refetch.
    */
   removedRoomId?: string;
 }
@@ -23,7 +22,7 @@ function isChatRoom(
 
 /**
  * Soft-update the sidebar room list without `router.refresh()` (which re-ran
- * full layout RSC including paginated `listRooms`).
+ * full layout RSC including `listRooms`).
  *
  * - Pass a `ChatRoom` to upsert (join/create).
  * - Pass `{ removedRoomId }` after leave so the row drops immediately.

--- a/apps/web/src/components/chat/organization-chat-list.actions.ts
+++ b/apps/web/src/components/chat/organization-chat-list.actions.ts
@@ -66,42 +66,6 @@ export async function listOrganizationArchivedChatRoomsAction(): Promise<
   }
 }
 
-export async function loadMoreOrganizationChatRoomsAction(
-  cursor: string,
-): Promise<OrganizationChatListActionResult<ChatRoomsPage>> {
-  const cleanCursor = cursor.trim();
-  if (!cleanCursor) {
-    return listFail("Cursor is required.");
-  }
-
-  try {
-    const page = await chatRoomService.listRooms(undefined, "active", {
-      cursor: cleanCursor,
-    });
-    return listOk(page);
-  } catch {
-    return listCatch("Could not load more chat rooms.");
-  }
-}
-
-export async function loadMoreOrganizationArchivedChatRoomsAction(
-  cursor: string,
-): Promise<OrganizationChatListActionResult<ChatRoomsPage>> {
-  const cleanCursor = cursor.trim();
-  if (!cleanCursor) {
-    return listFail("Cursor is required.");
-  }
-
-  try {
-    const page = await chatRoomService.listArchivedRooms({
-      cursor: cleanCursor,
-    });
-    return listOk(page);
-  } catch {
-    return listCatch("Could not load more archived chat rooms.");
-  }
-}
-
 export async function markOrganizationChatRoomReadAction(
   roomId: string,
 ): Promise<OrganizationChatListActionResult<ChatRoom>> {

--- a/apps/web/src/components/chat/organization-chat-list.client.tsx
+++ b/apps/web/src/components/chat/organization-chat-list.client.tsx
@@ -15,7 +15,6 @@ import {
   type ReactNode,
   useEffect,
   useMemo,
-  useRef,
   useState,
   useTransition,
 } from "react";
@@ -78,8 +77,6 @@ import {
 import {
   listOrganizationArchivedChatRoomsAction,
   listOrganizationChatRoomsAction,
-  loadMoreOrganizationArchivedChatRoomsAction,
-  loadMoreOrganizationChatRoomsAction,
 } from "./organization-chat-list.actions";
 import { partitionRoomsForSidebar } from "./partition-rooms-for-sidebar";
 import {
@@ -93,34 +90,13 @@ const ORGANIZATION_CHAT_POLL_MS = 15_000;
  *  infinite-loops the render-time pendingInvitations sync (React #301). */
 const EMPTY_PENDING_INVITATIONS: ChatRoomInvitation[] = [];
 
-/** Upsert first-page rooms; keep older rows previously appended via load-more. */
-function upsertFirstPageRooms(
-  firstPage: ChatRoom[],
-  existing: ChatRoom[],
-): ChatRoom[] {
-  const firstPageIds = new Set(firstPage.map((room) => room.id));
-  const older = existing.filter((room) => !firstPageIds.has(room.id));
-  return [...firstPage, ...older];
-}
-
-function appendUniqueRooms(
-  existing: ChatRoom[],
-  incoming: ChatRoom[],
-): ChatRoom[] {
-  const existingIds = new Set(existing.map((room) => room.id));
-  const unique = incoming.filter((room) => !existingIds.has(room.id));
-  return [...existing, ...unique];
-}
-
 /** Same absolute slot as live room rows so archived height matches Channels/DMs. */
 const ARCHIVED_TRAILING_CONTROL_CLASS =
   "absolute top-1/2 right-1 z-10 flex size-8 -translate-y-1/2 items-center justify-center md:size-7";
 
 interface OrganizationChatListProps {
   rooms: ChatRoom[];
-  roomsNextCursor: string | null;
   archivedRooms: ChatRoom[];
-  archivedRoomsNextCursor: string | null;
   pendingInvitations?: ChatRoomInvitation[];
   currentUserId: string;
   organizationId: string | null;
@@ -232,9 +208,7 @@ function ChatMembershipRevokedListBridge({
 
 export function OrganizationChatList({
   rooms,
-  roomsNextCursor,
   archivedRooms,
-  archivedRoomsNextCursor,
   pendingInvitations = EMPTY_PENDING_INVITATIONS,
   currentUserId,
   organizationId,
@@ -250,16 +224,8 @@ export function OrganizationChatList({
   const [roomRows, setRoomRows] = useState(() => applyRoomReadOverlays(rooms));
   const [archivedRows, setArchivedRows] = useState(archivedRooms);
   const [pendingRows, setPendingRows] = useState(pendingInvitations);
-  const [activeNextCursor, setActiveNextCursor] = useState(roomsNextCursor);
-  const [archivedNextCursor, setArchivedNextCursor] = useState(
-    archivedRoomsNextCursor,
-  );
   const [prevRooms, setPrevRooms] = useState(rooms);
-  const [prevRoomsNextCursor, setPrevRoomsNextCursor] =
-    useState(roomsNextCursor);
   const [prevArchivedRooms, setPrevArchivedRooms] = useState(archivedRooms);
-  const [prevArchivedRoomsNextCursor, setPrevArchivedRoomsNextCursor] =
-    useState(archivedRoomsNextCursor);
   const [prevPendingInvitations, setPrevPendingInvitations] =
     useState(pendingInvitations);
   const [channelSectionOpen, setChannelSectionOpen] = useState(true);
@@ -278,11 +244,6 @@ export function OrganizationChatList({
   const [_isRestoring, startRestoreTransition] = useTransition();
   const [_isDeleting, startDeleteTransition] = useTransition();
   const [_isRespondingInvite, startInviteResponseTransition] = useTransition();
-  const [isLoadingMoreActive, startLoadMoreActiveTransition] = useTransition();
-  const [isLoadingMoreArchived, startLoadMoreArchivedTransition] =
-    useTransition();
-  const hasAppendedActiveRef = useRef(false);
-  const hasAppendedArchivedRef = useRef(false);
   const activeRoomId = getActiveRoomIdFromPathname(pathname);
   const unreadRoomCount = countChatRoomsWithUnreadAttention(roomRows, {
     activeRoomId,
@@ -296,25 +257,14 @@ export function OrganizationChatList({
       </LazyAblyProvider>
     ) : null;
 
-  // Adjust local list when RSC props change (no Effect — keep load-more history).
-  if (rooms !== prevRooms || roomsNextCursor !== prevRoomsNextCursor) {
+  // Replace local list when RSC props change (full membership-visible set).
+  if (rooms !== prevRooms) {
     setPrevRooms(rooms);
-    setPrevRoomsNextCursor(roomsNextCursor);
-    setRoomRows(applyRoomReadOverlays(upsertFirstPageRooms(rooms, roomRows)));
-    if (!hasAppendedActiveRef.current) {
-      setActiveNextCursor(roomsNextCursor);
-    }
+    setRoomRows(applyRoomReadOverlays(rooms));
   }
-  if (
-    archivedRooms !== prevArchivedRooms ||
-    archivedRoomsNextCursor !== prevArchivedRoomsNextCursor
-  ) {
+  if (archivedRooms !== prevArchivedRooms) {
     setPrevArchivedRooms(archivedRooms);
-    setPrevArchivedRoomsNextCursor(archivedRoomsNextCursor);
-    setArchivedRows(upsertFirstPageRooms(archivedRooms, archivedRows));
-    if (!hasAppendedArchivedRef.current) {
-      setArchivedNextCursor(archivedRoomsNextCursor);
-    }
+    setArchivedRows(archivedRooms);
   }
   if (pendingInvitations !== prevPendingInvitations) {
     setPrevPendingInvitations(pendingInvitations);
@@ -342,28 +292,10 @@ export function OrganizationChatList({
         return;
       }
       if (activeResult.ok) {
-        setRoomRows((current) =>
-          applyRoomReadOverlays(
-            hasAppendedActiveRef.current
-              ? upsertFirstPageRooms(activeResult.value.rooms, current)
-              : activeResult.value.rooms,
-          ),
-        );
-        setActiveNextCursor((prev) =>
-          hasAppendedActiveRef.current ? prev : activeResult.value.nextCursor,
-        );
+        setRoomRows(applyRoomReadOverlays(activeResult.value.rooms));
       }
       if (archivedResult.ok) {
-        setArchivedRows((current) =>
-          hasAppendedArchivedRef.current
-            ? upsertFirstPageRooms(archivedResult.value.rooms, current)
-            : archivedResult.value.rooms,
-        );
-        setArchivedNextCursor((prev) =>
-          hasAppendedArchivedRef.current
-            ? prev
-            : archivedResult.value.nextCursor,
-        );
+        setArchivedRows(archivedResult.value.rooms);
       }
       if (pendingResult.ok) {
         setPendingRows(pendingResult.value);
@@ -472,30 +404,10 @@ export function OrganizationChatList({
           return;
         }
         if (activeResult.ok) {
-          // No load-more history: replace. After load-more: keep older pages
-          // but still refresh first-page memberships.
-          setRoomRows((current) =>
-            applyRoomReadOverlays(
-              hasAppendedActiveRef.current
-                ? upsertFirstPageRooms(activeResult.value.rooms, current)
-                : activeResult.value.rooms,
-            ),
-          );
-          setActiveNextCursor((prev) =>
-            hasAppendedActiveRef.current ? prev : activeResult.value.nextCursor,
-          );
+          setRoomRows(applyRoomReadOverlays(activeResult.value.rooms));
         }
         if (archivedResult.ok) {
-          setArchivedRows((current) =>
-            hasAppendedArchivedRef.current
-              ? upsertFirstPageRooms(archivedResult.value.rooms, current)
-              : archivedResult.value.rooms,
-          );
-          setArchivedNextCursor((prev) =>
-            hasAppendedArchivedRef.current
-              ? prev
-              : archivedResult.value.nextCursor,
-          );
+          setArchivedRows(archivedResult.value.rooms);
         }
         if (pendingResult.ok) {
           setPendingRows(pendingResult.value);
@@ -568,44 +480,6 @@ export function OrganizationChatList({
     );
   }
 
-  function handleLoadMoreActiveRooms() {
-    if (!activeNextCursor || isLoadingMoreActive) {
-      return;
-    }
-    const cursor = activeNextCursor;
-    startLoadMoreActiveTransition(async () => {
-      const result = await loadMoreOrganizationChatRoomsAction(cursor);
-      if (!result.ok) {
-        toast.error(t("loadMoreError"));
-        return;
-      }
-      hasAppendedActiveRef.current = true;
-      setRoomRows((current) =>
-        applyRoomReadOverlays(appendUniqueRooms(current, result.value.rooms)),
-      );
-      setActiveNextCursor(result.value.nextCursor);
-    });
-  }
-
-  function handleLoadMoreArchivedRooms() {
-    if (!archivedNextCursor || isLoadingMoreArchived) {
-      return;
-    }
-    const cursor = archivedNextCursor;
-    startLoadMoreArchivedTransition(async () => {
-      const result = await loadMoreOrganizationArchivedChatRoomsAction(cursor);
-      if (!result.ok) {
-        toast.error(t("loadMoreError"));
-        return;
-      }
-      hasAppendedArchivedRef.current = true;
-      setArchivedRows((current) =>
-        appendUniqueRooms(current, result.value.rooms),
-      );
-      setArchivedNextCursor(result.value.nextCursor);
-    });
-  }
-
   function handleAcceptInvitation(invitation: ChatRoomInvitation) {
     if (respondingInvitation) {
       return;
@@ -625,11 +499,7 @@ export function OrganizationChatList({
       // Guest room appears on next list refresh; pull rooms immediately.
       const roomsResult = await listOrganizationChatRoomsAction();
       if (roomsResult.ok) {
-        setRoomRows((current) =>
-          applyRoomReadOverlays(
-            upsertFirstPageRooms(roomsResult.value.rooms, current),
-          ),
-        );
+        setRoomRows(applyRoomReadOverlays(roomsResult.value.rooms));
       }
       router.push(`/chat/rooms/${invitation.roomId}`);
       router.refresh();
@@ -919,22 +789,6 @@ export function OrganizationChatList({
                     </SidebarMenuItem>
                   );
                 })}
-                {archivedNextCursor ? (
-                  <SidebarMenuItem>
-                    <div className="group-data-[collapsible=icon]:hidden px-3 py-1">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="text-muted-foreground hover:text-foreground w-full text-xs"
-                        disabled={isLoadingMoreArchived}
-                        onClick={handleLoadMoreArchivedRooms}
-                      >
-                        {isLoadingMoreArchived ? t("loading") : t("loadMore")}
-                      </Button>
-                    </div>
-                  </SidebarMenuItem>
-                ) : null}
               </SidebarMenu>
             </CollapsibleContent>
           </Collapsible>
@@ -1028,21 +882,6 @@ export function OrganizationChatList({
             </SidebarMenu>
           </CollapsibleContent>
         </Collapsible>
-
-        {activeNextCursor ? (
-          <div className="group-data-[collapsible=icon]:hidden px-3 py-1">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="text-muted-foreground hover:text-foreground w-full text-xs"
-              disabled={isLoadingMoreActive}
-              onClick={handleLoadMoreActiveRooms}
-            >
-              {isLoadingMoreActive ? t("loading") : t("loadMore")}
-            </Button>
-          </div>
-        ) : null}
       </SidebarGroupContent>
     </SidebarGroup>
   );

--- a/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
@@ -122,6 +122,26 @@ describe("chatRoomService.listRooms", () => {
     });
   });
 
+  it("stops when nextCursor does not advance", async () => {
+    getChatRoomsMock.mockResolvedValue(emptyPage([room("room-1")], "room-1"));
+
+    const { chatRoomService } = await import("../chat-room.service");
+    const page = await chatRoomService.listRooms();
+
+    expect(page.rooms.map((item) => item.id)).toEqual(["room-1"]);
+    expect(page.nextCursor).toBeNull();
+    expect(getChatRoomsMock).toHaveBeenCalledTimes(2);
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(1, {
+      limit: 100,
+      status: "active",
+    });
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(2, {
+      limit: 100,
+      status: "active",
+      cursor: "room-1",
+    });
+  });
+
   it("passes archived status when listing archived rooms", async () => {
     getChatRoomsMock.mockResolvedValue(emptyPage([room("archived-1")]));
 

--- a/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
+++ b/apps/web/src/lib/services/__tests__/chat-room.service.test.ts
@@ -59,7 +59,7 @@ function emptyPage(
     meta: {
       pagination: {
         cursor: null,
-        limit: 20,
+        limit: 100,
         total: data.length,
         nextCursor,
       },
@@ -73,49 +73,52 @@ describe("chatRoomService.listRooms", () => {
     vi.resetModules();
   });
 
-  it("returns a single page and does not walk nextCursor", async () => {
-    getChatRoomsMock.mockResolvedValueOnce(
-      emptyPage([room("room-1"), room("room-2")], "room-2"),
-    );
+  it("walks nextCursor until exhausted and returns the full set", async () => {
+    getChatRoomsMock
+      .mockResolvedValueOnce(
+        emptyPage([room("room-1"), room("room-2")], "room-2"),
+      )
+      .mockResolvedValueOnce(emptyPage([room("room-3")]));
 
     const { chatRoomService } = await import("../chat-room.service");
     const page = await chatRoomService.listRooms();
 
-    expect(page.rooms.map((item) => item.id)).toEqual(["room-1", "room-2"]);
-    expect(page.nextCursor).toBe("room-2");
-    expect(getChatRoomsMock).toHaveBeenCalledTimes(1);
-    expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 20,
+    expect(page.rooms.map((item) => item.id)).toEqual([
+      "room-1",
+      "room-2",
+      "room-3",
+    ]);
+    expect(page.nextCursor).toBeNull();
+    expect(getChatRoomsMock).toHaveBeenCalledTimes(2);
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(1, {
+      limit: 100,
       status: "active",
     });
-  });
-
-  it("passes cursor for load-more", async () => {
-    getChatRoomsMock.mockResolvedValueOnce(emptyPage([room("room-3")]));
-
-    const { chatRoomService } = await import("../chat-room.service");
-    const page = await chatRoomService.listRooms(undefined, "active", {
-      cursor: "room-2",
-    });
-
-    expect(page.rooms.map((item) => item.id)).toEqual(["room-3"]);
-    expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 20,
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(2, {
+      limit: 100,
       status: "active",
       cursor: "room-2",
     });
   });
 
-  it("passes kind filter", async () => {
-    getChatRoomsMock.mockResolvedValue(emptyPage([room("dm-1")]));
+  it("passes kind filter on every page", async () => {
+    getChatRoomsMock
+      .mockResolvedValueOnce(emptyPage([room("dm-1")], "dm-1"))
+      .mockResolvedValueOnce(emptyPage([room("dm-2")]));
 
     const { chatRoomService } = await import("../chat-room.service");
     await chatRoomService.listRooms("direct");
 
-    expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 20,
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(1, {
+      limit: 100,
       status: "active",
       kind: "direct",
+    });
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(2, {
+      limit: 100,
+      status: "active",
+      kind: "direct",
+      cursor: "dm-1",
     });
   });
 
@@ -126,8 +129,9 @@ describe("chatRoomService.listRooms", () => {
     const page = await chatRoomService.listRooms("channel", "archived");
 
     expect(page.rooms.map((item) => item.id)).toEqual(["archived-1"]);
+    expect(page.nextCursor).toBeNull();
     expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 20,
+      limit: 100,
       status: "archived",
       kind: "channel",
     });
@@ -266,21 +270,30 @@ describe("chatRoomService.listArchivedRooms", () => {
     vi.resetModules();
   });
 
-  it("requests archived organization channels as a single page", async () => {
-    getChatRoomsMock.mockResolvedValue(
-      emptyPage([room("archived-1")], "archived-1"),
-    );
+  it("walks archived organization channels until exhausted", async () => {
+    getChatRoomsMock
+      .mockResolvedValueOnce(emptyPage([room("archived-1")], "archived-1"))
+      .mockResolvedValueOnce(emptyPage([room("archived-2")]));
 
     const { chatRoomService } = await import("../chat-room.service");
     const page = await chatRoomService.listArchivedRooms();
 
-    expect(page.rooms.map((item) => item.id)).toEqual(["archived-1"]);
-    expect(page.nextCursor).toBe("archived-1");
-    expect(getChatRoomsMock).toHaveBeenCalledTimes(1);
-    expect(getChatRoomsMock).toHaveBeenCalledWith({
-      limit: 20,
+    expect(page.rooms.map((item) => item.id)).toEqual([
+      "archived-1",
+      "archived-2",
+    ]);
+    expect(page.nextCursor).toBeNull();
+    expect(getChatRoomsMock).toHaveBeenCalledTimes(2);
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(1, {
+      limit: 100,
       status: "archived",
       kind: "channel",
+    });
+    expect(getChatRoomsMock).toHaveBeenNthCalledWith(2, {
+      limit: 100,
+      status: "archived",
+      kind: "channel",
+      cursor: "archived-1",
     });
   });
 });

--- a/apps/web/src/lib/services/chat-room.service.ts
+++ b/apps/web/src/lib/services/chat-room.service.ts
@@ -22,11 +22,11 @@ import type {
 
 const ROOM_MESSAGE_LIMIT = 100;
 const THREAD_LIST_PAGE_LIMIT = 50;
-/** Cold fill / poll / load-more page size — Core default and tasks parity. */
-const ROOM_LIST_PAGE_LIMIT = 20;
+/** Membership-visible / archived list page size — Core max, fewer walks. */
+const ROOM_LIST_PAGE_LIMIT = 100;
 /** Discoverable browse may still walk multiple pages up to Core max page size. */
 const DISCOVERABLE_CHANNEL_PAGE_LIMIT = 100;
-/** Hard stop so a bad nextCursor cannot loop forever on discoverable walks. */
+/** Hard stop so a bad nextCursor cannot loop forever on list walks. */
 const ROOM_LIST_MAX_PAGES = 50;
 
 export interface ChatRoomMessagesPage {
@@ -45,22 +45,30 @@ export interface ChatRoomThreadsPage {
 }
 
 export const chatRoomService = (() => {
+  /** Walk Core pages so the sidebar shows the full membership-visible set. */
   const listRooms = cache(async function listRooms(
     kind?: ChatRoomKind,
     status: "active" | "archived" = "active",
-    options?: { cursor?: string },
   ): Promise<ChatRoomsPage> {
-    const cursor = options?.cursor;
-    const response = await coreClient.getChatRooms({
-      limit: ROOM_LIST_PAGE_LIMIT,
-      status,
-      ...(kind ? { kind } : {}),
-      ...(cursor ? { cursor } : {}),
-    });
-    return {
-      rooms: response.data,
-      nextCursor: response.meta?.pagination?.nextCursor ?? null,
-    };
+    const rooms: ChatRoom[] = [];
+    let cursor: string | undefined;
+
+    for (let page = 0; page < ROOM_LIST_MAX_PAGES; page += 1) {
+      const response = await coreClient.getChatRooms({
+        limit: ROOM_LIST_PAGE_LIMIT,
+        status,
+        ...(kind ? { kind } : {}),
+        ...(cursor ? { cursor } : {}),
+      });
+      rooms.push(...response.data);
+      const nextCursor = response.meta?.pagination?.nextCursor ?? null;
+      if (!nextCursor) {
+        return { rooms, nextCursor: null };
+      }
+      cursor = nextCursor;
+    }
+
+    return { rooms, nextCursor: null };
   });
 
   async function listDiscoverableChannels(options?: {
@@ -93,11 +101,11 @@ export const chatRoomService = (() => {
     return rooms;
   }
 
-  const listArchivedRooms = cache(async function listArchivedRooms(options?: {
-    cursor?: string;
-  }): Promise<ChatRoomsPage> {
-    return listRooms("channel", "archived", options);
-  });
+  const listArchivedRooms = cache(
+    async function listArchivedRooms(): Promise<ChatRoomsPage> {
+      return listRooms("channel", "archived");
+    },
+  );
 
   /** Pending room invitations for the signed-in invitee (External sidebar). */
   const listPendingInvitations = cache(

--- a/apps/web/src/lib/services/chat-room.service.ts
+++ b/apps/web/src/lib/services/chat-room.service.ts
@@ -60,8 +60,11 @@ export const chatRoomService = (() => {
         ...(kind ? { kind } : {}),
         ...(cursor ? { cursor } : {}),
       });
-      rooms.push(...response.data);
       const nextCursor = response.meta?.pagination?.nextCursor ?? null;
+      if (cursor !== undefined && nextCursor === cursor) {
+        return { rooms, nextCursor: null };
+      }
+      rooms.push(...response.data);
       if (!nextCursor) {
         return { rooms, nextCursor: null };
       }

--- a/docs/adr/0012-membership-visible-rooms-listed-in-full.md
+++ b/docs/adr/0012-membership-visible-rooms-listed-in-full.md
@@ -1,0 +1,10 @@
+# ADR 0012: Membership-visible rooms are listed in full
+
+- Status: Accepted
+- Date: 2026-08-21
+
+The chat room list (sidebar and `/chat`) always shows the complete **membership-visible rooms** set for the current workspace, including archived channels the caller may restore. Web walks Core pages until exhausted. The UI has no Load more.
+
+SOK-722 paged rooms and jobs so first paint stayed cheap. Rooms are a roster, not a history; one cursor across channels, external, and Directs hid Directs first. Jobs stay paged.
+
+Rejected: raise Core page size only; silent cap at 100; keep Load more after a high cap.


### PR DESCRIPTION
## Summary

The chat sidebar and `/chat` list always show the complete membership-visible rooms set for the current workspace (channels, external, Directs). Archived channels the caller may restore are listed the same way. Load more is gone.

[SOK-722](https://linear.app/masumi/issue/SOK-722/sidebar-and-jobs-list-stop-fetching-entire-histories-on-first-paint) paged rooms and jobs so first paint stayed cheap. One cursor covered every kind, so Directs hid behind the button once channels filled the first page. Rooms are a roster, not a history. Jobs stay paged.

Web walks Core pages (100 per page) until exhausted. See ADR [0012](docs/adr/0012-membership-visible-rooms-listed-in-full.md).

## Verification

- `pnpm --filter web test src/lib/services/__tests__/chat-room.service.test.ts`
- `pnpm --filter web test src/components/chat/__tests__/organization-chat-list-pending-default.test.tsx`
- `pnpm --filter web test src/app/\(app\)/chat/__tests__/chats-page-progressive-rooms.test.tsx`
- `pnpm test` (workspace, green)
- Husky `pnpm check && pnpm typecheck` on commit