### PR TITLE
feat(chat): hover mentions for Message card

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/room-composer-quote-preview.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-composer-quote-preview.test.tsx
@@ -1,0 +1,104 @@
+import { render } from "@testing-library/react";
+import { type ReactNode, type Ref, useImperativeHandle } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RoomComposer } from "@/app/chat/components/room-composer";
+import type { RoomMentionParticipant } from "@/app/chat/components/room-helpers";
+import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useFormatter: () => ({
+    dateTime: () => "",
+  }),
+}));
+
+vi.mock("@/components/chat/composer-wysiwyg-editor", () => ({
+  ComposerWysiwygEditor: ({
+    ref,
+  }: {
+    ref?: Ref<{
+      focus: () => void;
+      insertText: (text: string) => void;
+      openMentions: () => void;
+      applyFormat: () => void;
+      insertLink: () => void;
+      getSelectedPlainText: () => string;
+    }>;
+  }) => {
+    useImperativeHandle(ref, () => ({
+      focus: () => undefined,
+      insertText: () => undefined,
+      openMentions: () => undefined,
+      applyFormat: () => undefined,
+      insertLink: () => undefined,
+      getSelectedPlainText: () => "",
+      flushTrailingEmoticon: () => undefined,
+    }));
+    return <div role="textbox" />;
+  },
+}));
+
+vi.mock("@/components/chat/room-message-composer", () => ({
+  ROOM_COMPOSER_TEXTAREA_CLASSNAME: "",
+  ROOM_COMPOSER_TOOL_BUTTON_CLASSNAME: "",
+  RoomComposerEmojiPicker: () => null,
+  RoomMessageComposer: ({ aboveEditor }: { aboveEditor?: ReactNode }) => (
+    <div>{aboveEditor}</div>
+  ),
+}));
+
+vi.mock("@/components/chat/composer-format-toolbar", () => ({
+  ComposerFormatToolbar: () => null,
+}));
+
+vi.mock("@/components/chat/composer-add-link-dialog", () => ({
+  ComposerAddLinkDialog: () => null,
+}));
+
+const coworkerMention: MentionRecordEntry<RoomMentionParticipant> = {
+  value: "Elena",
+  slug: "elena",
+  data: {
+    kind: "coworker",
+    id: "cow_1",
+    name: "Elena",
+    slug: "elena",
+    image: null,
+  },
+};
+
+describe("RoomComposer quote preview mentions", () => {
+  it("keeps sent mention Direct chips when the picker catalog is hidden", () => {
+    const { container } = render(
+      <RoomComposer
+        value=""
+        onValueChange={() => undefined}
+        mentions={{ cow_1: coworkerMention }}
+        onSelectedKeysChange={() => undefined}
+        placeholder="Message"
+        attachments={[]}
+        onAttachmentsChange={() => undefined}
+        onSubmit={(event) => event.preventDefault()}
+        isSending={false}
+        sendDisabled={false}
+        showMentionShortcut={false}
+        allowAttachments={false}
+        pendingQuote={{
+          messageId: "msg-1",
+          authorName: "Ada",
+          snippet: "@cow_1:elena please look",
+          attachment: null,
+        }}
+        onClearPendingQuote={() => undefined}
+        canOpenHumanDirect
+      />,
+    );
+
+    const chip = container.querySelector(
+      '[data-direct-kind="coworker"][data-direct-id="cow_1"]',
+    );
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveTextContent("@Elena");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-composer-quote-preview.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-composer-quote-preview.test.tsx
@@ -1,10 +1,9 @@
 import { render } from "@testing-library/react";
 import { type ReactNode, type Ref, useImperativeHandle } from "react";
 import { describe, expect, it, vi } from "vitest";
-
-import { RoomComposer } from "@/app/chat/components/room-composer";
-import type { RoomMentionParticipant } from "@/app/chat/components/room-helpers";
 import type { MentionRecordEntry } from "@/components/ui/mention-textarea";
+import { RoomComposer } from "../room-composer";
+import type { RoomMentionParticipant } from "../room-helpers";
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -52,7 +52,7 @@ function mention(
 }
 
 function hoverChip(kind: "human" | "coworker", id: string, label: string) {
-  return `<span class="text-primary font-medium" data-direct-kind="${kind}" data-direct-id="${id}">@${label}</span>`;
+  return `<span class="text-primary font-medium whitespace-nowrap" data-direct-kind="${kind}" data-direct-id="${id}">@${label}</span>`;
 }
 
 describe("formatRoomMarkdownMentions", () => {
@@ -108,7 +108,9 @@ describe("formatRoomMarkdownMentions", () => {
 
     expect(formatted).toContain("@Elena");
     expect(formatted).toContain("@Alice Smith");
-    expect(formatted).toContain('class="text-primary font-medium"');
+    expect(formatted).toContain(
+      'class="text-primary font-medium whitespace-nowrap"',
+    );
   });
 
   it("leaves unknown mention tokens unstyled", () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -12,6 +12,7 @@ import {
   membershipVisibleChannelLinks,
   membershipVisibleChannelOptions,
   mergeMembershipVisibleRooms,
+  parseMentionDirectChip,
   partitionRoomMentionSuggestions,
   ROOM_MENTION_ALL_ID,
   ROOM_MENTION_ALL_SLUG,
@@ -50,7 +51,88 @@ function mention(
   };
 }
 
+function directChip(kind: "human" | "coworker", id: string, label: string) {
+  return `<span class="text-primary font-medium cursor-pointer" data-direct-kind="${kind}" data-direct-id="${id}">@${label}</span>`;
+}
+
 describe("formatRoomMarkdownMentions", () => {
+  it("makes a resolved coworker chip a Direct target", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${coworker.id}:${coworker.slug} please look`,
+      coworkersById: new Map([[coworker.id, coworker]]),
+      coworkersBySlug: new Map([[coworker.slug, coworker]]),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+    });
+
+    expect(formatted).toBe(
+      `${directChip("coworker", coworker.id, "Elena")} please look`,
+    );
+  });
+
+  it("makes a resolved human chip a Direct target when human Directs are allowed", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${human.id}:alice-smith please look`,
+      coworkersById: new Map(),
+      coworkersBySlug: new Map(),
+      usersById: new Map([[human.id, human]]),
+      usersBySlug: new Map([["alice-smith", human]]),
+      currentUserId: "user_self",
+      canOpenHumanDirect: true,
+    });
+
+    expect(formatted).toBe(
+      `${directChip("human", human.id, "Alice Smith")} please look`,
+    );
+  });
+
+  it("keeps a self mention as an inert chip", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${human.id}:alice-smith please look`,
+      coworkersById: new Map(),
+      coworkersBySlug: new Map(),
+      usersById: new Map([[human.id, human]]),
+      usersBySlug: new Map([["alice-smith", human]]),
+      currentUserId: human.id,
+      canOpenHumanDirect: true,
+    });
+
+    expect(formatted).toBe(
+      `<span class="text-primary font-medium">@Alice Smith</span> please look`,
+    );
+    expect(formatted).not.toContain("data-direct-kind");
+  });
+
+  it("keeps a human mention inert when human Directs are gated off", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${human.id}:alice-smith please look`,
+      coworkersById: new Map(),
+      coworkersBySlug: new Map(),
+      usersById: new Map([[human.id, human]]),
+      usersBySlug: new Map([["alice-smith", human]]),
+      currentUserId: "user_self",
+      canOpenHumanDirect: false,
+    });
+
+    expect(formatted).toBe(
+      `<span class="text-primary font-medium">@Alice Smith</span> please look`,
+    );
+    expect(formatted).not.toContain("data-direct-kind");
+  });
+
+  it("still makes a coworker chip a Direct target when human Directs are gated off", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${coworker.id}:${coworker.slug}`,
+      coworkersById: new Map([[coworker.id, coworker]]),
+      coworkersBySlug: new Map([[coworker.slug, coworker]]),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+      canOpenHumanDirect: false,
+    });
+
+    expect(formatted).toBe(directChip("coworker", coworker.id, "Elena"));
+  });
+
   it("renders coworker and human mention chips from tokens", () => {
     const content = `@${coworker.id}:${coworker.slug} please ping @${human.id}:alice-smith`;
     const formatted = formatRoomMarkdownMentions({
@@ -102,9 +184,7 @@ describe("formatRoomMarkdownMentions", () => {
       usersBySlug: new Map(),
     });
 
-    expect(formatted).toContain(
-      '<span class="text-primary font-medium">@Elena</span>',
-    );
+    expect(formatted).toContain(directChip("coworker", coworker.id, "Elena"));
     expect(formatted).toContain("and @nobody please");
     expect(formatted.match(/text-primary/g)).toHaveLength(1);
   });
@@ -116,10 +196,12 @@ describe("formatRoomMarkdownMentions", () => {
       coworkersBySlug: new Map(),
       usersById: new Map(),
       usersBySlug: new Map(),
+      canOpenHumanDirect: true,
     });
 
     expect(formatted).toContain(">@all</span>");
     expect(formatted).not.toContain("@all:all");
+    expect(formatted).not.toContain("data-direct-kind");
   });
 
   it("renders bare @all as an @all chip", () => {
@@ -132,6 +214,38 @@ describe("formatRoomMarkdownMentions", () => {
     });
 
     expect(formatted).toContain(">@all</span>");
+  });
+});
+
+describe("parseMentionDirectChip", () => {
+  it("reads kind and id from a formatted Direct chip", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${coworker.id}:${coworker.slug}`,
+      coworkersById: new Map([[coworker.id, coworker]]),
+      coworkersBySlug: new Map([[coworker.slug, coworker]]),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+    });
+    const root = document.createElement("div");
+    root.innerHTML = formatted;
+    const chip = root.querySelector("[data-direct-kind]");
+    expect(chip).not.toBeNull();
+    expect(parseMentionDirectChip(chip as Element)).toEqual({
+      kind: "coworker",
+      id: coworker.id,
+    });
+  });
+
+  it("rejects inert mention chips and Channel links", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<span class="text-primary font-medium">@all</span> <a href="/chat/rooms/room-1">#general</a>';
+    const allChip = root.querySelector("span");
+    const channelLink = root.querySelector("a");
+    expect(allChip).not.toBeNull();
+    expect(channelLink).not.toBeNull();
+    expect(parseMentionDirectChip(allChip as Element)).toBeNull();
+    expect(parseMentionDirectChip(channelLink as Element)).toBeNull();
   });
 });
 
@@ -152,9 +266,7 @@ describe("formatRoomMarkdownContent", () => {
       ],
     });
 
-    expect(formatted).toContain(
-      '<span class="text-primary font-medium">@Elena</span>',
-    );
+    expect(formatted).toContain(directChip("coworker", coworker.id, "Elena"));
     expect(formatted).toContain("[#general](/chat/rooms/room-general)");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -51,12 +51,12 @@ function mention(
   };
 }
 
-function directChip(kind: "human" | "coworker", id: string, label: string) {
-  return `<span class="text-primary font-medium cursor-pointer" data-direct-kind="${kind}" data-direct-id="${id}">@${label}</span>`;
+function hoverChip(kind: "human" | "coworker", id: string, label: string) {
+  return `<span class="text-primary font-medium" data-direct-kind="${kind}" data-direct-id="${id}">@${label}</span>`;
 }
 
 describe("formatRoomMarkdownMentions", () => {
-  it("makes a resolved coworker chip a Direct target", () => {
+  it("identifies a resolved coworker chip for hover", () => {
     const formatted = formatRoomMarkdownMentions({
       content: `@${coworker.id}:${coworker.slug} please look`,
       coworkersById: new Map([[coworker.id, coworker]]),
@@ -66,71 +66,34 @@ describe("formatRoomMarkdownMentions", () => {
     });
 
     expect(formatted).toBe(
-      `${directChip("coworker", coworker.id, "Elena")} please look`,
+      `${hoverChip("coworker", coworker.id, "Elena")} please look`,
     );
   });
 
-  it("makes a resolved human chip a Direct target when human Directs are allowed", () => {
+  it("identifies a resolved human chip for hover", () => {
     const formatted = formatRoomMarkdownMentions({
       content: `@${human.id}:alice-smith please look`,
       coworkersById: new Map(),
       coworkersBySlug: new Map(),
       usersById: new Map([[human.id, human]]),
       usersBySlug: new Map([["alice-smith", human]]),
-      currentUserId: "user_self",
-      canOpenHumanDirect: true,
     });
 
     expect(formatted).toBe(
-      `${directChip("human", human.id, "Alice Smith")} please look`,
+      `${hoverChip("human", human.id, "Alice Smith")} please look`,
     );
   });
 
-  it("keeps a self mention as an inert chip", () => {
-    const formatted = formatRoomMarkdownMentions({
-      content: `@${human.id}:alice-smith please look`,
-      coworkersById: new Map(),
-      coworkersBySlug: new Map(),
-      usersById: new Map([[human.id, human]]),
-      usersBySlug: new Map([["alice-smith", human]]),
-      currentUserId: human.id,
-      canOpenHumanDirect: true,
-    });
-
-    expect(formatted).toBe(
-      `<span class="text-primary font-medium">@Alice Smith</span> please look`,
-    );
-    expect(formatted).not.toContain("data-direct-kind");
-  });
-
-  it("keeps a human mention inert when human Directs are gated off", () => {
-    const formatted = formatRoomMarkdownMentions({
-      content: `@${human.id}:alice-smith please look`,
-      coworkersById: new Map(),
-      coworkersBySlug: new Map(),
-      usersById: new Map([[human.id, human]]),
-      usersBySlug: new Map([["alice-smith", human]]),
-      currentUserId: "user_self",
-      canOpenHumanDirect: false,
-    });
-
-    expect(formatted).toBe(
-      `<span class="text-primary font-medium">@Alice Smith</span> please look`,
-    );
-    expect(formatted).not.toContain("data-direct-kind");
-  });
-
-  it("still makes a coworker chip a Direct target when human Directs are gated off", () => {
+  it("still identifies a coworker chip when the human roster is empty", () => {
     const formatted = formatRoomMarkdownMentions({
       content: `@${coworker.id}:${coworker.slug}`,
       coworkersById: new Map([[coworker.id, coworker]]),
       coworkersBySlug: new Map([[coworker.slug, coworker]]),
       usersById: new Map(),
       usersBySlug: new Map(),
-      canOpenHumanDirect: false,
     });
 
-    expect(formatted).toBe(directChip("coworker", coworker.id, "Elena"));
+    expect(formatted).toBe(hoverChip("coworker", coworker.id, "Elena"));
   });
 
   it("renders coworker and human mention chips from tokens", () => {
@@ -168,8 +131,6 @@ describe("formatRoomMarkdownMentions", () => {
       coworkersBySlug: new Map(),
       usersById: new Map(),
       usersBySlug: new Map(),
-      currentUserId: "user_self",
-      canOpenHumanDirect: true,
     });
 
     expect(formatted).toBe(`@${human.id}:alice-smith please look`);
@@ -200,7 +161,7 @@ describe("formatRoomMarkdownMentions", () => {
       usersBySlug: new Map(),
     });
 
-    expect(formatted).toContain(directChip("coworker", coworker.id, "Elena"));
+    expect(formatted).toContain(hoverChip("coworker", coworker.id, "Elena"));
     expect(formatted).toContain("and @nobody please");
     expect(formatted.match(/text-primary/g)).toHaveLength(1);
   });
@@ -212,7 +173,6 @@ describe("formatRoomMarkdownMentions", () => {
       coworkersBySlug: new Map(),
       usersById: new Map(),
       usersBySlug: new Map(),
-      canOpenHumanDirect: true,
     });
 
     expect(formatted).toContain(">@all</span>");
@@ -282,7 +242,7 @@ describe("formatRoomMarkdownContent", () => {
       ],
     });
 
-    expect(formatted).toContain(directChip("coworker", coworker.id, "Elena"));
+    expect(formatted).toContain(hoverChip("coworker", coworker.id, "Elena"));
     expect(formatted).toContain("[#general](/chat/rooms/room-general)");
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts
@@ -161,6 +161,22 @@ describe("formatRoomMarkdownMentions", () => {
     expect(formatted).not.toContain("text-primary");
   });
 
+  it("leaves a departed roster mention unstyled", () => {
+    const formatted = formatRoomMarkdownMentions({
+      content: `@${human.id}:alice-smith please look`,
+      coworkersById: new Map(),
+      coworkersBySlug: new Map(),
+      usersById: new Map(),
+      usersBySlug: new Map(),
+      currentUserId: "user_self",
+      canOpenHumanDirect: true,
+    });
+
+    expect(formatted).toBe(`@${human.id}:alice-smith please look`);
+    expect(formatted).not.toContain("data-direct-kind");
+    expect(formatted).not.toContain("text-primary");
+  });
+
   it("does not highlight bare @words or email local-parts", () => {
     const formatted = formatRoomMarkdownMentions({
       content: "ping @nobody and alice@example.com",

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx
@@ -58,4 +58,25 @@ describe("RoomMessageMarkdown mention hover", () => {
     expect(card).toHaveTextContent("AI coworker");
     expect(card).toHaveTextContent("Message");
   });
+
+  it("keeps the mention chip mounted when parent lookups change", () => {
+    const props = {
+      content: `@${coworker.id}:${coworker.slug} please look`,
+      coworkersById: new Map([[coworker.id, coworker]]),
+      coworkersBySlug: new Map([[coworker.slug, coworker]]),
+    };
+    const { rerender } = render(
+      <RoomMessageMarkdown {...props} openingDirectParticipantKey={null} />,
+    );
+    const chip = screen.getByRole("button", { name: "Elena" });
+
+    rerender(
+      <RoomMessageMarkdown
+        {...props}
+        openingDirectParticipantKey="coworker:cow_1"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Elena" })).toBe(chip);
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatRoomCoworkerParticipant } from "@/lib/clients/generated/core";
+import { RoomMessageMarkdown } from "../room-mention-markdown";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const labels: Record<string, string> = {
+      coworkerBadge: "AI coworker",
+      humanBadge: "Human",
+      openDirectMessage: "Message",
+    };
+    return labels[key] ?? key;
+  },
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    "data-testid"?: string;
+  }) => <div {...props}>{children}</div>,
+}));
+
+const coworker: ChatRoomCoworkerParticipant = {
+  id: "cow_1",
+  name: "Elena",
+  slug: "elena",
+  caption: "Research assistant",
+  image: null,
+  presence: "online",
+};
+
+describe("RoomMessageMarkdown mention hover", () => {
+  it("shows the participant card and Message on a resolved coworker chip", async () => {
+    const user = userEvent.setup();
+    const onOpenDirect = vi.fn();
+    render(
+      <RoomMessageMarkdown
+        content={`@${coworker.id}:${coworker.slug} please look`}
+        coworkersById={new Map([[coworker.id, coworker]])}
+        coworkersBySlug={new Map([[coworker.slug, coworker]])}
+        onOpenDirectMessage={onOpenDirect}
+        canOpenHumanDirect
+      />,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Elena" }));
+
+    const card = screen.getByTestId("chat-participant-hover-card");
+    expect(card).toHaveTextContent("Elena");
+    expect(card).toHaveTextContent("AI coworker");
+    expect(card).toHaveTextContent("Message");
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx
@@ -79,4 +79,23 @@ describe("RoomMessageMarkdown mention hover", () => {
 
     expect(screen.getByRole("button", { name: "Elena" })).toBe(chip);
   });
+
+  it("survives a blank-to-nonblank rerender", () => {
+    const maps = {
+      coworkersById: new Map([[coworker.id, coworker]]),
+      coworkersBySlug: new Map([[coworker.slug, coworker]]),
+    };
+    const { rerender } = render(
+      <RoomMessageMarkdown content="   " {...maps} />,
+    );
+
+    rerender(
+      <RoomMessageMarkdown
+        content={`@${coworker.id}:${coworker.slug} please look`}
+        {...maps}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Elena" })).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
+++ b/apps/web/src/app/(app)/chat/components/chat-participant-hover-card.tsx
@@ -44,6 +44,8 @@ interface ChatParticipantHoverCardProps {
    * a link/row that already owns activation). Still hoverable.
    */
   interactive?: boolean;
+  openDelay?: number;
+  closeDelay?: number;
 }
 
 interface TriggerChildProps {
@@ -149,6 +151,8 @@ export function ChatParticipantHoverCard({
   isOpeningDirect = false,
   isDirectActionBusy = false,
   interactive = true,
+  openDelay = 200,
+  closeDelay = 100,
 }: ChatParticipantHoverCardProps) {
   const t = useTranslations("App.Channels");
 
@@ -170,7 +174,7 @@ export function ChatParticipantHoverCard({
   });
 
   return (
-    <HoverCard openDelay={200} closeDelay={100}>
+    <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
       <HoverCardTrigger asChild>
         {renderHoverTrigger({
           profileName: profile.name,

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -538,7 +538,7 @@ export function RoomComposer({
               <PendingQuotePreview
                 quote={pendingQuote}
                 onDismiss={onClearPendingQuote}
-                mentions={composerMentions}
+                mentions={mentions}
                 channelLinks={channelLinks}
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -69,7 +69,9 @@ import {
 import { getInitials } from "@/lib/utils/text";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import {
+  type ChatParticipantHoverProfile,
   formatRoomMarkdownContent,
+  handleSentMentionDirectClick,
   type PendingRoomQuote,
   partitionRoomMentionSuggestions,
   ROOM_QUOTE_MARKDOWN_CLASSNAME,
@@ -170,11 +172,17 @@ function PendingQuotePreview({
   onDismiss,
   mentions,
   channelLinks,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirectMessage,
 }: {
   quote: PendingRoomQuote;
   onDismiss: () => void;
   mentions: Record<string, MentionRecordEntry<RoomMentionParticipant>>;
   channelLinks: readonly ChannelLinkTarget[];
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }) {
   const t = useTranslations("App.Channels.Quote");
   const { coworkersById, coworkersBySlug, usersById, usersBySlug } =
@@ -202,7 +210,16 @@ function PendingQuotePreview({
             />
           ) : null}
           {quote.snippet.trim() ? (
-            <div className="text-muted-foreground line-clamp-4 min-w-0 flex-1 text-xs leading-5">
+            <div
+              className="text-muted-foreground line-clamp-4 min-w-0 flex-1 text-xs leading-5"
+              onClick={(event) => {
+                handleSentMentionDirectClick(event, {
+                  coworkersById,
+                  usersById,
+                  onOpenDirect: onOpenDirectMessage,
+                });
+              }}
+            >
               <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
                 {formatRoomMarkdownContent({
                   content: quote.snippet,
@@ -210,6 +227,8 @@ function PendingQuotePreview({
                   coworkersBySlug,
                   usersById,
                   usersBySlug,
+                  currentUserId,
+                  canOpenHumanDirect,
                   channelLinks,
                 })}
               </Markdown>
@@ -253,6 +272,9 @@ export function RoomComposer({
   onClearPendingQuote,
   onChromeResize,
   focusOnMount = false,
+  currentUserId,
+  canOpenHumanDirect = false,
+  onOpenDirectMessage,
 }: {
   ref?: Ref<RoomComposerHandle>;
   /** When set, attaches mint via room chat file endpoint. */
@@ -283,6 +305,9 @@ export function RoomComposer({
   onChromeResize?: () => void;
   /** Focus the editor after mount (room/thread open). */
   focusOnMount?: boolean;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }) {
   const t = useTranslations("App.Channels");
   const tToolbar = useTranslations("App.Channels.Toolbar");
@@ -515,6 +540,9 @@ export function RoomComposer({
                 onDismiss={onClearPendingQuote}
                 mentions={composerMentions}
                 channelLinks={channelLinks}
+                currentUserId={currentUserId}
+                canOpenHumanDirect={canOpenHumanDirect}
+                onOpenDirectMessage={onOpenDirectMessage}
               />
             ) : null}
             {formatToolbarOpen ? (

--- a/apps/web/src/app/(app)/chat/components/room-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-composer.tsx
@@ -45,7 +45,6 @@ import {
 } from "@/components/chat/room-message-composer";
 import { AttachmentSubmenu } from "@/components/drive/attachment-submenu";
 import { DriveFilePicker } from "@/components/drive/drive-file-picker";
-import Markdown from "@/components/markdown";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { FileChipMiniPreview } from "@/components/ui/file-chip-mini-preview";
@@ -70,13 +69,12 @@ import { getInitials } from "@/lib/utils/text";
 import { AiCoworkerIcon } from "./room-draft-shared";
 import {
   type ChatParticipantHoverProfile,
-  formatRoomMarkdownContent,
-  handleSentMentionDirectClick,
   type PendingRoomQuote,
   partitionRoomMentionSuggestions,
   ROOM_QUOTE_MARKDOWN_CLASSNAME,
   type RoomMentionParticipant,
 } from "./room-helpers";
+import { RoomMessageMarkdown } from "./room-mention-markdown";
 
 export interface RoomComposerAttachment extends RoomMessageComposerAttachment {
   mediaType: string | null;
@@ -175,6 +173,7 @@ function PendingQuotePreview({
   currentUserId,
   canOpenHumanDirect,
   onOpenDirectMessage,
+  openingDirectParticipantKey,
 }: {
   quote: PendingRoomQuote;
   onDismiss: () => void;
@@ -183,6 +182,7 @@ function PendingQuotePreview({
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }) {
   const t = useTranslations("App.Channels.Quote");
   const { coworkersById, coworkersBySlug, usersById, usersBySlug } =
@@ -210,28 +210,20 @@ function PendingQuotePreview({
             />
           ) : null}
           {quote.snippet.trim() ? (
-            <div
-              className="text-muted-foreground line-clamp-4 min-w-0 flex-1 text-xs leading-5"
-              onClick={(event) => {
-                handleSentMentionDirectClick(event, {
-                  coworkersById,
-                  usersById,
-                  onOpenDirect: onOpenDirectMessage,
-                });
-              }}
-            >
-              <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
-                {formatRoomMarkdownContent({
-                  content: quote.snippet,
-                  coworkersById,
-                  coworkersBySlug,
-                  usersById,
-                  usersBySlug,
-                  currentUserId,
-                  canOpenHumanDirect,
-                  channelLinks,
-                })}
-              </Markdown>
+            <div className="text-muted-foreground line-clamp-4 min-w-0 flex-1 text-xs leading-5">
+              <RoomMessageMarkdown
+                content={quote.snippet}
+                markdownClassName={ROOM_QUOTE_MARKDOWN_CLASSNAME}
+                coworkersById={coworkersById}
+                coworkersBySlug={coworkersBySlug}
+                usersById={usersById}
+                usersBySlug={usersBySlug}
+                channelLinks={channelLinks}
+                currentUserId={currentUserId}
+                canOpenHumanDirect={canOpenHumanDirect}
+                onOpenDirectMessage={onOpenDirectMessage}
+                openingDirectParticipantKey={openingDirectParticipantKey}
+              />
             </div>
           ) : null}
         </div>
@@ -275,6 +267,7 @@ export function RoomComposer({
   currentUserId,
   canOpenHumanDirect = false,
   onOpenDirectMessage,
+  openingDirectParticipantKey = null,
 }: {
   ref?: Ref<RoomComposerHandle>;
   /** When set, attaches mint via room chat file endpoint. */
@@ -308,6 +301,7 @@ export function RoomComposer({
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }) {
   const t = useTranslations("App.Channels");
   const tToolbar = useTranslations("App.Channels.Toolbar");
@@ -543,6 +537,7 @@ export function RoomComposer({
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}
                 onOpenDirectMessage={onOpenDirectMessage}
+                openingDirectParticipantKey={openingDirectParticipantKey}
               />
             ) : null}
             {formatToolbarOpen ? (

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -580,7 +580,7 @@ export interface MentionDirectTarget {
   id: string;
 }
 
-const MENTION_CHIP_CLASSNAME = "text-primary font-medium";
+const MENTION_CHIP_CLASSNAME = "text-primary font-medium whitespace-nowrap";
 
 export type MentionHoverUserLookup = Pick<
   ChatRoomUserParticipant,

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -581,7 +581,31 @@ export interface MentionDirectTarget {
 }
 
 const MENTION_CHIP_CLASSNAME = "text-primary font-medium";
-const MENTION_DIRECT_CHIP_CLASSNAME = `${MENTION_CHIP_CLASSNAME} cursor-pointer`;
+
+export type MentionHoverUserLookup = Pick<
+  ChatRoomUserParticipant,
+  "id" | "name"
+> &
+  Partial<Pick<ChatRoomUserParticipant, "email" | "image" | "presence">>;
+
+export function mentionDirectTargetFromAttributes(
+  attributes: Record<string, unknown>,
+): MentionDirectTarget | null {
+  const kindRaw =
+    attributes["data-direct-kind"] ??
+    attributes.dataDirectKind ??
+    attributes["data-directKind"];
+  const idRaw =
+    attributes["data-direct-id"] ??
+    attributes.dataDirectId ??
+    attributes["data-directId"];
+  const kind = typeof kindRaw === "string" ? kindRaw : null;
+  const id = typeof idRaw === "string" ? idRaw : null;
+  if ((kind !== "human" && kind !== "coworker") || !id) {
+    return null;
+  }
+  return { kind, id };
+}
 
 export function parseMentionDirectChip(
   node: Element,
@@ -590,19 +614,24 @@ export function parseMentionDirectChip(
   if (!(host instanceof HTMLElement)) {
     return null;
   }
-  const kind = host.dataset.directKind;
-  const id = host.dataset.directId;
-  if ((kind !== "human" && kind !== "coworker") || !id) {
-    return null;
+  return mentionDirectTargetFromAttributes({
+    "data-direct-kind": host.dataset.directKind,
+    "data-direct-id": host.dataset.directId,
+  });
+}
+
+function humanPresence(value: unknown): ChatRoomPresence {
+  if (value === "online" || value === "afk" || value === "offline") {
+    return value;
   }
-  return { kind, id };
+  return "offline";
 }
 
 export function chatParticipantProfileForDirectTarget(
   target: MentionDirectTarget,
   lookups: {
     coworkersById: Map<string, ChatRoomCoworkerParticipant>;
-    usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+    usersById?: Map<string, MentionHoverUserLookup>;
   },
 ): ChatParticipantHoverProfile | null {
   if (target.kind === "coworker") {
@@ -628,46 +657,10 @@ export function chatParticipantProfileForDirectTarget(
     kind: "human",
     id: user.id,
     name: user.name,
-    email: "",
-    image: null,
-    presence: "offline",
+    email: user.email ?? "",
+    image: user.image ?? null,
+    presence: humanPresence(user.presence),
   };
-}
-
-export function handleSentMentionDirectClick(
-  event: {
-    target: EventTarget | null;
-    preventDefault: () => void;
-    stopPropagation: () => void;
-  },
-  options: {
-    coworkersById: Map<string, ChatRoomCoworkerParticipant>;
-    usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-    onOpenDirect?: (profile: ChatParticipantHoverProfile) => void;
-  },
-): boolean {
-  if (!(event.target instanceof Node)) {
-    return false;
-  }
-  const element =
-    event.target instanceof Element ? event.target : event.target.parentElement;
-  if (!element) {
-    return false;
-  }
-  const target = parseMentionDirectChip(element);
-  if (!target) {
-    return false;
-  }
-  event.preventDefault();
-  event.stopPropagation();
-  const profile = chatParticipantProfileForDirectTarget(target, {
-    coworkersById: options.coworkersById,
-    usersById: options.usersById,
-  });
-  if (profile) {
-    options.onOpenDirect?.(profile);
-  }
-  return true;
 }
 
 export function resolveMentionDirectTarget({
@@ -677,17 +670,13 @@ export function resolveMentionDirectTarget({
   coworkersBySlug,
   usersById,
   usersBySlug,
-  currentUserId,
-  canOpenHumanDirect,
 }: {
   mentionId: string;
   mentionSlug: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
   coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
-  usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-  usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-  currentUserId?: string;
-  canOpenHumanDirect?: boolean;
+  usersById?: Map<string, MentionHoverUserLookup>;
+  usersBySlug?: Map<string, MentionHoverUserLookup>;
 }): MentionDirectTarget | null {
   if (isRoomMentionAllId(mentionId)) {
     return null;
@@ -697,11 +686,8 @@ export function resolveMentionDirectTarget({
   if (coworker) {
     return { kind: "coworker", id: coworker.id };
   }
-  if (!canOpenHumanDirect) {
-    return null;
-  }
   const user = usersById?.get(mentionId) ?? usersBySlug?.get(mentionSlug);
-  if (!user || user.id === currentUserId) {
+  if (!user) {
     return null;
   }
   return { kind: "human", id: user.id };
@@ -713,7 +699,7 @@ function mentionChipHtml(
 ): string {
   const label = escapeHtml(`@${displayName}`);
   if (target) {
-    return `<span class="${MENTION_DIRECT_CHIP_CLASSNAME}" data-direct-kind="${escapeHtml(target.kind)}" data-direct-id="${escapeHtml(target.id)}">${label}</span>`;
+    return `<span class="${MENTION_CHIP_CLASSNAME}" data-direct-kind="${escapeHtml(target.kind)}" data-direct-id="${escapeHtml(target.id)}">${label}</span>`;
   }
   return `<span class="${MENTION_CHIP_CLASSNAME}">${label}</span>`;
 }
@@ -724,16 +710,12 @@ export function formatRoomMarkdownMentions({
   coworkersBySlug,
   usersById,
   usersBySlug,
-  currentUserId,
-  canOpenHumanDirect,
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
   coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
-  usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-  usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-  currentUserId?: string;
-  canOpenHumanDirect?: boolean;
+  usersById?: Map<string, MentionHoverUserLookup>;
+  usersBySlug?: Map<string, MentionHoverUserLookup>;
 }): string {
   const matches = parseMentions(content);
   if (matches.length === 0) {
@@ -762,8 +744,6 @@ export function formatRoomMarkdownMentions({
           coworkersBySlug,
           usersById,
           usersBySlug,
-          currentUserId,
-          canOpenHumanDirect,
         }),
       );
     } else {
@@ -849,17 +829,13 @@ export function formatRoomMarkdownContent({
   coworkersBySlug,
   usersById,
   usersBySlug,
-  currentUserId,
-  canOpenHumanDirect,
   channelLinks = [],
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
   coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
-  usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-  usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
-  currentUserId?: string;
-  canOpenHumanDirect?: boolean;
+  usersById?: Map<string, MentionHoverUserLookup>;
+  usersBySlug?: Map<string, MentionHoverUserLookup>;
   channelLinks?: readonly ChannelLinkTarget[];
 }): string {
   return linkifyChannelLinksInMarkdown(
@@ -869,8 +845,6 @@ export function formatRoomMarkdownContent({
       coworkersBySlug,
       usersById,
       usersBySlug,
-      currentUserId,
-      canOpenHumanDirect,
     }),
     channelLinks,
   );

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -575,18 +575,165 @@ export function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
+export interface MentionDirectTarget {
+  kind: "human" | "coworker";
+  id: string;
+}
+
+const MENTION_CHIP_CLASSNAME = "text-primary font-medium";
+const MENTION_DIRECT_CHIP_CLASSNAME = `${MENTION_CHIP_CLASSNAME} cursor-pointer`;
+
+export function parseMentionDirectChip(
+  node: Element,
+): MentionDirectTarget | null {
+  const host = node.closest("[data-direct-kind]");
+  if (!(host instanceof HTMLElement)) {
+    return null;
+  }
+  const kind = host.dataset.directKind;
+  const id = host.dataset.directId;
+  if ((kind !== "human" && kind !== "coworker") || !id) {
+    return null;
+  }
+  return { kind, id };
+}
+
+export function chatParticipantProfileForDirectTarget(
+  target: MentionDirectTarget,
+  lookups: {
+    coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+    usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  },
+): ChatParticipantHoverProfile | null {
+  if (target.kind === "coworker") {
+    const coworker = lookups.coworkersById.get(target.id);
+    if (!coworker) {
+      return null;
+    }
+    return {
+      kind: "coworker",
+      id: coworker.id,
+      name: coworker.name,
+      slug: coworker.slug,
+      caption: coworker.caption,
+      image: coworker.image,
+      presence: coworker.presence,
+    };
+  }
+  const user = lookups.usersById?.get(target.id);
+  if (!user) {
+    return null;
+  }
+  return {
+    kind: "human",
+    id: user.id,
+    name: user.name,
+    email: "",
+    image: null,
+    presence: "offline",
+  };
+}
+
+export function handleSentMentionDirectClick(
+  event: {
+    target: EventTarget | null;
+    preventDefault: () => void;
+    stopPropagation: () => void;
+  },
+  options: {
+    coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+    usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+    onOpenDirect?: (profile: ChatParticipantHoverProfile) => void;
+  },
+): boolean {
+  if (!(event.target instanceof Node)) {
+    return false;
+  }
+  const element =
+    event.target instanceof Element ? event.target : event.target.parentElement;
+  if (!element) {
+    return false;
+  }
+  const target = parseMentionDirectChip(element);
+  if (!target) {
+    return false;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  const profile = chatParticipantProfileForDirectTarget(target, {
+    coworkersById: options.coworkersById,
+    usersById: options.usersById,
+  });
+  if (profile) {
+    options.onOpenDirect?.(profile);
+  }
+  return true;
+}
+
+export function resolveMentionDirectTarget({
+  mentionId,
+  mentionSlug,
+  coworkersById,
+  coworkersBySlug,
+  usersById,
+  usersBySlug,
+  currentUserId,
+  canOpenHumanDirect,
+}: {
+  mentionId: string;
+  mentionSlug: string;
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+}): MentionDirectTarget | null {
+  if (isRoomMentionAllId(mentionId)) {
+    return null;
+  }
+  const coworker =
+    coworkersById.get(mentionId) ?? coworkersBySlug.get(mentionSlug);
+  if (coworker) {
+    return { kind: "coworker", id: coworker.id };
+  }
+  if (!canOpenHumanDirect) {
+    return null;
+  }
+  const user = usersById?.get(mentionId) ?? usersBySlug?.get(mentionSlug);
+  if (!user || user.id === currentUserId) {
+    return null;
+  }
+  return { kind: "human", id: user.id };
+}
+
+function mentionChipHtml(
+  displayName: string,
+  target: MentionDirectTarget | null,
+): string {
+  const label = escapeHtml(`@${displayName}`);
+  if (target) {
+    return `<span class="${MENTION_DIRECT_CHIP_CLASSNAME}" data-direct-kind="${escapeHtml(target.kind)}" data-direct-id="${escapeHtml(target.id)}">${label}</span>`;
+  }
+  return `<span class="${MENTION_CHIP_CLASSNAME}">${label}</span>`;
+}
+
 export function formatRoomMarkdownMentions({
   content,
   coworkersById,
   coworkersBySlug,
   usersById,
   usersBySlug,
+  currentUserId,
+  canOpenHumanDirect,
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
   coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
   usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
   usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
 }): string {
   const matches = parseMentions(content);
   if (matches.length === 0) {
@@ -599,13 +746,26 @@ export function formatRoomMarkdownMentions({
     if (match.start > lastIndex) {
       formatted += content.slice(lastIndex, match.start);
     }
+    const coworker =
+      coworkersById.get(match.id) ?? coworkersBySlug.get(match.slug);
+    const user = usersById?.get(match.id) ?? usersBySlug?.get(match.slug);
     const displayName = isRoomMentionAllId(match.id)
       ? ROOM_MENTION_ALL_ID
-      : ((coworkersById.get(match.id) ?? coworkersBySlug.get(match.slug))
-          ?.name ??
-        (usersById?.get(match.id) ?? usersBySlug?.get(match.slug))?.name);
+      : (coworker?.name ?? user?.name);
     if (displayName) {
-      formatted += `<span class="text-primary font-medium">${escapeHtml(`@${displayName}`)}</span>`;
+      formatted += mentionChipHtml(
+        displayName,
+        resolveMentionDirectTarget({
+          mentionId: match.id,
+          mentionSlug: match.slug,
+          coworkersById,
+          coworkersBySlug,
+          usersById,
+          usersBySlug,
+          currentUserId,
+          canOpenHumanDirect,
+        }),
+      );
     } else {
       formatted += content.slice(match.start, match.end);
     }
@@ -689,6 +849,8 @@ export function formatRoomMarkdownContent({
   coworkersBySlug,
   usersById,
   usersBySlug,
+  currentUserId,
+  canOpenHumanDirect,
   channelLinks = [],
 }: {
   content: string;
@@ -696,6 +858,8 @@ export function formatRoomMarkdownContent({
   coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
   usersById?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
   usersBySlug?: Map<string, Pick<ChatRoomUserParticipant, "id" | "name">>;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
   channelLinks?: readonly ChannelLinkTarget[];
 }): string {
   return linkifyChannelLinksInMarkdown(
@@ -705,6 +869,8 @@ export function formatRoomMarkdownContent({
       coworkersBySlug,
       usersById,
       usersBySlug,
+      currentUserId,
+      canOpenHumanDirect,
     }),
     channelLinks,
   );

--- a/apps/web/src/app/(app)/chat/components/room-mention-markdown.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-mention-markdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChannelLinkTarget } from "@sokosumi/utils";
-import type { ReactNode } from "react";
+import { type MutableRefObject, type ReactNode, useMemo, useRef } from "react";
 import type { Components } from "react-markdown";
 
 import Markdown from "@/components/markdown";
@@ -31,14 +31,15 @@ function RoomMentionHoverSpan({
   node,
   children,
   className,
-  lookups,
+  lookupsRef,
   ...props
 }: {
   node?: unknown;
   children?: ReactNode;
   className?: string;
-  lookups: RoomMentionHoverLookups;
+  lookupsRef: MutableRefObject<RoomMentionHoverLookups>;
 } & Record<string, unknown>) {
+  const lookups = lookupsRef.current;
   const nodeProperties =
     node && typeof node === "object" && "properties" in node
       ? ((node as { properties?: Record<string, unknown> }).properties ?? {})
@@ -72,6 +73,8 @@ function RoomMentionHoverSpan({
       }
       isDirectActionBusy={lookups.openingDirectParticipantKey != null}
       interactive={lookups.interactive ?? true}
+      openDelay={100}
+      closeDelay={300}
     >
       {span}
     </ChatParticipantHoverCard>
@@ -118,10 +121,17 @@ export function RoomMessageMarkdown({
     openingDirectParticipantKey,
     interactive: hoverInteractive,
   };
+  const lookupsRef = useRef(lookups);
+  lookupsRef.current = lookups;
 
-  const components: Components = {
-    span: (props) => <RoomMentionHoverSpan {...props} lookups={lookups} />,
-  };
+  const components = useMemo<Components>(
+    () => ({
+      span: (props) => (
+        <RoomMentionHoverSpan {...props} lookupsRef={lookupsRef} />
+      ),
+    }),
+    [],
+  );
 
   return (
     <Markdown className={markdownClassName} components={components}>

--- a/apps/web/src/app/(app)/chat/components/room-mention-markdown.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-mention-markdown.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { ChannelLinkTarget } from "@sokosumi/utils";
+import type { ReactNode } from "react";
+import type { Components } from "react-markdown";
+
+import Markdown from "@/components/markdown";
+import type { ChatRoomCoworkerParticipant } from "@/lib/clients/generated/core";
+
+import { ChatParticipantHoverCard } from "./chat-participant-hover-card";
+import { participantDirectKey } from "./open-direct-with-participant";
+import {
+  type ChatParticipantHoverProfile,
+  chatParticipantProfileForDirectTarget,
+  formatRoomMarkdownContent,
+  type MentionHoverUserLookup,
+  mentionDirectTargetFromAttributes,
+} from "./room-helpers";
+
+interface RoomMentionHoverLookups {
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, MentionHoverUserLookup>;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirect?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
+  interactive?: boolean;
+}
+
+function RoomMentionHoverSpan({
+  node,
+  children,
+  className,
+  lookups,
+  ...props
+}: {
+  node?: unknown;
+  children?: ReactNode;
+  className?: string;
+  lookups: RoomMentionHoverLookups;
+} & Record<string, unknown>) {
+  const nodeProperties =
+    node && typeof node === "object" && "properties" in node
+      ? ((node as { properties?: Record<string, unknown> }).properties ?? {})
+      : {};
+  const target = mentionDirectTargetFromAttributes({
+    ...nodeProperties,
+    ...props,
+  });
+  const profile = target
+    ? chatParticipantProfileForDirectTarget(target, {
+        coworkersById: lookups.coworkersById,
+        usersById: lookups.usersById,
+      })
+    : null;
+  const span = (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  );
+  if (!profile) {
+    return span;
+  }
+  return (
+    <ChatParticipantHoverCard
+      profile={profile}
+      currentUserId={lookups.currentUserId}
+      canOpenHumanDirect={lookups.canOpenHumanDirect}
+      onOpenDirect={lookups.onOpenDirect}
+      isOpeningDirect={
+        lookups.openingDirectParticipantKey === participantDirectKey(profile)
+      }
+      isDirectActionBusy={lookups.openingDirectParticipantKey != null}
+      interactive={lookups.interactive ?? true}
+    >
+      {span}
+    </ChatParticipantHoverCard>
+  );
+}
+
+export function RoomMessageMarkdown({
+  content,
+  markdownClassName,
+  coworkersById,
+  coworkersBySlug,
+  usersById,
+  usersBySlug,
+  channelLinks = [],
+  currentUserId,
+  canOpenHumanDirect = false,
+  onOpenDirectMessage,
+  openingDirectParticipantKey = null,
+  hoverInteractive = true,
+}: {
+  content: string;
+  markdownClassName?: string;
+  coworkersById: Map<string, ChatRoomCoworkerParticipant>;
+  coworkersBySlug: Map<string, ChatRoomCoworkerParticipant>;
+  usersById?: Map<string, MentionHoverUserLookup>;
+  usersBySlug?: Map<string, MentionHoverUserLookup>;
+  channelLinks?: readonly ChannelLinkTarget[];
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
+  hoverInteractive?: boolean;
+}) {
+  if (!content.trim()) {
+    return null;
+  }
+
+  const lookups: RoomMentionHoverLookups = {
+    coworkersById,
+    usersById,
+    currentUserId,
+    canOpenHumanDirect,
+    onOpenDirect: onOpenDirectMessage,
+    openingDirectParticipantKey,
+    interactive: hoverInteractive,
+  };
+
+  const components: Components = {
+    span: (props) => <RoomMentionHoverSpan {...props} lookups={lookups} />,
+  };
+
+  return (
+    <Markdown className={markdownClassName} components={components}>
+      {formatRoomMarkdownContent({
+        content,
+        coworkersById,
+        coworkersBySlug,
+        usersById,
+        usersBySlug,
+        channelLinks,
+      })}
+    </Markdown>
+  );
+}

--- a/apps/web/src/app/(app)/chat/components/room-mention-markdown.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-mention-markdown.tsx
@@ -108,10 +108,6 @@ export function RoomMessageMarkdown({
   openingDirectParticipantKey?: string | null;
   hoverInteractive?: boolean;
 }) {
-  if (!content.trim()) {
-    return null;
-  }
-
   const lookups: RoomMentionHoverLookups = {
     coworkersById,
     usersById,
@@ -132,6 +128,10 @@ export function RoomMessageMarkdown({
     }),
     [],
   );
+
+  if (!content.trim()) {
+    return null;
+  }
 
   return (
     <Markdown className={markdownClassName} components={components}>

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -108,6 +108,7 @@ import {
   type ChatParticipantHoverProfile,
   formatMessageTime,
   formatRoomMarkdownContent,
+  handleSentMentionDirectClick,
   messageSender,
   ROOM_MESSAGE_MARKDOWN_CLASSNAME,
   ROOM_QUOTE_MARKDOWN_CLASSNAME,
@@ -264,6 +265,9 @@ function MessageQuoteBlock({
   usersById,
   usersBySlug,
   channelLinks,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirectMessage,
 }: {
   quote: RoomMessageQuoteSnapshot;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -271,6 +275,9 @@ function MessageQuoteBlock({
   usersById?: Map<string, UserMentionLookup>;
   usersBySlug?: Map<string, UserMentionLookup>;
   channelLinks: readonly ChannelLinkTarget[];
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }) {
   const t = useTranslations("App.Channels.Quote");
   const { expanded, setExpanded, overflows, contentRef } = useClampedOverflow(
@@ -300,16 +307,28 @@ function MessageQuoteBlock({
               expanded ? null : "line-clamp-4",
             )}
           >
-            <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
-              {formatRoomMarkdownContent({
-                content: quote.snippet,
-                coworkersById,
-                coworkersBySlug,
-                usersById,
-                usersBySlug,
-                channelLinks,
-              })}
-            </Markdown>
+            <div
+              onClick={(event) => {
+                handleSentMentionDirectClick(event, {
+                  coworkersById,
+                  usersById,
+                  onOpenDirect: onOpenDirectMessage,
+                });
+              }}
+            >
+              <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
+                {formatRoomMarkdownContent({
+                  content: quote.snippet,
+                  coworkersById,
+                  coworkersBySlug,
+                  usersById,
+                  usersBySlug,
+                  currentUserId,
+                  canOpenHumanDirect,
+                  channelLinks,
+                })}
+              </Markdown>
+            </div>
           </div>
         ) : null}
         {attachment ? (
@@ -464,6 +483,9 @@ function ChannelMarkdownSegment({
   usersById,
   usersBySlug,
   channelLinks,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirectMessage,
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -471,22 +493,37 @@ function ChannelMarkdownSegment({
   usersById?: Map<string, UserMentionLookup>;
   usersBySlug?: Map<string, UserMentionLookup>;
   channelLinks: readonly ChannelLinkTarget[];
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }) {
   if (!content.trim()) {
     return null;
   }
 
   return (
-    <Markdown className={ROOM_MESSAGE_MARKDOWN_CLASSNAME}>
-      {formatRoomMarkdownContent({
-        content,
-        coworkersById,
-        coworkersBySlug,
-        usersById,
-        usersBySlug,
-        channelLinks,
-      })}
-    </Markdown>
+    <div
+      onClick={(event) => {
+        handleSentMentionDirectClick(event, {
+          coworkersById,
+          usersById,
+          onOpenDirect: onOpenDirectMessage,
+        });
+      }}
+    >
+      <Markdown className={ROOM_MESSAGE_MARKDOWN_CLASSNAME}>
+        {formatRoomMarkdownContent({
+          content,
+          coworkersById,
+          coworkersBySlug,
+          usersById,
+          usersBySlug,
+          currentUserId,
+          canOpenHumanDirect,
+          channelLinks,
+        })}
+      </Markdown>
+    </div>
   );
 }
 
@@ -497,6 +534,9 @@ function ChannelMessageText({
   usersById,
   usersBySlug,
   channelLinks,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirectMessage,
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -504,6 +544,9 @@ function ChannelMessageText({
   usersById?: Map<string, UserMentionLookup>;
   usersBySlug?: Map<string, UserMentionLookup>;
   channelLinks: readonly ChannelLinkTarget[];
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }) {
   const segments = segmentRoomMessageContent(content);
 
@@ -516,6 +559,9 @@ function ChannelMessageText({
         usersById={usersById}
         usersBySlug={usersBySlug}
         channelLinks={channelLinks}
+        currentUserId={currentUserId}
+        canOpenHumanDirect={canOpenHumanDirect}
+        onOpenDirectMessage={onOpenDirectMessage}
       />
     );
   }
@@ -534,6 +580,9 @@ function ChannelMessageText({
                 usersById={usersById}
                 usersBySlug={usersBySlug}
                 channelLinks={channelLinks}
+                currentUserId={currentUserId}
+                canOpenHumanDirect={canOpenHumanDirect}
+                onOpenDirectMessage={onOpenDirectMessage}
               />
             );
           case "files": {
@@ -576,6 +625,9 @@ function ChannelMessageBody({
   usersById,
   usersBySlug,
   channelLinks,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirectMessage,
 }: {
   messageId: string;
   content: string;
@@ -584,6 +636,9 @@ function ChannelMessageBody({
   usersById?: Map<string, UserMentionLookup>;
   usersBySlug?: Map<string, UserMentionLookup>;
   channelLinks: readonly ChannelLinkTarget[];
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }) {
   const t = useTranslations("App.Channels.Message");
   const jumboEmojiCount = getJumboEmojiCount(content);
@@ -626,6 +681,9 @@ function ChannelMessageBody({
           usersById={usersById}
           usersBySlug={usersBySlug}
           channelLinks={channelLinks}
+          currentUserId={currentUserId}
+          canOpenHumanDirect={canOpenHumanDirect}
+          onOpenDirectMessage={onOpenDirectMessage}
         />
       </div>
       {!skipBodyClamp && (expanded || overflows) ? (
@@ -1952,6 +2010,9 @@ export function ChatMessageRow({
                   usersById={usersById}
                   usersBySlug={usersBySlug}
                   channelLinks={channelLinks}
+                  currentUserId={currentUserId}
+                  canOpenHumanDirect={canOpenHumanDirect}
+                  onOpenDirectMessage={onOpenDirectMessage}
                 />
               ) : null}
               {isEditing && onEditDraftChange && onCancelEdit && onSaveEdit ? (
@@ -2012,6 +2073,9 @@ export function ChatMessageRow({
                     usersById={usersById}
                     usersBySlug={usersBySlug}
                     channelLinks={channelLinks}
+                    currentUserId={currentUserId}
+                    canOpenHumanDirect={canOpenHumanDirect}
+                    onOpenDirectMessage={onOpenDirectMessage}
                   />
                   {isContinuation && showEdited ? (
                     <span className="text-muted-foreground ml-1.5 text-xs">

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -60,7 +60,6 @@ import {
   segmentRoomMessageContent,
 } from "@/app/chat/utils/room-message-segments";
 import { EmojiPicker } from "@/components/chat/emoji-picker";
-import Markdown from "@/components/markdown";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -107,13 +106,12 @@ import { AiCoworkerAvatarBadge } from "./room-draft-shared";
 import {
   type ChatParticipantHoverProfile,
   formatMessageTime,
-  formatRoomMarkdownContent,
-  handleSentMentionDirectClick,
   messageSender,
   ROOM_MESSAGE_MARKDOWN_CLASSNAME,
   ROOM_QUOTE_MARKDOWN_CLASSNAME,
   scrollToRoomMessageElement,
 } from "./room-helpers";
+import { RoomMessageMarkdown } from "./room-mention-markdown";
 
 type UserMentionLookup = Pick<ChatRoomUserParticipant, "id" | "name">;
 type RoomMessageQuoteSnapshot = Exclude<ChatRoomMessageQuote, null>;
@@ -268,6 +266,7 @@ function MessageQuoteBlock({
   currentUserId,
   canOpenHumanDirect,
   onOpenDirectMessage,
+  openingDirectParticipantKey,
 }: {
   quote: RoomMessageQuoteSnapshot;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -278,6 +277,7 @@ function MessageQuoteBlock({
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }) {
   const t = useTranslations("App.Channels.Quote");
   const { expanded, setExpanded, overflows, contentRef } = useClampedOverflow(
@@ -307,28 +307,20 @@ function MessageQuoteBlock({
               expanded ? null : "line-clamp-4",
             )}
           >
-            <div
-              onClick={(event) => {
-                handleSentMentionDirectClick(event, {
-                  coworkersById,
-                  usersById,
-                  onOpenDirect: onOpenDirectMessage,
-                });
-              }}
-            >
-              <Markdown className={ROOM_QUOTE_MARKDOWN_CLASSNAME}>
-                {formatRoomMarkdownContent({
-                  content: quote.snippet,
-                  coworkersById,
-                  coworkersBySlug,
-                  usersById,
-                  usersBySlug,
-                  currentUserId,
-                  canOpenHumanDirect,
-                  channelLinks,
-                })}
-              </Markdown>
-            </div>
+            <RoomMessageMarkdown
+              content={quote.snippet}
+              markdownClassName={ROOM_QUOTE_MARKDOWN_CLASSNAME}
+              coworkersById={coworkersById}
+              coworkersBySlug={coworkersBySlug}
+              usersById={usersById}
+              usersBySlug={usersBySlug}
+              channelLinks={channelLinks}
+              currentUserId={currentUserId}
+              canOpenHumanDirect={canOpenHumanDirect}
+              onOpenDirectMessage={onOpenDirectMessage}
+              openingDirectParticipantKey={openingDirectParticipantKey}
+              hoverInteractive={false}
+            />
           </div>
         ) : null}
         {attachment ? (
@@ -486,6 +478,7 @@ function ChannelMarkdownSegment({
   currentUserId,
   canOpenHumanDirect,
   onOpenDirectMessage,
+  openingDirectParticipantKey,
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -496,34 +489,22 @@ function ChannelMarkdownSegment({
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }) {
-  if (!content.trim()) {
-    return null;
-  }
-
   return (
-    <div
-      onClick={(event) => {
-        handleSentMentionDirectClick(event, {
-          coworkersById,
-          usersById,
-          onOpenDirect: onOpenDirectMessage,
-        });
-      }}
-    >
-      <Markdown className={ROOM_MESSAGE_MARKDOWN_CLASSNAME}>
-        {formatRoomMarkdownContent({
-          content,
-          coworkersById,
-          coworkersBySlug,
-          usersById,
-          usersBySlug,
-          currentUserId,
-          canOpenHumanDirect,
-          channelLinks,
-        })}
-      </Markdown>
-    </div>
+    <RoomMessageMarkdown
+      content={content}
+      markdownClassName={ROOM_MESSAGE_MARKDOWN_CLASSNAME}
+      coworkersById={coworkersById}
+      coworkersBySlug={coworkersBySlug}
+      usersById={usersById}
+      usersBySlug={usersBySlug}
+      channelLinks={channelLinks}
+      currentUserId={currentUserId}
+      canOpenHumanDirect={canOpenHumanDirect}
+      onOpenDirectMessage={onOpenDirectMessage}
+      openingDirectParticipantKey={openingDirectParticipantKey}
+    />
   );
 }
 
@@ -537,6 +518,7 @@ function ChannelMessageText({
   currentUserId,
   canOpenHumanDirect,
   onOpenDirectMessage,
+  openingDirectParticipantKey,
 }: {
   content: string;
   coworkersById: Map<string, ChatRoomCoworkerParticipant>;
@@ -547,6 +529,7 @@ function ChannelMessageText({
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }) {
   const segments = segmentRoomMessageContent(content);
 
@@ -562,6 +545,7 @@ function ChannelMessageText({
         currentUserId={currentUserId}
         canOpenHumanDirect={canOpenHumanDirect}
         onOpenDirectMessage={onOpenDirectMessage}
+        openingDirectParticipantKey={openingDirectParticipantKey}
       />
     );
   }
@@ -583,6 +567,7 @@ function ChannelMessageText({
                 currentUserId={currentUserId}
                 canOpenHumanDirect={canOpenHumanDirect}
                 onOpenDirectMessage={onOpenDirectMessage}
+                openingDirectParticipantKey={openingDirectParticipantKey}
               />
             );
           case "files": {
@@ -628,6 +613,7 @@ function ChannelMessageBody({
   currentUserId,
   canOpenHumanDirect,
   onOpenDirectMessage,
+  openingDirectParticipantKey,
 }: {
   messageId: string;
   content: string;
@@ -639,6 +625,7 @@ function ChannelMessageBody({
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }) {
   const t = useTranslations("App.Channels.Message");
   const jumboEmojiCount = getJumboEmojiCount(content);
@@ -684,6 +671,7 @@ function ChannelMessageBody({
           currentUserId={currentUserId}
           canOpenHumanDirect={canOpenHumanDirect}
           onOpenDirectMessage={onOpenDirectMessage}
+          openingDirectParticipantKey={openingDirectParticipantKey}
         />
       </div>
       {!skipBodyClamp && (expanded || overflows) ? (
@@ -2013,6 +2001,7 @@ export function ChatMessageRow({
                   currentUserId={currentUserId}
                   canOpenHumanDirect={canOpenHumanDirect}
                   onOpenDirectMessage={onOpenDirectMessage}
+                  openingDirectParticipantKey={openingDirectParticipantKey}
                 />
               ) : null}
               {isEditing && onEditDraftChange && onCancelEdit && onSaveEdit ? (
@@ -2076,6 +2065,7 @@ export function ChatMessageRow({
                     currentUserId={currentUserId}
                     canOpenHumanDirect={canOpenHumanDirect}
                     onOpenDirectMessage={onOpenDirectMessage}
+                    openingDirectParticipantKey={openingDirectParticipantKey}
                   />
                   {isContinuation && showEdited ? (
                     <span className="text-muted-foreground ml-1.5 text-xs">

--- a/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
@@ -27,6 +27,7 @@ import {
 } from "./room-composer";
 import {
   buildRoomComposerMessageContent,
+  type ChatParticipantHoverProfile,
   isRoomComposerEmpty,
   type PendingRoomQuote,
   type RoomMentionParticipant,
@@ -74,6 +75,9 @@ interface RoomSessionComposerProps {
   /** Claim in-flight lock with clientMessageId; return false to abort clear. */
   onBeforeSend?: (clientMessageId: string) => boolean;
   onSend: (request: RoomSessionSendRequest) => Promise<RoomSessionSendResult>;
+  currentUserId?: string;
+  canOpenHumanDirect?: boolean;
+  onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
 }
 
 /** Draft state lives here so room message lists do not re-render on typing. */
@@ -95,6 +99,9 @@ export function RoomSessionComposer({
   ref,
   onBeforeSend,
   onSend,
+  currentUserId,
+  canOpenHumanDirect,
+  onOpenDirectMessage,
 }: RoomSessionComposerProps) {
   const [composerValue, setComposerValue] = useState("");
   const [composerAttachments, setComposerAttachments] = useState<
@@ -210,6 +217,9 @@ export function RoomSessionComposer({
       onClearPendingQuote={onClearPendingQuote}
       onChromeResize={onChromeResize}
       focusOnMount={focusOnMount}
+      currentUserId={currentUserId}
+      canOpenHumanDirect={canOpenHumanDirect}
+      onOpenDirectMessage={onOpenDirectMessage}
     />
   );
 }

--- a/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-session-composer.tsx
@@ -78,6 +78,7 @@ interface RoomSessionComposerProps {
   currentUserId?: string;
   canOpenHumanDirect?: boolean;
   onOpenDirectMessage?: (profile: ChatParticipantHoverProfile) => void;
+  openingDirectParticipantKey?: string | null;
 }
 
 /** Draft state lives here so room message lists do not re-render on typing. */
@@ -102,6 +103,7 @@ export function RoomSessionComposer({
   currentUserId,
   canOpenHumanDirect,
   onOpenDirectMessage,
+  openingDirectParticipantKey,
 }: RoomSessionComposerProps) {
   const [composerValue, setComposerValue] = useState("");
   const [composerAttachments, setComposerAttachments] = useState<
@@ -220,6 +222,7 @@ export function RoomSessionComposer({
       currentUserId={currentUserId}
       canOpenHumanDirect={canOpenHumanDirect}
       onOpenDirectMessage={onOpenDirectMessage}
+      openingDirectParticipantKey={openingDirectParticipantKey}
     />
   );
 }

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2717,6 +2717,9 @@ export function RoomsClient({
               focusOnMount={!messagesPending}
               onBeforeSend={handleChannelBeforeSend}
               onSend={handleChannelSend}
+              currentUserId={currentUserId}
+              canOpenHumanDirect={canOpenHumanDirect}
+              onOpenDirectMessage={handleOpenDirectMessage}
             />
           }
           mainEnd={

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2720,6 +2720,7 @@ export function RoomsClient({
               currentUserId={currentUserId}
               canOpenHumanDirect={canOpenHumanDirect}
               onOpenDirectMessage={handleOpenDirectMessage}
+              openingDirectParticipantKey={openingDirectKey}
             />
           }
           mainEnd={

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -356,6 +356,9 @@ export function ThreadPanel({
           onChromeResize={scrollToBottomIfPinned}
           onBeforeSend={onBeforeSendReply}
           onSend={handleSendReply}
+          currentUserId={currentUserId}
+          canOpenHumanDirect={canOpenHumanDirect}
+          onOpenDirectMessage={onOpenDirectMessage}
         />
       </RoomFileDropZone>
     </aside>

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -359,6 +359,7 @@ export function ThreadPanel({
           currentUserId={currentUserId}
           canOpenHumanDirect={canOpenHumanDirect}
           onOpenDirectMessage={onOpenDirectMessage}
+          openingDirectParticipantKey={openingDirectParticipantKey}
         />
       </RoomFileDropZone>
     </aside>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -1,5 +1,6 @@
 import { linkifyBareDomainsInMarkdown } from "@sokosumi/utils";
 import Link from "next/link";
+import { useMemo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
@@ -58,139 +59,152 @@ export default function Markdown({
   // Display-only: bare domains → markdown links; room message body stays plain.
   const linkifiedChildren = linkifyBareDomainsInMarkdown(sanitizedChildren);
 
-  const components: Components = {
-    a: ({ href, children, className, node: _node, ...props }) => {
-      const classNames = cn(
-        "wrap-anywhere [overflow-wrap:anywhere]",
-        className,
-      );
-      if (isInternalAppPath(href)) {
-        return (
-          <Link href={href} className={classNames} {...props}>
-            {children}
-          </Link>
+  const defaultComponents: Components = useMemo(
+    () => ({
+      a: ({ href, children, className, node: _node, ...props }) => {
+        const classNames = cn(
+          "wrap-anywhere [overflow-wrap:anywhere]",
+          className,
         );
-      }
-      const sameTab = isSokosumiLink(href);
-      return (
-        <a
-          href={href}
-          {...props}
-          className={classNames}
-          {...(sameTab ? {} : { target: "_blank", rel: "noopener noreferrer" })}
-        >
-          {children}
-        </a>
-      );
-    },
-    img: ({ src, alt, ...props }) => {
-      const srcString = typeof src === "string" ? src : undefined;
-      if (srcString && isVideoUrl(srcString)) {
-        const mediaSrc = stripForcedDownloadParam(srcString);
+        if (isInternalAppPath(href)) {
+          return (
+            <Link href={href} className={classNames} {...props}>
+              {children}
+            </Link>
+          );
+        }
+        const sameTab = isSokosumiLink(href);
+        return (
+          <a
+            href={href}
+            {...props}
+            className={classNames}
+            {...(sameTab
+              ? {}
+              : { target: "_blank", rel: "noopener noreferrer" })}
+          >
+            {children}
+          </a>
+        );
+      },
+      img: ({ src, alt, ...props }) => {
+        const srcString = typeof src === "string" ? src : undefined;
+        if (srcString && isVideoUrl(srcString)) {
+          const mediaSrc = stripForcedDownloadParam(srcString);
+          return (
+            <video
+              src={mediaSrc}
+              controls
+              playsInline
+              preload="metadata"
+              className="h-auto w-full max-w-full rounded-lg"
+              aria-label={alt || undefined}
+            />
+          );
+        }
+        if (srcString && isAudioUrl(srcString)) {
+          const mediaSrc = stripForcedDownloadParam(srcString);
+          return (
+            <audio
+              src={mediaSrc}
+              controls
+              preload="metadata"
+              className="w-full max-w-full"
+              aria-label={alt || undefined}
+            />
+          );
+        }
+        return (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={src}
+            alt={alt}
+            className="h-auto max-w-full rounded-lg"
+            {...props}
+          />
+        );
+      },
+      video: ({ children, src, autoPlay: _autoPlay, ...props }) => {
+        const srcString =
+          typeof src === "string" ? stripForcedDownloadParam(src) : src;
         return (
           <video
-            src={mediaSrc}
+            {...props}
+            src={srcString}
+            className="h-auto w-full max-w-full rounded-lg"
             controls
             playsInline
             preload="metadata"
-            className="h-auto w-full max-w-full rounded-lg"
-            aria-label={alt || undefined}
-          />
+          >
+            {children}
+          </video>
         );
-      }
-      if (srcString && isAudioUrl(srcString)) {
-        const mediaSrc = stripForcedDownloadParam(srcString);
+      },
+      audio: ({ children, src, autoPlay: _autoPlay, ...props }) => {
+        const srcString =
+          typeof src === "string" ? stripForcedDownloadParam(src) : src;
         return (
           <audio
-            src={mediaSrc}
+            {...props}
+            src={srcString}
+            className="w-full max-w-full"
             controls
             preload="metadata"
-            className="w-full max-w-full"
-            aria-label={alt || undefined}
-          />
+          >
+            {children}
+          </audio>
         );
-      }
-      return (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={src}
-          alt={alt}
-          className="h-auto max-w-full rounded-lg"
-          {...props}
-        />
-      );
-    },
-    video: ({ children, src, autoPlay: _autoPlay, ...props }) => {
-      const srcString =
-        typeof src === "string" ? stripForcedDownloadParam(src) : src;
-      return (
-        <video
-          {...props}
-          src={srcString}
-          className="h-auto w-full max-w-full rounded-lg"
-          controls
-          playsInline
-          preload="metadata"
-        >
-          {children}
-        </video>
-      );
-    },
-    audio: ({ children, src, autoPlay: _autoPlay, ...props }) => {
-      const srcString =
-        typeof src === "string" ? stripForcedDownloadParam(src) : src;
-      return (
-        <audio
-          {...props}
-          src={srcString}
-          className="w-full max-w-full"
-          controls
-          preload="metadata"
-        >
-          {children}
-        </audio>
-      );
-    },
-    table: ({ children, className, ...props }) => (
-      <div className="border-border my-3 overflow-x-auto rounded-md border">
-        <table
-          {...props}
-          className={cn(
-            "w-full min-w-full caption-bottom border-collapse text-sm",
-            className,
-          )}
-        >
-          {children}
-        </table>
-      </div>
-    ),
-    code: ({ className, children, ...props }) => {
-      const codeText = String(children ?? "");
-      const isInline =
-        !className?.includes("language-") && !codeText.includes("\n");
-
-      if (isInline) {
-        return (
-          <code
+      },
+      table: ({ children, className, ...props }) => (
+        <div className="border-border my-3 overflow-x-auto rounded-md border">
+          <table
             {...props}
             className={cn(
-              "bg-muted text-foreground rounded px-1 py-0.5 font-mono text-xs wrap-break-word",
-              "before:content-none after:content-none",
+              "w-full min-w-full caption-bottom border-collapse text-sm",
               className,
             )}
           >
             {children}
+          </table>
+        </div>
+      ),
+      code: ({ className, children, ...props }) => {
+        const codeText = String(children ?? "");
+        const isInline =
+          !className?.includes("language-") && !codeText.includes("\n");
+
+        if (isInline) {
+          return (
+            <code
+              {...props}
+              className={cn(
+                "bg-muted text-foreground rounded px-1 py-0.5 font-mono text-xs wrap-break-word",
+                "before:content-none after:content-none",
+                className,
+              )}
+            >
+              {children}
+            </code>
+          );
+        }
+
+        return (
+          <code {...props} className={className}>
+            {children}
           </code>
         );
-      }
+      },
+    }),
+    [],
+  );
 
-      return (
-        <code {...props} className={className}>
-          {children}
-        </code>
-      );
-    },
-  };
+  const components = useMemo(
+    () =>
+      extraComponents
+        ? { ...defaultComponents, ...extraComponents }
+        : defaultComponents,
+    [defaultComponents, extraComponents],
+  );
 
   const baseTypographyClassName =
     "wrap-anywhere prose prose-sm prose-headings:mt-4 prose-headings:mb-2 prose-headings:font-semibold prose-headings:tracking-tight prose-headings:text-foreground prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-h4:text-sm prose-h5:text-sm prose-h6:text-sm prose-p:my-2 prose-p:leading-relaxed prose-p:text-foreground/80 prose-strong:font-bold prose-strong:text-foreground prose-em:italic prose-ul:my-2 prose-ul:list-disc prose-ul:ps-6 prose-ol:my-2 prose-ol:list-decimal prose-ol:ps-6 prose-li:my-1 prose-li:ps-1 prose-li:marker:text-muted-foreground prose-li:text-foreground/80 prose-a:text-primary prose-a:font-medium prose-a:underline prose-a:underline-offset-4 prose-a:decoration-primary/40 hover:prose-a:decoration-primary prose-pre:my-3 prose-pre:rounded-md prose-pre:border prose-pre:border-border prose-pre:bg-muted/40 prose-pre:px-4 prose-pre:py-3 prose-pre:text-sm prose-pre:leading-6 prose-pre:font-normal prose-pre:[tab-size:2] prose-pre:[text-wrap:pretty] prose-blockquote:my-3 prose-hr:my-4 prose-hr:border-border prose-hr:border-t prose-hr:border-b-0 prose-table:my-0 prose-thead:border-b prose-thead:border-border prose-th:bg-muted/40 prose-th:px-3 prose-th:py-2 prose-th:text-left prose-th:font-medium prose-th:text-foreground prose-td:px-3 prose-td:py-2 prose-td:align-top prose-td:text-foreground/80 prose-tr:border-b prose-tr:border-border prose-tr:last:border-b-0 max-w-none dark:prose-invert [&_u]:underline [&_s]:line-through [&_del]:line-through [&_strike]:line-through [&_pre]:max-w-full [&_pre]:overflow-x-auto";
@@ -204,7 +218,7 @@ export default function Markdown({
           [remarkEmoji, { emoticon: true }],
         ]}
         rehypePlugins={[rehypeRaw, [rehypeHighlight, { detect: true }]]}
-        components={{ ...components, ...extraComponents }}
+        components={components}
       >
         {linkifiedChildren}
       </ReactMarkdown>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -41,12 +41,14 @@ interface MarkdownProps {
   children: string;
   className?: string | undefined;
   highlightTerm?: string | undefined;
+  components?: Components;
 }
 
 export default function Markdown({
   children,
   className,
   highlightTerm,
+  components: extraComponents,
 }: MarkdownProps) {
   const highlightedChildren = applyMarkdownHighlighting(children, {
     term: highlightTerm,
@@ -202,7 +204,7 @@ export default function Markdown({
           [remarkEmoji, { emoticon: true }],
         ]}
         rehypePlugins={[rehypeRaw, [rehypeHighlight, { detect: true }]]}
-        components={components}
+        components={{ ...components, ...extraComponents }}
       >
         {linkifiedChildren}
       </ReactMarkdown>

--- a/apps/web/src/lib/utils/__tests__/sanitizeMarkdown.test.ts
+++ b/apps/web/src/lib/utils/__tests__/sanitizeMarkdown.test.ts
@@ -64,11 +64,12 @@ describe("sanitizeMarkdown", () => {
 
   it("keeps mention Direct chip identity on spans", () => {
     const sanitized = sanitizeMarkdown(
-      '<span class="text-primary font-medium" data-direct-kind="coworker" data-direct-id="cow_1">@Elena</span>',
+      '<span class="text-primary font-medium whitespace-nowrap" data-direct-kind="coworker" data-direct-id="cow_1">@Elena</span>',
     );
 
     expect(sanitized).toContain('data-direct-kind="coworker"');
     expect(sanitized).toContain('data-direct-id="cow_1"');
+    expect(sanitized).toContain("whitespace-nowrap");
     expect(sanitized).toContain("@Elena");
   });
 

--- a/apps/web/src/lib/utils/__tests__/sanitizeMarkdown.test.ts
+++ b/apps/web/src/lib/utils/__tests__/sanitizeMarkdown.test.ts
@@ -62,6 +62,17 @@ describe("sanitizeMarkdown", () => {
     expect(sanitized).toContain("controls");
   });
 
+  it("keeps mention Direct chip identity on spans", () => {
+    const sanitized = sanitizeMarkdown(
+      '<span class="text-primary font-medium cursor-pointer" data-direct-kind="coworker" data-direct-id="cow_1">@Elena</span>',
+    );
+
+    expect(sanitized).toContain('data-direct-kind="coworker"');
+    expect(sanitized).toContain('data-direct-id="cow_1"');
+    expect(sanitized).toContain("cursor-pointer");
+    expect(sanitized).toContain("@Elena");
+  });
+
   it("strips autoplay from video and audio tags", () => {
     const markdown = [
       '<video src="https://blob.example.com/clip.mp4" controls autoplay></video>',

--- a/apps/web/src/lib/utils/__tests__/sanitizeMarkdown.test.ts
+++ b/apps/web/src/lib/utils/__tests__/sanitizeMarkdown.test.ts
@@ -64,12 +64,11 @@ describe("sanitizeMarkdown", () => {
 
   it("keeps mention Direct chip identity on spans", () => {
     const sanitized = sanitizeMarkdown(
-      '<span class="text-primary font-medium cursor-pointer" data-direct-kind="coworker" data-direct-id="cow_1">@Elena</span>',
+      '<span class="text-primary font-medium" data-direct-kind="coworker" data-direct-id="cow_1">@Elena</span>',
     );
 
     expect(sanitized).toContain('data-direct-kind="coworker"');
     expect(sanitized).toContain('data-direct-id="cow_1"');
-    expect(sanitized).toContain("cursor-pointer");
     expect(sanitized).toContain("@Elena");
   });
 

--- a/apps/web/src/lib/utils/sanitizeMarkdown.ts
+++ b/apps/web/src/lib/utils/sanitizeMarkdown.ts
@@ -93,11 +93,11 @@ export function sanitizeMarkdown(markdown: string): string {
       audio: ["src", "controls", "loop", "muted", "width", "height"],
       source: ["src"],
       mark: ["class"],
-      span: ["class"],
+      span: ["class", "data-direct-kind", "data-direct-id"],
     },
     allowedClasses: {
       mark: ["bg-primary/50", "text-foreground", "rounded-sm", "px-0.5"],
-      span: ["text-primary", "font-medium"],
+      span: ["text-primary", "font-medium", "cursor-pointer"],
     },
   });
 

--- a/apps/web/src/lib/utils/sanitizeMarkdown.ts
+++ b/apps/web/src/lib/utils/sanitizeMarkdown.ts
@@ -97,7 +97,7 @@ export function sanitizeMarkdown(markdown: string): string {
     },
     allowedClasses: {
       mark: ["bg-primary/50", "text-foreground", "rounded-sm", "px-0.5"],
-      span: ["text-primary", "font-medium"],
+      span: ["text-primary", "font-medium", "whitespace-nowrap"],
     },
   });
 

--- a/apps/web/src/lib/utils/sanitizeMarkdown.ts
+++ b/apps/web/src/lib/utils/sanitizeMarkdown.ts
@@ -97,7 +97,7 @@ export function sanitizeMarkdown(markdown: string): string {
     },
     allowedClasses: {
       mark: ["bg-primary/50", "text-foreground", "rounded-sm", "px-0.5"],
-      span: ["text-primary", "font-medium", "cursor-pointer"],
+      span: ["text-primary", "font-medium"],
     },
   });
 


### PR DESCRIPTION
Hovering a resolved `@Name` on a sent chat message shows the same participant hover card as the avatar. **Message** on that card create-or-gets the 1:1 Direct (existing start-DM path and gates). The chip itself does not navigate.

## Why

Sent mention chips looked like links and did nothing. Starting a Direct meant hunting the roster. Click-to-open over-specified the chip; the hover card already has Message.

## What

- Display-time rewrite only: resolved human/coworker chips (including self) carry identity for the existing hover card. `@all`, unresolved, and departed names stay inert.
- Sent surfaces: main transcript, Threads, quotes (including composer quote preview when the `@` picker is hidden).
- **Message** reuses `openDirectWithParticipant` (guest/org-seat gates, coworker Direct, stay if already open). Self shows the card without Message.
- Composer and edit-composer mention pickers are unchanged. Avatar/roster hover Message stays.
- No Core API, schema, or stored-markdown change.

Closes [SOK-865](https://linear.app/masumi/issue/SOK-865/click-chat-mentions-to-open-a-direct)

## Verification

- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-helpers-mentions.test.ts`
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-mention-markdown.test.tsx`
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/`
- `pnpm --filter web typecheck` (also via husky `pnpm check && pnpm typecheck`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat mentions now display interactive participant hover cards.
  * Resolvable coworker and human mentions can support direct-message actions.
  * Mention chips retain their identity and styling when rendered in messages and quote previews.
  * Hover-card open and close timing can be customized.

* **Bug Fixes**
  * Improved mention rendering when participant data or mention-picker results change.
  * Prevented invalid `@all` mentions and channel links from being treated as direct-message targets.

* **Tests**
  * Added coverage for mention chips, hover cards, quote previews, departed users, and sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->