### PR TITLE
chore(agents): drop leftover core cursor skill links

### DIFF
--- a/apps/core/.cursor/skills/better-auth-best-practices
+++ b/apps/core/.cursor/skills/better-auth-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/better-auth-best-practices

--- a/apps/core/.cursor/skills/vitest
+++ b/apps/core/.cursor/skills/vitest
@@ -1,1 +1,0 @@
-../../.agents/skills/vitest


### PR DESCRIPTION
## Summary
- Remove leftover `apps/core/.cursor/skills` symlinks for `better-auth-best-practices` and `vitest`.
- Follow-up to #3931, which moved Core skills to `.agents/skills` and dropped `vitest`. These two links still pointed at the old root paths.

## Why
Cursor was still resolving Core skills through dangling `.cursor/skills` copies instead of the installed `.agents/skills` catalog.

## Verification
- Husky `precommit` (`pnpm check && pnpm typecheck`) passed on the commit.
- `git ls-files '**/.cursor/skills/**'` is empty after this change.
- Did not run the app test suite; this change is two unused skill symlinks only.