### PR TITLE
fix(chat): pin unfurl dismiss to card corner

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-message-row.test.tsx
@@ -1859,6 +1859,36 @@ describe("ChatMessageRow", () => {
     ).toBeInTheDocument();
   });
 
+  it("places the unfurl remove control on the card corner and only on that card's hover", () => {
+    renderRow({
+      currentUserId: "user-1",
+      onRemoveUnfurl: vi.fn(),
+      message: userMessage({
+        content: "Check https://ably.com",
+        unfurls: [
+          {
+            url: "https://ably.com",
+            title: "Ably",
+            description: null,
+            imageUrl: null,
+            siteName: "Ably",
+          },
+        ],
+      }),
+    });
+
+    const button = screen.getByRole("button", {
+      name: "Remove link preview: Ably",
+    });
+    expect(button.parentElement?.className).toContain("group/unfurl");
+    expect(button.className).toContain("group-hover/unfurl:");
+    expect(button.className).not.toMatch(
+      /(^|\s)\[@media\(hover:hover\)\]:group-hover:/,
+    );
+    expect(button.className).toContain("translate-x-1/2");
+    expect(button.className).toContain("-translate-y-1/2");
+  });
+
   it("does not show unfurl remove for another member", () => {
     renderRow({
       currentUserId: "user-2",

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -367,7 +367,7 @@ function MessageUnfurlCard({
   const siteLabel = unfurl.siteName?.trim() || null;
 
   return (
-    <div className="group relative mt-1.5 inline-block w-fit max-w-full">
+    <div className="group/unfurl relative mt-1.5 inline-block w-fit max-w-full">
       <a
         href={unfurl.url}
         target="_blank"
@@ -398,7 +398,7 @@ function MessageUnfurlCard({
           type="button"
           variant="secondary"
           size="icon"
-          className="border-border absolute top-1 right-1 z-10 size-6 rounded-full border opacity-100 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-hover:opacity-100"
+          className="border-border absolute top-0 right-0 z-10 size-6 translate-x-1/2 -translate-y-1/2 rounded-full border opacity-100 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-focus-within/unfurl:pointer-events-auto [@media(hover:hover)]:group-focus-within/unfurl:opacity-100 [@media(hover:hover)]:group-hover/unfurl:pointer-events-auto [@media(hover:hover)]:group-hover/unfurl:opacity-100"
           aria-label={t("remove", { title: unfurl.title })}
           onClick={(event) => {
             event.preventDefault();
@@ -427,7 +427,10 @@ function MessageUnfurlList({
   }
 
   return (
-    <div className="space-y-1" data-testid="room-message-unfurls">
+    <div
+      className={cn("space-y-1", canRemove && "pr-3")}
+      data-testid="room-message-unfurls"
+    >
       {unfurls.map((unfurl) => (
         <MessageUnfurlCard
           key={unfurl.url}


### PR DESCRIPTION
## Summary

The unfurl dismiss X was showing on message hover (the row `group`) and sitting inset over the card title. It now appears only when that unfurl is hovered or focused, with the button center on the top-right corner.

## Verification

- `pnpm test`
- `pnpm check`
- `pnpm typecheck`

Please confirm on the Vercel preview: hover the message vs hover an unfurl, including a small title-only card and a larger image card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unfurl card controls so the remove button appears consistently in the card’s top-right corner.
  * Refined hover and focus behavior to prevent unintended styling interactions.
  * Added spacing to ensure unfurl content remains clear when removal controls are available.

* **Tests**
  * Added coverage verifying unfurl removal button positioning and hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->