### PR TITLE
fix(admin): truncate user list credits for locale display

### DIFF
--- a/apps/web/src/components/admin/users/__tests__/user-list.test.tsx
+++ b/apps/web/src/components/admin/users/__tests__/user-list.test.tsx
@@ -39,8 +39,8 @@ function createUser(
 ): AdminUserOverviewItem {
   return {
     id: "user-1",
-    name: "Kevin Harris",
-    email: "homesafesa@gmail.com",
+    name: "Ada Lovelace",
+    email: "ada@example.com",
     createdAt: new Date("2026-08-22T00:00:00.000Z"),
     credits: 0,
     subscriptionPlan: "free",

--- a/apps/web/src/components/admin/users/__tests__/user-list.test.tsx
+++ b/apps/web/src/components/admin/users/__tests__/user-list.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { UserList } from "@/components/admin/users/user-list";
+import type { AdminUserOverviewItem } from "@/lib/services/admin-user.service";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: { count?: number }) => {
+    if (key === "totalCount") {
+      return `${values?.count} users`;
+    }
+    return key;
+  },
+  useFormatter: () => ({
+    number: (value: number) => new Intl.NumberFormat("en-US").format(value),
+    dateTime: () => "Aug 22, 2026",
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/config/env.public", () => ({
+  getEnvPublicConfig: () => ({
+    NEXT_PUBLIC_KEYBOARD_INPUT_DEBOUNCE_TIME: 0,
+  }),
+}));
+
+vi.mock("@/lib/actions/admin-users/action", () => ({
+  listAdminUsersAction: vi.fn(),
+}));
+
+function createUser(
+  overrides: Partial<AdminUserOverviewItem> = {},
+): AdminUserOverviewItem {
+  return {
+    id: "user-1",
+    name: "Kevin Harris",
+    email: "homesafesa@gmail.com",
+    createdAt: new Date("2026-08-22T00:00:00.000Z"),
+    credits: 0,
+    subscriptionPlan: "free",
+    subscriptionStatus: "active",
+    startedTaskCount: 1,
+    ...overrides,
+  };
+}
+
+describe("UserList credits", () => {
+  it("shows truncated locale-grouped credits like the rest of the product", () => {
+    render(
+      <UserList
+        initialPage={{
+          users: [createUser({ credits: 2807.025 })],
+          total: 1,
+          nextCursor: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("2,807")).toBeInTheDocument();
+    expect(screen.queryByText("2,807.025")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/users/user-list.tsx
+++ b/apps/web/src/components/admin/users/user-list.tsx
@@ -22,6 +22,7 @@ import type {
   AdminUserOverviewItem,
   AdminUserOverviewPage,
 } from "@/lib/services/admin-user.service";
+import { formatCreditsForDisplay } from "@/lib/utils/credits";
 
 interface UserListProps {
   initialPage: AdminUserOverviewPage;
@@ -145,7 +146,7 @@ export function UserList({ initialPage }: UserListProps) {
                     </span>
                   </TableCell>
                   <TableCell className="text-right tabular-nums">
-                    {formatter.number(user.credits)}
+                    {formatter.number(formatCreditsForDisplay(user.credits))}
                   </TableCell>
                   <TableCell>
                     {user.subscriptionPlan ? (


### PR DESCRIPTION
## Summary

Admin Users credits now match billing and org members: truncate to a whole credit, then locale-group with the viewing admin's language.

The table was printing stored millicredits (`2,807.025`). Everywhere else uses `formatCreditsForDisplay` then `formatter.number`, so English shows `2,807` and German `2.807`.

## User-facing

- Admin `/admin/users` Credits column shows whole credits with locale grouping (`,` vs `.`)
- Fractional millicredits are no longer visible in that list

## Verification

- [x] `pnpm test` (web 3715 passed, core 4196 passed)
- [x] Husky pre-commit: `biome check` + typecheck
- [x] Browser: `/admin/users` in `de` — `3.250` grouping, former `3,233.562` shows as `3.233`
