### PR TITLE
docs(agents): point AGENTS.md at caveman skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,10 @@ docs(readme): update setup instructions
 
 ## Agent skills
 
+### Caveman
+
+When the caveman skill is present, follow it for all replies. Off: "stop caveman" / "normal mode". See [`.agents/skills/caveman/`](.agents/skills/caveman/).
+
 ### Linear issue implementation
 
 Ship one Linear issue with `## Requirement` under **/poteto-mode** via [`.cursor/skills/sokosumi-linear-issue/`](.cursor/skills/sokosumi-linear-issue/). That skill owns Spec, allowlisted verify, TDD globs, draft PR, CI gate, pinned-`headSha` re-verify, Review `/goal`, and opt-in swarm-verify (user ask, `swarm-verify: true`, or label `swarm-verify`). Human merges. Bugs/refactors without a Linear Requirement use other poteto playbooks.
@@ -399,19 +403,3 @@ When Neon secrets are absent, provision skips and local Postgres remains the fal
 - **Agents catalog:** on a Neon agent branch forked from production, catalog/billing data comes from the parent. On empty local Postgres, `GET /v1/agents` / `/v1/categories` may 500 until `credit_cost` has rows (admin `POST /v1/credit-costs` / `/admin` UI) — missing data, not a broken build.
 - **Realtime (Ably) is unconfigured:** `POST /api/ably/auth` proxies Core `POST /v1/realtime/ably-token`; chat pages surface a "Something went wrong" modal when Core `ABLY_SUBSCRIBE_ONLY_KEY` / `ABLY_PUBLISH_ONLY_KEY` are placeholders. Optional; unrelated to setup.
 - Lint (`pnpm lint`), tests (`pnpm test`), and type checks do **not** need the DB or the servers running.
-
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
-
-Rules:
-- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
-- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- Not: "Sure! I'd be happy to help you with that."
-- Yes: "Bug in auth middleware. Fix:"
-
-Switch level: /caveman lite|full|ultra|wenyan
-Stop: "stop caveman" or "normal mode"
-
-Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
-
-Boundaries: code/commits/PRs written normal.


### PR DESCRIPTION
## Summary

Replace the inlined always-on caveman style dump in `AGENTS.md` with a skill pointer.

Caveman now applies only when [`.agents/skills/caveman/`](.agents/skills/caveman/) is present. Full rules stay in that skill. Off: `stop caveman` / `normal mode`.

## Why

The previous block duplicated the skill and fired for every agent that reads `AGENTS.md`, including runs with no caveman install.

## Verification

Docs-only change to `AGENTS.md`. No app, test, or schema impact.