### PR TITLE
ci(preview): deploy both networks once on human PR open

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          # Base SHA only: this workflow is privileged (issue_comment). Do not
+          # run the PR tree. Vercel still deploys pull_request.head.sha.
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -3,6 +3,8 @@ name: Preview deploy
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened]
 
 permissions:
   contents: read
@@ -10,12 +12,39 @@ permissions:
   issues: write
 
 jobs:
-  preview:
+  comment:
     name: Comment preview
     if: >
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
       contains(github.event.comment.body, '/deploy')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Deploy preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_TEAM_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ci/vercel-deploy.mjs preview
+
+  opened:
+    name: Opened preview
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   comment:
@@ -19,6 +17,10 @@ jobs:
       github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
       contains(github.event.comment.body, '/deploy')
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -41,6 +43,8 @@ jobs:
 
   opened:
     name: Opened preview
+    # Do not add this job as a required check: it only runs on opened, so later
+    # commits would have no check on the new SHA.
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.user.type != 'Bot' &&
@@ -51,6 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -62,5 +67,4 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_TEAM_ID }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/ci/vercel-deploy.mjs preview

--- a/scripts/ci/__tests__/vercel-deploy.test.mjs
+++ b/scripts/ci/__tests__/vercel-deploy.test.mjs
@@ -11,6 +11,8 @@ import {
   pickPreviewUrl,
   pollDeploymentUntilSettled,
   runPreviewDeployComment,
+  runPreviewDeployOpened,
+  runPreviewFromGithubEvent,
   runProductionDeploy,
   usageMessage,
   VERCEL_PROJECTS,
@@ -573,6 +575,188 @@ describe("pollDeploymentUntilSettled", () => {
   });
 });
 
+describe("runPreviewDeployOpened", () => {
+  function sameRepoPullRequest(overrides = {}) {
+    return {
+      user: { type: "User", login: "alice" },
+      head: { sha: "deadbeef", ref: "feat/x", repo: { id: 99, fork: false } },
+      base: { repo: { id: 99 } },
+      ...overrides,
+    };
+  }
+
+  it("deploys web and core on both networks at the PR HEAD", async () => {
+    const urls = [];
+    const created = [];
+    const result = await runPreviewDeployOpened({
+      pullRequest: sameRepoPullRequest(),
+      repoId: 99,
+      createDeployment: async (input) => {
+        created.push(input);
+        return {
+          id: `dpl_${input.target.name}`,
+          readyState: "READY",
+        };
+      },
+      pollDeployment: async (deployment) => deployment,
+      fetchImpl: async (url) => {
+        urls.push(String(url));
+        throw new Error(`unexpected fetch ${url}`);
+      },
+    });
+    assert.equal(result.kind, "deploy");
+    assert.equal(created.length, 4);
+    assert.deepEqual(
+      created.map((item) => `${item.target.network}:${item.target.app}`),
+      ["mainnet:web", "mainnet:core", "preprod:web", "preprod:core"],
+    );
+    assert.ok(created.every((item) => item.sha === "deadbeef"));
+    assert.ok(created.every((item) => item.ref === "feat/x"));
+    assert.ok(created.every((item) => item.repoId === 99));
+    assert.ok(created.every((item) => item.deploymentTarget === undefined));
+    assert.deepEqual(urls, []);
+  });
+
+  it("ignores pull requests opened by bots", async () => {
+    const created = [];
+    const result = await runPreviewDeployOpened({
+      pullRequest: sameRepoPullRequest({
+        user: { type: "Bot", login: "cursor[bot]" },
+      }),
+      repoId: 99,
+      createDeployment: async (input) => {
+        created.push(input);
+        return { id: "dpl", readyState: "READY" };
+      },
+      pollDeployment: async (deployment) => deployment,
+    });
+    assert.equal(result.kind, "ignore");
+    assert.deepEqual(created, []);
+  });
+
+  it("refuses fork pull requests without commenting", async () => {
+    const urls = [];
+    const created = [];
+    const result = await runPreviewDeployOpened({
+      pullRequest: {
+        user: { type: "User", login: "alice" },
+        head: { sha: "abc", ref: "feat", repo: { id: 2, fork: true } },
+        base: { repo: { id: 1 } },
+      },
+      createDeployment: async (input) => {
+        created.push(input);
+        return { id: "dpl", readyState: "READY" };
+      },
+      fetchImpl: async (url) => {
+        urls.push(String(url));
+        throw new Error(`unexpected fetch ${url}`);
+      },
+    });
+    assert.equal(result.kind, "fork");
+    assert.deepEqual(created, []);
+    assert.deepEqual(urls, []);
+  });
+
+  it("throws when a preview deployment is not READY and does not comment", async () => {
+    const urls = [];
+    await assert.rejects(
+      () =>
+        runPreviewDeployOpened({
+          pullRequest: sameRepoPullRequest(),
+          repoId: 99,
+          createDeployment: async (input) => ({
+            id: `dpl_${input.target.name}`,
+            readyState: input.target.app === "core" ? "ERROR" : "READY",
+          }),
+          pollDeployment: async (deployment) => deployment,
+          fetchImpl: async (url) => {
+            urls.push(String(url));
+            throw new Error(`unexpected fetch ${url}`);
+          },
+        }),
+      /sokosumi-core-mainnet \(ERROR\)/,
+    );
+    assert.deepEqual(urls, []);
+  });
+});
+
+describe("runPreviewFromGithubEvent", () => {
+  it("routes pull_request opened events to the opened deploy", async () => {
+    const created = [];
+    const result = await runPreviewFromGithubEvent({
+      eventName: "pull_request",
+      event: {
+        action: "opened",
+        pull_request: {
+          user: { type: "User", login: "alice" },
+          head: { sha: "deadbeef", ref: "feat/x", repo: { id: 99 } },
+          base: { repo: { id: 99 } },
+        },
+        repository: { id: 99 },
+      },
+      createDeployment: async (input) => {
+        created.push(input);
+        return { id: `dpl_${input.target.name}`, readyState: "READY" };
+      },
+      pollDeployment: async (deployment) => deployment,
+    });
+    assert.equal(result.kind, "deploy");
+    assert.equal(created.length, 4);
+  });
+
+  it("ignores pull_request events that are not opened", async () => {
+    const created = [];
+    for (const action of ["synchronize", "ready_for_review", "reopened"]) {
+      const result = await runPreviewFromGithubEvent({
+        eventName: "pull_request",
+        event: {
+          action,
+          pull_request: {
+            user: { type: "User", login: "alice" },
+            head: { sha: "deadbeef", ref: "feat/x", repo: { id: 99 } },
+            base: { repo: { id: 99 } },
+          },
+          repository: { id: 99 },
+        },
+        createDeployment: async (input) => {
+          created.push(input);
+          return { id: "dpl", readyState: "READY" };
+        },
+      });
+      assert.equal(result.kind, "ignore", action);
+    }
+    assert.deepEqual(created, []);
+  });
+
+  it("routes issue_comment events to the comment deploy", async () => {
+    const created = [];
+    const result = await runPreviewFromGithubEvent({
+      eventName: "issue_comment",
+      event: {
+        comment: { body: "/deploy mainnet", user: { login: "alice" }, id: 1 },
+        issue: { pull_request: {}, number: 12 },
+        repository: { id: 99 },
+      },
+      isPullRequest: true,
+      commentAuthor: "alice",
+      readPermission: async () => "write",
+      readPullRequest: async () => ({
+        head: { sha: "deadbeef", ref: "feat/x", repo: { id: 99 } },
+        base: { repo: { id: 99 } },
+      }),
+      createDeployment: async (input) => {
+        created.push(input);
+        return { id: `dpl_${input.target.app}`, readyState: "READY" };
+      },
+      pollDeployment: async (deployment) => deployment,
+      postComment: async () => {},
+      addReaction: async () => {},
+    });
+    assert.equal(result.kind, "deploy");
+    assert.equal(created.length, 2);
+  });
+});
+
 describe("runProductionDeploy", () => {
   it("deploys web and core on both networks as production", async () => {
     const created = [];
@@ -636,14 +820,27 @@ describe("git preview policy", () => {
     }
   });
 
-  it("runs comment-gated deploys from the default branch", async () => {
+  it("runs comment-gated deploys and one opened-PR deploy from Actions", async () => {
     const workflow = await readFile(
       path.join(repoRoot, ".github/workflows/preview-deploy.yml"),
       "utf8",
     );
     assert.match(workflow, /issue_comment:/);
     assert.match(workflow, /types:\s*\[created\]/);
-    assert.doesNotMatch(workflow, /pull_request:/);
+    assert.match(workflow, /pull_request:/);
+    assert.match(workflow, /types:\s*\[opened\]/);
+    assert.doesNotMatch(workflow, /ready_for_review/);
+    assert.doesNotMatch(workflow, /synchronize/);
+    assert.match(workflow, /github\.event_name == 'issue_comment'/);
+    assert.match(workflow, /github\.event_name == 'pull_request'/);
+    assert.match(
+      workflow,
+      /github\.event\.pull_request\.user\.type\s*!=\s*'Bot'/,
+    );
+    assert.match(
+      workflow,
+      /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+    );
     assert.match(workflow, /node scripts\/ci\/vercel-deploy\.mjs preview/);
     assert.match(workflow, /persist-credentials:\s*false/);
     assert.match(workflow, /secrets\.VERCEL_TOKEN/);

--- a/scripts/ci/__tests__/vercel-deploy.test.mjs
+++ b/scripts/ci/__tests__/vercel-deploy.test.mjs
@@ -896,7 +896,7 @@ describe("git preview policy", () => {
     assert.match(workflow, /persist-credentials:\s*false/);
     assert.match(
       workflow,
-      /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+      /ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/,
     );
     assert.match(workflow, /secrets\.VERCEL_TOKEN/);
     assert.match(workflow, /vars\.VERCEL_TEAM_ID/);
@@ -908,6 +908,10 @@ describe("git preview policy", () => {
     assert.doesNotMatch(openedJob, /GITHUB_TOKEN/);
     assert.doesNotMatch(openedJob, /issues:\s*write/);
     assert.doesNotMatch(openedJob, /pull-requests:\s*write/);
+    assert.doesNotMatch(
+      openedJob,
+      /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha/,
+    );
     assert.match(
       workflow,
       /contains\(github\.event\.comment\.body, '\/deploy'\)/,

--- a/scripts/ci/__tests__/vercel-deploy.test.mjs
+++ b/scripts/ci/__tests__/vercel-deploy.test.mjs
@@ -14,6 +14,7 @@ import {
   runPreviewDeployOpened,
   runPreviewFromGithubEvent,
   runProductionDeploy,
+  summarizeCliDeployResult,
   usageMessage,
   VERCEL_PROJECTS,
   VERCEL_TEAM_ID,
@@ -617,6 +618,21 @@ describe("runPreviewDeployOpened", () => {
     assert.deepEqual(urls, []);
   });
 
+  it("deploys draft pull requests", async () => {
+    const created = [];
+    const result = await runPreviewDeployOpened({
+      pullRequest: sameRepoPullRequest({ draft: true }),
+      repoId: 99,
+      createDeployment: async (input) => {
+        created.push(input);
+        return { id: `dpl_${input.target.name}`, readyState: "READY" };
+      },
+      pollDeployment: async (deployment) => deployment,
+    });
+    assert.equal(result.kind, "deploy");
+    assert.equal(created.length, 4);
+  });
+
   it("ignores pull requests opened by bots", async () => {
     const created = [];
     const result = await runPreviewDeployOpened({
@@ -810,6 +826,41 @@ describe("runProductionDeploy", () => {
   });
 });
 
+describe("summarizeCliDeployResult", () => {
+  it("keeps only id, name, and readyState from deployment payloads", () => {
+    assert.deepEqual(
+      summarizeCliDeployResult({
+        kind: "deploy",
+        deployments: [
+          {
+            id: "dpl_1",
+            name: "sokosumi-app-mainnet",
+            readyState: "READY",
+            env: [{ key: "DATABASE_URL" }],
+            project: { settings: { crons: [] } },
+          },
+        ],
+      }),
+      {
+        kind: "deploy",
+        deployments: [
+          {
+            id: "dpl_1",
+            name: "sokosumi-app-mainnet",
+            readyState: "READY",
+          },
+        ],
+      },
+    );
+  });
+
+  it("leaves results without deployments unchanged", () => {
+    assert.deepEqual(summarizeCliDeployResult({ kind: "ignore" }), {
+      kind: "ignore",
+    });
+  });
+});
+
 describe("git preview policy", () => {
   it("disables all automatic git deployments", async () => {
     for (const app of ["web", "core"]) {
@@ -843,10 +894,20 @@ describe("git preview policy", () => {
     );
     assert.match(workflow, /node scripts\/ci\/vercel-deploy\.mjs preview/);
     assert.match(workflow, /persist-credentials:\s*false/);
+    assert.match(
+      workflow,
+      /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+    );
     assert.match(workflow, /secrets\.VERCEL_TOKEN/);
     assert.match(workflow, /vars\.VERCEL_TEAM_ID/);
     assert.match(workflow, /secrets\.GITHUB_TOKEN/);
     assert.match(workflow, /issues:\s*write/);
+    assert.match(workflow, /pull-requests:\s*write/);
+    const openedJob = workflow.split(/opened:\s*\n/)[1];
+    assert.ok(openedJob);
+    assert.doesNotMatch(openedJob, /GITHUB_TOKEN/);
+    assert.doesNotMatch(openedJob, /issues:\s*write/);
+    assert.doesNotMatch(openedJob, /pull-requests:\s*write/);
     assert.match(
       workflow,
       /contains\(github\.event\.comment\.body, '\/deploy'\)/,

--- a/scripts/ci/vercel-deploy.mjs
+++ b/scripts/ci/vercel-deploy.mjs
@@ -542,6 +542,20 @@ export async function runProductionDeploy(options) {
   return { kind: "production", deployments: settled };
 }
 
+export function summarizeCliDeployResult(result) {
+  if (!Array.isArray(result?.deployments)) {
+    return result;
+  }
+  return {
+    kind: result.kind,
+    deployments: result.deployments.map((deployment) => ({
+      id: deployment.id,
+      name: deployment.name,
+      readyState: deployment.readyState,
+    })),
+  };
+}
+
 function requireVercelToken(env) {
   if (!env.VERCEL_TOKEN) {
     throw new Error("VERCEL_TOKEN is required");
@@ -574,7 +588,7 @@ async function cliPreview(env = process.env) {
     githubToken: env.GITHUB_TOKEN,
     teamId: env.VERCEL_ORG_ID ?? VERCEL_TEAM_ID,
   });
-  console.log(JSON.stringify(result));
+  console.log(JSON.stringify(summarizeCliDeployResult(result)));
 }
 
 async function cliProduction(env = process.env) {
@@ -591,7 +605,7 @@ async function cliProduction(env = process.env) {
     vercelToken: env.VERCEL_TOKEN,
     teamId: env.VERCEL_ORG_ID ?? VERCEL_TEAM_ID,
   });
-  console.log(JSON.stringify(result));
+  console.log(JSON.stringify(summarizeCliDeployResult(result)));
 }
 
 function isMainModule() {

--- a/scripts/ci/vercel-deploy.mjs
+++ b/scripts/ci/vercel-deploy.mjs
@@ -2,7 +2,7 @@
 /**
  * Create Vercel git deployments from GitHub Actions.
  *
- *   node scripts/ci/vercel-deploy.mjs preview     # `/deploy` PR comment
+ *   node scripts/ci/vercel-deploy.mjs preview     # PR opened (human, same-repo) or `/deploy` comment
  *   node scripts/ci/vercel-deploy.mjs production  # push to main
  */
 
@@ -259,6 +259,62 @@ function failedDeploymentNames(targets, deployments) {
   });
 }
 
+function previewGitSource(pullRequest, repoId) {
+  return {
+    repoId: repoId ?? pullRequest.base.repo.id,
+    ref: pullRequest.head.ref,
+    sha: pullRequest.head.sha,
+  };
+}
+
+function isSameRepoPullRequest(pullRequest) {
+  return pullRequest.head.repo?.id === pullRequest.base.repo.id;
+}
+
+async function settlePreviewDeployments(options) {
+  const {
+    networks,
+    git,
+    vercelToken,
+    teamId,
+    fetchImpl = globalThis.fetch,
+    createDeployment,
+    pollDeployment,
+  } = options;
+
+  const create =
+    createDeployment ??
+    ((input) =>
+      createGitDeployment({
+        token: vercelToken,
+        teamId,
+        fetchImpl,
+        ...input,
+      }));
+  const poll =
+    pollDeployment ??
+    ((deployment) =>
+      pollDeploymentUntilSettled({
+        deployment,
+        token: vercelToken,
+        teamId,
+        fetchImpl,
+      }));
+
+  const targets = deployTargets(networks);
+  const created = await Promise.all(
+    targets.map((target) => create({ target, ...git })),
+  );
+  const settled = await Promise.all(
+    created.map((deployment) => poll(deployment)),
+  );
+  const failed = failedDeploymentNames(targets, settled);
+  if (failed.length > 0) {
+    throw new Error(failed.join(", "));
+  }
+  return { kind: "deploy", deployments: settled };
+}
+
 export async function runPreviewDeployComment(options) {
   const {
     commentBody,
@@ -352,56 +408,85 @@ export async function runPreviewDeployComment(options) {
     throw new Error(`Pull request ${issueNumber} was not found`);
   }
 
-  if (pullRequest.head.repo?.id !== pullRequest.base.repo.id) {
+  if (!isSameRepoPullRequest(pullRequest)) {
     await comment(
       "Preview deploy is only available for branches in this repository, not forks.",
     );
     return { kind: "fork" };
   }
 
-  const create =
-    createDeployment ??
-    ((input) =>
-      createGitDeployment({
-        token: vercelToken,
-        teamId,
-        fetchImpl,
-        ...input,
-      }));
-  const poll =
-    pollDeployment ??
-    ((deployment) =>
-      pollDeploymentUntilSettled({
-        deployment,
-        token: vercelToken,
-        teamId,
-        fetchImpl,
-      }));
-
-  const targets = deployTargets(parsed.networks);
-  const git = {
-    repoId: repoId ?? pullRequest.base.repo.id,
-    ref: pullRequest.head.ref,
-    sha: pullRequest.head.sha,
-  };
-  let settled;
   try {
     await react("eyes");
-    const created = await Promise.all(
-      targets.map((target) => create({ target, ...git })),
-    );
-    settled = await Promise.all(created.map((deployment) => poll(deployment)));
-    const failed = failedDeploymentNames(targets, settled);
-    if (failed.length > 0) {
-      throw new Error(failed.join(", "));
-    }
+    const result = await settlePreviewDeployments({
+      networks: parsed.networks,
+      git: previewGitSource(pullRequest, repoId),
+      vercelToken,
+      teamId,
+      fetchImpl,
+      createDeployment,
+      pollDeployment,
+    });
+    await react("rocket");
+    return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await comment(`Preview deploy failed: ${message}`);
     throw error;
   }
-  await react("rocket");
-  return { kind: "deploy", deployments: settled };
+}
+
+export async function runPreviewDeployOpened(options) {
+  const {
+    pullRequest,
+    repoId,
+    vercelToken,
+    teamId = VERCEL_TEAM_ID,
+    fetchImpl = globalThis.fetch,
+    createDeployment,
+    pollDeployment,
+  } = options;
+
+  if (pullRequest.user?.type === "Bot") {
+    return { kind: "ignore" };
+  }
+
+  if (!isSameRepoPullRequest(pullRequest)) {
+    return { kind: "fork" };
+  }
+
+  return settlePreviewDeployments({
+    networks: [...NETWORKS],
+    git: previewGitSource(pullRequest, repoId),
+    vercelToken,
+    teamId,
+    fetchImpl,
+    createDeployment,
+    pollDeployment,
+  });
+}
+
+export async function runPreviewFromGithubEvent(options) {
+  const { eventName, event, ...rest } = options;
+  if (eventName === "pull_request") {
+    if (event.action !== "opened") {
+      return { kind: "ignore" };
+    }
+    return runPreviewDeployOpened({
+      ...rest,
+      pullRequest: event.pull_request,
+      repoId: rest.repoId ?? event.repository?.id,
+    });
+  }
+
+  return runPreviewDeployComment({
+    ...rest,
+    commentBody: rest.commentBody ?? event.comment.body,
+    commentAuthor: rest.commentAuthor ?? event.comment.user.login,
+    commentId: rest.commentId ?? event.comment.id,
+    isPullRequest: rest.isPullRequest ?? Boolean(event.issue?.pull_request),
+    issueNumber: rest.issueNumber ?? event.issue.number,
+    repoId: rest.repoId ?? event.repository?.id,
+  });
 }
 
 export async function runProductionDeploy(options) {
@@ -479,12 +564,9 @@ async function cliPreview(env = process.env) {
   }
   const event = await readGithubEvent(env);
   const [repoOwner, repoName] = env.GITHUB_REPOSITORY.split("/");
-  const result = await runPreviewDeployComment({
-    commentBody: event.comment.body,
-    commentAuthor: event.comment.user.login,
-    commentId: event.comment.id,
-    isPullRequest: Boolean(event.issue.pull_request),
-    issueNumber: event.issue.number,
+  const result = await runPreviewFromGithubEvent({
+    eventName: env.GITHUB_EVENT_NAME,
+    event,
     repoOwner,
     repoName,
     repoId: event.repository.id,


### PR DESCRIPTION
## Summary

Preview deploys still do not follow every git push. After this lands, **opening a same-repo pull request as a User** (draft or ready) builds **web + core on mainnet and preprod once**. Bot-opened PRs (GitHub Apps, Dependabot, cloud “Create PR”) stay dark until someone with write access comments `/deploy`. Later commits and draft → ready also stay on `/deploy`. Git auto-deploy remains off. Preview URLs still come from the Vercel GitHub App on the first git preview.

## Verification

- `node --test scripts/ci/__tests__/vercel-deploy.test.mjs scripts/ci/__tests__/turbo-remote-cache.test.mjs`
- Husky `pnpm check && pnpm typecheck` on commit
- After merge: open a human draft PR and confirm four Vercel git previews start; confirm a bot-opened PR does not; confirm `/deploy all` still works for a later SHA