### PR TITLE
fix(chat): drop hash from channel name placeholder

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5249,7 +5249,7 @@
       "CreateWizard": {
         "title": "Kanal erstellen",
         "nameLabel": "Name",
-        "namePlaceholder": "z. B. #welcome",
+        "namePlaceholder": "z. B. welcome",
         "nameHelp": "Kanäle sind Orte für Gespräche zu einem Thema. Wähle einen klaren Namen, den alle erkennen.",
         "nameRequired": "Kanalname ist erforderlich.",
         "next": "Weiter",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5249,7 +5249,7 @@
       "CreateWizard": {
         "title": "Create a channel",
         "nameLabel": "Name",
-        "namePlaceholder": "e.g. #welcome",
+        "namePlaceholder": "e.g. welcome",
         "nameHelp": "Channels are where conversations happen around a topic. Use a clear name people will recognize.",
         "nameRequired": "Channel name is required.",
         "next": "Next",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5249,7 +5249,7 @@
       "CreateWizard": {
         "title": "Crear un canal",
         "nameLabel": "Nombre",
-        "namePlaceholder": "p. ej. #welcome",
+        "namePlaceholder": "p. ej. welcome",
         "nameHelp": "Los canales son lugares para conversar sobre un tema. Usa un nombre claro que todos reconozcan.",
         "nameRequired": "El nombre del canal es obligatorio.",
         "next": "Siguiente",


### PR DESCRIPTION
The create-channel name field already shows a `#` prefix. The placeholder still said `e.g. #welcome`, which read as `##welcome`.

Placeholder copy is now `e.g. welcome` (and the de/es equivalents). Channel names are `welcome`, `general`, and similar.

## Verification

- `pnpm --filter web messages:parity` — de/es ok
- Husky precommit: `pnpm check` + `pnpm typecheck` passed