### PR TITLE
fix(core): stop preview x402 readiness cron from paging (SOK-860)

### DIFF
--- a/apps/core/src/services/agent-sync.x402-readiness.test.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.test.ts
@@ -9,6 +9,7 @@ import {
 const {
   captureExceptionMock,
   captureMessageMock,
+  envState,
   getX402AvailableNetworksMock,
   getX402AdminPurchasingWalletsMock,
   getX402BudgetsMock,
@@ -20,6 +21,15 @@ const {
 } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
   captureMessageMock: vi.fn(),
+  envState: {
+    NETWORK: "Preprod" as const,
+    DATABASE_URL: "https://example.com/database",
+    VERCEL_ENV: undefined as
+      | "production"
+      | "preview"
+      | "development"
+      | undefined,
+  },
   getX402AvailableNetworksMock: vi.fn(),
   getX402AdminPurchasingWalletsMock: vi.fn(),
   getX402BudgetsMock: vi.fn(),
@@ -36,10 +46,7 @@ vi.mock("@sentry/node", () => ({
 }));
 
 vi.mock("@/config/env", () => ({
-  getEnv: () => ({
-    NETWORK: "Preprod",
-    DATABASE_URL: "https://example.com/database",
-  }),
+  getEnv: () => ({ ...envState }),
 }));
 
 vi.mock("@/clients/masumi-payment.client", () => ({
@@ -81,6 +88,7 @@ import {
 describe("syncX402BuySideReadiness", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    envState.VERCEL_ENV = undefined;
     syncMetadataCreateManyMock.mockResolvedValue({ count: 1 });
     syncMetadataDeleteManyMock.mockResolvedValue({ count: 0 });
     syncMetadataFindUniqueMock.mockResolvedValue(null);
@@ -444,7 +452,9 @@ describe("syncX402BuySideReadiness", () => {
     // Cold: no readiness row has ever been written, so getX402ReadySources
     // returns [] and the ENTIRE x402 listing is hidden. The one-shot latch
     // would spend its single page minutes after deploy and then go quiet —
-    // never-recorded must bypass it.
+    // never-recorded must bypass it. Production (and unset VERCEL_ENV) must
+    // still page — including the latch bypass.
+    envState.VERCEL_ENV = "production";
     syncMetadataFindUniqueMock.mockResolvedValue(null);
     getX402BudgetsMock.mockResolvedValue(err("node unavailable"));
 
@@ -464,6 +474,43 @@ describe("syncX402BuySideReadiness", () => {
     syncMetadataCreateManyMock.mockResolvedValue({ count: 0 });
     await syncX402BuySideReadiness();
     expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("does not page Sentry for readiness check failures on Vercel preview", async () => {
+    // Preview mainnet Core crons hit the same never-recorded path with a
+    // non-admin PAYMENT_API_KEY and were paging CORE-37 as a fake prod
+    // outage. Gate only captureException — warn + failure marker +
+    // fail-closed (no readiness row) stay.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    envState.VERCEL_ENV = "preview";
+    syncMetadataFindUniqueMock.mockResolvedValue(null);
+    getX402BudgetsMock.mockResolvedValue(
+      err("x402 budgets 401: Unauthorized, admin access required"),
+    );
+
+    await expect(syncX402BuySideReadiness()).resolves.toBe(false);
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    expect(syncMetadataUpsertMock).not.toHaveBeenCalled();
+    expect(syncMetadataCreateManyMock).toHaveBeenCalledWith({
+      data: [
+        {
+          key: X402_BUY_SIDE_READINESS_FAILURE_KEY,
+          cursorId: "failed",
+          lastSyncedAt: expect.any(Date),
+        },
+      ],
+      skipDuplicates: true,
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[sync/agents] x402 buy-side readiness check failed:",
+      expect.stringContaining("admin access required"),
+    );
 
     consoleWarnSpy.mockRestore();
   });

--- a/apps/core/src/services/agent-sync.x402-readiness.ts
+++ b/apps/core/src/services/agent-sync.x402-readiness.ts
@@ -222,7 +222,17 @@ export async function syncX402BuySideReadiness(
       // The latch is deliberately bypassed while readiness has never been
       // recorded: silence would otherwise be indistinguishable from a
       // healthy deployment that simply has no x402 agents.
-      if (marker.count > 0 || hasNeverBeenRecorded) {
+      //
+      // Preview deploys (VERCEL_ENV === "preview") still warn and write the
+      // failure marker so fail-closed listing/pay behavior is unchanged, but
+      // they must not page Sentry — preview mainnet crons with a non-admin
+      // PAYMENT_API_KEY were flooding CORE-37 while live mainnet was fine.
+      // Use VERCEL_ENV, not SENTRY_ENVIRONMENT (mainnet project sets the
+      // latter to "production" on preview hosts too).
+      if (
+        getEnv().VERCEL_ENV !== "preview" &&
+        (marker.count > 0 || hasNeverBeenRecorded)
+      ) {
         Sentry.captureException(
           new Error(
             hasNeverBeenRecorded


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Live mainnet confirmation:** SOKOSUMI-CORE-37 events are only on `sokosumi-core-mainnet-*.preview.sokosumi.com` (17 hosts / 15 releases). Zero events on non-preview hosts. Live mainnet Core is not in CORE-37. Sentry `environment=production` is because the mainnet project sets `SENTRY_ENVIRONMENT` that way — detect preview via `VERCEL_ENV === "preview"`.
- **Lock (Jarvis):** Do not weaken fail-closed on a real never-recorded mainnet. Listing/pay still hide x402 when readiness was never recorded. Chosen path: stop preview crons from paging. Admin `PAYMENT_API_KEY` for `GET /x402/budgets` remains an ops/env check if live mainnet ever shows never-recorded (not changed in this PR).
- **What changed:** When `getEnv().VERCEL_ENV === "preview"`, skip `Sentry.captureException` for the x402 buy-side readiness check failure (`never_recorded` / `stale`). Keep `console.warn`, failure marker write, and fail-closed cache (no fake readiness row). Production / unset still pages, including the never-recorded latch bypass.
- **What did not change:** Listing/pay fail-closed intact; `/sync/agents` cron still runs; no secret changes; unrelated PRs untouched.

Fixes SOKOSUMI-CORE-37  
https://linear.app/masumi/issue/SOK-860/x402-buy-side-readiness-401-on-syncagents-core-37

Automated draft PR. Do not merge.

## Test plan

- [x] `pnpm --filter core test src/services/agent-sync.x402-readiness.test.ts` (preview does not capture; production never-recorded still captures)
- [x] `pnpm --filter core check`
- [x] `pnpm core:test` (4101 passed)
- [x] CI green on `019ba2b3a9937d7c1fe89099b926ff5b17e377fd`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-961229b3-6e24-4b55-9b9c-f7d47b6da22c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-961229b3-6e24-4b55-9b9c-f7d47b6da22c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

