### PR TITLE
fix(chat): drop mention firstChunkMs timeout

### DIFF
--- a/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.test.ts
@@ -99,7 +99,6 @@ import {
   dispatchChatRoomMention,
   listStaleSentChatRoomMentionIds,
   ROOM_COWORKER_CHUNK_MS,
-  ROOM_COWORKER_FIRST_CHUNK_MS,
   ROOM_COWORKER_STREAM_TIMEOUT,
   ROOM_COWORKER_TOTAL_MS,
   ROOM_SENT_STALE_MS,
@@ -175,14 +174,14 @@ beforeEach(() => {
 });
 
 describe("room coworker stream timeout budgets", () => {
-  it("uses idle chunk timeouts under a hard total, with stale above total", () => {
+  it("omits firstChunkMs so silent think is bounded only by totalMs", () => {
     expect(ROOM_COWORKER_STREAM_TIMEOUT).toEqual({
       totalMs: ROOM_COWORKER_TOTAL_MS,
-      firstChunkMs: ROOM_COWORKER_FIRST_CHUNK_MS,
       chunkMs: ROOM_COWORKER_CHUNK_MS,
     });
+    expect(ROOM_COWORKER_STREAM_TIMEOUT).not.toHaveProperty("firstChunkMs");
     expect(ROOM_COWORKER_CHUNK_MS).toBe(90_000);
-    expect(ROOM_COWORKER_FIRST_CHUNK_MS).toBe(90_000);
+    expect(ROOM_COWORKER_TOTAL_MS).toBe(240_000);
     expect(ROOM_COWORKER_TOTAL_MS).toBeGreaterThan(ROOM_COWORKER_CHUNK_MS);
     expect(ROOM_SENT_STALE_MS).toBeGreaterThan(ROOM_COWORKER_TOTAL_MS);
   });

--- a/apps/core/src/services/chat-room-coworker-dispatch.service.ts
+++ b/apps/core/src/services/chat-room-coworker-dispatch.service.ts
@@ -12,13 +12,17 @@ import { createCoworkerConversation } from "@/routes/v1/chats/stream/coworker-co
 
 /** Hard ceiling for streamText only (not conversation create ≤25s). */
 export const ROOM_COWORKER_TOTAL_MS = 240_000;
-/** AI SDK stall budgets; content chunks reset these. */
-export const ROOM_COWORKER_FIRST_CHUNK_MS = 90_000;
+/** AI SDK stall budget after content has started; content chunks reset this. */
 export const ROOM_COWORKER_CHUNK_MS = 90_000;
 
+/**
+ * No `firstChunkMs`: some coworkers think/tool for >90s with no content-bearing
+ * SSE. Mentions are waitUntil jobs and must still terminate — `totalMs` is that
+ * bound. `chunkMs` still kills a stall after output starts. Coworker 1:1 DMs
+ * omit this timeout entirely (live SSE + function cap).
+ */
 export const ROOM_COWORKER_STREAM_TIMEOUT = {
   totalMs: ROOM_COWORKER_TOTAL_MS,
-  firstChunkMs: ROOM_COWORKER_FIRST_CHUNK_MS,
   chunkMs: ROOM_COWORKER_CHUNK_MS,
 } as const;
 

--- a/packages/ai-provider/src/stream/commit-gate-stream.ts
+++ b/packages/ai-provider/src/stream/commit-gate-stream.ts
@@ -47,8 +47,8 @@ function isHeldSetupLifecyclePart(part: LanguageModelV4StreamPart): boolean {
 /**
  * Progress parts that leave the gate before answer text commits.
  *
- * Room coworker `streamText` uses AI SDK `firstChunkMs` / `chunkMs`. Those
- * timers only reset on output chunks (non-empty reasoning-delta, tool-call,
+ * Room coworker mention `streamText` uses AI SDK `chunkMs` (and `totalMs`).
+ * `chunkMs` only resets on output chunks (non-empty reasoning-delta, tool-call,
  * tool-input-delta, text-delta). Coworkers may run tools for minutes while
  * only emitting reasoning heartbeats — if the gate buffers those, Sokosumi
  * aborts as stalled even though the upstream stream is alive.


### PR DESCRIPTION
## Summary

Channel `@coworker` mentions aborted after 90s of silent think (`firstChunkMs`). Coworker 1:1 DMs have no that idle timer, so the same Hannah turn could succeed in a DM and fail in a channel.

This PR drops `firstChunkMs` on mention `streamText`. Mentions still terminate via `totalMs` (240s) so the status poll cannot hang. `chunkMs` (90s) still kills a stall after the first content-bearing chunk.

## Follow-up

Live Thought on channel mentions (Ably fan-out from dispatch, not a mentioner-only SSE): [SOK-853](https://linear.app/masumi/issue/SOK-853/live-thought-on-channel-coworker-mentions).

## Test plan

- [x] `pnpm --filter core test src/services/chat-room-coworker-dispatch.service.test.ts`
- [x] `pnpm check && pnpm typecheck` (pre-commit)
- [ ] After deploy: `@Hannah` in a channel that previously failed around 90s of thinking; mention should stay `sent` through the old 90s window and either reply or fail at `totalMs` / empty output, not `First chunk timeout of 90000ms exceeded`