### PR TITLE
fix(chat): drop title-only unfurl cards

### DIFF
--- a/apps/core/src/lib/__tests__/open-graph-html.test.ts
+++ b/apps/core/src/lib/__tests__/open-graph-html.test.ts
@@ -53,6 +53,34 @@ describe("parseOpenGraphFields", () => {
 });
 
 describe("toUnfurlCard", () => {
+  it("returns null when title exists but image and description are missing", () => {
+    expect(
+      toUnfurlCard(
+        {
+          title: "Sign In | Sentry",
+          description: null,
+          image: null,
+          siteName: "Sentry",
+        },
+        "https://masumi.sentry.io",
+        "https://masumi.sentry.io",
+      ),
+    ).toBeNull();
+
+    expect(
+      toUnfurlCard(
+        {
+          title: "Resend",
+          description: "  ",
+          image: null,
+          siteName: "Resend",
+        },
+        "https://resend.com",
+        "https://resend.com",
+      ),
+    ).toBeNull();
+  });
+
   it("requires a non-empty title", () => {
     expect(
       toUnfurlCard(
@@ -105,7 +133,7 @@ describe("toUnfurlCard", () => {
       toUnfurlCard(
         {
           title: "T",
-          description: null,
+          description: "D",
           image: "data:image/png;base64,xxx",
           siteName: null,
         },
@@ -115,9 +143,51 @@ describe("toUnfurlCard", () => {
     ).toEqual({
       url: "https://example.com/page",
       title: "T",
-      description: null,
+      description: "D",
       imageUrl: null,
       siteName: "example.com",
+    });
+  });
+
+  it("keeps a card with a description and no image", () => {
+    expect(
+      toUnfurlCard(
+        {
+          title: "Resend",
+          description: "Email for developers",
+          image: null,
+          siteName: "Resend",
+        },
+        "https://resend.com",
+        "https://resend.com",
+      ),
+    ).toEqual({
+      url: "https://resend.com",
+      title: "Resend",
+      description: "Email for developers",
+      imageUrl: null,
+      siteName: "Resend",
+    });
+  });
+
+  it("keeps a card with an image and no description", () => {
+    expect(
+      toUnfurlCard(
+        {
+          title: "Watch",
+          description: null,
+          image: "https://cdn.example/thumb.jpg",
+          siteName: "YouTube",
+        },
+        "https://youtube.com/watch?v=1",
+        "https://youtube.com/watch?v=1",
+      ),
+    ).toEqual({
+      url: "https://youtube.com/watch?v=1",
+      title: "Watch",
+      description: null,
+      imageUrl: "https://cdn.example/thumb.jpg",
+      siteName: "YouTube",
     });
   });
 
@@ -126,7 +196,7 @@ describe("toUnfurlCard", () => {
       toUnfurlCard(
         {
           title: "Example Domain",
-          description: null,
+          description: "Example description",
           image: null,
           siteName: null,
         },
@@ -139,7 +209,7 @@ describe("toUnfurlCard", () => {
       toUnfurlCard(
         {
           title: "T",
-          description: null,
+          description: "D",
           image: null,
           siteName: "  ",
         },

--- a/apps/core/src/lib/open-graph-html.ts
+++ b/apps/core/src/lib/open-graph-html.ts
@@ -1,3 +1,5 @@
+import { unfurlCardHasPreviewContent } from "@sokosumi/utils";
+
 /** Decoded OG/Twitter/title fields from HTML (no I/O). */
 export interface OpenGraphFields {
   title: string | null;
@@ -160,7 +162,8 @@ function resolveSiteName(
 }
 
 /**
- * Turn OG fields + fetch URL into a DTO card, or null if title missing.
+ * Turn OG fields + fetch URL into a DTO card, or null if title missing
+ * or the card would be title-only (no image and no description).
  * Resolves relative image against `finalUrl`; drops non-http(s) image URLs.
  */
 export function toUnfurlCard(
@@ -174,11 +177,15 @@ export function toUnfurlCard(
   }
 
   const imageUrl = fields.image ? resolveHttpUrl(fields.image, finalUrl) : null;
+  const description = fields.description?.trim() || null;
+  if (!unfurlCardHasPreviewContent({ imageUrl, description })) {
+    return null;
+  }
 
   return {
     url: requestedUrl,
     title,
-    description: fields.description,
+    description,
     imageUrl,
     siteName: resolveSiteName(fields, requestedUrl, finalUrl),
   };

--- a/apps/core/src/services/chat-room-message-unfurl.service.test.ts
+++ b/apps/core/src/services/chat-room-message-unfurl.service.test.ts
@@ -162,6 +162,47 @@ describe("scheduleChatRoomMessageUnfurls", () => {
     expect(publishByIdMock).not.toHaveBeenCalled();
   });
 
+  it("does not persist a title-only unfurl with no image and no description", async () => {
+    messageFindUniqueMock
+      .mockResolvedValueOnce({
+        id: MESSAGE_ID,
+        content: "see https://masumi.sentry.io",
+        deletedAt: null,
+        editedAt: null,
+        metadata: null,
+      })
+      .mockResolvedValueOnce({
+        id: MESSAGE_ID,
+        content: "see https://masumi.sentry.io",
+        deletedAt: null,
+      });
+
+    ssrfSafeFetchMock.mockResolvedValue(
+      new Response(
+        `<html><head><title>Sign In | Sentry</title></head></html>`,
+        {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        },
+      ),
+    );
+
+    const result = await scheduleChatRoomMessageUnfurls(MESSAGE_ID);
+
+    expect(result).toEqual({
+      messageId: MESSAGE_ID,
+      attempted: 1,
+      persisted: 0,
+    });
+    expect(deleteMetadataKeysMock).toHaveBeenCalledWith({
+      messageId: MESSAGE_ID,
+      keys: ["unfurls"],
+      contentMustEqual: "see https://masumi.sentry.io",
+    });
+    expect(mergeMetadataKeysMock).not.toHaveBeenCalled();
+    expect(publishByIdMock).toHaveBeenCalledWith(MESSAGE_ID, "unfurl");
+  });
+
   it("atomically clears unfurls key on empty scrape", async () => {
     messageFindUniqueMock
       .mockResolvedValueOnce({

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1774,6 +1774,114 @@ describe("ChatMessageRow", () => {
     );
   });
 
+  it("hides the unfurl card when the preview image fails and there is no description", () => {
+    renderRow({
+      message: userMessage({
+        content: "https://youtube.com/watch?v=1",
+        unfurls: [
+          {
+            url: "https://youtube.com/watch?v=1",
+            title: "Watch",
+            description: null,
+            imageUrl: "https://cdn.example.com/broken.jpg",
+            siteName: "YouTube",
+          },
+        ],
+      }),
+    });
+
+    fireEvent.error(
+      screen.getByRole("img", { name: "Preview image for Watch" }),
+    );
+
+    expect(screen.queryByTestId("room-message-unfurl")).not.toBeInTheDocument();
+  });
+
+  it("keeps the unfurl card when the preview image fails and a description remains", () => {
+    renderRow({
+      message: userMessage({
+        content: "https://example.com/article",
+        unfurls: [
+          {
+            url: "https://example.com/article",
+            title: "Example Article",
+            description: "A short summary of the page.",
+            imageUrl: "https://cdn.example.com/broken.jpg",
+            siteName: "Example",
+          },
+        ],
+      }),
+    });
+
+    fireEvent.error(
+      screen.getByRole("img", { name: "Preview image for Example Article" }),
+    );
+
+    const card = screen.getByTestId("room-message-unfurl");
+    expect(card).toHaveTextContent("Example Article");
+    expect(card).toHaveTextContent("A short summary of the page.");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("omits title-only unfurl cards that have no image and no description", () => {
+    renderRow({
+      message: userMessage({
+        content: "Check [Sentry](https://masumi.sentry.io)",
+        unfurls: [
+          {
+            url: "https://masumi.sentry.io",
+            title: "Sign In | Sentry",
+            description: null,
+            imageUrl: null,
+            siteName: "masumi.sentry.io",
+          },
+          {
+            url: "https://resend.com",
+            title: "Resend",
+            description: "  ",
+            imageUrl: null,
+            siteName: "resend.com",
+          },
+        ],
+      }),
+    });
+
+    expect(
+      screen.queryByTestId("room-message-unfurls"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders only unfurls that have an image or a description", () => {
+    renderRow({
+      message: userMessage({
+        content:
+          "See [Sentry](https://masumi.sentry.io) and https://example.com/article",
+        unfurls: [
+          {
+            url: "https://masumi.sentry.io",
+            title: "Sign In | Sentry",
+            description: null,
+            imageUrl: null,
+            siteName: "masumi.sentry.io",
+          },
+          {
+            url: "https://example.com/article",
+            title: "Example Article",
+            description: "A short summary of the page.",
+            imageUrl: null,
+            siteName: "Example",
+          },
+        ],
+      }),
+    });
+
+    const cards = screen.getAllByTestId("room-message-unfurl");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toHaveTextContent("Example Article");
+    expect(cards[0]).toHaveTextContent("A short summary of the page.");
+    expect(screen.queryByText("Sign In | Sentry")).not.toBeInTheDocument();
+  });
+
   it("omits unfurl cards when unfurls are null or empty", () => {
     const { rerender } = render(
       <ChatMessageRow
@@ -1809,7 +1917,7 @@ describe("ChatMessageRow", () => {
           {
             url: "https://example.com",
             title: "Example",
-            description: null,
+            description: "Example description",
             imageUrl: null,
             siteName: null,
           },
@@ -1836,14 +1944,14 @@ describe("ChatMessageRow", () => {
           {
             url: "https://ably.com",
             title: "Ably",
-            description: null,
+            description: "Realtime messaging",
             imageUrl: null,
             siteName: "Ably",
           },
           {
             url: "https://resend.com",
             title: "Resend",
-            description: null,
+            description: "Email for developers",
             imageUrl: null,
             siteName: "Resend",
           },
@@ -1869,7 +1977,7 @@ describe("ChatMessageRow", () => {
           {
             url: "https://example.com",
             title: "Example",
-            description: null,
+            description: "Example description",
             imageUrl: null,
             siteName: "Example",
           },
@@ -1892,7 +2000,7 @@ describe("ChatMessageRow", () => {
           {
             url: "https://example.com",
             title: "Example",
-            description: null,
+            description: "Example description",
             imageUrl: null,
             siteName: "Example",
           },
@@ -1915,7 +2023,7 @@ describe("ChatMessageRow", () => {
         {
           url: "https://ably.com",
           title: "Ably",
-          description: null,
+          description: "Realtime messaging",
           imageUrl: null,
           siteName: "Ably",
         },

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1797,6 +1797,61 @@ describe("ChatMessageRow", () => {
     expect(screen.queryByTestId("room-message-unfurl")).not.toBeInTheDocument();
   });
 
+  it("shows a replacement thumbnail after a later scrape when the first image failed", () => {
+    const coworkersById = new Map();
+    const coworkersBySlug = new Map();
+    const first = userMessage({
+      content: "https://youtube.com/watch?v=1",
+      unfurls: [
+        {
+          url: "https://youtube.com/watch?v=1",
+          title: "Watch",
+          description: null,
+          imageUrl: "https://cdn.example.com/broken.jpg",
+          siteName: "YouTube",
+        },
+      ],
+    });
+
+    const { rerender } = render(
+      <ChatMessageRow
+        message={first}
+        coworkersById={coworkersById}
+        coworkersBySlug={coworkersBySlug}
+        onToggleReaction={vi.fn()}
+      />,
+    );
+
+    fireEvent.error(
+      screen.getByRole("img", { name: "Preview image for Watch" }),
+    );
+    expect(screen.queryByTestId("room-message-unfurl")).not.toBeInTheDocument();
+
+    rerender(
+      <ChatMessageRow
+        message={{
+          ...first,
+          unfurls: [
+            {
+              url: "https://youtube.com/watch?v=1",
+              title: "Watch",
+              description: null,
+              imageUrl: "https://cdn.example.com/ok.jpg",
+              siteName: "YouTube",
+            },
+          ],
+        }}
+        coworkersById={coworkersById}
+        coworkersBySlug={coworkersBySlug}
+        onToggleReaction={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Preview image for Watch" }),
+    ).toHaveAttribute("src", "https://cdn.example.com/ok.jpg");
+  });
+
   it("keeps the unfurl card when the preview image fails and a description remains", () => {
     renderRow({
       message: userMessage({

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { type ChannelLinkTarget, getExtensionFromUrl } from "@sokosumi/utils";
+import {
+  type ChannelLinkTarget,
+  getExtensionFromUrl,
+  unfurlCardHasPreviewContent,
+} from "@sokosumi/utils";
 import {
   AlertCircle,
   Check,
@@ -330,16 +334,13 @@ function MessageQuoteBlock({
 function MessageUnfurlImage({
   imageUrl,
   title,
+  onError,
 }: {
   imageUrl: string;
   title: string;
+  onError: () => void;
 }) {
   const t = useTranslations("App.Channels.Unfurl");
-  const [failed, setFailed] = useState(false);
-
-  if (failed) {
-    return null;
-  }
 
   return (
     // eslint-disable-next-line @next/next/no-img-element
@@ -347,9 +348,7 @@ function MessageUnfurlImage({
       src={imageUrl}
       alt={t("imageAlt", { title })}
       className="mt-2 h-auto max-h-48 max-w-full rounded-md"
-      onError={() => {
-        setFailed(true);
-      }}
+      onError={onError}
     />
   );
 }
@@ -364,7 +363,15 @@ function MessageUnfurlCard({
   onRemove?: (url: string) => void;
 }) {
   const t = useTranslations("App.Channels.Unfurl");
+  const [imageFailed, setImageFailed] = useState(false);
   const siteLabel = unfurl.siteName?.trim() || null;
+  const description = unfurl.description?.trim() || null;
+  const imageUrl = unfurl.imageUrl?.trim() || null;
+  const showImage = Boolean(imageUrl) && !imageFailed;
+
+  if (!description && !showImage) {
+    return null;
+  }
 
   return (
     <div className="group relative mt-1.5 inline-block w-fit max-w-full">
@@ -384,13 +391,19 @@ function MessageUnfurlCard({
         <div className="text-foreground line-clamp-2 text-sm font-semibold leading-5">
           {unfurl.title}
         </div>
-        {unfurl.description?.trim() ? (
+        {description ? (
           <div className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-5">
-            {unfurl.description}
+            {description}
           </div>
         ) : null}
-        {unfurl.imageUrl ? (
-          <MessageUnfurlImage imageUrl={unfurl.imageUrl} title={unfurl.title} />
+        {showImage && imageUrl ? (
+          <MessageUnfurlImage
+            imageUrl={imageUrl}
+            title={unfurl.title}
+            onError={() => {
+              setImageFailed(true);
+            }}
+          />
         ) : null}
       </a>
       {canRemove && onRemove ? (
@@ -422,13 +435,14 @@ function MessageUnfurlList({
   canRemove: boolean;
   onRemove?: (url: string) => void;
 }) {
-  if (!unfurls || unfurls.length === 0) {
+  const visible = unfurls?.filter(unfurlCardHasPreviewContent) ?? [];
+  if (visible.length === 0) {
     return null;
   }
 
   return (
     <div className="space-y-1" data-testid="room-message-unfurls">
-      {unfurls.map((unfurl) => (
+      {visible.map((unfurl) => (
         <MessageUnfurlCard
           key={unfurl.url}
           unfurl={unfurl}

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -444,7 +444,7 @@ function MessageUnfurlList({
     <div className="space-y-1" data-testid="room-message-unfurls">
       {visible.map((unfurl) => (
         <MessageUnfurlCard
-          key={unfurl.url}
+          key={`${unfurl.url}:${unfurl.imageUrl ?? ""}`}
           unfurl={unfurl}
           canRemove={canRemove}
           onRemove={onRemove}

--- a/packages/utils/src/__tests__/unfurl-urls.test.ts
+++ b/packages/utils/src/__tests__/unfurl-urls.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractBareHttpUrls,
   selectUnfurlCandidateUrls,
+  unfurlCardHasPreviewContent,
 } from "../unfurl-urls.js";
 
 describe("extractBareHttpUrls", () => {
@@ -77,5 +78,37 @@ describe("selectUnfurlCandidateUrls", () => {
     expect(selectUnfurlCandidateUrls("https://cdn.example/shot.png")).toEqual(
       [],
     );
+  });
+});
+
+describe("unfurlCardHasPreviewContent", () => {
+  it("is false for title-only cards", () => {
+    expect(
+      unfurlCardHasPreviewContent({
+        imageUrl: null,
+        description: null,
+      }),
+    ).toBe(false);
+    expect(
+      unfurlCardHasPreviewContent({
+        imageUrl: "  ",
+        description: "  ",
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when an image or description is present", () => {
+    expect(
+      unfurlCardHasPreviewContent({
+        imageUrl: "https://cdn.example/i.png",
+        description: null,
+      }),
+    ).toBe(true);
+    expect(
+      unfurlCardHasPreviewContent({
+        imageUrl: null,
+        description: "A short summary",
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -333,6 +333,7 @@ export {
 export {
   extractBareHttpUrls,
   selectUnfurlCandidateUrls,
+  type UnfurlPreviewContent,
   unfurlCardHasPreviewContent,
 } from "./unfurl-urls.js";
 export {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -333,6 +333,7 @@ export {
 export {
   extractBareHttpUrls,
   selectUnfurlCandidateUrls,
+  unfurlCardHasPreviewContent,
 } from "./unfurl-urls.js";
 export {
   buildUserMetadataWithDesignMd,

--- a/packages/utils/src/unfurl-urls.ts
+++ b/packages/utils/src/unfurl-urls.ts
@@ -191,10 +191,14 @@ export function selectUnfurlCandidateUrls(markdown: string): string[] {
   return selected;
 }
 
-/** True when an unfurl has a thumbnail or a description (not title-only). */
-export function unfurlCardHasPreviewContent(card: {
+export interface UnfurlPreviewContent {
   imageUrl: string | null;
   description: string | null;
-}): boolean {
+}
+
+/** True when an unfurl has a thumbnail or a description (not title-only). */
+export function unfurlCardHasPreviewContent(
+  card: UnfurlPreviewContent,
+): boolean {
   return Boolean(card.imageUrl?.trim()) || Boolean(card.description?.trim());
 }

--- a/packages/utils/src/unfurl-urls.ts
+++ b/packages/utils/src/unfurl-urls.ts
@@ -190,3 +190,11 @@ export function selectUnfurlCandidateUrls(markdown: string): string[] {
 
   return selected;
 }
+
+/** True when an unfurl has a thumbnail or a description (not title-only). */
+export function unfurlCardHasPreviewContent(card: {
+  imageUrl: string | null;
+  description: string | null;
+}): boolean {
+  return Boolean(card.imageUrl?.trim()) || Boolean(card.description?.trim());
+}


### PR DESCRIPTION
## Summary

Chat no longer shows title-only unfurl chips. A card is kept only when Open Graph gives an image or a description. `Sign In | Sentry` with nothing else is dropped. Description-only and thumbnail previews stay.

Authors can still remove a remaining card (from #3946). Title-only chips are not created, so there is nothing to dismiss for those links.

Rebased onto `main` after #3946. Both intents kept: skip empty chips, keep author-remove on cards that remain.

## User-facing

- Title-only link previews no longer appear under room messages
- Existing stored title-only chips are hidden with no migration
- If a preview image 404s and there is no description, the whole card hides
- Author remove control is unchanged for cards that still qualify

## Verification

- `pnpm --filter @sokosumi/utils test src/__tests__/unfurl-urls.test.ts`
- `pnpm --filter core test src/lib/__tests__/open-graph-html.test.ts src/services/chat-room-message-unfurl.service.test.ts`
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-message-row.test.tsx`
- `pnpm --filter core typecheck` and `pnpm --filter web typecheck`

I did not click through this in a running browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved link previews by hiding title-only cards without an image or description.
  - Preserved descriptions when preview images fail to load.
  - Correctly handles replacement images and filters out empty previews.
  - Ensured invalid or blank preview content is not displayed or persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->