### PR TITLE
fix(core): authorize Drive Tasks files by task workspace

### DIFF
--- a/apps/core/src/routes/v1/drive/tasks/drive-tasks.routes.test.ts
+++ b/apps/core/src/routes/v1/drive/tasks/drive-tasks.routes.test.ts
@@ -190,6 +190,11 @@ describe("Drive Tasks Routes", () => {
     workspaceRepositoryMock.resolveWorkspaceForContext.mockResolvedValue({
       id: "ws_personal",
     });
+    prismaTaskFindFirstMock.mockResolvedValue({
+      id: "tsk_123",
+      archivedAt: null,
+      workspace: { userId: "user_123", organizationId: null },
+    });
   });
 
   describe("GET /v1/drive/tasks - List", () => {
@@ -217,7 +222,12 @@ describe("Drive Tasks Routes", () => {
         );
 
         expect(res.status).toBe(200);
-        expect(requireTaskReadForRouteVarsMock).toHaveBeenCalled();
+        expect(prismaTaskFindFirstMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: "tsk_123", archivedAt: null },
+          }),
+        );
+        expect(requireTaskReadForRouteVarsMock).not.toHaveBeenCalled();
       });
 
       it("omits PENDING and FAILED TaskFiles from results", async () => {
@@ -365,6 +375,30 @@ describe("Drive Tasks Routes", () => {
           name: "booth.pptx",
           fileUrl: "https://example.com/booth.pptx",
         });
+        expect(requireTaskReadForRouteVarsMock).not.toHaveBeenCalled();
+      });
+
+      it("returns 403 when the user is not a member of the task workspace org", async () => {
+        requireTaskReadForRouteVarsMock.mockRejectedValue(
+          forbidden("Workspace is missing"),
+        );
+        prismaTaskFindFirstMock.mockResolvedValue({
+          id: "tsk_foreign",
+          archivedAt: null,
+          workspace: { userId: null, organizationId: "org_other" },
+        });
+        prismaOrganizationFindUniqueMock.mockResolvedValue({
+          id: "org_other",
+        });
+        prismaMemberFindUniqueMock.mockResolvedValue(null);
+
+        const app = createDriveTasksApp();
+        const res = await app.request(
+          "http://localhost/?scope=me&taskId=tsk_foreign",
+        );
+
+        expect(res.status).toBe(403);
+        expect(prismaTaskFileFindManyMock).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/core/src/routes/v1/drive/tasks/drive-tasks.routes.test.ts
+++ b/apps/core/src/routes/v1/drive/tasks/drive-tasks.routes.test.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import type { RequestIdVariables } from "hono/request-id";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { forbidden } from "@/helpers/error";
 import { errorHandler } from "@/helpers/error-handler";
 import type { OpenAPIHonoWithAuth } from "@/lib/hono";
 import type { AuthenticationContext, AuthVariables } from "@/middleware/auth";
@@ -16,9 +17,11 @@ const {
   prismaTaskFileFindUniqueMock,
   prismaTaskFileCountMock,
   prismaTaskFindManyMock,
+  prismaTaskFindFirstMock,
   prismaTaskCountMock,
   prismaProjectFindManyMock,
   prismaMemberFindUniqueMock,
+  prismaOrganizationFindUniqueMock,
   prismaBlobFindManyMock,
   prismaBlobFindFirstMock,
   prismaBlobFindUniqueMock,
@@ -39,9 +42,11 @@ const {
   prismaTaskFileFindUniqueMock: vi.fn(),
   prismaTaskFileCountMock: vi.fn(),
   prismaTaskFindManyMock: vi.fn(),
+  prismaTaskFindFirstMock: vi.fn(),
   prismaTaskCountMock: vi.fn(),
   prismaProjectFindManyMock: vi.fn(),
   prismaMemberFindUniqueMock: vi.fn(),
+  prismaOrganizationFindUniqueMock: vi.fn(),
   prismaBlobFindManyMock: vi.fn(),
   prismaBlobFindFirstMock: vi.fn(),
   prismaBlobFindUniqueMock: vi.fn(),
@@ -69,6 +74,7 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     task: {
       findMany: prismaTaskFindManyMock,
+      findFirst: prismaTaskFindFirstMock,
       count: prismaTaskCountMock,
     },
     project: {
@@ -76,6 +82,9 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     member: {
       findUnique: prismaMemberFindUniqueMock,
+    },
+    organization: {
+      findUnique: prismaOrganizationFindUniqueMock,
     },
     blob: {
       findMany: prismaBlobFindManyMock,
@@ -308,6 +317,54 @@ describe("Drive Tasks Routes", () => {
             },
           }),
         );
+      });
+
+      it("lists READY files for an org task when Drive scope is me and session workspace is missing", async () => {
+        const taskId = "01a019d9-cda2-76f8-902a-d8ce5250ea6f";
+        requireTaskReadForRouteVarsMock.mockRejectedValue(
+          forbidden("Workspace is missing"),
+        );
+        prismaTaskFindFirstMock.mockResolvedValue({
+          id: taskId,
+          archivedAt: null,
+          workspace: { userId: null, organizationId: "org_123" },
+        });
+        prismaOrganizationFindUniqueMock.mockResolvedValue({
+          id: "org_123",
+        });
+        prismaMemberFindUniqueMock.mockResolvedValue({
+          userId: "user_123",
+          organizationId: "org_123",
+          role: "member",
+        });
+        prismaTaskFileFindManyMock.mockResolvedValue([
+          {
+            id: "tf_ready",
+            name: "booth.pptx",
+            fileUrl: "https://example.com/booth.pptx",
+            size: BigInt(4096),
+            mimeType:
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            status: "READY",
+            updatedAt: new Date("2026-08-24T12:00:00.000Z"),
+          },
+        ]);
+        prismaTaskFileCountMock.mockResolvedValue(1);
+
+        const app = createDriveTasksApp();
+        const res = await app.request(
+          `http://localhost/?scope=me&taskId=${taskId}`,
+        );
+
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.data).toHaveLength(1);
+        expect(json.data[0]).toMatchObject({
+          type: "task-file",
+          id: "tf_ready",
+          name: "booth.pptx",
+          fileUrl: "https://example.com/booth.pptx",
+        });
       });
     });
 

--- a/apps/core/src/routes/v1/drive/tasks/get.ts
+++ b/apps/core/src/routes/v1/drive/tasks/get.ts
@@ -6,11 +6,12 @@ import {
   requireCoworkerCapability,
   requireTaskReadForRouteVars,
 } from "@/helpers/access-control";
-import { badRequest, forbidden } from "@/helpers/error";
+import { badRequest, forbidden, notFound } from "@/helpers/error";
 import {
   jsonErrorResponse,
   jsonPaginatedSuccessResponse,
 } from "@/helpers/openapi";
+import { resolveMemberOrganizationById } from "@/helpers/organization";
 import {
   createPaginationMeta,
   parseCursorPagination,
@@ -29,6 +30,44 @@ import {
   driveTasksListSchema,
 } from "@/schemas/drive-tasks.schema";
 import { cursorPaginationQuerySchema } from "@/schemas/pagination.schema";
+
+async function requireUserTaskReadByWorkspaceMembership(
+  userId: string,
+  taskId: string,
+) {
+  const task = await prisma.task.findFirst({
+    where: {
+      id: taskId,
+      archivedAt: null,
+    },
+    include: {
+      workspace: {
+        select: {
+          userId: true,
+          organizationId: true,
+        },
+      },
+    },
+  });
+
+  if (!task) {
+    throw notFound("Task not found");
+  }
+
+  const organizationId = task.workspace.organizationId;
+  if (organizationId) {
+    await resolveMemberOrganizationById({
+      id: organizationId,
+      userId,
+      tx: prisma,
+    });
+    return;
+  }
+
+  if (task.workspace.userId !== userId) {
+    throw notFound("Task not found");
+  }
+}
 
 const query = z
   .object({
@@ -106,6 +145,7 @@ const route = createRoute({
     400: jsonErrorResponse("Bad Request"),
     401: jsonErrorResponse("Unauthorized"),
     403: jsonErrorResponse("Forbidden"),
+    404: jsonErrorResponse("Not Found"),
   },
 });
 
@@ -232,8 +272,15 @@ export default function mount(app: OpenAPIHonoWithAuth) {
 
     // Determine level
     if (taskId) {
-      // Level 3: TaskFile rows (READY + non-null fileUrl) only
-      await requireTaskReadForRouteVars(c.var, taskId);
+      if (isCoworkerAuthContext(authContext)) {
+        await requireTaskReadForRouteVars(c.var, taskId);
+      } else {
+        const userContext = requireUserContext(authContext);
+        await requireUserTaskReadByWorkspaceMembership(
+          userContext.userId,
+          taskId,
+        );
+      }
 
       // After access check, query TaskFiles directly (same filter as Level 2's files.some)
       const [taskFiles, taskFileCount] = await Promise.all([

--- a/apps/core/src/routes/v1/drive/tasks/index.test.ts
+++ b/apps/core/src/routes/v1/drive/tasks/index.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("drive tasks routes", () => {
+  it("enables workspace middleware so Level 3 file reads can resolve", () => {
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "index.ts"),
+      "utf8",
+    );
+    expect(source).toMatch(/includeWorkspaceContext:\s*true/);
+  });
+});

--- a/apps/core/src/routes/v1/drive/tasks/index.ts
+++ b/apps/core/src/routes/v1/drive/tasks/index.ts
@@ -3,7 +3,9 @@ import { OpenAPIHonoWithAuth } from "@/lib/hono";
 import mountCopy from "./copy.js";
 import mountGet from "./get.js";
 
-const app = new OpenAPIHonoWithAuth();
+const app = new OpenAPIHonoWithAuth({
+  includeWorkspaceContext: true,
+});
 
 mountGet(app);
 mountCopy(app);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Drive Tasks Level 3 never showed READY files, including the deep link `?view=tasks&taskId=01a019d9-cda2-76f8-902a-d8ce5250ea6f`. Earlier query filters were correct. The list failed before it read `TaskFile` rows.

`GET /v1/drive/tasks` called `requireTaskReadForRouteVars`, which requires session `workspaceContext`. The Drive Tasks router used `new OpenAPIHonoWithAuth()` without `includeWorkspaceContext: true`, so that context stayed `null` and every Level 3 request returned 403 `Workspace is missing`. The Files card on the task page kept working because `/v1/tasks` already enables workspace middleware.

A scope-less Drive deep link also cannot use session workspace as the ACL. The task lives in its own workspace. The user must be a member of that workspace, not of whatever Drive `scope=me` resolved.

## Scope

- `apps/core/src/routes/v1/drive/tasks/index.ts` enables `includeWorkspaceContext` so coworker Level 3 and copy can still use `requireTaskReadForRouteVars`.
- `apps/core/src/routes/v1/drive/tasks/get.ts` authorizes user Level 3 with `requireUserTaskReadByWorkspaceMembership`. Org tasks use `resolveMemberOrganizationById`. Personal tasks require `workspace.userId === userId`.
- Tests cover the production 403, the org-task + `scope=me` deep link, and a non-member 403.

Out of scope: web UI, TaskFile query filters, copy ACL shape beyond enabling workspace middleware.

## Tradeoffs

User Level 3 no longer ties read access to Better Auth `activeOrganizationId` or Drive `scope`. That matches a `taskId` deep link. Coworkers still use the session helper.

## Blast Radius

Only `GET /v1/drive/tasks` when `taskId` is set, plus Drive Tasks copy once workspace context exists. Users who belong to the task workspace now see READY files. Users who do not still get 403/404. Level 1 and Level 2 stay scope-scoped.

## Verification

Red, then green, on the Core route tests.

```
pnpm --filter core test src/routes/v1/drive/tasks/index.test.ts src/routes/v1/drive/tasks/drive-tasks.routes.test.ts
```

Before the fix the new cases failed with `expected 403 to be 200` and a missing `includeWorkspaceContext` match. After the fix, 28 tests passed.

Authenticated preview of the production task was not possible from this agent. Merge into `cursor/drive-tasks-web-sok-849-d8e0` so the existing preview Core rebuilds, then reopen the `taskId` URL.

Related: SOK-850, SOK-849, SOK-852.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b88b74f-1025-4ed9-ab79-8020f9c8d2ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b88b74f-1025-4ed9-ab79-8020f9c8d2ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

