### PR TITLE
feat(chat): jump in-chat search to newest hits

### DIFF
--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.test.ts
@@ -14,6 +14,7 @@ const {
   roomFindFirstMock,
   organizationFindUniqueMock,
   memberFindUniqueMock,
+  messageFindFirstMock,
   messageFindManyMock,
   messageCountMock,
   prismaTransactionMock,
@@ -22,6 +23,7 @@ const {
   roomFindFirstMock: vi.fn(),
   organizationFindUniqueMock: vi.fn(),
   memberFindUniqueMock: vi.fn(),
+  messageFindFirstMock: vi.fn(),
   messageFindManyMock: vi.fn(),
   messageCountMock: vi.fn(),
   prismaTransactionMock: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock("@/lib/db/prisma", () => ({
       findUnique: memberFindUniqueMock,
     },
     chatRoomMessage: {
+      findFirst: messageFindFirstMock,
       findMany: messageFindManyMock,
       count: messageCountMock,
     },
@@ -59,6 +62,10 @@ vi.mock("@vercel/functions", () => ({
 
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440001";
+const NEWER_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440011";
+const OLDER_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440010";
+const PARENT_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440021";
+const REPLY_MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440022";
 const USER_ID = "user_123";
 const ORG_ID = "org_1";
 
@@ -161,6 +168,62 @@ describe("GET /chats/rooms/{id}/messages", () => {
     expect(messageCountMock).not.toHaveBeenCalled();
   });
 
+  it("returns the live timeline in oldest-first reading order", async () => {
+    const newer = {
+      ...message(),
+      id: NEWER_MESSAGE_ID,
+      content: "Hello newer",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    const older = {
+      ...message(),
+      id: OLDER_MESSAGE_ID,
+      content: "Hello older",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    messageFindManyMock.mockResolvedValue([newer, older]);
+    messageCountMock.mockResolvedValue(2);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.map((row: { id: string }) => row.id)).toEqual([
+      OLDER_MESSAGE_ID,
+      NEWER_MESSAGE_ID,
+    ]);
+  });
+
+  it("returns search hits newest-first when q is set", async () => {
+    const newer = {
+      ...message(),
+      id: NEWER_MESSAGE_ID,
+      content: "Hello newer",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    const older = {
+      ...message(),
+      id: OLDER_MESSAGE_ID,
+      content: "Hello older",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    messageFindManyMock.mockResolvedValue([newer, older]);
+    messageCountMock.mockResolvedValue(2);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?q=Hello`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.map((row: { id: string }) => row.id)).toEqual([
+      NEWER_MESSAGE_ID,
+      OLDER_MESSAGE_ID,
+    ]);
+  });
+
   it("filters by content when q is set and searches all thread depths", async () => {
     const response = await createApp(userAuthContext).request(
       `/${ROOM_ID}/messages?q=Hello`,
@@ -186,6 +249,133 @@ describe("GET /chats/rooms/{id}/messages", () => {
 
     expect(response.status).toBe(422);
     expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects around combined with q", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?q=Hello&around=${MESSAGE_ID}`,
+    );
+
+    expect(response.status).toBe(422);
+    expect(messageFindFirstMock).not.toHaveBeenCalled();
+    expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects around combined with cursor", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?around=${MESSAGE_ID}&cursor=${OLDER_MESSAGE_ID}`,
+    );
+
+    expect(response.status).toBe(422);
+    expect(messageFindFirstMock).not.toHaveBeenCalled();
+    expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the around target is missing", async () => {
+    messageFindFirstMock.mockResolvedValue(null);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?around=${MESSAGE_ID}`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a reading-order window centred on around", async () => {
+    const center = {
+      ...message(),
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    const older = {
+      ...message(),
+      id: OLDER_MESSAGE_ID,
+      content: "Hello older",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const newer = {
+      ...message(),
+      id: NEWER_MESSAGE_ID,
+      content: "Hello newer",
+      createdAt: new Date("2026-01-03T00:00:00.000Z"),
+    };
+    messageFindFirstMock.mockResolvedValue(center);
+    messageFindManyMock.mockImplementation(
+      async (args: { orderBy?: Array<{ createdAt?: string }> }) => {
+        const createdAtOrder = args.orderBy?.[0]?.createdAt;
+        if (createdAtOrder === "desc") {
+          return [older];
+        }
+        return [newer];
+      },
+    );
+    messageCountMock.mockResolvedValue(3);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?around=${MESSAGE_ID}&limit=3`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.map((row: { id: string }) => row.id)).toEqual([
+      OLDER_MESSAGE_ID,
+      MESSAGE_ID,
+      NEWER_MESSAGE_ID,
+    ]);
+    expect(listStaleSentChatRoomMentionIdsMock).not.toHaveBeenCalled();
+  });
+
+  it("centres a reply around on its top-level parent", async () => {
+    const parent = {
+      ...message(),
+      id: PARENT_MESSAGE_ID,
+      content: "Thread parent",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    const reply = {
+      ...message(),
+      id: REPLY_MESSAGE_ID,
+      parentMessageId: PARENT_MESSAGE_ID,
+      content: "Thread reply",
+      createdAt: new Date("2026-01-02T01:00:00.000Z"),
+    };
+    const older = {
+      ...message(),
+      id: OLDER_MESSAGE_ID,
+      content: "Hello older",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const newer = {
+      ...message(),
+      id: NEWER_MESSAGE_ID,
+      content: "Hello newer",
+      createdAt: new Date("2026-01-03T00:00:00.000Z"),
+    };
+    messageFindFirstMock
+      .mockResolvedValueOnce(reply)
+      .mockResolvedValueOnce(parent);
+    messageFindManyMock.mockImplementation(
+      async (args: { orderBy?: Array<{ createdAt?: string }> }) => {
+        const createdAtOrder = args.orderBy?.[0]?.createdAt;
+        if (createdAtOrder === "desc") {
+          return [older];
+        }
+        return [newer];
+      },
+    );
+    messageCountMock.mockResolvedValue(3);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/messages?around=${REPLY_MESSAGE_ID}&limit=3`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.map((row: { id: string }) => row.id)).toEqual([
+      OLDER_MESSAGE_ID,
+      PARENT_MESSAGE_ID,
+      NEWER_MESSAGE_ID,
+    ]);
   });
 
   it("reclaims stale mentions on the timeline path without q", async () => {

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.test.ts
@@ -121,6 +121,9 @@ function message() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  messageFindFirstMock.mockReset();
+  messageFindManyMock.mockReset();
+  messageCountMock.mockReset();
   roomFindFirstMock.mockResolvedValue({
     id: ROOM_ID,
     organizationId: ORG_ID,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
@@ -29,7 +29,10 @@ import {
   mapChatRoomMessage,
   requireChatRoomUserMembership,
 } from "../../helpers";
-import { listChatRoomMessagesAround } from "../../message-window-around";
+import {
+  aroundWindowPaginationMeta,
+  listChatRoomMessagesAround,
+} from "../../message-window-around";
 
 const paramsSchema = z.object({
   id: z
@@ -140,12 +143,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           center,
           take,
         });
-      const paginationMeta = {
-        cursor: null,
-        limit: take,
-        total: count,
-        nextCursor: hasMoreOlder ? (messages[0]?.id ?? null) : null,
-      };
+      const paginationMeta = aroundWindowPaginationMeta(
+        messages,
+        take,
+        count,
+        hasMoreOlder,
+      );
       return ok(
         c,
         z

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { waitUntil } from "@vercel/functions";
 
+import { notFound, unprocessableEntity } from "@/helpers/error";
 import {
   jsonErrorResponse,
   jsonPaginatedSuccessResponse,
@@ -28,6 +29,7 @@ import {
   mapChatRoomMessage,
   requireChatRoomUserMembership,
 } from "../../helpers";
+import { listChatRoomMessagesAround } from "../../message-window-around";
 
 const paramsSchema = z.object({
   id: z
@@ -51,6 +53,16 @@ const querySchema = cursorPaginationQuerySchema.extend({
       description:
         "Case-insensitive substring match on message content. When set, searches top-level and thread replies and excludes soft-deleted messages.",
       example: "budget",
+    }),
+  around: z
+    .string()
+    .uuid()
+    .optional()
+    .openapi({
+      param: { name: "around", in: "query" },
+      description:
+        "Reading-order window of top-level messages centred on this message, or on its parent if it is a reply. Cannot be combined with q or cursor.",
+      example: "550e8400-e29b-41d4-a716-446655440001",
     }),
 });
 
@@ -84,6 +96,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const queryParams = c.req.valid("query");
     const { cursor, take, skip } = parseCursorPagination(queryParams);
     const takePlusOne = take + 1;
+    const searchQuery = queryParams.q;
+    const aroundId = queryParams.around;
+    if (aroundId && (searchQuery || cursor)) {
+      throw unprocessableEntity("around cannot be combined with q or cursor");
+    }
 
     // Avoid interactive transaction on this read-only path — room page loads
     // messages in parallel with room + members (SOKOSUMI-Q9). Membership gate
@@ -91,7 +108,56 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     // the default client is fine; Promise.all inside interactive txs is not
     // (#2559).
     await requireChatRoomUserMembership(id, userContext.userId, prisma);
-    const searchQuery = queryParams.q;
+
+    if (aroundId) {
+      const target = await prisma.chatRoomMessage.findFirst({
+        where: { id: aroundId, roomId: id },
+        include: chatRoomMessageInclude,
+      });
+      if (!target) {
+        throw notFound("Message not found");
+      }
+      let center = target;
+      if (target.parentMessageId) {
+        const parent = await prisma.chatRoomMessage.findFirst({
+          where: {
+            id: target.parentMessageId,
+            roomId: id,
+            parentMessageId: null,
+          },
+          include: chatRoomMessageInclude,
+        });
+        if (!parent) {
+          throw notFound("Message not found");
+        }
+        center = parent;
+      }
+      const { messages, hasMoreOlder, count } =
+        await listChatRoomMessagesAround({
+          tx: prisma,
+          scope: { roomId: id, parentMessageId: null },
+          center,
+          take,
+        });
+      const paginationMeta = {
+        cursor: null,
+        limit: take,
+        total: count,
+        nextCursor: hasMoreOlder ? (messages[0]?.id ?? null) : null,
+      };
+      return ok(
+        c,
+        z
+          .array(chatRoomMessageSchema)
+          .parse(
+            messages.map((message) =>
+              mapChatRoomMessage(message, userContext.userId),
+            ),
+          ),
+        paginationMeta,
+      );
+    }
+
     const where = searchQuery
       ? {
           roomId: id,
@@ -131,7 +197,11 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       hasMore,
       cursor,
     );
-    const orderedMessages = [...pageMessages].reverse();
+    // Search keeps newest-first so the hit you want is at the top. The live
+    // timeline still reverses into oldest-first reading order.
+    const orderedMessages = searchQuery
+      ? pageMessages
+      : [...pageMessages].reverse();
 
     // Polls hit this route; kick abandoned `sent` mentions so reclaim can run
     // after a killed waitUntil left them non-terminal. Skip on search — not a

--- a/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/messages/get.ts
@@ -84,6 +84,7 @@ const route = withGlobalHeaderParameters(
       401: jsonErrorResponse("Unauthorized"),
       403: jsonErrorResponse("Forbidden"),
       404: jsonErrorResponse("Room not found"),
+      422: jsonErrorResponse("Unprocessable Entity"),
       500: jsonErrorResponse("Internal Server Error"),
     },
   }),
@@ -134,7 +135,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       }
       const { messages, hasMoreOlder, count } =
         await listChatRoomMessagesAround({
-          tx: prisma,
+          db: prisma,
           scope: { roomId: id, parentMessageId: null },
           center,
           take,

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.test.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.test.ts
@@ -48,6 +48,8 @@ vi.mock("@/lib/db/prisma", () => ({
 const ROOM_ID = "550e8400-e29b-41d4-a716-446655440000";
 const PARENT_ID = "550e8400-e29b-41d4-a716-446655440001";
 const REPLY_ID = "550e8400-e29b-41d4-a716-446655440002";
+const OLDER_REPLY_ID = "550e8400-e29b-41d4-a716-446655440003";
+const NEWER_REPLY_ID = "550e8400-e29b-41d4-a716-446655440004";
 const USER_ID = "user_123";
 const ORG_ID = "org_1";
 
@@ -103,6 +105,9 @@ function replyMessage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  messageFindFirstMock.mockReset();
+  messageFindManyMock.mockReset();
+  messageCountMock.mockReset();
   roomFindFirstMock.mockResolvedValue({
     id: ROOM_ID,
     organizationId: ORG_ID,
@@ -167,5 +172,71 @@ describe("GET /chats/rooms/{id}/threads/{parentMessageId}/messages", () => {
     expect(response.status).toBe(404);
     expect(messageFindManyMock).not.toHaveBeenCalled();
     expect(messageCountMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects around combined with cursor", async () => {
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/threads/${PARENT_ID}/messages?around=${REPLY_ID}&cursor=${OLDER_REPLY_ID}`,
+    );
+
+    expect(response.status).toBe(422);
+    expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the around reply is not in this thread", async () => {
+    messageFindFirstMock
+      .mockResolvedValueOnce({ id: PARENT_ID })
+      .mockResolvedValueOnce(null);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/threads/${PARENT_ID}/messages?around=${REPLY_ID}`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(messageFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a reading-order window centred on around", async () => {
+    const center = {
+      ...replyMessage(),
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    const older = {
+      ...replyMessage(),
+      id: OLDER_REPLY_ID,
+      content: "Older reply",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const newer = {
+      ...replyMessage(),
+      id: NEWER_REPLY_ID,
+      content: "Newer reply",
+      createdAt: new Date("2026-01-03T00:00:00.000Z"),
+    };
+    messageFindFirstMock
+      .mockResolvedValueOnce({ id: PARENT_ID })
+      .mockResolvedValueOnce(center);
+    messageFindManyMock.mockImplementation(
+      async (args: { orderBy?: Array<{ createdAt?: string }> }) => {
+        const createdAtOrder = args.orderBy?.[0]?.createdAt;
+        if (createdAtOrder === "desc") {
+          return [older];
+        }
+        return [newer];
+      },
+    );
+    messageCountMock.mockResolvedValue(3);
+
+    const response = await createApp(userAuthContext).request(
+      `/${ROOM_ID}/threads/${PARENT_ID}/messages?around=${REPLY_ID}&limit=3`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.map((row: { id: string }) => row.id)).toEqual([
+      OLDER_REPLY_ID,
+      REPLY_ID,
+      NEWER_REPLY_ID,
+    ]);
   });
 });

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
@@ -24,7 +24,10 @@ import {
   mapChatRoomMessage,
   requireChatRoomUserMembership,
 } from "../../../../helpers";
-import { listChatRoomMessagesAround } from "../../../../message-window-around";
+import {
+  aroundWindowPaginationMeta,
+  listChatRoomMessagesAround,
+} from "../../../../message-window-around";
 
 const paramsSchema = z.object({
   id: z
@@ -131,12 +134,12 @@ export default function mount(app: OpenAPIHonoWithAuth) {
           center: target,
           take,
         });
-      const paginationMeta = {
-        cursor: null,
-        limit: take,
-        total: count,
-        nextCursor: hasMoreOlder ? (messages[0]?.id ?? null) : null,
-      };
+      const paginationMeta = aroundWindowPaginationMeta(
+        messages,
+        take,
+        count,
+        hasMoreOlder,
+      );
       return ok(
         c,
         z

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 
-import { notFound } from "@/helpers/error";
+import { notFound, unprocessableEntity } from "@/helpers/error";
 import {
   jsonErrorResponse,
   jsonPaginatedSuccessResponse,
@@ -24,6 +24,7 @@ import {
   mapChatRoomMessage,
   requireChatRoomUserMembership,
 } from "../../../../helpers";
+import { listChatRoomMessagesAround } from "../../../../message-window-around";
 
 const paramsSchema = z.object({
   id: z
@@ -42,6 +43,19 @@ const paramsSchema = z.object({
     }),
 });
 
+const querySchema = cursorPaginationQuerySchema.extend({
+  around: z
+    .string()
+    .uuid()
+    .optional()
+    .openapi({
+      param: { name: "around", in: "query" },
+      description:
+        "Reading-order window of replies centred on this reply. Must belong to this thread. Cannot be combined with cursor.",
+      example: "550e8400-e29b-41d4-a716-446655440002",
+    }),
+});
+
 const route = withGlobalHeaderParameters(
   createRoute({
     method: "get",
@@ -51,7 +65,7 @@ const route = withGlobalHeaderParameters(
     tags: ["Chat Rooms"],
     request: {
       params: paramsSchema,
-      query: cursorPaginationQuerySchema,
+      query: querySchema,
     },
     responses: {
       200: jsonPaginatedSuccessResponse(
@@ -73,6 +87,10 @@ export default function mount(app: OpenAPIHonoWithAuth) {
     const queryParams = c.req.valid("query");
     const { cursor, take, skip } = parseCursorPagination(queryParams);
     const takePlusOne = take + 1;
+    const aroundId = queryParams.around;
+    if (aroundId && cursor) {
+      throw unprocessableEntity("around cannot be combined with cursor");
+    }
 
     await requireChatRoomUserMembership(id, userContext.userId, prisma);
 
@@ -92,6 +110,44 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       roomId: id,
       parentMessageId: parent.id,
     };
+
+    if (aroundId) {
+      const target = await prisma.chatRoomMessage.findFirst({
+        where: {
+          id: aroundId,
+          roomId: id,
+          parentMessageId: parent.id,
+        },
+        include: chatRoomMessageInclude,
+      });
+      if (!target) {
+        throw notFound("Message not found");
+      }
+      const { messages, hasMoreOlder, count } =
+        await listChatRoomMessagesAround({
+          tx: prisma,
+          scope: where,
+          center: target,
+          take,
+        });
+      const paginationMeta = {
+        cursor: null,
+        limit: take,
+        total: count,
+        nextCursor: hasMoreOlder ? (messages[0]?.id ?? null) : null,
+      };
+      return ok(
+        c,
+        z
+          .array(chatRoomMessageSchema)
+          .parse(
+            messages.map((message) =>
+              mapChatRoomMessage(message, userContext.userId),
+            ),
+          ),
+        paginationMeta,
+      );
+    }
 
     const [messages, count] = await Promise.all([
       prisma.chatRoomMessage.findMany({

--- a/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
+++ b/apps/core/src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.ts
@@ -75,6 +75,7 @@ const route = withGlobalHeaderParameters(
       401: jsonErrorResponse("Unauthorized"),
       403: jsonErrorResponse("Forbidden"),
       404: jsonErrorResponse("Thread not found"),
+      422: jsonErrorResponse("Unprocessable Entity"),
       500: jsonErrorResponse("Internal Server Error"),
     },
   }),
@@ -125,7 +126,7 @@ export default function mount(app: OpenAPIHonoWithAuth) {
       }
       const { messages, hasMoreOlder, count } =
         await listChatRoomMessagesAround({
-          tx: prisma,
+          db: prisma,
           scope: where,
           center: target,
           take,

--- a/apps/core/src/routes/v1/chats/rooms/message-window-around.ts
+++ b/apps/core/src/routes/v1/chats/rooms/message-window-around.ts
@@ -72,8 +72,7 @@ export async function listChatRoomMessagesAround({
   const [olderPlus, newer, count] = await Promise.all([
     db.chatRoomMessage.findMany({
       where: {
-        ...scope,
-        ...createdAtIdSide(center.createdAt, center.id, "older"),
+        AND: [scope, createdAtIdSide(center.createdAt, center.id, "older")],
       },
       take: takePlusOne,
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
@@ -81,8 +80,7 @@ export async function listChatRoomMessagesAround({
     }),
     db.chatRoomMessage.findMany({
       where: {
-        ...scope,
-        ...createdAtIdSide(center.createdAt, center.id, "newer"),
+        AND: [scope, createdAtIdSide(center.createdAt, center.id, "newer")],
       },
       take,
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
@@ -104,11 +102,26 @@ export async function listChatRoomMessagesAround({
     messages[0] != null &&
     assembled[0] != null &&
     messages[0].id !== assembled[0].id;
-  const hasMoreOlder =
-    droppedOlder ||
-    (assembled[0]?.id === center.id
-      ? olderClosest.length > 0 || hasMoreOlderFromFetch
-      : hasMoreOlderFromFetch);
+  const hasMoreOlder = droppedOlder || hasMoreOlderFromFetch;
 
   return { messages, hasMoreOlder, count };
+}
+
+export function aroundWindowPaginationMeta(
+  messages: ReadonlyArray<{ id: string }>,
+  take: number,
+  count: number,
+  hasMoreOlder: boolean,
+): {
+  cursor: null;
+  limit: number;
+  total: number;
+  nextCursor: string | null;
+} {
+  return {
+    cursor: null,
+    limit: take,
+    total: count,
+    nextCursor: hasMoreOlder ? (messages[0]?.id ?? null) : null,
+  };
 }

--- a/apps/core/src/routes/v1/chats/rooms/message-window-around.ts
+++ b/apps/core/src/routes/v1/chats/rooms/message-window-around.ts
@@ -6,8 +6,15 @@ type ChatRoomMessageWithSender = Prisma.ChatRoomMessageGetPayload<{
   include: typeof chatRoomMessageInclude;
 }>;
 
+interface ChatRoomMessageReadClient {
+  chatRoomMessage: {
+    findMany: Prisma.TransactionClient["chatRoomMessage"]["findMany"];
+    count: Prisma.TransactionClient["chatRoomMessage"]["count"];
+  };
+}
+
 interface ListChatRoomMessagesAroundOptions {
-  tx: Prisma.TransactionClient;
+  db: ChatRoomMessageReadClient;
   scope: Prisma.ChatRoomMessageWhereInput;
   center: ChatRoomMessageWithSender;
   take: number;
@@ -52,7 +59,7 @@ function trimCentered<T>(
  * `hasMoreOlder` is true when Load older from this window would return rows.
  */
 export async function listChatRoomMessagesAround({
-  tx,
+  db,
   scope,
   center,
   take,
@@ -63,7 +70,7 @@ export async function listChatRoomMessagesAround({
 }> {
   const takePlusOne = take + 1;
   const [olderPlus, newer, count] = await Promise.all([
-    tx.chatRoomMessage.findMany({
+    db.chatRoomMessage.findMany({
       where: {
         ...scope,
         ...createdAtIdSide(center.createdAt, center.id, "older"),
@@ -72,7 +79,7 @@ export async function listChatRoomMessagesAround({
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       include: chatRoomMessageInclude,
     }),
-    tx.chatRoomMessage.findMany({
+    db.chatRoomMessage.findMany({
       where: {
         ...scope,
         ...createdAtIdSide(center.createdAt, center.id, "newer"),
@@ -81,7 +88,7 @@ export async function listChatRoomMessagesAround({
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       include: chatRoomMessageInclude,
     }),
-    tx.chatRoomMessage.count({ where: scope }),
+    db.chatRoomMessage.count({ where: scope }),
   ]);
 
   const hasMoreOlderFromFetch = olderPlus.length === takePlusOne;

--- a/apps/core/src/routes/v1/chats/rooms/message-window-around.ts
+++ b/apps/core/src/routes/v1/chats/rooms/message-window-around.ts
@@ -1,0 +1,107 @@
+import type { Prisma } from "@sokosumi/database";
+
+import { chatRoomMessageInclude } from "./helpers";
+
+type ChatRoomMessageWithSender = Prisma.ChatRoomMessageGetPayload<{
+  include: typeof chatRoomMessageInclude;
+}>;
+
+interface ListChatRoomMessagesAroundOptions {
+  tx: Prisma.TransactionClient;
+  scope: Prisma.ChatRoomMessageWhereInput;
+  center: ChatRoomMessageWithSender;
+  take: number;
+}
+
+function createdAtIdSide(
+  createdAt: Date,
+  id: string,
+  side: "older" | "newer",
+): Prisma.ChatRoomMessageWhereInput {
+  if (side === "older") {
+    return {
+      OR: [
+        { createdAt: { lt: createdAt } },
+        { AND: [{ createdAt }, { id: { lt: id } }] },
+      ],
+    };
+  }
+  return {
+    OR: [
+      { createdAt: { gt: createdAt } },
+      { AND: [{ createdAt }, { id: { gt: id } }] },
+    ],
+  };
+}
+
+function trimCentered<T>(
+  items: readonly T[],
+  centerIndex: number,
+  take: number,
+): T[] {
+  if (items.length <= take) {
+    return [...items];
+  }
+  const idealStart = Math.max(0, centerIndex - Math.floor((take - 1) / 2));
+  const start = Math.min(idealStart, items.length - take);
+  return items.slice(start, start + take);
+}
+
+/**
+ * Contiguous reading-order window (oldest → newest) centred on `center`.
+ * `hasMoreOlder` is true when Load older from this window would return rows.
+ */
+export async function listChatRoomMessagesAround({
+  tx,
+  scope,
+  center,
+  take,
+}: ListChatRoomMessagesAroundOptions): Promise<{
+  messages: ChatRoomMessageWithSender[];
+  hasMoreOlder: boolean;
+  count: number;
+}> {
+  const takePlusOne = take + 1;
+  const [olderPlus, newer, count] = await Promise.all([
+    tx.chatRoomMessage.findMany({
+      where: {
+        ...scope,
+        ...createdAtIdSide(center.createdAt, center.id, "older"),
+      },
+      take: takePlusOne,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      include: chatRoomMessageInclude,
+    }),
+    tx.chatRoomMessage.findMany({
+      where: {
+        ...scope,
+        ...createdAtIdSide(center.createdAt, center.id, "newer"),
+      },
+      take,
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      include: chatRoomMessageInclude,
+    }),
+    tx.chatRoomMessage.count({ where: scope }),
+  ]);
+
+  const hasMoreOlderFromFetch = olderPlus.length === takePlusOne;
+  const olderClosest = olderPlus.slice(0, take);
+  const assembled = [...olderClosest].reverse().concat(center, newer);
+  const centerIndex = assembled.findIndex((row) => row.id === center.id);
+  const messages = trimCentered(
+    assembled,
+    centerIndex < 0 ? 0 : centerIndex,
+    take,
+  );
+  const droppedOlder =
+    messages[0] != null &&
+    assembled[0] != null &&
+    messages[0].id !== assembled[0].id;
+  const hasMoreOlder =
+    droppedOlder ||
+    (assembled[0]?.id === center.id
+      ? olderClosest.length > 0 || hasMoreOlderFromFetch
+      : hasMoreOlderFromFetch);
+
+  return { messages, hasMoreOlder, count };
+}

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -733,9 +733,12 @@ export async function listThreadMessagesAction(
 export async function getRoomThreadAction(
   roomId: string,
   parentMessageId: string,
-): Promise<RoomActionResult<ChatRoomThread | null>> {
+): Promise<RoomActionResult<ChatRoomThread>> {
   try {
     const thread = await chatRoomService.getThread(roomId, parentMessageId);
+    if (!thread) {
+      return roomFail("Could not load thread.");
+    }
     return roomOk(thread);
   } catch (error) {
     return roomCatch(error, "Could not load thread.");

--- a/apps/web/src/app/(app)/chat/actions.ts
+++ b/apps/web/src/app/(app)/chat/actions.ts
@@ -690,7 +690,7 @@ export async function sendRoomMessageAction(
 
 export async function listRoomMessagesAction(
   roomId: string,
-  options?: { cursor?: string },
+  options?: { cursor?: string; around?: string },
 ): Promise<
   RoomActionResult<{
     messages: ChatRoomMessage[];
@@ -700,6 +700,7 @@ export async function listRoomMessagesAction(
   try {
     const page = await chatRoomService.listMessages(roomId, {
       cursor: options?.cursor,
+      around: options?.around,
     });
     return roomOk(page);
   } catch (error) {
@@ -710,7 +711,7 @@ export async function listRoomMessagesAction(
 export async function listThreadMessagesAction(
   roomId: string,
   parentMessageId: string,
-  options?: { cursor?: string },
+  options?: { cursor?: string; around?: string },
 ): Promise<
   RoomActionResult<{
     messages: ChatRoomMessage[];
@@ -721,9 +722,21 @@ export async function listThreadMessagesAction(
     const page = await chatRoomService.listThreadMessages(
       roomId,
       parentMessageId,
-      { cursor: options?.cursor },
+      { cursor: options?.cursor, around: options?.around },
     );
     return roomOk(page);
+  } catch (error) {
+    return roomCatch(error, "Could not load thread.");
+  }
+}
+
+export async function getRoomThreadAction(
+  roomId: string,
+  parentMessageId: string,
+): Promise<RoomActionResult<ChatRoomThread | null>> {
+  try {
+    const thread = await chatRoomService.getThread(roomId, parentMessageId);
+    return roomOk(thread);
   } catch (error) {
     return roomCatch(error, "Could not load thread.");
   }

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-search-highlight.test.ts
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-helpers-search-highlight.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  highlightRoomMessageElement,
+  scrollToRoomMessageElement,
+} from "@/app/chat/components/room-helpers";
+
+describe("search jump highlight", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("scrolls the landed message into view instantly and marks it as the search hit", () => {
+    const article = document.createElement("article");
+    article.setAttribute("data-message-id", "msg-1");
+    article.scrollIntoView = vi.fn();
+    document.body.append(article);
+
+    expect(highlightRoomMessageElement("msg-1")).toBe(true);
+
+    expect(article.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "auto",
+      block: "center",
+    });
+    expect(article.dataset.searchLanded).toBe("true");
+    expect(article.className).toContain("ring-primary");
+    expect(article.className).toContain("bg-primary/");
+  });
+
+  it("quote jump still uses smooth scroll and does not paint search highlight", () => {
+    const article = document.createElement("article");
+    article.setAttribute("data-message-id", "msg-2");
+    article.scrollIntoView = vi.fn();
+    document.body.append(article);
+
+    expect(scrollToRoomMessageElement("msg-2")).toBe(true);
+
+    expect(article.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+    });
+    expect(article.dataset.searchLanded).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/(app)/chat/components/__tests__/room-search-panel.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/room-search-panel.test.tsx
@@ -4,7 +4,6 @@ import { RoomSearchPanel } from "@/app/chat/components/room-search-panel";
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 
 const getChatRoomMessagesMock = vi.fn();
-const scrollToRoomMessageElementMock = vi.fn((_messageId: string) => true);
 
 vi.mock("@/lib/clients/core.browser.client", () => ({
   coreClient: {
@@ -12,17 +11,6 @@ vi.mock("@/lib/clients/core.browser.client", () => ({
       getChatRoomMessagesMock(...args),
   },
 }));
-
-vi.mock("@/app/chat/components/room-helpers", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/app/chat/components/room-helpers")
-  >("@/app/chat/components/room-helpers");
-  return {
-    ...actual,
-    scrollToRoomMessageElement: (messageId: string) =>
-      scrollToRoomMessageElementMock(messageId),
-  };
-});
 
 vi.mock("@/lib/utils/datetime.client", () => ({
   useLocalizedDateTime: () => ({
@@ -76,8 +64,7 @@ describe("RoomSearchPanel", () => {
       <RoomSearchPanel
         roomId="550e8400-e29b-41d4-a716-446655440000"
         labels={labels}
-        loadedMessages={[]}
-        onOpenThread={vi.fn()}
+        onJumpToMessage={vi.fn()}
       />,
     );
 
@@ -92,8 +79,7 @@ describe("RoomSearchPanel", () => {
       <RoomSearchPanel
         roomId="550e8400-e29b-41d4-a716-446655440000"
         labels={labels}
-        loadedMessages={[]}
-        onOpenThread={vi.fn()}
+        onJumpToMessage={vi.fn()}
       />,
     );
 
@@ -121,8 +107,7 @@ describe("RoomSearchPanel", () => {
       <RoomSearchPanel
         roomId="550e8400-e29b-41d4-a716-446655440000"
         labels={labels}
-        loadedMessages={[]}
-        onOpenThread={vi.fn()}
+        onJumpToMessage={vi.fn()}
       />,
     );
 
@@ -134,5 +119,59 @@ describe("RoomSearchPanel", () => {
     expect(await screen.findByTestId("room-search-empty")).toHaveTextContent(
       labels.empty,
     );
+  });
+
+  it("lists search hits in API order, newest first", async () => {
+    const newer = message({
+      id: "550e8400-e29b-41d4-a716-446655440002",
+      content: "Newer budget",
+    });
+    const older = message({
+      id: "550e8400-e29b-41d4-a716-446655440001",
+      content: "Older budget",
+    });
+    getChatRoomMessagesMock.mockResolvedValue({ data: [newer, older] });
+
+    render(
+      <RoomSearchPanel
+        roomId="550e8400-e29b-41d4-a716-446655440000"
+        labels={labels}
+        onJumpToMessage={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("room-search-trigger"));
+    fireEvent.change(screen.getByTestId("room-search-input"), {
+      target: { value: "budget" },
+    });
+
+    const results = await screen.findAllByTestId("room-search-result");
+    expect(results).toHaveLength(2);
+    expect(results[0]).toHaveTextContent("Newer budget");
+    expect(results[1]).toHaveTextContent("Older budget");
+  });
+
+  it("closes the popover and jumps to the selected hit", async () => {
+    const hit = message();
+    const onJumpToMessage = vi.fn();
+    getChatRoomMessagesMock.mockResolvedValue({ data: [hit] });
+
+    render(
+      <RoomSearchPanel
+        roomId="550e8400-e29b-41d4-a716-446655440000"
+        labels={labels}
+        onJumpToMessage={onJumpToMessage}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("room-search-trigger"));
+    fireEvent.change(screen.getByTestId("room-search-input"), {
+      target: { value: "budget" },
+    });
+
+    fireEvent.click(await screen.findByTestId("room-search-result"));
+
+    expect(onJumpToMessage).toHaveBeenCalledWith(hit);
+    expect(screen.queryByTestId("room-search-panel")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -81,6 +81,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     scrollToBottom: vi.fn(),
     pinToBottomAfterOwnSend: vi.fn(),
     scrollToBottomIfPinned: vi.fn(),
+    suppressStickToBottom: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-messages-pending.test.tsx
@@ -82,6 +82,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     pinToBottomAfterOwnSend: vi.fn(),
     scrollToBottomIfPinned: vi.fn(),
     suppressStickToBottom: vi.fn(),
+    releaseStickToBottomSuppress: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     scrollToBottom: vi.fn(),
     pinToBottomAfterOwnSend: vi.fn(),
     scrollToBottomIfPinned: vi.fn(),
+    suppressStickToBottom: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-room-header.test.tsx
@@ -95,6 +95,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     pinToBottomAfterOwnSend: vi.fn(),
     scrollToBottomIfPinned: vi.fn(),
     suppressStickToBottom: vi.fn(),
+    releaseStickToBottomSuppress: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
@@ -91,6 +91,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
     suppressStickToBottom: vi.fn(),
+    releaseStickToBottomSuppress: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-scroll-on-send.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     scrollToBottom: vi.fn(),
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
+    suppressStickToBottom: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-thread-open-loading.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-thread-open-loading.test.tsx
@@ -87,6 +87,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     pinToBottomAfterOwnSend: vi.fn(),
     scrollToBottomIfPinned: vi.fn(),
     suppressStickToBottom: vi.fn(),
+    releaseStickToBottomSuppress: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-thread-open-loading.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/rooms-client-thread-open-loading.test.tsx
@@ -86,6 +86,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     scrollToBottom: vi.fn(),
     pinToBottomAfterOwnSend: vi.fn(),
     scrollToBottomIfPinned: vi.fn(),
+    suppressStickToBottom: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-empty-loading.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-empty-loading.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     contentMinHeight: null,
     pinToBottomAfterOwnSend: () => undefined,
     suppressStickToBottom: () => undefined,
+    releaseStickToBottomSuppress: () => undefined,
     scrollToBottomIfPinned: () => undefined,
   }),
 }));

--- a/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-empty-loading.test.tsx
+++ b/apps/web/src/app/(app)/chat/components/__tests__/thread-panel-empty-loading.test.tsx
@@ -40,6 +40,7 @@ vi.mock("@/app/chat/hooks/use-stick-to-bottom", () => ({
     contentRef: { current: null },
     contentMinHeight: null,
     pinToBottomAfterOwnSend: () => undefined,
+    suppressStickToBottom: () => undefined,
     scrollToBottomIfPinned: () => undefined,
   }),
 }));

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -249,7 +249,10 @@ export function pendingQuoteFromMessage(
 }
 
 /** Soft-fail scroll to a room message article when it is still in the DOM. */
-export function scrollToRoomMessageElement(messageId: string): boolean {
+export function scrollToRoomMessageElement(
+  messageId: string,
+  options?: { behavior?: ScrollBehavior },
+): boolean {
   if (typeof document === "undefined") {
     return false;
   }
@@ -259,16 +262,23 @@ export function scrollToRoomMessageElement(messageId: string): boolean {
   if (!target) {
     return false;
   }
-  target.scrollIntoView({ behavior: "smooth", block: "center" });
+  target.scrollIntoView({
+    behavior: options?.behavior ?? "smooth",
+    block: "center",
+  });
   return true;
 }
 
-const ROOM_MESSAGE_HIGHLIGHT_MS = 1500;
-const ROOM_MESSAGE_HIGHLIGHT_CLASS = "bg-accent/50";
+const ROOM_MESSAGE_HIGHLIGHT_MS = 2500;
+const ROOM_MESSAGE_HIGHLIGHT_CLASSES = [
+  "ring-2",
+  "ring-primary",
+  "bg-primary/20",
+] as const;
 
 /** Scroll into view and apply a short-lived highlight when the node exists. */
 export function highlightRoomMessageElement(messageId: string): boolean {
-  if (!scrollToRoomMessageElement(messageId)) {
+  if (!scrollToRoomMessageElement(messageId, { behavior: "auto" })) {
     return false;
   }
   const target = document.querySelector<HTMLElement>(
@@ -277,9 +287,11 @@ export function highlightRoomMessageElement(messageId: string): boolean {
   if (!target) {
     return false;
   }
-  target.classList.add(ROOM_MESSAGE_HIGHLIGHT_CLASS);
+  target.dataset.searchLanded = "true";
+  target.classList.add(...ROOM_MESSAGE_HIGHLIGHT_CLASSES);
   window.setTimeout(() => {
-    target.classList.remove(ROOM_MESSAGE_HIGHLIGHT_CLASS);
+    delete target.dataset.searchLanded;
+    target.classList.remove(...ROOM_MESSAGE_HIGHLIGHT_CLASSES);
   }, ROOM_MESSAGE_HIGHLIGHT_MS);
   return true;
 }

--- a/apps/web/src/app/(app)/chat/components/room-helpers.ts
+++ b/apps/web/src/app/(app)/chat/components/room-helpers.ts
@@ -263,6 +263,27 @@ export function scrollToRoomMessageElement(messageId: string): boolean {
   return true;
 }
 
+const ROOM_MESSAGE_HIGHLIGHT_MS = 1500;
+const ROOM_MESSAGE_HIGHLIGHT_CLASS = "bg-accent/50";
+
+/** Scroll into view and apply a short-lived highlight when the node exists. */
+export function highlightRoomMessageElement(messageId: string): boolean {
+  if (!scrollToRoomMessageElement(messageId)) {
+    return false;
+  }
+  const target = document.querySelector<HTMLElement>(
+    `[data-message-id="${CSS.escape(messageId)}"]`,
+  );
+  if (!target) {
+    return false;
+  }
+  target.classList.add(ROOM_MESSAGE_HIGHLIGHT_CLASS);
+  window.setTimeout(() => {
+    target.classList.remove(ROOM_MESSAGE_HIGHLIGHT_CLASS);
+  }, ROOM_MESSAGE_HIGHLIGHT_MS);
+  return true;
+}
+
 export function messageSender(message: ChatRoomMessage): MessageSenderProfile {
   if (message.sender.type === "user") {
     const user = message.sender.user;

--- a/apps/web/src/app/(app)/chat/components/room-message-row.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-message-row.tsx
@@ -1841,7 +1841,7 @@ export function ChatMessageRow({
       data-message-id={message.id}
       aria-label={isContinuation ? sender.name : undefined}
       className={cn(
-        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45",
+        "group relative -mx-2 flex min-w-0 max-w-full gap-3.5 overflow-x-clip rounded-md pl-2 transition-colors hover:bg-muted/45 data-[search-landed=true]:bg-primary/20 data-[search-landed=true]:ring-2 data-[search-landed=true]:ring-primary",
         reserveHoverActionGutter && "[@media(hover:hover)]:pr-48",
         showActions && TOUCH_MESSAGE_SELECT_NONE_CLASS,
         isContinuation

--- a/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/room-search-panel.tsx
@@ -2,10 +2,7 @@
 
 import { Loader2, Search } from "lucide-react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
-import {
-  messageSender,
-  scrollToRoomMessageElement,
-} from "@/app/chat/components/room-helpers";
+import { messageSender } from "@/app/chat/components/room-helpers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -20,8 +17,6 @@ import { useLocalizedDateTime } from "@/lib/utils/datetime.client";
 
 const SEARCH_PAGE_SIZE = 50;
 const SEARCH_DEBOUNCE_MS = 250;
-const HIGHLIGHT_MS = 1500;
-const HIGHLIGHT_CLASS = "bg-accent/50";
 
 export interface RoomSearchPanelLabels {
   open: string;
@@ -36,32 +31,13 @@ export interface RoomSearchPanelLabels {
 interface RoomSearchPanelProps {
   roomId: string;
   labels: RoomSearchPanelLabels;
-  loadedMessages: ChatRoomMessage[];
-  onOpenThread: (parent: ChatRoomMessage) => void;
-}
-
-function highlightRoomMessageElement(messageId: string): boolean {
-  if (!scrollToRoomMessageElement(messageId)) {
-    return false;
-  }
-  const target = document.querySelector<HTMLElement>(
-    `[data-message-id="${CSS.escape(messageId)}"]`,
-  );
-  if (!target) {
-    return false;
-  }
-  target.classList.add(HIGHLIGHT_CLASS);
-  window.setTimeout(() => {
-    target.classList.remove(HIGHLIGHT_CLASS);
-  }, HIGHLIGHT_MS);
-  return true;
+  onJumpToMessage: (hit: ChatRoomMessage) => void;
 }
 
 export function RoomSearchPanel({
   roomId,
   labels,
-  loadedMessages,
-  onOpenThread,
+  onJumpToMessage,
 }: RoomSearchPanelProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -133,21 +109,7 @@ export function RoomSearchPanel({
   }
 
   function handleSelect(hit: ChatRoomMessage) {
-    if (hit.parentMessageId) {
-      const parent = loadedMessages.find(
-        (message) => message.id === hit.parentMessageId,
-      );
-      if (parent) {
-        onOpenThread(parent);
-        window.setTimeout(() => {
-          highlightRoomMessageElement(hit.id);
-        }, 0);
-        handleOpenChange(false);
-        return;
-      }
-    }
-
-    highlightRoomMessageElement(hit.id);
+    onJumpToMessage(hit);
     handleOpenChange(false);
   }
 

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -535,6 +535,7 @@ export function RoomsClient({
     useState(selectedRoomId);
   const historicalTimelineRef = useRef(false);
   const historicalThreadRef = useRef(false);
+  const [searchHoldOffBottom, setSearchHoldOffBottom] = useState(false);
   // RoomsClient stays mounted across /chat/rooms/[id] navigations. Progressive
   // room switch must drop the prior timeline so skeleton shows and hydrate
   // cannot merge room A into room B (or show A under B's header).
@@ -542,6 +543,7 @@ export function RoomsClient({
     setSyncedHistoryRoomId(selectedRoomId);
     historicalTimelineRef.current = false;
     historicalThreadRef.current = false;
+    setSearchHoldOffBottom(false);
     if (messagesPromise != null) {
       setMessagesState([]);
       setOlderNextCursor(null);
@@ -647,6 +649,7 @@ export function RoomsClient({
     scrollToBottom,
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
+    suppressStickToBottom,
   } = useStickToBottom({
     resetKey: selectedRoomId,
   });
@@ -1829,6 +1832,10 @@ export function RoomsClient({
       return;
     }
     await performRoomSearchJump(hit, {
+      holdOffBottom: () => {
+        suppressStickToBottom();
+        setSearchHoldOffBottom(true);
+      },
       highlight: highlightRoomMessageElement,
       afterRender: waitForSearchJumpPaint,
       loadAroundInRoom: async (aroundId) => {
@@ -2418,6 +2425,7 @@ export function RoomsClient({
 
       if (historicalTimelineRef.current) {
         historicalTimelineRef.current = false;
+        setSearchHoldOffBottom(false);
         const live = await listRoomMessagesAction(roomId);
         if (live.ok && isStillSelectedRoom(roomId)) {
           setMessagesState(live.value.messages);
@@ -2509,6 +2517,7 @@ export function RoomsClient({
 
       if (historicalThreadRef.current) {
         historicalThreadRef.current = false;
+        setSearchHoldOffBottom(false);
         const live = await listThreadMessagesAction(roomId, parentMessageId);
         if (live.ok && isStillSelectedRoom(roomId)) {
           setThreadMessages(live.value.messages);
@@ -2822,6 +2831,7 @@ export function RoomsClient({
             threadParentMessage ? (
               <ThreadPanel
                 parentMessage={threadParentMessage}
+                holdOffBottom={searchHoldOffBottom}
                 replies={displayThreadMessages}
                 isLoading={isThreadLoading}
                 olderNextCursor={threadOlderNextCursor}

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -588,6 +588,11 @@ export function RoomsClient({
     : messageLoadFailedState;
 
   const handleDeferredHistoryResolved = useCallback((page: RoomMessagePage) => {
+    if (historicalTimelineRef.current) {
+      setDeferredHistoryPending(false);
+      setMessageLoadFailedState(false);
+      return;
+    }
     setMessagesState((current) => mergeRoomMessages(current, page.messages));
     setOlderNextCursor(page.nextCursor);
     setMessageLoadFailedState(page.failed);
@@ -650,8 +655,10 @@ export function RoomsClient({
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
     suppressStickToBottom,
+    releaseStickToBottomSuppress,
   } = useStickToBottom({
     resetKey: selectedRoomId,
+    holdOffBottom: searchHoldOffBottom,
   });
   // When history lands, pin live edge in layout (same frame as skeleton →
   // messages) so the list does not paint mid-jump then scroll.
@@ -660,6 +667,9 @@ export function RoomsClient({
     const wasPending = wasHistoryPendingRef.current;
     wasHistoryPendingRef.current = messagesPending;
     if (!wasPending || messagesPending) {
+      return;
+    }
+    if (historicalTimelineRef.current) {
       return;
     }
     scrollToBottom();
@@ -894,10 +904,12 @@ export function RoomsClient({
       if (!isStillSelectedRoom(roomId)) {
         return false;
       }
-      setMessagesState((current) =>
-        mergeRoomMessages(current, roomResult.value.messages),
-      );
-      if (threadResult?.ok && threadParentId) {
+      if (!historicalTimelineRef.current) {
+        setMessagesState((current) =>
+          mergeRoomMessages(current, roomResult.value.messages),
+        );
+      }
+      if (threadResult?.ok && threadParentId && !historicalThreadRef.current) {
         setThreadMessages((current) =>
           mergeRoomMessages(current, threadResult.value.messages),
         );
@@ -1836,6 +1848,10 @@ export function RoomsClient({
         suppressStickToBottom();
         setSearchHoldOffBottom(true);
       },
+      releaseHoldOffBottom: () => {
+        releaseStickToBottomSuppress();
+        setSearchHoldOffBottom(false);
+      },
       highlight: highlightRoomMessageElement,
       afterRender: waitForSearchJumpPaint,
       loadAroundInRoom: async (aroundId) => {
@@ -1897,6 +1913,7 @@ export function RoomsClient({
   function closeThreadSidePanel() {
     threadLoadGenerationRef.current += 1;
     historicalThreadRef.current = false;
+    setSearchHoldOffBottom(false);
     setIsThreadLoading(false);
     setThreadParentMessage(null);
     setThreadMessages([]);
@@ -2379,6 +2396,15 @@ export function RoomsClient({
       // Coworker stream rooms keep SSE even with a pending quote (Core persists
       // the quote snapshot on the user message). Classic POST stays for non-stream.
       if (shouldUseCoworkerRoomStream(selectedRoom)) {
+        if (historicalTimelineRef.current) {
+          historicalTimelineRef.current = false;
+          setSearchHoldOffBottom(false);
+          const live = await listRoomMessagesAction(roomId);
+          if (live.ok && isStillSelectedRoom(roomId)) {
+            setMessagesState(live.value.messages);
+            setOlderNextCursor(live.value.nextCursor);
+          }
+        }
         const started = sendStreamMessage(request.content, {
           quote: request.quote,
         });

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import {
   deleteRoomMessageAction,
   editRoomMessageAction,
+  getRoomThreadAction,
   listRoomMessagesAction,
   listThreadMessagesAction,
   markThreadReadAction,
@@ -30,6 +31,7 @@ import {
 } from "@/app/chat/actions";
 import { chatMobileHeightShellClass } from "@/app/chat/components/chat-mobile-tab-registry";
 import DaySeparator from "@/app/chat/components/day-separator";
+import { highlightRoomMessageElement } from "@/app/chat/components/room-helpers";
 import { RoomSearchPanel } from "@/app/chat/components/room-search-panel";
 import { ThreadListPanel } from "@/app/chat/components/thread-list-panel";
 import { UnreadThreadsPanel } from "@/app/chat/components/unread-threads-panel";
@@ -85,6 +87,10 @@ import { markOutboundSentTick } from "@/app/chat/utils/outbound-sent-tick";
 import { applyReplySoftDeleteToParentIfUnchanged } from "@/app/chat/utils/parent-thread-preview";
 import { peekPendingRoomMessage } from "@/app/chat/utils/pending-room-message";
 import { roomReadAttentionMarker } from "@/app/chat/utils/room-read-attention-marker";
+import {
+  performRoomSearchJump,
+  waitForSearchJumpPaint,
+} from "@/app/chat/utils/room-search-jump";
 import { shouldShowRoomRosterControl } from "@/app/chat/utils/should-show-room-roster-control";
 import { useHeaderRoomSlotHost } from "@/app/components/header/use-header-room-slot-host";
 import { applyChatMembershipRevokedUi } from "@/components/chat/apply-chat-membership-revoked-ui";
@@ -334,8 +340,7 @@ interface RoomHeaderChromeProps {
   room: ChatRoom;
   displayName: string;
   isDirectRoom: boolean;
-  topLevelRoomMessages: ChatRoomMessage[];
-  onOpenThread: (message: ChatRoomMessage) => boolean | Promise<boolean>;
+  onJumpToMessage: (hit: ChatRoomMessage) => void;
   threadListOpen: boolean;
   onToggleThreadList: () => void;
   rosterOpen: boolean;
@@ -357,8 +362,7 @@ function RoomHeaderChrome({
   room,
   displayName,
   isDirectRoom,
-  topLevelRoomMessages,
-  onOpenThread,
+  onJumpToMessage,
   threadListOpen,
   onToggleThreadList,
   rosterOpen,
@@ -397,8 +401,7 @@ function RoomHeaderChrome({
           <RoomSearchPanel
             key={room.id}
             roomId={room.id}
-            loadedMessages={topLevelRoomMessages}
-            onOpenThread={onOpenThread}
+            onJumpToMessage={onJumpToMessage}
             labels={{
               open: t("RoomSearch.open"),
               placeholder: t("RoomSearch.placeholder"),
@@ -530,11 +533,15 @@ export function RoomsClient({
   const [syncedRosterPromise, setSyncedRosterPromise] = useState(rosterPromise);
   const [syncedHistoryRoomId, setSyncedHistoryRoomId] =
     useState(selectedRoomId);
+  const historicalTimelineRef = useRef(false);
+  const historicalThreadRef = useRef(false);
   // RoomsClient stays mounted across /chat/rooms/[id] navigations. Progressive
   // room switch must drop the prior timeline so skeleton shows and hydrate
   // cannot merge room A into room B (or show A under B's header).
   if (selectedRoomId !== syncedHistoryRoomId) {
     setSyncedHistoryRoomId(selectedRoomId);
+    historicalTimelineRef.current = false;
+    historicalThreadRef.current = false;
     if (messagesPromise != null) {
       setMessagesState([]);
       setOlderNextCursor(null);
@@ -1071,7 +1078,10 @@ export function RoomsClient({
       const isHardDelete =
         event.eventType === "delete" && message.deletedAt == null;
 
-      if (route.mergeIntoRoomTimeline) {
+      if (
+        route.mergeIntoRoomTimeline &&
+        !(historicalTimelineRef.current && event.eventType === "create")
+      ) {
         applyMessagesFlashingOutboundConfirms(setMessagesState, (current) =>
           filterTopLevelChatRoomMessages(
             applyFullChatRoomMessageEvent(current, {
@@ -1088,7 +1098,10 @@ export function RoomsClient({
         return isHardDelete ? null : message;
       });
 
-      if (route.mergeIntoOpenThread) {
+      if (
+        route.mergeIntoOpenThread &&
+        !(historicalThreadRef.current && event.eventType === "create")
+      ) {
         applyMessagesFlashingOutboundConfirms(setThreadMessages, (current) =>
           applyFullChatRoomMessageEvent(current, {
             eventType: event.eventType,
@@ -1488,7 +1501,7 @@ export function RoomsClient({
       if (cancelled) {
         return;
       }
-      if (result.ok) {
+      if (result.ok && !historicalTimelineRef.current) {
         setMessagesState((current) =>
           mergeRoomMessages(current, result.value.messages),
         );
@@ -1542,9 +1555,11 @@ export function RoomsClient({
     if (selectedRoomIdRef.current !== roomId || !result.ok) {
       return;
     }
-    setMessagesState((current) =>
-      mergeRoomMessages(current, result.value.messages),
-    );
+    if (!historicalTimelineRef.current) {
+      setMessagesState((current) =>
+        mergeRoomMessages(current, result.value.messages),
+      );
+    }
     setThreadParentMessage((current) =>
       current
         ? (result.value.messages.find((message) => message.id === current.id) ??
@@ -1554,7 +1569,8 @@ export function RoomsClient({
     if (
       threadResult?.ok &&
       threadParentId != null &&
-      threadParentMessageIdRef.current === threadParentId
+      threadParentMessageIdRef.current === threadParentId &&
+      !historicalThreadRef.current
     ) {
       setThreadMessages((current) =>
         mergeRoomMessages(current, threadResult.value.messages),
@@ -1636,12 +1652,12 @@ export function RoomsClient({
       if (cancelled) {
         return;
       }
-      if (threadResult.ok) {
+      if (threadResult.ok && !historicalThreadRef.current) {
         setThreadMessages((current) =>
           mergeRoomMessages(current, threadResult.value.messages),
         );
       }
-      if (roomResult.ok) {
+      if (roomResult.ok && !historicalTimelineRef.current) {
         setMessagesState((current) =>
           mergeRoomMessages(current, roomResult.value.messages),
         );
@@ -1798,6 +1814,67 @@ export function RoomsClient({
     return loadThreadMessages(parentMessage);
   }
 
+  async function handleSearchJump(hit: ChatRoomMessage) {
+    const roomId = selectedRoom?.id;
+    if (!roomId) {
+      return;
+    }
+    await performRoomSearchJump(hit, {
+      highlight: highlightRoomMessageElement,
+      afterRender: waitForSearchJumpPaint,
+      loadAroundInRoom: async (aroundId) => {
+        const result = await listRoomMessagesAction(roomId, {
+          around: aroundId,
+        });
+        if (!result.ok) {
+          toast.error(result.error.message);
+          return false;
+        }
+        if (!isStillSelectedRoom(roomId)) {
+          return false;
+        }
+        historicalTimelineRef.current = true;
+        setMessagesState(result.value.messages);
+        setOlderNextCursor(result.value.nextCursor);
+        return true;
+      },
+      findLoadedParent: (parentId) =>
+        topLevelRoomMessages.find((message) => message.id === parentId) ??
+        (threadParentMessage?.id === parentId
+          ? threadParentMessage
+          : undefined),
+      loadParent: async (parentId) => {
+        const result = await getRoomThreadAction(roomId, parentId);
+        if (!result.ok) {
+          toast.error(result.error.message);
+          return null;
+        }
+        if (!result.value) {
+          toast.error("Could not load thread.");
+          return null;
+        }
+        return result.value.parentMessage;
+      },
+      openThread: handleOpenThreadFromMessage,
+      loadAroundInThread: async (parentId, aroundId) => {
+        const result = await listThreadMessagesAction(roomId, parentId, {
+          around: aroundId,
+        });
+        if (!result.ok) {
+          toast.error(result.error.message);
+          return false;
+        }
+        if (!isStillSelectedRoom(roomId)) {
+          return false;
+        }
+        historicalThreadRef.current = true;
+        setThreadMessages(result.value.messages);
+        setThreadOlderNextCursor(result.value.nextCursor);
+        return true;
+      },
+    });
+  }
+
   async function handleOpenThreadFromList(
     parentMessage: ChatRoomMessage,
   ): Promise<boolean> {
@@ -1807,6 +1884,7 @@ export function RoomsClient({
 
   function closeThreadSidePanel() {
     threadLoadGenerationRef.current += 1;
+    historicalThreadRef.current = false;
     setIsThreadLoading(false);
     setThreadParentMessage(null);
     setThreadMessages([]);
@@ -1844,6 +1922,7 @@ export function RoomsClient({
     // Reply list is wiped below — drop thread outbound jobs so a switch or
     // reopen cannot keep orphan retries after the shells are gone (ADR: no outbox).
     clearClassicOutboundQueue(classicThreadRefs);
+    historicalThreadRef.current = false;
     setThreadParentMessage(parentMessage);
     setThreadMessages([]);
     setThreadOlderNextCursor(null);
@@ -2446,8 +2525,7 @@ export function RoomsClient({
         room={selectedRoom}
         displayName={selectedRoomDisplayName}
         isDirectRoom={isDirectRoom}
-        topLevelRoomMessages={topLevelRoomMessages}
-        onOpenThread={handleOpenThreadFromMessage}
+        onJumpToMessage={handleSearchJump}
         threadListOpen={threadListOpen}
         onToggleThreadList={() => {
           setRosterOpen(false);

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -1078,18 +1078,21 @@ export function RoomsClient({
       const isHardDelete =
         event.eventType === "delete" && message.deletedAt == null;
 
-      if (
-        route.mergeIntoRoomTimeline &&
-        !(historicalTimelineRef.current && event.eventType === "create")
-      ) {
-        applyMessagesFlashingOutboundConfirms(setMessagesState, (current) =>
-          filterTopLevelChatRoomMessages(
+      if (route.mergeIntoRoomTimeline) {
+        applyMessagesFlashingOutboundConfirms(setMessagesState, (current) => {
+          if (
+            historicalTimelineRef.current &&
+            !current.some((row) => row.id === message.id)
+          ) {
+            return current;
+          }
+          return filterTopLevelChatRoomMessages(
             applyFullChatRoomMessageEvent(current, {
               eventType: event.eventType,
               message,
             }),
-          ),
-        );
+          );
+        });
       }
       setThreadParentMessage((current) => {
         if (current?.id !== message.id) {
@@ -1098,16 +1101,19 @@ export function RoomsClient({
         return isHardDelete ? null : message;
       });
 
-      if (
-        route.mergeIntoOpenThread &&
-        !(historicalThreadRef.current && event.eventType === "create")
-      ) {
-        applyMessagesFlashingOutboundConfirms(setThreadMessages, (current) =>
-          applyFullChatRoomMessageEvent(current, {
+      if (route.mergeIntoOpenThread) {
+        applyMessagesFlashingOutboundConfirms(setThreadMessages, (current) => {
+          if (
+            historicalThreadRef.current &&
+            !current.some((row) => row.id === message.id)
+          ) {
+            return current;
+          }
+          return applyFullChatRoomMessageEvent(current, {
             eventType: event.eventType,
             message,
-          }),
-        );
+          });
+        });
         // Look first, then room re-sync — mark-read effect can race if it
         // runs before look lands; open path uses the same order.
         // Use the ref (not openThreadParentId) so this []-deps handler stays
@@ -1395,11 +1401,14 @@ export function RoomsClient({
     // Room switch: replace. Same room RSC refresh (e.g. revalidatePath):
     // merge so client-loaded older pages are not wiped by the latest page.
     if (isChannelSwitch) {
+      historicalTimelineRef.current = false;
       setMessagesState(messages);
       setOlderNextCursor(messagesNextCursor);
       setMessageLoadFailedState(messageLoadFailed);
-    } else {
+    } else if (!historicalTimelineRef.current) {
       setMessagesState((current) => mergeRoomMessages(current, messages));
+      setMessageLoadFailedState(messageLoadFailed);
+    } else {
       setMessageLoadFailedState(messageLoadFailed);
     }
     setThreadParentMessage((current) =>
@@ -1847,10 +1856,6 @@ export function RoomsClient({
         const result = await getRoomThreadAction(roomId, parentId);
         if (!result.ok) {
           toast.error(result.error.message);
-          return null;
-        }
-        if (!result.value) {
-          toast.error("Could not load thread.");
           return null;
         }
         return result.value.parentMessage;
@@ -2411,6 +2416,14 @@ export function RoomsClient({
             : null,
       });
 
+      if (historicalTimelineRef.current) {
+        historicalTimelineRef.current = false;
+        const live = await listRoomMessagesAction(roomId);
+        if (live.ok && isStillSelectedRoom(roomId)) {
+          setMessagesState(live.value.messages);
+          setOlderNextCursor(live.value.nextCursor);
+        }
+      }
       setMessagesState((current) => appendMessage(current, pending));
       pinToBottomAfterOwnSend();
 
@@ -2494,6 +2507,14 @@ export function RoomsClient({
             : null,
       });
 
+      if (historicalThreadRef.current) {
+        historicalThreadRef.current = false;
+        const live = await listThreadMessagesAction(roomId, parentMessageId);
+        if (live.ok && isStillSelectedRoom(roomId)) {
+          setThreadMessages(live.value.messages);
+          setThreadOlderNextCursor(live.value.nextCursor);
+        }
+      }
       setThreadMessages((current) => appendMessage(current, pending));
 
       enqueueClassicThreadJob({

--- a/apps/web/src/app/(app)/chat/components/rooms-client.tsx
+++ b/apps/web/src/app/(app)/chat/components/rooms-client.tsx
@@ -2393,18 +2393,21 @@ export function RoomsClient({
       if (!selectedRoom) return { ok: false };
       const roomId = selectedRoom.id;
 
+      if (historicalTimelineRef.current) {
+        const live = await listRoomMessagesAction(roomId);
+        if (!live.ok) {
+          toast.error(live.error.message);
+        } else if (isStillSelectedRoom(roomId)) {
+          historicalTimelineRef.current = false;
+          setSearchHoldOffBottom(false);
+          setMessagesState(live.value.messages);
+          setOlderNextCursor(live.value.nextCursor);
+        }
+      }
+
       // Coworker stream rooms keep SSE even with a pending quote (Core persists
       // the quote snapshot on the user message). Classic POST stays for non-stream.
       if (shouldUseCoworkerRoomStream(selectedRoom)) {
-        if (historicalTimelineRef.current) {
-          historicalTimelineRef.current = false;
-          setSearchHoldOffBottom(false);
-          const live = await listRoomMessagesAction(roomId);
-          if (live.ok && isStillSelectedRoom(roomId)) {
-            setMessagesState(live.value.messages);
-            setOlderNextCursor(live.value.nextCursor);
-          }
-        }
         const started = sendStreamMessage(request.content, {
           quote: request.quote,
         });
@@ -2449,15 +2452,6 @@ export function RoomsClient({
             : null,
       });
 
-      if (historicalTimelineRef.current) {
-        historicalTimelineRef.current = false;
-        setSearchHoldOffBottom(false);
-        const live = await listRoomMessagesAction(roomId);
-        if (live.ok && isStillSelectedRoom(roomId)) {
-          setMessagesState(live.value.messages);
-          setOlderNextCursor(live.value.nextCursor);
-        }
-      }
       setMessagesState((current) => appendMessage(current, pending));
       pinToBottomAfterOwnSend();
 
@@ -2496,6 +2490,18 @@ export function RoomsClient({
       if (!selectedRoom || !threadParentMessage) return { ok: false };
       const roomId = selectedRoom.id;
       const parentMessageId = threadParentMessage.id;
+
+      if (historicalThreadRef.current) {
+        const live = await listThreadMessagesAction(roomId, parentMessageId);
+        if (!live.ok) {
+          toast.error(live.error.message);
+        } else if (isStillSelectedRoom(roomId)) {
+          historicalThreadRef.current = false;
+          setSearchHoldOffBottom(false);
+          setThreadMessages(live.value.messages);
+          setThreadOlderNextCursor(live.value.nextCursor);
+        }
+      }
 
       if (shouldUseCoworkerRoomStream(selectedRoom)) {
         const started = sendStreamMessage(request.content, {
@@ -2541,15 +2547,6 @@ export function RoomsClient({
             : null,
       });
 
-      if (historicalThreadRef.current) {
-        historicalThreadRef.current = false;
-        setSearchHoldOffBottom(false);
-        const live = await listThreadMessagesAction(roomId, parentMessageId);
-        if (live.ok && isStillSelectedRoom(roomId)) {
-          setThreadMessages(live.value.messages);
-          setThreadOlderNextCursor(live.value.nextCursor);
-        }
-      }
       setThreadMessages((current) => appendMessage(current, pending));
 
       enqueueClassicThreadJob({

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -3,7 +3,7 @@
 import type { ChannelLinkTarget } from "@sokosumi/utils";
 import { ChevronLeft, Loader2, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { CHAT_MESSAGE_LIST_SCROLLER_CLASS } from "@/app/chat/chat-message-list-scroller";
 import { useStickToBottom } from "@/app/chat/hooks/use-stick-to-bottom";
 import { isCurrentUserMentionerOfFailedShell } from "@/app/chat/utils/coworker-thought";
@@ -76,6 +76,7 @@ export function ThreadPanel({
   showMentionShortcut = true,
   allowAttachments = true,
   roomId,
+  holdOffBottom = false,
 }: {
   parentMessage: ChatRoomMessage;
   replies: ChatRoomMessage[];
@@ -122,6 +123,7 @@ export function ThreadPanel({
   showMentionShortcut?: boolean;
   allowAttachments?: boolean;
   roomId: string;
+  holdOffBottom?: boolean;
 }) {
   const t = useTranslations("App.Channels");
   const threadComposerRef = useRef<RoomComposerHandle | null>(null);
@@ -131,9 +133,16 @@ export function ThreadPanel({
     contentMinHeight,
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
+    suppressStickToBottom,
   } = useStickToBottom({
     resetKey: parentMessage.id,
   });
+
+  useEffect(() => {
+    if (holdOffBottom) {
+      suppressStickToBottom();
+    }
+  }, [holdOffBottom, suppressStickToBottom]);
 
   function handleQuote(message: ChatRoomMessage) {
     onQuote?.(message);

--- a/apps/web/src/app/(app)/chat/components/thread-panel.tsx
+++ b/apps/web/src/app/(app)/chat/components/thread-panel.tsx
@@ -136,6 +136,7 @@ export function ThreadPanel({
     suppressStickToBottom,
   } = useStickToBottom({
     resetKey: parentMessage.id,
+    holdOffBottom,
   });
 
   useEffect(() => {

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -65,6 +65,7 @@ function Harness({ resetKey }: { resetKey: string | null }) {
     contentRef,
     scrollToBottomIfPinned,
     pinToBottomAfterOwnSend,
+    suppressStickToBottom,
     contentMinHeight,
   } = useStickToBottom({
     resetKey,
@@ -88,6 +89,9 @@ function Harness({ resetKey }: { resetKey: string | null }) {
       </button>
       <button type="button" onClick={() => pinToBottomAfterOwnSend()}>
         own-send-pin
+      </button>
+      <button type="button" onClick={() => suppressStickToBottom()}>
+        suppress-stick
       </button>
     </div>
   );
@@ -177,6 +181,31 @@ describe("useStickToBottom", () => {
     });
 
     expect(scroller.scrollTop).toBe(1000 + STICK_TO_BOTTOM_NEAR_PX + 50);
+  });
+
+  it("does not recover-pin on content growth while suppressed", () => {
+    render(<Harness resetKey="room-1" />);
+    const scroller = screen.getByTestId("scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    });
+    act(() => {
+      screen.getByRole("button", { name: "suppress-stick" }).click();
+    });
+
+    const scrollTopBefore = scroller.scrollTop;
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1800,
+      clientHeight: 400,
+      scrollTop: scrollTopBefore,
+    });
+    act(() => {
+      fireResize();
+    });
+
+    expect(scroller.scrollTop).toBe(scrollTopBefore);
   });
 
   it("scrollToBottomIfPinned no-ops when unpinned", () => {

--- a/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
+++ b/apps/web/src/app/(app)/chat/hooks/__tests__/use-stick-to-bottom.test.tsx
@@ -59,7 +59,13 @@ function setScrollerMetrics(
   el.scrollTop = scrollTop;
 }
 
-function Harness({ resetKey }: { resetKey: string | null }) {
+function Harness({
+  resetKey,
+  holdOffBottom = false,
+}: {
+  resetKey: string | null;
+  holdOffBottom?: boolean;
+}) {
   const {
     scrollerRef,
     contentRef,
@@ -69,6 +75,7 @@ function Harness({ resetKey }: { resetKey: string | null }) {
     contentMinHeight,
   } = useStickToBottom({
     resetKey,
+    holdOffBottom,
   });
 
   return (
@@ -181,6 +188,43 @@ describe("useStickToBottom", () => {
     });
 
     expect(scroller.scrollTop).toBe(1000 + STICK_TO_BOTTOM_NEAR_PX + 50);
+  });
+
+  it("does not pin on mount rAF or content growth when holdOffBottom is set", () => {
+    const rafQueue: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb) => {
+        rafQueue.push(cb);
+        return rafQueue.length;
+      });
+
+    render(<Harness resetKey="thread-1" holdOffBottom />);
+    const scroller = screen.getByTestId("scroller");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 200,
+    });
+
+    act(() => {
+      for (const cb of rafQueue.splice(0)) {
+        cb(0);
+      }
+    });
+    expect(scroller.scrollTop).toBe(200);
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1800,
+      clientHeight: 400,
+      scrollTop: 200,
+    });
+    act(() => {
+      fireResize();
+    });
+    expect(scroller.scrollTop).toBe(200);
+
+    rafSpy.mockRestore();
   });
 
   it("does not recover-pin on content growth while suppressed", () => {

--- a/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
@@ -33,6 +33,9 @@ export function useStickToBottom({
   // Sticky flag measured on scroll *before* growth. Measuring after a
   // ResizeObserver jump can make a pinned user look scrolled-up for a frame.
   const stickToBottomRef = useRef(true);
+  // Search jump: keep the live-edge pin from yanking the viewport back to
+  // the newest row while we land on an older hit.
+  const suppressPinRef = useRef(false);
   // Last observed scroller scrollHeight so ResizeObserver can recover when a
   // growth-driven scroll event clears the sticky flag mid-frame.
   const lastScrollHeightRef = useRef(0);
@@ -45,8 +48,14 @@ export function useStickToBottom({
     if (!el) {
       return;
     }
+    suppressPinRef.current = false;
     el.scrollTop = el.scrollHeight;
     stickToBottomRef.current = true;
+  }, []);
+
+  const suppressStickToBottom = useCallback(() => {
+    stickToBottomRef.current = false;
+    suppressPinRef.current = true;
   }, []);
 
   /**
@@ -67,6 +76,7 @@ export function useStickToBottom({
   }, [scrollToBottom]);
 
   useEffect(() => {
+    suppressPinRef.current = false;
     stickToBottomRef.current = true;
     const frame = requestAnimationFrame(() => {
       scrollToBottom();
@@ -88,6 +98,10 @@ export function useStickToBottom({
       const nextHeight = scroller.scrollHeight;
       const growth = nextHeight - previousHeight;
       lastScrollHeightRef.current = nextHeight;
+
+      if (suppressPinRef.current) {
+        return;
+      }
 
       if (stickToBottomRef.current) {
         scroller.scrollTop = scroller.scrollHeight;
@@ -142,6 +156,10 @@ export function useStickToBottom({
       if (!node) {
         return;
       }
+      if (suppressPinRef.current) {
+        stickToBottomRef.current = false;
+        return;
+      }
       stickToBottomRef.current = distanceFromBottom(node) < nearBottomPx;
     }
 
@@ -158,5 +176,6 @@ export function useStickToBottom({
     scrollToBottom,
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
+    suppressStickToBottom,
   };
 }

--- a/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/app/(app)/chat/hooks/use-stick-to-bottom.ts
@@ -18,6 +18,8 @@ interface UseStickToBottomOptions {
   /** Room id (or similar): force pin, scroll to live edge, rebind observers. */
   resetKey?: string | null;
   nearBottomPx?: number;
+  /** Search jump: do not pin on mount/reset, and ignore content-growth pins. */
+  holdOffBottom?: boolean;
 }
 
 function distanceFromBottom(el: HTMLElement): number {
@@ -27,6 +29,7 @@ function distanceFromBottom(el: HTMLElement): number {
 export function useStickToBottom({
   resetKey = null,
   nearBottomPx = STICK_TO_BOTTOM_NEAR_PX,
+  holdOffBottom = false,
 }: UseStickToBottomOptions = {}) {
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -39,6 +42,8 @@ export function useStickToBottom({
   // Last observed scroller scrollHeight so ResizeObserver can recover when a
   // growth-driven scroll event clears the sticky flag mid-frame.
   const lastScrollHeightRef = useRef(0);
+  const holdOffBottomRef = useRef(holdOffBottom);
+  holdOffBottomRef.current = holdOffBottom;
   // Pixel min-height so short transcripts can justify-end in the scroller
   // (kept after native overflow swap; was required for Radix display:table).
   const [contentMinHeight, setContentMinHeight] = useState<number>();
@@ -56,6 +61,10 @@ export function useStickToBottom({
   const suppressStickToBottom = useCallback(() => {
     stickToBottomRef.current = false;
     suppressPinRef.current = true;
+  }, []);
+
+  const releaseStickToBottomSuppress = useCallback(() => {
+    suppressPinRef.current = false;
   }, []);
 
   /**
@@ -76,6 +85,20 @@ export function useStickToBottom({
   }, [scrollToBottom]);
 
   useEffect(() => {
+    if (holdOffBottom) {
+      stickToBottomRef.current = false;
+      suppressPinRef.current = true;
+      return;
+    }
+    suppressPinRef.current = false;
+  }, [holdOffBottom]);
+
+  useEffect(() => {
+    if (holdOffBottomRef.current) {
+      stickToBottomRef.current = false;
+      suppressPinRef.current = true;
+      return;
+    }
     suppressPinRef.current = false;
     stickToBottomRef.current = true;
     const frame = requestAnimationFrame(() => {
@@ -177,5 +200,6 @@ export function useStickToBottom({
     pinToBottomAfterOwnSend,
     scrollToBottomIfPinned,
     suppressStickToBottom,
+    releaseStickToBottomSuppress,
   };
 }

--- a/apps/web/src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts
@@ -29,6 +29,7 @@ function message(overrides: Partial<ChatRoomMessage> = {}): ChatRoomMessage {
 
 function deps(overrides: Partial<Parameters<typeof performRoomSearchJump>[1]>) {
   return {
+    holdOffBottom: vi.fn(),
     highlight: vi.fn(() => false),
     afterRender: vi.fn(async () => {}),
     loadAroundInRoom: vi.fn(async () => false),
@@ -47,8 +48,32 @@ describe("performRoomSearchJump", () => {
 
     await performRoomSearchJump(hit, jump);
 
+    expect(jump.holdOffBottom).toHaveBeenCalled();
     expect(jump.highlight).toHaveBeenCalledWith(hit.id);
     expect(jump.loadAroundInRoom).not.toHaveBeenCalled();
+  });
+
+  it("holds the live edge off before loading an around window", async () => {
+    const hit = message();
+    const order: string[] = [];
+    const jump = deps({
+      holdOffBottom: vi.fn(() => {
+        order.push("hold");
+      }),
+      highlight: vi
+        .fn(() => false)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true),
+      loadAroundInRoom: vi.fn(async () => {
+        order.push("around");
+        return true;
+      }),
+    });
+
+    await performRoomSearchJump(hit, jump);
+
+    expect(order).toEqual(["hold", "around"]);
+    expect(jump.highlight).toHaveBeenLastCalledWith(hit.id);
   });
 
   it("loads around a top-level hit that is not rendered, then highlights", async () => {

--- a/apps/web/src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts
@@ -30,6 +30,7 @@ function message(overrides: Partial<ChatRoomMessage> = {}): ChatRoomMessage {
 function deps(overrides: Partial<Parameters<typeof performRoomSearchJump>[1]>) {
   return {
     holdOffBottom: vi.fn(),
+    releaseHoldOffBottom: vi.fn(),
     highlight: vi.fn(() => false),
     afterRender: vi.fn(async () => {}),
     loadAroundInRoom: vi.fn(async () => false),
@@ -50,6 +51,7 @@ describe("performRoomSearchJump", () => {
 
     expect(jump.holdOffBottom).toHaveBeenCalled();
     expect(jump.highlight).toHaveBeenCalledWith(hit.id);
+    expect(jump.releaseHoldOffBottom).toHaveBeenCalled();
     expect(jump.loadAroundInRoom).not.toHaveBeenCalled();
   });
 
@@ -74,6 +76,7 @@ describe("performRoomSearchJump", () => {
 
     expect(order).toEqual(["hold", "around"]);
     expect(jump.highlight).toHaveBeenLastCalledWith(hit.id);
+    expect(jump.releaseHoldOffBottom).not.toHaveBeenCalled();
   });
 
   it("loads around a top-level hit that is not rendered, then highlights", async () => {
@@ -109,6 +112,7 @@ describe("performRoomSearchJump", () => {
     expect(jump.openThread).toHaveBeenCalledWith(parent);
     expect(jump.loadParent).not.toHaveBeenCalled();
     expect(jump.highlight).toHaveBeenCalledWith(hit.id);
+    expect(jump.releaseHoldOffBottom).toHaveBeenCalled();
     expect(jump.loadAroundInThread).not.toHaveBeenCalled();
   });
 
@@ -133,5 +137,6 @@ describe("performRoomSearchJump", () => {
     expect(jump.openThread).toHaveBeenCalledWith(parent);
     expect(jump.loadAroundInThread).toHaveBeenCalledWith(parent.id, hit.id);
     expect(jump.highlight).toHaveBeenLastCalledWith(hit.id);
+    expect(jump.releaseHoldOffBottom).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts
+++ b/apps/web/src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { performRoomSearchJump } from "@/app/chat/utils/room-search-jump";
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+function message(overrides: Partial<ChatRoomMessage> = {}): ChatRoomMessage {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    roomId: "550e8400-e29b-41d4-a716-446655440000",
+    parentMessageId: null,
+    content: "Hello",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    editedAt: null,
+    deletedAt: null,
+    metadata: null,
+    replyCount: 0,
+    sender: {
+      type: "user",
+      user: {
+        id: "user_1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+      },
+    },
+    reactions: [],
+    ...overrides,
+  } as ChatRoomMessage;
+}
+
+function deps(overrides: Partial<Parameters<typeof performRoomSearchJump>[1]>) {
+  return {
+    highlight: vi.fn(() => false),
+    afterRender: vi.fn(async () => {}),
+    loadAroundInRoom: vi.fn(async () => false),
+    findLoadedParent: vi.fn(() => undefined),
+    loadParent: vi.fn(async () => null),
+    openThread: vi.fn(async () => true),
+    loadAroundInThread: vi.fn(async () => false),
+    ...overrides,
+  };
+}
+
+describe("performRoomSearchJump", () => {
+  it("highlights a top-level hit already in the DOM", async () => {
+    const hit = message();
+    const jump = deps({ highlight: vi.fn(() => true) });
+
+    await performRoomSearchJump(hit, jump);
+
+    expect(jump.highlight).toHaveBeenCalledWith(hit.id);
+    expect(jump.loadAroundInRoom).not.toHaveBeenCalled();
+  });
+
+  it("loads around a top-level hit that is not rendered, then highlights", async () => {
+    const hit = message();
+    const jump = deps({
+      highlight: vi
+        .fn(() => false)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true),
+      loadAroundInRoom: vi.fn(async () => true),
+    });
+
+    await performRoomSearchJump(hit, jump);
+
+    expect(jump.loadAroundInRoom).toHaveBeenCalledWith(hit.id);
+    expect(jump.highlight).toHaveBeenLastCalledWith(hit.id);
+    expect(jump.afterRender).toHaveBeenCalled();
+  });
+
+  it("opens the thread for a reply whose parent is loaded, then highlights", async () => {
+    const parent = message({ id: "550e8400-e29b-41d4-a716-446655440010" });
+    const hit = message({
+      id: "550e8400-e29b-41d4-a716-446655440011",
+      parentMessageId: parent.id,
+    });
+    const jump = deps({
+      highlight: vi.fn(() => true),
+      findLoadedParent: vi.fn(() => parent),
+    });
+
+    await performRoomSearchJump(hit, jump);
+
+    expect(jump.openThread).toHaveBeenCalledWith(parent);
+    expect(jump.loadParent).not.toHaveBeenCalled();
+    expect(jump.highlight).toHaveBeenCalledWith(hit.id);
+    expect(jump.loadAroundInThread).not.toHaveBeenCalled();
+  });
+
+  it("fetches a missing parent, opens the thread, then loads around an old reply", async () => {
+    const parent = message({ id: "550e8400-e29b-41d4-a716-446655440010" });
+    const hit = message({
+      id: "550e8400-e29b-41d4-a716-446655440011",
+      parentMessageId: parent.id,
+    });
+    const jump = deps({
+      highlight: vi
+        .fn(() => false)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true),
+      loadParent: vi.fn(async () => parent),
+      loadAroundInThread: vi.fn(async () => true),
+    });
+
+    await performRoomSearchJump(hit, jump);
+
+    expect(jump.loadParent).toHaveBeenCalledWith(parent.id);
+    expect(jump.openThread).toHaveBeenCalledWith(parent);
+    expect(jump.loadAroundInThread).toHaveBeenCalledWith(parent.id, hit.id);
+    expect(jump.highlight).toHaveBeenLastCalledWith(hit.id);
+  });
+});

--- a/apps/web/src/app/(app)/chat/utils/room-search-jump.ts
+++ b/apps/web/src/app/(app)/chat/utils/room-search-jump.ts
@@ -1,0 +1,63 @@
+import type { ChatRoomMessage } from "@/lib/clients/generated/core";
+
+export interface RoomSearchJumpDeps {
+  highlight: (messageId: string) => boolean;
+  afterRender: () => Promise<void>;
+  loadAroundInRoom: (aroundId: string) => Promise<boolean>;
+  findLoadedParent: (parentMessageId: string) => ChatRoomMessage | undefined;
+  loadParent: (parentMessageId: string) => Promise<ChatRoomMessage | null>;
+  openThread: (parent: ChatRoomMessage) => Promise<boolean>;
+  loadAroundInThread: (
+    parentMessageId: string,
+    aroundId: string,
+  ) => Promise<boolean>;
+}
+
+export async function waitForSearchJumpPaint(): Promise<void> {
+  if (typeof requestAnimationFrame === "undefined") {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve();
+      });
+    });
+  });
+}
+
+export async function performRoomSearchJump(
+  hit: ChatRoomMessage,
+  deps: RoomSearchJumpDeps,
+): Promise<void> {
+  if (hit.parentMessageId) {
+    const parent =
+      deps.findLoadedParent(hit.parentMessageId) ??
+      (await deps.loadParent(hit.parentMessageId));
+    if (!parent) {
+      return;
+    }
+    await deps.openThread(parent);
+    await deps.afterRender();
+    if (deps.highlight(hit.id)) {
+      return;
+    }
+    const loaded = await deps.loadAroundInThread(parent.id, hit.id);
+    if (!loaded) {
+      return;
+    }
+    await deps.afterRender();
+    deps.highlight(hit.id);
+    return;
+  }
+
+  if (deps.highlight(hit.id)) {
+    return;
+  }
+  const loaded = await deps.loadAroundInRoom(hit.id);
+  if (!loaded) {
+    return;
+  }
+  await deps.afterRender();
+  deps.highlight(hit.id);
+}

--- a/apps/web/src/app/(app)/chat/utils/room-search-jump.ts
+++ b/apps/web/src/app/(app)/chat/utils/room-search-jump.ts
@@ -1,8 +1,9 @@
 import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 
 export interface RoomSearchJumpDeps {
+  holdOffBottom: () => void;
   highlight: (messageId: string) => boolean;
-  afterRender: () => Promise<void>;
+  afterRender: (messageId: string) => Promise<void>;
   loadAroundInRoom: (aroundId: string) => Promise<boolean>;
   findLoadedParent: (parentMessageId: string) => ChatRoomMessage | undefined;
   loadParent: (parentMessageId: string) => Promise<ChatRoomMessage | null>;
@@ -13,23 +14,42 @@ export interface RoomSearchJumpDeps {
   ) => Promise<boolean>;
 }
 
-export async function waitForSearchJumpPaint(): Promise<void> {
-  if (typeof requestAnimationFrame === "undefined") {
-    return;
-  }
-  await new Promise<void>((resolve) => {
-    requestAnimationFrame(() => {
+export async function waitForSearchJumpPaint(
+  messageId?: string,
+): Promise<void> {
+  const deadline = Date.now() + 1500;
+  while (Date.now() < deadline) {
+    if (
+      messageId &&
+      typeof document !== "undefined" &&
+      document.querySelector(`[data-message-id="${CSS.escape(messageId)}"]`)
+    ) {
+      return;
+    }
+    if (typeof requestAnimationFrame === "undefined") {
+      return;
+    }
+    await new Promise<void>((resolve) => {
       requestAnimationFrame(() => {
         resolve();
       });
     });
-  });
+    if (!messageId) {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          resolve();
+        });
+      });
+      return;
+    }
+  }
 }
 
 export async function performRoomSearchJump(
   hit: ChatRoomMessage,
   deps: RoomSearchJumpDeps,
 ): Promise<void> {
+  deps.holdOffBottom();
   if (hit.parentMessageId) {
     const parent =
       deps.findLoadedParent(hit.parentMessageId) ??
@@ -38,7 +58,7 @@ export async function performRoomSearchJump(
       return;
     }
     await deps.openThread(parent);
-    await deps.afterRender();
+    await deps.afterRender(hit.id);
     if (deps.highlight(hit.id)) {
       return;
     }
@@ -46,7 +66,7 @@ export async function performRoomSearchJump(
     if (!loaded) {
       return;
     }
-    await deps.afterRender();
+    await deps.afterRender(hit.id);
     deps.highlight(hit.id);
     return;
   }
@@ -58,6 +78,6 @@ export async function performRoomSearchJump(
   if (!loaded) {
     return;
   }
-  await deps.afterRender();
+  await deps.afterRender(hit.id);
   deps.highlight(hit.id);
 }

--- a/apps/web/src/app/(app)/chat/utils/room-search-jump.ts
+++ b/apps/web/src/app/(app)/chat/utils/room-search-jump.ts
@@ -2,6 +2,7 @@ import type { ChatRoomMessage } from "@/lib/clients/generated/core";
 
 export interface RoomSearchJumpDeps {
   holdOffBottom: () => void;
+  releaseHoldOffBottom: () => void;
   highlight: (messageId: string) => boolean;
   afterRender: (messageId: string) => Promise<void>;
   loadAroundInRoom: (aroundId: string) => Promise<boolean>;
@@ -17,8 +18,10 @@ export interface RoomSearchJumpDeps {
 export async function waitForSearchJumpPaint(
   messageId?: string,
 ): Promise<void> {
-  const deadline = Date.now() + 1500;
-  while (Date.now() < deadline) {
+  if (typeof requestAnimationFrame === "undefined") {
+    return;
+  }
+  for (let frame = 0; frame < 3; frame += 1) {
     if (
       messageId &&
       typeof document !== "undefined" &&
@@ -26,22 +29,11 @@ export async function waitForSearchJumpPaint(
     ) {
       return;
     }
-    if (typeof requestAnimationFrame === "undefined") {
-      return;
-    }
     await new Promise<void>((resolve) => {
       requestAnimationFrame(() => {
         resolve();
       });
     });
-    if (!messageId) {
-      await new Promise<void>((resolve) => {
-        requestAnimationFrame(() => {
-          resolve();
-        });
-      });
-      return;
-    }
   }
 }
 
@@ -60,6 +52,7 @@ export async function performRoomSearchJump(
     await deps.openThread(parent);
     await deps.afterRender(hit.id);
     if (deps.highlight(hit.id)) {
+      deps.releaseHoldOffBottom();
       return;
     }
     const loaded = await deps.loadAroundInThread(parent.id, hit.id);
@@ -72,6 +65,7 @@ export async function performRoomSearchJump(
   }
 
   if (deps.highlight(hit.id)) {
+    deps.releaseHoldOffBottom();
     return;
   }
   const loaded = await deps.loadAroundInRoom(hit.id);

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -13866,6 +13866,20 @@ export type GetChatsRoomsByIdThreadsByParentMessageIdMessagesErrors = {
         };
     };
     /**
+     * Unprocessable Entity
+     */
+    422: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
      * Internal Server Error
      */
     500: {
@@ -14453,6 +14467,20 @@ export type GetChatsRoomsByIdMessagesErrors = {
      * Room not found
      */
     404: {
+        error: string;
+        message: string;
+        kind?: string;
+        meta: {
+            timestamp: Date;
+            requestId: string;
+            path: string;
+            method: string;
+        };
+    };
+    /**
+     * Unprocessable Entity
+     */
+    422: {
         error: string;
         message: string;
         kind?: string;

--- a/apps/web/src/lib/clients/generated/core/types.gen.ts
+++ b/apps/web/src/lib/clients/generated/core/types.gen.ts
@@ -13814,6 +13814,10 @@ export type GetChatsRoomsByIdThreadsByParentMessageIdMessagesData = {
          * Number of items to return (max 100)
          */
         limit?: number;
+        /**
+         * Reading-order window of replies centred on this reply. Must belong to this thread. Cannot be combined with cursor.
+         */
+        around?: string;
     };
     url: '/chats/rooms/{id}/threads/{parentMessageId}/messages';
 };
@@ -14408,6 +14412,10 @@ export type GetChatsRoomsByIdMessagesData = {
          * Case-insensitive substring match on message content. When set, searches top-level and thread replies and excludes soft-deleted messages.
          */
         q?: string;
+        /**
+         * Reading-order window of top-level messages centred on this message, or on its parent if it is a reply. Cannot be combined with q or cursor.
+         */
+        around?: string;
     };
     url: '/chats/rooms/{id}/messages';
 };

--- a/apps/web/src/lib/services/chat-room.service.ts
+++ b/apps/web/src/lib/services/chat-room.service.ts
@@ -316,11 +316,12 @@ export const chatRoomService = (() => {
 
   const listMessages = cache(async function listMessages(
     roomId: string,
-    options?: { cursor?: string; limit?: number },
+    options?: { cursor?: string; limit?: number; around?: string },
   ): Promise<ChatRoomMessagesPage> {
     const response = await coreClient.getChatRoomMessages(roomId, {
       limit: options?.limit ?? ROOM_MESSAGE_LIMIT,
-      cursor: options?.cursor,
+      cursor: options?.around ? undefined : options?.cursor,
+      around: options?.around,
     });
     return {
       messages: response.data,
@@ -331,20 +332,39 @@ export const chatRoomService = (() => {
   const listThreadMessages = cache(async function listThreadMessages(
     roomId: string,
     parentMessageId: string,
-    options?: { cursor?: string; limit?: number },
+    options?: { cursor?: string; limit?: number; around?: string },
   ): Promise<ChatRoomMessagesPage> {
     const response = await coreClient.getChatRoomThreadMessages(
       roomId,
       parentMessageId,
       {
         limit: options?.limit ?? ROOM_MESSAGE_LIMIT,
-        cursor: options?.cursor,
+        cursor: options?.around ? undefined : options?.cursor,
+        around: options?.around,
       },
     );
     return {
       messages: response.data,
       nextCursor: response.meta?.pagination?.nextCursor ?? null,
     };
+  });
+
+  const getThread = cache(async function getThread(
+    roomId: string,
+    parentMessageId: string,
+  ): Promise<ChatRoomThread | null> {
+    try {
+      const response = await coreClient.getChatRoomThread(
+        roomId,
+        parentMessageId,
+      );
+      return response.data;
+    } catch (error) {
+      if (error instanceof CoreApiRequestError && error.status === 404) {
+        return null;
+      }
+      throw error;
+    }
   });
 
   const listThreads = cache(async function listThreads(
@@ -477,6 +497,7 @@ export const chatRoomService = (() => {
     listThreads,
     countUnreadThreads,
     listThreadMessages,
+    getThread,
     leaveRoom,
     removeMember,
     markRead,


### PR DESCRIPTION
## Why

In-chat search listed oldest matches first, so the hit you want was buried. Clicking a result often did nothing: the room did not scroll, nothing was highlighted, and a thread reply did not open unless its parent was already loaded.

## What

- Search hits stay newest-first. The live timeline is still oldest-first reading order.
- Clicking a result closes the popover, scrolls to that message, and applies the existing short-lived highlight.
- Off-screen hits load a contiguous `around` window (parent if the hit is a reply) instead of merging a hole into the live tail.
- Thread replies open the thread, then land on the reply (including older than the first thread page).
- Sending from a historical window restores the latest page so the new message is not dropped onto old history.

Closes [SOK-864](https://linear.app/masumi/issue/SOK-864/newest-first-in-chat-search-with-jump-and-highlight)

## Verification

- `pnpm --filter core test src/routes/v1/chats/rooms/[id]/messages/get.test.ts src/routes/v1/chats/rooms/[id]/threads/[parentMessageId]/messages/get.test.ts` — 17 passed
- `pnpm --filter web test src/app/(app)/chat/components/__tests__/room-search-panel.test.tsx src/app/(app)/chat/utils/__tests__/room-search-jump.test.ts` — 9 passed
- Husky pre-commit: `pnpm check && pnpm typecheck`

- [ ] Open a room, Search in this chat, confirm newest hit is at the top
- [ ] Click a visible hit: popover closes, message scrolls into view, brief highlight
- [ ] Click an older hit not on the current page: room lands on that message with highlight, list stays contiguous
- [ ] Click a thread-reply hit: thread opens, then the reply is highlighted
- [ ] Reopen the room to return to the live tail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual message loading centered around a selected message or thread reply.
  * Improved search navigation by loading surrounding history, opening relevant threads, and highlighting results.
  * Added smoother, centered scrolling for message and quote navigation.

* **Bug Fixes**
  * Preserved correct ordering for timeline and search results.
  * Prevented automatic scroll-to-bottom behavior from interrupting historical message searches.
  * Added clearer validation for incompatible navigation options and unavailable messages.

* **Tests**
  * Expanded coverage for message windows, search navigation, ordering, scrolling, and thread behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->