### PR TITLE
chore: disable CodeRabbit docstring coverage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,3 +2,6 @@ reviews:
   review_status: false
   auto_review:
     enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"


### PR DESCRIPTION
## Summary

Turns off CodeRabbit's Docstring Coverage pre-merge check. This repo does not require JSDoc on every function touched by a diff.

Title, description, and issue-assessment pre-merge checks are unchanged.

```yaml
reviews:
  pre_merge_checks:
    docstrings:
      mode: "off"
```

CodeRabbit reads `.coderabbit.yaml` from the branch under review. After this merges, existing PRs pick it up on rebase (or by carrying the same snippet). Re-run with `@coderabbitai run pre-merge checks`.

## Verification

- [ ] On a PR that touches undocumented functions, Docstring Coverage no longer appears in Failed checks
- [ ] Other pre-merge checks still run
- [ ] `mode: "off"` stays a quoted string (unquoted `off` is YAML `false`)
