### PR TITLE
chore: assign both owners to every path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,2 @@
 # Global Owners
 * @mrosberghaus @francisluz
-
-# Frontend
-apps/web/ @francisluz
-
-# Backend
-apps/core/ @mrosberghaus
-
-# Packages
-packages/ @mrosberghaus @francisluz
-


### PR DESCRIPTION
## Summary
- Remove path-specific CODEOWNERS rules for `apps/web/`, `apps/core/`, and `packages/`
- `@mrosberghaus` and `@francisluz` now own every file in the repo

## Why
Later matching CODEOWNERS rules overrode the global owners, so web PRs only required Francis and core PRs only required Matt.

## Verification
- Pre-commit: `pnpm check` (Biome, 3471 files) and `pnpm typecheck` (17 turbo tasks) passed
- Inspected `.github/CODEOWNERS` — single global rule remains