### PR TITLE
feat(ci): add /deploy all alias

### DIFF
--- a/scripts/ci/__tests__/vercel-deploy.test.mjs
+++ b/scripts/ci/__tests__/vercel-deploy.test.mjs
@@ -106,7 +106,11 @@ describe("isWritePermission", () => {
 describe("usageMessage", () => {
   it("lists the four commands and does not deploy on its own", () => {
     const message = usageMessage();
-    assert.match(message, /\/deploy <mainnet\|preprod\|all>/);
+    assert.match(
+      message,
+      /Usage: `\/deploy <mainnet\|preprod> \[mainnet\|preprod\]` or `\/deploy all`/,
+    );
+    assert.doesNotMatch(message, /<mainnet\|preprod\|all>/);
     assert.match(message, /\/deploy mainnet/);
     assert.match(message, /\/deploy preprod/);
     assert.match(message, /\/deploy mainnet preprod/);

--- a/scripts/ci/__tests__/vercel-deploy.test.mjs
+++ b/scripts/ci/__tests__/vercel-deploy.test.mjs
@@ -44,6 +44,12 @@ describe("parseDeployComment", () => {
       kind: "usage",
     });
     assert.deepEqual(parseDeployComment("/deploy staging"), { kind: "usage" });
+    assert.deepEqual(parseDeployComment("/deploy all mainnet"), {
+      kind: "usage",
+    });
+    assert.deepEqual(parseDeployComment("/deploy all preprod"), {
+      kind: "usage",
+    });
   });
 
   it("parses one or both networks from the first line", () => {
@@ -71,6 +77,14 @@ describe("parseDeployComment", () => {
       kind: "deploy",
       networks: ["mainnet"],
     });
+    assert.deepEqual(parseDeployComment("/deploy all"), {
+      kind: "deploy",
+      networks: ["mainnet", "preprod"],
+    });
+    assert.deepEqual(parseDeployComment("/deploy ALL"), {
+      kind: "deploy",
+      networks: ["mainnet", "preprod"],
+    });
   });
 });
 
@@ -90,12 +104,13 @@ describe("isWritePermission", () => {
 });
 
 describe("usageMessage", () => {
-  it("lists the three commands and does not deploy on its own", () => {
+  it("lists the four commands and does not deploy on its own", () => {
     const message = usageMessage();
-    assert.match(message, /\/deploy <mainnet\|preprod>/);
+    assert.match(message, /\/deploy <mainnet\|preprod\|all>/);
     assert.match(message, /\/deploy mainnet/);
     assert.match(message, /\/deploy preprod/);
     assert.match(message, /\/deploy mainnet preprod/);
+    assert.match(message, /\/deploy all/);
     assert.doesNotMatch(message, /@vercel/);
   });
 });

--- a/scripts/ci/vercel-deploy.mjs
+++ b/scripts/ci/vercel-deploy.mjs
@@ -75,7 +75,7 @@ export function isWritePermission(permission) {
 
 export function usageMessage() {
   return [
-    "Usage: `/deploy <mainnet|preprod|all> [mainnet|preprod]`",
+    "Usage: `/deploy <mainnet|preprod> [mainnet|preprod]` or `/deploy all`",
     "",
     "`/deploy mainnet`",
     "`/deploy preprod`",

--- a/scripts/ci/vercel-deploy.mjs
+++ b/scripts/ci/vercel-deploy.mjs
@@ -55,6 +55,10 @@ export function parseDeployComment(body) {
   }
 
   const unique = [...new Set(rest)];
+  if (unique.length === 1 && unique[0] === "all") {
+    return { kind: "deploy", networks: [...NETWORKS] };
+  }
+
   if (unique.some((token) => !NETWORKS.includes(token))) {
     return { kind: "usage" };
   }
@@ -71,11 +75,12 @@ export function isWritePermission(permission) {
 
 export function usageMessage() {
   return [
-    "Usage: `/deploy <mainnet|preprod> [mainnet|preprod]`",
+    "Usage: `/deploy <mainnet|preprod|all> [mainnet|preprod]`",
     "",
     "`/deploy mainnet`",
     "`/deploy preprod`",
     "`/deploy mainnet preprod`",
+    "`/deploy all`",
     "",
     "Deploys web + core for the named network(s) at this PR's current HEAD. Later pushes stay undeployed until you comment again.",
   ].join("\n");


### PR DESCRIPTION
## Summary

`/deploy all` on a PR comment deploys web + core for both mainnet and preprod at the PR HEAD. Same as `/deploy mainnet preprod`.

Bare `/deploy` help now lists it. Mixed tokens (`/deploy all mainnet`) still get usage.

## Verification

- `pnpm ci:test` — 37/37 pass
- husky `pnpm check && pnpm typecheck` — green