### PR TITLE
fix(drive): reuse cached list after remount

### DIFF
--- a/apps/web/src/app/(app)/drive/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/drive/__tests__/page.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -111,6 +112,31 @@ vi.mock("@/lib/utils/drive-file-list.client", async (importOriginal) => {
 
 import DrivePage from "@/app/drive/page";
 
+function createDriveQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 60_000,
+      },
+    },
+  });
+}
+
+let queryClient = createDriveQueryClient();
+
+function driveTree() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <DrivePage />
+    </QueryClientProvider>
+  );
+}
+
+function renderDrive() {
+  return render(driveTree());
+}
+
 function reportsFolder() {
   return {
     type: "folder" as const,
@@ -142,6 +168,7 @@ function listedStore() {
 
 describe("DrivePage workspace remount", () => {
   beforeEach(() => {
+    queryClient = createDriveQueryClient();
     searchParams = new URLSearchParams();
     replaceMock.mockReset();
     pushMock.mockReset();
@@ -166,7 +193,7 @@ describe("DrivePage workspace remount", () => {
     const user = userEvent.setup();
     useSessionMock.mockReturnValue(sessionFor("org_a"));
 
-    const { rerender } = render(<DrivePage />);
+    const { rerender } = renderDrive();
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Reports" })).toBeVisible();
@@ -178,7 +205,7 @@ describe("DrivePage workspace remount", () => {
     expect(screen.getByTitle("saveAction")).toBeVisible();
 
     useSessionMock.mockReturnValue(sessionFor("org_b"));
-    rerender(<DrivePage />);
+    rerender(driveTree());
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Reports" })).toBeVisible();
@@ -193,7 +220,7 @@ describe("DrivePage workspace remount", () => {
     searchParams = new URLSearchParams("folder=Reports");
     useSessionMock.mockReturnValue(sessionFor("org_a"));
 
-    const { rerender } = render(<DrivePage />);
+    const { rerender } = renderDrive();
 
     await waitFor(() => {
       expect(listDriveItemsMock).toHaveBeenCalled();
@@ -201,7 +228,7 @@ describe("DrivePage workspace remount", () => {
     expect(replaceMock).not.toHaveBeenCalled();
 
     useSessionMock.mockReturnValue(sessionFor("org_b"));
-    rerender(<DrivePage />);
+    rerender(driveTree());
 
     await waitFor(() => {
       expect(replaceMock).toHaveBeenCalledWith("/drive");
@@ -211,12 +238,12 @@ describe("DrivePage workspace remount", () => {
   it("does not mount personal drive while the session is pending", async () => {
     useSessionMock.mockReturnValue(pendingSession());
 
-    const { rerender } = render(<DrivePage />);
+    const { rerender } = renderDrive();
 
     expect(listDriveItemsMock).not.toHaveBeenCalled();
 
     useSessionMock.mockReturnValue(sessionFor("org_a"));
-    rerender(<DrivePage />);
+    rerender(driveTree());
 
     await waitFor(() => {
       expect(listDriveItemsMock).toHaveBeenCalled();
@@ -232,7 +259,7 @@ describe("DrivePage workspace remount", () => {
   it("does not remount as personal when the session briefly goes pending", async () => {
     useSessionMock.mockReturnValue(sessionFor("org_a"));
 
-    const { rerender } = render(<DrivePage />);
+    const { rerender } = renderDrive();
 
     await waitFor(() => {
       expect(listDriveItemsMock).toHaveBeenCalled();
@@ -240,9 +267,9 @@ describe("DrivePage workspace remount", () => {
     const callsAfterFirstLoad = listDriveItemsMock.mock.calls.length;
 
     useSessionMock.mockReturnValue(pendingSession());
-    rerender(<DrivePage />);
+    rerender(driveTree());
     useSessionMock.mockReturnValue(sessionFor("org_a"));
-    rerender(<DrivePage />);
+    rerender(driveTree());
 
     expect(listDriveItemsMock).toHaveBeenCalledTimes(callsAfterFirstLoad);
     expect(
@@ -252,5 +279,42 @@ describe("DrivePage workspace remount", () => {
           (options as { organizationId?: string }).organizationId === "org_a",
       ),
     ).toBe(true);
+  });
+
+  it("does not refetch the same workspace after a refresh remount", async () => {
+    useSessionMock.mockReturnValue(sessionFor("org_a"));
+
+    const { rerender, unmount } = renderDrive();
+
+    await waitFor(() => {
+      expect(listDriveItemsMock).toHaveBeenCalledTimes(1);
+    });
+
+    useSessionMock.mockReturnValue(sessionFor("org_b"));
+    rerender(driveTree());
+
+    await waitFor(() => {
+      expect(listDriveItemsMock).toHaveBeenCalledTimes(2);
+    });
+    expect(listedStore()).toMatchObject({
+      scope: "org",
+      organizationId: "org_b",
+    });
+
+    unmount();
+    useSessionMock.mockReturnValue(sessionFor("org_b"));
+    renderDrive();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Reports" })).toBeVisible();
+    });
+
+    expect(listDriveItemsMock).toHaveBeenCalledTimes(2);
+    expect(
+      listDriveItemsMock.mock.calls.filter(
+        ([options]) =>
+          (options as { organizationId?: string }).organizationId === "org_b",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/apps/web/src/app/(app)/drive/page.tsx
+++ b/apps/web/src/app/(app)/drive/page.tsx
@@ -300,6 +300,9 @@ function DrivePageWorkspace({
   const [uiWorkspaceId, setUiWorkspaceId] = useState(activeOrganizationId);
 
   const fetchOrgNameAbortRef = useRef<AbortController | null>(null);
+  const debouncedSetSearchQuery = useDebouncedCallback((value: string) => {
+    setDebouncedSearchQuery(value);
+  }, getEnvPublicConfig().NEXT_PUBLIC_KEYBOARD_INPUT_DEBOUNCE_TIME);
 
   if (uiWorkspaceId !== activeOrganizationId) {
     setUiWorkspaceId(activeOrganizationId);
@@ -313,6 +316,7 @@ function DrivePageWorkspace({
     setMoveDialogOpen(false);
     setItemToMove(null);
     setSelectedDestination(null);
+    debouncedSetSearchQuery.cancel();
     setSearchQuery("");
     setDebouncedSearchQuery("");
   }
@@ -330,10 +334,6 @@ function DrivePageWorkspace({
     pathname,
     segments: [{ label: t("breadcrumb"), href: "/drive" }],
   });
-
-  const debouncedSetSearchQuery = useDebouncedCallback((value: string) => {
-    setDebouncedSearchQuery(value);
-  }, getEnvPublicConfig().NEXT_PUBLIC_KEYBOARD_INPUT_DEBOUNCE_TIME);
 
   function handleSearchChange(value: string) {
     setSearchQuery(value);

--- a/apps/web/src/app/(app)/drive/page.tsx
+++ b/apps/web/src/app/(app)/drive/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { getExtensionFromUrl, type Session } from "@sokosumi/utils";
+import { getExtensionFromUrl } from "@sokosumi/utils";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Building2,
   Check,
@@ -18,13 +19,7 @@ import {
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useFormatter, useTranslations } from "next-intl";
-import {
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type ReactElement, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useDebouncedCallback } from "use-debounce";
 import { ListMobileCreateFab } from "@/app/components/list-mobile-create-fab";
@@ -91,6 +86,7 @@ import {
 } from "@/lib/utils/drive-file-upload.client";
 import { classifyFilePreview } from "@/lib/utils/file-preview";
 import { formatBytes } from "@/lib/utils/format-bytes";
+import { DRIVE_ITEMS_QUERY_KEY, getDriveItemsQueryOptions } from "@/queries";
 
 function withoutLegacyDriveScopeParam(
   params: URLSearchParams,
@@ -175,15 +171,6 @@ function FileNameWithPreview({
   );
 }
 
-function workspaceKeyFromSession(
-  session: Session | null | undefined,
-): string | null {
-  if (!session) {
-    return null;
-  }
-  return session.session.activeOrganizationId ?? "personal";
-}
-
 interface DrivePageWorkspaceProps {
   activeOrganizationId: string | null;
 }
@@ -233,24 +220,22 @@ function DriveListSkeleton(): ReactElement {
 
 export default function DrivePage(): ReactElement {
   const { data: session } = useSession();
-  // Pending/refetch must not collapse to "personal" — that remounts Drive twice
-  // (personal, then the real org) on first paint and after router.refresh().
-  const workspaceKeyRef = useRef(workspaceKeyFromSession(session));
-  const nextWorkspaceKey = workspaceKeyFromSession(session);
-  if (nextWorkspaceKey) {
-    workspaceKeyRef.current = nextWorkspaceKey;
+  // Unknown session is not personal. Hold the last known workspace so a
+  // pending refetch cannot switch the list query to `{ scope: "me" }`.
+  const workspaceFromSession = session
+    ? (session.session.activeOrganizationId ?? null)
+    : undefined;
+  const workspaceIdRef = useRef(workspaceFromSession);
+  if (workspaceFromSession !== undefined) {
+    workspaceIdRef.current = workspaceFromSession;
   }
-  const workspaceKey = workspaceKeyRef.current;
-  const activeOrganizationId =
-    workspaceKey && workspaceKey !== "personal" ? workspaceKey : null;
+  const activeOrganizationId = workspaceIdRef.current;
   const router = useRouter();
   const searchParams = useSearchParams();
   const previousWorkspaceIdRef = useRef<string | null | undefined>(undefined);
 
-  // Lives on the wrapper so remounting DrivePageWorkspace cannot treat a
-  // workspace switch as first paint and skip clearing a stale folder query.
   useEffect(() => {
-    if (!session) {
+    if (activeOrganizationId === undefined) {
       return;
     }
     if (previousWorkspaceIdRef.current === undefined) {
@@ -268,9 +253,9 @@ export default function DrivePage(): ReactElement {
     params.delete("folder");
     const query = params.toString();
     router.replace(query ? `/drive?${query}` : "/drive");
-  }, [session, activeOrganizationId, router, searchParams]);
+  }, [activeOrganizationId, router, searchParams]);
 
-  if (!workspaceKey) {
+  if (activeOrganizationId === undefined) {
     return (
       <div className={cn("w-full px-2", LIST_MOBILE_CREATE_FAB_CLEARANCE)}>
         <DriveListSkeleton />
@@ -278,12 +263,7 @@ export default function DrivePage(): ReactElement {
     );
   }
 
-  return (
-    <DrivePageWorkspace
-      key={workspaceKey}
-      activeOrganizationId={activeOrganizationId}
-    />
-  );
+  return <DrivePageWorkspace activeOrganizationId={activeOrganizationId} />;
 }
 
 function DrivePageWorkspace({
@@ -292,11 +272,10 @@ function DrivePageWorkspace({
   const t = useTranslations("App.Drive");
   const formatter = useFormatter();
   const { data: session } = useSession();
+  const queryClient = useQueryClient();
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const [items, setItems] = useState<DriveItem[]>([]);
-  const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [editingItemPath, setEditingItemPath] = useState<string | null>(null);
@@ -318,9 +297,25 @@ function DrivePageWorkspace({
   const [loadingAllFolders, setLoadingAllFolders] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+  const [uiWorkspaceId, setUiWorkspaceId] = useState(activeOrganizationId);
 
-  const loadItemsAbortRef = useRef<AbortController | null>(null);
   const fetchOrgNameAbortRef = useRef<AbortController | null>(null);
+
+  if (uiWorkspaceId !== activeOrganizationId) {
+    setUiWorkspaceId(activeOrganizationId);
+    setEditingItemPath(null);
+    setEditingItemName("");
+    setDeleteDialogOpen(false);
+    setItemToDelete(null);
+    setCreateFolderDialogOpen(false);
+    setNewFolderName("");
+    setSnapshotFolder(null);
+    setMoveDialogOpen(false);
+    setItemToMove(null);
+    setSelectedDestination(null);
+    setSearchQuery("");
+    setDebouncedSearchQuery("");
+  }
 
   const driveStore = driveStoreForActiveWorkspace(activeOrganizationId);
   const scope = driveStore.scope;
@@ -345,40 +340,27 @@ function DrivePageWorkspace({
     debouncedSetSearchQuery(value);
   }
 
-  const loadItems = useCallback(async () => {
-    loadItemsAbortRef.current?.abort();
-    const controller = new AbortController();
-    loadItemsAbortRef.current = controller;
-
-    setLoading(true);
-    try {
-      const loaded = await listDriveItems({
-        ...driveStore,
-        ...(currentFolder ? { folder: currentFolder } : {}),
-        ...(debouncedSearchQuery.trim()
-          ? { q: debouncedSearchQuery.trim() }
-          : {}),
-        signal: controller.signal,
-      });
-
-      if (!controller.signal.aborted) {
-        setItems(loaded);
-      }
-    } catch (err) {
-      if (!controller.signal.aborted) {
-        console.error("Failed to load Drive items", err);
-        toast.error(t("loadFilesError"));
-      }
-    } finally {
-      if (!controller.signal.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [scope, activeOrganizationId, currentFolder, debouncedSearchQuery, t]);
+  const driveItemsQuery = useQuery(
+    getDriveItemsQueryOptions({
+      store: driveStore,
+      folder: currentFolder,
+      search: debouncedSearchQuery,
+    }),
+  );
+  const items = driveItemsQuery.data ?? [];
+  const loading = driveItemsQuery.isPending;
 
   useEffect(() => {
-    void loadItems();
-  }, [loadItems]);
+    if (!driveItemsQuery.isError) {
+      return;
+    }
+    console.error("Failed to load Drive items", driveItemsQuery.error);
+    toast.error(t("loadFilesError"));
+  }, [driveItemsQuery.error, driveItemsQuery.isError, t]);
+
+  async function refreshDriveItems() {
+    await queryClient.invalidateQueries({ queryKey: DRIVE_ITEMS_QUERY_KEY });
+  }
 
   useEffect(() => {
     async function fetchOrganizationName() {
@@ -431,7 +413,7 @@ function DrivePageWorkspace({
         },
       });
 
-      await loadItems();
+      await refreshDriveItems();
     } catch (err) {
       if (isDriveFileUploadDuplicate(err)) {
         toast.error(t("uploadDuplicateError"));
@@ -479,7 +461,7 @@ function DrivePageWorkspace({
 
       setEditingItemPath(null);
       setEditingItemName("");
-      await loadItems();
+      await refreshDriveItems();
     } catch (err) {
       console.error(`Failed to rename ${item.type}`, err);
       if (isDuplicateResourceError(err)) {
@@ -524,7 +506,7 @@ function DrivePageWorkspace({
 
       setDeleteDialogOpen(false);
       setItemToDelete(null);
-      await loadItems();
+      await refreshDriveItems();
     } catch (err) {
       console.error(`Failed to delete ${itemToDelete.type}`, err);
       toast.error(
@@ -610,7 +592,7 @@ function DrivePageWorkspace({
       setCreateFolderDialogOpen(false);
       setNewFolderName("");
       setSnapshotFolder(null);
-      await loadItems();
+      await refreshDriveItems();
     } catch (err) {
       console.error("Failed to create folder", err);
 
@@ -676,7 +658,7 @@ function DrivePageWorkspace({
       setMoveDialogOpen(false);
       setItemToMove(null);
       setSelectedDestination(null);
-      await loadItems();
+      await refreshDriveItems();
     } catch (err) {
       console.error(`Failed to move ${itemToMove.type}`, err);
       toast.error(

--- a/apps/web/src/queries/__tests__/drive.test.ts
+++ b/apps/web/src/queries/__tests__/drive.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getDriveItemsQueryKey,
+  getDriveItemsQueryOptions,
+} from "@/queries/drive";
+
+const listDriveItemsMock = vi.fn();
+
+vi.mock("@/lib/utils/drive-file-list.client", () => ({
+  listDriveItems: (...args: unknown[]) => listDriveItemsMock(...args),
+}));
+
+describe("getDriveItemsQueryOptions", () => {
+  beforeEach(() => {
+    listDriveItemsMock.mockReset();
+  });
+
+  it("keys the list by store, folder, and search", () => {
+    const store = { scope: "org" as const, organizationId: "org_b" };
+
+    expect(
+      getDriveItemsQueryKey({
+        store,
+        folder: "Reports",
+        search: "q",
+      }),
+    ).toEqual(["drive", "items", store, "Reports", "q"]);
+  });
+
+  it("lists the store folder with the search query", async () => {
+    const items = [{ type: "folder", name: "Reports" }];
+    listDriveItemsMock.mockResolvedValue(items);
+    const store = { scope: "org" as const, organizationId: "org_b" };
+
+    const options = getDriveItemsQueryOptions({
+      store,
+      folder: "Reports",
+      search: "  budget  ",
+    });
+    const queryFn = options.queryFn;
+    if (!queryFn) {
+      throw new Error("queryFn is required");
+    }
+
+    const signal = new AbortController().signal;
+    await expect(queryFn({ signal } as never)).resolves.toEqual(items);
+    expect(listDriveItemsMock).toHaveBeenCalledWith({
+      ...store,
+      folder: "Reports",
+      q: "budget",
+      signal,
+    });
+    expect(options.refetchOnWindowFocus).toBe(false);
+  });
+});

--- a/apps/web/src/queries/drive.ts
+++ b/apps/web/src/queries/drive.ts
@@ -1,0 +1,38 @@
+import { queryOptions } from "@tanstack/react-query";
+import {
+  type DriveWorkspaceStore,
+  listDriveItems,
+} from "@/lib/utils/drive-file-list.client";
+
+export const DRIVE_ITEMS_QUERY_KEY = ["drive", "items"] as const;
+
+export function getDriveItemsQueryKey(params: {
+  store: DriveWorkspaceStore;
+  folder: string;
+  search: string;
+}) {
+  return [
+    ...DRIVE_ITEMS_QUERY_KEY,
+    params.store,
+    params.folder,
+    params.search,
+  ] as const;
+}
+
+export function getDriveItemsQueryOptions(params: {
+  store: DriveWorkspaceStore;
+  folder: string;
+  search: string;
+}) {
+  return queryOptions({
+    queryKey: getDriveItemsQueryKey(params),
+    refetchOnWindowFocus: false,
+    queryFn: ({ signal }) =>
+      listDriveItems({
+        ...params.store,
+        ...(params.folder ? { folder: params.folder } : {}),
+        ...(params.search.trim() ? { q: params.search.trim() } : {}),
+        signal,
+      }),
+  });
+}

--- a/apps/web/src/queries/index.ts
+++ b/apps/web/src/queries/index.ts
@@ -1,2 +1,3 @@
+export * from "./drive";
 export * from "./get-query-client";
 export * from "./jobs";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drive listed twice after an org switch because `setActive` remounted the page (`key={workspaceKey}`) and `router.refresh()` remounted it again. Each remount started `loading` as `true` and fetched in a mount effect. Holding the last workspace key cannot survive that unmount.

This replaces the remount workaround with a React Query list keyed by store + folder + search. `QueryProvider` lives above the app-frame Suspense boundary, so a refresh remount reuses the cached list (`isPending` stays false). Workspace-owned UI (rename, dialogs, search) resets in place when `activeOrganizationId` changes. Folder-query cleanup stays on the wrapper. A pending search debounce is cancelled on switch so it cannot refill the new workspace query.

Unknown session is not treated as personal: the last known workspace is held so a pending refetch cannot switch the query to `{ scope: "me" }`.

Root cause confirmed by a remount test that failed on the workaround (`listDriveItems` called 3 times) and passes here (2 calls: once per workspace).

## Linear

[SOK-862](https://linear.app/masumi/issue/SOK-862/drive-acl-must-follow-the-active-workspace)

## Verification

- `pnpm --filter web test src/app/(app)/drive/__tests__/page.test.tsx src/queries/__tests__/drive.test.ts` — 7 passed
- `pnpm --filter web test src/lib/utils/__tests__/drive-file-list.client.test.ts` — 13 passed
- Husky `pnpm check && pnpm typecheck` on each commit

Live org-switch in the browser was not run: Core did not boot in this VM (`DATABASE_URL` / auth env missing from the start wrapper). The remount unit test is the seam that reproduces the double fetch.

## Out of scope

`DriveFilePicker` still remounts on `activeOrganizationId ?? "personal"`. Same pending-as-personal pattern; not the Drive page list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-451b28aa-9152-48cf-9eff-1b705931d32a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-451b28aa-9152-48cf-9eff-1b705931d32a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

