### PR TITLE
fix(chat): stop composer selection jump

### DIFF
--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -10,7 +10,6 @@ import {
   ROOM_COMPOSER_EDITOR_PLACEHOLDER_CLASSNAME,
   ROOM_COMPOSER_MENTION_ANCHOR_ATTR,
 } from "@/components/chat/room-message-composer";
-import { MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX } from "@/components/ui/mention-textarea-utils";
 
 const getPopupPositionFromRect = vi.hoisted(() =>
   vi.fn(() => ({
@@ -86,11 +85,9 @@ describe("ComposerWysiwygEditor", () => {
     }
 
     render(<Harness />);
-    // Chromium uses this margin inside overflow:auto during mouse selection.
-    // 252px on a max-h-40 editor jumps scrollTop to the start and explodes the range.
-    expect(screen.getByRole("textbox")).not.toHaveStyle({
-      scrollMarginTop: `${MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX}px`,
-    });
+    // Any inline scroll-margin on the overflow:auto host makes Chromium
+    // yank scrollTop during mouse selection. Do not put picker clearance here.
+    expect(screen.getByRole("textbox").style.scrollMarginTop).toBe("");
   });
 
   it("uses data-placeholder for classic empty:before (single-line) placeholder", () => {

--- a/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
+++ b/apps/web/src/components/chat/__tests__/composer-wysiwyg-editor.test.tsx
@@ -10,6 +10,7 @@ import {
   ROOM_COMPOSER_EDITOR_PLACEHOLDER_CLASSNAME,
   ROOM_COMPOSER_MENTION_ANCHOR_ATTR,
 } from "@/components/chat/room-message-composer";
+import { MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX } from "@/components/ui/mention-textarea-utils";
 
 const getPopupPositionFromRect = vi.hoisted(() =>
   vi.fn(() => ({
@@ -70,7 +71,26 @@ describe("ComposerWysiwygEditor", () => {
     render(<Harness />);
     const editor = screen.getByRole("textbox");
     expect(editor).toHaveClass("markdown-compose-surface");
-    expect(editor).toHaveStyle({ scrollMarginTop: "252px" });
+  });
+
+  it("does not put mention-picker scroll-margin on the overflowing editor host", () => {
+    function Harness() {
+      const [value, setValue] = useState("");
+      return (
+        <ComposerWysiwygEditor
+          value={value}
+          onChange={setValue}
+          mentions={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+    // Chromium uses this margin inside overflow:auto during mouse selection.
+    // 252px on a max-h-40 editor jumps scrollTop to the start and explodes the range.
+    expect(screen.getByRole("textbox")).not.toHaveStyle({
+      scrollMarginTop: `${MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX}px`,
+    });
   });
 
   it("uses data-placeholder for classic empty:before (single-line) placeholder", () => {

--- a/apps/web/src/components/chat/__tests__/room-message-composer-send.test.tsx
+++ b/apps/web/src/components/chat/__tests__/room-message-composer-send.test.tsx
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX } from "@/components/ui/mention-textarea-utils";
 
-import { RoomMessageComposer } from "../room-message-composer";
+import {
+  ROOM_COMPOSER_MENTION_ANCHOR_ATTR,
+  RoomMessageComposer,
+} from "../room-message-composer";
 
 vi.mock("@/components/chat/emoji-picker", () => ({
   EmojiPicker: () => null,
@@ -199,7 +202,9 @@ describe("RoomMessageComposer send pointer path", () => {
       </RoomMessageComposer>,
     );
 
-    const shell = document.querySelector("[data-room-composer-mention-anchor]");
+    const shell = document.querySelector(
+      `[${ROOM_COMPOSER_MENTION_ANCHOR_ATTR}]`,
+    );
     expect(shell).toHaveStyle({
       scrollMarginTop: `${MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX}px`,
     });

--- a/apps/web/src/components/chat/__tests__/room-message-composer-send.test.tsx
+++ b/apps/web/src/components/chat/__tests__/room-message-composer-send.test.tsx
@@ -3,6 +3,8 @@ import type { FormEvent } from "react";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX } from "@/components/ui/mention-textarea-utils";
+
 import { RoomMessageComposer } from "../room-message-composer";
 
 vi.mock("@/components/chat/emoji-picker", () => ({
@@ -180,5 +182,26 @@ describe("RoomMessageComposer send pointer path", () => {
       detail: 1,
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("puts mention-picker scroll-margin on the mention-anchor shell", () => {
+    render(
+      <RoomMessageComposer
+        onSubmit={(event) => event.preventDefault()}
+        attachments={[]}
+        onRemoveAttachment={() => undefined}
+        removeAttachmentLabel={(name) => name}
+        isSending={false}
+        sendDisabled={false}
+        sendAriaLabel="Send"
+      >
+        <div role="textbox" contentEditable tabIndex={0} />
+      </RoomMessageComposer>,
+    );
+
+    const shell = document.querySelector("[data-room-composer-mention-anchor]");
+    expect(shell).toHaveStyle({
+      scrollMarginTop: `${MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX}px`,
+    });
   });
 });

--- a/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
+++ b/apps/web/src/components/chat/composer-wysiwyg-editor.tsx
@@ -32,7 +32,6 @@ import {
   getPopupPositionFromRect,
   getSuggestionPopupFixedStyle,
   isWhitespaceChar,
-  MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX,
   MENTION_CLASSNAME,
   type MentionRecordEntry,
   type MentionSuggestionGroup,
@@ -1251,7 +1250,6 @@ export function ComposerWysiwygEditor<TData = unknown>({
         data-placeholder={placeholder}
         role="textbox"
         aria-multiline="true"
-        style={{ scrollMarginTop: MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX }}
         className={cn(
           "outline-none focus:outline-none",
           "wrap-anywhere [word-break:break-word] whitespace-pre-wrap",

--- a/apps/web/src/components/chat/room-message-composer.tsx
+++ b/apps/web/src/components/chat/room-message-composer.tsx
@@ -14,6 +14,7 @@ import { chatMobileComposerSafeAreaPbClass } from "@/app/chat/components/chat-mo
 import { EmojiPicker } from "@/components/chat/emoji-picker";
 import { FileChipMiniPreviewWithMetadata } from "@/components/jobs/job-details/file-chip-with-metadata";
 import { Button } from "@/components/ui/button";
+import { MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX } from "@/components/ui/mention-textarea-utils";
 import { useKeyboardOpen } from "@/hooks/use-keyboard-open";
 import { cn } from "@/lib/utils";
 import { withEditableTextSize } from "@/lib/utils/editable-text-size";
@@ -161,9 +162,12 @@ export function RoomMessageComposer({
       onSubmit={onSubmit}
     >
       <div className="w-full">
+        {/* scroll-margin on the shell, not the overflow:auto editor. Chromium
+            uses editor scroll-margin during mouse selection and jumps long drafts. */}
         <div
           className="border-border overflow-hidden rounded-xl border bg-background"
           data-room-composer-mention-anchor
+          style={{ scrollMarginTop: MENTION_ANCHOR_SCROLL_MARGIN_TOP_PX }}
         >
           {attachments.length > 0 ? (
             <div className="flex flex-wrap gap-2 px-4 pt-4">


### PR DESCRIPTION
## Summary

Selecting text in a long chat composer from the bottom up no longer jumps to the top of the draft and swallows almost everything.

The mention-picker clearance (`scroll-margin-top: 252px`) lived on the overflowing contenteditable. Chromium applies that margin during mouse selection, so a 160px-tall editor yanks `scrollTop` to the start and the pointer maps onto earlier lines. The margin now sits on the composer shell (`data-room-composer-mention-anchor`) instead, so the picker still gets room above the composer.

## Verification

- `pnpm test` (turbo, 17/17 tasks)
- Husky `pnpm check && pnpm typecheck` on commit
- Chromium mouse-drag harness against the real `ComposerWysiwygEditor`: 40px upward drag on a 20-line scrolled draft stayed local (20 chars) instead of swallowing most of the text

Did not drive a signed-in `/chat` session in this worktree (no local `.env`).