### PR TITLE
fix(chat): omit guests from channel roster save

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
@@ -1093,6 +1093,24 @@ describe("PATCH /chats/rooms/{id}", () => {
       (row: { userId: string }) => row.userId,
     );
     expect(createdIds).not.toContain(guestId);
+    // Ignore, do not promote: echoed guests must not enter the host upgrade.
+    expect(userMemberUpdateManyMock).toHaveBeenCalledWith({
+      where: {
+        roomId: ROOM_ID,
+        userId: { in: [USER_ID] },
+        access: "guest",
+      },
+      data: { access: "member" },
+    });
+    expect(
+      userMemberUpdateManyMock.mock.calls[0][0].where.userId.in,
+    ).not.toContain(guestId);
+    expect(readStateDeleteManyMock).toHaveBeenCalledWith({
+      where: {
+        roomId: ROOM_ID,
+        userId: { notIn: expect.arrayContaining([USER_ID, guestId]) },
+      },
+    });
   });
 
   it("still 400s when memberUserIds includes a non-guest who is not an organization member", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
@@ -220,6 +220,51 @@ function directRoom() {
   });
 }
 
+const GUEST_ID = "user_guest";
+const SOUPIE_ID = "cow_soupie";
+
+function hostUserMember(userId: string, name: string, email: string) {
+  return {
+    userId,
+    access: "member" as const,
+    user: {
+      id: userId,
+      name,
+      email,
+      image: null,
+      sessions: [],
+    },
+  };
+}
+
+function guestUserMember(userId: string) {
+  return {
+    userId,
+    access: "guest" as const,
+    user: {
+      id: userId,
+      name: "Guest",
+      email: "guest@example.com",
+      image: null,
+      sessions: [],
+    },
+  };
+}
+
+function externalChannelWithGuest(
+  guestId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return channelRoom({
+    discoverability: "external",
+    userMembers: [
+      hostUserMember(USER_ID, "Ada", "ada@example.com"),
+      guestUserMember(guestId),
+    ],
+    ...overrides,
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   prismaTransactionMock.mockImplementation(async (callback) => callback(tx));
@@ -875,77 +920,19 @@ describe("PATCH /chats/rooms/{id}", () => {
   });
 
   it("preserves guest rows when PATCH rewrites memberUserIds without the guest", async () => {
-    const guestId = "user_guest";
-    const existing = channelRoom({
-      discoverability: "external",
+    const existing = externalChannelWithGuest(GUEST_ID);
+    const updated = externalChannelWithGuest(GUEST_ID, {
       userMembers: [
-        {
-          userId: USER_ID,
-          access: "member",
-          user: {
-            id: USER_ID,
-            name: "Ada",
-            email: "ada@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-        {
-          userId: guestId,
-          access: "guest",
-          user: {
-            id: guestId,
-            name: "Guest",
-            email: "guest@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-      ],
-    });
-    const updated = channelRoom({
-      discoverability: "external",
-      userMembers: [
-        {
-          userId: USER_ID,
-          access: "member",
-          user: {
-            id: USER_ID,
-            name: "Ada",
-            email: "ada@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-        {
-          userId: OTHER_USER_ID,
-          access: "member",
-          user: {
-            id: OTHER_USER_ID,
-            name: "Bob",
-            email: "bob@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-        {
-          userId: guestId,
-          access: "guest",
-          user: {
-            id: guestId,
-            name: "Guest",
-            email: "guest@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
+        hostUserMember(USER_ID, "Ada", "ada@example.com"),
+        hostUserMember(OTHER_USER_ID, "Bob", "bob@example.com"),
+        guestUserMember(GUEST_ID),
       ],
     });
     roomFindFirstMock.mockResolvedValueOnce(existing);
     memberFindUniqueMock.mockResolvedValue({ role: "member" });
     roomUpdateMock.mockResolvedValueOnce(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
-    userMemberFindManyMock.mockResolvedValue([{ userId: guestId }]);
+    userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
     userMemberCreateManyMock.mockResolvedValue({ count: 2 });
     readStateDeleteManyMock.mockResolvedValue({ count: 0 });
     readStateCreateManyMock.mockResolvedValue({ count: 0 });
@@ -986,13 +973,13 @@ describe("PATCH /chats/rooms/{id}", () => {
     const createdIds = userMemberCreateManyMock.mock.calls[0][0].data.map(
       (row: { userId: string }) => row.userId,
     );
-    expect(createdIds).not.toContain(guestId);
+    expect(createdIds).not.toContain(GUEST_ID);
     // Guest read state must not be swept when not in memberUserIds.
     expect(readStateDeleteManyMock).toHaveBeenCalledWith({
       where: {
         roomId: ROOM_ID,
         userId: {
-          notIn: expect.arrayContaining([USER_ID, OTHER_USER_ID, guestId]),
+          notIn: expect.arrayContaining([USER_ID, OTHER_USER_ID, GUEST_ID]),
         },
       },
     });
@@ -1005,42 +992,12 @@ describe("PATCH /chats/rooms/{id}", () => {
   });
 
   it("adds a coworker when memberUserIds echoes existing guests (not org members)", async () => {
-    const guestId = "user_guest";
-    const addedCoworkerId = "cow_soupie";
-    const existing = channelRoom({
-      discoverability: "external",
-      userMembers: [
-        {
-          userId: USER_ID,
-          access: "member",
-          user: {
-            id: USER_ID,
-            name: "Ada",
-            email: "ada@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-        {
-          userId: guestId,
-          access: "guest",
-          user: {
-            id: guestId,
-            name: "Guest",
-            email: "guest@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-      ],
-    });
-    const updated = channelRoom({
-      discoverability: "external",
-      userMembers: existing.userMembers,
+    const existing = externalChannelWithGuest(GUEST_ID);
+    const updated = externalChannelWithGuest(GUEST_ID, {
       coworkerMembers: [
         {
           coworker: {
-            id: addedCoworkerId,
+            id: SOUPIE_ID,
             name: "Soupie",
             slug: "soupie",
             image: null,
@@ -1052,19 +1009,19 @@ describe("PATCH /chats/rooms/{id}", () => {
     memberFindManyMock.mockImplementation(
       async ({ where }: { where: { userId: { in: string[] } } }) =>
         where.userId.in
-          .filter((userId) => userId !== guestId)
+          .filter((userId) => userId !== GUEST_ID)
           .map((userId) => ({ userId })),
     );
     coworkerFindManyMock.mockResolvedValue([
       {
-        id: addedCoworkerId,
+        id: SOUPIE_ID,
         name: "Soupie",
         baseURL: "https://chat.example.com",
       },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
-    userMemberFindManyMock.mockResolvedValue([{ userId: guestId }]);
+    userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
     userMemberCreateManyMock.mockResolvedValue({ count: 1 });
     readStateDeleteManyMock.mockResolvedValue({ count: 0 });
     readStateCreateManyMock.mockResolvedValue({ count: 0 });
@@ -1077,14 +1034,14 @@ describe("PATCH /chats/rooms/{id}", () => {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        memberUserIds: [USER_ID, guestId],
-        coworkerIds: [addedCoworkerId],
+        memberUserIds: [USER_ID, GUEST_ID],
+        coworkerIds: [SOUPIE_ID],
       }),
     });
 
     expect(response.status).toBe(200);
     expect(coworkerMemberCreateManyMock).toHaveBeenCalledWith({
-      data: [{ roomId: ROOM_ID, coworkerId: addedCoworkerId }],
+      data: [{ roomId: ROOM_ID, coworkerId: SOUPIE_ID }],
     });
     expect(userMemberDeleteManyMock).toHaveBeenCalledWith({
       where: { roomId: ROOM_ID, access: "member" },
@@ -1092,7 +1049,7 @@ describe("PATCH /chats/rooms/{id}", () => {
     const createdIds = userMemberCreateManyMock.mock.calls[0][0].data.map(
       (row: { userId: string }) => row.userId,
     );
-    expect(createdIds).not.toContain(guestId);
+    expect(createdIds).not.toContain(GUEST_ID);
     // Ignore, do not promote: echoed guests must not enter the host upgrade.
     expect(userMemberUpdateManyMock).toHaveBeenCalledWith({
       where: {
@@ -1104,11 +1061,11 @@ describe("PATCH /chats/rooms/{id}", () => {
     });
     expect(
       userMemberUpdateManyMock.mock.calls[0][0].where.userId.in,
-    ).not.toContain(guestId);
+    ).not.toContain(GUEST_ID);
     expect(readStateDeleteManyMock).toHaveBeenCalledWith({
       where: {
         roomId: ROOM_ID,
-        userId: { notIn: expect.arrayContaining([USER_ID, guestId]) },
+        userId: { notIn: expect.arrayContaining([USER_ID, GUEST_ID]) },
       },
     });
   });
@@ -1140,42 +1097,12 @@ describe("PATCH /chats/rooms/{id}", () => {
   });
 
   it("adds a coworker on an external channel when memberUserIds omits guests", async () => {
-    const guestId = "user_guest";
-    const addedCoworkerId = "cow_soupie";
-    const existing = channelRoom({
-      discoverability: "external",
-      userMembers: [
-        {
-          userId: USER_ID,
-          access: "member",
-          user: {
-            id: USER_ID,
-            name: "Ada",
-            email: "ada@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-        {
-          userId: guestId,
-          access: "guest",
-          user: {
-            id: guestId,
-            name: "Guest",
-            email: "guest@example.com",
-            image: null,
-            sessions: [],
-          },
-        },
-      ],
-    });
-    const updated = channelRoom({
-      discoverability: "external",
-      userMembers: existing.userMembers,
+    const existing = externalChannelWithGuest(GUEST_ID);
+    const updated = externalChannelWithGuest(GUEST_ID, {
       coworkerMembers: [
         {
           coworker: {
-            id: addedCoworkerId,
+            id: SOUPIE_ID,
             name: "Soupie",
             slug: "soupie",
             image: null,
@@ -1187,19 +1114,19 @@ describe("PATCH /chats/rooms/{id}", () => {
     memberFindManyMock.mockImplementation(
       async ({ where }: { where: { userId: { in: string[] } } }) =>
         where.userId.in
-          .filter((userId) => userId !== guestId)
+          .filter((userId) => userId !== GUEST_ID)
           .map((userId) => ({ userId })),
     );
     coworkerFindManyMock.mockResolvedValue([
       {
-        id: addedCoworkerId,
+        id: SOUPIE_ID,
         name: "Soupie",
         baseURL: "https://chat.example.com",
       },
     ]);
     roomUpdateMock.mockResolvedValueOnce(updated);
     userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
-    userMemberFindManyMock.mockResolvedValue([{ userId: guestId }]);
+    userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
     userMemberCreateManyMock.mockResolvedValue({ count: 1 });
     readStateDeleteManyMock.mockResolvedValue({ count: 0 });
     readStateCreateManyMock.mockResolvedValue({ count: 0 });
@@ -1213,16 +1140,56 @@ describe("PATCH /chats/rooms/{id}", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         memberUserIds: [USER_ID],
-        coworkerIds: [addedCoworkerId],
+        coworkerIds: [SOUPIE_ID],
       }),
     });
 
     expect(response.status).toBe(200);
     expect(coworkerMemberCreateManyMock).toHaveBeenCalledWith({
-      data: [{ roomId: ROOM_ID, coworkerId: addedCoworkerId }],
+      data: [{ roomId: ROOM_ID, coworkerId: SOUPIE_ID }],
     });
     expect(userMemberDeleteManyMock).toHaveBeenCalledWith({
       where: { roomId: ROOM_ID, access: "member" },
+    });
+  });
+
+  it("upgrades a guest who is now an organization member when they appear in memberUserIds", async () => {
+    const existing = externalChannelWithGuest(GUEST_ID);
+    const updated = externalChannelWithGuest(GUEST_ID, {
+      userMembers: [
+        hostUserMember(USER_ID, "Ada", "ada@example.com"),
+        {
+          ...guestUserMember(GUEST_ID),
+          access: "member",
+        },
+      ],
+    });
+    roomFindFirstMock.mockResolvedValueOnce(existing);
+    roomUpdateMock.mockResolvedValueOnce(updated);
+    userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
+    userMemberUpdateManyMock.mockResolvedValue({ count: 1 });
+    userMemberFindManyMock.mockResolvedValue([{ userId: GUEST_ID }]);
+    userMemberCreateManyMock.mockResolvedValue({ count: 1 });
+    readStateDeleteManyMock.mockResolvedValue({ count: 0 });
+    readStateCreateManyMock.mockResolvedValue({ count: 0 });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        memberUserIds: [USER_ID, GUEST_ID],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(userMemberUpdateManyMock).toHaveBeenCalledWith({
+      where: {
+        roomId: ROOM_ID,
+        userId: { in: expect.arrayContaining([GUEST_ID]) },
+        access: "guest",
+      },
+      data: { access: "member" },
     });
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.test.ts
@@ -1003,4 +1003,208 @@ describe("PATCH /chats/rooms/{id}", () => {
       expect.arrayContaining([expect.stringMatching(/Guest left/i)]),
     );
   });
+
+  it("adds a coworker when memberUserIds echoes existing guests (not org members)", async () => {
+    const guestId = "user_guest";
+    const addedCoworkerId = "cow_soupie";
+    const existing = channelRoom({
+      discoverability: "external",
+      userMembers: [
+        {
+          userId: USER_ID,
+          access: "member",
+          user: {
+            id: USER_ID,
+            name: "Ada",
+            email: "ada@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          userId: guestId,
+          access: "guest",
+          user: {
+            id: guestId,
+            name: "Guest",
+            email: "guest@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+      ],
+    });
+    const updated = channelRoom({
+      discoverability: "external",
+      userMembers: existing.userMembers,
+      coworkerMembers: [
+        {
+          coworker: {
+            id: addedCoworkerId,
+            name: "Soupie",
+            slug: "soupie",
+            image: null,
+          },
+        },
+      ],
+    });
+    roomFindFirstMock.mockResolvedValueOnce(existing);
+    memberFindManyMock.mockImplementation(
+      async ({ where }: { where: { userId: { in: string[] } } }) =>
+        where.userId.in
+          .filter((userId) => userId !== guestId)
+          .map((userId) => ({ userId })),
+    );
+    coworkerFindManyMock.mockResolvedValue([
+      {
+        id: addedCoworkerId,
+        name: "Soupie",
+        baseURL: "https://chat.example.com",
+      },
+    ]);
+    roomUpdateMock.mockResolvedValueOnce(updated);
+    userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
+    userMemberFindManyMock.mockResolvedValue([{ userId: guestId }]);
+    userMemberCreateManyMock.mockResolvedValue({ count: 1 });
+    readStateDeleteManyMock.mockResolvedValue({ count: 0 });
+    readStateCreateManyMock.mockResolvedValue({ count: 0 });
+    coworkerMemberDeleteManyMock.mockResolvedValue({ count: 0 });
+    coworkerMemberCreateManyMock.mockResolvedValue({ count: 1 });
+    mentionUpdateManyMock.mockResolvedValue({ count: 0 });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        memberUserIds: [USER_ID, guestId],
+        coworkerIds: [addedCoworkerId],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(coworkerMemberCreateManyMock).toHaveBeenCalledWith({
+      data: [{ roomId: ROOM_ID, coworkerId: addedCoworkerId }],
+    });
+    expect(userMemberDeleteManyMock).toHaveBeenCalledWith({
+      where: { roomId: ROOM_ID, access: "member" },
+    });
+    const createdIds = userMemberCreateManyMock.mock.calls[0][0].data.map(
+      (row: { userId: string }) => row.userId,
+    );
+    expect(createdIds).not.toContain(guestId);
+  });
+
+  it("still 400s when memberUserIds includes a non-guest who is not an organization member", async () => {
+    const outsiderId = "user_outsider";
+    roomFindFirstMock.mockResolvedValueOnce(channelRoom());
+    memberFindManyMock.mockImplementation(
+      async ({ where }: { where: { userId: { in: string[] } } }) =>
+        where.userId.in
+          .filter((userId) => userId !== outsiderId)
+          .map((userId) => ({ userId })),
+    );
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        memberUserIds: [USER_ID, outsiderId],
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(
+      "Room human members must belong to the organization",
+    );
+    expect(roomUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("adds a coworker on an external channel when memberUserIds omits guests", async () => {
+    const guestId = "user_guest";
+    const addedCoworkerId = "cow_soupie";
+    const existing = channelRoom({
+      discoverability: "external",
+      userMembers: [
+        {
+          userId: USER_ID,
+          access: "member",
+          user: {
+            id: USER_ID,
+            name: "Ada",
+            email: "ada@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+        {
+          userId: guestId,
+          access: "guest",
+          user: {
+            id: guestId,
+            name: "Guest",
+            email: "guest@example.com",
+            image: null,
+            sessions: [],
+          },
+        },
+      ],
+    });
+    const updated = channelRoom({
+      discoverability: "external",
+      userMembers: existing.userMembers,
+      coworkerMembers: [
+        {
+          coworker: {
+            id: addedCoworkerId,
+            name: "Soupie",
+            slug: "soupie",
+            image: null,
+          },
+        },
+      ],
+    });
+    roomFindFirstMock.mockResolvedValueOnce(existing);
+    memberFindManyMock.mockImplementation(
+      async ({ where }: { where: { userId: { in: string[] } } }) =>
+        where.userId.in
+          .filter((userId) => userId !== guestId)
+          .map((userId) => ({ userId })),
+    );
+    coworkerFindManyMock.mockResolvedValue([
+      {
+        id: addedCoworkerId,
+        name: "Soupie",
+        baseURL: "https://chat.example.com",
+      },
+    ]);
+    roomUpdateMock.mockResolvedValueOnce(updated);
+    userMemberDeleteManyMock.mockResolvedValue({ count: 1 });
+    userMemberFindManyMock.mockResolvedValue([{ userId: guestId }]);
+    userMemberCreateManyMock.mockResolvedValue({ count: 1 });
+    readStateDeleteManyMock.mockResolvedValue({ count: 0 });
+    readStateCreateManyMock.mockResolvedValue({ count: 0 });
+    coworkerMemberDeleteManyMock.mockResolvedValue({ count: 0 });
+    coworkerMemberCreateManyMock.mockResolvedValue({ count: 1 });
+    mentionUpdateManyMock.mockResolvedValue({ count: 0 });
+
+    const app = createApp(userAuthContext);
+    const response = await app.request(`/${ROOM_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        memberUserIds: [USER_ID],
+        coworkerIds: [addedCoworkerId],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(coworkerMemberCreateManyMock).toHaveBeenCalledWith({
+      data: [{ roomId: ROOM_ID, coworkerId: addedCoworkerId }],
+    });
+    expect(userMemberDeleteManyMock).toHaveBeenCalledWith({
+      where: { roomId: ROOM_ID, access: "member" },
+    });
+  });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/patch.ts
@@ -27,13 +27,14 @@ import {
   assertChatRoomPatchAuth,
   buildUniqueRoomSlug,
   chatRoomInclude,
+  filterOrganizationUserIds,
   mapChatRoomWithSidebarFlags,
   membershipAccessForUser,
+  normalizeUniqueStrings,
   requireChatRoomUserAccess,
   resolveWorkspaceIdForChatRoom,
   slugifyRoomName,
   validateChatCoworkerIds,
-  validateOrganizationUserIds,
 } from "../helpers";
 import {
   diffChannelMembershipRoster,
@@ -233,11 +234,32 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           let nextCoworkers = priorCoworkers;
 
           if (body.memberUserIds !== undefined) {
-            const memberUserIds = await validateOrganizationUserIds(
+            // Host roster only. Guest ids echoed in memberUserIds are ignored
+            // (they are not org members); they must not 400 the rewrite.
+            const requestedUserIds = normalizeUniqueStrings([
+              userContext.userId,
+              ...body.memberUserIds,
+            ]);
+            const foundHostIds = await filterOrganizationUserIds(
               organizationId,
-              [userContext.userId, ...body.memberUserIds],
+              requestedUserIds,
               tx,
             );
+            const guestIdsOnRoom = new Set(
+              existing.userMembers
+                .filter((member) => member.access === "guest")
+                .map((member) => member.userId),
+            );
+            const unexpected = requestedUserIds.filter(
+              (userId) =>
+                !foundHostIds.includes(userId) && !guestIdsOnRoom.has(userId),
+            );
+            if (unexpected.length > 0) {
+              throw badRequest(
+                "Room human members must belong to the organization",
+              );
+            }
+            const memberUserIds = foundHostIds;
             const users = await tx.user.findMany({
               where: { id: { in: memberUserIds } },
               select: { id: true, name: true },

--- a/apps/core/src/schemas/chat-room.schema.ts
+++ b/apps/core/src/schemas/chat-room.schema.ts
@@ -244,6 +244,8 @@ export const updateChatRoomRequestSchema = z
       .max(MAX_ROOM_MEMBERS)
       .optional()
       .openapi({
+        description:
+          "Host-org roster rewrite. Existing guest members are room-scoped and survive this field: ids already `access=guest` on the room are ignored (not 400) unless they are now organization members, in which case they upgrade to `access=member`. Omit a guest to keep them. Do not use this field to add or remove guests.",
         example: ["user_123", "user_456"],
       }),
     coworkerIds: z

--- a/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-roster.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-roster.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatRoom, Coworker, Member } from "@/lib/clients/generated/core";
+import { EditChannelDialog } from "../edit-channel-dialog";
+
+const { updateRoomActionMock } = vi.hoisted(() => ({
+  updateRoomActionMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/app/chat/actions", () => ({
+  archiveRoomAction: vi.fn(),
+  leaveRoomAction: vi.fn(),
+  updateRoomAction: updateRoomActionMock,
+}));
+
+const HOST_USER_ID = "user-host";
+const GUEST_USER_ID = "user-guest";
+const COWORKER_ID = "cow-soupie";
+
+function hostMember(): Member {
+  return {
+    id: "member-host",
+    organizationId: "org-1",
+    role: "owner",
+    seatAssignedAt: null,
+    createdAt: new Date("2026-07-01T12:00:00.000Z"),
+    lastSeenAt: null,
+    user: {
+      id: HOST_USER_ID,
+      name: "Ada",
+      email: "ada@example.com",
+      image: null,
+    },
+  };
+}
+
+function soupie(): Coworker {
+  return {
+    id: COWORKER_ID,
+    name: "Soupie",
+    slug: "soupie",
+    caption: null,
+    image: null,
+    createdAt: new Date("2026-07-01T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+  } as Coworker;
+}
+
+function externalChannel(): ChatRoom {
+  return {
+    id: "019ff075-f49c-76cf-8104-39905b4fc081",
+    organizationId: "org-1",
+    organizationName: "Acme",
+    name: "general",
+    slug: "general",
+    kind: "channel",
+    directKey: null,
+    topic: null,
+    discoverability: "external",
+    createdByUserId: HOST_USER_ID,
+    createdAt: new Date("2026-07-01T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+    unreadCount: 0,
+    unreadMentionCount: 0,
+    pinnedAt: null,
+    mutedAt: null,
+    markedUnread: false,
+    myAccess: "member",
+    userMembers: [
+      {
+        id: HOST_USER_ID,
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+        presence: "offline",
+        access: "member",
+      },
+      {
+        id: GUEST_USER_ID,
+        name: "Guest",
+        email: "guest@example.com",
+        image: null,
+        presence: "offline",
+        access: "guest",
+      },
+    ],
+    coworkerMembers: [
+      {
+        id: COWORKER_ID,
+        name: "Soupie",
+        slug: "soupie",
+        caption: null,
+        image: null,
+        presence: "offline",
+      },
+    ],
+  };
+}
+
+describe("EditChannelDialog host roster payload", () => {
+  it("omits guest user ids from memberUserIds when saving a coworker onto an external channel", async () => {
+    updateRoomActionMock.mockResolvedValue({
+      ok: true,
+      value: externalChannel(),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <EditChannelDialog
+        channel={externalChannel()}
+        members={[hostMember()]}
+        coworkers={[soupie()]}
+        canEditMembers
+        canManageSettings
+        canArchive
+        canLeave
+        canInviteGuests={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "editChannel" }));
+    await user.click(screen.getByRole("button", { name: "Dialog.save" }));
+
+    await waitFor(() => {
+      expect(updateRoomActionMock).toHaveBeenCalled();
+    });
+
+    const [, body] = updateRoomActionMock.mock.calls[0] as [
+      string,
+      { memberUserIds: string[]; coworkerIds: string[] },
+    ];
+    expect(body.memberUserIds).toEqual([HOST_USER_ID]);
+    expect(body.memberUserIds).not.toContain(GUEST_USER_ID);
+    expect(body.coworkerIds).toEqual([COWORKER_ID]);
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-roster.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-roster.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/app/chat/actions", () => ({
 const HOST_USER_ID = "user-host";
 const GUEST_USER_ID = "user-guest";
 const COWORKER_ID = "cow-soupie";
+const CHANNEL_ID = "019ff075-f49c-76cf-8104-39905b4fc081";
 
 function hostMember(): Member {
   return {
@@ -53,18 +54,33 @@ function hostMember(): Member {
 function soupie(): Coworker {
   return {
     id: COWORKER_ID,
-    name: "Soupie",
-    slug: "soupie",
-    caption: null,
-    image: null,
     createdAt: new Date("2026-07-01T12:00:00.000Z"),
     updatedAt: new Date("2026-07-01T12:00:00.000Z"),
-  } as Coworker;
+    archivedAt: null,
+    isWhitelisted: true,
+    priority: 0,
+    slug: "soupie",
+    name: "Soupie",
+    caption: null,
+    vendor: {
+      id: "vendor-1",
+      createdAt: new Date("2026-07-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T12:00:00.000Z"),
+      name: "Acme",
+      slug: "acme",
+      logos: { light: null, dark: null },
+    },
+    url: null,
+    baseURL: "https://chat.example.com",
+    description: null,
+    capabilities: ["chat"],
+    image: null,
+  };
 }
 
 function externalChannel(): ChatRoom {
   return {
-    id: "019ff075-f49c-76cf-8104-39905b4fc081",
+    id: CHANNEL_ID,
     organizationId: "org-1",
     organizationName: "Acme",
     name: "general",
@@ -100,21 +116,12 @@ function externalChannel(): ChatRoom {
         access: "guest",
       },
     ],
-    coworkerMembers: [
-      {
-        id: COWORKER_ID,
-        name: "Soupie",
-        slug: "soupie",
-        caption: null,
-        image: null,
-        presence: "offline",
-      },
-    ],
+    coworkerMembers: [],
   };
 }
 
 describe("EditChannelDialog host roster payload", () => {
-  it("omits guest user ids from memberUserIds when saving a coworker onto an external channel", async () => {
+  it("omits guest user ids from memberUserIds when adding a coworker on an external channel", async () => {
     updateRoomActionMock.mockResolvedValue({
       ok: true,
       value: externalChannel(),
@@ -135,18 +142,17 @@ describe("EditChannelDialog host roster payload", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "editChannel" }));
+    await user.click(screen.getByText("Soupie"));
     await user.click(screen.getByRole("button", { name: "Dialog.save" }));
 
     await waitFor(() => {
-      expect(updateRoomActionMock).toHaveBeenCalled();
+      expect(updateRoomActionMock).toHaveBeenCalledWith(
+        CHANNEL_ID,
+        expect.objectContaining({
+          memberUserIds: [HOST_USER_ID],
+          coworkerIds: [COWORKER_ID],
+        }),
+      );
     });
-
-    const [, body] = updateRoomActionMock.mock.calls[0] as [
-      string,
-      { memberUserIds: string[]; coworkerIds: string[] },
-    ];
-    expect(body.memberUserIds).toEqual([HOST_USER_ID]);
-    expect(body.memberUserIds).not.toContain(GUEST_USER_ID);
-    expect(body.coworkerIds).toEqual([COWORKER_ID]);
   });
 });

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -58,6 +58,13 @@ function isDiscoverability(value: string): value is Discoverability {
   return value === "public" || value === "private" || value === "external";
 }
 
+/** Host-org roster only. Guests are room-scoped and must not be sent as memberUserIds. */
+function hostRosterUserIds(channel: ChatRoom): string[] {
+  return channel.userMembers
+    .filter((member) => member.access !== "guest")
+    .map((member) => member.id);
+}
+
 export function EditChannelDialog({
   channel,
   members,
@@ -107,8 +114,8 @@ export function EditChannelDialog({
   const [discoverability, setDiscoverability] = useState<Discoverability>(
     channelDiscoverability(channel.discoverability),
   );
-  const [memberIds, setMemberIds] = useState<string[]>(
-    channel.userMembers.map((member) => member.id),
+  const [memberIds, setMemberIds] = useState<string[]>(() =>
+    hostRosterUserIds(channel),
   );
   const [coworkerIds, setCoworkerIds] = useState<string[]>(
     channel.coworkerMembers.map((coworker) => coworker.id),
@@ -122,7 +129,7 @@ export function EditChannelDialog({
     setName(channel.name);
     setTopic(channel.topic ?? "");
     setDiscoverability(channelDiscoverability(channel.discoverability));
-    setMemberIds(channel.userMembers.map((member) => member.id));
+    setMemberIds(hostRosterUserIds(channel));
     setCoworkerIds(channel.coworkerMembers.map((coworker) => coworker.id));
     setGuestMembers(
       channel.userMembers.filter((member) => member.access === "guest"),

--- a/apps/web/src/lib/clients/generated/core/schemas.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/schemas.gen.ts
@@ -6035,6 +6035,7 @@ export const UpdateChatRoomRequestSchema = {
                 minLength: 1
             },
             maxItems: 500,
+            description: 'Host-org roster rewrite. Existing guest members are room-scoped and survive this field: ids already `access=guest` on the room are ignored (not 400) unless they are now organization members, in which case they upgrade to `access=member`. Omit a guest to keep them. Do not use this field to add or remove guests.',
             example: [
                 'user_123',
                 'user_456'

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -1710,6 +1710,9 @@ export type UpdateChatRoomRequest = {
     name?: string;
     topic?: string | null;
     discoverability?: ChatRoomDiscoverability;
+    /**
+     * Host-org roster rewrite. Existing guest members are room-scoped and survive this field: ids already `access=guest` on the room are ignored (not 400) unless they are now organization members, in which case they upgrade to `access=member`. Omit a guest to keep them. Do not use this field to add or remove guests.
+     */
     memberUserIds?: Array<string>;
     coworkerIds?: Array<string>;
 };


### PR DESCRIPTION
## Summary

Saving channel members (for example adding a coworker) on an External channel failed with `Room human members must belong to the organization`.

Edit Channel seeded `memberUserIds` from every room human, including Guests. Guests are room-scoped and are not organization members, so Core rejected the whole roster rewrite — including the coworker add.

## Changes

- Web: host roster payload uses `access !== "guest"` only. Guests stay in the guest section.
- Core: Guest ids echoed in `memberUserIds` are ignored instead of 400ing. A non-guest who is not an org member still 400s.

## Verification

- `pnpm --filter core test src/routes/v1/chats/rooms/[id]/patch.test.ts` — 21 passed
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/edit-channel-dialog` — 2 passed
- Pre-commit: `pnpm check` and `pnpm typecheck` passed

Could not exercise the live mainnet room `019ff075-f49c-76cf-8104-39905b4fc081`.