### PR TITLE
feat(chat): publish Ably id envelope over 64KB

### DIFF
--- a/apps/core/src/lib/ably/ably-message-size.test.ts
+++ b/apps/core/src/lib/ably/ably-message-size.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatRoomMessage } from "@/schemas/chat-room.schema";
+
+import {
+  ABLY_MAX_MESSAGE_SIZE,
+  ablyPublishSize,
+  CHAT_ROOM_MESSAGE_EVENT_NAME,
+  chatRoomMessagePublishBody,
+  isChatRoomMessageIdEnvelope,
+} from "./ably-message-size";
+
+function baseMessage(
+  overrides: Partial<ChatRoomMessage> = {},
+): ChatRoomMessage {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    roomId: "660e8400-e29b-41d4-a716-446655440000",
+    parentMessageId: null,
+    content: "hello",
+    createdAt: "2026-08-03T12:00:00.000Z",
+    deletedAt: null,
+    editedAt: null,
+    sender: {
+      type: "coworker",
+      coworker: {
+        id: "cow_123",
+        name: "Hermes",
+        slug: "hermes",
+        caption: null,
+        image: null,
+        presence: "online",
+      },
+    },
+    mentions: [],
+    reactions: [],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: null,
+    quote: null,
+    membership: null,
+    unfurls: null,
+    ...overrides,
+  };
+}
+
+describe("chatRoomMessagePublishBody", () => {
+  it("keeps the full DTO when it already fits maxMessageSize", () => {
+    const message = baseMessage();
+    const body = chatRoomMessagePublishBody("create", message);
+    expect(body).toEqual({ eventType: "create", message });
+    expect(
+      ablyPublishSize(CHAT_ROOM_MESSAGE_EVENT_NAME, body),
+    ).toBeLessThanOrEqual(ABLY_MAX_MESSAGE_SIZE);
+  });
+
+  it("switches to an id envelope when the full create is over the limit", () => {
+    const message = baseMessage({
+      content: "x".repeat(70_000),
+      metadata: {
+        reasoning: [{ type: "reasoning", text: "y".repeat(400) }],
+      },
+    });
+    const full = { eventType: "create" as const, message };
+    expect(ablyPublishSize(CHAT_ROOM_MESSAGE_EVENT_NAME, full)).toBeGreaterThan(
+      ABLY_MAX_MESSAGE_SIZE,
+    );
+
+    const body = chatRoomMessagePublishBody("create", message);
+    expect(isChatRoomMessageIdEnvelope(body)).toBe(true);
+    expect(body).toEqual({
+      eventType: "create",
+      messageId: message.id,
+      roomId: message.roomId,
+      parentMessageId: null,
+    });
+    expect(
+      ablyPublishSize(CHAT_ROOM_MESSAGE_EVENT_NAME, body),
+    ).toBeLessThanOrEqual(ABLY_MAX_MESSAGE_SIZE);
+  });
+});

--- a/apps/core/src/lib/ably/ably-message-size.ts
+++ b/apps/core/src/lib/ably/ably-message-size.ts
@@ -1,0 +1,67 @@
+import type { ChatRoomMessageEventType } from "@sokosumi/utils";
+
+import type { ChatRoomMessage } from "@/schemas/chat-room.schema";
+
+/** Ably default ClientOptions.maxMessageSize (bytes). */
+export const ABLY_MAX_MESSAGE_SIZE = 65_536;
+
+export const CHAT_ROOM_MESSAGE_EVENT_NAME = "chat_room_message";
+
+export type ChatRoomMessageFullEventType = Extract<
+  ChatRoomMessageEventType,
+  "create" | "update" | "delete"
+>;
+
+export interface ChatRoomMessageFullEventBody {
+  eventType: ChatRoomMessageFullEventType;
+  message: ChatRoomMessage;
+}
+
+/** Over-limit create/update/delete: identity only (ADR 0014). */
+export interface ChatRoomMessageIdEnvelope {
+  eventType: ChatRoomMessageFullEventType;
+  messageId: string;
+  roomId: string;
+  parentMessageId: string | null;
+}
+
+export type ChatRoomMessagePublishBody =
+  | ChatRoomMessageFullEventBody
+  | ChatRoomMessageIdEnvelope;
+
+/**
+ * Ably REST publish size before HTTP: event name length + UTF-8 bytes of
+ * JSON-encoded data (see ably getMessageSize / dataSizeBytes).
+ */
+export function ablyPublishSize(name: string, data: unknown): number {
+  const encoded =
+    typeof data === "string" ? data : JSON.stringify(data ?? null);
+  return name.length + Buffer.byteLength(encoded, "utf8");
+}
+
+export function isChatRoomMessageIdEnvelope(
+  body: ChatRoomMessagePublishBody,
+): body is ChatRoomMessageIdEnvelope {
+  return !("message" in body);
+}
+
+/**
+ * Full DTO when it fits maxMessageSize; otherwise an id envelope.
+ * Does not shrink or truncate the DTO (ADR 0014).
+ */
+export function chatRoomMessagePublishBody(
+  eventType: ChatRoomMessageFullEventType,
+  message: ChatRoomMessage,
+): ChatRoomMessagePublishBody {
+  const full: ChatRoomMessageFullEventBody = { eventType, message };
+  const bytes = ablyPublishSize(CHAT_ROOM_MESSAGE_EVENT_NAME, full);
+  if (bytes <= ABLY_MAX_MESSAGE_SIZE) {
+    return full;
+  }
+  return {
+    eventType,
+    messageId: message.id,
+    roomId: message.roomId,
+    parentMessageId: message.parentMessageId,
+  };
+}

--- a/apps/core/src/lib/ably/publish.test.ts
+++ b/apps/core/src/lib/ably/publish.test.ts
@@ -137,6 +137,53 @@ describe("publishChatRoomMessageEvent", () => {
     });
   });
 
+  it("publishes an id envelope when the full create exceeds Ably maxMessageSize", async () => {
+    publishMock.mockClear();
+    const message = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      roomId: "660e8400-e29b-41d4-a716-446655440000",
+      parentMessageId: null as string | null,
+      content: "x".repeat(70_000),
+      createdAt: "2026-08-03T12:00:00.000Z",
+      deletedAt: null,
+      editedAt: null,
+      sender: {
+        type: "coworker" as const,
+        coworker: {
+          id: "cow_123",
+          name: "Hermes",
+          slug: "hermes",
+          caption: null,
+          image: null,
+          presence: "online" as const,
+        },
+      },
+      mentions: [],
+      reactions: [],
+      threadReplyCount: 0,
+      threadLastReplyAt: null,
+      metadata: {
+        reasoning: [{ type: "reasoning", text: "y".repeat(400) }],
+      },
+      quote: null,
+      membership: null,
+      unfurls: null,
+    };
+
+    await publishChatRoomMessageEvent({
+      eventType: "create",
+      message,
+    });
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(publishMock).toHaveBeenCalledWith("chat_room_message", {
+      eventType: "create",
+      messageId: message.id,
+      roomId: message.roomId,
+      parentMessageId: null,
+    });
+  });
+
   it("publishes a patch envelope for reaction events on the room channel", async () => {
     const patch = {
       reactions: [

--- a/apps/core/src/lib/ably/publish.ts
+++ b/apps/core/src/lib/ably/publish.ts
@@ -13,6 +13,13 @@ import {
 
 import type { ChatRoomMessage } from "@/schemas/chat-room.schema";
 
+import {
+  ablyPublishSize,
+  CHAT_ROOM_MESSAGE_EVENT_NAME,
+  type ChatRoomMessageFullEventType,
+  chatRoomMessagePublishBody,
+  isChatRoomMessageIdEnvelope,
+} from "./ably-message-size";
 import { getRestClient } from "./client";
 
 interface JobStatusData {
@@ -93,12 +100,6 @@ export async function publishNotificationEvent({
   await channel.publish("notification_created", notification);
 }
 
-/** Full DTO body for create / update / delete. */
-export type ChatRoomMessageFullEventType = Extract<
-  ChatRoomMessageEventType,
-  "create" | "update" | "delete"
->;
-
 /** Patch body for high-chatter slices (SOK-737). */
 export type ChatRoomMessagePatchEventType = Extract<
   ChatRoomMessageEventType,
@@ -157,7 +158,7 @@ export async function publishChatRoomMessageEvent(
   const channel = client.channels.get(makeChatRoomChannelName(roomId));
 
   if (isPatchEventInput(input)) {
-    await channel.publish("chat_room_message", {
+    await channel.publish(CHAT_ROOM_MESSAGE_EVENT_NAME, {
       eventType: input.eventType,
       messageId: input.messageId,
       roomId: input.roomId,
@@ -167,10 +168,19 @@ export async function publishChatRoomMessageEvent(
     return;
   }
 
-  await channel.publish("chat_room_message", {
-    eventType: input.eventType,
-    message: input.message,
-  });
+  const body = chatRoomMessagePublishBody(input.eventType, input.message);
+  if (isChatRoomMessageIdEnvelope(body)) {
+    const full = {
+      eventType: input.eventType,
+      message: input.message,
+    };
+    console.info("Published chat_room_message id envelope", {
+      messageId: body.messageId,
+      roomId: body.roomId,
+      bytes: ablyPublishSize(CHAT_ROOM_MESSAGE_EVENT_NAME, full),
+    });
+  }
+  await channel.publish(CHAT_ROOM_MESSAGE_EVENT_NAME, body);
 }
 
 interface PublishChatMembershipRevokedInput {

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -91,7 +91,10 @@ import useIsApplePlatform from "@/hooks/use-is-apple-platform";
 import { useIsMobileMedia } from "@/hooks/use-mobile";
 import {
   type ChatRoomMessageEventData,
+  chatRoomMessageIdEnvelopeAction,
+  isChatRoomMessageIdEnvelope,
   isChatRoomMessagePatchEvent,
+  tombstoneChatRoomMessage,
 } from "@/lib/ably";
 import { applyChatRoomMessagePatch } from "@/lib/ably/apply-chat-room-message-patch";
 import { hydrateChatRoomMessageFromRealtime } from "@/lib/ably/hydrate-chat-room-message";
@@ -883,6 +886,7 @@ export function RoomsClient({
   skipRealtimeWhileStreamingRef.current = isCoworkerStreamRoom;
   const threadParentMessageIdRef = useRef<string | null>(null);
   threadParentMessageIdRef.current = threadParentMessage?.id ?? null;
+  const refreshLatestRef = useRef<() => Promise<void>>(async () => {});
 
   const handleChatRoomRealtimeMessage = useCallback(
     (event: ChatRoomMessageEventData) => {
@@ -890,6 +894,65 @@ export function RoomsClient({
         skipRealtimeWhileStreamingRef.current &&
         isCoworkerStreamingRef.current
       ) {
+        return;
+      }
+
+      if (isChatRoomMessageIdEnvelope(event)) {
+        const action = chatRoomMessageIdEnvelopeAction(
+          event,
+          selectedRoomIdRef.current,
+        );
+        if (action.kind === "ignore") {
+          return;
+        }
+        if (action.kind === "refresh") {
+          void refreshLatestRef.current();
+          return;
+        }
+
+        const route = routeRealtimeChatRoomMessage(
+          {
+            id: action.messageId,
+            parentMessageId: action.parentMessageId,
+          },
+          threadParentMessageIdRef.current,
+          "delete",
+        );
+
+        if (route.mergeIntoRoomTimeline) {
+          setMessagesState((current) => {
+            const existing = current.find(
+              (message) => message.id === action.messageId,
+            );
+            if (!existing) {
+              return current;
+            }
+            return filterTopLevelChatRoomMessages(
+              mergeRoomMessages(current, [tombstoneChatRoomMessage(existing)]),
+            );
+          });
+        }
+
+        setThreadParentMessage((current) => {
+          if (current?.id !== action.messageId) {
+            return current;
+          }
+          return tombstoneChatRoomMessage(current);
+        });
+
+        if (route.mergeIntoOpenThread) {
+          setThreadMessages((current) => {
+            const existing = current.find(
+              (message) => message.id === action.messageId,
+            );
+            if (!existing) {
+              return current;
+            }
+            return mergeRoomMessages(current, [
+              tombstoneChatRoomMessage(existing),
+            ]);
+          });
+        }
         return;
       }
 
@@ -1391,6 +1454,48 @@ export function RoomsClient({
     };
   }, [selectedRoom?.id, hasPendingRoomCoworkerMention]);
 
+  const refreshFocusedRoomMessages = useCallback(async () => {
+    const roomId = selectedRoomIdRef.current;
+    if (!roomId) {
+      return;
+    }
+    if (
+      skipRealtimeWhileStreamingRef.current &&
+      isCoworkerStreamingRef.current
+    ) {
+      return;
+    }
+    const threadParentId = threadParentMessageIdRef.current;
+    const [result, threadResult] = await Promise.all([
+      listRoomMessagesAction(roomId),
+      threadParentId
+        ? listThreadMessagesAction(roomId, threadParentId)
+        : Promise.resolve(null),
+    ]);
+    if (selectedRoomIdRef.current !== roomId || !result.ok) {
+      return;
+    }
+    setMessagesState((current) =>
+      mergeRoomMessages(current, result.value.messages),
+    );
+    setThreadParentMessage((current) =>
+      current
+        ? (result.value.messages.find((message) => message.id === current.id) ??
+          current)
+        : current,
+    );
+    if (
+      threadResult?.ok &&
+      threadParentId != null &&
+      threadParentMessageIdRef.current === threadParentId
+    ) {
+      setThreadMessages((current) =>
+        mergeRoomMessages(current, threadResult.value.messages),
+      );
+    }
+  }, []);
+  refreshLatestRef.current = refreshFocusedRoomMessages;
+
   // Ably Pub/Sub is primary (RoomMessageRealtimeBridge). Keep a short poll +
   // focus/visibility refresh so human peer rows still land when Ably drops or
   // lags while the room stays open.
@@ -1399,42 +1504,16 @@ export function RoomsClient({
       return;
     }
 
-    const roomId = selectedRoom.id;
-    const skipWhileStreaming = shouldUseCoworkerRoomStream(selectedRoom);
     let cancelled = false;
 
     const refreshLatest = async () => {
       if (document.visibilityState !== "visible") {
         return;
       }
-      if (skipWhileStreaming && isCoworkerStreaming) {
+      if (cancelled) {
         return;
       }
-      const threadParentId = threadParentMessageRef.current?.id;
-      const [result, threadResult] = await Promise.all([
-        listRoomMessagesAction(roomId),
-        threadParentId
-          ? listThreadMessagesAction(roomId, threadParentId)
-          : Promise.resolve(null),
-      ]);
-      if (cancelled || !result.ok) {
-        return;
-      }
-      setMessagesState((current) =>
-        mergeRoomMessages(current, result.value.messages),
-      );
-      setThreadParentMessage((current) =>
-        current
-          ? (result.value.messages.find(
-              (message) => message.id === current.id,
-            ) ?? current)
-          : current,
-      );
-      if (threadResult?.ok) {
-        setThreadMessages((current) =>
-          mergeRoomMessages(current, threadResult.value.messages),
-        );
-      }
+      await refreshFocusedRoomMessages();
     };
 
     const intervalId = window.setInterval(refreshLatest, ROOM_LIVE_POLL_MS);
@@ -1452,7 +1531,7 @@ export function RoomsClient({
       window.removeEventListener("focus", refreshLatest);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [selectedRoom?.id, isCoworkerStreaming]);
+  }, [selectedRoom?.id, refreshFocusedRoomMessages]);
 
   useEffect(() => {
     if (

--- a/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
+++ b/apps/web/src/app/(app)/chat/utils/chat-room-message-scope.ts
@@ -11,8 +11,9 @@
  *
  * ## Realtime routing table (SOK-736)
  *
- * Ably `chat_room_message` carries `eventType` plus either a full message DTO
- * (create/update/delete) or a field patch (reaction/unfurl/mention_status,
+ * Ably `chat_room_message` carries `eventType` plus a full message DTO
+ * (create/update/delete), an id envelope when that DTO exceeds Ably
+ * maxMessageSize (ADR 0014), or a field patch (reaction/unfurl/mention_status,
  * SOK-737). Landing (where the apply goes) is decided by parent vs reply +
  * open thread id; `eventType` documents mutation intent so clients do not
  * guess from payload shape alone.

--- a/apps/web/src/lib/ably/__tests__/apply-chat-room-message-id-envelope.test.ts
+++ b/apps/web/src/lib/ably/__tests__/apply-chat-room-message-id-envelope.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+import {
+  chatRoomMessageIdEnvelopeAction,
+  tombstoneChatRoomMessage,
+} from "../apply-chat-room-message-id-envelope";
+import type { ChatRoomMessageIdEnvelopeData } from "../schema";
+
+function envelope(
+  overrides: Partial<ChatRoomMessageIdEnvelopeData> = {},
+): ChatRoomMessageIdEnvelopeData {
+  return {
+    eventType: "create",
+    messageId: "msg-1",
+    roomId: "room-1",
+    parentMessageId: null,
+    ...overrides,
+  };
+}
+
+function baseMessage(
+  overrides: Partial<ChatRoomMessage> = {},
+): ChatRoomMessage {
+  return {
+    id: "msg-1",
+    roomId: "room-1",
+    parentMessageId: null,
+    content: "hello world",
+    createdAt: new Date("2026-08-06T12:00:00.000Z"),
+    deletedAt: null,
+    editedAt: null,
+    sender: {
+      type: "user",
+      user: {
+        id: "user-1",
+        name: "Alice",
+        email: "alice@example.com",
+        image: null,
+        presence: "online",
+      },
+    },
+    mentions: [
+      {
+        id: "men-1",
+        coworkerId: "cow-1",
+        status: "responded",
+        responseMessageId: null,
+      },
+    ],
+    reactions: [
+      {
+        emoji: "👍",
+        count: 1,
+        reactedByCurrentUser: true,
+        reactors: [{ id: "user-1", name: "Alice" }],
+      },
+    ],
+    threadReplyCount: 0,
+    threadLastReplyAt: null,
+    metadata: { reasoning: [{ type: "reasoning", text: "secret" }] },
+    quote: null,
+    membership: null,
+    unfurls: null,
+    ...overrides,
+  };
+}
+
+describe("chatRoomMessageIdEnvelopeAction", () => {
+  it("ignores envelopes for a room that is not focused", () => {
+    expect(chatRoomMessageIdEnvelopeAction(envelope(), "room-other")).toEqual({
+      kind: "ignore",
+    });
+  });
+
+  it("refreshes on create and update for the focused room", () => {
+    expect(
+      chatRoomMessageIdEnvelopeAction(
+        envelope({ eventType: "create" }),
+        "room-1",
+      ),
+    ).toEqual({ kind: "refresh" });
+    expect(
+      chatRoomMessageIdEnvelopeAction(
+        envelope({ eventType: "update" }),
+        "room-1",
+      ),
+    ).toEqual({ kind: "refresh" });
+  });
+
+  it("tombstones by id on delete for the focused room", () => {
+    expect(
+      chatRoomMessageIdEnvelopeAction(
+        envelope({ eventType: "delete", parentMessageId: "parent-1" }),
+        "room-1",
+      ),
+    ).toEqual({
+      kind: "tombstone",
+      messageId: "msg-1",
+      parentMessageId: "parent-1",
+    });
+  });
+});
+
+describe("tombstoneChatRoomMessage", () => {
+  it("clears body and marks deletedAt without changing id or sender", () => {
+    const existing = baseMessage();
+    const tombstoned = tombstoneChatRoomMessage(existing);
+    expect(tombstoned.id).toBe(existing.id);
+    expect(tombstoned.sender).toEqual(existing.sender);
+    expect(tombstoned.content).toBe("");
+    expect(tombstoned.deletedAt).toBeInstanceOf(Date);
+    expect(tombstoned.metadata).toBeNull();
+    expect(tombstoned.mentions).toEqual([]);
+    expect(tombstoned.reactions).toEqual([]);
+    expect(tombstoned.quote).toBeNull();
+    expect(tombstoned.unfurls).toBeNull();
+    expect(tombstoned.membership).toBeNull();
+  });
+
+  it("keeps an existing deletedAt", () => {
+    const deletedAt = new Date("2026-08-01T00:00:00.000Z");
+    const tombstoned = tombstoneChatRoomMessage(baseMessage({ deletedAt }));
+    expect(tombstoned.deletedAt).toEqual(deletedAt);
+  });
+});

--- a/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
+++ b/apps/web/src/lib/ably/__tests__/chat-room-message-event-schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatRoomMessageEventDataSchema,
+  isChatRoomMessageIdEnvelope,
   isChatRoomMessagePatchEvent,
 } from "../schema";
 
@@ -38,12 +39,42 @@ describe("chatRoomMessageEventDataSchema", () => {
       if (parsed.success) {
         expect(parsed.data.eventType).toBe(eventType);
         expect(isChatRoomMessagePatchEvent(parsed.data)).toBe(false);
-        if (!isChatRoomMessagePatchEvent(parsed.data)) {
+        expect(isChatRoomMessageIdEnvelope(parsed.data)).toBe(false);
+        if ("message" in parsed.data) {
           expect(parsed.data.message.id).toBe("msg-1");
         }
       }
     },
   );
+
+  it.each([...fullEventTypes])(
+    "accepts eventType %s as an id envelope without a message DTO",
+    (eventType) => {
+      const parsed = chatRoomMessageEventDataSchema.safeParse({
+        eventType,
+        messageId: "msg-1",
+        roomId: "room-1",
+        parentMessageId: null,
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(isChatRoomMessagePatchEvent(parsed.data)).toBe(false);
+        expect(isChatRoomMessageIdEnvelope(parsed.data)).toBe(true);
+        if (isChatRoomMessageIdEnvelope(parsed.data)) {
+          expect(parsed.data.messageId).toBe("msg-1");
+          expect(parsed.data.roomId).toBe("room-1");
+        }
+      }
+    },
+  );
+
+  it("rejects an id envelope missing routing keys", () => {
+    const parsed = chatRoomMessageEventDataSchema.safeParse({
+      eventType: "create",
+      messageId: "msg-1",
+    });
+    expect(parsed.success).toBe(false);
+  });
 
   it("accepts a reaction patch envelope", () => {
     const parsed = chatRoomMessageEventDataSchema.safeParse({

--- a/apps/web/src/lib/ably/__tests__/personalize-chat-room-message-event.test.ts
+++ b/apps/web/src/lib/ably/__tests__/personalize-chat-room-message-event.test.ts
@@ -67,13 +67,24 @@ describe("personalizeChatRoomMessageEvent", () => {
 
     const personalized = personalizeChatRoomMessageEvent(event, "me");
     expect(personalized.eventType).toBe("create");
-    if (personalized.eventType !== "create") {
+    if (!("message" in personalized)) {
       return;
     }
     const first = personalized.message.reactions[0] as {
       reactedByCurrentUser?: boolean;
     };
     expect(first.reactedByCurrentUser).toBe(true);
+  });
+
+  it("leaves create id envelopes unchanged", () => {
+    const event = {
+      eventType: "create" as const,
+      messageId: "msg-1",
+      roomId: "room-1",
+      parentMessageId: null,
+    } satisfies ChatRoomMessageEventData;
+
+    expect(personalizeChatRoomMessageEvent(event, "me")).toEqual(event);
   });
 
   it("personalizes reaction patches only", () => {

--- a/apps/web/src/lib/ably/apply-chat-room-message-id-envelope.ts
+++ b/apps/web/src/lib/ably/apply-chat-room-message-id-envelope.ts
@@ -1,0 +1,51 @@
+import type { ChatRoomMessageIdEnvelopeData } from "@/lib/ably/schema";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+export type ChatRoomMessageIdEnvelopeAction =
+  | { kind: "ignore" }
+  | { kind: "refresh" }
+  | {
+      kind: "tombstone";
+      messageId: string;
+      parentMessageId: string | null;
+    };
+
+/**
+ * Decide how a focused-room client applies an over-limit Ably id envelope
+ * (ADR 0014). Create/update never invent a row; delete tombstones by id
+ * because list GET omits deleted messages.
+ */
+export function chatRoomMessageIdEnvelopeAction(
+  event: ChatRoomMessageIdEnvelopeData,
+  selectedRoomId: string | null,
+): ChatRoomMessageIdEnvelopeAction {
+  if (event.roomId !== selectedRoomId) {
+    return { kind: "ignore" };
+  }
+  if (event.eventType === "delete") {
+    return {
+      kind: "tombstone",
+      messageId: event.messageId,
+      parentMessageId: event.parentMessageId,
+    };
+  }
+  return { kind: "refresh" };
+}
+
+/** In-place tombstone matching Core's mapped delete DTO. */
+export function tombstoneChatRoomMessage(
+  existing: ChatRoomMessage,
+): ChatRoomMessage {
+  return {
+    ...existing,
+    content: "",
+    deletedAt: existing.deletedAt ?? new Date(),
+    editedAt: null,
+    mentions: [],
+    reactions: [],
+    metadata: null,
+    quote: null,
+    membership: null,
+    unfurls: null,
+  };
+}

--- a/apps/web/src/lib/ably/index.ts
+++ b/apps/web/src/lib/ably/index.ts
@@ -1,3 +1,4 @@
+export * from "./apply-chat-room-message-id-envelope";
 export * from "./apply-chat-room-message-patch";
 export * from "./personalize-chat-room-message-event";
 export * from "./schema";

--- a/apps/web/src/lib/ably/personalize-chat-room-message-event.ts
+++ b/apps/web/src/lib/ably/personalize-chat-room-message-event.ts
@@ -1,5 +1,8 @@
 import type { ChatRoomMessageEventData } from "./schema";
-import { isChatRoomMessagePatchEvent } from "./schema";
+import {
+  isChatRoomMessageIdEnvelope,
+  isChatRoomMessagePatchEvent,
+} from "./schema";
 
 interface ReactionLike {
   reactedByCurrentUser: boolean;
@@ -78,6 +81,10 @@ export function personalizeChatRoomMessageEvent(
         ),
       },
     };
+  }
+
+  if (isChatRoomMessageIdEnvelope(event)) {
+    return event;
   }
 
   return {

--- a/apps/web/src/lib/ably/schema.ts
+++ b/apps/web/src/lib/ably/schema.ts
@@ -75,6 +75,14 @@ const chatRoomMessageFullEventSchema = z.object({
   message: chatRoomMessageFullEventMessageSchema,
 });
 
+/** Over-limit create/update/delete: identity only (ADR 0014). */
+const chatRoomMessageIdEnvelopeSchema = z.object({
+  eventType: z.enum(["create", "update", "delete"]),
+  messageId: z.string().min(1),
+  roomId: z.string().min(1),
+  parentMessageId: z.string().nullable(),
+});
+
 const chatRoomMessageReactionEventSchema = z.object({
   eventType: z.literal("reaction"),
   messageId: z.string().min(1),
@@ -106,11 +114,13 @@ const chatRoomMessageMentionStatusEventSchema = z.object({
 });
 
 /**
- * Ably `chat_room_message` body (SOK-736 + SOK-737).
- * Full DTO for create/update/delete; field patch for reaction/unfurl/mention_status.
+ * Ably `chat_room_message` body (SOK-736 + SOK-737 + ADR 0014).
+ * Full DTO or id envelope for create/update/delete; field patch for
+ * reaction/unfurl/mention_status.
  */
 export const chatRoomMessageEventDataSchema = z.union([
   chatRoomMessageFullEventSchema,
+  chatRoomMessageIdEnvelopeSchema,
   chatRoomMessageReactionEventSchema,
   chatRoomMessageUnfurlEventDataSchema,
   chatRoomMessageMentionStatusEventSchema,
@@ -124,9 +134,13 @@ export type ChatRoomMessageFullEventData = z.infer<
   typeof chatRoomMessageFullEventSchema
 >;
 
-export type ChatRoomMessagePatchEventData = Exclude<
+export type ChatRoomMessageIdEnvelopeData = z.infer<
+  typeof chatRoomMessageIdEnvelopeSchema
+>;
+
+export type ChatRoomMessagePatchEventData = Extract<
   ChatRoomMessageEventData,
-  ChatRoomMessageFullEventData
+  { eventType: "reaction" | "unfurl" | "mention_status" }
 >;
 
 export function isChatRoomMessagePatchEvent(
@@ -136,5 +150,16 @@ export function isChatRoomMessagePatchEvent(
     event.eventType === "reaction" ||
     event.eventType === "unfurl" ||
     event.eventType === "mention_status"
+  );
+}
+
+export function isChatRoomMessageIdEnvelope(
+  event: ChatRoomMessageEventData,
+): event is ChatRoomMessageIdEnvelopeData {
+  return (
+    (event.eventType === "create" ||
+      event.eventType === "update" ||
+      event.eventType === "delete") &&
+    !("message" in event)
   );
 }

--- a/docs/adr/0014-chat-room-message-ably-id-envelope.md
+++ b/docs/adr/0014-chat-room-message-ably-id-envelope.md
@@ -1,0 +1,19 @@
+# ADR 0014: Chat room message Ably full DTO or id envelope
+
+- Status: Accepted
+- Date: 2026-08-24
+
+Ably `chat_room_message` **create / update / delete** carry a full message DTO when that JSON fits Ably’s 64KB `maxMessageSize`. When it does not, Core publishes an **id envelope** `{ eventType, messageId, roomId, parentMessageId }` on the same event name and types — not a smaller fake DTO. Focused clients refetch via the existing room/thread message lists. Field patches (SOK-737) are unchanged.
+
+**Why:** SOK-736 put unbounded assistant (and other) rows on a 64KB pipe. Thought stays on the DB row and on HTTP (ADR 0002). Silently dropping Thought or truncating `content` on the wire makes the client treat a lie as the message (`mergeRoomMessages` incoming-wins). Poll then “heals” only if it runs. Measure size **before** publish; never send an oversize body and never catch `40009` as a shrink fallback.
+
+**Apply:**
+
+- **Create / update** id envelope: do not invent a row. Focused room (and open thread when `parentMessageId` matches) runs the same HTTP refresh as the 3s live poll. Other attached rooms ignore the envelope, as they ignore full creates today.
+- **Delete** id envelope: tombstone immediately by `messageId` if the row is on screen. List GET omits deleted rows; merge does not drop missing ids. Mapped deletes are already empty (`content: ""`, `metadata: null`) and should keep taking the full-DTO path after the size check.
+- Old web clients that cannot parse the id envelope drop it; focused-room poll remains the compat backstop. Do not dual-publish full DTO plus envelope.
+- Log when an id envelope is emitted (messageId, roomId, measured bytes). Not Sentry — this is an expected path.
+
+**Rejected:** shrinking/truncating the full DTO until it fits; always-id-envelope (gives up snappy full creates); raising Ably account limits; a new `eventType`; a GET-by-id route; a placeholder bubble; `fitChatRoomMessageFullEvent` as a safety net.
+
+**Out of scope:** product caps on assistant `content`; changing field patches.

--- a/packages/utils/src/chat-room-message-event-type.ts
+++ b/packages/utils/src/chat-room-message-event-type.ts
@@ -1,6 +1,7 @@
 /**
  * Stable intent for Ably `chat_room_message` publishes (SOK-736).
- * create/update/delete carry a full message DTO; reaction/unfurl/
+ * create/update/delete carry a full message DTO when it fits Ably
+ * maxMessageSize, otherwise an id envelope (ADR 0014). reaction/unfurl/
  * mention_status carry a field patch (SOK-737).
  */
 export const CHAT_ROOM_MESSAGE_EVENT_TYPES = [


### PR DESCRIPTION
Supersedes #3913 (payload shrinker, closed).

## Why

Production `publishChatRoomMessageEvent` threw Ably `40009` when a full `chat_room_message` create exceeded `maxMessageSize` (65536). Sentry SOKOSUMI-CORE-38: persist succeeded; realtime fan-out failed.

The previous approach (#3913) shrunk/truncated the wire DTO. That masked the limit and could show truncated text or missing Thought until poll. Closed in favor of this protocol fix.

## Scope

- ADR 0014: create/update/delete carry a **full DTO when it fits**, otherwise an **id envelope** `{ eventType, messageId, roomId, parentMessageId }`.
- Measure size before publish. Never send an oversize body. Never shrink content or drop Thought on the wire.
- Focused clients: create/update envelope → existing list HTTP refresh (no invented row). Delete envelope → tombstone by id if the row is on screen.
- Field patches (SOK-737) unchanged. Old web clients drop the unknown envelope; focused-room poll remains the compat backstop.

Replaces #3913. Fixes SOKOSUMI-CORE-38.

## Tradeoffs

Huge assistant creates are not instant on Ably; peers wait for the list refetch (~same as today’s poll backstop, but triggered immediately). Mapped deletes stay on the full-DTO path (already empty).

## Blast radius

Core Ably chat publish + web room realtime apply. Other Ably events unchanged.

## Verification

- `pnpm --filter core test src/lib/ably/ably-message-size.test.ts src/lib/ably/publish.test.ts`
- `pnpm --filter web test src/lib/ably/__tests__/apply-chat-room-message-id-envelope.test.ts src/lib/ably/__tests__/chat-room-message-event-schema.test.ts`
- `pnpm test` (workspace)
- `pnpm --filter core typecheck` / `pnpm --filter web typecheck`