### PR TITLE
feat(chat): open settings from channel title

### DIFF
--- a/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-roster.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-roster.test.tsx
@@ -139,7 +139,11 @@ describe("EditChannelDialog host roster payload", () => {
         canArchive
         canLeave
         canInviteGuests={false}
-      />,
+      >
+        <button type="button" aria-label="editChannel">
+          edit
+        </button>
+      </EditChannelDialog>,
     );
 
     await user.click(screen.getByRole("button", { name: "editChannel" }));
@@ -175,7 +179,11 @@ describe("EditChannelDialog host roster payload", () => {
         canArchive
         canLeave
         canInviteGuests={false}
-      />,
+      >
+        <button type="button" aria-label="editChannel">
+          edit
+        </button>
+      </EditChannelDialog>,
     );
 
     await user.click(screen.getByRole("button", { name: "editChannel" }));

--- a/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-trigger.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/edit-channel-dialog-trigger.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { ChatRoom } from "@/lib/clients/generated/core";
 import { EditChannelDialog } from "../edit-channel-dialog";
@@ -44,7 +45,8 @@ function channel(): ChatRoom {
 }
 
 describe("EditChannelDialog trigger", () => {
-  it("uses the gear icon, not sliders", () => {
+  it("opens from the provided trigger and has no settings gear", async () => {
+    const user = userEvent.setup();
     render(
       <EditChannelDialog
         channel={channel()}
@@ -55,12 +57,20 @@ describe("EditChannelDialog trigger", () => {
         canManageSettings={false}
         canArchive={false}
         canLeave={false}
-      />,
+      >
+        <button type="button" aria-label="editChannel" title="editChannel">
+          general
+        </button>
+      </EditChannelDialog>,
     );
 
     const trigger = screen.getByRole("button", { name: "editChannel" });
-    const icon = trigger.querySelector("svg");
-    expect(icon?.classList.contains("lucide-settings")).toBe(true);
-    expect(icon?.classList.contains("lucide-settings-2")).toBe(false);
+    expect(trigger).toHaveTextContent("general");
+    expect(document.querySelector(".lucide-settings")).toBeNull();
+
+    await user.click(trigger);
+    expect(
+      screen.getByRole("heading", { name: "Dialog.editTitle" }),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -172,17 +172,22 @@ vi.mock("../edit-channel-dialog", () => ({
     membersLoadFailed,
     members,
     coworkers,
+    children,
   }: {
     membersLoadFailed?: boolean;
     members?: unknown[];
     coworkers?: unknown[];
+    children?: ReactNode;
   }) => (
-    <div
-      data-testid="edit-channel-dialog-probe"
-      data-members-load-failed={String(Boolean(membersLoadFailed))}
-      data-members-count={String(members?.length ?? 0)}
-      data-coworkers-count={String(coworkers?.length ?? 0)}
-    />
+    <>
+      {children}
+      <div
+        data-testid="edit-channel-dialog-probe"
+        data-members-load-failed={String(Boolean(membersLoadFailed))}
+        data-members-count={String(members?.length ?? 0)}
+        data-coworkers-count={String(coworkers?.length ?? 0)}
+      />
+    </>
   ),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -185,7 +185,12 @@ vi.mock("../draft-direct-message", () => ({
 }));
 
 vi.mock("../edit-channel-dialog", () => ({
-  EditChannelDialog: () => <div data-testid="edit-channel-dialog-probe" />,
+  EditChannelDialog: ({ children }: { children?: ReactNode }) => (
+    <>
+      {children}
+      <div data-testid="edit-channel-dialog-probe" />
+    </>
+  ),
 }));
 
 vi.mock("@/components/chat/channel-discoverability-icon", () => ({
@@ -294,18 +299,35 @@ function renderRoom(room: ChatRoom) {
 }
 
 describe("RoomsClient room header chrome", () => {
-  it("keeps search with the title and paints the title as the landmark", () => {
+  it("opens channel settings from the title and keeps search with the right actions", () => {
     renderRoom(channelRoom());
 
     const title = screen.getByTestId("room-open-title");
     const search = screen.getByTestId("room-search-trigger");
     const threads = screen.getByTestId("unread-threads-trigger");
 
+    expect(title.tagName).toBe("BUTTON");
+    expect(title).toHaveAttribute("title", "editChannel");
+    expect(title).toHaveAccessibleName("general");
     expect(title).toHaveClass("text-foreground");
-    expect(title).not.toHaveClass("text-muted-foreground");
-    expect(title.parentElement).toContainElement(search);
-    expect(title.parentElement).not.toContainElement(threads);
+    expect(title.className).toContain("[@media(hover:hover)]:hover:bg-");
+    expect(search.parentElement).toContainElement(threads);
+    expect(title.parentElement).not.toContainElement(search);
+    expect(screen.getByRole("button", { name: "general" })).toBe(title);
     expect(screen.getByTestId("edit-channel-dialog-probe")).toBeTruthy();
+  });
+
+  it("keeps Direct titles static and still puts search with the right actions", () => {
+    renderRoom(humanDirectRoom());
+
+    const title = screen.getByTestId("room-open-title");
+    const search = screen.getByTestId("room-search-trigger");
+    const threads = screen.getByTestId("unread-threads-trigger");
+
+    expect(title.tagName).not.toBe("BUTTON");
+    expect(search.parentElement).toContainElement(threads);
+    expect(screen.queryByRole("button", { name: "editChannel" })).toBeNull();
+    expect(screen.queryByTestId("edit-channel-dialog-probe")).toBeNull();
   });
 
   it("opens the Members rail from the face stack and yields the rail to threads", async () => {

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -194,7 +194,9 @@ vi.mock("../edit-channel-dialog", () => ({
 }));
 
 vi.mock("@/components/chat/channel-discoverability-icon", () => ({
-  ChannelDiscoverabilityIcon: () => null,
+  ChannelDiscoverabilityIcon: () => (
+    <span data-testid="channel-discoverability-icon" />
+  ),
 }));
 
 vi.mock("@/components/chat/live-member-presence-dot", () => ({
@@ -299,7 +301,7 @@ function renderRoom(room: ChatRoom) {
 }
 
 describe("RoomsClient room header chrome", () => {
-  it("opens channel settings from the title and keeps search with the right actions", () => {
+  it("makes the channel title the settings trigger and keeps search with the right actions", () => {
     renderRoom(channelRoom());
 
     const title = screen.getByTestId("room-open-title");
@@ -309,8 +311,12 @@ describe("RoomsClient room header chrome", () => {
     expect(title.tagName).toBe("BUTTON");
     expect(title).toHaveAttribute("title", "editChannel");
     expect(title).toHaveAccessibleName("general");
+    expect(title).toContainElement(
+      screen.getByTestId("channel-discoverability-icon"),
+    );
     expect(title).toHaveClass("text-foreground");
     expect(title.className).toContain("[@media(hover:hover)]:hover:bg-");
+    expect(title.className).toContain("focus-visible:ring-inset");
     expect(search.parentElement).toContainElement(threads);
     expect(title.parentElement).not.toContainElement(search);
     expect(screen.getByRole("button", { name: "general" })).toBe(title);

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
   type FormEvent,
-  type ReactNode,
+  type ReactElement,
   useEffect,
   useState,
   useTransition,
@@ -98,7 +98,8 @@ export function EditChannelDialog({
    */
   canInviteGuests?: boolean;
   membersLoadFailed?: boolean;
-  children: ReactNode;
+  /** Single element for DialogTrigger asChild; must accept merged props and ref. */
+  children: ReactElement;
 }) {
   const t = useTranslations("App.Channels");
   const tActions = useTranslations("App.Channels.Actions");

--- a/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
+++ b/apps/web/src/app/(app)/chat/components/edit-channel-dialog.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import {
-  Archive as ArchiveIcon,
-  Loader2,
-  LogOut,
-  Settings,
-} from "lucide-react";
+import { Archive as ArchiveIcon, Loader2, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type FormEvent, useEffect, useState, useTransition } from "react";
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
 import { toast } from "sonner";
 import {
   archiveRoomAction,
@@ -76,6 +77,7 @@ export function EditChannelDialog({
   canLeave,
   canInviteGuests = false,
   membersLoadFailed = false,
+  children,
 }: {
   channel: ChatRoom;
   members: Member[];
@@ -96,6 +98,7 @@ export function EditChannelDialog({
    */
   canInviteGuests?: boolean;
   membersLoadFailed?: boolean;
+  children: ReactNode;
 }) {
   const t = useTranslations("App.Channels");
   const tActions = useTranslations("App.Channels.Actions");
@@ -210,17 +213,7 @@ export function EditChannelDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8 rounded-full"
-            aria-label={t("editChannel")}
-            title={t("editChannel")}
-          >
-            <Settings className="size-4" aria-hidden />
-          </Button>
-        </DialogTrigger>
+        <DialogTrigger asChild>{children}</DialogTrigger>
         {/* The fixed-height participant list makes this dialog ~755px tall, which
             overflows a shorter phone — on a 667px iPhone SE the title and close
             button sat above the viewport and Cancel below it, with nothing to

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
@@ -169,7 +169,7 @@ export function RoomSearchPanel({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        align="start"
+        align="end"
         className="w-[min(100vw-2rem,24rem)] p-0"
         data-testid="room-search-panel"
       >

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -380,38 +380,59 @@ function RoomHeaderChrome({
     <div className="flex min-w-0 flex-1 items-center justify-between gap-1.5 overflow-hidden md:gap-4">
       <div className="flex min-w-0 items-center gap-1.5 md:gap-2">
         {isDirectRoom ? (
-          <MessageCircle className="text-muted-foreground size-4 shrink-0" />
+          <>
+            <MessageCircle className="text-muted-foreground size-4 shrink-0" />
+            <p
+              className="text-foreground min-w-0 truncate text-sm"
+              data-testid="room-open-title"
+            >
+              {displayName}
+            </p>
+          </>
         ) : (
-          <ChannelDiscoverabilityIcon
-            className="text-muted-foreground"
-            discoverability={room.discoverability}
-          />
+          <EditChannelDialog
+            channel={room}
+            members={organizationMembers}
+            coworkers={coworkers}
+            currentUserId={currentUserId}
+            canEditMembers={canEditMembers}
+            canManageSettings={canManageSettings}
+            canArchive={canArchive}
+            canLeave={canLeave}
+            canInviteGuests={canInviteGuests}
+            membersLoadFailed={membersLoadFailed}
+          >
+            <button
+              type="button"
+              className="text-foreground [@media(hover:hover)]:hover:bg-accent flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              title={t("editChannel")}
+              data-testid="room-open-title"
+            >
+              <ChannelDiscoverabilityIcon
+                className="text-muted-foreground"
+                discoverability={room.discoverability}
+              />
+              <span className="min-w-0 truncate">{displayName}</span>
+            </button>
+          </EditChannelDialog>
         )}
-        <p
-          className="text-foreground min-w-0 truncate text-sm"
-          data-testid="room-open-title"
-        >
-          {displayName}
-        </p>
-        <div className="shrink-0">
-          <RoomSearchPanel
-            key={room.id}
-            roomId={room.id}
-            loadedMessages={topLevelRoomMessages}
-            onOpenThread={onOpenThread}
-            labels={{
-              open: t("RoomSearch.open"),
-              placeholder: t("RoomSearch.placeholder"),
-              idle: t("RoomSearch.idle"),
-              empty: t("RoomSearch.empty"),
-              loading: t("RoomSearch.loading"),
-              error: t("RoomSearch.error"),
-              replyBadge: t("RoomSearch.replyBadge"),
-            }}
-          />
-        </div>
       </div>
       <div className="flex shrink-0 items-center gap-1.5 md:gap-2">
+        <RoomSearchPanel
+          key={room.id}
+          roomId={room.id}
+          loadedMessages={topLevelRoomMessages}
+          onOpenThread={onOpenThread}
+          labels={{
+            open: t("RoomSearch.open"),
+            placeholder: t("RoomSearch.placeholder"),
+            idle: t("RoomSearch.idle"),
+            empty: t("RoomSearch.empty"),
+            loading: t("RoomSearch.loading"),
+            error: t("RoomSearch.error"),
+            replyBadge: t("RoomSearch.replyBadge"),
+          }}
+        />
         <UnreadThreadsPanel
           key={`unread-threads-${room.id}`}
           isOpen={threadListOpen}
@@ -427,20 +448,6 @@ function RoomHeaderChrome({
             onToggleRoster={onToggleRoster}
           />
         ) : null}
-        {isDirectRoom ? null : (
-          <EditChannelDialog
-            channel={room}
-            members={organizationMembers}
-            coworkers={coworkers}
-            currentUserId={currentUserId}
-            canEditMembers={canEditMembers}
-            canManageSettings={canManageSettings}
-            canArchive={canArchive}
-            canLeave={canLeave}
-            canInviteGuests={canInviteGuests}
-            membersLoadFailed={membersLoadFailed}
-          />
-        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -404,7 +404,7 @@ function RoomHeaderChrome({
           >
             <button
               type="button"
-              className="text-foreground [@media(hover:hover)]:hover:bg-accent flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="text-foreground [@media(hover:hover)]:hover:bg-accent [@media(hover:hover)]:dark:hover:bg-accent/50 flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:gap-2"
               title={t("editChannel")}
               data-testid="room-open-title"
             >


### PR DESCRIPTION
## Summary

Channel headers now open settings from the title, Slack-style. The settings gear is gone. The discoverability icon and Channel name are one control: click or tap opens the existing edit-Channel dialog. Desktop hover shows a rounded background and the existing **Edit channel** tooltip. Direct titles stay static.

Search is back in the right action cluster (Search, Threads, Avatars). The search popover aligns to the end of that cluster.

## User-facing

- Channel name is tappable; it opens Channel settings
- Settings gear is removed from Channel headers
- Search sits with the other header actions on the right

## Verification

- [x] `pnpm --filter web test` (3715 passed)
- [x] Husky pre-commit: `biome check` + typecheck
- [ ] Open a Channel and confirm icon+name opens the edit dialog, there is no gear, and search is on the right
- [ ] Confirm Direct titles are still static and still have search on the right
- [ ] Desktop: hover the Channel name and confirm the tooltip is **Edit channel** with no chevron

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel names in the chat header can now be edited by selecting the title.
  * Direct-message room titles remain static and display a message icon.
  * Search and unread-thread actions are grouped with the room title.

* **UI Improvements**
  * Room search is now aligned to the right for improved header layout.
  * Channel discoverability status is visible in the editable header control.

* **Tests**
  * Expanded coverage for channel editing, direct-message headers, and room search interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->